### PR TITLE
Migrate shell controls to gpui-component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "anyhow",
  "directories",
  "gpui",
+ "gpui-component",
  "indexmap",
  "libghostty-vt",
  "portable-pty",
@@ -78,6 +79,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +107,15 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -488,6 +507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base62"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +837,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1440,6 +1478,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +1713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,6 +1836,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1987,6 +2063,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2221,57 @@ dependencies = [
  "zed-font-kit",
  "zed-scap",
  "zed-xim",
+]
+
+[[package]]
+name = "gpui-component"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d021d46b4088d3d93a57ccdf443da85695a77272108caca2f6fe5369f584966a"
+dependencies = [
+ "aho-corasick",
+ "anyhow",
+ "chrono",
+ "core-text",
+ "enum-iterator",
+ "gpui",
+ "gpui-component-macros",
+ "gpui-macros",
+ "html5ever",
+ "itertools 0.13.0",
+ "lsp-types",
+ "markdown",
+ "markup5ever_rcdom",
+ "notify",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "regex",
+ "ropey",
+ "rust-i18n",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "smallvec",
+ "smol",
+ "tracing",
+ "tree-sitter",
+ "tree-sitter-json",
+ "unicode-segmentation",
+ "uuid",
+ "zed-sum-tree",
+]
+
+[[package]]
+name = "gpui-component-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86fbc2d84bf91717b171320e6adc600d91ccb3ed259448f3b006787633c1c615"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2426,6 +2564,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,6 +2671,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2631,6 +2807,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,6 +2878,26 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2787,6 +2999,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2839,6 +3060,26 @@ checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -3011,6 +3252,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "lyon"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3329,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "markdown"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
+dependencies = [
+ "unicode-id",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -3190,6 +3479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3315,6 +3605,43 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "normpath"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.1",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "ntapi"
@@ -3730,6 +4057,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3891,6 +4256,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty_assertions"
@@ -4407,6 +4778,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ropey"
+version = "2.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4045a00dc327d084a2bbf126976e14125b54f23bd30511d45b842eba76c52d74"
+dependencies = [
+ "str_indices",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4445,6 +4825,60 @@ dependencies = [
  "globset",
  "sha2",
  "walkdir",
+]
+
+[[package]]
+name = "rust-i18n"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda2551fdfaf6cc5ee283adc15e157047b92ae6535cf80f6d4962d05717dc332"
+dependencies = [
+ "globwalk",
+ "once_cell",
+ "regex",
+ "rust-i18n-macro",
+ "rust-i18n-support",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-i18n-macro"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22baf7d7f56656d23ebe24f6bb57a5d40d2bce2a5f1c503e692b5b2fa450f965"
+dependencies = [
+ "glob",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "rust-i18n-support",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "rust-i18n-support"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940ed4f52bba4c0152056d771e563b7133ad9607d4384af016a134b58d758f19"
+dependencies = [
+ "arc-swap",
+ "base62",
+ "globwalk",
+ "itertools 0.11.0",
+ "lazy_static",
+ "normpath",
+ "once_cell",
+ "proc-macro2",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "siphasher",
+ "toml 0.8.23",
+ "triomphe",
 ]
 
 [[package]]
@@ -4836,6 +5270,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5085,12 +5532,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -5719,6 +6203,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "arc-swap",
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5805,6 +6330,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
 
 [[package]]
+name = "unicode-id"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5851,6 +6382,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6905,6 +7442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "workspace-hack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beffa227304dbaea3ad6a06ac674f9bc83a3dec3b7f63eeb442de37e7cb6bb01"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7012,6 +7555,17 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml5ever"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+]
 
 [[package]]
 name = "xmlwriter"
@@ -7252,6 +7806,18 @@ dependencies = [
  "windows-capture",
  "x11",
  "xcb",
+]
+
+[[package]]
+name = "zed-sum-tree"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d490156d0d7311855564d6e1d6dccab992405a0c0e15e1c8ef18920c02177e35"
+dependencies = [
+ "arrayvec",
+ "log",
+ "rayon",
+ "workspace-hack",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ portable-pty = "0.8"
 # GPUI is the Rust UI framework used by Zed. If crates.io does not have the
 # needed version, switch this dependency to Zed's Git repository during this task.
 gpui = { version = "0.2", features = ["runtime_shaders"] }
+gpui-component = "0.5.1"
 
 # libghostty-rs currently exposes Ghostty VT bindings through libghostty-vt.
 # Alas keeps this behind src/terminal/ghostty_adapter.rs. If the project adds

--- a/src/ui/command_picker.rs
+++ b/src/ui/command_picker.rs
@@ -2,6 +2,10 @@ use crate::config::CommandEntry;
 use gpui::{
     App, ClickEvent, IntoElement, ParentElement, SharedString, Styled, Window, div, prelude::*, rgb,
 };
+use gpui_component::{
+    Sizable,
+    button::{Button, ButtonVariants},
+};
 use indexmap::IndexMap;
 
 pub fn render_command_picker(
@@ -33,16 +37,11 @@ pub fn render_command_picker(
                         .child("New Terminal Tab"),
                 )
                 .child(
-                    div()
-                        .id("cancel-command-picker")
-                        .px_2()
-                        .py_1()
-                        .rounded_md()
-                        .text_xs()
-                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                    Button::new("cancel-command-picker")
+                        .xsmall()
+                        .ghost()
+                        .label("Cancel")
                         .text_color(rgb(0x374151))
-                        .bg(rgb(0xe5e7eb))
-                        .child("Cancel")
                         .on_click(on_cancel),
                 ),
         )

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -2,12 +2,16 @@ use crate::{
     app::{InspectorPaneState, InspectorTab, SelectedWorktree},
     git::GitInspectorState,
     project::FileTreeNode,
-    ui::theme::{ACCENT, ACCENT_TEXT, DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
+    ui::theme::{DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
 };
 
 use gpui::{
     AnyElement, App, ClickEvent, FontWeight, IntoElement, ParentElement, SharedString, Styled,
     Window, div, prelude::*, px,
+};
+use gpui_component::{
+    Sizable,
+    tab::{Tab, TabBar},
 };
 
 pub fn render_project_inspector(
@@ -64,56 +68,30 @@ fn render_tab_bar(
     selected_tab: InspectorTab,
     on_select_tab: impl Fn(InspectorTab, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
 ) -> impl IntoElement {
-    div()
-        .flex()
-        .items_center()
-        .gap_1()
-        .p_1()
-        .rounded_md()
-        .bg(PANEL_BORDER)
-        .child(render_tab_button(
-            "inspector-tab-files",
-            "Files",
-            InspectorTab::Files,
-            selected_tab,
-            on_select_tab.clone(),
-        ))
-        .child(render_tab_button(
-            "inspector-tab-changes",
-            "Changes",
-            InspectorTab::Changes,
-            selected_tab,
-            on_select_tab,
-        ))
-}
+    let selected_index = match selected_tab {
+        InspectorTab::Files => 0,
+        InspectorTab::Changes => 1,
+    };
+    let on_select_files = on_select_tab.clone();
 
-fn render_tab_button(
-    id: &'static str,
-    label: &'static str,
-    tab: InspectorTab,
-    selected_tab: InspectorTab,
-    on_select_tab: impl Fn(InspectorTab, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
-) -> impl IntoElement {
-    let is_active = tab == selected_tab;
-
-    div()
-        .id(id)
-        .flex_1()
-        .px_3()
-        .py_1()
-        .rounded_md()
-        .text_sm()
-        .font_weight(if is_active {
-            FontWeight::SEMIBOLD
-        } else {
-            FontWeight::NORMAL
-        })
-        .text_color(if is_active { ACCENT_TEXT } else { TEXT_MUTED })
-        .bg(if is_active { ACCENT } else { PANEL_BORDER })
-        .child(label)
-        .on_click(move |event, window, cx| {
-            on_select_tab(tab, event, window, cx);
-        })
+    TabBar::new("inspector-tab-bar")
+        .segmented()
+        .small()
+        .selected_index(selected_index)
+        .child(
+            Tab::new()
+                .label("Files")
+                .on_click(move |event, window, cx| {
+                    on_select_files(InspectorTab::Files, event, window, cx);
+                }),
+        )
+        .child(
+            Tab::new()
+                .label("Changes")
+                .on_click(move |event, window, cx| {
+                    on_select_tab(InspectorTab::Changes, event, window, cx);
+                }),
+        )
 }
 
 fn render_files_tab(state: &InspectorPaneState) -> AnyElement {

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -2544,6 +2544,8 @@ impl Render for AlasShell {
 pub fn run() -> anyhow::Result<()> {
     Application::new().run(|cx: &mut App| {
         crate::ui::lifecycle::setup_lifecycle(cx);
+        gpui_component::init(cx);
+
         cx.open_window(WindowOptions::default(), |window, cx| {
             let shell = cx.new(AlasShell::new);
             let weak_shell = shell.downgrade();
@@ -2551,7 +2553,7 @@ pub fn run() -> anyhow::Result<()> {
                 weak_shell.update(cx, |shell, _cx| shell.shutdown()).ok();
                 true
             });
-            shell
+            cx.new(|cx| gpui_component::Root::new(shell, window, cx))
         })
         .expect("failed to open Alas window");
     });

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -6,13 +6,16 @@ use crate::{
         RepositoryNode, SelectedWorktree, WorktreeNode,
     },
     git::WorktreeKind,
-    ui::theme::{
-        ACCENT, ACCENT_TEXT, DANGER, PANEL_BG, PANEL_BORDER, SIDEBAR_BG, TEXT, TEXT_MUTED,
-    },
+    ui::theme::{ACCENT, DANGER, PANEL_BG, PANEL_BORDER, SIDEBAR_BG, TEXT, TEXT_MUTED},
 };
 use gpui::{
-    App, ClickEvent, Div, FontWeight, IntoElement, MouseButton, ParentElement, SharedString,
-    Styled, Window, div, prelude::*, px,
+    App, ClickEvent, FontWeight, IntoElement, MouseButton, ParentElement, SharedString, Styled,
+    Window, div, prelude::*, px,
+};
+use gpui_component::{
+    Sizable,
+    button::{Button, ButtonVariants},
+    tag::Tag,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,16 +86,9 @@ pub fn render_sidebar(
                 .flex_col()
                 .gap_2()
                 .child(
-                    div()
-                        .id("add-repository")
-                        .px_3()
-                        .py_2()
-                        .rounded_md()
-                        .text_sm()
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .text_color(ACCENT_TEXT)
-                        .bg(ACCENT)
-                        .child("+ Add Repository")
+                    Button::new("add-repository")
+                        .primary()
+                        .label("+ Add Repository")
                         .on_click(on_add_repository),
                 )
                 .when(add_repository_error.is_some(), |element| {
@@ -433,13 +429,11 @@ fn render_sidebar_menu(
                         }),
                 )
                 .child(
-                    div()
-                        .id("close-sidebar-menu")
-                        .px_1()
-                        .rounded_md()
-                        .text_xs()
+                    Button::new("close-sidebar-menu")
+                        .xsmall()
+                        .ghost()
+                        .label("×")
                         .text_color(TEXT_MUTED)
-                        .child("×")
                         .on_click(move |event, window, cx| {
                             cx.stop_propagation();
                             on_close_sidebar_menu(event, window, cx);
@@ -494,16 +488,12 @@ fn overflow_button(
     menu_state: SidebarMenuState,
     on_open_sidebar_menu: impl Fn(SidebarMenuState, &mut Window, &mut App) + Clone + 'static,
 ) -> impl IntoElement {
-    div()
-        .id(id)
-        .px_2()
-        .py_1()
-        .rounded_md()
-        .text_sm()
-        .font_weight(FontWeight::SEMIBOLD)
+    Button::new(id)
+        .xsmall()
+        .ghost()
+        .compact()
+        .label("⋯")
         .text_color(TEXT_MUTED)
-        .bg(PANEL_BG)
-        .child("⋯")
         .on_click(move |_event, window, cx| {
             cx.stop_propagation();
             on_open_sidebar_menu(menu_state.clone(), window, cx);
@@ -517,27 +507,17 @@ fn menu_action_row(
     action_id: ActionId,
     on_sidebar_menu_action: impl Fn(ActionId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
 ) -> impl IntoElement {
-    div()
-        .id(id)
-        .px_2()
-        .py_1()
-        .rounded_md()
-        .text_sm()
+    Button::new(id)
+        .small()
+        .ghost()
+        .label(label)
         .text_color(if destructive { DANGER } else { TEXT })
-        .child(label)
         .on_click(move |event, window, cx| {
             cx.stop_propagation();
             on_sidebar_menu_action(action_id, event, window, cx);
         })
 }
 
-fn status_badge(label: &'static str) -> Div {
-    div()
-        .px_1()
-        .py_1()
-        .rounded_md()
-        .bg(PANEL_BORDER)
-        .text_xs()
-        .text_color(TEXT_MUTED)
-        .child(label)
+fn status_badge(label: &'static str) -> impl IntoElement {
+    Tag::secondary().small().child(label)
 }

--- a/src/ui/terminal_pane.rs
+++ b/src/ui/terminal_pane.rs
@@ -7,12 +7,16 @@ use crate::{
             CELL_HEIGHT_PX, TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE_PX,
             render_terminal_bounds_probe,
         },
-        theme::{ACCENT, ACCENT_TEXT, DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
+        theme::{DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
     },
 };
 use gpui::{
     AnyElement, App, Bounds, ClickEvent, IntoElement, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
     ParentElement, Pixels, ScrollWheelEvent, SharedString, Styled, Window, div, prelude::*,
+};
+use gpui_component::{
+    Sizable,
+    button::{Button, ButtonVariants},
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -95,15 +99,11 @@ pub fn render_terminal_pane(
                                         .gap_2()
                                         .child(format!("Exited: {status}"))
                                         .child(
-                                            div()
-                                                .id("restart-terminal")
-                                                .px_2()
-                                                .py_1()
-                                                .rounded_md()
-                                                .font_weight(gpui::FontWeight::SEMIBOLD)
-                                                .text_color(ACCENT_TEXT)
-                                                .bg(ACCENT)
-                                                .child("Restart")
+                                            Button::new("restart-terminal")
+                                                .small()
+                                                .primary()
+                                                .compact()
+                                                .label("Restart")
                                                 .on_click(on_restart),
                                         ),
                                 )
@@ -183,31 +183,15 @@ fn render_terminal_failure(
                 .flex()
                 .gap_2()
                 .child(
-                    div()
-                        .id("retry-terminal")
-                        .px_3()
-                        .py_2()
-                        .rounded_md()
-                        .text_sm()
-                        .font_weight(gpui::FontWeight::SEMIBOLD)
-                        .text_color(ACCENT_TEXT)
-                        .bg(ACCENT)
-                        .child("Retry")
+                    Button::new("retry-terminal")
+                        .primary()
+                        .label("Retry")
                         .on_click(on_retry),
                 )
                 .child(
-                    div()
-                        .id("edit-terminal-command")
-                        .px_3()
-                        .py_2()
-                        .rounded_md()
-                        .border_1()
-                        .border_color(PANEL_BORDER)
-                        .text_sm()
-                        .font_weight(gpui::FontWeight::SEMIBOLD)
-                        .text_color(TEXT)
-                        .bg(PANEL_BG)
-                        .child("Edit Command")
+                    Button::new("edit-terminal-command")
+                        .outline()
+                        .label("Edit Command")
                         .on_click(on_edit_command),
                 ),
         )

--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -1,9 +1,12 @@
 use crate::{
     app::{TerminalTab, TerminalTabId, TerminalTabKind},
-    ui::theme::{ACCENT, ACTIVE_TAB_BG, APP_BG, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
+    ui::theme::{ACCENT, APP_BG, PANEL_BG, PANEL_BORDER},
 };
-use gpui::{
-    App, ClickEvent, IntoElement, ParentElement, SharedString, Styled, Window, div, prelude::*,
+use gpui::{App, ClickEvent, IntoElement, ParentElement, Styled, Window, div, prelude::*};
+use gpui_component::{
+    Sizable,
+    button::Button,
+    tab::{Tab, TabBar},
 };
 
 pub fn render_workspace(
@@ -42,6 +45,8 @@ fn render_tab_bar(
     on_select_tab: impl Fn(TerminalTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
     on_new_tab: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
 ) -> impl IntoElement {
+    let selected_index = tabs.iter().position(|tab| Some(tab.id) == active_tab);
+
     div()
         .id("workspace-tab-bar")
         .flex()
@@ -52,46 +57,33 @@ fn render_tab_bar(
         .border_b_1()
         .border_color(PANEL_BORDER)
         .bg(PANEL_BG)
-        .children(tabs.iter().map(move |tab| {
-            let tab_id = tab.id;
-            let is_active = Some(tab_id) == active_tab;
-            let label = tab.name.clone();
-            let kind = tab.kind;
-            let on_select_tab = on_select_tab.clone();
-
-            div()
-                .id(SharedString::from(format!("workspace-tab-{}", tab_id.0)))
-                .px_3()
-                .py_1()
-                .rounded_md()
-                .border_1()
-                .border_color(if is_active { ACCENT } else { PANEL_BORDER })
-                .bg(if is_active { ACTIVE_TAB_BG } else { PANEL_BG })
-                .text_sm()
-                .text_color(if is_active { TEXT } else { TEXT_MUTED })
-                .font_weight(if is_active {
-                    gpui::FontWeight::SEMIBOLD
-                } else {
-                    gpui::FontWeight::NORMAL
-                })
-                .child(format!("{}{}", tab_kind_prefix(kind), label))
-                .on_click(move |event, window, cx| {
-                    on_select_tab(tab_id, event, window, cx);
-                })
-        }))
         .child(
-            div()
-                .id("workspace-new-tab")
-                .px_3()
-                .py_1()
-                .rounded_md()
-                .border_1()
-                .border_color(PANEL_BORDER)
-                .bg(PANEL_BG)
-                .text_sm()
-                .font_weight(gpui::FontWeight::SEMIBOLD)
+            TabBar::new("workspace-tabs")
+                .segmented()
+                .small()
+                .when_some(selected_index, |tab_bar, index| {
+                    tab_bar.selected_index(index)
+                })
+                .children(tabs.iter().map(move |tab| {
+                    let tab_id = tab.id;
+                    let label = tab.name.clone();
+                    let kind = tab.kind;
+                    let on_select_tab = on_select_tab.clone();
+
+                    Tab::new()
+                        .label(format!("{}{}", tab_kind_prefix(kind), label))
+                        .on_click(move |event, window, cx| {
+                            on_select_tab(tab_id, event, window, cx);
+                        })
+                })),
+        )
+        .child(
+            Button::new("workspace-new-tab")
+                .small()
+                .outline()
+                .compact()
+                .label("+")
                 .text_color(ACCENT)
-                .child("+")
                 .on_click(on_new_tab),
         )
 }


### PR DESCRIPTION
## Summary
- initialize gpui-component in the app shell and wrap AlasShell with Root
- migrate low-risk non-terminal controls to gpui-component buttons, tabs, and tags
- leave Ghostty terminal canvas/rendering/input paths unchanged

## Validation
- cargo fmt --all -- --check
- DOCS_RS=1 cargo clippy --all-targets --all-features -- -D warnings

Full all-features build/clippy/test are blocked locally because libghostty-vt-sys requires zig, which is not installed in this environment.