### PR TITLE
feat: overhaul UI to three-column flush terminal shell

### DIFF
--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -11,6 +11,27 @@
 7. Prune stale worktrees and confirm the destructive prompt.
 8. Open command settings and configure at least two commands.
 
+## UI Overhaul
+
+1. On macOS, start Alas with `cargo run` and confirm the normal titlebar is visually reclaimed: app content is flush with the window and traffic-light buttons sit approximately 20px from the top.
+2. Confirm the top-left safe area is reserved in the left sidebar: no repository row, text, or button sits under the traffic-light buttons.
+3. Drag the window from the top-left safe/chrome area and confirm the window moves.
+4. Try dragging from terminal content, repository rows, worktree rows, and right-sidebar rows; confirm those areas do not drag the window.
+5. Confirm Linux still shows conventional window chrome if tested on Linux.
+6. Confirm the app reads as three columns: repository/worktree tree, flush terminal pane, grouped files/Git tree.
+7. Expand and collapse repository nodes in the left sidebar.
+8. Right-click a repository row and a worktree row; confirm contextual popover menus show the expected actions.
+9. Click each overflow button and confirm it opens the same action set as right-click.
+10. Use the bottom icon-only add repository button; confirm its hover tooltip says “Add repository.”
+11. Select a worktree and confirm the center terminal starts without a persistent `Worktree:` label or workspace card border.
+12. Hover the top edge of the terminal; confirm terminal tabs and the new-tab control appear.
+13. Open a second terminal tab and confirm the tab overlay remains available for switching.
+14. Confirm terminal scroll, mouse, keyboard, paste, resize, and alternate-screen behavior still match the Terminal Emulator Behavior section.
+15. Confirm the right sidebar shows a single grouped tree with Changed and Files sections, not Files/Changes tabs.
+16. Expand and collapse directories in the right Files section.
+17. Create or modify a file and confirm the Changed section updates independently of the Files section.
+18. Confirm the old full-width bottom status bar is gone.
+
 ## Desktop Packaging and Lifecycle
 
 ### macOS `.app`
@@ -76,8 +97,10 @@
 7. Mouse: verify shell scrollback still works; in mouse-aware TUIs, verify clicks/wheel are sent when supported.
 8. Resize: run `stty size`, resize the window, run `stty size` again, confirm cell size changed correctly.
 
-## Files and Changes Inspector
+## Grouped Project Inspector
 
-1. Files tab shows worktree files.
-2. Changes tab shows modified/untracked files.
-3. File loading errors do not break terminal input.
+1. Select a worktree and confirm the right sidebar shows a single grouped tree, not separate Files and Changes tabs.
+2. Confirm the Changed section shows modified/untracked files with status badges.
+3. Confirm the Files section shows worktree files and supports directory expand/collapse.
+4. Confirm file loading errors remain scoped to the Files section and do not break terminal input.
+5. Confirm Git status loading errors remain scoped to the Changed section and do not break terminal input.

--- a/docs/superpowers/plans/2026-04-30-ui-overhaul.md
+++ b/docs/superpowers/plans/2026-04-30-ui-overhaul.md
@@ -1,0 +1,1664 @@
+# Alas UI Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the approved macOS-first, Superconductor-inspired three-column UI overhaul with a collapsible repository tree, flush terminal center pane, grouped right inspector tree, contextual popovers, and icon-only add repository control.
+
+**Architecture:** Keep the existing Alas app model, terminal backend/session code, Git services, and file tree service. Add small UI view-model helpers for testable tree/overlay state, then refactor the GPUI surfaces around `gpui-component` tree/menu/button primitives. Keep platform-specific window chrome isolated in one module.
+
+**Tech Stack:** Rust 2024, GPUI 0.2, gpui-component 0.5.1 (`tree`, `button`, `menu`, `popover`, `IconName`), Ghostty-backed terminal renderer, existing Cargo test suite.
+
+---
+
+## Reference Inputs
+
+- Approved spec: `docs/superpowers/specs/2026-04-30-ui-overhaul-design.md`
+- Existing UI files:
+  - `src/ui/shell.rs`
+  - `src/ui/sidebar.rs`
+  - `src/ui/inspector.rs`
+  - `src/ui/workspace.rs`
+  - `src/ui/terminal_pane.rs`
+  - `src/ui/theme.rs`
+- Relevant GPUI component APIs:
+  - `gpui_component::tree::{tree, TreeEntry, TreeItem, TreeState}`
+  - `gpui_component::list::ListItem`
+  - `gpui_component::menu::{ContextMenuExt, DropdownMenu as _, PopupMenu, PopupMenuItem}`
+  - `gpui_component::button::{Button, ButtonVariants}`
+  - `gpui_component::{Icon, IconName, Sizable}`
+- Relevant GPUI window chrome APIs:
+  - `gpui::WindowOptions`
+  - `gpui::TitlebarOptions`
+  - `gpui::point`
+  - `gpui::px`
+
+## File Structure
+
+Create or modify these files.
+
+- Create `src/ui/view_models.rs`
+  - Pure, testable UI helpers for tree expansion state, repo tree rows, grouped inspector rows, and terminal tab overlay visibility.
+  - No GPUI element construction here.
+- Create `src/ui/chrome.rs`
+  - Window options for macOS transparent titlebar and traffic-light placement.
+  - Constants for traffic-light safe area.
+- Modify `src/ui/mod.rs`
+  - Export new UI modules.
+- Modify `src/ui/shell.rs`
+  - Add tree state fields.
+  - Use `chrome::alas_window_options()` in `run()`.
+  - Compose three-column layout directly.
+  - Remove full-width status bar from default render path.
+  - Track terminal tab overlay hover state.
+- Modify `src/ui/workspace.rs`
+  - Replace rounded workspace card with flush center pane and hover/focus tab overlay.
+- Modify `src/ui/terminal_pane.rs`
+  - Remove persistent worktree label/top chrome.
+  - Keep terminal bounds probe, error state, restart/retry flows, and focus/input hooks.
+- Modify `src/ui/sidebar.rs`
+  - Migrate repository/worktree display to `gpui-component` tree rows.
+  - Replace inline contextual menus with popover/dropdown/context menus.
+  - Replace labeled add button with icon-only button and tooltip.
+- Modify `src/ui/inspector.rs`
+  - Replace Files/Changes tabs with a single grouped Changed/Files tree.
+- Modify `src/ui/theme.rs`
+  - Add small number of reusable colors/tokens for chrome/terminal/sidebar polish.
+- Modify `docs/manual-test.md`
+  - Add manual checks for frameless macOS chrome, hover terminal tabs, grouped right tree, left tree menus, and icon-only add button.
+- Create `tests/ui_view_model_tests.rs`
+  - Tests for pure helper behavior.
+
+Keep existing files focused. Do not move terminal backend code, Git services, or file tree loading code.
+
+---
+
+### Task 1: Add testable UI view models
+
+**Files:**
+- Create: `src/ui/view_models.rs`
+- Modify: `src/ui/mod.rs`
+- Test: `tests/ui_view_model_tests.rs`
+
+- [ ] **Step 1: Write failing tests for view-model helpers**
+
+Create `tests/ui_view_model_tests.rs` with these tests:
+
+```rust
+use std::path::PathBuf;
+
+use alas::{
+    app::{InspectorPaneState, RepositoryNode, SelectedWorktree, TerminalTabStatus, WorktreeNode},
+    git::{ChangedFile, GitInspectorState, WorktreeKind},
+    project::FileTreeNode,
+    ui::view_models::{
+        InspectorTreeRow, RepoTreeRow, TreeExpansionKey, TreeExpansionState,
+        build_inspector_tree_rows, build_repo_tree_rows, terminal_tab_overlay_visible,
+    },
+};
+
+fn worktree(path: &str, branch: &str, archived: bool, kind: WorktreeKind) -> WorktreeNode {
+    WorktreeNode {
+        path: PathBuf::from(path),
+        branch: Some(branch.to_string()),
+        head: Some("abc123".to_string()),
+        kind,
+        archived,
+    }
+}
+
+#[test]
+fn expansion_state_tracks_repository_and_file_keys() {
+    let repo_key = TreeExpansionKey::Repository("repo-1".to_string());
+    let file_key = TreeExpansionKey::File(PathBuf::from("/repo/src"));
+    let mut state = TreeExpansionState::default();
+
+    assert!(!state.is_expanded(&repo_key));
+    state.set_expanded(repo_key.clone(), true);
+    state.toggle(file_key.clone());
+
+    assert!(state.is_expanded(&repo_key));
+    assert!(state.is_expanded(&file_key));
+
+    state.toggle(file_key.clone());
+    assert!(!state.is_expanded(&file_key));
+}
+
+#[test]
+fn repo_tree_rows_filter_archived_worktrees_and_mark_selection() {
+    let mut expansion = TreeExpansionState::default();
+    expansion.set_expanded(TreeExpansionKey::Repository("repo-1".to_string()), true);
+
+    let repos = vec![RepositoryNode {
+        id: "repo-1".to_string(),
+        name: "alas".to_string(),
+        path: PathBuf::from("/repo"),
+        worktrees: vec![
+            worktree("/repo", "main", false, WorktreeKind::Main),
+            worktree("/repo/old", "old", true, WorktreeKind::Linked),
+        ],
+        show_archived: false,
+        unavailable: false,
+    }];
+    let selected = SelectedWorktree {
+        repo_id: "repo-1".to_string(),
+        path: PathBuf::from("/repo"),
+    };
+
+    let rows = build_repo_tree_rows(&repos, Some(&selected), &expansion);
+
+    assert_eq!(
+        rows,
+        vec![
+            RepoTreeRow::Repository {
+                id: "repo-1".to_string(),
+                name: "alas".to_string(),
+                unavailable: false,
+                expanded: true,
+            },
+            RepoTreeRow::Worktree {
+                repo_id: "repo-1".to_string(),
+                path: PathBuf::from("/repo"),
+                label: "main".to_string(),
+                selected: true,
+                archived: false,
+                kind: WorktreeKind::Main,
+            },
+        ]
+    );
+}
+
+#[test]
+fn grouped_inspector_rows_keep_file_and_git_errors_independent() {
+    let selected = SelectedWorktree {
+        repo_id: "repo-1".to_string(),
+        path: PathBuf::from("/repo"),
+    };
+    let mut state = InspectorPaneState::default();
+    state.set_files_error("files down");
+    state.set_changes(GitInspectorState {
+        branch: Some("main".to_string()),
+        changed_files: vec![ChangedFile {
+            status: "M".to_string(),
+            path: "src/ui/shell.rs".to_string(),
+        }],
+        recent_commits: Vec::new(),
+    });
+
+    let file_expansion = TreeExpansionState::default();
+    let rows = build_inspector_tree_rows(Some(&selected), &state, &file_expansion);
+
+    assert!(rows.contains(&InspectorTreeRow::Context {
+        branch_label: "main".to_string(),
+        changed_count: Some(1),
+    }));
+    assert!(rows.contains(&InspectorTreeRow::ChangedFile {
+        status: "M".to_string(),
+        path: "src/ui/shell.rs".to_string(),
+    }));
+    assert!(rows.contains(&InspectorTreeRow::Error {
+        section: "Files",
+        message: "files down".to_string(),
+    }));
+}
+
+#[test]
+fn grouped_inspector_rows_flatten_file_tree_with_truncation() {
+    let selected = SelectedWorktree {
+        repo_id: "repo-1".to_string(),
+        path: PathBuf::from("/repo"),
+    };
+    let mut state = InspectorPaneState::default();
+    state.set_changes(GitInspectorState {
+        branch: None,
+        changed_files: Vec::new(),
+        recent_commits: Vec::new(),
+    });
+    state.set_files(FileTreeNode {
+        name: "repo".to_string(),
+        path: PathBuf::from("/repo"),
+        is_dir: true,
+        truncated: false,
+        children: vec![FileTreeNode {
+            name: "src".to_string(),
+            path: PathBuf::from("/repo/src"),
+            is_dir: true,
+            truncated: true,
+            children: vec![FileTreeNode {
+                name: "main.rs".to_string(),
+                path: PathBuf::from("/repo/src/main.rs"),
+                is_dir: false,
+                children: Vec::new(),
+                truncated: false,
+            }],
+        }],
+    });
+
+    let mut file_expansion = TreeExpansionState::default();
+    file_expansion.set_expanded(TreeExpansionKey::File(PathBuf::from("/repo/src")), true);
+    let rows = build_inspector_tree_rows(Some(&selected), &state, &file_expansion);
+
+    assert!(rows.contains(&InspectorTreeRow::Context {
+        branch_label: "Detached HEAD".to_string(),
+        changed_count: Some(0),
+    }));
+    assert!(rows.contains(&InspectorTreeRow::File {
+        depth: 0,
+        name: "src".to_string(),
+        path: PathBuf::from("/repo/src"),
+        is_dir: true,
+        expanded: true,
+    }));
+    assert!(rows.contains(&InspectorTreeRow::File {
+        depth: 1,
+        name: "main.rs".to_string(),
+        path: PathBuf::from("/repo/src/main.rs"),
+        is_dir: false,
+        expanded: false,
+    }));
+    assert!(rows.contains(&InspectorTreeRow::Truncated { depth: 1 }));
+}
+
+#[test]
+fn terminal_tab_overlay_visibility_matches_design() {
+    assert!(!terminal_tab_overlay_visible(false, false, 1, None, false));
+    assert!(terminal_tab_overlay_visible(true, false, 1, None, false));
+    assert!(terminal_tab_overlay_visible(false, true, 1, None, false));
+    assert!(terminal_tab_overlay_visible(false, false, 2, None, false));
+    assert!(terminal_tab_overlay_visible(
+        false,
+        false,
+        1,
+        Some(&TerminalTabStatus::Exited(Some(1))),
+        false,
+    ));
+    assert!(terminal_tab_overlay_visible(
+        false,
+        false,
+        1,
+        Some(&TerminalTabStatus::Failed),
+        false,
+    ));
+    assert!(terminal_tab_overlay_visible(false, false, 1, None, true));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --test ui_view_model_tests --all-features
+```
+
+Expected: FAIL because `alas::ui::view_models` does not exist.
+
+- [ ] **Step 3: Export the new module**
+
+Modify `src/ui/mod.rs`:
+
+```rust
+pub mod view_models;
+```
+
+Add it alongside the existing UI modules.
+
+- [ ] **Step 4: Implement `src/ui/view_models.rs`**
+
+Create `src/ui/view_models.rs` with the pure helper types and functions needed by the tests. Use this implementation shape:
+
+```rust
+use std::{collections::HashSet, path::PathBuf};
+
+use crate::{
+    app::{InspectorPaneState, RepositoryNode, SelectedWorktree, TerminalTabStatus},
+    git::WorktreeKind,
+    project::FileTreeNode,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TreeExpansionKey {
+    Repository(String),
+    File(PathBuf),
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TreeExpansionState {
+    expanded: HashSet<TreeExpansionKey>,
+}
+
+impl TreeExpansionState {
+    pub fn is_expanded(&self, key: &TreeExpansionKey) -> bool {
+        self.expanded.contains(key)
+    }
+
+    pub fn set_expanded(&mut self, key: TreeExpansionKey, expanded: bool) {
+        if expanded {
+            self.expanded.insert(key);
+        } else {
+            self.expanded.remove(&key);
+        }
+    }
+
+    pub fn toggle(&mut self, key: TreeExpansionKey) {
+        if !self.expanded.remove(&key) {
+            self.expanded.insert(key);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepoTreeRow {
+    Repository {
+        id: String,
+        name: String,
+        unavailable: bool,
+        expanded: bool,
+    },
+    Worktree {
+        repo_id: String,
+        path: PathBuf,
+        label: String,
+        selected: bool,
+        archived: bool,
+        kind: WorktreeKind,
+    },
+}
+
+pub fn build_repo_tree_rows(
+    repositories: &[RepositoryNode],
+    selected_worktree: Option<&SelectedWorktree>,
+    expansion: &TreeExpansionState,
+) -> Vec<RepoTreeRow> {
+    let mut rows = Vec::new();
+
+    for repository in repositories {
+        let key = TreeExpansionKey::Repository(repository.id.clone());
+        let expanded = expansion.is_expanded(&key);
+        rows.push(RepoTreeRow::Repository {
+            id: repository.id.clone(),
+            name: repository.name.clone(),
+            unavailable: repository.unavailable,
+            expanded,
+        });
+
+        if !expanded {
+            continue;
+        }
+
+        for worktree in repository
+            .worktrees
+            .iter()
+            .filter(|worktree| repository.show_archived || !worktree.archived)
+        {
+            let label = worktree.branch.clone().unwrap_or_else(|| {
+                worktree
+                    .path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| worktree.path.display().to_string())
+            });
+            let selected = selected_worktree.is_some_and(|selected| {
+                selected.repo_id == repository.id && selected.path == worktree.path
+            });
+
+            rows.push(RepoTreeRow::Worktree {
+                repo_id: repository.id.clone(),
+                path: worktree.path.clone(),
+                label,
+                selected,
+                archived: worktree.archived,
+                kind: worktree.kind.clone(),
+            });
+        }
+    }
+
+    rows
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InspectorTreeRow {
+    EmptyState(String),
+    Context {
+        branch_label: String,
+        changed_count: Option<usize>,
+    },
+    Section(&'static str),
+    Loading(&'static str),
+    Error {
+        section: &'static str,
+        message: String,
+    },
+    ChangedFile {
+        status: String,
+        path: String,
+    },
+    Clean,
+    File {
+        depth: usize,
+        name: String,
+        path: PathBuf,
+        is_dir: bool,
+        expanded: bool,
+    },
+    Truncated {
+        depth: usize,
+    },
+}
+
+pub fn build_inspector_tree_rows(
+    selected_worktree: Option<&SelectedWorktree>,
+    state: &InspectorPaneState,
+    file_expansion: &TreeExpansionState,
+) -> Vec<InspectorTreeRow> {
+    if selected_worktree.is_none() {
+        return vec![InspectorTreeRow::EmptyState(
+            "Select a worktree to inspect files and changes.".to_string(),
+        )];
+    }
+
+    let branch_label = state
+        .changes
+        .as_ref()
+        .and_then(|changes| changes.branch.clone())
+        .unwrap_or_else(|| "Detached HEAD".to_string());
+    let changed_count = state
+        .changes
+        .as_ref()
+        .map(|changes| changes.changed_files.len());
+
+    let mut rows = vec![InspectorTreeRow::Context {
+        branch_label,
+        changed_count,
+    }];
+
+    rows.push(InspectorTreeRow::Section("Changed"));
+    match (&state.changes, &state.changes_error) {
+        (_, Some(error)) => rows.push(InspectorTreeRow::Error {
+            section: "Changed",
+            message: error.clone(),
+        }),
+        (None, None) => rows.push(InspectorTreeRow::Loading("Changed")),
+        (Some(changes), None) if changes.changed_files.is_empty() => {
+            rows.push(InspectorTreeRow::Clean)
+        }
+        (Some(changes), None) => rows.extend(changes.changed_files.iter().map(|file| {
+            InspectorTreeRow::ChangedFile {
+                status: file.status.clone(),
+                path: file.path.clone(),
+            }
+        })),
+    }
+
+    rows.push(InspectorTreeRow::Section("Files"));
+    match (&state.files, &state.files_error) {
+        (_, Some(error)) => rows.push(InspectorTreeRow::Error {
+            section: "Files",
+            message: error.clone(),
+        }),
+        (None, None) => rows.push(InspectorTreeRow::Loading("Files")),
+        (Some(root), None) if root.children.is_empty() => rows.push(InspectorTreeRow::EmptyState(
+            "No files found.".to_string(),
+        )),
+        (Some(root), None) => {
+            for child in &root.children {
+                flatten_file_rows(child, 0, file_expansion, &mut rows);
+            }
+            if root.truncated {
+                rows.push(InspectorTreeRow::Truncated { depth: 0 });
+            }
+        }
+    }
+
+    rows
+}
+
+fn flatten_file_rows(
+    node: &FileTreeNode,
+    depth: usize,
+    file_expansion: &TreeExpansionState,
+    rows: &mut Vec<InspectorTreeRow>,
+) {
+    let expansion_key = TreeExpansionKey::File(node.path.clone());
+    let expanded = node.is_dir && file_expansion.is_expanded(&expansion_key);
+
+    rows.push(InspectorTreeRow::File {
+        depth,
+        name: node.name.clone(),
+        path: node.path.clone(),
+        is_dir: node.is_dir,
+        expanded,
+    });
+
+    if !expanded {
+        return;
+    }
+
+    for child in &node.children {
+        flatten_file_rows(child, depth + 1, file_expansion, rows);
+    }
+
+    if node.truncated {
+        rows.push(InspectorTreeRow::Truncated { depth: depth + 1 });
+    }
+}
+
+pub fn terminal_tab_overlay_visible(
+    hovered: bool,
+    terminal_focused: bool,
+    tab_count: usize,
+    terminal_status: Option<&TerminalTabStatus>,
+    terminal_error: bool,
+) -> bool {
+    hovered
+        || terminal_focused
+        || tab_count > 1
+        || terminal_error
+        || matches!(
+            terminal_status,
+            Some(TerminalTabStatus::Exited(_) | TerminalTabStatus::Failed)
+        )
+}
+```
+
+- [ ] **Step 5: Run the focused tests**
+
+Run:
+
+```bash
+cargo test --test ui_view_model_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run format check**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: PASS. If it fails, run `cargo fmt --all`, then re-run the check.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/mod.rs src/ui/view_models.rs tests/ui_view_model_tests.rs
+git commit -m "test: add UI view model helpers"
+```
+
+---
+
+### Task 2: Isolate macOS window chrome options
+
+**Files:**
+- Create: `src/ui/chrome.rs`
+- Modify: `src/ui/mod.rs`
+- Modify: `src/ui/shell.rs`
+
+- [ ] **Step 1: Write the chrome module**
+
+Create `src/ui/chrome.rs`:
+
+```rust
+use gpui::{IntoElement, WindowOptions, div, prelude::*, px};
+
+pub const TRAFFIC_LIGHT_LEFT_PX: f32 = 20.0;
+pub const TRAFFIC_LIGHT_TOP_PX: f32 = 20.0;
+pub const MAC_SAFE_AREA_WIDTH_PX: f32 = 116.0;
+pub const MAC_SAFE_AREA_HEIGHT_PX: f32 = 56.0;
+
+pub fn mac_titlebar_safe_area_height_px() -> f32 {
+    if cfg!(target_os = "macos") {
+        MAC_SAFE_AREA_HEIGHT_PX
+    } else {
+        0.0
+    }
+}
+
+pub fn alas_window_options() -> WindowOptions {
+    let mut options = WindowOptions::default();
+
+    #[cfg(target_os = "macos")]
+    {
+        options.titlebar = Some(gpui::TitlebarOptions {
+            title: None,
+            appears_transparent: true,
+            traffic_light_position: Some(gpui::point(
+                px(TRAFFIC_LIGHT_LEFT_PX),
+                px(TRAFFIC_LIGHT_TOP_PX),
+            )),
+        });
+    }
+
+    options
+}
+
+pub fn render_mac_titlebar_safe_area_spacer() -> impl IntoElement {
+    div()
+        .id("mac-titlebar-safe-area-spacer")
+        .flex_shrink_0()
+        .w(px(MAC_SAFE_AREA_WIDTH_PX))
+        .h(px(mac_titlebar_safe_area_height_px()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn macos_window_options_use_transparent_titlebar_and_moved_traffic_lights() {
+        let options = alas_window_options();
+        let titlebar = options.titlebar.expect("titlebar options");
+        assert!(titlebar.appears_transparent);
+        assert!(titlebar.title.is_none());
+        assert!(titlebar.traffic_light_position.is_some());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn non_macos_window_options_keep_default_titlebar() {
+        let options = alas_window_options();
+        let titlebar = options.titlebar.expect("default titlebar options");
+        assert!(!titlebar.appears_transparent);
+    }
+}
+```
+
+Note: GPUI exposes transparent titlebar and traffic-light positioning on macOS. The safe-area spacer must be rendered at the top of the left sidebar, not as a root absolute overlay, so left-sidebar rows do not sit under the traffic-light buttons while the center and right columns remain flush. There is no separate app-drawn window-drag implementation in this pass; manual testing must verify that the remaining transparent titlebar/safe region has acceptable native dragging behavior and that terminal/tree rows do not drag the window.
+
+- [ ] **Step 2: Export `chrome` module**
+
+Modify `src/ui/mod.rs`:
+
+```rust
+pub mod chrome;
+```
+
+- [ ] **Step 3: Use chrome options when opening the window**
+
+In `src/ui/shell.rs`, update the existing nested `ui` import block to include `chrome::alas_window_options`.
+
+Replace:
+
+```rust
+cx.open_window(WindowOptions::default(), |window, cx| {
+```
+
+with:
+
+```rust
+cx.open_window(alas_window_options(), |window, cx| {
+```
+
+Remove `WindowOptions` from the `gpui` import list if it is no longer used directly in `shell.rs`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+cargo test --lib --all-features chrome
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run a build check**
+
+Run:
+
+```bash
+cargo check --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/chrome.rs src/ui/mod.rs src/ui/shell.rs
+git commit -m "feat: isolate macOS window chrome options"
+```
+
+---
+
+### Task 3: Make the center workspace a true flush terminal with hover tabs
+
+**Files:**
+- Modify: `src/ui/shell.rs`
+- Modify: `src/ui/workspace.rs`
+- Modify: `src/ui/terminal_pane.rs`
+- Modify: `src/ui/theme.rs`
+- Test: `tests/ui_view_model_tests.rs` from Task 1 already covers overlay visibility logic
+
+- [ ] **Step 1: Add center-pane theme tokens**
+
+Modify `src/ui/theme.rs` and add these constants near the existing colors:
+
+```rust
+pub const TERMINAL_BG: Rgba = rgb_const(0x141518);
+pub const OVERLAY_BG: Rgba = rgb_const(0x25272d);
+pub const OVERLAY_BORDER: Rgba = rgb_const(0x444850);
+pub const SIDEBAR_SECTION_TEXT: Rgba = rgb_const(0x8f96a3);
+```
+
+- [ ] **Step 2: Add terminal tab hover state to the shell**
+
+In `src/ui/shell.rs`, add a field to `AlasShell`:
+
+```rust
+terminal_tab_overlay_hovered: bool,
+```
+
+Initialize it in `AlasShell::new`:
+
+```rust
+terminal_tab_overlay_hovered: false,
+```
+
+In `render`, before rendering the workspace, compute:
+
+```rust
+let terminal_focused = self.terminal_focus.contains_focused(window, cx);
+let show_terminal_tabs = crate::ui::view_models::terminal_tab_overlay_visible(
+    self.terminal_tab_overlay_hovered,
+    terminal_focused,
+    workspace_tabs.len(),
+    status_bar_terminal_status.as_ref(),
+    active_terminal_error.is_some(),
+);
+```
+
+If `status_bar_terminal_status` is renamed later because the bottom status bar is removed, keep the value under a local name such as `active_tab_status_for_overlay`.
+
+- [ ] **Step 3: Add an overlay hover listener**
+
+In `src/ui/shell.rs`, create this listener near the existing terminal listeners:
+
+```rust
+let on_terminal_tabs_hover = cx.listener(
+    |shell, hovered: &bool, _window, cx| {
+        if shell.terminal_tab_overlay_hovered != *hovered {
+            shell.terminal_tab_overlay_hovered = *hovered;
+            cx.notify();
+        }
+    },
+);
+```
+
+- [ ] **Step 4: Change `render_workspace` signature**
+
+Modify `src/ui/workspace.rs` so `render_workspace` accepts the overlay visibility and hover listener:
+
+```rust
+pub fn render_workspace(
+    tabs: &[TerminalTab],
+    active_tab: Option<TerminalTabId>,
+    show_tabs: bool,
+    on_tabs_hover: impl Fn(&bool, &mut Window, &mut App) + 'static,
+    on_select_tab: impl Fn(TerminalTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_new_tab: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    terminal_body: impl IntoElement,
+) -> impl IntoElement
+```
+
+Update the call site in `src/ui/shell.rs` to pass `show_terminal_tabs` and `on_terminal_tabs_hover` before the existing tab callbacks.
+
+- [ ] **Step 5: Replace workspace card rendering with a flush pane**
+
+In `src/ui/workspace.rs`, replace the current rounded-card layout. Inside the new `render_workspace` function from Step 4, return this element:
+
+```rust
+div()
+    .id("workspace")
+    .relative()
+    .flex()
+    .flex_col()
+    .flex_1()
+    .size_full()
+    .overflow_hidden()
+    .bg(TERMINAL_BG)
+    .on_hover(on_tabs_hover)
+    .child(
+        div()
+            .absolute()
+            .top_0()
+            .right_0()
+            .bottom_0()
+            .left_0()
+            .child(terminal_body),
+    )
+    .when(show_tabs, |element| {
+        element.child(render_tab_bar_overlay(
+            tabs,
+            active_tab,
+            on_select_tab,
+            on_new_tab,
+        ))
+    })
+```
+
+Add `render_tab_bar_overlay` by adapting the old `render_tab_bar` body:
+
+```rust
+fn render_tab_bar_overlay(
+    tabs: &[TerminalTab],
+    active_tab: Option<TerminalTabId>,
+    on_select_tab: impl Fn(TerminalTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_new_tab: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    let selected_index = tabs.iter().position(|tab| Some(tab.id) == active_tab);
+
+    div()
+        .id("workspace-tab-overlay")
+        .absolute()
+        .top(px(8.0))
+        .left_0()
+        .right_0()
+        .flex()
+        .justify_center()
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap_1()
+                .px_2()
+                .py_1()
+                .rounded_full()
+                .border_1()
+                .border_color(OVERLAY_BORDER)
+                .bg(OVERLAY_BG)
+                .child(
+                    TabBar::new("workspace-tabs")
+                        .segmented()
+                        .small()
+                        .when_some(selected_index, |tab_bar, index| tab_bar.selected_index(index))
+                        .children(tabs.iter().map(move |tab| {
+                            let tab_id = tab.id;
+                            let label = tab.name.clone();
+                            let kind = tab.kind;
+                            let on_select_tab = on_select_tab.clone();
+
+                            Tab::new()
+                                .label(format!("{}{}", tab_kind_prefix(kind), label))
+                                .on_click(move |event, window, cx| {
+                                    on_select_tab(tab_id, event, window, cx);
+                                })
+                        })),
+                )
+                .child(
+                    Button::new("workspace-new-tab")
+                        .small()
+                        .ghost()
+                        .compact()
+                        .label("+")
+                        .text_color(ACCENT)
+                        .on_click(on_new_tab),
+                ),
+        )
+}
+```
+
+Keep `tab_kind_prefix` unchanged. Do not use unsupported z-index helpers; the overlay is painted above the terminal because it is added as a later child of the relative workspace container.
+
+- [ ] **Step 6: Remove terminal pane top label and padding chrome**
+
+In `src/ui/terminal_pane.rs`, remove the child block that renders:
+
+```rust
+format!(
+    "Worktree: {}",
+    selected_worktree
+        .expect("checked selected worktree")
+        .path
+        .display()
+)
+```
+
+Also remove the surrounding `.p_3()` and `.gap_2()` from the normal terminal state. The normal state should be:
+
+```rust
+element.flex_col().child(
+    div()
+        .flex_1()
+        .overflow_hidden()
+        .relative()
+        .on_any_mouse_down(on_mouse_down)
+        .capture_any_mouse_up(on_mouse_up)
+        .on_mouse_move(on_mouse_move)
+        .child(render_terminal_body(terminal_frame, terminal_metrics))
+        .child(
+            div()
+                .absolute()
+                .size_full()
+                .child(render_terminal_bounds_probe(on_body_bounds)),
+        ),
+)
+```
+
+Set the terminal pane normal background to `TERMINAL_BG` instead of `PANEL_BG` so the center column reads as the terminal surface. Keep the exited-state message and the Restart action. Render them as an absolute/subtle overlay near the bottom or as status content inside the hover tab overlay. Do not remove the restart callback and do not reintroduce a persistent top bar.
+
+- [ ] **Step 7: Remove unused imports**
+
+After editing `workspace.rs` and `terminal_pane.rs`, remove unused imports such as `APP_BG` or `PANEL_BORDER` if the compiler reports them.
+
+- [ ] **Step 8: Run focused tests and checks**
+
+Run:
+
+```bash
+cargo test --test ui_view_model_tests --all-features
+cargo check --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ui/shell.rs src/ui/workspace.rs src/ui/terminal_pane.rs src/ui/theme.rs tests/ui_view_model_tests.rs
+git commit -m "feat: make terminal workspace flush with hover tabs"
+```
+
+---
+
+### Task 4: Replace the left sidebar with a gpui-component repository tree and popover menus
+
+**Files:**
+- Modify: `src/ui/shell.rs`
+- Modify: `src/ui/sidebar.rs`
+- Test: `tests/ui_view_model_tests.rs`
+
+- [ ] **Step 1: Add tree state fields to `AlasShell`**
+
+In `src/ui/shell.rs`, import `TreeExpansionState`:
+
+```rust
+use crate::ui::view_models::TreeExpansionState;
+```
+
+Add fields:
+
+```rust
+repo_tree_expansion: TreeExpansionState,
+```
+
+Initialize the field in `AlasShell::new`:
+
+```rust
+repo_tree_expansion: TreeExpansionState::default(),
+```
+
+Default behavior: when repositories are refreshed, repository nodes may start collapsed. The user can expand them. If manual testing shows the first repository should open by default for discoverability, make that a small follow-up after this task.
+
+- [ ] **Step 2: Update `render_sidebar` signature**
+
+In `src/ui/sidebar.rs`, replace the existing `render_sidebar` signature with one that receives mutable view-state inputs through callbacks instead of owning shell state directly:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+pub fn render_sidebar(
+    repositories: &[RepositoryNode],
+    selected_worktree: Option<&SelectedWorktree>,
+    expansion: &TreeExpansionState,
+    on_toggle_repository: impl Fn(String, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_add_repository: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    on_select_worktree: impl Fn(String, PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_sidebar_menu_action: impl Fn(SidebarMenuState, ActionId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    add_repository_error: Option<&str>,
+) -> impl IntoElement
+```
+
+Remove `sidebar_menu`, `on_open_sidebar_menu`, and `on_close_sidebar_menu` from the left-sidebar API after popovers are in place. Keep `SidebarMenuState` as the action target passed back to the shell.
+
+- [ ] **Step 3: Wire repository expansion callback in `shell.rs`**
+
+In `src/ui/shell.rs`, add an owned-`String` callback before rendering the sidebar. Use the current project pattern for `on_select_worktree` so the callback matches `render_sidebar`'s `Fn(String, &ClickEvent, &mut Window, &mut App)` shape:
+
+```rust
+let view = cx.entity().downgrade();
+let on_toggle_repository = move |repo_id: String,
+                                 _event: &ClickEvent,
+                                 _window: &mut Window,
+                                 app: &mut App| {
+    view.update(app, |shell, cx| {
+        shell
+            .repo_tree_expansion
+            .toggle(crate::ui::view_models::TreeExpansionKey::Repository(repo_id.clone()));
+        cx.notify();
+    })
+    .ok();
+};
+```
+
+Update the `render_sidebar` call to pass `&self.repo_tree_expansion` and the new callbacks.
+
+- [ ] **Step 4: Build tree rows using `gpui-component` row primitives**
+
+In `src/ui/sidebar.rs`, import:
+
+```rust
+use crate::ui::chrome::render_mac_titlebar_safe_area_spacer;
+use gpui_component::{
+    Icon, IconName, Sizable,
+    button::{Button, ButtonVariants},
+    list::ListItem,
+    menu::{DropdownMenu as _, PopupMenu, PopupMenuItem},
+};
+```
+
+At the top of the sidebar column, render `render_mac_titlebar_safe_area_spacer()` before repository rows. This reserves the macOS traffic-light safe area only in the left sidebar; do not add matching top padding to the terminal or right sidebar.
+
+Use `build_repo_tree_rows(repositories, selected_worktree, expansion)` from `src/ui/view_models.rs` to render rows. It is acceptable for this pass to render the rows inside a scrollable column while using `gpui-component::ListItem`, `Button`, and popover menu primitives. If direct `gpui_component::tree::TreeState` integration is straightforward, use it; if it causes selection/expansion conflicts, keep the tested `TreeExpansionState` and `ListItem` rows for this task, then create a follow-up to adopt `TreeState` fully. The key requirement for this task is a collapsible tree UI using gpui-component row/menu/button primitives, not a large state rewrite.
+
+Render repository rows with:
+
+- chevron icon (`IconName::ChevronRight` or `IconName::ChevronDown`),
+- repo name,
+- unavailable badge if needed,
+- overflow dropdown button.
+
+Render worktree rows with:
+
+- indentation,
+- branch icon or text glyph,
+- label,
+- main/linked/archived badges,
+- selected row styling.
+
+- [ ] **Step 5: Implement popup menu builders**
+
+Replace inline `render_sidebar_menu` blocks with menu builders returning `PopupMenu` items.
+
+Add helper in `sidebar.rs`:
+
+```rust
+fn build_sidebar_popup_menu(
+    mut menu: PopupMenu,
+    repository: RepositoryNode,
+    worktree: Option<WorktreeNode>,
+    menu_state: SidebarMenuState,
+    on_sidebar_menu_action: impl Fn(SidebarMenuState, ActionId, &ClickEvent, &mut Window, &mut App)
+        + Clone
+        + 'static,
+) -> PopupMenu {
+    let registry = ActionRegistry::default();
+    let scope = if worktree.is_some() {
+        ActionScope::Worktree
+    } else {
+        ActionScope::Repository
+    };
+
+    for action in registry
+        .actions()
+        .iter()
+        .filter(|action| action.scope == scope)
+        .filter(|action| action_is_available(action, &repository, worktree.as_ref()))
+    {
+        let action_id = action.id;
+        let label = sidebar_action_label(action, &repository);
+        let destructive = action.destructive;
+        let menu_state = menu_state.clone();
+        let on_sidebar_menu_action = on_sidebar_menu_action.clone();
+
+        menu = menu.item(
+            PopupMenuItem::new(label)
+                .when(destructive, |item| item)
+                .on_click(move |event, window, cx| {
+                    on_sidebar_menu_action(menu_state.clone(), action_id, event, window, cx);
+                }),
+        );
+    }
+
+    menu
+}
+```
+
+The `dropdown_menu` and `context_menu` builders require `'static` closures. Clone `RepositoryNode` and `WorktreeNode` values before moving them into those closures; do not capture borrowed `&RepositoryNode` or `&WorktreeNode` references.
+
+If `.when(destructive, |item| item)` is not useful, remove it and apply destructive color through a custom `PopupMenuItem::element` later. Do not block the migration on destructive text coloring.
+
+Use a formatted unique id such as `Button::new(SharedString::from(format!("repository-actions-{repo_id}"))).ghost().compact().icon(IconName::Ellipsis).dropdown_menu(move |menu, window, cx| build_sidebar_popup_menu(menu, repository.clone(), None, menu_state.clone(), on_sidebar_menu_action.clone()))` for repository overflow buttons. Use an equivalent formatted `worktree-actions-{repo_id}-{path}` id for worktree overflow buttons and pass `Some(worktree.clone())`.
+
+- [ ] **Step 6: Preserve right-click behavior**
+
+Add `ContextMenuExt` where practical:
+
+```rust
+use gpui_component::menu::ContextMenuExt;
+```
+
+Wrap repository and worktree row elements with `.context_menu(move |menu, window, cx| { build_sidebar_popup_menu(menu, repository.clone(), worktree.clone(), menu_state.clone(), on_sidebar_menu_action.clone()) })` so right-click and overflow expose the same actions. Right-click support is required before this task is committed. If `ContextMenuExt` conflicts with nested click handlers, use a direct right-button `on_mouse_down` handler plus a small anchored `Popover` fallback, but do not drop right-click behavior.
+
+- [ ] **Step 7: Replace add repository button**
+
+At the bottom of `render_sidebar`, replace the labeled primary button with:
+
+```rust
+Button::new("add-repository")
+    .ghost()
+    .compact()
+    .icon(IconName::Plus)
+    .tooltip("Add repository")
+    .on_click(on_add_repository)
+```
+
+Keep `add_repository_error` rendered below or beside the bottom control in compact danger styling.
+
+- [ ] **Step 8: Update action callback in `shell.rs`**
+
+Because `render_sidebar` now passes the `SidebarMenuState` with the clicked action, adjust the shell callback to:
+
+```rust
+let on_sidebar_menu_action = move |menu: SidebarMenuState,
+                                   action_id: ActionId,
+                                   _event: &ClickEvent,
+                                   window: &mut Window,
+                                   cx: &mut App| {
+    let view = view.clone();
+    view.update(cx, |shell, cx| {
+        shell.handle_sidebar_menu_action_from_target(menu, action_id, window, cx);
+    })
+    .ok();
+};
+```
+
+Add a new shell method rather than rewriting the existing method in place:
+
+```rust
+fn handle_sidebar_menu_action_from_target(
+    &mut self,
+    menu: SidebarMenuState,
+    action_id: ActionId,
+    window: &mut Window,
+    cx: &mut Context<Self>,
+) {
+    self.sidebar_menu = Some(menu);
+    self.handle_sidebar_menu_action(action_id, window, cx);
+}
+```
+
+This preserves the existing action handling logic and confirmations while the UI menu state is migrated away from inline menus.
+
+After the popover path works, remove obsolete inline-menu render helpers and unused callbacks (`open_sidebar_menu`, `close_sidebar_menu`, `render_sidebar_menu`, `menu_action_row`) if they are no longer referenced. Do not leave dead code that would fail Clippy with `-D warnings`.
+
+- [ ] **Step 9: Run focused tests and checks**
+
+Run:
+
+```bash
+cargo test --test ui_view_model_tests --all-features
+cargo test --test action_registry_tests --all-features
+cargo check --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/ui/shell.rs src/ui/sidebar.rs tests/ui_view_model_tests.rs
+git commit -m "feat: modernize repository sidebar tree"
+```
+
+---
+
+### Task 5: Replace the right inspector tabs with a grouped Changed/Files tree
+
+**Files:**
+- Modify: `src/ui/inspector.rs`
+- Modify: `src/ui/shell.rs` only if its inspector call signature changes
+- Test: `tests/ui_view_model_tests.rs`
+
+- [ ] **Step 1: Remove tab-specific rendering from `inspector.rs`**
+
+In `src/ui/inspector.rs`, remove usage of:
+
+```rust
+gpui_component::tab::{Tab, TabBar}
+```
+
+Keep `InspectorTab` in the app state for compatibility if removing it would cause broad churn. The UI no longer needs to call `render_tab_bar`.
+
+- [ ] **Step 2: Add file expansion state to the shell**
+
+In `src/ui/shell.rs`, add a field to `AlasShell`:
+
+```rust
+file_tree_expansion: TreeExpansionState,
+```
+
+Initialize it in `AlasShell::new`:
+
+```rust
+file_tree_expansion: TreeExpansionState::default(),
+```
+
+Reset it when a new worktree is selected, next to the existing inspector reset in `select_worktree`:
+
+```rust
+self.inspector_state.clear_for_new_worktree();
+self.file_tree_expansion = TreeExpansionState::default();
+```
+
+Add a file-toggle callback before rendering the inspector. Use the same owned-closure pattern as other shell callbacks so it matches `render_project_inspector`'s `Fn(PathBuf, &ClickEvent, &mut Window, &mut App)` signature:
+
+```rust
+let view = cx.entity().downgrade();
+let on_toggle_file_tree_node = move |path: PathBuf,
+                                     _event: &ClickEvent,
+                                     _window: &mut Window,
+                                     app: &mut App| {
+    view.update(app, |shell, cx| {
+        shell
+            .file_tree_expansion
+            .toggle(crate::ui::view_models::TreeExpansionKey::File(path.clone()));
+        cx.notify();
+    })
+    .ok();
+};
+```
+
+- [ ] **Step 3: Update `render_project_inspector` signature**
+
+Change:
+
+```rust
+pub fn render_project_inspector(
+    selected_worktree: Option<&SelectedWorktree>,
+    state: &InspectorPaneState,
+    on_select_tab: impl Fn(InspectorTab, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+) -> impl IntoElement
+```
+
+to:
+
+```rust
+pub fn render_project_inspector(
+    selected_worktree: Option<&SelectedWorktree>,
+    state: &InspectorPaneState,
+    file_expansion: &TreeExpansionState,
+    on_toggle_file: impl Fn(PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+) -> impl IntoElement
+```
+
+Then update the call in `src/ui/shell.rs` to pass `&self.file_tree_expansion` and `on_toggle_file_tree_node`. Remove the now-unused `on_select_inspector_tab` closure if no other code needs it.
+
+- [ ] **Step 4: Render grouped rows from the view model**
+
+In `inspector.rs`, import:
+
+```rust
+use crate::ui::view_models::{
+    InspectorTreeRow, TreeExpansionState, build_inspector_tree_rows,
+};
+```
+
+Inside `render_project_inspector`, build rows:
+
+```rust
+let rows = build_inspector_tree_rows(selected_worktree, state, file_expansion);
+```
+
+Render a single scrollable column:
+
+```rust
+div()
+    .id("project-inspector")
+    .flex()
+    .flex_col()
+    .flex_shrink_0()
+    .size_full()
+    .w(px(320.0))
+    .px_4()
+    .py_3()
+    .gap_2()
+    .border_l_1()
+    .border_color(PANEL_BORDER)
+    .bg(PANEL_BG)
+    .text_color(TEXT)
+    .child(render_inspector_rows(rows, on_toggle_file))
+```
+
+Do not show the old “Inspector” title if it wastes top space. Prefer compact context rows.
+
+- [ ] **Step 5: Add row renderer with file expand/collapse affordances**
+
+Add:
+
+```rust
+fn render_inspector_rows(
+    rows: Vec<InspectorTreeRow>,
+    on_toggle_file: impl Fn(PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+) -> impl IntoElement {
+    div()
+        .id("grouped-inspector-tree")
+        .flex()
+        .flex_col()
+        .flex_1()
+        .min_h(px(0.0))
+        .overflow_scroll()
+        .gap_1()
+        .children(rows.into_iter().map(move |row| {
+            render_inspector_row(row, on_toggle_file.clone())
+        }))
+}
+
+fn render_inspector_row(
+    row: InspectorTreeRow,
+    on_toggle_file: impl Fn(PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+) -> AnyElement {
+    match row {
+        InspectorTreeRow::EmptyState(message) => empty_text_owned(message).into_any_element(),
+        InspectorTreeRow::Context { branch_label, changed_count } => {
+            let count = changed_count
+                .map(|count| format!(" · {count} changed"))
+                .unwrap_or_default();
+            div()
+                .px_1()
+                .pb_2()
+                .text_xs()
+                .text_color(TEXT_MUTED)
+                .child(SharedString::from(format!("{branch_label}{count}")))
+                .into_any_element()
+        }
+        InspectorTreeRow::Section(title) => section_header(title).into_any_element(),
+        InspectorTreeRow::Loading(section) => {
+            loading_text_owned(format!("Loading {section}…")).into_any_element()
+        }
+        InspectorTreeRow::Error { section, message } => {
+            warning_text(section, &message).into_any_element()
+        }
+        InspectorTreeRow::ChangedFile { status, path } => {
+            changed_file_row(status, path).into_any_element()
+        }
+        InspectorTreeRow::Clean => empty_text("No changed files.").into_any_element(),
+        InspectorTreeRow::File { depth, name, path, is_dir, expanded } => {
+            file_row(depth, name, path, is_dir, expanded, on_toggle_file).into_any_element()
+        }
+        InspectorTreeRow::Truncated { depth } => truncated_row(depth).into_any_element(),
+    }
+}
+```
+
+Implement `empty_text_owned`, `loading_text_owned`, `changed_file_row`, `file_row`, and `truncated_row` by adapting the existing `empty_text`, `loading_text`, `render_file_node`, and `render_changes` styling. `file_row` must show an expand/collapse affordance for directories and call `on_toggle_file(path, event, window, cx)` when a directory row is clicked. Use `IconName::FolderClosed`, `IconName::FolderOpen`, and `IconName::File` if the imports stay simple; otherwise use text glyphs for this task.
+
+- [ ] **Step 6: Remove obsolete functions**
+
+Remove or stop using:
+
+- `render_tab_bar`
+- `render_files_tab`
+- `render_changes_tab`
+- recursive `render_file_node` if replaced by flattened rows
+- `render_changes` if replaced by grouped row renderer
+
+Keep shared helpers like `section_header`, `loading_text`, `empty_text`, and `warning_text` if still used.
+
+- [ ] **Step 7: Run focused tests and checks**
+
+Run:
+
+```bash
+cargo test --test ui_view_model_tests --all-features
+cargo test --test inspector_state_tests --all-features
+cargo check --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ui/inspector.rs src/ui/shell.rs tests/ui_view_model_tests.rs
+git commit -m "feat: show grouped project inspector tree"
+```
+
+---
+
+### Task 6: Compose final three-column shell and remove the old status bar path
+
+**Files:**
+- Modify: `src/ui/shell.rs`
+- Modify: `src/ui/theme.rs` if final spacing/color tokens are needed
+
+- [ ] **Step 1: Remove status-bar rendering from the default layout**
+
+In `src/ui/shell.rs`, remove the final root child that calls `render_status_bar` with `status_bar_repo`, `status_bar_tab`, and `status_bar_terminal_status`.
+
+If `render_status_bar` becomes unused, remove the helper function and any imports only used by it. If it is still useful for a hidden future path, leave it private but unused only if the compiler allows it. Prefer removing unused code.
+
+- [ ] **Step 2: Compose the root as three direct columns**
+
+In `src/ui/shell.rs`, the root render should have this shape:
+
+```rust
+div()
+    .on_action(cx.listener(|_shell, _: &crate::ui::lifecycle::Quit, _window, cx| {
+        cx.quit();
+    }))
+    .relative()
+    .flex()
+    .size_full()
+    .bg(APP_BG)
+    .text_color(TEXT)
+    .child(render_sidebar(
+        self.model.repositories(),
+        self.model.selected_worktree(),
+        &self.repo_tree_expansion,
+        on_toggle_repository,
+        cx.listener(|shell, _event, _window, cx| shell.open_add_repository_dialog(cx)),
+        on_select_worktree,
+        on_sidebar_menu_action,
+        self.add_repository_error(),
+    ))
+    .child(
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_w(px(0.0))
+            .when(self.command_picker.is_some(), |element| {
+                // Preserve the existing command picker render block here.
+                element
+            })
+            .when(self.command_settings_dialog.is_some(), |element| {
+                // Preserve the existing command settings dialog render block here.
+                element
+            })
+            .when(self.create_worktree_dialog.is_some(), |element| {
+                // Preserve the existing create-worktree dialog render block here.
+                element
+            })
+            .child(
+                div()
+                    .flex()
+                    .flex_1()
+                    .track_focus(&self.terminal_focus)
+                    .on_key_down(on_terminal_key_down)
+                    .child(render_workspace(
+                        workspace_tabs,
+                        active_workspace_tab,
+                        show_terminal_tabs,
+                        on_terminal_tabs_hover,
+                        on_select_terminal_tab,
+                        on_new_terminal_tab,
+                        render_terminal_pane(
+                            self.model.selected_worktree(),
+                            active_tab,
+                            terminal_frame,
+                            active_terminal_status,
+                            self.terminal_metrics,
+                            active_terminal_error,
+                            on_retry_terminal,
+                            on_edit_terminal_command,
+                            on_restart_terminal,
+                            on_focus_terminal,
+                            on_terminal_scroll,
+                            on_terminal_mouse_down,
+                            on_terminal_mouse_up,
+                            on_terminal_mouse_move,
+                            on_terminal_body_bounds,
+                        ),
+                    )),
+            ),
+    )
+    .child(render_project_inspector(
+        self.model.selected_worktree(),
+        &self.inspector_state,
+        &self.file_tree_expansion,
+        on_toggle_file_tree_node,
+    ))
+```
+
+The macOS safe-area spacer is rendered inside `render_sidebar`, not at the root. This keeps the center terminal and right sidebar flush with the window top while preventing left-sidebar rows from overlapping traffic-light buttons.
+
+- [ ] **Step 3: Keep command picker and dialogs functional**
+
+The current shell renders command picker and command/create-worktree dialogs above the workspace inside the center column. Preserve that behavior by placing these dialog blocks before the terminal focus/key wrapper and before the `render_workspace` call inside the center column.
+
+Do not move dialog business logic. Only relocate the existing render blocks so they still appear above the center pane. Keep `.track_focus(&self.terminal_focus)` and `.on_key_down(on_terminal_key_down)` on the inner workspace wrapper only, not on the outer center column, so dialog key events do not bubble into terminal input handling.
+
+- [ ] **Step 4: Compile and fix unused variables**
+
+Run:
+
+```bash
+cargo check --all-features
+```
+
+Expected: PASS. Remove now-unused locals such as `status_bar_repo`, `status_bar_tab`, or `active_workspace_tab` only if they no longer feed active tab logic.
+
+- [ ] **Step 5: Run focused terminal tests**
+
+Run:
+
+```bash
+cargo test --test terminal_render_tests --all-features
+cargo test --test terminal_session_tests --all-features
+cargo test --test workspace_session_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/shell.rs src/ui/theme.rs
+git commit -m "feat: compose frameless three-column shell"
+```
+
+---
+
+### Task 7: Update manual tests and run full verification
+
+**Files:**
+- Modify: `docs/manual-test.md`
+
+- [ ] **Step 1: Update manual test script**
+
+Edit `docs/manual-test.md` and add a new section after “Repository and Worktree Management”:
+
+```markdown
+## UI Overhaul
+
+1. On macOS, start Alas with `cargo run` and confirm the normal titlebar is visually reclaimed: app content is flush with the window and traffic-light buttons sit approximately 20px from the top.
+2. Confirm the top-left safe area is reserved in the left sidebar: no repository row, text, or button sits under the traffic-light buttons.
+3. Drag the window from the top-left safe/chrome area and confirm the window moves.
+4. Try dragging from terminal content, repository rows, worktree rows, and right-sidebar rows; confirm those areas do not drag the window.
+5. Confirm Linux still shows conventional window chrome if tested on Linux.
+6. Confirm the app reads as three columns: repository/worktree tree, flush terminal pane, grouped files/Git tree.
+7. Expand and collapse repository nodes in the left sidebar.
+8. Right-click a repository row and a worktree row; confirm contextual popover menus show the expected actions.
+9. Click each overflow button and confirm it opens the same action set as right-click.
+10. Use the bottom icon-only add repository button; confirm its hover tooltip says “Add repository.”
+11. Select a worktree and confirm the center terminal starts without a persistent `Worktree:` label or workspace card border.
+12. Hover the top edge of the terminal; confirm terminal tabs and the new-tab control appear.
+13. Open a second terminal tab and confirm the tab overlay remains available for switching.
+14. Confirm terminal scroll, mouse, keyboard, paste, resize, and alternate-screen behavior still match the Terminal Emulator Behavior section.
+15. Confirm the right sidebar shows a single grouped tree with Changed and Files sections, not Files/Changes tabs.
+16. Expand and collapse directories in the right Files section.
+17. Create or modify a file and confirm the Changed section updates independently of the Files section.
+18. Confirm the old full-width bottom status bar is gone.
+```
+
+Also replace the existing stale `## Files and Changes Inspector` section at the bottom of `docs/manual-test.md` with:
+
+```markdown
+## Grouped Project Inspector
+
+1. Select a worktree and confirm the right sidebar shows a single grouped tree, not separate Files and Changes tabs.
+2. Confirm the Changed section shows modified/untracked files with status badges.
+3. Confirm the Files section shows worktree files and supports directory expand/collapse.
+4. Confirm file loading errors remain scoped to the Files section and do not break terminal input.
+5. Confirm Git status loading errors remain scoped to the Changed section and do not break terminal input.
+```
+
+- [ ] **Step 2: Run format check**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: PASS. If it fails, run `cargo fmt --all`, then re-run the check.
+
+- [ ] **Step 3: Run Clippy**
+
+Run:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run build**
+
+Run:
+
+```bash
+cargo build --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full tests**
+
+Run:
+
+```bash
+cargo test --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit docs and verification fixes**
+
+```bash
+git add docs/manual-test.md src tests
+git commit -m "docs: update manual tests for UI overhaul"
+```
+
+If no source/test files changed in this task, use:
+
+```bash
+git add docs/manual-test.md
+git commit -m "docs: update manual tests for UI overhaul"
+```
+
+---
+
+## Implementation Notes
+
+- Keep UI strings, comments, and logs in English.
+- Keep all destructive action confirmations intact.
+- Do not rewrite terminal backend/session logic.
+- Do not add file open/edit/delete features in the right tree.
+- If exact `gpui-component::tree::TreeState` integration causes implementation friction, land the collapsible tree using `TreeExpansionState` plus `gpui-component::ListItem`, `Button`, `Icon`, and popover/menu primitives. Record the full `TreeState` migration as a follow-up rather than destabilizing the UI overhaul.
+- The old `sidebar_menu` shell field can remain temporarily as an adapter for existing action handling. Remove it only if doing so is a straightforward cleanup after popover action dispatch works.
+- If custom SVG assets are needed, add them under `assets/` and include them in a focused commit. Prefer `IconName::Plus`, `IconName::Ellipsis`, `IconName::FolderClosed`, `IconName::FolderOpen`, `IconName::File`, and `IconName::SquareTerminal` first.
+- The macOS titlebar change must be manually verified. Automated tests can only check the `WindowOptions` construction.

--- a/docs/superpowers/specs/2026-04-30-ui-overhaul-design.md
+++ b/docs/superpowers/specs/2026-04-30-ui-overhaul-design.md
@@ -1,0 +1,243 @@
+# Alas UI Overhaul Design
+
+Date: 2026-04-30
+
+## Goal
+
+Overhaul the Alas UI into a macOS-first, frameless, three-column workspace inspired by Superconductor while preserving the existing terminal, repository, worktree, file, and Git behavior.
+
+The target layout is:
+
+```text
+[ repo/worktree tree ][ flush terminal/main pane ][ grouped files/git tree ]
+```
+
+The center terminal is the visual anchor. It should run top-to-bottom with no persistent title strip, no workspace card, no full-width status bar, and no always-visible worktree label.
+
+## Non-goals
+
+- Pixel-perfect Superconductor cloning.
+- Linux frameless/custom titlebar parity in this pass.
+- Replacing the terminal backend, session model, Git services, or file tree service.
+- Building a full file explorer with file open/edit/rename/delete actions.
+- Introducing split panes or a broader terminal workspace redesign beyond hover tabs.
+- Large architectural rewrites unrelated to the requested UI overhaul.
+
+## Design Approach
+
+Use an incremental component modernization approach.
+
+Keep the existing `AlasShell`, app model, terminal backend/session code, Git services, and file tree service. Refactor the GPUI view surfaces around them:
+
+- left repository sidebar moves to `gpui-component` tree/menu/popover primitives where feasible,
+- right inspector becomes a single grouped tree,
+- center workspace becomes a flush terminal column with hover terminal tabs,
+- contextual menus move from inline blocks to popovers.
+
+This minimizes risk to terminal behavior while delivering the requested look and component migration.
+
+## Product Shape and Visual Direction
+
+Alas becomes a macOS-first frameless desktop app with three persistent columns.
+
+The visual language is strongly Superconductor-inspired: dark calm surfaces, compact typography, subtle borders, rounded controls where they help, and icon-first utility controls. Alas should still feel distinct, primarily through its true flush terminal center column.
+
+On macOS, remove or replace the normal titlebar where GPUI supports it. Reserve only a small top-left safe/chrome area for the traffic-light buttons, positioned approximately 20px from the top. The center terminal and right sidebar start at the top edge.
+
+Window dragging is scoped to the top-left safe/chrome region. Terminal content, tree rows, and other interactive controls should not become accidental drag regions.
+
+The current full-width bottom status bar is removed. Status is folded into local contextual surfaces:
+
+- active repo/worktree state in the left tree,
+- branch and changed-file metadata in the right grouped tree,
+- terminal process/tab state in the hover tab overlay or inline terminal states.
+
+## Layout and Chrome
+
+The root shell remains a GPUI view, but its layout becomes a horizontal three-column flex row:
+
+1. **Left sidebar**: fixed-width repository/worktree tree, dark sidebar surface, top-left macOS safe area.
+2. **Center pane**: flexible true flush terminal surface.
+3. **Right sidebar**: fixed-width grouped files/Git tree.
+
+Remove the current `render_status_bar` from the default layout. Remove the current center `render_workspace` rounded card and persistent tab bar.
+
+The center pane should fill all available vertical space. Any terminal tabs or tab actions are overlays, not structural chrome.
+
+### macOS Frameless Gate
+
+Include an implementation spike/gate for exact frameless behavior. Use GPUI window options or platform APIs if available. If exact titlebar removal is constrained, keep the titlebar/custom chrome work isolated so the main three-column layout can land without coupling sidebar or terminal code to platform-specific APIs.
+
+Linux can keep conventional window chrome for now.
+
+## Left Repository Sidebar
+
+The left sidebar becomes a `gpui-component`-based collapsible tree.
+
+### Structure
+
+- Repository nodes are top-level tree parents.
+- Worktrees are child rows.
+- Repository rows show compact identity: repo name, unavailable state when relevant, and an overflow/context affordance.
+- Worktree rows show branch/worktree name, main/linked/archived state, selection state, and practical Git metadata where available.
+- Archived worktrees stay hidden unless “show archived” is enabled for that repository.
+
+### Actions
+
+Preserve existing actions:
+
+- add repository,
+- remove repository,
+- create worktree,
+- remove worktree,
+- archive/unarchive worktree,
+- prune worktrees,
+- show/hide archived worktrees,
+- command settings.
+
+Right-click and overflow controls open contextual menus through the existing `ActionRegistry`. Menus should render as `gpui-component` popovers/menus instead of inline blocks inserted into the sidebar layout.
+
+### Add Repository Control
+
+Replace the current labeled primary button with an icon-only image button at the bottom of the left sidebar.
+
+Use built-in `gpui-component` icons/buttons first. Add custom local SVG assets only when they materially improve visual quality. On hover/focus, show a tooltip or popover label such as “Add repository.” Add-repository errors remain visible near the bottom control, styled compactly.
+
+## Right Grouped Inspector Tree
+
+The right sidebar becomes a single grouped tree instead of Files/Changes tabs.
+
+### Top Context
+
+Show selected branch or detached-head state and a compact changed-file count/status summary when available. If no worktree is selected, show a quiet empty state.
+
+### Sections
+
+The tree has two primary sections.
+
+#### Changed
+
+- Lists changed files from the Git inspector.
+- Shows status badges such as `M`, `A`, `D`, and `U` where available.
+- Shows “No changed files.” when clean.
+- Shows Git inspector loading/error state independently of file loading.
+
+#### Files
+
+- Shows the loaded file tree rooted at the selected worktree.
+- Uses tree indentation and expand/collapse affordances.
+- Uses `gpui-component` tree where feasible, with custom row rendering for file/directory icons and status.
+- Shows file tree loading/error state independently of Git changes.
+- Keeps truncation visible as a muted “additional entries hidden” row.
+
+### Scope
+
+This pass can add practical metadata if it is already available or cheap to compute, but should not become a full file explorer. File opening/editing/actions are not required unless they already exist.
+
+The current file tree service loads to a depth and node budget. The UI should include expanded/collapsed row state, but implementation may initially render loaded nodes only and avoid recursive filesystem loading on expansion unless explicitly planned.
+
+## Terminal/Main Pane
+
+The terminal pane is the app’s visual anchor.
+
+### Main Surface
+
+- Remove the persistent `Worktree: ...` label.
+- Remove the surrounding workspace card chrome.
+- Terminal canvas fills the center column from top to bottom.
+- Terminal background should read as the center column, not as a nested panel.
+- Clicking the terminal focuses it.
+
+Keyboard, mouse, scroll, paste, resize, and focus behavior continue to route through the existing terminal backend/session code.
+
+Removing chrome must not reduce terminal cell measurement accuracy. Bounds probing must measure the actual drawable terminal area.
+
+### Terminal Tabs
+
+Terminal tabs remain per worktree.
+
+The tab strip becomes an overlay anchored to the top edge of the center column. It appears on hover/focus and can also appear when:
+
+- there is more than one terminal tab,
+- a terminal exits or fails,
+- the user invokes a tab-related action.
+
+The new-tab control lives in this overlay. Tab labels stay compact and may include command/agent prefixes.
+
+### Terminal States
+
+- **No worktree selected**: show a centered, low-chrome empty state.
+- **Startup or I/O failure**: show an inline failure panel with command, cwd, cause, Retry, and Edit Command, without restoring a full workspace header.
+- **Process exited**: preserve the final terminal screen. Expose restart/status in the hover tab overlay or a subtle inline overlay, not a persistent top bar.
+
+## State and Data Flow
+
+Data flow remains close to today.
+
+### Worktree Selection
+
+1. User selects a worktree in the left tree.
+2. The app updates the selected worktree in the model.
+3. The app resolves or creates the selected worktree’s active terminal tab.
+4. The app starts or reuses the terminal backend session.
+5. The app clears inspector state and refreshes files and Git changes.
+6. The right grouped tree updates from `InspectorPaneState` and selected worktree metadata.
+
+### Actions and Menus
+
+Left tree row actions dispatch through the existing `ActionRegistry`. The same action availability and destructive/confirmation behavior should be preserved. Popover/menu state is UI-layer state, not domain state.
+
+### UI State Additions
+
+Add or adapt UI state for:
+
+- expanded/collapsed repository nodes,
+- expanded/collapsed file tree nodes,
+- active contextual popover/menu target,
+- hover/focus visibility for terminal tabs.
+
+Keep these states in the UI layer unless a value needs to persist beyond the current view/session.
+
+### Assets
+
+If custom icons are added, keep them under `assets/` and reference them through a small UI helper. Prefer `gpui-component` built-ins and text/icons already available before adding assets.
+
+## Error Handling
+
+- Repository unavailable state remains scoped to its repository row.
+- Add-repository errors remain local to the bottom add control.
+- Worktree action failures use existing dialogs/errors where possible.
+- File tree errors appear only in the Files section.
+- Git inspector errors appear only in the Changed section.
+- Terminal errors remain per active terminal tab and do not break sidebar interaction.
+- Destructive actions keep confirmations.
+
+## Testing and Verification
+
+Add or update tests for UI-independent state transformations where practical:
+
+- tree expansion state,
+- grouped inspector row construction,
+- action/menu availability from `ActionRegistry`,
+- preservation of terminal tab/session behavior after layout refactoring.
+
+Existing tests for the app model, file tree, Git inspector, workspace session, terminal sessions, and terminal rendering should continue passing.
+
+Update `docs/manual-test.md` to cover:
+
+- macOS frameless/custom chrome and traffic-light safe area,
+- hover terminal tabs and new-tab control,
+- true flush terminal with no persistent worktree label,
+- left repo/worktree tree expansion and context popovers,
+- right grouped Changed/Files tree,
+- icon-only add repository button and hover label,
+- absence of the old full-width status bar.
+
+Before finishing implementation, run the relevant project checks:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo build --all-features
+cargo test --all-features
+```

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -1,0 +1,65 @@
+use gpui::{IntoElement, WindowOptions, div, prelude::*, px};
+
+pub const TRAFFIC_LIGHT_LEFT_PX: f32 = 20.0;
+pub const TRAFFIC_LIGHT_TOP_PX: f32 = 20.0;
+pub const MAC_SAFE_AREA_WIDTH_PX: f32 = 116.0;
+pub const MAC_SAFE_AREA_HEIGHT_PX: f32 = 56.0;
+
+pub fn mac_titlebar_safe_area_height_px() -> f32 {
+    if cfg!(target_os = "macos") {
+        MAC_SAFE_AREA_HEIGHT_PX
+    } else {
+        0.0
+    }
+}
+
+pub fn alas_window_options() -> WindowOptions {
+    let options = WindowOptions::default();
+
+    #[cfg(target_os = "macos")]
+    let options = {
+        let mut options = options;
+        options.titlebar = Some(gpui::TitlebarOptions {
+            title: None,
+            appears_transparent: true,
+            traffic_light_position: Some(gpui::point(
+                px(TRAFFIC_LIGHT_LEFT_PX),
+                px(TRAFFIC_LIGHT_TOP_PX),
+            )),
+        });
+        options
+    };
+
+    options
+}
+
+pub fn render_mac_titlebar_safe_area_spacer() -> impl IntoElement {
+    div()
+        .id("mac-titlebar-safe-area-spacer")
+        .flex_shrink_0()
+        .w(px(MAC_SAFE_AREA_WIDTH_PX))
+        .h(px(mac_titlebar_safe_area_height_px()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn macos_window_options_use_transparent_titlebar_and_moved_traffic_lights() {
+        let options = alas_window_options();
+        let titlebar = options.titlebar.expect("titlebar options");
+        assert!(titlebar.appears_transparent);
+        assert!(titlebar.title.is_none());
+        assert!(titlebar.traffic_light_position.is_some());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn non_macos_window_options_keep_default_titlebar() {
+        let options = alas_window_options();
+        let titlebar = options.titlebar.expect("default titlebar options");
+        assert!(!titlebar.appears_transparent);
+    }
+}

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -1,232 +1,183 @@
+use std::path::PathBuf;
+
 use crate::{
-    app::{InspectorPaneState, InspectorTab, SelectedWorktree},
-    git::GitInspectorState,
-    project::FileTreeNode,
+    app::{InspectorPaneState, SelectedWorktree},
     ui::theme::{DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
+    ui::view_models::{InspectorTreeRow, TreeExpansionState, build_inspector_tree_rows},
 };
 
 use gpui::{
     AnyElement, App, ClickEvent, FontWeight, IntoElement, ParentElement, SharedString, Styled,
     Window, div, prelude::*, px,
 };
-use gpui_component::{
-    Sizable,
-    tab::{Tab, TabBar},
-};
+use gpui_component::{Icon, IconName, Sizable, list::ListItem};
 
 pub fn render_project_inspector(
     selected_worktree: Option<&SelectedWorktree>,
     state: &InspectorPaneState,
-    on_select_tab: impl Fn(InspectorTab, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    file_expansion: &TreeExpansionState,
+    on_toggle_file: impl Fn(PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
 ) -> impl IntoElement {
+    let rows = build_inspector_tree_rows(selected_worktree, state, file_expansion);
+
     div()
+        .id("project-inspector")
         .flex()
         .flex_col()
         .flex_shrink_0()
         .size_full()
         .w(px(320.0))
-        .p_4()
-        .gap_3()
+        .px_4()
+        .py_3()
+        .gap_2()
         .border_l_1()
         .border_color(PANEL_BORDER)
         .bg(PANEL_BG)
         .text_color(TEXT)
-        .child(
-            div()
-                .text_lg()
-                .font_weight(FontWeight::BOLD)
-                .child("Inspector"),
-        )
-        .child(render_tab_bar(state.selected_tab, on_select_tab))
-        .when(selected_worktree.is_none(), |element| {
-            element.child(
-                div()
-                    .text_sm()
-                    .text_color(TEXT_MUTED)
-                    .child("Select a worktree to inspect its files and changes."),
-            )
-        })
-        .when(selected_worktree.is_some(), |element| {
-            let selected_worktree = selected_worktree.expect("checked selected worktree");
-            element
-                .child(
-                    div()
-                        .text_xs()
-                        .text_color(TEXT_MUTED)
-                        .child(SharedString::from(
-                            selected_worktree.path.display().to_string(),
-                        )),
-                )
-                .child(match state.selected_tab {
-                    InspectorTab::Files => render_files_tab(state),
-                    InspectorTab::Changes => render_changes_tab(state),
-                })
-        })
+        .child(render_inspector_rows(rows, on_toggle_file))
 }
 
-fn render_tab_bar(
-    selected_tab: InspectorTab,
-    on_select_tab: impl Fn(InspectorTab, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+fn render_inspector_rows(
+    rows: Vec<InspectorTreeRow>,
+    on_toggle_file: impl Fn(PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
 ) -> impl IntoElement {
-    let selected_index = match selected_tab {
-        InspectorTab::Files => 0,
-        InspectorTab::Changes => 1,
-    };
-    let on_select_files = on_select_tab.clone();
-
-    TabBar::new("inspector-tab-bar")
-        .segmented()
-        .small()
-        .selected_index(selected_index)
-        .child(
-            Tab::new()
-                .label("Files")
-                .on_click(move |event, window, cx| {
-                    on_select_files(InspectorTab::Files, event, window, cx);
-                }),
-        )
-        .child(
-            Tab::new()
-                .label("Changes")
-                .on_click(move |event, window, cx| {
-                    on_select_tab(InspectorTab::Changes, event, window, cx);
-                }),
-        )
-}
-
-fn render_files_tab(state: &InspectorPaneState) -> AnyElement {
     div()
-        .id("inspector-files-scroll")
+        .id("grouped-inspector-tree")
         .flex()
         .flex_col()
         .flex_1()
         .min_h(px(0.0))
-        .gap_2()
         .overflow_scroll()
-        .when(state.files_error.is_some(), |element| {
-            element.child(warning_text(
-                "Files tree load failed",
-                state.files_error.as_deref().unwrap_or_default(),
-            ))
-        })
-        .when(
-            state.files.is_none() && state.files_error.is_none(),
-            |element| element.child(loading_text("Loading file tree…")),
-        )
-        .when(state.files.is_some(), |element| {
-            let root = state.files.as_ref().expect("checked files state");
-            element
-                .when(root.children.is_empty(), |element| {
-                    element.child(empty_text("No files found."))
-                })
-                .when(!root.children.is_empty(), |element| {
-                    element.child(render_file_node(root, 0))
-                })
-        })
-        .into_any_element()
-}
-
-fn render_file_node(node: &FileTreeNode, depth: usize) -> impl IntoElement {
-    div()
-        .flex()
-        .flex_col()
         .gap_1()
-        .child(div().pl(px((depth * 12) as f32)).text_sm().child(format!(
-            "{} {}",
-            if node.is_dir { "▸" } else { "☰" },
-            node.name
-        )))
         .children(
-            node.children
-                .iter()
-                .map(move |child| render_file_node(child, depth + 1)),
+            rows.into_iter()
+                .map(move |row| render_inspector_row(row, on_toggle_file.clone())),
         )
-        .when(node.truncated, |element| {
-            element.child(
-                div()
-                    .pl(px(((depth + 1) * 12) as f32))
-                    .text_xs()
-                    .text_color(TEXT_MUTED)
-                    .child("… additional entries hidden"),
-            )
-        })
 }
 
-fn render_changes_tab(state: &InspectorPaneState) -> AnyElement {
-    div()
-        .id("inspector-changes-scroll")
-        .flex()
-        .flex_col()
-        .flex_1()
-        .min_h(px(0.0))
-        .gap_2()
-        .overflow_scroll()
-        .when(state.changes_error.is_some(), |element| {
-            element.child(warning_text(
-                "Git changes refresh failed",
-                state.changes_error.as_deref().unwrap_or_default(),
-            ))
-        })
-        .when(
-            state.changes.is_none() && state.changes_error.is_none(),
-            |element| element.child(loading_text("Loading Git changes…")),
-        )
-        .when(state.changes.is_some(), |element| {
-            let changes = state.changes.as_ref().expect("checked changes state");
-            element.child(render_changes(changes))
-        })
-        .into_any_element()
-}
-
-fn render_changes(state: &GitInspectorState) -> impl IntoElement {
-    div()
-        .flex()
-        .flex_col()
-        .gap_2()
-        .child(section_header("Branch"))
-        .child(
-            div().text_sm().child(SharedString::from(
-                state
-                    .branch
-                    .as_deref()
-                    .unwrap_or("Detached HEAD")
-                    .to_string(),
-            )),
-        )
-        .child(section_header("Changed Files"))
-        .when(state.changed_files.is_empty(), |element| {
-            element.child(empty_text("No changed files."))
-        })
-        .children(state.changed_files.iter().map(|file| {
+fn render_inspector_row(
+    row: InspectorTreeRow,
+    on_toggle_file: impl Fn(PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+) -> AnyElement {
+    match row {
+        InspectorTreeRow::EmptyState => {
+            empty_text_owned("Select a worktree to inspect its files and changes.".to_string())
+                .into_any_element()
+        }
+        InspectorTreeRow::Context {
+            branch_label,
+            changed_count,
+        } => {
+            let count = changed_count
+                .map(|count| format!(" · {count} changed"))
+                .unwrap_or_default();
             div()
-                .flex()
-                .gap_2()
-                .text_sm()
-                .child(
-                    div()
-                        .w(px(32.0))
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .text_color(TEXT_MUTED)
-                        .child(SharedString::from(file.status.clone())),
-                )
-                .child(SharedString::from(file.path.clone()))
-        }))
+                .px_1()
+                .pb_2()
+                .text_xs()
+                .text_color(TEXT_MUTED)
+                .child(SharedString::from(format!("{branch_label}{count}")))
+                .into_any_element()
+        }
+        InspectorTreeRow::Section { title } => section_header(title).into_any_element(),
+        InspectorTreeRow::Loading { section } => {
+            loading_text_owned(format!("Loading {section}…")).into_any_element()
+        }
+        InspectorTreeRow::Error { section, message } => {
+            warning_text(section, &message).into_any_element()
+        }
+        InspectorTreeRow::ChangedFile { status, path } => {
+            changed_file_row(status, path).into_any_element()
+        }
+        InspectorTreeRow::Clean { path } => empty_text_owned(path).into_any_element(),
+        InspectorTreeRow::File {
+            depth,
+            name,
+            path,
+            is_dir,
+            expanded,
+        } => file_row(depth, name, path, is_dir, expanded, on_toggle_file).into_any_element(),
+        InspectorTreeRow::Truncated { depth } => truncated_row(depth).into_any_element(),
+    }
 }
 
-fn section_header(title: &'static str) -> impl IntoElement {
+fn section_header(title: impl Into<String>) -> impl IntoElement {
     div()
         .pt_2()
         .text_sm()
         .font_weight(FontWeight::SEMIBOLD)
-        .child(title)
+        .child(SharedString::from(title.into()))
 }
 
-fn loading_text(text: &'static str) -> impl IntoElement {
+fn loading_text_owned(text: String) -> impl IntoElement {
     div().text_sm().text_color(TEXT_MUTED).child(text)
 }
 
-fn empty_text(text: &'static str) -> impl IntoElement {
+fn empty_text_owned(text: String) -> impl IntoElement {
     div().text_sm().text_color(TEXT_MUTED).child(text)
+}
+
+fn changed_file_row(status: String, path: String) -> impl IntoElement {
+    div()
+        .flex()
+        .gap_2()
+        .text_sm()
+        .child(
+            div()
+                .w(px(32.0))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(TEXT_MUTED)
+                .child(SharedString::from(status)),
+        )
+        .child(div().truncate().child(SharedString::from(path)))
+}
+
+fn file_row(
+    depth: usize,
+    name: String,
+    path: PathBuf,
+    is_dir: bool,
+    expanded: bool,
+    on_toggle_file: impl Fn(PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+) -> impl IntoElement {
+    let row_id = SharedString::from(format!("inspector-file-row-{}", path.display()));
+    let row = ListItem::new(row_id).child(
+        div()
+            .flex()
+            .items_center()
+            .gap_2()
+            .text_sm()
+            .pl(px((depth * 12) as f32))
+            .child(
+                Icon::new(if is_dir {
+                    if expanded {
+                        IconName::FolderOpen
+                    } else {
+                        IconName::FolderClosed
+                    }
+                } else {
+                    IconName::File
+                })
+                .small(),
+            )
+            .child(div().truncate().child(name)),
+    );
+
+    if is_dir {
+        row.on_click(move |event, window, cx| {
+            on_toggle_file(path.clone(), event, window, cx);
+        })
+    } else {
+        row
+    }
+}
+
+fn truncated_row(depth: usize) -> impl IntoElement {
+    div()
+        .pl(px(((depth + 1) * 12) as f32))
+        .text_xs()
+        .text_color(TEXT_MUTED)
+        .child("… additional entries hidden")
 }
 
 fn warning_text(title: &'static str, error: &str) -> impl IntoElement {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod chrome;
 pub mod command_picker;
 pub mod dialogs;
 pub mod inspector;
@@ -8,6 +9,7 @@ pub mod terminal_canvas;
 pub mod terminal_pane;
 pub mod terminal_view;
 pub mod theme;
+pub mod view_models;
 pub mod workspace;
 
 pub use shell::run;

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -5,8 +5,8 @@ use std::{
 
 use crate::{
     app::{
-        ActionId, AlasModel, InspectorPaneState, InspectorTab, RepositoryNode, TerminalTabId,
-        TerminalTabKind, TerminalTabStatus, WorkspaceSession,
+        ActionId, AlasModel, InspectorPaneState, RepositoryNode, TerminalTabId, TerminalTabKind,
+        TerminalTabStatus, WorkspaceSession,
     },
     config::{
         AppConfig, AppConfigStore, AppRepository, CommandEntry, RepoConfigStore,
@@ -24,6 +24,7 @@ use crate::{
         },
     },
     ui::{
+        chrome::alas_window_options,
         command_picker::render_command_picker,
         dialogs::{
             AddRepositoryDialogState, CommandSettingsDialogState, ConfirmPruneWorktreesDialog,
@@ -34,16 +35,19 @@ use crate::{
         sidebar::{SidebarMenuState, render_sidebar},
         terminal_canvas::measure_terminal_metrics,
         terminal_pane::render_terminal_pane,
-        terminal_view::{TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE_PX},
-        theme::{APP_BG, DANGER, PANEL_BG, PANEL_BORDER, SUCCESS, TEXT, TEXT_MUTED},
+        terminal_view::{
+            TERMINAL_CANVAS_HORIZONTAL_PADDING_PX, TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE_PX,
+        },
+        theme::{APP_BG, TEXT},
+        view_models::TreeExpansionState,
         workspace::render_workspace,
     },
 };
 use gpui::{
     App, Application, Bounds, ClipboardItem, Context, FocusHandle, IntoElement, KeyDownEvent,
     MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PathPromptOptions, Pixels,
-    PromptLevel, Render, ScrollDelta, ScrollWheelEvent, SharedString, Window, WindowOptions, div,
-    prelude::*, px, rgb,
+    PromptLevel, Render, ScrollDelta, ScrollWheelEvent, SharedString, Window, div, prelude::*, px,
+    rgb,
 };
 use indexmap::IndexMap;
 use std::borrow::BorrowMut;
@@ -100,6 +104,7 @@ pub struct AlasShell {
     command_settings_active_field: CommandSettingsField,
     command_picker: Option<CommandPickerState>,
     sidebar_menu: Option<SidebarMenuState>,
+    repo_tree_expansion: TreeExpansionState,
     confirm_remove_repository_dialog: Option<ConfirmRemoveRepositoryDialog>,
     confirm_remove_worktree_dialog: Option<ConfirmRemoveWorktreeDialog>,
     confirm_prune_worktrees_dialog: Option<ConfirmPruneWorktreesDialog>,
@@ -110,6 +115,7 @@ pub struct AlasShell {
     active_terminal: Option<TerminalSessionRef>,
     terminal_error: Option<String>,
     terminal_focus: FocusHandle,
+    terminal_tab_overlay_hovered: bool,
     terminal_metrics: TerminalMetrics,
     terminal_size: Option<TerminalSize>,
     terminal_body_size_px: Option<(f32, f32)>,
@@ -117,6 +123,7 @@ pub struct AlasShell {
     terminal_scroll_offset_rows: usize,
     inspector_state: InspectorPaneState,
     inspector_request_generation: u64,
+    file_tree_expansion: TreeExpansionState,
 }
 
 impl AlasShell {
@@ -137,6 +144,7 @@ impl AlasShell {
             command_settings_active_field: CommandSettingsField::DefaultName,
             command_picker: None,
             sidebar_menu: None,
+            repo_tree_expansion: TreeExpansionState::default(),
             confirm_remove_repository_dialog: None,
             confirm_remove_worktree_dialog: None,
             confirm_prune_worktrees_dialog: None,
@@ -147,6 +155,7 @@ impl AlasShell {
             active_terminal: None,
             terminal_error: None,
             terminal_focus: cx.focus_handle(),
+            terminal_tab_overlay_hovered: false,
             terminal_metrics: TerminalMetrics::fallback(),
             terminal_size: None,
             terminal_body_size_px: None,
@@ -154,6 +163,7 @@ impl AlasShell {
             terminal_scroll_offset_rows: 0,
             inspector_state: InspectorPaneState::default(),
             inspector_request_generation: 0,
+            file_tree_expansion: TreeExpansionState::default(),
         };
         shell.refresh_repositories();
         shell.start_terminal_refresh(cx);
@@ -276,7 +286,10 @@ impl AlasShell {
 
     fn current_terminal_size(&self) -> TerminalSize {
         self.terminal_body_size_px
-            .map(|(width, height)| self.terminal_metrics.size_from_pixels(width, height))
+            .map(|(width, height)| {
+                let width = (width - (2.0 * TERMINAL_CANVAS_HORIZONTAL_PADDING_PX)).max(0.0);
+                self.terminal_metrics.size_from_pixels(width, height)
+            })
             .or(self.terminal_size)
             .unwrap_or(TerminalSize { cols: 80, rows: 24 })
     }
@@ -466,8 +479,17 @@ impl AlasShell {
         modifiers: gpui::Modifiers,
     ) -> Option<TerminalMouseInput> {
         let bounds = self.terminal_body_bounds?;
-        let x_px = f32::from(position.x) - f32::from(bounds.origin.x);
+        let mut x_px = f32::from(position.x) - f32::from(bounds.origin.x);
         let y_px = f32::from(position.y) - f32::from(bounds.origin.y);
+
+        let horizontal_padding = TERMINAL_CANVAS_HORIZONTAL_PADDING_PX;
+        x_px -= horizontal_padding;
+
+        let content_width = (f32::from(bounds.size.width) - (2.0 * horizontal_padding)).max(0.0);
+        if x_px < 0.0 || x_px >= content_width {
+            return None;
+        }
+
         let cell = mouse_cell_position(x_px, y_px, self.terminal_metrics)?;
 
         Some(TerminalMouseInput {
@@ -966,6 +988,7 @@ impl AlasShell {
         self.sidebar_menu = None;
         self.terminal_scroll_offset_rows = 0;
         self.inspector_state.clear_for_new_worktree();
+        self.file_tree_expansion = TreeExpansionState::default();
         self.inspector_request_generation = self.inspector_request_generation.wrapping_add(1);
         let inspector_request_generation = self.inspector_request_generation;
         self.refresh_git_inspector(
@@ -1130,18 +1153,6 @@ impl AlasShell {
         self.command_picker = None;
     }
 
-    fn open_sidebar_menu(&mut self, menu: SidebarMenuState) {
-        if self.sidebar_menu.as_ref() == Some(&menu) {
-            self.sidebar_menu = None;
-        } else {
-            self.sidebar_menu = Some(menu);
-        }
-    }
-
-    fn close_sidebar_menu(&mut self) {
-        self.sidebar_menu = None;
-    }
-
     fn handle_sidebar_menu_action(
         &mut self,
         action_id: ActionId,
@@ -1208,6 +1219,17 @@ impl AlasShell {
         }
 
         cx.notify();
+    }
+
+    fn handle_sidebar_menu_action_from_target(
+        &mut self,
+        menu: SidebarMenuState,
+        action_id: ActionId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.sidebar_menu = Some(menu);
+        self.handle_sidebar_menu_action(action_id, window, cx);
     }
 
     fn handle_command_picker_key_down(&mut self, event: &KeyDownEvent) -> bool {
@@ -1831,56 +1853,6 @@ fn render_create_worktree_field(
         )
 }
 
-fn render_status_bar(
-    repo_summary: String,
-    tab_summary: String,
-    terminal_status: Option<&TerminalTabStatus>,
-) -> impl IntoElement {
-    let (status_label, status_color) = match terminal_status {
-        Some(TerminalTabStatus::Running) => ("running".to_string(), SUCCESS),
-        Some(TerminalTabStatus::Exited(Some(code))) => (
-            format!("exited {code}"),
-            if *code == 0 { SUCCESS } else { DANGER },
-        ),
-        Some(TerminalTabStatus::Exited(None)) => ("exited".to_string(), TEXT_MUTED),
-        Some(TerminalTabStatus::Failed) => ("failed".to_string(), DANGER),
-        Some(TerminalTabStatus::NotStarted) => ("not started".to_string(), TEXT_MUTED),
-        None => ("no terminal".to_string(), TEXT_MUTED),
-    };
-
-    div()
-        .flex()
-        .items_center()
-        .justify_between()
-        .gap_3()
-        .px_4()
-        .py_2()
-        .border_t_1()
-        .border_color(PANEL_BORDER)
-        .bg(PANEL_BG)
-        .text_xs()
-        .text_color(TEXT_MUTED)
-        .child(
-            div()
-                .flex()
-                .items_center()
-                .gap_2()
-                .overflow_hidden()
-                .child(div().text_color(TEXT).child("Workspace"))
-                .child(div().child("•"))
-                .child(div().truncate().child(repo_summary)),
-        )
-        .child(
-            div()
-                .flex()
-                .items_center()
-                .gap_2()
-                .child(div().text_color(TEXT).child(tab_summary))
-                .child(div().child("•"))
-                .child(div().text_color(status_color).child(status_label)),
-        )
-}
-
 impl Render for AlasShell {
     fn render(&mut self, window: &mut gpui::Window, cx: &mut Context<Self>) -> impl IntoElement {
         let measured_metrics =
@@ -1920,16 +1892,16 @@ impl Render for AlasShell {
                 .ok();
             };
         let view = cx.entity().downgrade();
-        let on_select_inspector_tab = move |tab: InspectorTab,
-                                            _event: &gpui::ClickEvent,
-                                            _window: &mut Window,
-                                            app: &mut App| {
-            view.update(app, |shell, cx| {
-                shell.inspector_state.select_tab(tab);
-                cx.notify();
-            })
-            .ok();
-        };
+        let on_toggle_file_tree_node =
+            move |path: PathBuf, _event: &gpui::ClickEvent, _window: &mut Window, app: &mut App| {
+                view.update(app, |shell, cx| {
+                    shell
+                        .file_tree_expansion
+                        .toggle(crate::ui::view_models::TreeExpansionKey::File(path.clone()));
+                    cx.notify();
+                })
+                .ok();
+            };
         let on_submit_create_worktree = cx.listener(|shell, _event, _window, cx| {
             shell.create_worktree_from_dialog(cx);
             cx.notify();
@@ -1990,6 +1962,16 @@ impl Render for AlasShell {
             {
                 cx.stop_propagation();
                 cx.notify();
+                return;
+            }
+
+            let is_tab = event.keystroke.key.eq_ignore_ascii_case("tab")
+                || event.keystroke.key_char.as_deref() == Some("\t");
+            if is_tab {
+                if shell.write_terminal_input(event) {
+                    cx.notify();
+                }
+                cx.stop_propagation();
                 return;
             }
 
@@ -2099,6 +2081,12 @@ impl Render for AlasShell {
         let on_new_terminal_tab = cx.listener(|shell, _event, _window, cx| {
             shell.open_command_picker(cx);
         });
+        let on_terminal_tabs_hover = cx.listener(|shell, hovered: &bool, _window, cx| {
+            if shell.terminal_tab_overlay_hovered != *hovered {
+                shell.terminal_tab_overlay_hovered = *hovered;
+                cx.notify();
+            }
+        });
         let view = cx.entity().downgrade();
         let on_select_command = move |name: String,
                                       command: String,
@@ -2116,33 +2104,30 @@ impl Render for AlasShell {
             cx.notify();
         });
         let view = cx.entity().downgrade();
-        let on_open_sidebar_menu =
-            move |menu: SidebarMenuState, _window: &mut Window, app: &mut App| {
-                view.update(app, |shell, cx| {
-                    shell.open_sidebar_menu(menu);
-                    cx.notify();
-                })
-                .ok();
-            };
-        let view = cx.entity().downgrade();
-        let on_sidebar_menu_action = move |action_id: ActionId,
-                                           _event: &gpui::ClickEvent,
-                                           window: &mut Window,
-                                           app: &mut App| {
+        let on_toggle_repository = move |repo_id: String,
+                                         _event: &gpui::ClickEvent,
+                                         _window: &mut Window,
+                                         app: &mut App| {
             view.update(app, |shell, cx| {
-                shell.handle_sidebar_menu_action(action_id, window, cx);
+                shell.repo_tree_expansion.toggle(
+                    crate::ui::view_models::TreeExpansionKey::Repository(repo_id.clone()),
+                );
+                cx.notify();
             })
             .ok();
         };
         let view = cx.entity().downgrade();
-        let on_close_sidebar_menu =
-            move |_event: &gpui::ClickEvent, _window: &mut Window, app: &mut App| {
-                view.update(app, |shell, cx| {
-                    shell.close_sidebar_menu();
-                    cx.notify();
-                })
-                .ok();
-            };
+        let on_sidebar_menu_action = move |menu: SidebarMenuState,
+                                           action_id: ActionId,
+                                           _event: &gpui::ClickEvent,
+                                           window: &mut Window,
+                                           app: &mut App| {
+            let view = view.clone();
+            view.update(app, |shell, cx| {
+                shell.handle_sidebar_menu_action_from_target(menu, action_id, window, cx);
+            })
+            .ok();
+        };
         let workspace_tabs = self
             .model
             .selected_worktree()
@@ -2159,38 +2144,6 @@ impl Render for AlasShell {
         let active_tab = workspace_tabs
             .iter()
             .find(|tab| Some(tab.id) == active_workspace_tab);
-        let status_bar_repo = self
-            .model
-            .selected_worktree()
-            .map(|selected| {
-                let repository = self
-                    .model
-                    .repositories()
-                    .iter()
-                    .find(|repository| repository.id == selected.repo_id);
-                let worktree = repository.and_then(|repository| {
-                    repository
-                        .worktrees
-                        .iter()
-                        .find(|worktree| worktree.path == selected.path)
-                });
-                let repo_name = repository
-                    .map(|repository| repository.name.as_str())
-                    .unwrap_or(selected.repo_id.as_str());
-                let branch = worktree
-                    .and_then(|worktree| worktree.branch.as_deref())
-                    .unwrap_or("detached");
-                let path = selected
-                    .path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or_else(|| selected.path.to_str().unwrap_or("worktree"));
-                format!("{repo_name} • {branch} • {path}")
-            })
-            .unwrap_or_else(|| "No worktree selected".to_string());
-        let status_bar_tab = active_tab
-            .map(|tab| tab.name.clone())
-            .unwrap_or_else(|| "No terminal tab".to_string());
         let active_terminal_error = active_tab
             .and_then(|tab| tab.failure_cause.as_deref())
             .or_else(|| {
@@ -2204,42 +2157,45 @@ impl Render for AlasShell {
         } else {
             active_tab.and_then(|tab| terminal_status_from_tab_status(&tab.status))
         };
-        let status_bar_terminal_status = if active_terminal_error.is_some() {
+        let terminal_overlay_status = if active_terminal_error.is_some() {
             Some(TerminalTabStatus::Failed)
         } else {
             active_tab.map(|tab| tab.status.clone())
         };
+        let terminal_focused = self.terminal_focus.contains_focused(window, cx);
+        let show_terminal_tabs = crate::ui::view_models::terminal_tab_overlay_visible(
+            self.terminal_tab_overlay_hovered,
+            terminal_focused,
+            workspace_tabs.len(),
+            terminal_overlay_status.as_ref(),
+            active_terminal_error.is_some(),
+        );
 
         div()
             .on_action(cx.listener(|_shell, _: &crate::ui::lifecycle::Quit, _window, cx| {
                 cx.quit();
             }))
+            .relative()
             .flex()
-            .flex_col()
             .size_full()
             .bg(APP_BG)
             .text_color(TEXT)
-            .child(
-                div()
-                    .flex()
-                    .flex_1()
-                    .overflow_hidden()
-                    .child(render_sidebar(
-                        self.model.repositories(),
-                        self.model.selected_worktree(),
-                        self.sidebar_menu.as_ref(),
-                        cx.listener(|shell, _event, _window, cx| shell.open_add_repository_dialog(cx)),
-                        on_select_worktree,
-                        on_open_sidebar_menu,
-                        on_sidebar_menu_action,
-                        on_close_sidebar_menu,
-                        self.add_repository_error(),
-                    ))
+            .child(render_sidebar(
+                self.model.repositories(),
+                self.model.selected_worktree(),
+                &self.repo_tree_expansion,
+                on_toggle_repository,
+                cx.listener(|shell, _event, _window, cx| shell.open_add_repository_dialog(cx)),
+                on_select_worktree,
+                on_sidebar_menu_action,
+                self.add_repository_error(),
+            ))
             .child(
                 div()
                     .flex()
                     .flex_col()
                     .flex_1()
+                    .min_w(px(0.0))
                     .when(self.command_picker.is_some(), |element| {
                         let picker = self.command_picker.as_ref().unwrap();
                         element.child(render_command_picker(
@@ -2505,6 +2461,8 @@ impl Render for AlasShell {
                             .child(render_workspace(
                                 workspace_tabs,
                                 active_workspace_tab,
+                                show_terminal_tabs,
+                                on_terminal_tabs_hover,
                                 on_select_terminal_tab,
                                 on_new_terminal_tab,
                                 render_terminal_pane(
@@ -2530,13 +2488,8 @@ impl Render for AlasShell {
             .child(render_project_inspector(
                 self.model.selected_worktree(),
                 &self.inspector_state,
-                on_select_inspector_tab,
-            )),
-            )
-            .child(render_status_bar(
-                status_bar_repo,
-                status_bar_tab,
-                status_bar_terminal_status.as_ref(),
+                &self.file_tree_expansion,
+                on_toggle_file_tree_node,
             ))
     }
 }
@@ -2546,7 +2499,7 @@ pub fn run() -> anyhow::Result<()> {
         crate::ui::lifecycle::setup_lifecycle(cx);
         gpui_component::init(cx);
 
-        cx.open_window(WindowOptions::default(), |window, cx| {
+        cx.open_window(alas_window_options(), |window, cx| {
             let shell = cx.new(AlasShell::new);
             let weak_shell = shell.downgrade();
             window.on_window_should_close(cx, move |_window, cx| {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -6,15 +6,21 @@ use crate::{
         RepositoryNode, SelectedWorktree, WorktreeNode,
     },
     git::WorktreeKind,
-    ui::theme::{ACCENT, DANGER, PANEL_BG, PANEL_BORDER, SIDEBAR_BG, TEXT, TEXT_MUTED},
+    ui::{
+        chrome::render_mac_titlebar_safe_area_spacer,
+        theme::{DANGER, PANEL_BG, PANEL_BORDER, SIDEBAR_BG, TEXT, TEXT_MUTED},
+        view_models::{RepoTreeRow, TreeExpansionState, build_repo_tree_rows},
+    },
 };
 use gpui::{
-    App, ClickEvent, FontWeight, IntoElement, MouseButton, ParentElement, SharedString, Styled,
-    Window, div, prelude::*, px,
+    App, ClickEvent, FontWeight, IntoElement, ParentElement, SharedString, Styled, Window, div,
+    prelude::*, px,
 };
 use gpui_component::{
-    Sizable,
+    Icon, IconName, Sizable,
     button::{Button, ButtonVariants},
+    list::ListItem,
+    menu::{ContextMenuExt, DropdownMenu as _, PopupMenu, PopupMenuItem},
     tag::Tag,
 };
 
@@ -29,14 +35,17 @@ pub struct SidebarMenuState {
 pub fn render_sidebar(
     repositories: &[RepositoryNode],
     selected_worktree: Option<&SelectedWorktree>,
-    sidebar_menu: Option<&SidebarMenuState>,
+    expansion: &TreeExpansionState,
+    on_toggle_repository: impl Fn(String, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
     on_add_repository: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
     on_select_worktree: impl Fn(String, PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
-    on_open_sidebar_menu: impl Fn(SidebarMenuState, &mut Window, &mut App) + Clone + 'static,
-    on_sidebar_menu_action: impl Fn(ActionId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
-    on_close_sidebar_menu: impl Fn(&ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_sidebar_menu_action: impl Fn(SidebarMenuState, ActionId, &ClickEvent, &mut Window, &mut App)
+    + Clone
+    + 'static,
     add_repository_error: Option<&str>,
 ) -> impl IntoElement {
+    let rows = build_repo_tree_rows(repositories, selected_worktree, expansion);
+
     div()
         .flex()
         .flex_col()
@@ -49,6 +58,7 @@ pub fn render_sidebar(
         .border_color(PANEL_BORDER)
         .bg(SIDEBAR_BG)
         .text_color(TEXT)
+        .child(render_mac_titlebar_safe_area_spacer())
         .child(
             div()
                 .text_lg()
@@ -68,16 +78,74 @@ pub fn render_sidebar(
                     .child("No repositories configured. Add a Git repository to begin."),
             )
         })
-        .children(repositories.iter().map(|repository| {
-            render_repository(
-                repository,
-                selected_worktree,
-                sidebar_menu,
-                on_select_worktree.clone(),
-                on_open_sidebar_menu.clone(),
-                on_sidebar_menu_action.clone(),
-                on_close_sidebar_menu.clone(),
-            )
+        .children(rows.into_iter().map(|row| match row {
+            RepoTreeRow::Repository {
+                id,
+                name,
+                unavailable,
+                expanded,
+            } => {
+                let repository = repositories
+                    .iter()
+                    .find(|r| r.id == id)
+                    .cloned()
+                    .expect("repository row must have a matching repository");
+                let menu_state = SidebarMenuState {
+                    repo_id: id.clone(),
+                    worktree_path: None,
+                    scope: ActionScope::Repository,
+                };
+                render_repository_row(
+                    id,
+                    name,
+                    unavailable,
+                    expanded,
+                    repository,
+                    menu_state,
+                    on_toggle_repository.clone(),
+                    on_sidebar_menu_action.clone(),
+                )
+                .into_any_element()
+            }
+            RepoTreeRow::Worktree {
+                repo_id,
+                path,
+                label,
+                selected,
+                archived,
+                kind,
+            } => {
+                let repository = repositories
+                    .iter()
+                    .find(|r| r.id == repo_id)
+                    .cloned()
+                    .expect("worktree row must have a matching repository");
+                let worktree = repository
+                    .worktrees
+                    .iter()
+                    .find(|w| w.path == path)
+                    .cloned()
+                    .expect("worktree row must have a matching worktree");
+                let menu_state = SidebarMenuState {
+                    repo_id: repo_id.clone(),
+                    worktree_path: Some(path.clone()),
+                    scope: ActionScope::Worktree,
+                };
+                render_worktree_row(
+                    repo_id,
+                    path,
+                    label,
+                    selected,
+                    archived,
+                    kind,
+                    repository,
+                    worktree,
+                    menu_state,
+                    on_select_worktree.clone(),
+                    on_sidebar_menu_action.clone(),
+                )
+                .into_any_element()
+            }
         }))
         .child(
             div()
@@ -87,8 +155,10 @@ pub fn render_sidebar(
                 .gap_2()
                 .child(
                     Button::new("add-repository")
-                        .primary()
-                        .label("+ Add Repository")
+                        .ghost()
+                        .compact()
+                        .icon(IconName::Plus)
+                        .tooltip("Add repository")
                         .on_click(on_add_repository),
                 )
                 .when(add_repository_error.is_some(), |element| {
@@ -102,355 +172,228 @@ pub fn render_sidebar(
         )
 }
 
-fn render_repository(
-    repository: &RepositoryNode,
-    selected_worktree: Option<&SelectedWorktree>,
-    sidebar_menu: Option<&SidebarMenuState>,
-    on_select_worktree: impl Fn(String, PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
-    on_open_sidebar_menu: impl Fn(SidebarMenuState, &mut Window, &mut App) + Clone + 'static,
-    on_sidebar_menu_action: impl Fn(ActionId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
-    on_close_sidebar_menu: impl Fn(&ClickEvent, &mut Window, &mut App) + Clone + 'static,
+#[allow(clippy::too_many_arguments)]
+fn render_repository_row(
+    repo_id: String,
+    name: String,
+    unavailable: bool,
+    expanded: bool,
+    repository: RepositoryNode,
+    menu_state: SidebarMenuState,
+    on_toggle_repository: impl Fn(String, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_sidebar_menu_action: impl Fn(SidebarMenuState, ActionId, &ClickEvent, &mut Window, &mut App)
+    + Clone
+    + 'static,
 ) -> impl IntoElement {
-    let repository_menu = SidebarMenuState {
-        repo_id: repository.id.clone(),
-        worktree_path: None,
-        scope: ActionScope::Repository,
+    let repo_id_for_click = repo_id.clone();
+    let on_toggle = move |event: &ClickEvent, window: &mut Window, cx: &mut App| {
+        if event.is_right_click() {
+            return;
+        }
+        on_toggle_repository(repo_id_for_click.clone(), event, window, cx);
     };
-    let repository_menu_is_open = sidebar_menu == Some(&repository_menu);
-    let has_visible_worktrees = repository
-        .worktrees
-        .iter()
-        .any(|worktree| repository.show_archived || !worktree.archived);
 
-    div()
-        .flex()
-        .flex_col()
-        .gap_2()
+    let repo_id_for_button = repo_id.clone();
+    let repository_for_suffix = repository.clone();
+    let menu_state_for_suffix = menu_state.clone();
+    let on_action_for_suffix = on_sidebar_menu_action.clone();
+
+    let repository_for_context = repository.clone();
+    let menu_state_for_context = menu_state.clone();
+    let on_action_for_context = on_sidebar_menu_action.clone();
+
+    ListItem::new(SharedString::from(format!("repo-row-{repo_id}")))
+        .on_click(on_toggle)
         .child(
             div()
                 .flex()
-                .items_start()
-                .justify_between()
+                .items_center()
                 .gap_2()
-                .on_mouse_down(MouseButton::Right, {
-                    let on_open_sidebar_menu = on_open_sidebar_menu.clone();
-                    let repository_menu = repository_menu.clone();
-                    move |event, window, cx| {
-                        cx.stop_propagation();
-                        if event.button == MouseButton::Right {
-                            on_open_sidebar_menu(repository_menu.clone(), window, cx);
-                        }
-                    }
-                })
+                .child(
+                    Icon::new(if expanded {
+                        IconName::ChevronDown
+                    } else {
+                        IconName::ChevronRight
+                    })
+                    .small(),
+                )
                 .child(
                     div()
-                        .flex()
-                        .flex_col()
-                        .gap_1()
-                        .overflow_hidden()
-                        .child(
-                            div()
-                                .flex()
-                                .items_center()
-                                .gap_2()
-                                .child(
-                                    div()
-                                        .font_weight(FontWeight::SEMIBOLD)
-                                        .truncate()
-                                        .child(repository.name.clone()),
-                                )
-                                .when(repository.unavailable, |element| {
-                                    element.child(status_badge("Unavailable"))
-                                }),
-                        )
-                        .child(
-                            div()
-                                .text_xs()
-                                .text_color(TEXT_MUTED)
-                                .truncate()
-                                .child(repository.path.display().to_string()),
-                        ),
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .truncate()
+                        .child(name),
                 )
-                .child(overflow_button(
-                    SharedString::from(format!("repository-actions-{}", repository.id)),
-                    repository_menu,
-                    on_open_sidebar_menu.clone(),
-                )),
+                .when(unavailable, |el| el.child(status_badge("Unavailable"))),
         )
-        .when(repository_menu_is_open, |element| {
-            element.child(render_sidebar_menu(
-                repository,
-                None,
-                on_sidebar_menu_action.clone(),
-                on_close_sidebar_menu.clone(),
-            ))
+        .suffix(move |_window: &mut Window, _cx: &mut App| {
+            let repository = repository_for_suffix.clone();
+            let menu_state = menu_state_for_suffix.clone();
+            let on_sidebar_menu_action = on_action_for_suffix.clone();
+            Button::new(SharedString::from(format!(
+                "repository-actions-{repo_id_for_button}"
+            )))
+            .ghost()
+            .compact()
+            .icon(IconName::Ellipsis)
+            .on_click(|_event, _window, cx| {
+                cx.stop_propagation();
+            })
+            .dropdown_menu(move |menu, _window, _cx| {
+                build_sidebar_popup_menu(
+                    menu,
+                    repository.clone(),
+                    None,
+                    menu_state.clone(),
+                    on_sidebar_menu_action.clone(),
+                )
+            })
+            .into_any_element()
         })
-        .when(repository.unavailable, |element| {
-            element.child(
-                div()
-                    .ml_3()
-                    .p_2()
-                    .rounded_md()
-                    .border_1()
-                    .border_color(PANEL_BORDER)
-                    .bg(PANEL_BG)
-                    .text_sm()
-                    .text_color(TEXT_MUTED)
-                    .child(
-                        "Repository unavailable or moved. Check the path or remove it from Alas.",
-                    ),
+        .context_menu(move |menu, _window, _cx| {
+            build_sidebar_popup_menu(
+                menu,
+                repository_for_context.clone(),
+                None,
+                menu_state_for_context.clone(),
+                on_action_for_context.clone(),
             )
         })
-        .when(
-            !repository.unavailable && repository.worktrees.is_empty(),
-            |element| {
-                element.child(
-                    div()
-                        .ml_3()
-                        .p_2()
-                        .rounded_md()
-                        .bg(PANEL_BG)
-                        .text_sm()
-                        .text_color(TEXT_MUTED)
-                        .child("No worktrees found for this repository."),
-                )
-            },
-        )
-        .when(
-            !repository.unavailable && !repository.worktrees.is_empty() && !has_visible_worktrees,
-            |element| {
-                element.child(
-                    div()
-                        .ml_3()
-                        .p_2()
-                        .rounded_md()
-                        .bg(PANEL_BG)
-                        .text_sm()
-                        .text_color(TEXT_MUTED)
-                        .child("No visible worktrees. Show archived worktrees to view archived entries."),
-                )
-            },
-        )
-        .children(
-            repository
-                .worktrees
-                .iter()
-                .filter(|worktree| repository.show_archived || !worktree.archived)
-                .map(|worktree| {
-                    render_worktree_row(
-                        repository,
-                        worktree,
-                        selected_worktree,
-                        sidebar_menu,
-                        on_select_worktree.clone(),
-                        on_open_sidebar_menu.clone(),
-                        on_sidebar_menu_action.clone(),
-                        on_close_sidebar_menu.clone(),
-                    )
-                }),
-        )
 }
 
 #[allow(clippy::too_many_arguments)]
 fn render_worktree_row(
-    repository: &RepositoryNode,
-    worktree: &WorktreeNode,
-    selected_worktree: Option<&SelectedWorktree>,
-    sidebar_menu: Option<&SidebarMenuState>,
+    repo_id: String,
+    path: PathBuf,
+    label: String,
+    selected: bool,
+    archived: bool,
+    kind: WorktreeKind,
+    repository: RepositoryNode,
+    worktree: WorktreeNode,
+    menu_state: SidebarMenuState,
     on_select_worktree: impl Fn(String, PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
-    on_open_sidebar_menu: impl Fn(SidebarMenuState, &mut Window, &mut App) + Clone + 'static,
-    on_sidebar_menu_action: impl Fn(ActionId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
-    on_close_sidebar_menu: impl Fn(&ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_sidebar_menu_action: impl Fn(SidebarMenuState, ActionId, &ClickEvent, &mut Window, &mut App)
+    + Clone
+    + 'static,
 ) -> impl IntoElement {
-    let label = worktree.branch.clone().unwrap_or_else(|| {
-        worktree
-            .path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .map(ToString::to_string)
-            .unwrap_or_else(|| worktree.path.display().to_string())
-    });
-    let is_main = worktree.kind == WorktreeKind::Main;
-    let repo_id = repository.id.clone();
-    let worktree_path = worktree.path.clone();
-    let menu_state = SidebarMenuState {
-        repo_id: repo_id.clone(),
-        worktree_path: Some(worktree_path.clone()),
-        scope: ActionScope::Worktree,
+    let repo_id_for_click = repo_id.clone();
+    let path_for_click = path.clone();
+    let on_click = move |event: &ClickEvent, window: &mut Window, cx: &mut App| {
+        if event.is_right_click() {
+            return;
+        }
+        on_select_worktree(
+            repo_id_for_click.clone(),
+            path_for_click.clone(),
+            event,
+            window,
+            cx,
+        );
     };
-    let menu_is_open = sidebar_menu == Some(&menu_state);
-    let is_selected = selected_worktree
-        .is_some_and(|selected| selected.repo_id == repo_id && selected.path == worktree_path);
-    let is_subdued = worktree.archived || repository.unavailable;
-    let row_id = SharedString::from(format!(
-        "select-worktree-{repo_id}-{}",
-        worktree_path.display()
-    ));
 
-    div()
-        .flex()
-        .flex_col()
-        .gap_1()
-        .child(
-            div()
-                .ml_3()
-                .px_2()
-                .py_1()
-                .rounded_md()
-                .border_1()
-                .border_color(if is_selected { ACCENT } else { SIDEBAR_BG })
-                .id(row_id)
-                .text_sm()
-                .text_color(if is_subdued { TEXT_MUTED } else { TEXT })
-                .bg(if is_selected { PANEL_BG } else { SIDEBAR_BG })
-                .flex()
-                .items_center()
-                .justify_between()
-                .gap_2()
-                .on_mouse_down(MouseButton::Right, {
-                    let on_open_sidebar_menu = on_open_sidebar_menu.clone();
-                    let menu_state = menu_state.clone();
-                    move |event, window, cx| {
-                        cx.stop_propagation();
-                        if event.button == MouseButton::Right {
-                            on_open_sidebar_menu(menu_state.clone(), window, cx);
-                        }
-                    }
-                })
-                .on_click({
-                    let on_select_worktree = on_select_worktree.clone();
-                    let repo_id = repo_id.clone();
-                    let worktree_path = worktree_path.clone();
-                    move |event, window, cx| {
-                        if event.is_right_click() {
-                            return;
-                        }
-                        on_select_worktree(
-                            repo_id.clone(),
-                            worktree_path.clone(),
-                            event,
-                            window,
-                            cx,
-                        );
-                    }
-                })
-                .child(
-                    div()
-                        .flex()
-                        .items_center()
-                        .gap_2()
-                        .overflow_hidden()
-                        .child(div().truncate().child(label))
-                        .when(worktree.archived, |element| {
-                            element.child(status_badge("Archived"))
-                        })
-                        .child(status_badge(if is_main { "Main" } else { "Linked" })),
-                )
-                .child(
-                    div()
-                        .flex()
-                        .items_center()
-                        .justify_end()
-                        .gap_2()
-                        .child(
-                            div()
-                                .w(px(44.0))
-                                .text_xs()
-                                .text_color(TEXT_MUTED)
-                                .child(" "),
-                        )
-                        .child(overflow_button(
-                            SharedString::from(format!(
-                                "worktree-actions-{repo_id}-{}",
-                                worktree_path.display()
-                            )),
-                            menu_state.clone(),
-                            on_open_sidebar_menu.clone(),
-                        )),
-                ),
-        )
-        .when(menu_is_open, |element| {
-            element.child(render_sidebar_menu(
-                repository,
-                Some(worktree),
-                on_sidebar_menu_action.clone(),
-                on_close_sidebar_menu.clone(),
-            ))
+    let is_main = kind == WorktreeKind::Main;
+
+    let repo_id_for_button = repo_id.clone();
+    let path_for_button = path.clone();
+    let repository_for_suffix = repository.clone();
+    let worktree_for_suffix = worktree.clone();
+    let menu_state_for_suffix = menu_state.clone();
+    let on_action_for_suffix = on_sidebar_menu_action.clone();
+
+    let repository_for_context = repository.clone();
+    let worktree_for_context = worktree.clone();
+    let menu_state_for_context = menu_state.clone();
+    let on_action_for_context = on_sidebar_menu_action.clone();
+
+    ListItem::new(SharedString::from(format!(
+        "worktree-row-{repo_id}-{}",
+        path.display()
+    )))
+    .selected(selected)
+    .on_click(on_click)
+    .child(
+        div()
+            .flex()
+            .items_center()
+            .gap_2()
+            .pl_4()
+            .child(div().truncate().child(label))
+            .when(archived, |el| el.child(status_badge("Archived")))
+            .child(status_badge(if is_main { "Main" } else { "Linked" })),
+    )
+    .suffix(move |_window: &mut Window, _cx: &mut App| {
+        let repository = repository_for_suffix.clone();
+        let worktree = worktree_for_suffix.clone();
+        let menu_state = menu_state_for_suffix.clone();
+        let on_sidebar_menu_action = on_action_for_suffix.clone();
+        Button::new(SharedString::from(format!(
+            "worktree-actions-{repo_id_for_button}-{}",
+            path_for_button.display()
+        )))
+        .ghost()
+        .compact()
+        .icon(IconName::Ellipsis)
+        .on_click(|_event, _window, cx| {
+            cx.stop_propagation();
         })
+        .dropdown_menu(move |menu, _window, _cx| {
+            build_sidebar_popup_menu(
+                menu,
+                repository.clone(),
+                Some(worktree.clone()),
+                menu_state.clone(),
+                on_sidebar_menu_action.clone(),
+            )
+        })
+        .into_any_element()
+    })
+    .context_menu(move |menu, _window, _cx| {
+        build_sidebar_popup_menu(
+            menu,
+            repository_for_context.clone(),
+            Some(worktree_for_context.clone()),
+            menu_state_for_context.clone(),
+            on_action_for_context.clone(),
+        )
+    })
 }
 
-fn render_sidebar_menu(
-    repository: &RepositoryNode,
-    worktree: Option<&WorktreeNode>,
-    on_sidebar_menu_action: impl Fn(ActionId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
-    on_close_sidebar_menu: impl Fn(&ClickEvent, &mut Window, &mut App) + Clone + 'static,
-) -> impl IntoElement {
+fn build_sidebar_popup_menu(
+    mut menu: PopupMenu,
+    repository: RepositoryNode,
+    worktree: Option<WorktreeNode>,
+    menu_state: SidebarMenuState,
+    on_sidebar_menu_action: impl Fn(SidebarMenuState, ActionId, &ClickEvent, &mut Window, &mut App)
+    + Clone
+    + 'static,
+) -> PopupMenu {
     let registry = ActionRegistry::default();
     let scope = if worktree.is_some() {
         ActionScope::Worktree
     } else {
         ActionScope::Repository
     };
-    let actions = registry
+
+    for action in registry
         .actions()
         .iter()
         .filter(|action| action.scope == scope)
-        .filter(|action| action_is_available(action, repository, worktree))
-        .cloned()
-        .collect::<Vec<_>>();
+        .filter(|action| action_is_available(action, &repository, worktree.as_ref()))
+    {
+        let action_id = action.id;
+        let label = sidebar_action_label(action, &repository);
+        let _destructive = action.destructive;
+        let menu_state = menu_state.clone();
+        let on_sidebar_menu_action = on_sidebar_menu_action.clone();
 
-    div()
-        .ml_3()
-        .mr_1()
-        .p_1()
-        .rounded_md()
-        .border_1()
-        .border_color(PANEL_BORDER)
-        .bg(PANEL_BG)
-        .flex()
-        .flex_col()
-        .gap_1()
-        .child(
-            div()
-                .flex()
-                .items_center()
-                .justify_between()
-                .px_2()
-                .py_1()
-                .child(
-                    div()
-                        .text_xs()
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .text_color(TEXT_MUTED)
-                        .child(if scope == ActionScope::Repository {
-                            "Repository actions"
-                        } else {
-                            "Worktree actions"
-                        }),
-                )
-                .child(
-                    Button::new("close-sidebar-menu")
-                        .xsmall()
-                        .ghost()
-                        .label("×")
-                        .text_color(TEXT_MUTED)
-                        .on_click(move |event, window, cx| {
-                            cx.stop_propagation();
-                            on_close_sidebar_menu(event, window, cx);
-                        }),
-                ),
-        )
-        .children(actions.into_iter().map(move |action| {
-            let on_sidebar_menu_action = on_sidebar_menu_action.clone();
-            let action_id = action.id;
-            menu_action_row(
-                SharedString::from(format!("sidebar-action-{action_id:?}")),
-                sidebar_action_label(&action, repository),
-                action.destructive,
-                action_id,
-                on_sidebar_menu_action,
-            )
-        }))
+        menu = menu.item(
+            PopupMenuItem::new(label).on_click(move |event, window, cx| {
+                on_sidebar_menu_action(menu_state.clone(), action_id, event, window, cx);
+            }),
+        );
+    }
+
+    menu
 }
 
 fn action_is_available(
@@ -481,41 +424,6 @@ fn sidebar_action_label(action: &ActionDefinition, repository: &RepositoryNode) 
         ActionId::ToggleArchivedWorktrees => "Show archived".into(),
         _ => action.label.into(),
     }
-}
-
-fn overflow_button(
-    id: SharedString,
-    menu_state: SidebarMenuState,
-    on_open_sidebar_menu: impl Fn(SidebarMenuState, &mut Window, &mut App) + Clone + 'static,
-) -> impl IntoElement {
-    Button::new(id)
-        .xsmall()
-        .ghost()
-        .compact()
-        .label("⋯")
-        .text_color(TEXT_MUTED)
-        .on_click(move |_event, window, cx| {
-            cx.stop_propagation();
-            on_open_sidebar_menu(menu_state.clone(), window, cx);
-        })
-}
-
-fn menu_action_row(
-    id: SharedString,
-    label: SharedString,
-    destructive: bool,
-    action_id: ActionId,
-    on_sidebar_menu_action: impl Fn(ActionId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
-) -> impl IntoElement {
-    Button::new(id)
-        .small()
-        .ghost()
-        .label(label)
-        .text_color(if destructive { DANGER } else { TEXT })
-        .on_click(move |event, window, cx| {
-            cx.stop_propagation();
-            on_sidebar_menu_action(action_id, event, window, cx);
-        })
 }
 
 fn status_badge(label: &'static str) -> impl IntoElement {

--- a/src/ui/terminal_canvas.rs
+++ b/src/ui/terminal_canvas.rs
@@ -3,7 +3,7 @@ use crate::{
         GhosttyCellStyle, GhosttyRenderFrame, TerminalColor, TerminalCursorShape, TerminalMetrics,
         background_runs_with_defaults, effective_background, text_runs,
     },
-    ui::terminal_view::TERMINAL_FONT_FAMILY,
+    ui::terminal_view::{TERMINAL_CANVAS_HORIZONTAL_PADDING_PX, TERMINAL_FONT_FAMILY},
 };
 use gpui::{
     App, Bounds, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, LayoutId,
@@ -274,7 +274,7 @@ fn paint_terminal_rect(
     window.paint_quad(fill(
         Bounds::new(
             point(
-                bounds.origin.x + px(col as f32 * metrics.cell_width_px),
+                terminal_paint_x_origin(bounds.origin.x, col, metrics),
                 bounds.origin.y + px(row as f32 * metrics.cell_height_px),
             ),
             size(
@@ -304,7 +304,7 @@ fn paint_terminal_text_run(
     }
 
     let text_origin = point(
-        bounds.origin.x + px(col as f32 * metrics.cell_width_px),
+        terminal_paint_x_origin(bounds.origin.x, col, metrics),
         bounds.origin.y + px(row as f32 * metrics.cell_height_px),
     );
     let foreground = effective_foreground(&style, default_foreground, default_background);
@@ -354,7 +354,7 @@ fn paint_terminal_cursor(
     color: TerminalColor,
 ) {
     let origin = point(
-        bounds.origin.x + px(col as f32 * metrics.cell_width_px),
+        terminal_paint_x_origin(bounds.origin.x, col, metrics),
         bounds.origin.y + px(row as f32 * metrics.cell_height_px),
     );
     let cell_width = px(metrics.cell_width_px);
@@ -413,6 +413,10 @@ fn paint_cursor_cell_text(
         frame.default_foreground,
         frame.default_background,
     );
+}
+
+fn terminal_paint_x_origin(origin_x: Pixels, col: usize, metrics: TerminalMetrics) -> Pixels {
+    origin_x + px(col as f32 * metrics.cell_width_px + TERMINAL_CANVAS_HORIZONTAL_PADDING_PX)
 }
 
 fn effective_foreground(

--- a/src/ui/terminal_pane.rs
+++ b/src/ui/terminal_pane.rs
@@ -7,7 +7,7 @@ use crate::{
             CELL_HEIGHT_PX, TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE_PX,
             render_terminal_bounds_probe,
         },
-        theme::{DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
+        theme::{DANGER, PANEL_BG, PANEL_BORDER, TERMINAL_BG, TEXT, TEXT_MUTED},
     },
 };
 use gpui::{
@@ -42,7 +42,7 @@ pub fn render_terminal_pane(
         .flex()
         .flex_1()
         .size_full()
-        .bg(PANEL_BG)
+        .bg(TERMINAL_BG)
         .text_color(TEXT)
         .on_click(on_focus)
         .on_scroll_wheel(on_scroll)
@@ -70,75 +70,61 @@ pub fn render_terminal_pane(
         .when(
             selected_worktree.is_some() && terminal_error.is_none(),
             |element| {
-                element
-                    .flex_col()
-                    .p_3()
-                    .gap_2()
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .justify_between()
-                            .text_xs()
-                            .text_color(TEXT_MUTED)
-                            .child(format!(
-                                "Worktree: {}",
-                                selected_worktree
-                                    .expect("checked selected worktree")
-                                    .path
-                                    .display()
-                            ))
-                            .when(terminal_exited(terminal_status), |element| {
-                                let status = terminal_exit_status(terminal_status)
-                                    .map(|status| status.to_string())
-                                    .unwrap_or_else(|| "unknown".to_string());
-                                element.child(
-                                    div()
-                                        .flex()
-                                        .items_center()
-                                        .gap_2()
-                                        .child(format!("Exited: {status}"))
-                                        .child(
-                                            Button::new("restart-terminal")
-                                                .small()
-                                                .primary()
-                                                .compact()
-                                                .label("Restart")
-                                                .on_click(on_restart),
-                                        ),
-                                )
-                            }),
-                    )
-                    .when(terminal_exited(terminal_status), |element| {
-                        element.child(
+                element.flex_col().child(
+                    div()
+                        .flex_1()
+                        .overflow_hidden()
+                        .relative()
+                        .on_any_mouse_down(on_mouse_down)
+                        .capture_any_mouse_up(on_mouse_up)
+                        .on_mouse_move(on_mouse_move)
+                        .child(render_terminal_body(terminal_frame, terminal_metrics))
+                        .child(
                             div()
-                                .px_3()
-                                .py_2()
-                                .rounded_md()
-                                .border_1()
-                                .border_color(PANEL_BORDER)
-                                .bg(PANEL_BG)
-                                .text_xs()
-                                .text_color(TEXT_MUTED)
-                                .child("Process exited; final screen is preserved."),
+                                .absolute()
+                                .size_full()
+                                .child(render_terminal_bounds_probe(on_body_bounds)),
                         )
-                    })
-                    .child(
-                        div()
-                            .flex_1()
-                            .overflow_hidden()
-                            .relative()
-                            .on_any_mouse_down(on_mouse_down)
-                            .capture_any_mouse_up(on_mouse_up)
-                            .on_mouse_move(on_mouse_move)
-                            .child(render_terminal_body(terminal_frame, terminal_metrics))
-                            .child(
+                        .when(terminal_exited(terminal_status), |element| {
+                            let status = terminal_exit_status(terminal_status)
+                                .map(|status| status.to_string())
+                                .unwrap_or_else(|| "unknown".to_string());
+                            element.child(
                                 div()
                                     .absolute()
-                                    .size_full()
-                                    .child(render_terminal_bounds_probe(on_body_bounds)),
-                            ),
-                    )
+                                    .bottom_0()
+                                    .left_0()
+                                    .right_0()
+                                    .flex()
+                                    .flex_col()
+                                    .px_3()
+                                    .py_2()
+                                    .bg(PANEL_BG)
+                                    .border_t_1()
+                                    .border_color(PANEL_BORDER)
+                                    .text_xs()
+                                    .text_color(TEXT_MUTED)
+                                    .child(
+                                        div()
+                                            .flex()
+                                            .items_center()
+                                            .justify_between()
+                                            .child(format!("Exited: {status}"))
+                                            .child(
+                                                Button::new("restart-terminal")
+                                                    .small()
+                                                    .primary()
+                                                    .compact()
+                                                    .label("Restart")
+                                                    .on_click(on_restart),
+                                            ),
+                                    )
+                                    .child(
+                                        div().child("Process exited; final screen is preserved."),
+                                    ),
+                            )
+                        }),
+                )
             },
         )
 }

--- a/src/ui/terminal_view.rs
+++ b/src/ui/terminal_view.rs
@@ -13,6 +13,11 @@ pub const TERMINAL_FONT_SIZE_PX: f32 = 14.0;
 pub const CELL_WIDTH_PX: f32 = 9.0;
 pub const CELL_HEIGHT_PX: f32 = 19.0;
 
+// Horizontal padding (left/right) inside the terminal canvas for visual breathing
+// room. Keep this value in sync with terminal mouse/size calculations so input
+// mapping stays aligned.
+pub const TERMINAL_CANVAS_HORIZONTAL_PADDING_PX: f32 = 8.0;
+
 type BoundsCallback = dyn Fn(Bounds<Pixels>, &mut App);
 
 pub fn terminal_size_from_pixels(width_px: f32, height_px: f32) -> TerminalSize {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -20,3 +20,7 @@ pub const ACCENT_TEXT: Rgba = rgb_const(0x0b1220);
 pub const ACTIVE_TAB_BG: Rgba = rgb_const(0x22313b);
 pub const DANGER: Rgba = rgb_const(0xff6b7a);
 pub const SUCCESS: Rgba = rgb_const(0x6ee08d);
+pub const TERMINAL_BG: Rgba = rgb_const(0x141518);
+pub const OVERLAY_BG: Rgba = rgb_const(0x25272d);
+pub const OVERLAY_BORDER: Rgba = rgb_const(0x444850);
+pub const SIDEBAR_SECTION_TEXT: Rgba = rgb_const(0x8f96a3);

--- a/src/ui/view_models.rs
+++ b/src/ui/view_models.rs
@@ -1,0 +1,257 @@
+use std::path::PathBuf;
+
+use crate::app::{InspectorPaneState, RepositoryNode, SelectedWorktree, TerminalTabStatus};
+use crate::git::WorktreeKind;
+use crate::project::FileTreeNode;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TreeExpansionKey {
+    Repository(String),
+    File(PathBuf),
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct TreeExpansionState {
+    expanded: std::collections::HashSet<TreeExpansionKey>,
+}
+
+impl TreeExpansionState {
+    pub fn is_expanded(&self, key: &TreeExpansionKey) -> bool {
+        self.expanded.contains(key)
+    }
+
+    pub fn set_expanded(&mut self, key: TreeExpansionKey, expanded: bool) {
+        if expanded {
+            self.expanded.insert(key);
+        } else {
+            self.expanded.remove(&key);
+        }
+    }
+
+    pub fn toggle(&mut self, key: TreeExpansionKey) {
+        if self.expanded.contains(&key) {
+            self.expanded.remove(&key);
+        } else {
+            self.expanded.insert(key);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepoTreeRow {
+    Repository {
+        id: String,
+        name: String,
+        unavailable: bool,
+        expanded: bool,
+    },
+    Worktree {
+        repo_id: String,
+        path: PathBuf,
+        label: String,
+        selected: bool,
+        archived: bool,
+        kind: WorktreeKind,
+    },
+}
+
+pub fn build_repo_tree_rows(
+    repos: &[RepositoryNode],
+    selected: Option<&SelectedWorktree>,
+    expansion: &TreeExpansionState,
+) -> Vec<RepoTreeRow> {
+    let mut rows = Vec::new();
+    for repo in repos {
+        let expanded = expansion.is_expanded(&TreeExpansionKey::Repository(repo.id.clone()));
+        rows.push(RepoTreeRow::Repository {
+            id: repo.id.clone(),
+            name: repo.name.clone(),
+            unavailable: repo.unavailable,
+            expanded,
+        });
+        if expanded {
+            for worktree in &repo.worktrees {
+                if !repo.show_archived && worktree.archived {
+                    continue;
+                }
+                let is_selected =
+                    selected.is_some_and(|s| s.repo_id == repo.id && s.path == worktree.path);
+                let label = worktree.branch.clone().unwrap_or_else(|| {
+                    worktree
+                        .path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| worktree.path.display().to_string())
+                });
+                rows.push(RepoTreeRow::Worktree {
+                    repo_id: repo.id.clone(),
+                    path: worktree.path.clone(),
+                    label,
+                    selected: is_selected,
+                    archived: worktree.archived,
+                    kind: worktree.kind.clone(),
+                });
+            }
+        }
+    }
+    rows
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InspectorTreeRow {
+    EmptyState,
+    Context {
+        branch_label: String,
+        changed_count: Option<usize>,
+    },
+    Section {
+        title: String,
+    },
+    Loading {
+        section: &'static str,
+    },
+    Error {
+        section: &'static str,
+        message: String,
+    },
+    ChangedFile {
+        status: String,
+        path: String,
+    },
+    Clean {
+        path: String,
+    },
+    File {
+        depth: usize,
+        name: String,
+        path: PathBuf,
+        is_dir: bool,
+        expanded: bool,
+    },
+    Truncated {
+        depth: usize,
+    },
+}
+
+pub fn build_inspector_tree_rows(
+    selected: Option<&SelectedWorktree>,
+    state: &InspectorPaneState,
+    file_expansion: &TreeExpansionState,
+) -> Vec<InspectorTreeRow> {
+    let mut rows = Vec::new();
+
+    if selected.is_none() {
+        rows.push(InspectorTreeRow::EmptyState);
+        return rows;
+    }
+
+    // Changes section
+    if let Some(ref changes) = state.changes {
+        let branch_label = changes
+            .branch
+            .clone()
+            .unwrap_or_else(|| "Detached HEAD".to_string());
+        let changed_count = Some(changes.changed_files.len());
+        rows.push(InspectorTreeRow::Context {
+            branch_label,
+            changed_count,
+        });
+        if changes.changed_files.is_empty() {
+            rows.push(InspectorTreeRow::Clean {
+                path: "No changes".to_string(),
+            });
+        } else {
+            for file in &changes.changed_files {
+                rows.push(InspectorTreeRow::ChangedFile {
+                    status: file.status.clone(),
+                    path: file.path.clone(),
+                });
+            }
+        }
+    } else if state.changes_error.is_some() {
+        rows.push(InspectorTreeRow::Error {
+            section: "Changes",
+            message: state.changes_error.clone().unwrap(),
+        });
+    } else {
+        rows.push(InspectorTreeRow::Loading { section: "Changes" });
+    }
+
+    // Files section
+    if let Some(ref files) = state.files {
+        rows.push(InspectorTreeRow::Section {
+            title: "Files".to_string(),
+        });
+        let start = rows.len();
+        flatten_file_tree(files, 0, file_expansion, &mut rows);
+        if rows.len() == start {
+            rows.push(InspectorTreeRow::Clean {
+                path: "No files found".to_string(),
+            });
+        }
+    } else if state.files_error.is_some() {
+        rows.push(InspectorTreeRow::Error {
+            section: "Files",
+            message: state.files_error.clone().unwrap(),
+        });
+    } else {
+        rows.push(InspectorTreeRow::Section {
+            title: "Files".to_string(),
+        });
+        rows.push(InspectorTreeRow::Loading { section: "Files" });
+    }
+
+    rows
+}
+
+fn flatten_file_tree(
+    node: &FileTreeNode,
+    depth: usize,
+    expansion: &TreeExpansionState,
+    rows: &mut Vec<InspectorTreeRow>,
+) {
+    // Root node is not shown; its children are at depth 0.
+    // If the root itself is truncated, surface that signal.
+    if depth > 0 {
+        let expanded =
+            node.is_dir && expansion.is_expanded(&TreeExpansionKey::File(node.path.clone()));
+        rows.push(InspectorTreeRow::File {
+            depth: depth - 1,
+            name: node.name.clone(),
+            path: node.path.clone(),
+            is_dir: node.is_dir,
+            expanded,
+        });
+        if node.truncated {
+            rows.push(InspectorTreeRow::Truncated { depth });
+        }
+        if expanded {
+            for child in &node.children {
+                flatten_file_tree(child, depth + 1, expansion, rows);
+            }
+        }
+    } else {
+        if node.truncated {
+            rows.push(InspectorTreeRow::Truncated { depth: 0 });
+        }
+        for child in &node.children {
+            flatten_file_tree(child, depth + 1, expansion, rows);
+        }
+    }
+}
+
+pub fn terminal_tab_overlay_visible(
+    hovered: bool,
+    terminal_focused: bool,
+    tab_count: usize,
+    status: Option<&TerminalTabStatus>,
+    terminal_error: bool,
+) -> bool {
+    hovered
+        || terminal_focused
+        || tab_count > 1
+        || terminal_error
+        || status
+            .is_some_and(|s| matches!(s, TerminalTabStatus::Exited(_) | TerminalTabStatus::Failed))
+}

--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -1,6 +1,6 @@
 use crate::{
     app::{TerminalTab, TerminalTabId, TerminalTabKind},
-    ui::theme::{ACCENT, APP_BG, PANEL_BG, PANEL_BORDER},
+    ui::theme::{ACCENT, OVERLAY_BG, OVERLAY_BORDER, TERMINAL_BG},
 };
 use gpui::{App, ClickEvent, IntoElement, ParentElement, Styled, Window, div, prelude::*};
 use gpui_component::{
@@ -12,34 +12,42 @@ use gpui_component::{
 pub fn render_workspace(
     tabs: &[TerminalTab],
     active_tab: Option<TerminalTabId>,
+    show_tabs: bool,
+    on_tabs_hover: impl Fn(&bool, &mut Window, &mut App) + 'static,
     on_select_tab: impl Fn(TerminalTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
     on_new_tab: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
     terminal_body: impl IntoElement,
 ) -> impl IntoElement {
     div()
         .id("workspace")
+        .relative()
         .flex()
         .flex_col()
         .flex_1()
         .size_full()
-        .p_3()
-        .bg(APP_BG)
+        .overflow_hidden()
+        .bg(TERMINAL_BG)
+        .on_hover(on_tabs_hover)
         .child(
             div()
-                .flex()
-                .flex_col()
-                .flex_1()
-                .overflow_hidden()
-                .rounded_lg()
-                .border_1()
-                .border_color(PANEL_BORDER)
-                .bg(PANEL_BG)
-                .child(render_tab_bar(tabs, active_tab, on_select_tab, on_new_tab))
-                .child(div().flex().flex_1().overflow_hidden().child(terminal_body)),
+                .absolute()
+                .top_0()
+                .right_0()
+                .bottom_0()
+                .left_0()
+                .child(terminal_body),
         )
+        .when(show_tabs, |element| {
+            element.child(render_tab_bar_overlay(
+                tabs,
+                active_tab,
+                on_select_tab,
+                on_new_tab,
+            ))
+        })
 }
 
-fn render_tab_bar(
+fn render_tab_bar_overlay(
     tabs: &[TerminalTab],
     active_tab: Option<TerminalTabId>,
     on_select_tab: impl Fn(TerminalTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
@@ -48,43 +56,53 @@ fn render_tab_bar(
     let selected_index = tabs.iter().position(|tab| Some(tab.id) == active_tab);
 
     div()
-        .id("workspace-tab-bar")
+        .id("workspace-tab-overlay")
+        .absolute()
+        .top_2()
+        .left_0()
+        .right_0()
         .flex()
-        .items_center()
-        .gap_1()
-        .px_2()
-        .py_2()
-        .border_b_1()
-        .border_color(PANEL_BORDER)
-        .bg(PANEL_BG)
+        .justify_center()
         .child(
-            TabBar::new("workspace-tabs")
-                .segmented()
-                .small()
-                .when_some(selected_index, |tab_bar, index| {
-                    tab_bar.selected_index(index)
-                })
-                .children(tabs.iter().map(move |tab| {
-                    let tab_id = tab.id;
-                    let label = tab.name.clone();
-                    let kind = tab.kind;
-                    let on_select_tab = on_select_tab.clone();
-
-                    Tab::new()
-                        .label(format!("{}{}", tab_kind_prefix(kind), label))
-                        .on_click(move |event, window, cx| {
-                            on_select_tab(tab_id, event, window, cx);
+            div()
+                .flex()
+                .items_center()
+                .gap_1()
+                .px_2()
+                .py_1()
+                .rounded_full()
+                .border_1()
+                .border_color(OVERLAY_BORDER)
+                .bg(OVERLAY_BG)
+                .child(
+                    TabBar::new("workspace-tabs")
+                        .segmented()
+                        .small()
+                        .when_some(selected_index, |tab_bar, index| {
+                            tab_bar.selected_index(index)
                         })
-                })),
-        )
-        .child(
-            Button::new("workspace-new-tab")
-                .small()
-                .outline()
-                .compact()
-                .label("+")
-                .text_color(ACCENT)
-                .on_click(on_new_tab),
+                        .children(tabs.iter().map(move |tab| {
+                            let tab_id = tab.id;
+                            let label = tab.name.clone();
+                            let kind = tab.kind;
+                            let on_select_tab = on_select_tab.clone();
+
+                            Tab::new()
+                                .label(format!("{}{}", tab_kind_prefix(kind), label))
+                                .on_click(move |event, window, cx| {
+                                    on_select_tab(tab_id, event, window, cx);
+                                })
+                        })),
+                )
+                .child(
+                    Button::new("workspace-new-tab")
+                        .small()
+                        .outline()
+                        .compact()
+                        .label("+")
+                        .text_color(ACCENT)
+                        .on_click(on_new_tab),
+                ),
         )
 }
 

--- a/tests/ui_view_model_tests.rs
+++ b/tests/ui_view_model_tests.rs
@@ -1,0 +1,299 @@
+use std::path::PathBuf;
+
+use alas::{
+    app::{InspectorPaneState, RepositoryNode, SelectedWorktree, TerminalTabStatus, WorktreeNode},
+    git::{ChangedFile, GitInspectorState, WorktreeKind},
+    project::FileTreeNode,
+    ui::view_models::{
+        InspectorTreeRow, RepoTreeRow, TreeExpansionKey, TreeExpansionState,
+        build_inspector_tree_rows, build_repo_tree_rows, terminal_tab_overlay_visible,
+    },
+};
+
+fn worktree(path: &str, branch: &str, archived: bool, kind: WorktreeKind) -> WorktreeNode {
+    WorktreeNode {
+        path: PathBuf::from(path),
+        branch: Some(branch.to_string()),
+        head: Some("abc123".to_string()),
+        kind,
+        archived,
+    }
+}
+
+#[test]
+fn expansion_state_tracks_repository_and_file_keys() {
+    let repo_key = TreeExpansionKey::Repository("repo-1".to_string());
+    let file_key = TreeExpansionKey::File(PathBuf::from("/repo/src"));
+    let mut state = TreeExpansionState::default();
+
+    assert!(!state.is_expanded(&repo_key));
+    state.set_expanded(repo_key.clone(), true);
+    state.toggle(file_key.clone());
+
+    assert!(state.is_expanded(&repo_key));
+    assert!(state.is_expanded(&file_key));
+
+    state.toggle(file_key.clone());
+    assert!(!state.is_expanded(&file_key));
+}
+
+#[test]
+fn repo_tree_rows_filter_archived_worktrees_and_mark_selection() {
+    let mut expansion = TreeExpansionState::default();
+    expansion.set_expanded(TreeExpansionKey::Repository("repo-1".to_string()), true);
+
+    let repos = vec![RepositoryNode {
+        id: "repo-1".to_string(),
+        name: "alas".to_string(),
+        path: PathBuf::from("/repo"),
+        worktrees: vec![
+            worktree("/repo", "main", false, WorktreeKind::Main),
+            worktree("/repo/old", "old", true, WorktreeKind::Linked),
+        ],
+        show_archived: false,
+        unavailable: false,
+    }];
+    let selected = SelectedWorktree {
+        repo_id: "repo-1".to_string(),
+        path: PathBuf::from("/repo"),
+    };
+
+    let rows = build_repo_tree_rows(&repos, Some(&selected), &expansion);
+
+    assert_eq!(
+        rows,
+        vec![
+            RepoTreeRow::Repository {
+                id: "repo-1".to_string(),
+                name: "alas".to_string(),
+                unavailable: false,
+                expanded: true,
+            },
+            RepoTreeRow::Worktree {
+                repo_id: "repo-1".to_string(),
+                path: PathBuf::from("/repo"),
+                label: "main".to_string(),
+                selected: true,
+                archived: false,
+                kind: WorktreeKind::Main,
+            },
+        ]
+    );
+}
+
+#[test]
+fn grouped_inspector_rows_keep_file_and_git_errors_independent() {
+    let selected = SelectedWorktree {
+        repo_id: "repo-1".to_string(),
+        path: PathBuf::from("/repo"),
+    };
+    let mut state = InspectorPaneState::default();
+    state.set_files_error("files down");
+    state.set_changes(GitInspectorState {
+        branch: Some("main".to_string()),
+        changed_files: vec![ChangedFile {
+            status: "M".to_string(),
+            path: "src/ui/shell.rs".to_string(),
+        }],
+        recent_commits: Vec::new(),
+    });
+
+    let file_expansion = TreeExpansionState::default();
+    let rows = build_inspector_tree_rows(Some(&selected), &state, &file_expansion);
+
+    assert!(rows.contains(&InspectorTreeRow::Context {
+        branch_label: "main".to_string(),
+        changed_count: Some(1),
+    }));
+    assert!(rows.contains(&InspectorTreeRow::ChangedFile {
+        status: "M".to_string(),
+        path: "src/ui/shell.rs".to_string(),
+    }));
+    assert!(rows.contains(&InspectorTreeRow::Error {
+        section: "Files",
+        message: "files down".to_string(),
+    }));
+}
+
+#[test]
+fn grouped_inspector_rows_flatten_file_tree_with_truncation() {
+    let selected = SelectedWorktree {
+        repo_id: "repo-1".to_string(),
+        path: PathBuf::from("/repo"),
+    };
+    let mut state = InspectorPaneState::default();
+    state.set_changes(GitInspectorState {
+        branch: None,
+        changed_files: Vec::new(),
+        recent_commits: Vec::new(),
+    });
+    state.set_files(FileTreeNode {
+        name: "repo".to_string(),
+        path: PathBuf::from("/repo"),
+        is_dir: true,
+        truncated: false,
+        children: vec![FileTreeNode {
+            name: "src".to_string(),
+            path: PathBuf::from("/repo/src"),
+            is_dir: true,
+            truncated: true,
+            children: vec![FileTreeNode {
+                name: "main.rs".to_string(),
+                path: PathBuf::from("/repo/src/main.rs"),
+                is_dir: false,
+                children: Vec::new(),
+                truncated: false,
+            }],
+        }],
+    });
+
+    let mut file_expansion = TreeExpansionState::default();
+    file_expansion.set_expanded(TreeExpansionKey::File(PathBuf::from("/repo/src")), true);
+    let rows = build_inspector_tree_rows(Some(&selected), &state, &file_expansion);
+
+    assert!(rows.contains(&InspectorTreeRow::Context {
+        branch_label: "Detached HEAD".to_string(),
+        changed_count: Some(0),
+    }));
+    assert!(rows.contains(&InspectorTreeRow::File {
+        depth: 0,
+        name: "src".to_string(),
+        path: PathBuf::from("/repo/src"),
+        is_dir: true,
+        expanded: true,
+    }));
+    assert!(rows.contains(&InspectorTreeRow::File {
+        depth: 1,
+        name: "main.rs".to_string(),
+        path: PathBuf::from("/repo/src/main.rs"),
+        is_dir: false,
+        expanded: false,
+    }));
+    assert!(rows.contains(&InspectorTreeRow::Truncated { depth: 1 }));
+}
+
+#[test]
+fn terminal_tab_overlay_visibility_matches_design() {
+    assert!(!terminal_tab_overlay_visible(false, false, 1, None, false));
+    assert!(terminal_tab_overlay_visible(true, false, 1, None, false));
+    assert!(terminal_tab_overlay_visible(false, true, 1, None, false));
+    assert!(terminal_tab_overlay_visible(false, false, 2, None, false));
+    assert!(terminal_tab_overlay_visible(
+        false,
+        false,
+        1,
+        Some(&TerminalTabStatus::Exited(Some(1))),
+        false,
+    ));
+    assert!(terminal_tab_overlay_visible(
+        false,
+        false,
+        1,
+        Some(&TerminalTabStatus::Failed),
+        false,
+    ));
+    assert!(terminal_tab_overlay_visible(false, false, 1, None, true));
+}
+
+#[test]
+fn grouped_inspector_rows_emit_loading_when_data_is_pending() {
+    let selected = SelectedWorktree {
+        repo_id: "repo-1".to_string(),
+        path: PathBuf::from("/repo"),
+    };
+    let state = InspectorPaneState::default();
+    let file_expansion = TreeExpansionState::default();
+    let rows = build_inspector_tree_rows(Some(&selected), &state, &file_expansion);
+
+    // When changes and files are still None (and no error yet),
+    // loading rows should be emitted instead of blank sections.
+    assert!(
+        rows.contains(&InspectorTreeRow::Loading { section: "Changes" }),
+        "expected Loading row for pending Changes section"
+    );
+    assert!(
+        rows.iter()
+            .any(|r| matches!(r, InspectorTreeRow::Section { title } if title == "Files")),
+        "expected Section header for Files"
+    );
+    assert!(
+        rows.contains(&InspectorTreeRow::Loading { section: "Files" }),
+        "expected Loading row for pending Files section"
+    );
+}
+
+#[test]
+fn grouped_inspector_rows_show_empty_state_when_files_are_empty() {
+    let selected = SelectedWorktree {
+        repo_id: "repo-1".to_string(),
+        path: PathBuf::from("/repo"),
+    };
+    let mut state = InspectorPaneState::default();
+    state.set_changes(GitInspectorState {
+        branch: Some("main".to_string()),
+        changed_files: Vec::new(),
+        recent_commits: Vec::new(),
+    });
+    state.set_files(FileTreeNode {
+        name: "repo".to_string(),
+        path: PathBuf::from("/repo"),
+        is_dir: true,
+        truncated: false,
+        children: Vec::new(),
+    });
+
+    let file_expansion = TreeExpansionState::default();
+    let rows = build_inspector_tree_rows(Some(&selected), &state, &file_expansion);
+
+    // When the file tree is loaded but has no visible children,
+    // an empty-state row should appear.
+    assert!(
+        rows.contains(&InspectorTreeRow::Clean {
+            path: "No files found".to_string(),
+        }),
+        "expected empty-state row for files when root has no children"
+    );
+}
+
+#[test]
+fn grouped_inspector_rows_preserve_root_truncation() {
+    let selected = SelectedWorktree {
+        repo_id: "repo-1".to_string(),
+        path: PathBuf::from("/repo"),
+    };
+    let mut state = InspectorPaneState::default();
+    state.set_changes(GitInspectorState {
+        branch: Some("main".to_string()),
+        changed_files: Vec::new(),
+        recent_commits: Vec::new(),
+    });
+    state.set_files(FileTreeNode {
+        name: "repo".to_string(),
+        path: PathBuf::from("/repo"),
+        is_dir: true,
+        truncated: true,
+        children: vec![FileTreeNode {
+            name: "src".to_string(),
+            path: PathBuf::from("/repo/src"),
+            is_dir: true,
+            truncated: false,
+            children: vec![FileTreeNode {
+                name: "main.rs".to_string(),
+                path: PathBuf::from("/repo/src/main.rs"),
+                is_dir: false,
+                truncated: false,
+                children: Vec::new(),
+            }],
+        }],
+    });
+
+    let file_expansion = TreeExpansionState::default();
+    let rows = build_inspector_tree_rows(Some(&selected), &state, &file_expansion);
+
+    // When the root node is truncated, a Truncated row at depth 0
+    // should appear even though the root itself is not displayed.
+    assert!(
+        rows.contains(&InspectorTreeRow::Truncated { depth: 0 }),
+        "expected Truncated row for root-level truncation"
+    );
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
Part of stack `ui-overhaul`

Commit: bc07823
<!-- gg:managed:end -->

## Summary
Implemented the terminal UI overhaul as a cohesive three-column shell redesign:

- macOS-first window framing with transparent titlebar treatment and top-left safe-area handling.
- Left repository/worktree sidebar using expandable tree rows with action menus.
- Center flush terminal workspace with hover-only tab overlay (no persistent chrome card).
- Right inspector rebuilt as a single grouped Files/Changes tree with directory expand/collapse.
- Keystroke/input handling fixes (including `Tab`) so terminal input stays focused in terminal UI.
- Added subtle horizontal terminal content padding for better visual spacing without altering vertical spacing.

## Key changes

### 1) Window chrome and shell layout
- Added `src/ui/chrome.rs` with dedicated macOS window options.
- Moved terminal/titlebar composition to the shell root.
- Refactored `src/ui/shell.rs` to compose the root as three direct columns:
  - Left: sidebar
  - Center: command picker / dialogs + terminal workspace
  - Right: project inspector
- Removed the old always-on bottom status bar.

### 2) Sidebar and repo/worktree navigation
- Reworked sidebar rendering with reusable row tree state in `src/ui/view_models.rs`.
- Added repository/worktree expansion state handling and popup/overflow actions.
- Added contextual action menus and icon-only add-repository control.

### 3) Grouped inspector tree
- Replaced old fixed tabs in `src/ui/inspector.rs` with grouped sections (Changed / Files).
- Added file-tree row expansion state and flattening renderer.

### 4) Terminal UX and behavior fixes
- Kept terminal surface flush with overlay tab bar in `src/ui/workspace.rs` and `src/ui/terminal_pane.rs`.
- Fixed focus handling so pressing `Tab` in terminal remains terminal input in TUI programs.
- Added terminal horizontal padding constant (`TERMINAL_CANVAS_HORIZONTAL_PADDING_PX`) in `src/ui/terminal_view.rs`, applied in paint + hit-testing so cursor/mouse mapping stays aligned.

### 5) Validation
- Added `tests/ui_view_model_tests.rs` for new tree/overlay behavior.
- Updated `docs/manual-test.md` with revised UI-overhaul checks.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --all-features`
- `cargo test --all-features`

All tests are passing in this branch.

## Notes
- This branch is intentionally organized as a single final squash commit on this stack head: `4ede2c6`.