### PR TITLE
feat: use macOS window material for sidebar background

### DIFF
--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -32,6 +32,25 @@
 17. Create or modify a file and confirm the Changed section updates independently of the Files section.
 18. Confirm the old full-width bottom status bar is gone.
 
+## macOS Window Material
+
+1. On macOS, set a colorful desktop wallpaper or place a colorful window (e.g.
+   Finder showing a vivid background) where Alas's sidebar will sit.
+2. Start Alas with `cargo run`.
+3. Confirm the left sidebar is visibly translucent: the wallpaper / window
+   behind Alas shows through as a soft blurred wash.
+4. Confirm the titlebar drag region (the strip above the sidebar/terminal
+   reserved by `mac_titlebar_safe_area_height_px`) also shows the blurred
+   material around the traffic-light buttons.
+5. Confirm the terminal canvas remains fully opaque — text legibility is
+   unchanged from the prior build.
+6. Confirm the floating tab overlay pill (when terminal tabs are visible)
+   remains fully opaque.
+7. Drag a colorful window behind Alas across the desktop and verify the blur
+   under the sidebar updates in real time.
+8. On Linux, repeat steps (2)–(7) and confirm the sidebar and root are fully
+   opaque (no behavior change vs. the prior build).
+
 ## Desktop Packaging and Lifecycle
 
 ### macOS `.app`

--- a/src/ui/chrome.rs
+++ b/src/ui/chrome.rs
@@ -1,4 +1,4 @@
-use gpui::{IntoElement, WindowOptions, div, prelude::*, px};
+use gpui::{IntoElement, Window, WindowBackgroundAppearance, WindowOptions, div, prelude::*, px};
 
 pub const TRAFFIC_LIGHT_LEFT_PX: f32 = 20.0;
 pub const TRAFFIC_LIGHT_TOP_PX: f32 = 20.0;
@@ -41,6 +41,18 @@ pub fn render_mac_titlebar_safe_area_spacer() -> impl IntoElement {
         .h(px(mac_titlebar_safe_area_height_px()))
 }
 
+pub fn macos_window_background_appearance() -> WindowBackgroundAppearance {
+    if cfg!(target_os = "macos") {
+        WindowBackgroundAppearance::Blurred
+    } else {
+        WindowBackgroundAppearance::Opaque
+    }
+}
+
+pub fn apply_window_background_appearance(window: &Window) {
+    window.set_background_appearance(macos_window_background_appearance());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -61,5 +73,23 @@ mod tests {
         let options = alas_window_options();
         let titlebar = options.titlebar.expect("default titlebar options");
         assert!(!titlebar.appears_transparent);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn macos_window_uses_blurred_background_appearance() {
+        assert_eq!(
+            macos_window_background_appearance(),
+            gpui::WindowBackgroundAppearance::Blurred,
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn non_macos_window_uses_opaque_background_appearance() {
+        assert_eq!(
+            macos_window_background_appearance(),
+            gpui::WindowBackgroundAppearance::Opaque,
+        );
     }
 }

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -24,7 +24,7 @@ use crate::{
         },
     },
     ui::{
-        chrome::alas_window_options,
+        chrome::{alas_window_options, apply_window_background_appearance},
         command_picker::render_command_picker,
         dialogs::{
             AddRepositoryDialogState, CommandSettingsDialogState, ConfirmPruneWorktreesDialog,
@@ -38,7 +38,7 @@ use crate::{
         terminal_view::{
             TERMINAL_CANVAS_HORIZONTAL_PADDING_PX, TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE_PX,
         },
-        theme::{APP_BG, TEXT},
+        theme::{TEXT, root_background},
         view_models::TreeExpansionState,
         workspace::render_workspace,
     },
@@ -2178,7 +2178,10 @@ impl Render for AlasShell {
             .relative()
             .flex()
             .size_full()
-            .bg(APP_BG)
+            // On macOS the root is intentionally unpainted so the window's
+            // NSVisualEffectView material shows through anywhere a child
+            // does not paint its own background.
+            .when_some(root_background(), |element, color| element.bg(color))
             .text_color(TEXT)
             .child(render_sidebar(
                 self.model.repositories(),
@@ -2500,6 +2503,7 @@ pub fn run() -> anyhow::Result<()> {
         gpui_component::init(cx);
 
         cx.open_window(alas_window_options(), |window, cx| {
+            apply_window_background_appearance(window);
             let shell = cx.new(AlasShell::new);
             let weak_shell = shell.downgrade();
             window.on_window_should_close(cx, move |_window, cx| {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -8,7 +8,7 @@ use crate::{
     git::WorktreeKind,
     ui::{
         chrome::render_mac_titlebar_safe_area_spacer,
-        theme::{DANGER, PANEL_BG, PANEL_BORDER, SIDEBAR_BG, TEXT, TEXT_MUTED},
+        theme::{DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED, sidebar_background},
         view_models::{RepoTreeRow, TreeExpansionState, build_repo_tree_rows},
     },
 };
@@ -56,7 +56,7 @@ pub fn render_sidebar(
         .gap_3()
         .border_r_1()
         .border_color(PANEL_BORDER)
-        .bg(SIDEBAR_BG)
+        .bg(sidebar_background())
         .text_color(TEXT)
         .child(render_mac_titlebar_safe_area_spacer())
         .child(

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -9,8 +9,18 @@ const fn rgb_const(hex: u32) -> Rgba {
     }
 }
 
+const fn rgba_const(hex: u32, alpha: f32) -> Rgba {
+    Rgba {
+        r: ((hex >> 16) & 0xff) as f32 / 255.0,
+        g: ((hex >> 8) & 0xff) as f32 / 255.0,
+        b: (hex & 0xff) as f32 / 255.0,
+        a: alpha,
+    }
+}
+
 pub const APP_BG: Rgba = rgb_const(0x202124);
 pub const SIDEBAR_BG: Rgba = rgb_const(0x27282b);
+pub const SIDEBAR_BG_TRANSLUCENT: Rgba = rgba_const(0x27282b, 0.70);
 pub const PANEL_BG: Rgba = rgb_const(0x1e1f22);
 pub const PANEL_BORDER: Rgba = rgb_const(0x34363a);
 pub const TEXT: Rgba = rgb_const(0xe8eaed);
@@ -24,3 +34,70 @@ pub const TERMINAL_BG: Rgba = rgb_const(0x141518);
 pub const OVERLAY_BG: Rgba = rgb_const(0x25272d);
 pub const OVERLAY_BORDER: Rgba = rgb_const(0x444850);
 pub const SIDEBAR_SECTION_TEXT: Rgba = rgb_const(0x8f96a3);
+
+pub fn sidebar_background() -> Rgba {
+    if cfg!(target_os = "macos") {
+        SIDEBAR_BG_TRANSLUCENT
+    } else {
+        SIDEBAR_BG
+    }
+}
+
+pub fn root_background() -> Option<Rgba> {
+    if cfg!(target_os = "macos") {
+        None
+    } else {
+        Some(APP_BG)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rgba_const_decomposes_hex_and_uses_provided_alpha() {
+        let color = rgba_const(0x27282b, 0.7);
+        assert!((color.r - (0x27 as f32 / 255.0)).abs() < f32::EPSILON);
+        assert!((color.g - (0x28 as f32 / 255.0)).abs() < f32::EPSILON);
+        assert!((color.b - (0x2b as f32 / 255.0)).abs() < f32::EPSILON);
+        assert!((color.a - 0.7).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn sidebar_bg_translucent_uses_70_percent_alpha() {
+        assert!((SIDEBAR_BG_TRANSLUCENT.a - 0.7).abs() < f32::EPSILON);
+        assert!((SIDEBAR_BG_TRANSLUCENT.r - SIDEBAR_BG.r).abs() < f32::EPSILON);
+        assert!((SIDEBAR_BG_TRANSLUCENT.g - SIDEBAR_BG.g).abs() < f32::EPSILON);
+        assert!((SIDEBAR_BG_TRANSLUCENT.b - SIDEBAR_BG.b).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn sidebar_background_is_translucent_on_macos() {
+        let bg = sidebar_background();
+        assert!((bg.a - 0.7).abs() < f32::EPSILON);
+        assert!((bg.r - SIDEBAR_BG.r).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn sidebar_background_is_opaque_off_macos() {
+        let bg = sidebar_background();
+        assert!((bg.a - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn root_background_is_none_on_macos() {
+        assert!(root_background().is_none());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn root_background_is_app_bg_off_macos() {
+        let bg = root_background().expect("root_background should be Some off macOS");
+        assert!((bg.a - 1.0).abs() < f32::EPSILON);
+        assert!((bg.r - APP_BG.r).abs() < f32::EPSILON);
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
On macOS, switch the GPUI window to WindowBackgroundAppearance::Blurred so
NSVisualEffectView shows under the content view, drop the opaque root fill,
and tint the sidebar at 70% alpha so the material shows through. Terminal
canvas, the floating tab pill, panels, and dialogs stay opaque.

- theme: add rgba_const helper and SIDEBAR_BG_TRANSLUCENT constant
- theme: add platform-aware sidebar_background() / root_background() accessors
- chrome: add macos_window_background_appearance() and apply_window_background_appearance()
- shell: apply window background appearance after open_window
- shell: switch root paint to when_some(root_background(), ...)
- sidebar: route .bg() through sidebar_background()
- docs: add macOS Window Material section to manual-test.md

Linux and Windows behavior is unchanged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
<!-- gg:managed:end -->