### PR TITLE
Add syntax-highlighted source viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,9 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
+ "tree-sitter-highlight",
+ "tree-sitter-json",
+ "tree-sitter-rust",
 ]
 
 [[package]]
@@ -6247,6 +6250,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-highlight"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc5f880ad8d8f94e88cb81c3557024cf1a8b75e3b504c50481ed4f5a6006ff3"
+dependencies = [
+ "regex",
+ "streaming-iterator",
+ "thiserror 2.0.18",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-json"
 version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6261,6 +6276,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "triomphe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ gpui-component = "0.5.1"
 # Alas keeps this behind src/terminal/ghostty_adapter.rs. If the project adds
 # higher-level PTY/process crates, add them here without changing TerminalBackend.
 libghostty-vt = { version = "0.1", optional = true }
+tree-sitter-highlight = "0.25.10"
+tree-sitter-rust = "0.24.2"
+tree-sitter-json = "0.24.8"
 
 [features]
 default = ["ghostty-vt"]

--- a/src/app/file_loader.rs
+++ b/src/app/file_loader.rs
@@ -1,17 +1,29 @@
-use std::{fs, path::Path};
+use std::{fs, io::Read, path::Path};
 
 pub const MAX_TEXT_FILE_BYTES: u64 = 2 * 1024 * 1024;
+const BINARY_SAMPLE_BYTES: usize = 8 * 1024;
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum FileLoadError {
     #[error("path is a directory")]
     Directory,
+    #[error("path is not a regular file")]
+    NotRegularFile,
     #[error("file is too large ({size} bytes, max {max} bytes)")]
     TooLarge { size: u64, max: u64 },
+    #[error("binary files cannot be previewed")]
+    Binary,
     #[error("file is not valid UTF-8")]
     InvalidUtf8,
     #[error("failed to read file: {0}")]
     Read(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedSourceFile {
+    pub text: String,
+    pub size_bytes: u64,
+    pub line_count: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -33,10 +45,17 @@ impl FileLoader {
     }
 
     pub fn load_text(&self, path: &Path) -> Result<String, FileLoadError> {
+        self.load_source_file(path).map(|file| file.text)
+    }
+
+    pub fn load_source_file(&self, path: &Path) -> Result<LoadedSourceFile, FileLoadError> {
         let metadata =
             fs::metadata(path).map_err(|error| FileLoadError::Read(error.to_string()))?;
         if metadata.is_dir() {
             return Err(FileLoadError::Directory);
+        }
+        if !metadata.is_file() {
+            return Err(FileLoadError::NotRegularFile);
         }
         if metadata.len() > self.max_bytes {
             return Err(FileLoadError::TooLarge {
@@ -45,7 +64,29 @@ impl FileLoader {
             });
         }
 
+        reject_binary_sample(path)?;
         let bytes = fs::read(path).map_err(|error| FileLoadError::Read(error.to_string()))?;
-        String::from_utf8(bytes).map_err(|_| FileLoadError::InvalidUtf8)
+        let text = String::from_utf8(bytes).map_err(|_| FileLoadError::InvalidUtf8)?;
+        let line_count = text.lines().count().max(1);
+
+        Ok(LoadedSourceFile {
+            text,
+            size_bytes: metadata.len(),
+            line_count,
+        })
     }
+}
+
+fn reject_binary_sample(path: &Path) -> Result<(), FileLoadError> {
+    let mut file = fs::File::open(path).map_err(|error| FileLoadError::Read(error.to_string()))?;
+    let mut buffer = [0_u8; BINARY_SAMPLE_BYTES];
+    let read = file
+        .read(&mut buffer)
+        .map_err(|error| FileLoadError::Read(error.to_string()))?;
+
+    if buffer[..read].contains(&0) {
+        return Err(FileLoadError::Binary);
+    }
+
+    Ok(())
 }

--- a/src/app/language.rs
+++ b/src/app/language.rs
@@ -1,0 +1,76 @@
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DetectedLanguage {
+    Rust,
+    TypeScript,
+    JavaScript,
+    Json,
+    Toml,
+    Yaml,
+    Python,
+    Markdown,
+    Shell,
+    Css,
+    Html,
+    PlainText,
+    Unknown,
+}
+
+impl DetectedLanguage {
+    pub fn label(self) -> &'static str {
+        match self {
+            DetectedLanguage::Rust => "Rust",
+            DetectedLanguage::TypeScript => "TypeScript",
+            DetectedLanguage::JavaScript => "JavaScript",
+            DetectedLanguage::Json => "JSON",
+            DetectedLanguage::Toml => "TOML",
+            DetectedLanguage::Yaml => "YAML",
+            DetectedLanguage::Python => "Python",
+            DetectedLanguage::Markdown => "Markdown",
+            DetectedLanguage::Shell => "Shell",
+            DetectedLanguage::Css => "CSS",
+            DetectedLanguage::Html => "HTML",
+            DetectedLanguage::PlainText => "Plain Text",
+            DetectedLanguage::Unknown => "Plain Text",
+        }
+    }
+}
+
+pub fn detect_language(path: &Path) -> DetectedLanguage {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    let lower_name = file_name.to_ascii_lowercase();
+
+    match lower_name.as_str() {
+        "cargo.toml" => return DetectedLanguage::Toml,
+        "package.json" | "tsconfig.json" => return DetectedLanguage::Json,
+        "dockerfile" => return DetectedLanguage::Shell,
+        "makefile" | ".gitignore" | ".dockerignore" => return DetectedLanguage::PlainText,
+        _ => {}
+    }
+
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("rs") => DetectedLanguage::Rust,
+        Some("ts" | "tsx" | "mts" | "cts") => DetectedLanguage::TypeScript,
+        Some("js" | "jsx" | "mjs" | "cjs") => DetectedLanguage::JavaScript,
+        Some("json" | "jsonc") => DetectedLanguage::Json,
+        Some("toml") => DetectedLanguage::Toml,
+        Some("yaml" | "yml") => DetectedLanguage::Yaml,
+        Some("py" | "pyw") => DetectedLanguage::Python,
+        Some("md" | "markdown") => DetectedLanguage::Markdown,
+        Some("sh" | "bash" | "zsh" | "fish") => DetectedLanguage::Shell,
+        Some("css") => DetectedLanguage::Css,
+        Some("html" | "htm") => DetectedLanguage::Html,
+        Some("txt" | "text" | "log") => DetectedLanguage::PlainText,
+        Some(_) => DetectedLanguage::Unknown,
+        None => DetectedLanguage::Unknown,
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,16 +2,23 @@ pub mod action_registry;
 pub mod actions;
 pub mod file_loader;
 pub mod inspector_state;
+pub mod language;
 pub mod model;
+pub mod syntax;
 pub mod workspace;
 
 pub use action_registry::{
     ActionAvailability, ActionDefinition, ActionHandlerId, ActionId, ActionRegistry, ActionScope,
 };
 pub use actions::AppAction;
-pub use file_loader::{FileLoadError, FileLoader};
+pub use file_loader::{FileLoadError, FileLoader, LoadedSourceFile};
 pub use inspector_state::{InspectorPaneState, InspectorTab};
+pub use language::{DetectedLanguage, detect_language};
 pub use model::{AlasModel, RepositoryNode, SelectedWorktree, WorktreeNode};
+pub use syntax::{
+    HighlightError, HighlightedLine, HighlightedSource, HighlightedSpan, SourceTokenStyle,
+    highlight_source,
+};
 pub use workspace::WorkspaceTabId as TerminalTabId;
 pub use workspace::{
     FILE_TAB_MAX_BYTES, FileTabLoadState, FileTabState, MarkdownTabState, MarkdownViewMode,

--- a/src/app/syntax.rs
+++ b/src/app/syntax.rs
@@ -1,0 +1,221 @@
+use std::borrow::Cow;
+
+use crate::app::DetectedLanguage;
+use tree_sitter_highlight::{
+    Error as TreeSitterError, Highlight, HighlightConfiguration, HighlightEvent, Highlighter,
+};
+
+const HIGHLIGHT_NAMES: &[&str] = &[
+    "attribute",
+    "comment",
+    "constant",
+    "constant.builtin",
+    "constructor",
+    "function",
+    "function.builtin",
+    "keyword",
+    "number",
+    "operator",
+    "property",
+    "punctuation",
+    "punctuation.bracket",
+    "punctuation.delimiter",
+    "string",
+    "string.special",
+    "type",
+    "type.builtin",
+    "variable",
+    "variable.builtin",
+    "variable.parameter",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HighlightedSource {
+    pub lines: Vec<HighlightedLine>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HighlightedLine {
+    pub spans: Vec<HighlightedSpan>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HighlightedSpan {
+    pub text: String,
+    pub style: SourceTokenStyle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceTokenStyle {
+    Plain,
+    Keyword,
+    String,
+    Number,
+    Comment,
+    Function,
+    Type,
+    Property,
+    Punctuation,
+    Constant,
+    Variable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum HighlightError {
+    #[error("syntax highlighting is unavailable for {0}")]
+    Unsupported(&'static str),
+    #[error("syntax highlighting failed: {0}")]
+    Failed(String),
+}
+
+pub fn highlight_source(
+    text: &str,
+    language: DetectedLanguage,
+) -> Result<HighlightedSource, HighlightError> {
+    let Some(mut config) = highlight_config(language)? else {
+        return Err(HighlightError::Unsupported(language.label()));
+    };
+    config.configure(HIGHLIGHT_NAMES);
+
+    let text = normalize_line_endings(text);
+    let text = text.as_ref();
+
+    let mut highlighter = Highlighter::new();
+    let events = highlighter
+        .highlight(&config, text.as_bytes(), None, |_| None)
+        .map_err(highlight_error)?;
+
+    let mut active_style = SourceTokenStyle::Plain;
+    let mut stack = Vec::new();
+    let mut spans = Vec::new();
+
+    for event in events {
+        match event.map_err(highlight_error)? {
+            HighlightEvent::Source { start, end } => {
+                if start < end {
+                    push_text_span(&mut spans, &text[start..end], active_style);
+                }
+            }
+            HighlightEvent::HighlightStart(highlight) => {
+                stack.push(active_style);
+                active_style = style_for_highlight(highlight);
+            }
+            HighlightEvent::HighlightEnd => {
+                active_style = stack.pop().unwrap_or(SourceTokenStyle::Plain);
+            }
+        }
+    }
+
+    Ok(split_spans_into_lines(spans))
+}
+
+fn normalize_line_endings(text: &str) -> Cow<'_, str> {
+    if text.contains("\r\n") {
+        Cow::Owned(text.replace("\r\n", "\n"))
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
+fn highlight_config(
+    language: DetectedLanguage,
+) -> Result<Option<HighlightConfiguration>, HighlightError> {
+    match language {
+        DetectedLanguage::Rust => HighlightConfiguration::new(
+            tree_sitter_rust::LANGUAGE.into(),
+            "rust",
+            tree_sitter_rust::HIGHLIGHTS_QUERY,
+            tree_sitter_rust::INJECTIONS_QUERY,
+            "",
+        )
+        .map(Some)
+        .map_err(|error| HighlightError::Failed(error.to_string())),
+        DetectedLanguage::Json => HighlightConfiguration::new(
+            tree_sitter_json::LANGUAGE.into(),
+            "json",
+            tree_sitter_json::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        )
+        .map(Some)
+        .map_err(|error| HighlightError::Failed(error.to_string())),
+        DetectedLanguage::TypeScript
+        | DetectedLanguage::JavaScript
+        | DetectedLanguage::Toml
+        | DetectedLanguage::Yaml
+        | DetectedLanguage::Python
+        | DetectedLanguage::Markdown
+        | DetectedLanguage::Shell
+        | DetectedLanguage::Css
+        | DetectedLanguage::Html
+        | DetectedLanguage::PlainText
+        | DetectedLanguage::Unknown => Ok(None),
+    }
+}
+
+fn style_for_highlight(highlight: Highlight) -> SourceTokenStyle {
+    let name = HIGHLIGHT_NAMES
+        .get(highlight.0)
+        .copied()
+        .unwrap_or_default();
+
+    match name {
+        "keyword" | "operator" => SourceTokenStyle::Keyword,
+        "string" | "string.special" => SourceTokenStyle::String,
+        "number" => SourceTokenStyle::Number,
+        "comment" => SourceTokenStyle::Comment,
+        "function" | "function.builtin" | "constructor" => SourceTokenStyle::Function,
+        "type" | "type.builtin" => SourceTokenStyle::Type,
+        "property" => SourceTokenStyle::Property,
+        "punctuation" | "punctuation.bracket" | "punctuation.delimiter" => {
+            SourceTokenStyle::Punctuation
+        }
+        "constant" | "constant.builtin" => SourceTokenStyle::Constant,
+        "variable" | "variable.builtin" | "variable.parameter" => SourceTokenStyle::Variable,
+        _ => SourceTokenStyle::Plain,
+    }
+}
+
+fn push_text_span(spans: &mut Vec<HighlightedSpan>, text: &str, style: SourceTokenStyle) {
+    if text.is_empty() {
+        return;
+    }
+    if let Some(last) = spans.last_mut()
+        && last.style == style
+    {
+        last.text.push_str(text);
+        return;
+    }
+    spans.push(HighlightedSpan {
+        text: text.to_string(),
+        style,
+    });
+}
+
+fn split_spans_into_lines(spans: Vec<HighlightedSpan>) -> HighlightedSource {
+    let mut lines = vec![HighlightedLine { spans: Vec::new() }];
+
+    for span in spans {
+        for (index, part) in span.text.split('\n').enumerate() {
+            if index > 0 {
+                lines.push(HighlightedLine { spans: Vec::new() });
+            }
+            if !part.is_empty() {
+                lines
+                    .last_mut()
+                    .expect("at least one line")
+                    .spans
+                    .push(HighlightedSpan {
+                        text: part.to_string(),
+                        style: span.style,
+                    });
+            }
+        }
+    }
+
+    HighlightedSource { lines }
+}
+
+fn highlight_error(error: TreeSitterError) -> HighlightError {
+    HighlightError::Failed(error.to_string())
+}

--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use crate::app::{DetectedLanguage, HighlightedSource, detect_language};
 use crate::terminal::{CommandSpec, TerminalBackendSession};
 
-pub const FILE_TAB_MAX_BYTES: u64 = 1_048_576;
+pub const FILE_TAB_MAX_BYTES: u64 = 2 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WorkspaceTabId(pub u64);
@@ -39,8 +40,16 @@ pub enum TerminalTabStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FileTabLoadState {
     Loading,
-    Loaded { content: String },
-    Error { message: String },
+    Loaded {
+        content: String,
+        size_bytes: u64,
+        line_count: usize,
+        highlight: Option<HighlightedSource>,
+        highlight_error: Option<String>,
+    },
+    Error {
+        message: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -71,6 +80,7 @@ pub struct TerminalTabState {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileTabState {
     pub file_path: PathBuf,
+    pub language: DetectedLanguage,
     pub load_state: FileTabLoadState,
 }
 
@@ -239,6 +249,7 @@ impl WorkspaceSession {
             .unwrap_or_else(|| file_path.display().to_string());
 
         let file = FileTabState {
+            language: detect_language(&file_path),
             file_path,
             load_state: FileTabLoadState::Loading,
         };

--- a/src/ui/file_pane.rs
+++ b/src/ui/file_pane.rs
@@ -24,7 +24,7 @@ fn render_file_content(load_state: &FileTabLoadState) -> AnyElement {
             .text_color(TEXT_MUTED)
             .child("Loading file…")
             .into_any_element(),
-        FileTabLoadState::Loaded { content } => div()
+        FileTabLoadState::Loaded { content, .. } => div()
             .id("file-pane-content")
             .flex()
             .flex_1()

--- a/src/ui/markdown_pane.rs
+++ b/src/ui/markdown_pane.rs
@@ -33,10 +33,10 @@ pub fn render_markdown_pane(
             | (FileTabLoadState::Loaded { .. }, MarkdownViewMode::Code) => {
                 render_source_viewer(&tab.file)
             }
-            (FileTabLoadState::Loaded { content }, MarkdownViewMode::Preview) => {
+            (FileTabLoadState::Loaded { content, .. }, MarkdownViewMode::Preview) => {
                 render_preview(content)
             }
-            (FileTabLoadState::Loaded { content }, MarkdownViewMode::Split) => div()
+            (FileTabLoadState::Loaded { content, .. }, MarkdownViewMode::Split) => div()
                 .flex()
                 .flex_1()
                 .min_h(px(0.0))

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -5,9 +5,9 @@ use std::{
 
 use crate::{
     app::{
-        ActionId, AlasModel, FILE_TAB_MAX_BYTES, FileTabLoadState, InspectorPaneState,
+        ActionId, AlasModel, FileLoader, FileTabLoadState, HighlightError, InspectorPaneState,
         MarkdownViewMode, RepositoryNode, TerminalTabKind, TerminalTabStatus, WorkspaceSession,
-        WorkspaceTabContent, WorkspaceTabId, WorkspaceTabKind,
+        WorkspaceTabContent, WorkspaceTabId, WorkspaceTabKind, highlight_source,
     },
     config::{
         AppConfig, AppConfigStore, AppRepository, CommandEntry, RepoConfigStore,
@@ -32,10 +32,10 @@ use crate::{
             ConfirmRemoveRepositoryDialog, ConfirmRemoveWorktreeDialog, CreateWorktreeDialogState,
             CreateWorktreeField,
         },
-        file_pane::render_file_pane,
         inspector::render_project_inspector,
         markdown_pane::render_markdown_pane,
         sidebar::{SidebarMenuState, render_sidebar},
+        source_viewer::render_source_viewer,
         terminal_canvas::measure_terminal_metrics,
         terminal_pane::render_terminal_pane,
         terminal_view::{
@@ -1332,30 +1332,30 @@ impl AlasShell {
                 return Err("file is outside the selected worktree".to_string());
             }
 
-            let metadata = std::fs::metadata(&file_path)
-                .map_err(|error| format!("failed to read file metadata: {error}"))?;
+            let loaded = FileLoader::default()
+                .load_source_file(&file_path)
+                .map_err(|error| error.to_string())?;
+            let language = crate::app::detect_language(&file_path);
+            let (highlight, highlight_error) = match highlight_source(&loaded.text, language) {
+                Ok(highlight) => (Some(highlight), None),
+                Err(HighlightError::Unsupported(_)) => (None, None),
+                Err(error) => (None, Some(error.to_string())),
+            };
 
-            if !metadata.is_file() {
-                return Err("path is not a regular file".to_string());
-            }
-            if metadata.len() > FILE_TAB_MAX_BYTES {
-                return Err(format!(
-                    "file is too large ({} bytes, max {FILE_TAB_MAX_BYTES})",
-                    metadata.len()
-                ));
-            }
-
-            let content = std::fs::read_to_string(&file_path)
-                .map_err(|error| format!("failed to read file: {error}"))?;
-
-            Ok(content)
+            Ok(FileTabLoadState::Loaded {
+                content: loaded.text,
+                size_bytes: loaded.size_bytes,
+                line_count: loaded.line_count,
+                highlight,
+                highlight_error,
+            })
         });
 
         cx.spawn(async move |this, cx| {
             let result = task.await;
             this.update(cx, |shell, cx| {
                 let load_state = match result {
-                    Ok(content) => FileTabLoadState::Loaded { content },
+                    Ok(load_state) => load_state,
                     Err(message) => FileTabLoadState::Error { message },
                 };
                 let _ = shell
@@ -2498,9 +2498,7 @@ impl Render for AlasShell {
         let selected_worktree = self.model.selected_worktree();
         let terminal_state = active_tab.and_then(|t| t.terminal_tab_state());
         let workspace_body = match active_tab.map(|tab| &tab.content) {
-            Some(WorkspaceTabContent::File(state)) => {
-                render_file_pane(&state.load_state).into_any_element()
-            }
+            Some(WorkspaceTabContent::File(state)) => render_source_viewer(state),
             Some(WorkspaceTabContent::Markdown(state)) => render_markdown_pane(
                 active_tab
                     .map(|tab| tab.id)

--- a/src/ui/source_viewer.rs
+++ b/src/ui/source_viewer.rs
@@ -1,8 +1,13 @@
 use crate::{
-    app::{FileTabLoadState, FileTabState},
-    ui::theme::{DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
+    app::{FileTabLoadState, FileTabState, HighlightedLine, SourceTokenStyle},
+    ui::{
+        terminal_view::{CELL_HEIGHT_PX, TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE_PX},
+        theme::{DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
+    },
 };
-use gpui::{AnyElement, IntoElement, ParentElement, SharedString, Styled, div, prelude::*, px};
+use gpui::{
+    AnyElement, IntoElement, ParentElement, Rgba, SharedString, Styled, div, prelude::*, px, rgb,
+};
 
 pub fn render_source_viewer(file: &FileTabState) -> AnyElement {
     div()
@@ -35,21 +40,60 @@ pub fn render_source_viewer(file: &FileTabState) -> AnyElement {
         .when(
             matches!(file.load_state, FileTabLoadState::Loaded { .. }),
             |element| {
-                let FileTabLoadState::Loaded { content } = &file.load_state else {
+                let FileTabLoadState::Loaded {
+                    content,
+                    size_bytes,
+                    line_count,
+                    highlight,
+                    highlight_error,
+                } = &file.load_state
+                else {
                     return element;
                 };
                 element
                     .child(
                         div()
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .gap_3()
                             .px_3()
                             .py_2()
                             .border_b_1()
                             .border_color(PANEL_BORDER)
                             .text_xs()
                             .text_color(TEXT_MUTED)
-                            .child(SharedString::from(file.file_path.display().to_string())),
+                            .child(
+                                div().truncate().child(SharedString::from(
+                                    file.file_path.display().to_string(),
+                                )),
+                            )
+                            .child(SharedString::from(format!(
+                                "{} • {} lines • {}",
+                                file.language.label(),
+                                line_count,
+                                format_bytes(*size_bytes)
+                            ))),
                     )
-                    .child(render_source_lines(content))
+                    .when(highlight_error.is_some(), |element| {
+                        element.child(
+                            div()
+                                .px_3()
+                                .py_1()
+                                .border_b_1()
+                                .border_color(PANEL_BORDER)
+                                .text_xs()
+                                .text_color(TEXT_MUTED)
+                                .child(SharedString::from(
+                                    highlight_error.clone().unwrap_or_default(),
+                                )),
+                        )
+                    })
+                    .child(render_source_lines(
+                        content,
+                        *line_count,
+                        highlight.as_ref(),
+                    ))
             },
         )
         .when(
@@ -67,7 +111,15 @@ pub fn render_source_viewer(file: &FileTabState) -> AnyElement {
         .into_any_element()
 }
 
-fn render_source_lines(content: &str) -> impl IntoElement {
+fn render_source_lines(
+    content: &str,
+    line_count: usize,
+    highlighted: Option<&crate::app::HighlightedSource>,
+) -> impl IntoElement {
+    let gutter_width = ((line_count.max(1).ilog10() + 1) as f32 * 9.0 + 24.0).max(48.0);
+    let plain_lines: Vec<&str> = content.lines().collect();
+    let visual_line_count = line_count.max(plain_lines.len()).max(1);
+
     div()
         .id("source-viewer-lines")
         .flex()
@@ -77,26 +129,95 @@ fn render_source_lines(content: &str) -> impl IntoElement {
         .overflow_scroll()
         .p_3()
         .gap_0()
-        .children(content.lines().enumerate().map(|(index, line)| {
+        .font_family(TERMINAL_FONT_FAMILY)
+        .text_size(px(TERMINAL_FONT_SIZE_PX))
+        .line_height(px(CELL_HEIGHT_PX))
+        .children((0..visual_line_count).map(move |index| {
+            let plain_line = plain_lines.get(index).copied().unwrap_or_default();
+            let highlighted_line = highlighted.and_then(|source| source.lines.get(index));
+            render_source_line(index, gutter_width, plain_line, highlighted_line)
+        }))
+}
+
+fn render_source_line(
+    index: usize,
+    gutter_width: f32,
+    plain_line: &str,
+    highlighted_line: Option<&HighlightedLine>,
+) -> impl IntoElement {
+    div()
+        .flex()
+        .items_start()
+        .min_w(px(0.0))
+        .h(px(CELL_HEIGHT_PX))
+        .whitespace_nowrap()
+        .child(
+            div()
+                .w(px(gutter_width))
+                .flex_shrink_0()
+                .pr_3()
+                .text_color(TEXT_MUTED)
+                .child(format!("{}", index + 1)),
+        )
+        .child(
             div()
                 .flex()
-                .items_start()
-                .font_family("monospace")
-                .text_sm()
-                .line_height(px(20.0))
-                .child(
-                    div()
-                        .w(px(48.0))
-                        .flex_shrink_0()
-                        .pr_3()
-                        .text_color(TEXT_MUTED)
-                        .child(format!("{}", index + 1)),
-                )
-                .child(
-                    div()
-                        .flex_1()
-                        .text_color(TEXT)
-                        .child(SharedString::from(line.to_string())),
-                )
-        }))
+                .min_w(px(0.0))
+                .text_color(TEXT)
+                .children(render_code_spans(plain_line, highlighted_line)),
+        )
+}
+
+fn render_code_spans(
+    plain_line: &str,
+    highlighted_line: Option<&HighlightedLine>,
+) -> Vec<AnyElement> {
+    if let Some(line) = highlighted_line
+        && !line.spans.is_empty()
+    {
+        return line
+            .spans
+            .iter()
+            .map(|span| {
+                div()
+                    .text_color(token_color(span.style))
+                    .child(SharedString::from(span.text.clone()))
+                    .into_any_element()
+            })
+            .collect();
+    }
+
+    vec![
+        div()
+            .text_color(TEXT)
+            .child(SharedString::from(plain_line.to_string()))
+            .into_any_element(),
+    ]
+}
+
+fn token_color(style: SourceTokenStyle) -> Rgba {
+    match style {
+        SourceTokenStyle::Plain => TEXT,
+        SourceTokenStyle::Keyword => rgb(0xff7ab2),
+        SourceTokenStyle::String => rgb(0xa6da95),
+        SourceTokenStyle::Number | SourceTokenStyle::Constant => rgb(0xf5a97f),
+        SourceTokenStyle::Comment => TEXT_MUTED,
+        SourceTokenStyle::Function => rgb(0x8aadf4),
+        SourceTokenStyle::Type => rgb(0x7dc4e4),
+        SourceTokenStyle::Property | SourceTokenStyle::Variable => rgb(0xc6a0f6),
+        SourceTokenStyle::Punctuation => rgb(0xcad3f5),
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = 1024.0 * 1024.0;
+
+    if bytes >= 1024 * 1024 {
+        format!("{:.1} MiB", bytes as f64 / MIB)
+    } else if bytes >= 1024 {
+        format!("{:.1} KiB", bytes as f64 / KIB)
+    } else {
+        format!("{bytes} B")
+    }
 }

--- a/tests/file_loader_tests.rs
+++ b/tests/file_loader_tests.rs
@@ -6,11 +6,15 @@ use alas::app::{FileLoadError, FileLoader};
 fn loads_utf8_text_file() {
     let temp = tempfile::tempdir().expect("tempdir");
     let path = temp.path().join("notes.md");
-    fs::write(&path, "hello").expect("write file");
+    fs::write(&path, "hello\nworld").expect("write file");
 
-    let content = FileLoader::default().load_text(&path).expect("load text");
+    let loaded = FileLoader::default()
+        .load_source_file(&path)
+        .expect("load source file");
 
-    assert_eq!(content, "hello");
+    assert_eq!(loaded.text, "hello\nworld");
+    assert_eq!(loaded.size_bytes, 11);
+    assert_eq!(loaded.line_count, 2);
 }
 
 #[test]
@@ -22,6 +26,24 @@ fn rejects_directories() {
         .expect_err("directory should fail");
 
     assert_eq!(error, FileLoadError::Directory);
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_non_regular_files() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("pipe");
+    let status = std::process::Command::new("mkfifo")
+        .arg(&path)
+        .status()
+        .expect("create fifo");
+    assert!(status.success());
+
+    let error = FileLoader::default()
+        .load_text(&path)
+        .expect_err("fifo should fail before reading");
+
+    assert_eq!(error, FileLoadError::NotRegularFile);
 }
 
 #[test]
@@ -48,6 +70,19 @@ fn rejects_non_utf8_files() {
         .expect_err("invalid UTF-8 should fail");
 
     assert_eq!(error, FileLoadError::InvalidUtf8);
+}
+
+#[test]
+fn rejects_binary_nul_sample() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let path = temp.path().join("binary.dat");
+    fs::write(&path, [b'a', 0, b'b']).expect("write file");
+
+    let error = FileLoader::default()
+        .load_text(&path)
+        .expect_err("NUL byte should fail");
+
+    assert_eq!(error, FileLoadError::Binary);
 }
 
 #[test]

--- a/tests/language_tests.rs
+++ b/tests/language_tests.rs
@@ -1,0 +1,41 @@
+use std::path::Path;
+
+use alas::app::{DetectedLanguage, detect_language};
+
+#[test]
+fn detects_common_source_extensions() {
+    let cases = [
+        ("src/main.rs", DetectedLanguage::Rust),
+        ("app.tsx", DetectedLanguage::TypeScript),
+        ("index.mjs", DetectedLanguage::JavaScript),
+        ("config.json", DetectedLanguage::Json),
+        ("pyproject.toml", DetectedLanguage::Toml),
+        ("workflow.yml", DetectedLanguage::Yaml),
+        ("script.py", DetectedLanguage::Python),
+        ("README.md", DetectedLanguage::Markdown),
+        ("install.sh", DetectedLanguage::Shell),
+        ("style.css", DetectedLanguage::Css),
+        ("index.html", DetectedLanguage::Html),
+        ("notes.txt", DetectedLanguage::PlainText),
+        ("unknown.xyz", DetectedLanguage::Unknown),
+    ];
+
+    for (path, language) in cases {
+        assert_eq!(detect_language(Path::new(path)), language, "{path}");
+    }
+}
+
+#[test]
+fn detects_special_filenames() {
+    let cases = [
+        ("Cargo.toml", DetectedLanguage::Toml),
+        ("package.json", DetectedLanguage::Json),
+        ("Dockerfile", DetectedLanguage::Shell),
+        ("Makefile", DetectedLanguage::PlainText),
+        (".gitignore", DetectedLanguage::PlainText),
+    ];
+
+    for (path, language) in cases {
+        assert_eq!(detect_language(Path::new(path)), language, "{path}");
+    }
+}

--- a/tests/syntax_tests.rs
+++ b/tests/syntax_tests.rs
@@ -1,0 +1,47 @@
+use alas::app::{DetectedLanguage, SourceTokenStyle, highlight_source};
+
+#[test]
+fn highlights_rust_source_with_tree_sitter() {
+    let highlighted = highlight_source(
+        "fn main() {\n    println!(\"hi\");\n}\n",
+        DetectedLanguage::Rust,
+    )
+    .expect("highlight rust");
+
+    assert!(
+        highlighted
+            .lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .any(|span| span.style == SourceTokenStyle::Keyword && span.text == "fn")
+    );
+    assert!(
+        highlighted
+            .lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .any(|span| span.style == SourceTokenStyle::String && span.text.contains("hi"))
+    );
+}
+
+#[test]
+fn unsupported_languages_fall_back_to_plain_text() {
+    let error = highlight_source("hello", DetectedLanguage::PlainText)
+        .expect_err("plain text has no highlighter");
+
+    assert!(error.to_string().contains("unavailable"));
+}
+
+#[test]
+fn highlighted_crlf_lines_do_not_render_carriage_returns() {
+    let highlighted =
+        highlight_source("fn main() {\r\n}\r\n", DetectedLanguage::Rust).expect("highlight rust");
+
+    assert!(
+        highlighted
+            .lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .all(|span| !span.text.contains('\r'))
+    );
+}

--- a/tests/workspace_session_tests.rs
+++ b/tests/workspace_session_tests.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
 use alas::app::{
-    FileTabLoadState, MarkdownViewMode, TerminalTabId, TerminalTabKind, TerminalTabStatus,
-    WorkspaceSession, WorkspaceTabContent, WorkspaceTabKind,
+    DetectedLanguage, FileTabLoadState, MarkdownViewMode, TerminalTabId, TerminalTabKind,
+    TerminalTabStatus, WorkspaceSession, WorkspaceTabContent, WorkspaceTabKind,
 };
 use alas::terminal::{CommandSpec, TerminalBackendSession};
 
@@ -478,6 +478,10 @@ fn file_tab_load_state_can_be_updated() {
             file,
             FileTabLoadState::Loaded {
                 content: "hello".to_string(),
+                size_bytes: 5,
+                line_count: 1,
+                highlight: None,
+                highlight_error: None,
             },
         )
         .expect("set file state");
@@ -486,7 +490,7 @@ fn file_tab_load_state_can_be_updated() {
     match &active.content {
         WorkspaceTabContent::File(state) => assert!(matches!(
             &state.load_state,
-            FileTabLoadState::Loaded { content } if content == "hello"
+            FileTabLoadState::Loaded { content, .. } if content == "hello"
         )),
         WorkspaceTabContent::Markdown(_) | WorkspaceTabContent::Terminal(_) => {
             panic!("expected file tab")
@@ -508,6 +512,7 @@ fn markdown_files_open_in_split_mode_by_default() {
     match &active.content {
         WorkspaceTabContent::Markdown(state) => {
             assert_eq!(state.view_mode, MarkdownViewMode::Split);
+            assert_eq!(state.file.language, DetectedLanguage::Markdown);
             assert!(matches!(state.file.load_state, FileTabLoadState::Loading));
         }
         WorkspaceTabContent::File(_) | WorkspaceTabContent::Terminal(_) => {


### PR DESCRIPTION
## Summary
- add guarded source file loading and language detection
- render read-only source tabs with monospace line gutter and plain-text fallback
- add tree-sitter highlighting for Rust and JSON

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --all-features
- cargo test --all-features