### PR TITLE
Add harness notification preferences

### DIFF
--- a/src/app/action_registry.rs
+++ b/src/app/action_registry.rs
@@ -10,6 +10,7 @@ pub enum ActionId {
     PruneWorktrees,
     ToggleArchivedWorktrees,
     CommandSettings,
+    NotificationPreferences,
     OpenPath,
     CopyPath,
 }
@@ -43,6 +44,7 @@ pub enum ActionHandlerId {
     PruneWorktrees,
     ToggleArchivedWorktrees,
     CommandSettings,
+    NotificationPreferences,
     OpenPath,
     CopyPath,
 }
@@ -154,6 +156,15 @@ impl Default for ActionRegistry {
                     scope: ActionScope::Repository,
                     availability: ActionAvailability::WhenRepositoryAvailable,
                     handler: ActionHandlerId::CommandSettings,
+                    destructive: false,
+                    requires_confirmation: false,
+                },
+                ActionDefinition {
+                    id: ActionId::NotificationPreferences,
+                    label: "Notification Preferences",
+                    scope: ActionScope::Global,
+                    availability: ActionAvailability::Always,
+                    handler: ActionHandlerId::NotificationPreferences,
                     destructive: false,
                     requires_confirmation: false,
                 },

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -8,6 +8,8 @@ pub struct AppConfig {
     pub repositories: Vec<AppRepository>,
     #[serde(default)]
     pub archived_worktrees: IndexMap<String, Vec<PathBuf>>,
+    #[serde(default)]
+    pub notifications: NotificationPrefs,
 }
 
 impl AppConfig {
@@ -23,6 +25,36 @@ impl AppConfig {
             paths.retain(|archived_path| archived_path != path);
         }
     }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct NotificationPrefs {
+    #[serde(default)]
+    pub harness_completion: HarnessCompletionNotificationPrefs,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct HarnessCompletionNotificationPrefs {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_true")]
+    pub success: bool,
+    #[serde(default = "default_true")]
+    pub failure: bool,
+}
+
+impl Default for HarnessCompletionNotificationPrefs {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            success: true,
+            failure: true,
+        }
+    }
+}
+
+const fn default_true() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 
 use crate::app::TerminalTabId;
+use crate::config::NotificationPrefs;
 use crate::terminal::HarnessKind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -20,6 +21,7 @@ pub enum HarnessCompletionSource {
 pub struct HookSignal {
     pub harness: HarnessKind,
     pub source: HarnessCompletionSource,
+    pub outcome: HarnessCompletionOutcome,
     pub terminal_tab_id: Option<TerminalTabId>,
 }
 
@@ -27,27 +29,120 @@ pub struct HookSignal {
 pub struct HarnessCompletionEvent {
     pub harness: HarnessKind,
     pub source: HarnessCompletionSource,
+    pub outcome: HarnessCompletionOutcome,
     pub terminal_tab_id: Option<TerminalTabId>,
     pub title: String,
     pub body: String,
 }
 
-pub trait NotificationService {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HookBackedHarness {
+    ClaudeCode,
+    Codex,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HarnessCompletionOutcome {
+    Success,
+    Failure,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HarnessNotificationSource {
+    HookBacked(HookBackedHarness),
+    Unsupported(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HarnessCompletionNotificationEvent {
+    pub source: HarnessNotificationSource,
+    pub outcome: HarnessCompletionOutcome,
+    pub title: String,
+    pub body: String,
+    pub repo_id: Option<String>,
+    pub worktree_path: Option<std::path::PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NotificationDecision {
+    Allowed,
+    Disabled,
+    SuccessDisabled,
+    FailureDisabled,
+    UnsupportedHarness,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NotificationService;
+
+impl NotificationService {
+    pub fn harness_completion_decision(
+        &self,
+        prefs: &NotificationPrefs,
+        event: &HarnessCompletionNotificationEvent,
+    ) -> NotificationDecision {
+        let completion_prefs = &prefs.harness_completion;
+        if !completion_prefs.enabled {
+            return NotificationDecision::Disabled;
+        }
+        if matches!(event.source, HarnessNotificationSource::Unsupported(_)) {
+            return NotificationDecision::UnsupportedHarness;
+        }
+
+        match event.outcome {
+            HarnessCompletionOutcome::Success if !completion_prefs.success => {
+                NotificationDecision::SuccessDisabled
+            }
+            HarnessCompletionOutcome::Failure if !completion_prefs.failure => {
+                NotificationDecision::FailureDisabled
+            }
+            HarnessCompletionOutcome::Success | HarnessCompletionOutcome::Failure => {
+                NotificationDecision::Allowed
+            }
+        }
+    }
+}
+
+pub trait NotificationSink {
     fn notify_harness_completed(&mut self, event: HarnessCompletionEvent) -> anyhow::Result<()>;
+}
+
+impl NotificationSink for NotificationService {
+    fn notify_harness_completed(&mut self, _event: HarnessCompletionEvent) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
 pub struct NotificationController<N> {
     notifier: N,
+    preferences: NotificationPrefs,
+    notification_service: NotificationService,
 }
 
 impl<N> NotificationController<N> {
     pub fn new(notifier: N) -> Self {
-        Self { notifier }
+        Self::new_with_preferences(notifier, NotificationPrefs::default())
+    }
+
+    pub fn new_with_preferences(notifier: N, preferences: NotificationPrefs) -> Self {
+        Self {
+            notifier,
+            preferences,
+            notification_service: NotificationService,
+        }
     }
 
     pub fn notifier(&self) -> &N {
         &self.notifier
+    }
+
+    pub fn preferences(&self) -> &NotificationPrefs {
+        &self.preferences
+    }
+
+    pub fn update_preferences(&mut self, preferences: NotificationPrefs) {
+        self.preferences = preferences;
     }
 
     pub fn into_notifier(self) -> N {
@@ -55,8 +150,17 @@ impl<N> NotificationController<N> {
     }
 }
 
-impl<N: NotificationService> NotificationController<N> {
+impl<N: NotificationSink> NotificationController<N> {
     pub fn handle_hook_signal(&mut self, signal: HookSignal) -> anyhow::Result<()> {
+        let notification_event = notification_event(&signal);
+        if self
+            .notification_service
+            .harness_completion_decision(&self.preferences, &notification_event)
+            != NotificationDecision::Allowed
+        {
+            return Ok(());
+        }
+
         self.notifier
             .notify_harness_completed(completion_event(signal))
     }
@@ -91,6 +195,7 @@ fn parse_claude_code_hook(payload: &Value) -> Option<HookSignal> {
     Some(HookSignal {
         harness: HarnessKind::ClaudeCode,
         source,
+        outcome: hook_outcome(payload)?,
         terminal_tab_id: terminal_tab_id(payload),
     })
 }
@@ -104,7 +209,47 @@ fn parse_codex_notify(payload: &Value) -> Option<HookSignal> {
     Some(HookSignal {
         harness: HarnessKind::Codex,
         source,
+        outcome: hook_outcome(payload)?,
         terminal_tab_id: terminal_tab_id(payload),
+    })
+}
+
+fn hook_outcome(payload: &Value) -> Option<HarnessCompletionOutcome> {
+    payload
+        .get("success")
+        .and_then(Value::as_bool)
+        .map(|success| {
+            if success {
+                HarnessCompletionOutcome::Success
+            } else {
+                HarnessCompletionOutcome::Failure
+            }
+        })
+        .or_else(|| string_outcome(payload.get("outcome").and_then(Value::as_str)))
+        .or_else(|| string_outcome(payload.get("status").and_then(Value::as_str)))
+        .or_else(|| exit_code_outcome(payload.get("exit_code").and_then(Value::as_i64)))
+        .or_else(|| exit_code_outcome(payload.get("code").and_then(Value::as_i64)))
+}
+
+fn string_outcome(value: Option<&str>) -> Option<HarnessCompletionOutcome> {
+    match value?.to_ascii_lowercase().as_str() {
+        "success" | "succeeded" | "ok" | "complete" | "completed" | "passed" => {
+            Some(HarnessCompletionOutcome::Success)
+        }
+        "failure" | "failed" | "error" | "errored" | "cancelled" | "canceled" => {
+            Some(HarnessCompletionOutcome::Failure)
+        }
+        _ => None,
+    }
+}
+
+fn exit_code_outcome(value: Option<i64>) -> Option<HarnessCompletionOutcome> {
+    value.map(|code| {
+        if code == 0 {
+            HarnessCompletionOutcome::Success
+        } else {
+            HarnessCompletionOutcome::Failure
+        }
     })
 }
 
@@ -120,9 +265,24 @@ fn completion_event(signal: HookSignal) -> HarnessCompletionEvent {
     HarnessCompletionEvent {
         harness: signal.harness,
         source: signal.source,
+        outcome: signal.outcome,
         terminal_tab_id: signal.terminal_tab_id,
         title: format!("{} completed", signal.harness.display_name()),
         body: completion_body(signal.source),
+    }
+}
+
+fn notification_event(signal: &HookSignal) -> HarnessCompletionNotificationEvent {
+    HarnessCompletionNotificationEvent {
+        source: HarnessNotificationSource::HookBacked(match signal.harness {
+            HarnessKind::ClaudeCode => HookBackedHarness::ClaudeCode,
+            HarnessKind::Codex => HookBackedHarness::Codex,
+        }),
+        outcome: signal.outcome,
+        title: format!("{} completed", signal.harness.display_name()),
+        body: completion_body(signal.source),
+        repo_id: None,
+        worktree_path: None,
     }
 }
 

--- a/src/ui/dialogs.rs
+++ b/src/ui/dialogs.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::config::{CommandConfig, CommandEntry, RepoConfigFile};
+use crate::config::{AppConfig, CommandConfig, CommandEntry, RepoConfigFile};
 use indexmap::IndexMap;
 
 #[derive(Debug, Clone, Default)]
@@ -26,6 +26,33 @@ pub struct CommandSettingsDialogState {
     pub default_name: String,
     pub entries: Vec<(String, String)>,
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NotificationPreferencesDialogState {
+    pub harness_completion_enabled: bool,
+    pub harness_completion_success: bool,
+    pub harness_completion_failure: bool,
+    pub error: Option<String>,
+}
+
+impl NotificationPreferencesDialogState {
+    pub fn from_config(config: &AppConfig) -> Self {
+        let prefs = &config.notifications.harness_completion;
+        Self {
+            harness_completion_enabled: prefs.enabled,
+            harness_completion_success: prefs.success,
+            harness_completion_failure: prefs.failure,
+            error: None,
+        }
+    }
+
+    pub fn apply_to_config(&self, config: &mut AppConfig) {
+        let prefs = &mut config.notifications.harness_completion;
+        prefs.enabled = self.harness_completion_enabled;
+        prefs.success = self.harness_completion_success;
+        prefs.failure = self.harness_completion_failure;
+    }
 }
 
 impl CommandSettingsDialogState {

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -14,6 +14,7 @@ use crate::{
         ResolvedRepoConfig, repository_id_for_path,
     },
     git::{GitInspectorService, GitRunner, GitWorktreeService},
+    notifications::{NotificationController, NotificationService},
     project::FileTreeService,
     terminal::{
         CommandSpec, GhosttyRenderFrame, GhosttyTerminalBackend, TerminalBackend, TerminalKeyInput,
@@ -30,7 +31,7 @@ use crate::{
         dialogs::{
             AddRepositoryDialogState, CommandSettingsDialogState, ConfirmPruneWorktreesDialog,
             ConfirmRemoveRepositoryDialog, ConfirmRemoveWorktreeDialog, CreateWorktreeDialogState,
-            CreateWorktreeField,
+            CreateWorktreeField, NotificationPreferencesDialogState,
         },
         inspector::render_project_inspector,
         markdown_pane::render_markdown_pane,
@@ -109,6 +110,8 @@ pub struct AlasShell {
     command_settings_dialog: Option<CommandSettingsDialogState>,
     command_settings_focus: FocusHandle,
     command_settings_active_field: CommandSettingsField,
+    notification_preferences_dialog: Option<NotificationPreferencesDialogState>,
+    notification_controller: NotificationController<NotificationService>,
     command_picker: Option<CommandPickerState>,
     sidebar_menu: Option<SidebarMenuState>,
     confirm_remove_repository_dialog: Option<ConfirmRemoveRepositoryDialog>,
@@ -136,6 +139,7 @@ impl AlasShell {
         let app_config_store =
             AppConfigStore::default_store().expect("failed to resolve app config store");
         let config = app_config_store.load().unwrap_or_default();
+        let notification_preferences = config.notifications.clone();
 
         let mut shell = Self {
             model: AlasModel::default(),
@@ -147,6 +151,11 @@ impl AlasShell {
             command_settings_dialog: None,
             command_settings_focus: cx.focus_handle(),
             command_settings_active_field: CommandSettingsField::DefaultName,
+            notification_preferences_dialog: None,
+            notification_controller: NotificationController::new_with_preferences(
+                NotificationService,
+                notification_preferences,
+            ),
             command_picker: None,
             sidebar_menu: None,
             confirm_remove_repository_dialog: None,
@@ -1002,6 +1011,60 @@ impl AlasShell {
         }
     }
 
+    fn open_notification_preferences_dialog(&mut self) {
+        self.notification_preferences_dialog = Some(
+            NotificationPreferencesDialogState::from_config(&self.config),
+        );
+    }
+
+    fn close_notification_preferences_dialog(&mut self) {
+        self.notification_preferences_dialog = None;
+    }
+
+    fn toggle_harness_completion_notifications(&mut self) {
+        if let Some(dialog) = self.notification_preferences_dialog.as_mut() {
+            dialog.harness_completion_enabled = !dialog.harness_completion_enabled;
+            dialog.error = None;
+        }
+    }
+
+    fn toggle_success_completion_notifications(&mut self) {
+        if let Some(dialog) = self.notification_preferences_dialog.as_mut() {
+            dialog.harness_completion_success = !dialog.harness_completion_success;
+            dialog.error = None;
+        }
+    }
+
+    fn toggle_failure_completion_notifications(&mut self) {
+        if let Some(dialog) = self.notification_preferences_dialog.as_mut() {
+            dialog.harness_completion_failure = !dialog.harness_completion_failure;
+            dialog.error = None;
+        }
+    }
+
+    fn save_notification_preferences_from_dialog(&mut self) {
+        let Some(dialog) = self.notification_preferences_dialog.clone() else {
+            return;
+        };
+        let mut next_config = self.config.clone();
+        dialog.apply_to_config(&mut next_config);
+
+        if let Err(error) = self.app_config_store.save(&next_config) {
+            self.set_notification_preferences_error(error.to_string());
+            return;
+        }
+        self.config = next_config;
+        self.notification_controller
+            .update_preferences(self.config.notifications.clone());
+        self.notification_preferences_dialog = None;
+    }
+
+    fn set_notification_preferences_error(&mut self, error: impl Into<String>) {
+        if let Some(dialog) = self.notification_preferences_dialog.as_mut() {
+            dialog.error = Some(error.into());
+        }
+    }
+
     fn create_worktree_from_dialog(&mut self, cx: &mut Context<Self>) {
         let Some(dialog) = self.create_worktree_dialog.clone() else {
             return;
@@ -1452,6 +1515,7 @@ impl AlasShell {
                 }
             }
             ActionId::AddRepository => self.open_add_repository_dialog(cx),
+            ActionId::NotificationPreferences => self.open_notification_preferences_dialog(),
         }
 
         cx.notify();
@@ -2042,6 +2106,50 @@ fn render_command_settings_field(
         )
 }
 
+fn render_notification_toggle(
+    id: &'static str,
+    label: &'static str,
+    checked: bool,
+    on_toggle: impl Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .flex()
+        .items_center()
+        .justify_between()
+        .gap_3()
+        .px_2()
+        .py_2()
+        .rounded_md()
+        .bg(rgb(0xffffff))
+        .border_1()
+        .border_color(rgb(0xd1d5db))
+        .child(div().text_sm().text_color(rgb(0x111827)).child(label))
+        .child(
+            div()
+                .w(px(44.0))
+                .h(px(24.0))
+                .rounded_full()
+                .flex()
+                .items_center()
+                .justify_center()
+                .text_xs()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(if checked {
+                    rgb(0xffffff)
+                } else {
+                    rgb(0x4b5563)
+                })
+                .bg(if checked {
+                    rgb(0x2563eb)
+                } else {
+                    rgb(0xe5e7eb)
+                })
+                .child(if checked { "On" } else { "Off" }),
+        )
+        .on_click(on_toggle)
+}
+
 fn render_create_worktree_field(
     label: &'static str,
     value: &str,
@@ -2252,6 +2360,29 @@ impl Render for AlasShell {
                     cx.notify();
                 }
             });
+        let on_toggle_harness_completion_notifications =
+            cx.listener(|shell, _event, _window, cx| {
+                shell.toggle_harness_completion_notifications();
+                cx.notify();
+            });
+        let on_toggle_success_completion_notifications =
+            cx.listener(|shell, _event, _window, cx| {
+                shell.toggle_success_completion_notifications();
+                cx.notify();
+            });
+        let on_toggle_failure_completion_notifications =
+            cx.listener(|shell, _event, _window, cx| {
+                shell.toggle_failure_completion_notifications();
+                cx.notify();
+            });
+        let on_submit_notification_preferences = cx.listener(|shell, _event, _window, cx| {
+            shell.save_notification_preferences_from_dialog();
+            cx.notify();
+        });
+        let on_cancel_notification_preferences = cx.listener(|shell, _event, _window, cx| {
+            shell.close_notification_preferences_dialog();
+            cx.notify();
+        });
         let on_terminal_key_down = cx.listener(|shell, event: &KeyDownEvent, _window, cx| {
             if shell.handle_terminal_key_down(event, cx) {
                 cx.stop_propagation();
@@ -2542,6 +2673,10 @@ impl Render for AlasShell {
                 self.model.repositories(),
                 self.model.selected_worktree(),
                 cx.listener(|shell, _event, _window, cx| shell.open_add_repository_dialog(cx)),
+                cx.listener(|shell, _event, _window, cx| {
+                    shell.open_notification_preferences_dialog();
+                    cx.notify();
+                }),
                 on_select_worktree,
                 on_sidebar_menu_action,
                 self.add_repository_error(),
@@ -2559,6 +2694,92 @@ impl Render for AlasShell {
                             on_select_command,
                             on_cancel_command_picker,
                         ))
+                    })
+                    .when(self.notification_preferences_dialog.is_some(), |element| {
+                        let dialog = self.notification_preferences_dialog.as_ref().unwrap();
+                        element.child(
+                            div()
+                                .m_3()
+                                .p_3()
+                                .rounded_md()
+                                .border_1()
+                                .border_color(rgb(0xbfdbfe))
+                                .bg(rgb(0xeff6ff))
+                                .flex()
+                                .flex_col()
+                                .gap_2()
+                                .child(
+                                    div()
+                                        .text_sm()
+                                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                                        .child("Notification Preferences"),
+                                )
+                                .child(
+                                    div()
+                                        .text_xs()
+                                        .text_color(rgb(0x4b5563))
+                                        .child("Hook-backed harnesses"),
+                                )
+                                .child(render_notification_toggle(
+                                    "harness-completion-notifications",
+                                    "Harness completion notifications",
+                                    dialog.harness_completion_enabled,
+                                    on_toggle_harness_completion_notifications,
+                                ))
+                                .child(render_notification_toggle(
+                                    "harness-completion-success-notifications",
+                                    "Successful completions",
+                                    dialog.harness_completion_success,
+                                    on_toggle_success_completion_notifications,
+                                ))
+                                .child(render_notification_toggle(
+                                    "harness-completion-failure-notifications",
+                                    "Failed completions",
+                                    dialog.harness_completion_failure,
+                                    on_toggle_failure_completion_notifications,
+                                ))
+                                .when(dialog.error.is_some(), |element| {
+                                    element.child(
+                                        div()
+                                            .text_sm()
+                                            .text_color(rgb(0xdc2626))
+                                            .child(SharedString::from(
+                                                dialog.error.clone().unwrap_or_default(),
+                                            )),
+                                    )
+                                })
+                                .child(
+                                    div()
+                                        .flex()
+                                        .gap_2()
+                                        .child(
+                                            div()
+                                                .id("submit-notification-preferences")
+                                                .px_3()
+                                                .py_2()
+                                                .rounded_md()
+                                                .text_sm()
+                                                .font_weight(gpui::FontWeight::SEMIBOLD)
+                                                .text_color(rgb(0xffffff))
+                                                .bg(rgb(0x2563eb))
+                                                .child("Save")
+                                                .on_click(on_submit_notification_preferences),
+                                        )
+                                        .child(
+                                            div()
+                                                .id("cancel-notification-preferences")
+                                                .px_3()
+                                                .py_2()
+                                                .rounded_md()
+                                                .text_sm()
+                                                .font_weight(gpui::FontWeight::SEMIBOLD)
+                                                .text_color(rgb(0x374151))
+                                                .bg(rgb(0xe5e7eb))
+                                                .child("Cancel")
+                                                .on_click(on_cancel_notification_preferences),
+                                        ),
+                                ),
+                        )
                     })
                     .when(self.command_settings_dialog.is_some(), |element| {
                         let dialog = self.command_settings_dialog.as_ref().unwrap();

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -36,6 +36,7 @@ pub fn render_sidebar(
     repositories: &[RepositoryNode],
     selected_worktree: Option<&SelectedWorktree>,
     on_add_repository: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    on_notification_preferences: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
     on_select_worktree: impl Fn(String, PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
     on_sidebar_menu_action: impl Fn(SidebarMenuState, ActionId, &ClickEvent, &mut Window, &mut App)
     + Clone
@@ -109,10 +110,17 @@ pub fn render_sidebar(
                     )
                 })),
         )
+        .child(
+            Button::new("notification-preferences")
+                .ghost()
+                .compact()
+                .mt_auto()
+                .label("Notifications")
+                .on_click(on_notification_preferences),
+        )
         .when(add_repository_error.is_some(), |element| {
             element.child(
                 div()
-                    .mt_auto()
                     .text_sm()
                     .text_color(DANGER)
                     .child(add_repository_error.unwrap_or_default().to_string()),

--- a/tests/action_registry_tests.rs
+++ b/tests/action_registry_tests.rs
@@ -18,6 +18,7 @@ fn registry_contains_all_current_repo_and_worktree_actions() {
             ActionId::PruneWorktrees,
             ActionId::ToggleArchivedWorktrees,
             ActionId::CommandSettings,
+            ActionId::NotificationPreferences,
             ActionId::OpenPath,
             ActionId::CopyPath,
         ]
@@ -61,7 +62,7 @@ fn actions_are_scoped_for_context_menus() {
 
     assert_eq!(
         ids_for_scope(&registry, ActionScope::Global),
-        vec![ActionId::AddRepository]
+        vec![ActionId::AddRepository, ActionId::NotificationPreferences]
     );
     assert_eq!(
         ids_for_scope(&registry, ActionScope::Repository),
@@ -149,6 +150,12 @@ fn actions_include_availability_and_handler_identity() {
         ActionId::CommandSettings,
         ActionAvailability::WhenRepositoryAvailable,
         ActionHandlerId::CommandSettings,
+    );
+    assert_action(
+        &registry,
+        ActionId::NotificationPreferences,
+        ActionAvailability::Always,
+        ActionHandlerId::NotificationPreferences,
     );
     assert_action(
         &registry,

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -2,7 +2,7 @@ use alas::config::{
     AppConfig, AppConfigStore, AppRepository, CommandConfig, CommandEntry, RepoConfigFile,
     RepoConfigStore, ResolvedRepoConfig,
 };
-use alas::ui::dialogs::CommandSettingsDialogState;
+use alas::ui::dialogs::{CommandSettingsDialogState, NotificationPreferencesDialogState};
 use indexmap::IndexMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -34,11 +34,67 @@ fn app_config_round_trips_repositories_and_archives() {
             name: Some("Repo One".to_string()),
         }],
         archived_worktrees,
+        ..AppConfig::default()
     };
 
     store.save(&config).unwrap();
 
     assert!(config_path.exists());
+    assert_eq!(store.load().unwrap(), config);
+}
+
+#[test]
+fn app_config_defaults_enable_harness_completion_notifications() {
+    let config = AppConfig::default();
+    let prefs = config.notifications.harness_completion;
+
+    assert!(prefs.enabled);
+    assert!(prefs.success);
+    assert!(prefs.failure);
+}
+
+#[test]
+fn app_config_loads_notification_defaults_from_existing_toml() {
+    let toml = r#"
+        [[repositories]]
+        id = "repo-1"
+        path = "/tmp/repo-1"
+    "#;
+
+    let config: AppConfig = toml::from_str(toml).unwrap();
+    let prefs = config.notifications.harness_completion;
+
+    assert!(prefs.enabled);
+    assert!(prefs.success);
+    assert!(prefs.failure);
+}
+
+#[test]
+fn app_config_loads_partial_notification_defaults_as_enabled() {
+    let toml = r#"
+        [notifications.harness_completion]
+        success = false
+    "#;
+
+    let config: AppConfig = toml::from_str(toml).unwrap();
+    let prefs = config.notifications.harness_completion;
+
+    assert!(prefs.enabled);
+    assert!(!prefs.success);
+    assert!(prefs.failure);
+}
+
+#[test]
+fn app_config_round_trips_notification_preferences() {
+    let temp = tempdir().unwrap();
+    let store = AppConfigStore::new(temp.path().join("config.toml"));
+    let mut config = AppConfig::default();
+    config.notifications.harness_completion.enabled = false;
+    config.notifications.harness_completion.success = false;
+    config.notifications.harness_completion.failure = true;
+
+    store.save(&config).unwrap();
+
     assert_eq!(store.load().unwrap(), config);
 }
 
@@ -235,6 +291,46 @@ fn command_settings_dialog_rejects_missing_default_entry() {
         dialog.to_repo_config().unwrap_err(),
         "Default command must match a named command"
     );
+}
+
+#[test]
+fn notification_preferences_dialog_initializes_from_config() {
+    let mut config = AppConfig::default();
+    config.notifications.harness_completion.enabled = false;
+    config.notifications.harness_completion.success = true;
+    config.notifications.harness_completion.failure = false;
+
+    let dialog = NotificationPreferencesDialogState::from_config(&config);
+
+    assert!(!dialog.harness_completion_enabled);
+    assert!(dialog.harness_completion_success);
+    assert!(!dialog.harness_completion_failure);
+    assert_eq!(dialog.error, None);
+}
+
+#[test]
+fn notification_preferences_dialog_applies_only_notification_preferences() {
+    let mut config = AppConfig {
+        repositories: vec![AppRepository {
+            id: "repo-1".to_string(),
+            path: PathBuf::from("/tmp/repo-1"),
+            name: Some("Repo One".to_string()),
+        }],
+        ..AppConfig::default()
+    };
+    let dialog = NotificationPreferencesDialogState {
+        harness_completion_enabled: false,
+        harness_completion_success: false,
+        harness_completion_failure: true,
+        error: Some("ignored".to_string()),
+    };
+
+    dialog.apply_to_config(&mut config);
+
+    assert_eq!(config.repositories.len(), 1);
+    assert!(!config.notifications.harness_completion.enabled);
+    assert!(!config.notifications.harness_completion.success);
+    assert!(config.notifications.harness_completion.failure);
 }
 
 #[test]

--- a/tests/notification_hook_tests.rs
+++ b/tests/notification_hook_tests.rs
@@ -1,9 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use alas::app::{TerminalTabKind, WorkspaceSession};
+use alas::config::NotificationPrefs;
 use alas::notifications::{
-    HarnessCompletionEvent, HarnessCompletionSource, HookProvider, NotificationController,
-    NotificationService,
+    HarnessCompletionEvent, HarnessCompletionOutcome, HarnessCompletionSource, HookProvider,
+    NotificationController, NotificationSink,
 };
 use alas::terminal::{CommandSpec, HarnessKind};
 use serde_json::json;
@@ -13,7 +14,7 @@ struct FakeNotifier {
     completions: Vec<HarnessCompletionEvent>,
 }
 
-impl NotificationService for FakeNotifier {
+impl NotificationSink for FakeNotifier {
     fn notify_harness_completed(&mut self, event: HarnessCompletionEvent) -> anyhow::Result<()> {
         self.completions.push(event);
         Ok(())
@@ -22,6 +23,10 @@ impl NotificationService for FakeNotifier {
 
 fn controller() -> NotificationController<FakeNotifier> {
     NotificationController::new(FakeNotifier::default())
+}
+
+fn controller_with_preferences(prefs: NotificationPrefs) -> NotificationController<FakeNotifier> {
+    NotificationController::new_with_preferences(FakeNotifier::default(), prefs)
 }
 
 fn cwd() -> PathBuf {
@@ -129,6 +134,7 @@ fn claude_stop_hook_notifies() {
             HookProvider::ClaudeCode,
             &json!({
                 "hook_event_name": "Stop",
+                "success": true,
                 "terminal_tab_id": 7
             }),
         )
@@ -138,6 +144,7 @@ fn claude_stop_hook_notifies() {
     let event = &controller.notifier().completions[0];
     assert_eq!(event.harness, HarnessKind::ClaudeCode);
     assert_eq!(event.source, HarnessCompletionSource::ClaudeCodeStop);
+    assert_eq!(event.outcome, HarnessCompletionOutcome::Success);
     assert_eq!(event.terminal_tab_id.map(|id| id.0), Some(7));
 }
 
@@ -149,7 +156,8 @@ fn claude_subagent_stop_hook_notifies() {
         .handle_raw_hook_payload(
             HookProvider::ClaudeCode,
             &json!({
-                "hook_event_name": "SubagentStop"
+                "hook_event_name": "SubagentStop",
+                "outcome": "success"
             }),
         )
         .expect("handle hook");
@@ -172,6 +180,7 @@ fn codex_agent_turn_complete_hook_notifies() {
             HookProvider::Codex,
             &json!({
                 "type": "agent-turn-complete",
+                "status": "success",
                 "alas_terminal_tab_id": 11
             }),
         )
@@ -196,6 +205,7 @@ fn hook_tab_id_falls_back_when_primary_id_is_not_numeric() {
             HookProvider::ClaudeCode,
             &json!({
                 "hook_event_name": "Stop",
+                "exit_code": 0,
                 "terminal_tab_id": "7",
                 "alas_terminal_tab_id": 7
             }),
@@ -205,6 +215,109 @@ fn hook_tab_id_falls_back_when_primary_id_is_not_numeric() {
     assert_eq!(controller.notifier().completions.len(), 1);
     let event = &controller.notifier().completions[0];
     assert_eq!(event.terminal_tab_id.map(|id| id.0), Some(7));
+}
+
+#[test]
+fn hook_payload_without_outcome_does_not_notify() {
+    let mut controller = controller();
+
+    controller
+        .handle_raw_hook_payload(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "terminal_tab_id": 7
+            }),
+        )
+        .expect("handle hook");
+
+    assert!(controller.notifier().completions.is_empty());
+}
+
+#[test]
+fn disabled_harness_completion_preferences_suppress_hook_notifications() {
+    let mut prefs = NotificationPrefs::default();
+    prefs.harness_completion.enabled = false;
+    let mut controller = controller_with_preferences(prefs);
+
+    controller
+        .handle_raw_hook_payload(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "success": true
+            }),
+        )
+        .expect("handle hook");
+
+    assert!(controller.notifier().completions.is_empty());
+}
+
+#[test]
+fn success_and_failure_preferences_gate_hook_notifications_independently() {
+    let mut prefs = NotificationPrefs::default();
+    prefs.harness_completion.success = false;
+    let mut controller = controller_with_preferences(prefs);
+
+    controller
+        .handle_raw_hook_payload(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "success": true
+            }),
+        )
+        .expect("handle hook");
+
+    controller
+        .handle_raw_hook_payload(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "success": false
+            }),
+        )
+        .expect("handle hook");
+
+    assert_eq!(controller.notifier().completions.len(), 1);
+    assert_eq!(
+        controller.notifier().completions[0].outcome,
+        HarnessCompletionOutcome::Failure
+    );
+}
+
+#[test]
+fn controller_preferences_can_be_updated_after_construction() {
+    let mut prefs = NotificationPrefs::default();
+    prefs.harness_completion.success = false;
+    let mut controller = controller_with_preferences(prefs);
+
+    controller
+        .handle_raw_hook_payload(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "success": true
+            }),
+        )
+        .expect("handle hook");
+    assert!(controller.notifier().completions.is_empty());
+
+    let prefs = NotificationPrefs::default();
+    controller.update_preferences(prefs.clone());
+    assert_eq!(controller.preferences(), &prefs);
+
+    controller
+        .handle_raw_hook_payload(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "success": true
+            }),
+        )
+        .expect("handle hook");
+
+    assert_eq!(controller.notifier().completions.len(), 1);
 }
 
 #[test]

--- a/tests/notification_service_tests.rs
+++ b/tests/notification_service_tests.rs
@@ -1,0 +1,107 @@
+use alas::{
+    config::NotificationPrefs,
+    notifications::{
+        HarnessCompletionNotificationEvent, HarnessCompletionOutcome, HarnessNotificationSource,
+        HookBackedHarness, NotificationDecision, NotificationService,
+    },
+};
+
+#[test]
+fn supported_success_completion_is_allowed_by_default() {
+    assert_eq!(
+        decision(
+            NotificationPrefs::default(),
+            HarnessCompletionOutcome::Success
+        ),
+        NotificationDecision::Allowed
+    );
+}
+
+#[test]
+fn supported_failure_completion_is_allowed_by_default() {
+    assert_eq!(
+        decision(
+            NotificationPrefs::default(),
+            HarnessCompletionOutcome::Failure
+        ),
+        NotificationDecision::Allowed
+    );
+}
+
+#[test]
+fn global_disabled_suppresses_supported_completions() {
+    let mut prefs = NotificationPrefs::default();
+    prefs.harness_completion.enabled = false;
+
+    assert_eq!(
+        decision(prefs.clone(), HarnessCompletionOutcome::Success),
+        NotificationDecision::Disabled
+    );
+    assert_eq!(
+        decision(prefs, HarnessCompletionOutcome::Failure),
+        NotificationDecision::Disabled
+    );
+}
+
+#[test]
+fn success_disabled_suppresses_success_only() {
+    let mut prefs = NotificationPrefs::default();
+    prefs.harness_completion.success = false;
+
+    assert_eq!(
+        decision(prefs.clone(), HarnessCompletionOutcome::Success),
+        NotificationDecision::SuccessDisabled
+    );
+    assert_eq!(
+        decision(prefs, HarnessCompletionOutcome::Failure),
+        NotificationDecision::Allowed
+    );
+}
+
+#[test]
+fn failure_disabled_suppresses_failure_only() {
+    let mut prefs = NotificationPrefs::default();
+    prefs.harness_completion.failure = false;
+
+    assert_eq!(
+        decision(prefs.clone(), HarnessCompletionOutcome::Failure),
+        NotificationDecision::FailureDisabled
+    );
+    assert_eq!(
+        decision(prefs, HarnessCompletionOutcome::Success),
+        NotificationDecision::Allowed
+    );
+}
+
+#[test]
+fn unsupported_harness_is_suppressed_when_notifications_are_enabled() {
+    let service = NotificationService;
+    let event = HarnessCompletionNotificationEvent {
+        source: HarnessNotificationSource::Unsupported("plain shell".to_string()),
+        outcome: HarnessCompletionOutcome::Success,
+        title: "Done".to_string(),
+        body: String::new(),
+        repo_id: None,
+        worktree_path: None,
+    };
+
+    assert_eq!(
+        service.harness_completion_decision(&NotificationPrefs::default(), &event),
+        NotificationDecision::UnsupportedHarness
+    );
+}
+
+fn decision(prefs: NotificationPrefs, outcome: HarnessCompletionOutcome) -> NotificationDecision {
+    let service = NotificationService;
+    service.harness_completion_decision(
+        &prefs,
+        &HarnessCompletionNotificationEvent {
+            source: HarnessNotificationSource::HookBacked(HookBackedHarness::ClaudeCode),
+            outcome,
+            title: "Done".to_string(),
+            body: String::new(),
+            repo_id: None,
+            worktree_path: None,
+        },
+    )
+}


### PR DESCRIPTION
## Summary
- add persisted harness completion notification preferences with defaults enabled
- add notification gating for hook-backed harness completion events
- add preferences UI/state and action wiring

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --all-features
- cargo test --all-features