### PR TITLE
Add image preview workspace tabs

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -21,7 +21,8 @@ pub use syntax::{
 };
 pub use workspace::WorkspaceTabId as TerminalTabId;
 pub use workspace::{
-    FILE_TAB_MAX_BYTES, FileTabLoadState, FileTabState, MarkdownTabState, MarkdownViewMode,
-    TerminalTabKind, TerminalTabState, TerminalTabStatus, WorkspaceSession, WorkspaceTab,
-    WorkspaceTabContent, WorkspaceTabId, WorkspaceTabKind, WorktreeKey,
+    FILE_TAB_MAX_BYTES, FileTabLoadState, FileTabState, ImagePreflight, ImageTabState, ImageZoom,
+    MarkdownTabState, MarkdownViewMode, TerminalTabKind, TerminalTabState, TerminalTabStatus,
+    WorkspaceSession, WorkspaceTab, WorkspaceTabContent, WorkspaceTabId, WorkspaceTabKind,
+    WorktreeKey, is_supported_image_path, preflight_image_path,
 };

--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -850,9 +850,23 @@ pub fn preflight_image_path(path: &Path) -> ImagePreflight {
         return ImagePreflight::UnsupportedExtension(extension);
     }
 
-    match std::fs::metadata(path) {
-        Ok(metadata) if metadata.is_file() => ImagePreflight::Ready,
-        Ok(_) => ImagePreflight::NotAFile,
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            return match error.kind() {
+                ErrorKind::NotFound => ImagePreflight::NotFound,
+                ErrorKind::PermissionDenied => ImagePreflight::PermissionDenied,
+                _ => ImagePreflight::IoError(error.to_string()),
+            };
+        }
+    };
+
+    if !metadata.is_file() {
+        return ImagePreflight::NotAFile;
+    }
+
+    match std::fs::File::open(path) {
+        Ok(_) => ImagePreflight::Ready,
         Err(error) => match error.kind() {
             ErrorKind::NotFound => ImagePreflight::NotFound,
             ErrorKind::PermissionDenied => ImagePreflight::PermissionDenied,

--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -1,10 +1,14 @@
 use std::collections::HashMap;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use crate::app::{DetectedLanguage, HighlightedSource, detect_language};
 use crate::terminal::{CommandSpec, TerminalBackendSession};
 
 pub const FILE_TAB_MAX_BYTES: u64 = 2 * 1024 * 1024;
+pub const IMAGE_ZOOM_MIN: f32 = 0.10;
+pub const IMAGE_ZOOM_MAX: f32 = 10.0;
+pub const IMAGE_ZOOM_STEP: f32 = 0.25;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct WorkspaceTabId(pub u64);
@@ -20,6 +24,7 @@ pub enum TerminalTabKind {
 pub enum WorkspaceTabKind {
     Terminal(TerminalTabKind),
     File,
+    Image,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,14 +96,105 @@ pub struct MarkdownTabState {
     pub preview_scroll_offset_rows: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ImageZoom {
+    Fit,
+    Fixed(f32),
+}
+
+impl ImageZoom {
+    pub fn zoom_in(self) -> Self {
+        Self::Fixed((self.fixed_start() + IMAGE_ZOOM_STEP).clamp(IMAGE_ZOOM_MIN, IMAGE_ZOOM_MAX))
+    }
+
+    pub fn zoom_out(self) -> Self {
+        Self::Fixed((self.fixed_start() - IMAGE_ZOOM_STEP).clamp(IMAGE_ZOOM_MIN, IMAGE_ZOOM_MAX))
+    }
+
+    pub fn is_min(self) -> bool {
+        matches!(self, Self::Fixed(value) if value <= IMAGE_ZOOM_MIN)
+    }
+
+    pub fn is_max(self) -> bool {
+        matches!(self, Self::Fixed(value) if value >= IMAGE_ZOOM_MAX)
+    }
+
+    pub fn label(self) -> String {
+        match self {
+            Self::Fit => "Fit".to_string(),
+            Self::Fixed(value) => format!("{:.0}%", value * 100.0),
+        }
+    }
+
+    fn fixed_start(self) -> f32 {
+        match self {
+            Self::Fit => 1.0,
+            Self::Fixed(value) => value,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImagePreflight {
+    Ready,
+    UnsupportedExtension(String),
+    NotFound,
+    PermissionDenied,
+    NotAFile,
+    IoError(String),
+}
+
+impl ImagePreflight {
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::Ready => "Image ready",
+            Self::UnsupportedExtension(_) => "Unsupported image format",
+            Self::NotFound => "Image file not found",
+            Self::PermissionDenied => "Image file is not readable",
+            Self::NotAFile => "Selected path is not a file",
+            Self::IoError(_) => "Image file could not be opened",
+        }
+    }
+
+    pub fn detail(&self) -> String {
+        match self {
+            Self::Ready => "Ready".to_string(),
+            Self::UnsupportedExtension(extension) if extension.is_empty() => {
+                "The file has no extension supported by the image viewer.".to_string()
+            }
+            Self::UnsupportedExtension(extension) => {
+                format!("'.{extension}' is not supported by the image viewer.")
+            }
+            Self::NotFound => "The file no longer exists at this path.".to_string(),
+            Self::PermissionDenied => {
+                "The app does not have permission to read this file.".to_string()
+            }
+            Self::NotAFile => {
+                "Directories and special files cannot be previewed as images.".to_string()
+            }
+            Self::IoError(error) => error.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImageTabState {
+    pub path: PathBuf,
+    pub display_path: PathBuf,
+    pub path_key: PathBuf,
+    pub zoom: ImageZoom,
+    pub preflight: ImagePreflight,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum WorkspaceTabContent {
     Terminal(TerminalTabState),
     File(FileTabState),
     Markdown(MarkdownTabState),
+    Image(ImageTabState),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WorkspaceTab {
     pub id: WorkspaceTabId,
     pub name: String,
@@ -110,21 +206,25 @@ impl WorkspaceTab {
     pub fn terminal_tab_state(&self) -> Option<&TerminalTabState> {
         match &self.content {
             WorkspaceTabContent::Terminal(state) => Some(state),
-            WorkspaceTabContent::File(_) | WorkspaceTabContent::Markdown(_) => None,
+            WorkspaceTabContent::File(_)
+            | WorkspaceTabContent::Markdown(_)
+            | WorkspaceTabContent::Image(_) => None,
         }
     }
 
     pub fn terminal_tab_state_mut(&mut self) -> Option<&mut TerminalTabState> {
         match &mut self.content {
             WorkspaceTabContent::Terminal(state) => Some(state),
-            WorkspaceTabContent::File(_) | WorkspaceTabContent::Markdown(_) => None,
+            WorkspaceTabContent::File(_)
+            | WorkspaceTabContent::Markdown(_)
+            | WorkspaceTabContent::Image(_) => None,
         }
     }
 
     pub fn terminal_kind(&self) -> Option<TerminalTabKind> {
         match self.kind {
             WorkspaceTabKind::Terminal(kind) => Some(kind),
-            WorkspaceTabKind::File => None,
+            WorkspaceTabKind::File | WorkspaceTabKind::Image => None,
         }
     }
 
@@ -136,11 +236,33 @@ impl WorkspaceTab {
         matches!(self.kind, WorkspaceTabKind::File)
     }
 
+    pub fn is_image(&self) -> bool {
+        matches!(self.kind, WorkspaceTabKind::Image)
+    }
+
+    pub fn image_tab_state(&self) -> Option<&ImageTabState> {
+        match &self.content {
+            WorkspaceTabContent::Image(state) => Some(state),
+            WorkspaceTabContent::Terminal(_)
+            | WorkspaceTabContent::File(_)
+            | WorkspaceTabContent::Markdown(_) => None,
+        }
+    }
+
+    pub fn image_tab_state_mut(&mut self) -> Option<&mut ImageTabState> {
+        match &mut self.content {
+            WorkspaceTabContent::Image(state) => Some(state),
+            WorkspaceTabContent::Terminal(_)
+            | WorkspaceTabContent::File(_)
+            | WorkspaceTabContent::Markdown(_) => None,
+        }
+    }
+
     pub fn file_tab_path(&self) -> Option<&PathBuf> {
         match &self.content {
             WorkspaceTabContent::File(state) => Some(&state.file_path),
             WorkspaceTabContent::Markdown(state) => Some(&state.file.file_path),
-            WorkspaceTabContent::Terminal(_) => None,
+            WorkspaceTabContent::Terminal(_) | WorkspaceTabContent::Image(_) => None,
         }
     }
 }
@@ -268,6 +390,49 @@ impl WorkspaceSession {
             name,
             kind: WorkspaceTabKind::File,
             content,
+        };
+
+        self.tabs.entry(key.clone()).or_default().push(tab);
+        self.active_tabs.insert(key, id);
+        id
+    }
+
+    pub fn open_or_focus_image_tab(
+        &mut self,
+        repo_id: impl Into<String>,
+        worktree_path: PathBuf,
+        image_path: PathBuf,
+    ) -> WorkspaceTabId {
+        let key = WorktreeKey::new(repo_id, worktree_path.clone());
+        let path_key = image_path_key(&worktree_path, &image_path);
+        if let Some(existing_id) = self.tabs.get(&key).and_then(|tabs| {
+            tabs.iter().find_map(|tab| match &tab.content {
+                WorkspaceTabContent::Image(state) if state.path_key == path_key => Some(tab.id),
+                _ => None,
+            })
+        }) {
+            self.active_tabs.insert(key, existing_id);
+            return existing_id;
+        }
+
+        self.next_tab_id += 1;
+        let id = WorkspaceTabId(self.next_tab_id);
+        let name = image_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("Image")
+            .to_string();
+        let tab = WorkspaceTab {
+            id,
+            name,
+            kind: WorkspaceTabKind::Image,
+            content: WorkspaceTabContent::Image(ImageTabState {
+                path: image_path.clone(),
+                display_path: image_path.clone(),
+                path_key,
+                zoom: ImageZoom::Fit,
+                preflight: preflight_image_path(&image_path),
+            }),
         };
 
         self.tabs.entry(key.clone()).or_default().push(tab);
@@ -417,6 +582,34 @@ impl WorkspaceSession {
         let key = WorktreeKey::new(repo_id, path.to_path_buf());
         let tab = self.known_terminal_tab_mut(&key, tab_id)?;
         tab.scroll_offset_rows = scroll_offset_rows;
+        Ok(())
+    }
+
+    pub fn set_image_zoom(
+        &mut self,
+        repo_id: impl Into<String>,
+        path: &Path,
+        tab_id: WorkspaceTabId,
+        zoom: ImageZoom,
+    ) -> anyhow::Result<()> {
+        let key = WorktreeKey::new(repo_id, path.to_path_buf());
+        let tab = self.tab_mut_for_key(&key, tab_id).ok_or_else(|| {
+            anyhow::anyhow!(
+                "unknown workspace tab {:?} for repo '{}' worktree {}",
+                tab_id,
+                key.repo_id,
+                key.path.display()
+            )
+        })?;
+        let Some(state) = tab.image_tab_state_mut() else {
+            anyhow::bail!("workspace tab {:?} is not an image tab", tab_id);
+        };
+        state.zoom = match zoom {
+            ImageZoom::Fit => ImageZoom::Fit,
+            ImageZoom::Fixed(value) => {
+                ImageZoom::Fixed(value.clamp(IMAGE_ZOOM_MIN, IMAGE_ZOOM_MAX))
+            }
+        };
         Ok(())
     }
 
@@ -582,7 +775,7 @@ impl WorkspaceSession {
         match &mut tab.content {
             WorkspaceTabContent::File(state) => Ok(FileTabHandle::Text(state)),
             WorkspaceTabContent::Markdown(state) => Ok(FileTabHandle::Markdown(state)),
-            WorkspaceTabContent::Terminal(_) => {
+            WorkspaceTabContent::Terminal(_) | WorkspaceTabContent::Image(_) => {
                 anyhow::bail!("workspace tab {:?} is not a file tab", tab_id)
             }
         }
@@ -604,7 +797,9 @@ impl WorkspaceSession {
 
         match &mut tab.content {
             WorkspaceTabContent::Markdown(state) => Ok(state),
-            WorkspaceTabContent::File(_) | WorkspaceTabContent::Terminal(_) => {
+            WorkspaceTabContent::File(_)
+            | WorkspaceTabContent::Terminal(_)
+            | WorkspaceTabContent::Image(_) => {
                 anyhow::bail!("workspace tab {:?} is not a markdown tab", tab_id)
             }
         }
@@ -633,6 +828,56 @@ pub fn is_markdown_path(path: &Path) -> bool {
         .is_some_and(|extension| {
             extension.eq_ignore_ascii_case("md") || extension.eq_ignore_ascii_case("markdown")
         })
+}
+
+pub fn is_supported_image_path(path: &Path) -> bool {
+    let Some(extension) = normalized_extension(path) else {
+        return false;
+    };
+    gpui::Img::extensions()
+        .iter()
+        .any(|supported| supported.eq_ignore_ascii_case(&extension))
+}
+
+pub fn preflight_image_path(path: &Path) -> ImagePreflight {
+    let Some(extension) = normalized_extension(path) else {
+        return ImagePreflight::UnsupportedExtension(String::new());
+    };
+    if !gpui::Img::extensions()
+        .iter()
+        .any(|supported| supported.eq_ignore_ascii_case(&extension))
+    {
+        return ImagePreflight::UnsupportedExtension(extension);
+    }
+
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => ImagePreflight::Ready,
+        Ok(_) => ImagePreflight::NotAFile,
+        Err(error) => match error.kind() {
+            ErrorKind::NotFound => ImagePreflight::NotFound,
+            ErrorKind::PermissionDenied => ImagePreflight::PermissionDenied,
+            _ => ImagePreflight::IoError(error.to_string()),
+        },
+    }
+}
+
+fn normalized_extension(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+}
+
+fn image_path_key(worktree_path: &Path, image_path: &Path) -> PathBuf {
+    if let Ok(path) = std::fs::canonicalize(image_path) {
+        return path;
+    }
+
+    let absolute = if image_path.is_absolute() {
+        image_path.to_path_buf()
+    } else {
+        worktree_path.join(image_path)
+    };
+    normalize_file_path(&absolute)
 }
 
 fn normalize_file_path(path: &Path) -> PathBuf {

--- a/src/ui/image_view.rs
+++ b/src/ui/image_view.rs
@@ -1,0 +1,222 @@
+use crate::{
+    app::{ImagePreflight, ImageTabState, ImageZoom, WorkspaceTabId},
+    ui::theme::{ACCENT, ACCENT_TEXT, DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
+};
+use gpui::{
+    App, ClickEvent, IntoElement, ObjectFit, ParentElement, SharedString, Styled, StyledImage,
+    Window, div, img, prelude::*, px, rgb,
+};
+
+pub fn render_image_view(
+    tab_id: WorkspaceTabId,
+    state: &ImageTabState,
+    on_fit: impl Fn(WorkspaceTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_zoom_in: impl Fn(WorkspaceTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_zoom_out: impl Fn(WorkspaceTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+) -> impl IntoElement {
+    div()
+        .id("image-view")
+        .flex()
+        .flex_col()
+        .size_full()
+        .bg(rgb(0x111827))
+        .child(render_image_toolbar(
+            tab_id,
+            state,
+            on_fit,
+            on_zoom_in,
+            on_zoom_out,
+        ))
+        .child(render_image_body(state))
+}
+
+fn render_image_toolbar(
+    tab_id: WorkspaceTabId,
+    state: &ImageTabState,
+    on_fit: impl Fn(WorkspaceTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_zoom_in: impl Fn(WorkspaceTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_zoom_out: impl Fn(WorkspaceTabId, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+) -> impl IntoElement {
+    let zoom = state.zoom;
+    let file_name = state
+        .display_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("Image")
+        .to_string();
+
+    div()
+        .id("image-toolbar")
+        .flex()
+        .items_center()
+        .justify_between()
+        .gap_3()
+        .px_3()
+        .py_2()
+        .border_b_1()
+        .border_color(PANEL_BORDER)
+        .bg(PANEL_BG)
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap_2()
+                .child(toolbar_button("image-fit", "Fit", true, {
+                    let on_fit = on_fit.clone();
+                    move |event, window, cx| on_fit(tab_id, event, window, cx)
+                }))
+                .child(toolbar_button("image-zoom-out", "-", !zoom.is_min(), {
+                    let on_zoom_out = on_zoom_out.clone();
+                    move |event, window, cx| on_zoom_out(tab_id, event, window, cx)
+                }))
+                .child(
+                    div()
+                        .id("image-zoom-label")
+                        .min_w(px(56.0))
+                        .text_center()
+                        .text_sm()
+                        .font_weight(gpui::FontWeight::SEMIBOLD)
+                        .text_color(TEXT)
+                        .child(zoom.label()),
+                )
+                .child(toolbar_button("image-zoom-in", "+", !zoom.is_max(), {
+                    let on_zoom_in = on_zoom_in.clone();
+                    move |event, window, cx| on_zoom_in(tab_id, event, window, cx)
+                })),
+        )
+        .child(
+            div()
+                .min_w(px(0.0))
+                .text_sm()
+                .text_color(TEXT_MUTED)
+                .child(SharedString::from(file_name)),
+        )
+}
+
+fn toolbar_button(
+    id: &'static str,
+    label: &'static str,
+    enabled: bool,
+    on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .px_3()
+        .py_1()
+        .rounded_md()
+        .border_1()
+        .border_color(PANEL_BORDER)
+        .bg(if enabled { ACCENT } else { PANEL_BG })
+        .text_sm()
+        .font_weight(gpui::FontWeight::SEMIBOLD)
+        .text_color(if enabled { ACCENT_TEXT } else { TEXT_MUTED })
+        .child(label)
+        .when(enabled, |element| element.on_click(on_click))
+}
+
+fn render_image_body(state: &ImageTabState) -> impl IntoElement {
+    div()
+        .id("image-body")
+        .flex()
+        .flex_1()
+        .items_center()
+        .justify_center()
+        .overflow_scroll()
+        .bg(rgb(0x111827))
+        .when(state.preflight != ImagePreflight::Ready, |element| {
+            element.child(render_preflight_error(state))
+        })
+        .when(state.preflight == ImagePreflight::Ready, |element| {
+            element.child(render_ready_image(state))
+        })
+}
+
+fn render_ready_image(state: &ImageTabState) -> impl IntoElement {
+    let path = state.path.clone();
+    let file_name = state
+        .display_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("image")
+        .to_string();
+    let loading = || render_image_message("Loading image...", "").into_any_element();
+    let fallback_file_name = file_name.clone();
+    let fallback = move || {
+        render_image_message(
+            "Image could not be decoded",
+            &format!(
+                "{} may be corrupt or use unsupported encoding.",
+                fallback_file_name
+            ),
+        )
+        .into_any_element()
+    };
+
+    match state.zoom {
+        ImageZoom::Fit => div()
+            .size_full()
+            .flex()
+            .items_center()
+            .justify_center()
+            .child(
+                img(path)
+                    .id("image-preview")
+                    .size_full()
+                    .object_fit(ObjectFit::Contain)
+                    .with_loading(loading)
+                    .with_fallback(fallback),
+            ),
+        ImageZoom::Fixed(zoom) => div()
+            .size_full()
+            .flex()
+            .items_center()
+            .justify_center()
+            .p_6()
+            .child(
+                img(path)
+                    .id("image-preview")
+                    .w(px(960.0 * zoom))
+                    .object_fit(ObjectFit::Contain)
+                    .with_loading(loading)
+                    .with_fallback(fallback),
+            ),
+    }
+}
+
+fn render_preflight_error(state: &ImageTabState) -> impl IntoElement {
+    render_image_message(
+        state.preflight.title().to_string(),
+        state.preflight.detail(),
+    )
+}
+
+fn render_image_message(title: impl Into<String>, detail: impl Into<String>) -> impl IntoElement {
+    let title = title.into();
+    let detail = detail.into();
+    div()
+        .max_w(px(560.0))
+        .p_4()
+        .rounded_lg()
+        .border_1()
+        .border_color(PANEL_BORDER)
+        .bg(PANEL_BG)
+        .flex()
+        .flex_col()
+        .gap_2()
+        .text_center()
+        .child(
+            div()
+                .text_sm()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(DANGER)
+                .child(SharedString::from(title)),
+        )
+        .when(!detail.is_empty(), |element| {
+            element.child(
+                div()
+                    .text_sm()
+                    .text_color(TEXT_MUTED)
+                    .child(SharedString::from(detail)),
+            )
+        })
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ pub mod chrome;
 pub mod command_picker;
 pub mod dialogs;
 pub mod file_pane;
+pub mod image_view;
 pub mod inspector;
 pub mod lifecycle;
 pub mod markdown_pane;

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -5,9 +5,10 @@ use std::{
 
 use crate::{
     app::{
-        ActionId, AlasModel, FileLoader, FileTabLoadState, HighlightError, InspectorPaneState,
-        MarkdownViewMode, RepositoryNode, TerminalTabKind, TerminalTabStatus, WorkspaceSession,
-        WorkspaceTabContent, WorkspaceTabId, WorkspaceTabKind, highlight_source,
+        ActionId, AlasModel, FileLoader, FileTabLoadState, HighlightError, ImageZoom,
+        InspectorPaneState, MarkdownViewMode, RepositoryNode, TerminalTabKind, TerminalTabStatus,
+        WorkspaceSession, WorkspaceTabContent, WorkspaceTabId, WorkspaceTabKind, highlight_source,
+        is_supported_image_path,
     },
     config::{
         AppConfig, AppConfigStore, AppRepository, CommandEntry, RepoConfigStore,
@@ -33,6 +34,7 @@ use crate::{
             ConfirmRemoveRepositoryDialog, ConfirmRemoveWorktreeDialog, CreateWorktreeDialogState,
             CreateWorktreeField, NotificationPreferencesDialogState,
         },
+        image_view::render_image_view,
         inspector::render_project_inspector,
         markdown_pane::render_markdown_pane,
         sidebar::{SidebarMenuState, render_sidebar},
@@ -412,6 +414,11 @@ impl AlasShell {
 
     fn handle_terminal_key_down(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
         if self.handle_command_picker_key_down(event) {
+            cx.notify();
+            return true;
+        }
+
+        if self.handle_image_key_down(event) {
             cx.notify();
             return true;
         }
@@ -1174,6 +1181,40 @@ impl AlasShell {
             .is_some_and(|kind| matches!(kind, WorkspaceTabKind::Terminal(_)))
     }
 
+    fn active_image_zoom(&self) -> Option<(WorkspaceTabId, ImageZoom)> {
+        let selected = self.model.selected_worktree()?;
+        let tab = self
+            .workspace_session
+            .active_tab(&selected.repo_id, &selected.path)?;
+        tab.image_tab_state().map(|state| (tab.id, state.zoom))
+    }
+
+    fn set_image_zoom_for_tab(&mut self, tab_id: WorkspaceTabId, zoom: ImageZoom) {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return;
+        };
+        let _ =
+            self.workspace_session
+                .set_image_zoom(&selected.repo_id, &selected.path, tab_id, zoom);
+    }
+
+    fn handle_image_key_down(&mut self, event: &KeyDownEvent) -> bool {
+        let Some((tab_id, zoom)) = self.active_image_zoom() else {
+            return false;
+        };
+        if !event.keystroke.modifiers.platform {
+            return false;
+        }
+
+        match event.keystroke.key.as_str() {
+            "=" | "+" => self.set_image_zoom_for_tab(tab_id, zoom.zoom_in()),
+            "-" => self.set_image_zoom_for_tab(tab_id, zoom.zoom_out()),
+            "0" => self.set_image_zoom_for_tab(tab_id, ImageZoom::Fit),
+            _ => return false,
+        }
+        true
+    }
+
     fn should_route_terminal_input(&self) -> bool {
         Self::should_route_terminal_input_for(
             self.active_workspace_tab_kind(),
@@ -1352,6 +1393,16 @@ impl AlasShell {
             selected.path.join(file_path)
         };
 
+        if is_supported_image_path(&file_path) {
+            let tab_id = self.workspace_session.open_or_focus_image_tab(
+                &selected.repo_id,
+                selected.path.clone(),
+                file_path,
+            );
+            self.select_workspace_tab(tab_id);
+            return;
+        }
+
         let tab_id = self.workspace_session.open_file_tab(
             &selected.repo_id,
             selected.path.clone(),
@@ -1381,7 +1432,7 @@ impl AlasShell {
             .and_then(|tab| match &tab.content {
                 WorkspaceTabContent::File(state) => Some(state.load_state.clone()),
                 WorkspaceTabContent::Markdown(state) => Some(state.file.load_state.clone()),
-                WorkspaceTabContent::Terminal(_) => None,
+                WorkspaceTabContent::Terminal(_) | WorkspaceTabContent::Image(_) => None,
             })
             .is_some_and(|state| matches!(state, FileTabLoadState::Loaded { .. }));
 
@@ -2215,6 +2266,9 @@ fn render_status_bar(
         None if matches!(active_tab_kind, Some(WorkspaceTabKind::File)) => {
             ("file".to_string(), TEXT_MUTED)
         }
+        None if matches!(active_tab_kind, Some(WorkspaceTabKind::Image)) => {
+            ("image".to_string(), TEXT_MUTED)
+        }
         None if active_tab_kind.is_none() => ("no tab".to_string(), TEXT_MUTED),
         None => ("no terminal".to_string(), TEXT_MUTED),
     };
@@ -2501,6 +2555,47 @@ impl Render for AlasShell {
             shell.open_command_picker(cx);
         });
         let view = cx.entity().downgrade();
+        let on_image_fit = move |tab_id: WorkspaceTabId,
+                                 _event: &gpui::ClickEvent,
+                                 _window: &mut Window,
+                                 app: &mut App| {
+            view.update(app, |shell, cx| {
+                shell.set_image_zoom_for_tab(tab_id, ImageZoom::Fit);
+                cx.notify();
+            })
+            .ok();
+        };
+        let view = cx.entity().downgrade();
+        let on_image_zoom_in = move |tab_id: WorkspaceTabId,
+                                     _event: &gpui::ClickEvent,
+                                     _window: &mut Window,
+                                     app: &mut App| {
+            view.update(app, |shell, cx| {
+                if let Some((active_tab_id, zoom)) = shell.active_image_zoom()
+                    && active_tab_id == tab_id
+                {
+                    shell.set_image_zoom_for_tab(tab_id, zoom.zoom_in());
+                    cx.notify();
+                }
+            })
+            .ok();
+        };
+        let view = cx.entity().downgrade();
+        let on_image_zoom_out = move |tab_id: WorkspaceTabId,
+                                      _event: &gpui::ClickEvent,
+                                      _window: &mut Window,
+                                      app: &mut App| {
+            view.update(app, |shell, cx| {
+                if let Some((active_tab_id, zoom)) = shell.active_image_zoom()
+                    && active_tab_id == tab_id
+                {
+                    shell.set_image_zoom_for_tab(tab_id, zoom.zoom_out());
+                    cx.notify();
+                }
+            })
+            .ok();
+        };
+        let view = cx.entity().downgrade();
         let on_set_markdown_mode = move |tab_id: WorkspaceTabId,
                                          mode: MarkdownViewMode,
                                          _event: &gpui::ClickEvent,
@@ -2637,6 +2732,16 @@ impl Render for AlasShell {
                 state,
                 on_set_markdown_mode,
             ),
+            Some(WorkspaceTabContent::Image(state)) => render_image_view(
+                active_tab
+                    .map(|tab| tab.id)
+                    .expect("active image tab has id"),
+                state,
+                on_image_fit,
+                on_image_zoom_in,
+                on_image_zoom_out,
+            )
+            .into_any_element(),
             Some(WorkspaceTabContent::Terminal(_)) | None => render_terminal_pane(
                 selected_worktree,
                 active_tab,

--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -130,5 +130,6 @@ fn tab_label(tab: &WorkspaceTab) -> String {
             TerminalTabKind::Agent => format!("⚙ {}", tab.name),
         },
         WorkspaceTabKind::File => tab.name.clone(),
+        WorkspaceTabKind::Image => format!("▧ {}", tab.name),
     }
 }

--- a/tests/workspace_session_tests.rs
+++ b/tests/workspace_session_tests.rs
@@ -604,6 +604,33 @@ fn image_preflight_reports_unsupported_extensions() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn image_preflight_reports_permission_denied_when_file_cannot_be_read() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let worktree = std::env::temp_dir().join(format!(
+        "alas-image-permission-denied-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&worktree).expect("create temp worktree");
+    let image = worktree.join("photo.png");
+    std::fs::write(&image, b"not really a png").expect("write image path");
+    let original_permissions = std::fs::metadata(&image)
+        .expect("image metadata")
+        .permissions();
+
+    std::fs::set_permissions(&image, std::fs::Permissions::from_mode(0o000))
+        .expect("remove read permission");
+    let preflight = preflight_image_path(&image);
+    std::fs::set_permissions(&image, original_permissions).expect("restore permissions");
+
+    assert_eq!(preflight, ImagePreflight::PermissionDenied);
+
+    let _ = std::fs::remove_file(image);
+    let _ = std::fs::remove_dir(worktree);
+}
+
 #[test]
 fn image_zoom_transitions_clamp_and_fit_resets() {
     assert_eq!(ImageZoom::Fit.zoom_in(), ImageZoom::Fixed(1.25));

--- a/tests/workspace_session_tests.rs
+++ b/tests/workspace_session_tests.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
 use alas::app::{
-    DetectedLanguage, FileTabLoadState, MarkdownViewMode, TerminalTabId, TerminalTabKind,
-    TerminalTabStatus, WorkspaceSession, WorkspaceTabContent, WorkspaceTabKind,
+    DetectedLanguage, FileTabLoadState, ImagePreflight, ImageZoom, MarkdownViewMode, TerminalTabId,
+    TerminalTabKind, TerminalTabStatus, WorkspaceSession, WorkspaceTabContent, WorkspaceTabKind,
+    is_supported_image_path, preflight_image_path,
 };
 use alas::terminal::{CommandSpec, TerminalBackendSession};
 
@@ -492,7 +493,9 @@ fn file_tab_load_state_can_be_updated() {
             &state.load_state,
             FileTabLoadState::Loaded { content, .. } if content == "hello"
         )),
-        WorkspaceTabContent::Markdown(_) | WorkspaceTabContent::Terminal(_) => {
+        WorkspaceTabContent::Markdown(_)
+        | WorkspaceTabContent::Terminal(_)
+        | WorkspaceTabContent::Image(_) => {
             panic!("expected file tab")
         }
     }
@@ -515,7 +518,9 @@ fn markdown_files_open_in_split_mode_by_default() {
             assert_eq!(state.file.language, DetectedLanguage::Markdown);
             assert!(matches!(state.file.load_state, FileTabLoadState::Loading));
         }
-        WorkspaceTabContent::File(_) | WorkspaceTabContent::Terminal(_) => {
+        WorkspaceTabContent::File(_)
+        | WorkspaceTabContent::Terminal(_)
+        | WorkspaceTabContent::Image(_) => {
             panic!("expected markdown tab")
         }
     }
@@ -544,7 +549,9 @@ fn markdown_mode_can_switch_between_code_preview_and_split() {
         WorkspaceTabContent::Markdown(state) => {
             assert_eq!(state.view_mode, MarkdownViewMode::Split);
         }
-        WorkspaceTabContent::File(_) | WorkspaceTabContent::Terminal(_) => {
+        WorkspaceTabContent::File(_)
+        | WorkspaceTabContent::Terminal(_)
+        | WorkspaceTabContent::Image(_) => {
             panic!("expected markdown tab")
         }
     }
@@ -575,4 +582,87 @@ fn opening_same_markdown_file_focuses_existing_tab() {
         session.active_tab("repo", &path).map(|tab| tab.id),
         Some(first)
     );
+}
+
+#[test]
+fn image_extension_detection_is_case_insensitive() {
+    assert!(is_supported_image_path(&PathBuf::from("photo.PNG")));
+    assert!(is_supported_image_path(&PathBuf::from("photo.JpEg")));
+    assert!(is_supported_image_path(&PathBuf::from("vector.SVG")));
+    assert!(!is_supported_image_path(&PathBuf::from("notes.txt")));
+}
+
+#[test]
+fn image_preflight_reports_unsupported_extensions() {
+    assert_eq!(
+        preflight_image_path(&PathBuf::from("notes.txt")),
+        ImagePreflight::UnsupportedExtension("txt".to_string())
+    );
+    assert_eq!(
+        preflight_image_path(&PathBuf::from("README")),
+        ImagePreflight::UnsupportedExtension(String::new())
+    );
+}
+
+#[test]
+fn image_zoom_transitions_clamp_and_fit_resets() {
+    assert_eq!(ImageZoom::Fit.zoom_in(), ImageZoom::Fixed(1.25));
+    assert_eq!(ImageZoom::Fit.zoom_out(), ImageZoom::Fixed(0.75));
+    assert_eq!(ImageZoom::Fixed(9.9).zoom_in(), ImageZoom::Fixed(10.0));
+    assert_eq!(ImageZoom::Fixed(0.2).zoom_out(), ImageZoom::Fixed(0.1));
+    assert_eq!(ImageZoom::Fit.label(), "Fit");
+    assert_eq!(ImageZoom::Fixed(1.5).label(), "150%");
+}
+
+#[test]
+fn opening_same_image_path_reuses_existing_tab_and_preserves_zoom() {
+    let mut session = WorkspaceSession::default();
+    let worktree = std::env::temp_dir().join(format!("alas-image-dedupe-{}", std::process::id()));
+    std::fs::create_dir_all(&worktree).expect("create temp worktree");
+    let image = worktree.join("photo.png");
+    std::fs::write(&image, b"not really a png").expect("write image path");
+
+    let first = session.open_or_focus_image_tab("repo", worktree.clone(), image.clone());
+    session
+        .set_image_zoom("repo", &worktree, first, ImageZoom::Fixed(2.0))
+        .expect("set zoom");
+    let second = session.open_or_focus_image_tab("repo", worktree.clone(), image.clone());
+
+    assert_eq!(first, second);
+    assert_eq!(session.tabs_for_worktree("repo", &worktree).len(), 1);
+    let active = session.active_tab("repo", &worktree).expect("active tab");
+    let image_state = active.image_tab_state().expect("image tab");
+    assert_eq!(image_state.zoom, ImageZoom::Fixed(2.0));
+    assert_eq!(image_state.preflight, ImagePreflight::Ready);
+
+    let _ = std::fs::remove_file(image);
+    let _ = std::fs::remove_dir(worktree);
+}
+
+#[test]
+fn opening_distinct_images_creates_distinct_tabs() {
+    let mut session = WorkspaceSession::default();
+    let worktree = PathBuf::from("/repo/a");
+
+    let first = session.open_or_focus_image_tab("repo", worktree.clone(), worktree.join("a.png"));
+    let second = session.open_or_focus_image_tab("repo", worktree.clone(), worktree.join("b.png"));
+
+    assert_ne!(first, second);
+    assert_eq!(session.tabs_for_worktree("repo", &worktree).len(), 2);
+    assert_eq!(
+        session.active_tab("repo", &worktree).map(|tab| tab.kind),
+        Some(WorkspaceTabKind::Image)
+    );
+}
+
+#[test]
+fn image_tab_does_not_expose_terminal_state() {
+    let mut session = WorkspaceSession::default();
+    let worktree = PathBuf::from("/repo/a");
+    let tab_id = session.open_or_focus_image_tab("repo", worktree.clone(), worktree.join("a.png"));
+
+    let active = session.active_tab("repo", &worktree).expect("active tab");
+    assert_eq!(active.id, tab_id);
+    assert!(active.terminal_tab_state().is_none());
+    assert!(active.image_tab_state().is_some());
 }


### PR DESCRIPTION
Adds read-only image preview tabs with fit-to-window, basic zoom controls, path deduplication, and unsupported/corrupt-file states.