### PR TITLE
Add ACP agent chat workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "anyhow",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash 2.1.2",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
+dependencies = [
+ "anyhow",
+ "derive_more 2.1.1",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,11 +97,14 @@ dependencies = [
 name = "alas"
 version = "0.1.0"
 dependencies = [
+ "agent-client-protocol",
  "anyhow",
  "directories",
  "gpui",
  "gpui-component",
- "indexmap",
+ "indexmap 2.14.0",
+ "keyring",
+ "libc",
  "libghostty-vt",
  "portable-pty",
  "pretty_assertions",
@@ -481,7 +535,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.18",
  "v_frame",
@@ -791,7 +845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "heck 0.4.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "proc-macro2",
  "quote",
@@ -853,6 +907,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
@@ -1018,6 +1073,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1263,6 +1327,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,16 +1373,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1690,6 +1821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,6 +2022,19 @@ checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
+]
+
+[[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite 2.6.1",
+ "pin-project",
+ "smallvec",
 ]
 
 [[package]]
@@ -2169,7 +2319,7 @@ dependencies = [
  "core-video",
  "cosmic-text",
  "ctor",
- "derive_more",
+ "derive_more 0.99.20",
  "embed-resource",
  "etagere",
  "filedescriptor",
@@ -2206,7 +2356,7 @@ dependencies = [
  "rand 0.9.4",
  "raw-window-handle",
  "resvg",
- "schemars",
+ "schemars 1.2.1",
  "seahash",
  "serde",
  "serde_json",
@@ -2263,7 +2413,7 @@ dependencies = [
  "regex",
  "ropey",
  "rust-i18n",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_repr",
@@ -2306,7 +2456,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae39dc6d3d201be97e4bc08d96dbef2bc5b5c3d5734e05786e8cc3043342351c"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.2",
 ]
 
@@ -2331,7 +2481,7 @@ dependencies = [
  "async-compression",
  "async-fs",
  "bytes",
- "derive_more",
+ "derive_more 0.99.20",
  "futures",
  "gpui_util",
  "http",
@@ -2426,7 +2576,7 @@ dependencies = [
  "nix 0.29.0",
  "regex",
  "rust-embed",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_json_lenient",
@@ -2469,7 +2619,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2487,6 +2637,12 @@ dependencies = [
  "num-traits",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2800,6 +2956,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,6 +3043,17 @@ name = "imgref"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -3064,6 +3237,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
 ]
 
 [[package]]
@@ -3522,7 +3715,7 @@ dependencies = [
  "half",
  "hashbrown 0.15.5",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "num-traits",
  "once_cell",
@@ -3715,6 +3908,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -4030,6 +4229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4466,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4811,6 +5022,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey 0.2.2",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ropey"
 version = "2.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5084,12 +5330,25 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
- "indexmap",
+ "indexmap 2.14.0",
  "ref-cast",
  "schemars_derive",
  "serde",
@@ -5240,7 +5499,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -5254,7 +5513,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e033097bf0d2b59a62b42c18ebbb797503839b26afdda2c4e1415cb6c813540"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5303,12 +5562,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -5611,6 +5901,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5626,6 +5922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -5646,6 +5951,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5977,6 +6294,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6045,9 +6393,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6080,6 +6442,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6103,7 +6466,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -6136,7 +6499,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -6150,7 +6513,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.2",
@@ -6709,7 +7072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6735,7 +7098,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -7436,7 +7799,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7467,7 +7830,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7486,7 +7849,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ directories = "6"
 indexmap = { version = "2", features = ["serde"] }
 portable-pty = "0.8"
 pulldown-cmark = "0.12"
+agent-client-protocol = "0.11.1"
+keyring = { version = "3", default-features = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 # GPUI is the Rust UI framework used by Zed. If crates.io does not have the
 # needed version, switch this dependency to Zed's Git repository during this task.

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -123,3 +123,24 @@
 3. Confirm the Files section shows worktree files and supports directory expand/collapse.
 4. Confirm file loading errors remain scoped to the Files section and do not break terminal input.
 5. Confirm Git status loading errors remain scoped to the Changed section and do not break terminal input.
+
+## ACP Agent Chat
+
+1. Ensure an ACP provider is installed, for example `opencode acp` or another provider command.
+2. Open Alas and select a worktree.
+3. Open provider settings and add a global provider with command/args.
+4. Authenticate from Alas if the provider reports auth is required.
+5. Use `+ → Agent Chat` and select the provider.
+6. Send a prompt and confirm streamed transcript updates appear.
+7. Trigger a file read/write or terminal command and confirm the tool card shows the side effect under Allow Everything.
+8. Restart Alas and confirm the chat returns.
+9. Confirm the composer is enabled only if ACP resume succeeds; otherwise the transcript is read-only.
+
+## ACP Provider Auto-Discovery
+
+1. Ensure `opencode` is installed and available on `PATH`.
+2. Start Alas with no configured `opencode` provider.
+3. Open Provider Settings and confirm OpenCode appears with command `opencode` and args `["acp"]`.
+4. Disable OpenCode, restart Alas, and confirm it stays disabled.
+5. Remove OpenCode, save settings, restart Alas, and confirm it is not re-added.
+6. If `claude` or `codex` are installed, confirm they appear only as suggestions unless manually configured.

--- a/docs/superpowers/plans/2026-05-01-acp-provider-auto-discovery.md
+++ b/docs/superpowers/plans/2026-05-01-acp-provider-auto-discovery.md
@@ -1,0 +1,751 @@
+# ACP Provider Auto-Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Silently auto-configure verified installed ACP providers on startup, while preserving user config and showing unverified provider suggestions.
+
+**Architecture:** Add a focused provider discovery module under `src/agent` that scans safe PATH directories and returns verified providers plus suggestions. Extend app config with ignored provider ids, merge verified discoveries into config during startup, and pass filtered suggestions into Provider Settings.
+
+**Tech Stack:** Rust, serde/TOML app config, GPUI view-model/UI tests, existing `AgentProviderConfig` and `ProviderSettingsState`.
+
+---
+
+## File Structure
+
+- `src/agent/discovery.rs` — new focused module for known provider registry, PATH scanning, discovery result types, merge/filter helpers, and ignore helper.
+- `src/agent/mod.rs` — export discovery types/functions.
+- `src/agent/provider.rs` — extend `ProviderSettingsState` with discovery suggestions and error/suggestion helper methods if needed.
+- `src/config/types.rs` — add defaulted `AgentProviderDiscoveryConfig` to `AppConfig`.
+- `src/ui/provider_settings.rs` — render suggestions below configured providers.
+- `src/ui/shell.rs` — run discovery at startup, save config on merge, pass suggestions to settings, record ignored ids on known provider removal.
+- `tests/agent_provider_discovery_tests.rs` — pure discovery/merge tests with fake PATH directories.
+- `tests/agent_ui_view_model_tests.rs` — provider settings suggestion state/render helper coverage.
+- `tests/config_tests.rs` — app config round-trip/default compatibility for discovery config.
+
+---
+
+### Task 1: Add Discovery Config Model
+
+**Files:**
+- Modify: `src/config/types.rs`
+- Test: `tests/config_tests.rs`
+
+- [ ] **Step 1: Add config tests**
+
+Add tests to `tests/config_tests.rs`:
+
+```rust
+#[test]
+fn app_config_defaults_provider_discovery_config() {
+    let config: AppConfig = toml::from_str("").expect("empty config");
+
+    assert!(config.agent_provider_discovery.ignored_provider_ids.is_empty());
+}
+
+#[test]
+fn app_config_round_trips_provider_discovery_ignored_ids() {
+    let mut config = AppConfig::default();
+    config
+        .agent_provider_discovery
+        .ignored_provider_ids
+        .push("opencode".to_string());
+
+    let toml = toml::to_string(&config).expect("serialize config");
+    assert!(toml.contains("agent_provider_discovery"));
+    assert!(toml.contains("opencode"));
+
+    let loaded: AppConfig = toml::from_str(&toml).expect("deserialize config");
+    assert_eq!(loaded, config);
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cargo test --test config_tests app_config_defaults_provider_discovery_config --all-features
+```
+
+Expected: FAIL because `agent_provider_discovery` does not exist.
+
+- [ ] **Step 3: Implement config model**
+
+In `src/config/types.rs`, add:
+
+```rust
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentProviderDiscoveryConfig {
+    #[serde(default)]
+    pub ignored_provider_ids: Vec<String>,
+}
+```
+
+Extend `AppConfig`:
+
+```rust
+#[serde(default)]
+pub agent_provider_discovery: AgentProviderDiscoveryConfig,
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test --test config_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config/types.rs tests/config_tests.rs
+git commit -m "feat: add ACP provider discovery config"
+```
+
+---
+
+### Task 2: Implement Provider Discovery Core
+
+**Files:**
+- Create: `src/agent/discovery.rs`
+- Modify: `src/agent/mod.rs`
+- Test: `tests/agent_provider_discovery_tests.rs`
+
+- [ ] **Step 1: Add failing discovery tests**
+
+Create `tests/agent_provider_discovery_tests.rs` with helpers that create executable fake binaries in temp directories. On Unix, mark files executable via `std::os::unix::fs::PermissionsExt`; on other platforms, file existence is enough or guard with `#[cfg]` helpers.
+
+Test cases:
+
+```rust
+#[test]
+fn opencode_on_path_is_verified_provider() {
+    // fake PATH contains executable `opencode`
+    // discover_agent_providers_from_path(path)
+    // assert one verified provider: id opencode, command opencode, args ["acp"], enabled true
+}
+
+#[test]
+fn claude_and_codex_on_path_are_suggestions_only() {
+    // fake PATH contains executable `claude` and `codex`
+    // assert verified is empty
+    // assert suggestions ids are claude and codex with clear non-ready messages
+}
+
+#[test]
+fn missing_or_empty_path_does_not_error() {
+    // discover from None or ""
+    // assert no providers and no suggestions
+}
+
+#[test]
+fn ignores_empty_relative_and_non_executable_path_entries() {
+    // PATH includes empty segment, relative segment, and a directory containing non-executable opencode
+    // assert opencode is not verified
+}
+
+#[test]
+fn duplicate_path_matches_are_deduped() {
+    // two PATH dirs contain opencode
+    // assert only one verified provider
+}
+
+#[test]
+fn duplicate_suggestion_matches_are_deduped() {
+    // two PATH dirs contain claude
+    // assert only one claude suggestion
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cargo test --test agent_provider_discovery_tests --all-features
+```
+
+Expected: FAIL because module/functions do not exist.
+
+- [ ] **Step 3: Implement discovery types and registry**
+
+In `src/agent/discovery.rs`, define:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentProviderSuggestion {
+    pub id: String,
+    pub display_name: String,
+    pub command: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ProviderDiscoveryResult {
+    pub verified_providers: Vec<AgentProviderConfig>,
+    pub suggestions: Vec<AgentProviderSuggestion>,
+}
+```
+
+Add known provider registry entries:
+
+- `opencode`: display `OpenCode`, command `opencode`, verified args `vec!["acp"]`.
+- `claude`: display `Claude Code`, command `claude`, suggestion only.
+- `codex`: display `Codex`, command `codex`, suggestion only.
+
+- [ ] **Step 4: Implement safe PATH scanning**
+
+Expose testable functions:
+
+```rust
+pub fn discover_agent_providers() -> ProviderDiscoveryResult;
+pub fn discover_agent_providers_from_path(path_env: Option<&str>) -> ProviderDiscoveryResult;
+pub fn is_known_discoverable_provider_id(provider_id: &str) -> bool;
+```
+
+Rules:
+
+- Use `std::env::split_paths` for PATH parsing.
+- Ignore empty and relative path entries.
+- Ignore path entries that are not directories.
+- For each known command, check `dir.join(command)`.
+- Require executable files on Unix (`mode & 0o111 != 0`).
+- On non-Unix, require `is_file()`.
+- Deduplicate by provider id.
+- Do not execute any provider command.
+
+- [ ] **Step 5: Export module**
+
+Update `src/agent/mod.rs` with only the exports implemented in this task:
+
+```rust
+mod discovery;
+pub use discovery::{
+    AgentProviderSuggestion, ProviderDiscoveryResult, discover_agent_providers,
+    discover_agent_providers_from_path, is_known_discoverable_provider_id,
+};
+```
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+cargo test --test agent_provider_discovery_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/agent/discovery.rs src/agent/mod.rs tests/agent_provider_discovery_tests.rs
+git commit -m "feat: discover installed ACP providers"
+```
+
+---
+
+### Task 3: Add Discovery Merge and Suggestion Filtering
+
+**Files:**
+- Modify: `src/agent/discovery.rs`
+- Test: `tests/agent_provider_discovery_tests.rs`
+
+- [ ] **Step 1: Add failing merge tests**
+
+Add tests:
+
+```rust
+#[test]
+fn merge_appends_missing_verified_provider_and_reports_changed() {
+    // config default + opencode discovery
+    // assert changed true and config.agent_providers[0].id == "opencode"
+}
+
+#[test]
+fn merge_preserves_existing_provider_without_overwrite_or_reenable() {
+    // config has disabled opencode with custom command/args
+    // discovery has default opencode
+    // assert changed false and custom disabled provider unchanged
+}
+
+#[test]
+fn merge_skips_ignored_provider_id() {
+    // config ignored_provider_ids contains opencode
+    // discovery has opencode
+    // assert changed false and providers empty
+}
+
+#[test]
+fn suggestions_are_filtered_for_configured_and_ignored_ids() {
+    // discovery suggestions include claude/codex
+    // config has claude configured and codex ignored
+    // assert filtered suggestions empty
+}
+
+#[test]
+fn record_ignored_known_provider_id_dedupes() {
+    // call helper twice with opencode
+    // assert ignored ids contains one opencode
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cargo test --test agent_provider_discovery_tests --all-features
+```
+
+Expected: FAIL because merge/filter helpers do not exist.
+
+- [ ] **Step 3: Implement merge/filter helpers**
+
+In `src/agent/discovery.rs`, add:
+
+```rust
+pub fn merge_discovered_agent_providers(
+    config: &mut AppConfig,
+    discovery: &ProviderDiscoveryResult,
+) -> bool;
+
+pub fn filtered_provider_suggestions(
+    config: &AppConfig,
+    discovery: &ProviderDiscoveryResult,
+) -> Vec<AgentProviderSuggestion>;
+
+pub fn ignore_discovered_provider_id(config: &mut AppConfig, provider_id: &str) -> bool;
+```
+
+Update `src/agent/mod.rs` to re-export these Task 3 helpers after they exist:
+
+```rust
+pub use discovery::{
+    filtered_provider_suggestions, ignore_discovered_provider_id,
+    merge_discovered_agent_providers,
+};
+```
+
+Rules:
+
+- Merge appends only verified providers whose id is neither configured nor ignored.
+- Merge never mutates existing provider fields.
+- Filtering removes suggestions whose id is configured or ignored.
+- Ignore helper only records ids known to the registry.
+- Ignore helper deduplicates and returns whether config changed.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test --test agent_provider_discovery_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/discovery.rs tests/agent_provider_discovery_tests.rs
+git commit -m "feat: merge discovered ACP providers"
+```
+
+---
+
+### Task 4: Wire Startup Auto-Configuration
+
+**Files:**
+- Modify: `src/ui/shell.rs`
+- Test: `tests/agent_provider_discovery_tests.rs` or focused Shell helper tests if accessible
+
+- [ ] **Step 1: Extract testable startup helper**
+
+Add a required testable helper near discovery or shell integration that accepts a save closure. This makes startup save-failure behavior deterministic without needing to instantiate GPUI shell state.
+
+Suggested API:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderDiscoveryStartupResult {
+    pub changed: bool,
+    pub suggestions: Vec<AgentProviderSuggestion>,
+    pub error: Option<String>,
+}
+
+pub fn apply_provider_discovery_to_config(
+    config: &mut AppConfig,
+    discovery: &ProviderDiscoveryResult,
+    save: impl FnOnce(&AppConfig) -> anyhow::Result<()>,
+) -> ProviderDiscoveryStartupResult
+```
+
+Rules:
+
+- Call `merge_discovered_agent_providers`.
+- Call `save` only when merge changed config.
+- Always return filtered suggestions from the post-merge config.
+- If save fails, keep startup alive and return `error: Some("failed to persist auto-discovered providers: ...")`.
+
+- [ ] **Step 2: Add startup behavior tests**
+
+Add tests for the helper:
+
+```rust
+#[test]
+fn startup_discovery_returns_filtered_suggestions_after_merge() {
+    // opencode verified + claude suggestion
+    // save closure records it was called and returns Ok(())
+    // after apply, config has opencode and suggestions contain claude only
+}
+
+#[test]
+fn startup_discovery_save_failure_returns_deterministic_error_without_aborting() {
+    // opencode verified + empty config
+    // save closure returns anyhow!("disk full")
+    // assert config still has opencode for current session
+    // assert result.changed == true
+    // assert result.error contains "failed to persist auto-discovered providers"
+    // assert result.error contains "disk full"
+}
+
+#[test]
+fn startup_discovery_does_not_save_when_config_unchanged() {
+    // config already has opencode
+    // save closure panics if called
+    // assert changed false and no error
+}
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run:
+
+```bash
+cargo test --test agent_provider_discovery_tests --all-features
+```
+
+Expected: FAIL until helper/wiring exists.
+
+- [ ] **Step 4: Export startup helper**
+
+Update `src/agent/mod.rs` to re-export the new helper and result so integration tests and Shell code can use them:
+
+```rust
+pub use discovery::{
+    ProviderDiscoveryStartupResult, apply_provider_discovery_to_config,
+    filtered_provider_suggestions, ignore_discovered_provider_id,
+    merge_discovered_agent_providers,
+    // keep the existing discovery exports too
+};
+```
+
+- [ ] **Step 5: Wire Shell startup**
+
+In `src/ui/shell.rs`, during `AlasShell::new` after config load and before provider settings use:
+
+1. Run `discover_agent_providers()`.
+2. Call `merge_discovered_agent_providers(&mut config, &discovery)`.
+3. If changed, call `app_config_store.save(&config)`.
+4. Compute filtered suggestions and store them in Shell state or pass into `ProviderSettingsState` when opened.
+5. If save fails, keep startup alive and retain deterministic error text for provider settings.
+
+Add fields to `AlasShell` if needed:
+
+```rust
+provider_discovery_suggestions: Vec<AgentProviderSuggestion>,
+provider_discovery_error: Option<String>,
+```
+
+- [ ] **Step 6: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --test agent_provider_discovery_tests --all-features
+cargo test --test config_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/shell.rs src/agent/discovery.rs src/agent/mod.rs tests/agent_provider_discovery_tests.rs
+git commit -m "feat: auto-configure discovered ACP providers"
+```
+
+---
+
+### Task 5: Show Provider Discovery Suggestions
+
+**Files:**
+- Modify: `src/agent/provider.rs`
+- Modify: `src/ui/provider_settings.rs`
+- Modify: `src/ui/shell.rs`
+- Test: `tests/agent_ui_view_model_tests.rs`
+
+- [ ] **Step 1: Add failing view-model tests**
+
+In `tests/agent_ui_view_model_tests.rs`, add tests:
+
+```rust
+#[test]
+fn provider_settings_tracks_discovery_suggestions() {
+    let mut state = ProviderSettingsState::default();
+    state.discovery_suggestions.push(AgentProviderSuggestion {
+        id: "claude".to_string(),
+        display_name: "Claude Code".to_string(),
+        command: "claude".to_string(),
+        message: "Claude Code found, but ACP command is not verified yet.".to_string(),
+    });
+
+    assert_eq!(state.discovery_suggestions[0].id, "claude");
+}
+
+#[test]
+fn provider_settings_error_can_report_discovery_save_failure() {
+    let mut state = ProviderSettingsState::default();
+    state.error = Some("failed to persist auto-discovered providers".to_string());
+
+    assert!(state.error.as_deref().unwrap().contains("auto-discovered"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cargo test --test agent_ui_view_model_tests provider_settings_tracks_discovery_suggestions --all-features
+```
+
+Expected: FAIL because `discovery_suggestions` does not exist/export is missing.
+
+- [ ] **Step 3: Extend provider settings state**
+
+In `src/agent/provider.rs`, add this field to `ProviderSettingsState`:
+
+```rust
+pub discovery_suggestions: Vec<AgentProviderSuggestion>,
+```
+
+Keep the existing `ProviderSettingsState` derive unchanged. Do not add serde derives to `ProviderSettingsState`; it is view-model state, not persisted config. Import `AgentProviderSuggestion` from the agent discovery exports.
+
+- [ ] **Step 4: Render suggestions**
+
+In `src/ui/provider_settings.rs`, render a suggestions section after provider rows and before buttons when suggestions are non-empty:
+
+- heading: `Discovered tools`
+- each card text: `{display_name} found`
+- message: suggestion message
+- command hint: `Command: claude`
+
+Use existing theme colors (`TEXT`, `TEXT_MUTED`, `PANEL_BORDER`) and readable text colors.
+
+- [ ] **Step 5: Populate settings from Shell**
+
+When `open_provider_settings` creates `ProviderSettingsState`, include the discovery fields in the current struct literal or construct a mutable settings value before assigning it:
+
+```rust
+let mut settings = ProviderSettingsState {
+    providers: self.config.agent_providers.clone(),
+    selected_provider_id: self.config.agent_providers.first().map(|provider| provider.id.clone()),
+    discovery_suggestions: self.provider_discovery_suggestions.clone(),
+    ..ProviderSettingsState::default()
+};
+if let Some(error) = self.provider_discovery_error.clone() {
+    settings.error = Some(error);
+}
+self.provider_settings = Some(settings);
+```
+
+Adapt field initialization to the exact current `open_provider_settings` code.
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+cargo test --test agent_ui_view_model_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/agent/provider.rs src/ui/provider_settings.rs src/ui/shell.rs tests/agent_ui_view_model_tests.rs
+git commit -m "feat: show ACP provider discovery suggestions"
+```
+
+---
+
+### Task 6: Record Ignored Provider IDs on Removal
+
+**Files:**
+- Modify: `src/ui/shell.rs`
+- Test: `tests/agent_provider_discovery_tests.rs` or shell helper tests
+
+- [ ] **Step 1: Add failing removal/ignore test**
+
+If `remove_provider_settings_entry` cannot be tested directly, extract a publicly reachable helper in `src/agent/discovery.rs` and re-export it from `src/agent/mod.rs`:
+
+```rust
+pub fn remove_provider_and_record_discovery_ignore(
+    config: &mut AppConfig,
+    settings: &mut ProviderSettingsState,
+    provider_id: &str,
+) -> bool
+```
+
+If the helper is added, update `src/agent/mod.rs`:
+
+```rust
+pub use discovery::remove_provider_and_record_discovery_ignore;
+```
+
+Test:
+
+```rust
+#[test]
+fn removing_known_discovered_provider_records_ignored_id() {
+    let mut config = AppConfig::default();
+    let mut settings = ProviderSettingsState::default();
+    settings.add_provider(AgentProviderConfig::new("opencode", "OpenCode", "opencode"));
+
+    let changed = remove_provider_and_record_discovery_ignore(&mut config, &mut settings, "opencode");
+
+    assert!(changed);
+    assert!(settings.providers.is_empty());
+    assert_eq!(config.agent_provider_discovery.ignored_provider_ids, vec!["opencode"]);
+}
+
+#[test]
+fn saving_after_removal_persists_ignored_provider_ids() {
+    // Use AppConfigStore with a temp config path or a smaller save helper.
+    // Remove opencode through the helper, assign settings.providers into config.agent_providers,
+    // save config, reload it, and assert ignored_provider_ids contains opencode.
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cargo test --test agent_provider_discovery_tests removing_known_discovered_provider_records_ignored_id --all-features
+```
+
+Expected: FAIL until helper/wiring exists.
+
+- [ ] **Step 3: Implement removal ignore wiring**
+
+Update `remove_provider_settings_entry` in `src/ui/shell.rs`:
+
+- Before or after removing from settings, call `ignore_discovered_provider_id(&mut self.config, provider_id)`.
+- Recompute `self.provider_discovery_suggestions` using current config and the latest discovery result if stored, or remove matching suggestion locally.
+- Ensure `save_provider_settings` persists both updated providers and updated ignored ids.
+
+Do not ignore unknown custom provider ids.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test --test agent_provider_discovery_tests --all-features
+cargo test --test agent_ui_view_model_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/shell.rs src/agent/discovery.rs tests/agent_provider_discovery_tests.rs
+git commit -m "feat: remember ignored discovered ACP providers"
+```
+
+---
+
+### Task 7: Full Verification and Manual Docs
+
+**Files:**
+- Modify: `docs/manual-test.md`
+
+- [ ] **Step 1: Add manual test section**
+
+Append a short section:
+
+```markdown
+## ACP Provider Auto-Discovery
+
+1. Ensure `opencode` is installed and available on `PATH`.
+2. Start Alas with no configured `opencode` provider.
+3. Open Provider Settings and confirm OpenCode appears with command `opencode` and args `["acp"]`.
+4. Disable OpenCode, restart Alas, and confirm it stays disabled.
+5. Remove OpenCode, save settings, restart Alas, and confirm it is not re-added.
+6. If `claude` or `codex` are installed, confirm they appear only as suggestions unless manually configured.
+```
+
+- [ ] **Step 2: Run formatting**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run clippy**
+
+Run:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run build**
+
+Run:
+
+```bash
+cargo build --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+cargo test --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit docs if verification passes**
+
+```bash
+git add docs/manual-test.md
+git commit -m "docs: add ACP provider discovery manual test"
+```
+
+- [ ] **Step 7: Final status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean working tree.

--- a/docs/superpowers/plans/2026-05-01-center-pane-acp.md
+++ b/docs/superpowers/plans/2026-05-01-center-pane-acp.md
@@ -1,0 +1,2772 @@
+# Center Pane ACP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ACP-backed Agent Chat tabs to the Alas center pane with global manual providers, in-app auth, durable resume behavior, filesystem/terminal callbacks, and provider settings.
+
+**Architecture:** Add ACP as a new workspace tab content type, with provider config and persisted thread state kept separate from live ACP runtime connections. Implement an `agent` module with focused submodules for domain types, provider config/auth, runtime lifecycle, callbacks, terminal command execution, persistence, and test fakes. Integrate UI through the existing `WorkspaceSession`, `render_workspace` tab bar, and `AlasShell` active-tab routing without rewriting terminal/file/markdown surfaces.
+
+**Tech Stack:** Rust 2024, GPUI/gpui-component, serde/toml/serde_json, `agent-client-protocol` crate, OS credential storage via `keyring`, standard subprocess/file APIs, existing Alas app/config/workspace/session patterns.
+
+---
+
+## Scope and Sequencing Notes
+
+This plan implements the approved first subproject from `docs/superpowers/specs/2026-05-01-center-pane-acp-design.md`: ACP foundation with full contracts. It intentionally does not implement ACP registry install/update management.
+
+Use TDD for each task. Keep commits small and do not batch unrelated tasks. If the real `agent-client-protocol` Rust API names differ from examples below, adapt the runtime wrapper while keeping the public Alas-owned interfaces and tests intact.
+
+## File Structure
+
+Create these new files:
+
+- `src/agent/mod.rs` — exports the ACP/agent feature modules.
+- `src/agent/types.rs` — provider ids, trust modes, auth status, thread status, transcript/tool/plan data types.
+- `src/agent/provider.rs` — global provider config model, env/auth metadata, validation helpers.
+- `src/agent/credentials.rs` — OS secure credential store trait and `keyring` implementation, plus test memory store.
+- `src/agent/persistence.rs` — local persisted Agent Chat records and JSON store.
+- `src/agent/permission.rs` — trust-mode policy decisions for permission, filesystem, and terminal callbacks.
+- `src/agent/filesystem.rs` — ACP filesystem callback implementation against disk.
+- `src/agent/terminal.rs` — protocol-only terminal command callback service.
+- `src/agent/runtime.rs` — live ACP runtime state machine, provider process lifecycle, session lifecycle, prompt/cancel facade.
+- `src/agent/fake.rs` — test fakes for runtime/connection behavior.
+- `src/ui/agent_pane.rs` — Agent Chat pane renderer.
+- `src/ui/provider_settings.rs` — global provider settings/auth UI renderer.
+- `tests/agent_provider_config_tests.rs` — provider config serialization/defaults/validation.
+- `tests/agent_workspace_tests.rs` — Agent Chat tab behavior in workspace session.
+- `tests/agent_persistence_tests.rs` — persisted thread store behavior.
+- `tests/agent_permission_tests.rs` — trust policy behavior.
+- `tests/agent_filesystem_tests.rs` — filesystem callback behavior.
+- `tests/agent_terminal_tests.rs` — protocol-only terminal callback behavior.
+- `tests/agent_runtime_tests.rs` — runtime state transitions using fakes.
+- `tests/agent_ui_view_model_tests.rs` — UI/view model state coverage.
+
+Modify these existing files:
+
+- `Cargo.toml` — add `agent-client-protocol`, `keyring`, and any small async/process helper only if needed.
+- `src/lib.rs` — export `agent` module.
+- `src/config/types.rs` — add global provider config to `AppConfig`.
+- `src/config/mod.rs` — re-export new provider config types if they live under `config`; otherwise re-export from `agent` as needed.
+- `src/app/workspace.rs` — add Agent Chat tab state/content/kind and mutation helpers.
+- `src/app/mod.rs` — re-export Agent Chat workspace types.
+- `src/ui/mod.rs` — export `agent_pane` and `provider_settings`.
+- `src/ui/workspace.rs` — make `+` action open a Terminal vs Agent Chat picker and add Agent Chat tab labels.
+- `src/ui/shell.rs` — store provider/settings/picker/runtime UI state, route Agent Chat tabs, connect UI events to runtime facade, persist thread changes.
+- `docs/manual-test.md` — add ACP manual acceptance steps.
+
+---
+
+### Task 1: Add Provider Config Types
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `src/config/types.rs`
+- Test: `tests/agent_provider_config_tests.rs`
+
+- [ ] **Step 1: Add failing provider config tests**
+
+Create `tests/agent_provider_config_tests.rs`:
+
+```rust
+use alas::config::AppConfig;
+use alas::agent::{AgentProviderConfig, AgentProviderEnvVar, AgentTrustMode, ProviderCwdPolicy};
+
+#[test]
+fn app_config_serializes_global_agent_providers_without_secret_values() {
+    let mut config = AppConfig::default();
+    config.agent_providers.push(AgentProviderConfig {
+        id: "opencode".to_string(),
+        display_name: "OpenCode".to_string(),
+        command: "opencode".to_string(),
+        args: vec!["acp".to_string()],
+        env: vec![AgentProviderEnvVar::secure_ref("OPENCODE_API_KEY", "opencode/api-key")],
+        cwd_policy: ProviderCwdPolicy::SelectedWorktree,
+        trust_mode: AgentTrustMode::AllowEverything,
+        enabled: true,
+    });
+
+    let toml = toml::to_string(&config).expect("serialize config");
+    assert!(toml.contains("agent_providers"));
+    assert!(toml.contains("opencode/api-key"));
+    assert!(!toml.contains("super-secret"));
+
+    let loaded: AppConfig = toml::from_str(&toml).expect("deserialize config");
+    assert_eq!(loaded.agent_providers[0].trust_mode, AgentTrustMode::AllowEverything);
+}
+
+#[test]
+fn provider_defaults_to_allow_everything_and_selected_worktree() {
+    let provider = AgentProviderConfig::new("codex", "Codex", "codex-acp");
+    assert_eq!(provider.trust_mode, AgentTrustMode::AllowEverything);
+    assert_eq!(provider.cwd_policy, ProviderCwdPolicy::SelectedWorktree);
+    assert!(provider.enabled);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_provider_config_tests --all-features`
+
+Expected: FAIL because `alas::agent` and `AppConfig::agent_providers` do not exist.
+
+- [ ] **Step 3: Add dependencies and minimal provider types**
+
+Modify `Cargo.toml`:
+
+```toml
+agent-client-protocol = "0.20"
+keyring = { version = "3", default-features = true }
+```
+
+If the ACP crate version has advanced, use the latest compatible version from `cargo search agent-client-protocol` and record the chosen version in the commit message.
+
+Create `src/agent/mod.rs`:
+
+```rust
+pub mod provider;
+pub mod types;
+
+pub use provider::{AgentProviderConfig, AgentProviderEnvVar, ProviderCwdPolicy};
+pub use types::AgentTrustMode;
+```
+
+Create `src/agent/types.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentTrustMode {
+    AllowEverything,
+    Ask,
+    WorktreeOnly,
+    Deny,
+}
+
+impl Default for AgentTrustMode {
+    fn default() -> Self {
+        Self::AllowEverything
+    }
+}
+```
+
+Create `src/agent/provider.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+use crate::agent::AgentTrustMode;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentProviderConfig {
+    pub id: String,
+    pub display_name: String,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: Vec<AgentProviderEnvVar>,
+    #[serde(default)]
+    pub cwd_policy: ProviderCwdPolicy,
+    #[serde(default)]
+    pub trust_mode: AgentTrustMode,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+impl AgentProviderConfig {
+    pub fn new(id: impl Into<String>, display_name: impl Into<String>, command: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            display_name: display_name.into(),
+            command: command.into(),
+            args: Vec::new(),
+            env: Vec::new(),
+            cwd_policy: ProviderCwdPolicy::default(),
+            trust_mode: AgentTrustMode::default(),
+            enabled: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentProviderEnvVar {
+    pub name: String,
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default)]
+    pub secure_ref: Option<String>,
+}
+
+impl AgentProviderEnvVar {
+    pub fn secure_ref(name: impl Into<String>, secure_ref: impl Into<String>) -> Self {
+        Self { name: name.into(), value: None, secure_ref: Some(secure_ref.into()) }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProviderCwdPolicy {
+    SelectedWorktree,
+    RepositoryRoot,
+    Fixed(std::path::PathBuf),
+}
+
+impl Default for ProviderCwdPolicy {
+    fn default() -> Self { Self::SelectedWorktree }
+}
+
+fn default_enabled() -> bool { true }
+```
+
+Modify `src/lib.rs`:
+
+```rust
+pub mod agent;
+```
+
+Modify `src/config/types.rs` `AppConfig`:
+
+```rust
+#[serde(default)]
+pub agent_providers: Vec<crate::agent::AgentProviderConfig>,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --test agent_provider_config_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run formatting**
+
+Run: `cargo fmt --all -- --check`
+
+Expected: PASS. If it fails, run `cargo fmt --all`, then rerun the check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/lib.rs src/agent src/config/types.rs tests/agent_provider_config_tests.rs
+git commit -m "feat: add ACP provider config model"
+```
+
+---
+
+### Task 2: Add Credential Store Abstraction
+
+**Files:**
+- Create: `src/agent/credentials.rs`
+- Modify: `src/agent/mod.rs`
+- Test: `tests/agent_provider_config_tests.rs`
+
+- [ ] **Step 1: Add failing credential-store tests**
+
+Append to `tests/agent_provider_config_tests.rs`:
+
+```rust
+use alas::agent::{CredentialStore, CredentialStoreKey, MemoryCredentialStore};
+
+#[test]
+fn memory_credential_store_round_trips_secret_by_provider_and_field() {
+    let store = MemoryCredentialStore::default();
+    let key = CredentialStoreKey::new("opencode", "OPENCODE_API_KEY");
+
+    store.write_secret(&key, "super-secret").expect("write secret");
+    assert_eq!(store.read_secret(&key).expect("read secret"), Some("super-secret".to_string()));
+    store.delete_secret(&key).expect("delete secret");
+    assert_eq!(store.read_secret(&key).expect("read after delete"), None);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_provider_config_tests --all-features`
+
+Expected: FAIL because credential types do not exist.
+
+- [ ] **Step 3: Implement credential store trait, memory store, and keyring store**
+
+Create `src/agent/credentials.rs`:
+
+```rust
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use anyhow::Context;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct CredentialStoreKey {
+    pub provider_id: String,
+    pub field: String,
+}
+
+impl CredentialStoreKey {
+    pub fn new(provider_id: impl Into<String>, field: impl Into<String>) -> Self {
+        Self { provider_id: provider_id.into(), field: field.into() }
+    }
+
+    fn service(&self) -> String { format!("alas.agent.{}", self.provider_id) }
+    fn username(&self) -> &str { &self.field }
+}
+
+pub trait CredentialStore: Send + Sync {
+    fn read_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<Option<String>>;
+    fn write_secret(&self, key: &CredentialStoreKey, value: &str) -> anyhow::Result<()>;
+    fn delete_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<()>;
+}
+
+#[derive(Clone, Default)]
+pub struct MemoryCredentialStore {
+    secrets: Arc<Mutex<HashMap<CredentialStoreKey, String>>>,
+}
+
+impl CredentialStore for MemoryCredentialStore {
+    fn read_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<Option<String>> {
+        Ok(self.secrets.lock().expect("credential lock").get(key).cloned())
+    }
+
+    fn write_secret(&self, key: &CredentialStoreKey, value: &str) -> anyhow::Result<()> {
+        self.secrets.lock().expect("credential lock").insert(key.clone(), value.to_string());
+        Ok(())
+    }
+
+    fn delete_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<()> {
+        self.secrets.lock().expect("credential lock").remove(key);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OsCredentialStore;
+
+impl CredentialStore for OsCredentialStore {
+    fn read_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<Option<String>> {
+        let entry = keyring::Entry::new(&key.service(), key.username())
+            .context("failed to create keyring entry")?;
+        match entry.get_password() {
+            Ok(secret) => Ok(Some(secret)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(error).context("failed to read secret from OS credential store"),
+        }
+    }
+
+    fn write_secret(&self, key: &CredentialStoreKey, value: &str) -> anyhow::Result<()> {
+        keyring::Entry::new(&key.service(), key.username())
+            .context("failed to create keyring entry")?
+            .set_password(value)
+            .context("failed to write secret to OS credential store")
+    }
+
+    fn delete_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<()> {
+        let entry = keyring::Entry::new(&key.service(), key.username())
+            .context("failed to create keyring entry")?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(error).context("failed to delete secret from OS credential store"),
+        }
+    }
+}
+```
+
+Modify `src/agent/mod.rs`:
+
+```rust
+pub mod credentials;
+pub use credentials::{CredentialStore, CredentialStoreKey, MemoryCredentialStore, OsCredentialStore};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --test agent_provider_config_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/credentials.rs src/agent/mod.rs tests/agent_provider_config_tests.rs
+git commit -m "feat: add secure credential store abstraction"
+```
+
+---
+
+### Task 3: Add Agent Thread Domain Types
+
+**Files:**
+- Modify: `src/agent/types.rs`
+- Test: `tests/agent_workspace_tests.rs`
+
+- [ ] **Step 1: Add failing tests for thread defaults**
+
+Create `tests/agent_workspace_tests.rs` with only domain tests first:
+
+```rust
+use std::path::PathBuf;
+
+use alas::agent::{AgentThreadState, AgentThreadStatus, AgentTranscriptEntry};
+
+#[test]
+fn new_agent_thread_starts_disconnected_with_empty_transcript() {
+    let state = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+
+    assert_eq!(state.provider_id, "opencode");
+    assert_eq!(state.status, AgentThreadStatus::Disconnected);
+    assert!(state.acp_session_id.is_none());
+    assert!(state.transcript.is_empty());
+    assert_eq!(state.draft, "");
+}
+
+#[test]
+fn transcript_entries_keep_role_and_text() {
+    let entry = AgentTranscriptEntry::user("hello");
+    assert_eq!(entry.text, "hello");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_workspace_tests --all-features`
+
+Expected: FAIL because thread types do not exist.
+
+- [ ] **Step 3: Implement minimal domain types**
+
+Extend `src/agent/types.rs`:
+
+```rust
+use std::path::PathBuf;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentThreadState {
+    pub provider_id: String,
+    pub acp_session_id: Option<String>,
+    pub worktree_path: PathBuf,
+    pub title: String,
+    pub status: AgentThreadStatus,
+    pub transcript: Vec<AgentTranscriptEntry>,
+    pub tool_calls: Vec<AgentToolCallState>,
+    pub plans: Vec<AgentPlanState>,
+    pub pending_permissions: Vec<AgentPermissionRequest>,
+    pub available_commands: Vec<AgentSlashCommand>,
+    pub available_modes: Vec<AgentModeOption>,
+    pub current_mode: Option<String>,
+    pub config_options: Vec<AgentConfigOption>,
+    pub draft: String,
+    pub resume: AgentResumeState,
+    pub debug_log: Vec<AgentDebugEvent>,
+}
+
+impl AgentThreadState {
+    pub fn new(provider_id: impl Into<String>, worktree_path: PathBuf) -> Self {
+        Self {
+            provider_id: provider_id.into(),
+            acp_session_id: None,
+            worktree_path,
+            title: "Agent Chat".to_string(),
+            status: AgentThreadStatus::Disconnected,
+            transcript: Vec::new(),
+            tool_calls: Vec::new(),
+            plans: Vec::new(),
+            pending_permissions: Vec::new(),
+            available_commands: Vec::new(),
+            available_modes: Vec::new(),
+            current_mode: None,
+            config_options: Vec::new(),
+            draft: String::new(),
+            resume: AgentResumeState::NotRestored,
+            debug_log: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentThreadStatus {
+    Disconnected,
+    Starting,
+    AuthRequired,
+    Ready,
+    Running,
+    Failed { message: String },
+    ReadOnly { reason: String },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTranscriptEntry {
+    pub role: AgentTranscriptRole,
+    pub text: String,
+}
+
+impl AgentTranscriptEntry {
+    pub fn user(text: impl Into<String>) -> Self {
+        Self { role: AgentTranscriptRole::User, text: text.into() }
+    }
+
+    pub fn agent(text: impl Into<String>) -> Self {
+        Self { role: AgentTranscriptRole::Agent, text: text.into() }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentTranscriptRole { User, Agent, Thought, System, Tool }
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentToolCallState { pub id: String, pub title: String, pub status: String }
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentPlanState { pub entries: Vec<String> }
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentPermissionRequest { pub id: String, pub description: String }
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentSlashCommand { pub name: String, pub description: Option<String> }
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentModeOption { pub id: String, pub name: String }
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentConfigOption { pub id: String, pub label: String, pub value: Option<String> }
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentResumeState {
+    NotRestored,
+    Pending,
+    Resumed,
+    Unsupported,
+    Failed { message: String },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentDebugEvent { pub message: String }
+```
+
+Update `src/agent/mod.rs` exports for the new types.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --test agent_workspace_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/types.rs src/agent/mod.rs tests/agent_workspace_tests.rs
+git commit -m "feat: add agent thread state types"
+```
+
+---
+
+### Task 4: Add Agent Chat Tabs to WorkspaceSession
+
+**Files:**
+- Modify: `src/app/workspace.rs`
+- Modify: `src/app/mod.rs`
+- Modify: `src/ui/workspace.rs`
+- Test: `tests/agent_workspace_tests.rs`
+
+- [ ] **Step 1: Add failing workspace tests**
+
+Append to `tests/agent_workspace_tests.rs`:
+
+```rust
+use alas::app::{TerminalTabKind, WorkspaceSession, WorkspaceTabContent, WorkspaceTabKind};
+use alas::terminal::CommandSpec;
+
+#[test]
+fn worktree_can_have_agent_chat_tabs_with_other_tab_kinds() {
+    let mut session = WorkspaceSession::default();
+    let path = PathBuf::from("/repo/a");
+    let terminal = session.create_terminal_tab(
+        "repo",
+        path.clone(),
+        "Shell".to_string(),
+        TerminalTabKind::Shell,
+        CommandSpec::shell_command("$SHELL", path.clone()),
+    );
+
+    let agent = session.create_agent_chat_tab("repo", path.clone(), "opencode".to_string());
+
+    let tabs = session.tabs_for_worktree("repo", &path);
+    assert_eq!(tabs.len(), 2);
+    assert_eq!(tabs[0].id, terminal);
+    assert_eq!(tabs[1].id, agent);
+    assert_eq!(tabs[1].kind, WorkspaceTabKind::AgentChat);
+    assert!(matches!(tabs[1].content, WorkspaceTabContent::AgentChat(_)));
+    assert_eq!(session.active_tab("repo", &path).map(|tab| tab.id), Some(agent));
+}
+
+#[test]
+fn terminal_specific_mutation_rejects_agent_chat_tabs() {
+    let mut session = WorkspaceSession::default();
+    let path = PathBuf::from("/repo/a");
+    let agent = session.create_agent_chat_tab("repo", path.clone(), "opencode".to_string());
+
+    let error = session
+        .set_tab_scroll_offset("repo", &path, agent, 12)
+        .expect_err("agent tab should reject terminal mutation")
+        .to_string();
+
+    assert!(error.contains("not a terminal tab"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_workspace_tests --all-features`
+
+Expected: FAIL because workspace Agent Chat methods/kinds do not exist.
+
+- [ ] **Step 3: Implement workspace model support**
+
+Modify `src/app/workspace.rs`:
+
+```rust
+use crate::agent::AgentThreadState;
+```
+
+Add variants:
+
+```rust
+pub enum WorkspaceTabKind {
+    Terminal(TerminalTabKind),
+    File,
+    AgentChat,
+}
+
+pub enum WorkspaceTabContent {
+    Terminal(TerminalTabState),
+    File(FileTabState),
+    Markdown(MarkdownTabState),
+    AgentChat(AgentThreadState),
+}
+```
+
+Update helper matches so AgentChat is non-terminal and non-file. Add:
+
+```rust
+pub fn is_agent_chat(&self) -> bool {
+    matches!(self.kind, WorkspaceTabKind::AgentChat)
+}
+
+pub fn agent_thread_state(&self) -> Option<&AgentThreadState> {
+    match &self.content {
+        WorkspaceTabContent::AgentChat(state) => Some(state),
+        _ => None,
+    }
+}
+
+pub fn agent_thread_state_mut(&mut self) -> Option<&mut AgentThreadState> {
+    match &mut self.content {
+        WorkspaceTabContent::AgentChat(state) => Some(state),
+        _ => None,
+    }
+}
+```
+
+Add `WorkspaceSession::create_agent_chat_tab`:
+
+```rust
+pub fn create_agent_chat_tab(
+    &mut self,
+    repo_id: impl Into<String>,
+    path: PathBuf,
+    provider_id: String,
+) -> WorkspaceTabId {
+    let key = WorktreeKey::new(repo_id, path.clone());
+    self.next_tab_id += 1;
+    let id = WorkspaceTabId(self.next_tab_id);
+    let tab = WorkspaceTab {
+        id,
+        name: "Agent Chat".to_string(),
+        kind: WorkspaceTabKind::AgentChat,
+        content: WorkspaceTabContent::AgentChat(AgentThreadState::new(provider_id, path)),
+    };
+    self.tabs.entry(key.clone()).or_default().push(tab);
+    self.active_tabs.insert(key, id);
+    id
+}
+```
+
+Update `known_file_tab_mut`, `known_markdown_tab_mut`, and `file_tab_path` matches to include AgentChat.
+
+Modify `src/app/mod.rs` to re-export agent workspace types if needed.
+
+Modify `src/ui/workspace.rs` `tab_label`:
+
+```rust
+WorkspaceTabKind::AgentChat => format!("◇ {}", tab.name),
+```
+
+- [ ] **Step 4: Run targeted tests**
+
+Run: `cargo test --test agent_workspace_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run existing workspace tests**
+
+Run: `cargo test --test workspace_session_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/workspace.rs src/app/mod.rs src/ui/workspace.rs tests/agent_workspace_tests.rs
+git commit -m "feat: add agent chat workspace tabs"
+```
+
+---
+
+### Task 5: Add Agent Thread Persistence Store
+
+**Files:**
+- Create: `src/agent/persistence.rs`
+- Modify: `src/agent/mod.rs`
+- Test: `tests/agent_persistence_tests.rs`
+
+- [ ] **Step 1: Add failing persistence tests**
+
+Create `tests/agent_persistence_tests.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use alas::agent::{AgentThreadRecord, AgentThreadState, AgentThreadStore, AgentTranscriptEntry};
+use tempfile::tempdir;
+
+#[test]
+fn thread_store_round_trips_persisted_thread_records() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentThreadStore::new(dir.path().join("agent_threads.json"));
+    let mut state = AgentThreadState::new("opencode", PathBuf::from("/repo/a"));
+    state.acp_session_id = Some("sess-1".to_string());
+    state.transcript.push(AgentTranscriptEntry::user("hello"));
+
+    let record = AgentThreadRecord::from_state("thread-1".to_string(), &state);
+    store.save_records(&[record.clone()]).expect("save records");
+
+    let loaded = store.load_records().expect("load records");
+    assert_eq!(loaded, vec![record]);
+}
+
+#[test]
+fn missing_thread_store_loads_empty_records() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentThreadStore::new(dir.path().join("missing.json"));
+    assert!(store.load_records().expect("load missing").is_empty());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_persistence_tests --all-features`
+
+Expected: FAIL because persistence types do not exist.
+
+- [ ] **Step 3: Implement JSON persistence**
+
+Create `src/agent/persistence.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+use crate::agent::AgentThreadState;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentThreadRecord {
+    pub thread_id: String,
+    pub state: AgentThreadState,
+}
+
+impl AgentThreadRecord {
+    pub fn from_state(thread_id: String, state: &AgentThreadState) -> Self {
+        Self { thread_id, state: state.clone() }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentThreadStore { path: PathBuf }
+
+impl AgentThreadStore {
+    pub fn new(path: PathBuf) -> Self { Self { path } }
+    pub fn path(&self) -> &Path { &self.path }
+
+    pub fn load_records(&self) -> anyhow::Result<Vec<AgentThreadRecord>> {
+        if !self.path.exists() { return Ok(Vec::new()); }
+        let contents = std::fs::read_to_string(&self.path)
+            .with_context(|| format!("failed to read agent thread store {}", self.path.display()))?;
+        serde_json::from_str(&contents)
+            .with_context(|| format!("failed to parse agent thread store {}", self.path.display()))
+    }
+
+    pub fn save_records(&self, records: &[AgentThreadRecord]) -> anyhow::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create agent thread store directory {}", parent.display()))?;
+        }
+        let contents = serde_json::to_string_pretty(records).context("failed to serialize agent thread records")?;
+        std::fs::write(&self.path, contents)
+            .with_context(|| format!("failed to write agent thread store {}", self.path.display()))
+    }
+}
+```
+
+Modify `src/agent/mod.rs`:
+
+```rust
+pub mod persistence;
+pub use persistence::{AgentThreadRecord, AgentThreadStore};
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test agent_persistence_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/persistence.rs src/agent/mod.rs tests/agent_persistence_tests.rs
+git commit -m "feat: persist agent chat thread records"
+```
+
+---
+
+### Task 6: Add Permission Policy Service
+
+**Files:**
+- Create: `src/agent/permission.rs`
+- Modify: `src/agent/mod.rs`
+- Test: `tests/agent_permission_tests.rs`
+
+- [ ] **Step 1: Add failing permission tests**
+
+Create `tests/agent_permission_tests.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use alas::agent::{AgentTrustMode, PermissionDecision, PermissionPolicy, PermissionRequestKind};
+use tempfile::tempdir;
+
+#[test]
+fn allow_everything_approves_filesystem_and_terminal_anywhere() {
+    let policy = PermissionPolicy::new(AgentTrustMode::AllowEverything, PathBuf::from("/repo/a"));
+
+    assert_eq!(
+        policy.decide(PermissionRequestKind::WriteFile(PathBuf::from("/tmp/outside.txt"))),
+        PermissionDecision::Allow,
+    );
+    assert_eq!(
+        policy.decide(PermissionRequestKind::RunTerminal { command: "rm -rf /tmp/example".to_string() }),
+        PermissionDecision::Allow,
+    );
+}
+
+#[test]
+fn worktree_only_rejects_write_outside_canonical_worktree() {
+    let worktree = tempdir().expect("worktree");
+    let outside = tempdir().expect("outside");
+    let policy = PermissionPolicy::new(AgentTrustMode::WorktreeOnly, worktree.path().to_path_buf());
+
+    assert_eq!(
+        policy.decide(PermissionRequestKind::WriteFile(outside.path().join("outside.txt"))),
+        PermissionDecision::Deny,
+    );
+    assert_eq!(
+        policy.decide(PermissionRequestKind::WriteFile(worktree.path().join("inside.txt"))),
+        PermissionDecision::Allow,
+    );
+}
+
+#[test]
+fn deny_rejects_all_side_effects() {
+    let policy = PermissionPolicy::new(AgentTrustMode::Deny, PathBuf::from("/repo/a"));
+    assert_eq!(
+        policy.decide(PermissionRequestKind::RunTerminal { command: "cargo test".to_string() }),
+        PermissionDecision::Deny,
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_permission_tests --all-features`
+
+Expected: FAIL because permission policy does not exist.
+
+- [ ] **Step 3: Implement policy decisions**
+
+Create `src/agent/permission.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use crate::agent::AgentTrustMode;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PermissionDecision { Allow, Ask, Deny }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PermissionRequestKind {
+    ReadFile(PathBuf),
+    WriteFile(PathBuf),
+    RunTerminal { command: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PermissionPolicy {
+    trust_mode: AgentTrustMode,
+    worktree_path: PathBuf,
+}
+
+impl PermissionPolicy {
+    pub fn new(trust_mode: AgentTrustMode, worktree_path: PathBuf) -> Self {
+        Self { trust_mode, worktree_path }
+    }
+
+    pub fn decide(&self, request: PermissionRequestKind) -> PermissionDecision {
+        match self.trust_mode {
+            AgentTrustMode::AllowEverything => PermissionDecision::Allow,
+            AgentTrustMode::Ask => PermissionDecision::Ask,
+            AgentTrustMode::Deny => PermissionDecision::Deny,
+            AgentTrustMode::WorktreeOnly => match request {
+                PermissionRequestKind::ReadFile(path) | PermissionRequestKind::WriteFile(path) => {
+                    if path_is_within(&path, &self.worktree_path) { PermissionDecision::Allow } else { PermissionDecision::Deny }
+                }
+                PermissionRequestKind::RunTerminal { .. } => PermissionDecision::Ask,
+            },
+        }
+    }
+}
+
+fn path_is_within(path: &Path, root: &Path) -> bool {
+    let Some(canonical_root) = canonicalize_policy_path(root) else { return false; };
+    let Some(canonical_path) = canonicalize_policy_path(path) else { return false; };
+    canonical_path.starts_with(canonical_root)
+}
+
+fn canonicalize_policy_path(path: &Path) -> Option<PathBuf> {
+    if let Ok(canonical) = path.canonicalize() {
+        return Some(canonical);
+    }
+
+    let mut missing_components = Vec::new();
+    let mut existing = path;
+    while !existing.exists() {
+        let file_name = existing.file_name()?.to_os_string();
+        missing_components.push(file_name);
+        existing = existing.parent()?;
+    }
+
+    let mut canonical = existing.canonicalize().ok()?;
+    for component in missing_components.into_iter().rev() {
+        canonical.push(component);
+    }
+    Some(canonical)
+}
+```
+
+Modify `src/agent/mod.rs` exports.
+
+- [ ] **Step 4: Run permission tests**
+
+Run: `cargo test --test agent_permission_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/permission.rs src/agent/mod.rs tests/agent_permission_tests.rs
+git commit -m "feat: add agent permission policy"
+```
+
+---
+
+### Task 7: Add Filesystem Callback Service
+
+**Files:**
+- Create: `src/agent/filesystem.rs`
+- Modify: `src/agent/mod.rs`
+- Test: `tests/agent_filesystem_tests.rs`
+
+- [ ] **Step 1: Add failing filesystem callback tests**
+
+Create `tests/agent_filesystem_tests.rs`:
+
+```rust
+use alas::agent::{AgentTrustMode, FilesystemCallbackService, PermissionDecision};
+use tempfile::tempdir;
+
+#[test]
+fn filesystem_service_reads_and_writes_text_files_when_allowed() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("note.txt");
+    let service = FilesystemCallbackService::new(AgentTrustMode::AllowEverything, dir.path().to_path_buf());
+
+    service.write_text_file(&file, "hello").expect("write file");
+    assert_eq!(service.read_text_file(&file).expect("read file"), "hello");
+}
+
+#[test]
+fn filesystem_service_denies_writes_when_policy_denies() {
+    let dir = tempdir().expect("tempdir");
+    let file = dir.path().join("note.txt");
+    let service = FilesystemCallbackService::new(AgentTrustMode::Deny, dir.path().to_path_buf());
+
+    let error = service.write_text_file(&file, "hello").expect_err("denied write").to_string();
+    assert!(error.contains("denied"));
+    assert!(!file.exists());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_filesystem_tests --all-features`
+
+Expected: FAIL because service does not exist.
+
+- [ ] **Step 3: Implement filesystem service**
+
+Create `src/agent/filesystem.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+
+use crate::agent::{AgentTrustMode, PermissionDecision, PermissionPolicy, PermissionRequestKind};
+
+#[derive(Clone, Debug)]
+pub struct FilesystemCallbackService {
+    policy: PermissionPolicy,
+}
+
+impl FilesystemCallbackService {
+    pub fn new(trust_mode: AgentTrustMode, worktree_path: PathBuf) -> Self {
+        Self { policy: PermissionPolicy::new(trust_mode, worktree_path) }
+    }
+
+    pub fn read_text_file(&self, path: &Path) -> anyhow::Result<String> {
+        match self.policy.decide(PermissionRequestKind::ReadFile(path.to_path_buf())) {
+            PermissionDecision::Allow => std::fs::read_to_string(path)
+                .with_context(|| format!("failed to read text file {}", path.display())),
+            PermissionDecision::Ask => anyhow::bail!("permission required before reading {}", path.display()),
+            PermissionDecision::Deny => anyhow::bail!("permission denied reading {}", path.display()),
+        }
+    }
+
+    pub fn write_text_file(&self, path: &Path, content: &str) -> anyhow::Result<()> {
+        match self.policy.decide(PermissionRequestKind::WriteFile(path.to_path_buf())) {
+            PermissionDecision::Allow => {
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("failed to create parent directory {}", parent.display()))?;
+                }
+                std::fs::write(path, content)
+                    .with_context(|| format!("failed to write text file {}", path.display()))
+            }
+            PermissionDecision::Ask => anyhow::bail!("permission required before writing {}", path.display()),
+            PermissionDecision::Deny => anyhow::bail!("permission denied writing {}", path.display()),
+        }
+    }
+}
+```
+
+Modify `src/agent/mod.rs` exports. In Task 19, the runtime dispatcher will catch `permission required` outcomes from this low-level service and turn them into pending `AgentPermissionRequest` records; the low-level service itself should not show UI.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test agent_filesystem_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/filesystem.rs src/agent/mod.rs tests/agent_filesystem_tests.rs
+git commit -m "feat: add ACP filesystem callback service"
+```
+
+---
+
+### Task 8: Add Protocol-Only Terminal Callback Service
+
+**Files:**
+- Create: `src/agent/terminal.rs`
+- Modify: `src/agent/mod.rs`
+- Test: `tests/agent_terminal_tests.rs`
+
+- [ ] **Step 1: Add failing terminal callback tests**
+
+Create `tests/agent_terminal_tests.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use alas::agent::{AgentTrustMode, AgentTerminalService, AgentTerminalStatus};
+use tempfile::tempdir;
+
+#[test]
+fn terminal_service_runs_command_and_captures_output() {
+    let dir = tempdir().expect("tempdir");
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, dir.path().to_path_buf());
+
+    let handle = service.create("printf hello", PathBuf::from(dir.path())).expect("create command");
+    let result = service.wait_for_exit(handle).expect("wait");
+
+    assert_eq!(result.status, AgentTerminalStatus::Exited(Some(0)));
+    assert_eq!(service.output(handle).expect("output"), "hello");
+    service.release(handle).expect("release");
+}
+
+#[test]
+fn terminal_service_streams_output_before_wait_for_exit() {
+    let dir = tempdir().expect("tempdir");
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, dir.path().to_path_buf());
+
+    let handle = service.create("printf hello; sleep 1", PathBuf::from(dir.path())).expect("create command");
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert!(service.output(handle).expect("output").contains("hello"));
+    service.kill(handle).expect("kill");
+    service.release(handle).expect("release");
+}
+
+#[test]
+fn terminal_service_denies_command_when_policy_denies() {
+    let dir = tempdir().expect("tempdir");
+    let mut service = AgentTerminalService::new(AgentTrustMode::Deny, dir.path().to_path_buf());
+
+    let error = service.create("printf hello", PathBuf::from(dir.path())).expect_err("denied").to_string();
+    assert!(error.contains("denied"));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_terminal_tests --all-features`
+
+Expected: FAIL because terminal service does not exist.
+
+- [ ] **Step 3: Implement protocol-only terminal service**
+
+Create `src/agent/terminal.rs`:
+
+```rust
+use std::{
+    collections::HashMap,
+    io::Read,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    sync::{Arc, Mutex},
+    thread,
+};
+
+use anyhow::Context;
+
+use crate::agent::{AgentTrustMode, PermissionDecision, PermissionPolicy, PermissionRequestKind};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct AgentTerminalHandle(pub u64);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AgentTerminalStatus { Running, Exited(Option<i32>), Failed }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentTerminalResult { pub status: AgentTerminalStatus }
+
+#[derive(Debug)]
+struct AgentTerminalCommandState {
+    command: String,
+    cwd: PathBuf,
+    child: Option<Child>,
+    output: Arc<Mutex<String>>,
+    status: AgentTerminalStatus,
+}
+
+#[derive(Debug)]
+pub struct AgentTerminalService {
+    next_handle: u64,
+    policy: PermissionPolicy,
+    commands: HashMap<AgentTerminalHandle, AgentTerminalCommandState>,
+}
+
+impl AgentTerminalService {
+    pub fn new(trust_mode: AgentTrustMode, worktree_path: PathBuf) -> Self {
+        Self { next_handle: 0, policy: PermissionPolicy::new(trust_mode, worktree_path), commands: HashMap::new() }
+    }
+
+    pub fn create(&mut self, command: &str, cwd: PathBuf) -> anyhow::Result<AgentTerminalHandle> {
+        match self.policy.decide(PermissionRequestKind::RunTerminal { command: command.to_string() }) {
+            PermissionDecision::Allow => {}
+            PermissionDecision::Ask => anyhow::bail!("permission required before running terminal command"),
+            PermissionDecision::Deny => anyhow::bail!("permission denied running terminal command"),
+        }
+
+        let mut child = Command::new(std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string()))
+            .args(["-lc", command])
+            .current_dir(&cwd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to start terminal command {command}"))?;
+
+        let output = Arc::new(Mutex::new(String::new()));
+        spawn_output_reader(child.stdout.take(), output.clone());
+        spawn_output_reader(child.stderr.take(), output.clone());
+
+        self.next_handle += 1;
+        let handle = AgentTerminalHandle(self.next_handle);
+        self.commands.insert(handle, AgentTerminalCommandState {
+            command: command.to_string(),
+            cwd,
+            child: Some(child),
+            output,
+            status: AgentTerminalStatus::Running,
+        });
+        Ok(handle)
+    }
+
+    pub fn wait_for_exit(&mut self, handle: AgentTerminalHandle) -> anyhow::Result<AgentTerminalResult> {
+        let state = self.commands.get_mut(&handle).context("unknown agent terminal handle")?;
+        if !matches!(state.status, AgentTerminalStatus::Running) {
+            return Ok(AgentTerminalResult { status: state.status.clone() });
+        }
+        let child = state.child.as_mut().context("terminal command has no child process")?;
+        let status = child.wait().with_context(|| format!("failed to wait for terminal command {}", state.command))?;
+        state.status = AgentTerminalStatus::Exited(status.code());
+        Ok(AgentTerminalResult { status: state.status.clone() })
+    }
+
+    pub fn output(&self, handle: AgentTerminalHandle) -> anyhow::Result<String> {
+        Ok(self.commands.get(&handle).context("unknown agent terminal handle")?.output.lock().expect("terminal output lock").clone())
+    }
+
+    pub fn kill(&mut self, handle: AgentTerminalHandle) -> anyhow::Result<()> {
+        let state = self.commands.get_mut(&handle).context("unknown agent terminal handle")?;
+        if let Some(child) = state.child.as_mut() {
+            let _ = child.kill();
+        }
+        state.status = AgentTerminalStatus::Failed;
+        Ok(())
+    }
+
+    pub fn release(&mut self, handle: AgentTerminalHandle) -> anyhow::Result<()> {
+        self.commands.remove(&handle).context("unknown agent terminal handle")?;
+        Ok(())
+    }
+}
+
+fn spawn_output_reader<R: Read + Send + 'static>(reader: Option<R>, output: Arc<Mutex<String>>) {
+    if let Some(mut reader) = reader {
+        thread::spawn(move || {
+            let mut buffer = [0_u8; 4096];
+            while let Ok(read) = reader.read(&mut buffer) {
+                if read == 0 { break; }
+                output.lock().expect("terminal output lock").push_str(&String::from_utf8_lossy(&buffer[..read]));
+            }
+        });
+    }
+}
+```
+
+This implementation starts the process in `create`, buffers output as it streams, waits in `wait_for_exit`, kills the child in `kill`, and releases handles in `release`. Runtime integration should call waiting work from a background task so UI rendering is not blocked. In Task 19, the runtime dispatcher will catch `permission required` outcomes and turn them into pending permission cards.
+
+Modify `src/agent/mod.rs` exports.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test agent_terminal_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/terminal.rs src/agent/mod.rs tests/agent_terminal_tests.rs
+git commit -m "feat: add protocol-only ACP terminal service"
+```
+
+---
+
+### Task 9: Add ACP Runtime State Machine Facade
+
+**Files:**
+- Create: `src/agent/runtime.rs`
+- Create: `src/agent/fake.rs`
+- Modify: `src/agent/mod.rs`
+- Test: `tests/agent_runtime_tests.rs`
+
+- [ ] **Step 1: Add failing runtime tests using fake connection**
+
+Create `tests/agent_runtime_tests.rs`:
+
+```rust
+use std::path::PathBuf;
+
+use alas::agent::{AgentRuntime, AgentRuntimeEvent, AgentThreadStatus, FakeAcpConnection};
+
+#[test]
+fn runtime_creates_new_session_and_applies_streamed_updates() {
+    let fake = FakeAcpConnection::new()
+        .with_new_session("sess-1")
+        .with_prompt_update(AgentRuntimeEvent::AgentMessageChunk("hello from agent".to_string()));
+    let mut runtime = AgentRuntime::with_connection("opencode", PathBuf::from("/repo/a"), fake);
+
+    runtime.initialize().expect("initialize");
+    runtime.create_session().expect("new session");
+    runtime.prompt("hello").expect("prompt");
+
+    let thread = runtime.thread();
+    assert_eq!(thread.acp_session_id.as_deref(), Some("sess-1"));
+    assert_eq!(thread.status, AgentThreadStatus::Ready);
+    assert!(thread.transcript.iter().any(|entry| entry.text == "hello from agent"));
+}
+
+#[test]
+fn runtime_cancel_can_interrupt_after_first_streamed_update() {
+    let fake = FakeAcpConnection::new()
+        .with_new_session("sess-1")
+        .with_prompt_update(AgentRuntimeEvent::AgentMessageChunk("partial".to_string()))
+        .with_prompt_update(AgentRuntimeEvent::NeedsPermission { id: "perm-1".to_string(), description: "Run command".to_string() });
+    let mut runtime = AgentRuntime::with_connection("opencode", PathBuf::from("/repo/a"), fake);
+
+    runtime.initialize().expect("initialize");
+    runtime.create_session().expect("new session");
+    runtime.prompt("hello").expect("prompt");
+
+    assert!(runtime.thread().pending_permissions.iter().any(|permission| permission.id == "perm-1"));
+}
+
+#[test]
+fn runtime_marks_restored_thread_read_only_when_resume_fails() {
+    let fake = FakeAcpConnection::new().with_resume_error("resume unsupported");
+    let mut runtime = AgentRuntime::with_connection("opencode", PathBuf::from("/repo/a"), fake);
+    runtime.thread_mut().acp_session_id = Some("sess-old".to_string());
+
+    runtime.resume_existing_session().expect("resume attempt handled");
+
+    assert!(matches!(runtime.thread().status, AgentThreadStatus::ReadOnly { .. }));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: FAIL because runtime/fake types do not exist.
+
+- [ ] **Step 3: Implement ACP-owned facade and fake connection**
+
+Create `src/agent/runtime.rs` with an Alas-owned trait so tests do not depend on real subprocesses:
+
+```rust
+use std::path::PathBuf;
+
+use crate::agent::{AgentThreadState, AgentThreadStatus, AgentTranscriptEntry};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AgentRuntimeEvent {
+    Initialized,
+    AuthRequired { instructions: Option<String> },
+    Ready,
+    AgentMessageChunk(String),
+    ThoughtChunk(String),
+    ToolCall { id: String, title: String, status: String },
+    Plan(Vec<String>),
+    AvailableCommands(Vec<crate::agent::AgentSlashCommand>),
+    AvailableModes { modes: Vec<crate::agent::AgentModeOption>, current: Option<String> },
+    ConfigOptions(Vec<crate::agent::AgentConfigOption>),
+    NeedsPermission { id: String, description: String },
+    Failed(String),
+}
+
+pub trait AgentEventSink {
+    fn emit(&mut self, event: AgentRuntimeEvent);
+}
+
+pub trait AcpConnection {
+    fn initialize(&mut self, sink: &mut dyn AgentEventSink) -> anyhow::Result<()>;
+    fn new_session(&mut self, sink: &mut dyn AgentEventSink) -> anyhow::Result<String>;
+    fn resume_session(&mut self, session_id: &str, sink: &mut dyn AgentEventSink) -> anyhow::Result<()>;
+    fn prompt(&mut self, session_id: &str, prompt: &str, sink: &mut dyn AgentEventSink) -> anyhow::Result<()>;
+    fn cancel(&mut self, session_id: &str) -> anyhow::Result<()>;
+}
+
+pub struct AgentRuntime<C> {
+    thread: AgentThreadState,
+    connection: C,
+}
+
+impl<C: AcpConnection> AgentRuntime<C> {
+    pub fn with_connection(provider_id: impl Into<String>, worktree_path: PathBuf, connection: C) -> Self {
+        Self { thread: AgentThreadState::new(provider_id, worktree_path), connection }
+    }
+
+    pub fn thread(&self) -> &AgentThreadState { &self.thread }
+    pub fn thread_mut(&mut self) -> &mut AgentThreadState { &mut self.thread }
+
+    pub fn initialize(&mut self) -> anyhow::Result<()> {
+        self.thread.status = AgentThreadStatus::Starting;
+        let mut sink = ThreadEventSink { thread: &mut self.thread };
+        self.connection.initialize(&mut sink)?;
+        if matches!(self.thread.status, AgentThreadStatus::Starting) {
+            self.thread.status = AgentThreadStatus::Ready;
+        }
+        Ok(())
+    }
+
+    pub fn create_session(&mut self) -> anyhow::Result<()> {
+        let mut sink = ThreadEventSink { thread: &mut self.thread };
+        let session_id = self.connection.new_session(&mut sink)?;
+        self.thread.acp_session_id = Some(session_id);
+        if !matches!(self.thread.status, AgentThreadStatus::AuthRequired | AgentThreadStatus::Failed { .. }) {
+            self.thread.status = AgentThreadStatus::Ready;
+        }
+        Ok(())
+    }
+
+    pub fn resume_existing_session(&mut self) -> anyhow::Result<()> {
+        let Some(session_id) = self.thread.acp_session_id.clone() else {
+            self.thread.status = AgentThreadStatus::ReadOnly { reason: "missing ACP session id".to_string() };
+            return Ok(());
+        };
+        let mut sink = ThreadEventSink { thread: &mut self.thread };
+        match self.connection.resume_session(&session_id, &mut sink) {
+            Ok(()) => self.thread.status = AgentThreadStatus::Ready,
+            Err(error) => self.thread.status = AgentThreadStatus::ReadOnly { reason: error.to_string() },
+        }
+        Ok(())
+    }
+
+    pub fn prompt(&mut self, prompt: &str) -> anyhow::Result<()> {
+        let session_id = self.thread.acp_session_id.clone().ok_or_else(|| anyhow::anyhow!("missing ACP session id"))?;
+        self.thread.status = AgentThreadStatus::Running;
+        self.thread.transcript.push(AgentTranscriptEntry::user(prompt));
+        let mut sink = ThreadEventSink { thread: &mut self.thread };
+        self.connection.prompt(&session_id, prompt, &mut sink)?;
+        if matches!(self.thread.status, AgentThreadStatus::Running) {
+            self.thread.status = AgentThreadStatus::Ready;
+        }
+        Ok(())
+    }
+
+    pub fn cancel(&mut self) -> anyhow::Result<()> {
+        if let Some(session_id) = self.thread.acp_session_id.clone() {
+            self.connection.cancel(&session_id)?;
+        }
+        self.thread.status = AgentThreadStatus::Ready;
+        Ok(())
+    }
+}
+
+struct ThreadEventSink<'a> { thread: &'a mut AgentThreadState }
+
+impl AgentEventSink for ThreadEventSink<'_> {
+    fn emit(&mut self, event: AgentRuntimeEvent) {
+        apply_runtime_event(self.thread, event);
+    }
+}
+
+pub fn apply_runtime_event(thread: &mut AgentThreadState, event: AgentRuntimeEvent) {
+    match event {
+        AgentRuntimeEvent::Initialized | AgentRuntimeEvent::Ready => thread.status = AgentThreadStatus::Ready,
+        AgentRuntimeEvent::AuthRequired { instructions } => {
+            thread.status = AgentThreadStatus::AuthRequired;
+            if let Some(instructions) = instructions { thread.debug_log.push(crate::agent::AgentDebugEvent { message: instructions }); }
+        }
+        AgentRuntimeEvent::AgentMessageChunk(text) => thread.transcript.push(AgentTranscriptEntry::agent(text)),
+        AgentRuntimeEvent::ThoughtChunk(text) => thread.transcript.push(AgentTranscriptEntry { role: crate::agent::AgentTranscriptRole::Thought, text }),
+        AgentRuntimeEvent::ToolCall { id, title, status } => thread.tool_calls.push(crate::agent::AgentToolCallState { id, title, status }),
+        AgentRuntimeEvent::Plan(entries) => thread.plans.push(crate::agent::AgentPlanState { entries }),
+        AgentRuntimeEvent::AvailableCommands(commands) => thread.available_commands = commands,
+        AgentRuntimeEvent::AvailableModes { modes, current } => { thread.available_modes = modes; thread.current_mode = current; },
+        AgentRuntimeEvent::ConfigOptions(options) => thread.config_options = options,
+        AgentRuntimeEvent::NeedsPermission { id, description } => thread.pending_permissions.push(crate::agent::AgentPermissionRequest { id, description }),
+        AgentRuntimeEvent::Failed(message) => thread.status = AgentThreadStatus::Failed { message },
+    }
+}
+```
+
+Create `src/agent/fake.rs`:
+
+```rust
+use crate::agent::runtime::{AcpConnection, AgentEventSink, AgentRuntimeEvent};
+
+#[derive(Clone, Debug, Default)]
+pub struct FakeAcpConnection {
+    new_session: Option<String>,
+    prompt_updates: Vec<AgentRuntimeEvent>,
+    resume_error: Option<String>,
+}
+
+impl FakeAcpConnection {
+    pub fn new() -> Self { Self::default() }
+    pub fn with_new_session(mut self, session_id: impl Into<String>) -> Self { self.new_session = Some(session_id.into()); self }
+    pub fn with_prompt_update(mut self, update: AgentRuntimeEvent) -> Self { self.prompt_updates.push(update); self }
+    pub fn with_resume_error(mut self, error: impl Into<String>) -> Self { self.resume_error = Some(error.into()); self }
+}
+
+impl AcpConnection for FakeAcpConnection {
+    fn initialize(&mut self, sink: &mut dyn AgentEventSink) -> anyhow::Result<()> { sink.emit(AgentRuntimeEvent::Initialized); Ok(()) }
+    fn new_session(&mut self, sink: &mut dyn AgentEventSink) -> anyhow::Result<String> { sink.emit(AgentRuntimeEvent::Ready); Ok(self.new_session.clone().unwrap_or_else(|| "sess-test".to_string())) }
+    fn resume_session(&mut self, _session_id: &str, sink: &mut dyn AgentEventSink) -> anyhow::Result<()> {
+        if let Some(error) = &self.resume_error { anyhow::bail!(error.clone()); }
+        sink.emit(AgentRuntimeEvent::Ready);
+        Ok(())
+    }
+    fn prompt(&mut self, _session_id: &str, _prompt: &str, sink: &mut dyn AgentEventSink) -> anyhow::Result<()> {
+        for update in self.prompt_updates.clone() { sink.emit(update); }
+        Ok(())
+    }
+    fn cancel(&mut self, _session_id: &str) -> anyhow::Result<()> { Ok(()) }
+}
+```
+
+Modify `src/agent/mod.rs` exports.
+
+- [ ] **Step 4: Run runtime tests**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/runtime.rs src/agent/fake.rs src/agent/mod.rs tests/agent_runtime_tests.rs
+git commit -m "feat: add ACP runtime state facade"
+```
+
+---
+
+### Task 10: Add Real ACP Process Connection Skeleton
+
+**Files:**
+- Modify: `src/agent/runtime.rs`
+- Modify: `src/agent/provider.rs`
+- Test: `tests/agent_runtime_tests.rs`
+
+- [ ] **Step 1: Add failing process launch validation test**
+
+Append to `tests/agent_runtime_tests.rs`:
+
+```rust
+use alas::agent::{AgentProviderConfig, AcpProcessConnection, ProviderCwdPolicy, resolve_provider_cwd};
+
+#[test]
+fn process_connection_reports_missing_provider_binary_with_context() {
+    let provider = AgentProviderConfig::new("missing", "Missing", "definitely-not-an-acp-binary");
+    let error = AcpProcessConnection::spawn(&provider, PathBuf::from("/tmp"))
+        .expect_err("missing binary should fail")
+        .to_string();
+    assert!(error.contains("definitely-not-an-acp-binary"));
+}
+
+#[test]
+fn provider_cwd_policy_resolves_launch_directory() {
+    let selected = PathBuf::from("/repo/worktrees/feature");
+    let repo_root = PathBuf::from("/repo");
+
+    let mut provider = AgentProviderConfig::new("opencode", "OpenCode", "opencode");
+    provider.cwd_policy = ProviderCwdPolicy::SelectedWorktree;
+    assert_eq!(resolve_provider_cwd(&provider, &selected, &repo_root), selected);
+
+    provider.cwd_policy = ProviderCwdPolicy::RepositoryRoot;
+    assert_eq!(resolve_provider_cwd(&provider, &selected, &repo_root), repo_root);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: FAIL because `AcpProcessConnection` does not exist.
+
+- [ ] **Step 3: Add process connection skeleton**
+
+In `src/agent/runtime.rs`, add a real-connection struct that launches the provider and clearly fails for unimplemented protocol calls. Keep this as a skeleton until UI and fake-backed flows are integrated:
+
+```rust
+use std::{path::PathBuf, process::{Child, Command, Stdio}};
+
+use anyhow::Context;
+use crate::agent::AgentProviderConfig;
+
+#[derive(Debug)]
+pub struct AcpProcessConnection {
+    _child: Child,
+}
+
+pub fn resolve_provider_cwd(provider: &AgentProviderConfig, selected_worktree: &PathBuf, repository_root: &PathBuf) -> PathBuf {
+    match &provider.cwd_policy {
+        crate::agent::ProviderCwdPolicy::SelectedWorktree => selected_worktree.clone(),
+        crate::agent::ProviderCwdPolicy::RepositoryRoot => repository_root.clone(),
+        crate::agent::ProviderCwdPolicy::Fixed(path) => path.clone(),
+    }
+}
+
+impl AcpProcessConnection {
+    pub fn spawn(provider: &AgentProviderConfig, cwd: PathBuf) -> anyhow::Result<Self> {
+        let mut command = Command::new(&provider.command);
+        command.args(&provider.args).current_dir(cwd).stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
+        let child = command.spawn()
+            .with_context(|| format!("failed to start ACP provider '{}' with command {}", provider.id, provider.command))?;
+        Ok(Self { _child: child })
+    }
+}
+
+impl AcpConnection for AcpProcessConnection {
+    fn initialize(&mut self, _sink: &mut dyn AgentEventSink) -> anyhow::Result<()> { anyhow::bail!("real ACP initialize is not wired yet") }
+    fn new_session(&mut self, _sink: &mut dyn AgentEventSink) -> anyhow::Result<String> { anyhow::bail!("real ACP session/new is not wired yet") }
+    fn resume_session(&mut self, _session_id: &str, _sink: &mut dyn AgentEventSink) -> anyhow::Result<()> { anyhow::bail!("real ACP session resume is not wired yet") }
+    fn prompt(&mut self, _session_id: &str, _prompt: &str, _sink: &mut dyn AgentEventSink) -> anyhow::Result<()> { anyhow::bail!("real ACP prompt is not wired yet") }
+    fn cancel(&mut self, _session_id: &str) -> anyhow::Result<()> { anyhow::bail!("real ACP cancel is not wired yet") }
+}
+```
+
+This deliberately creates a safe seam. A later task replaces the method bodies with actual `agent-client-protocol` crate calls after the UI and state flow are testable. Shell/runtime launch code must call `resolve_provider_cwd` instead of hard-coding the selected worktree.
+
+- [ ] **Step 4: Run runtime tests**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/runtime.rs tests/agent_runtime_tests.rs
+git commit -m "feat: add ACP provider process launch seam"
+```
+
+---
+
+### Task 11: Add Provider Settings View Model and UI Renderer
+
+**Files:**
+- Create: `src/ui/provider_settings.rs`
+- Modify: `src/ui/mod.rs`
+- Modify: `src/ui/shell.rs`
+- Test: `tests/agent_ui_view_model_tests.rs`
+
+- [ ] **Step 1: Add failing provider settings view-model tests**
+
+Create `tests/agent_ui_view_model_tests.rs`:
+
+```rust
+use alas::agent::{AgentProviderConfig, ProviderSettingsState};
+
+#[test]
+fn provider_settings_state_can_add_update_and_remove_provider() {
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(AgentProviderConfig::new("opencode", "OpenCode", "opencode"));
+    assert_eq!(state.providers.len(), 1);
+
+    state.providers[0].args = vec!["acp".to_string()];
+    assert_eq!(state.providers[0].args, vec!["acp".to_string()]);
+
+    state.remove_provider("opencode");
+    assert!(state.providers.is_empty());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_ui_view_model_tests --all-features`
+
+Expected: FAIL because settings state does not exist.
+
+- [ ] **Step 3: Add settings state to agent/provider module**
+
+In `src/agent/provider.rs` add:
+
+```rust
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ProviderSettingsState {
+    pub providers: Vec<AgentProviderConfig>,
+    pub selected_provider_id: Option<String>,
+    pub error: Option<String>,
+}
+
+impl ProviderSettingsState {
+    pub fn add_provider(&mut self, provider: AgentProviderConfig) {
+        self.selected_provider_id = Some(provider.id.clone());
+        self.providers.push(provider);
+    }
+
+    pub fn remove_provider(&mut self, provider_id: &str) {
+        self.providers.retain(|provider| provider.id != provider_id);
+        if self.selected_provider_id.as_deref() == Some(provider_id) {
+            self.selected_provider_id = self.providers.first().map(|provider| provider.id.clone());
+        }
+    }
+}
+```
+
+Export it from `src/agent/mod.rs`.
+
+- [ ] **Step 4: Add UI renderer skeleton**
+
+Create `src/ui/provider_settings.rs`:
+
+```rust
+use crate::{agent::ProviderSettingsState, ui::theme::{PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED}};
+use gpui::{div, IntoElement, ParentElement, SharedString, Styled, prelude::*};
+
+pub fn render_provider_settings(state: &ProviderSettingsState) -> impl IntoElement {
+    div()
+        .id("provider-settings")
+        .flex()
+        .flex_col()
+        .gap_2()
+        .p_3()
+        .rounded_md()
+        .border_1()
+        .border_color(PANEL_BORDER)
+        .bg(PANEL_BG)
+        .text_color(TEXT)
+        .child(div().font_weight(gpui::FontWeight::SEMIBOLD).child("Agent Providers"))
+        .when(state.providers.is_empty(), |element| {
+            element.child(div().text_sm().text_color(TEXT_MUTED).child("No ACP providers configured."))
+        })
+        .children(state.providers.iter().map(|provider| {
+            div()
+                .text_sm()
+                .child(SharedString::from(format!("{} — {}", provider.display_name, provider.command)))
+        }))
+}
+```
+
+Modify `src/ui/mod.rs`:
+
+```rust
+pub mod provider_settings;
+```
+
+Do not fully wire Shell editing yet; that is a later task.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --test agent_ui_view_model_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent/provider.rs src/agent/mod.rs src/ui/provider_settings.rs src/ui/mod.rs tests/agent_ui_view_model_tests.rs
+git commit -m "feat: add ACP provider settings state"
+```
+
+---
+
+### Task 12: Add Agent Chat Pane Renderer
+
+**Files:**
+- Create: `src/ui/agent_pane.rs`
+- Modify: `src/ui/mod.rs`
+- Test: `tests/agent_ui_view_model_tests.rs`
+
+- [ ] **Step 1: Add failing pane-label helper tests**
+
+Append to `tests/agent_ui_view_model_tests.rs`:
+
+```rust
+use std::path::PathBuf;
+use alas::agent::{AgentThreadState, AgentThreadStatus};
+use alas::ui::agent_pane::agent_status_label;
+
+#[test]
+fn agent_status_label_describes_read_only_resume_failure() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/a"));
+    thread.status = AgentThreadStatus::ReadOnly { reason: "resume unsupported".to_string() };
+
+    assert_eq!(agent_status_label(&thread), "Read-only: resume unsupported");
+}
+```
+
+If `alas::ui` is not exported from `src/lib.rs`, add `pub mod ui;` or move the helper to `agent::types` and test there. Prefer exporting `ui` only if existing tests already do it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --test agent_ui_view_model_tests --all-features`
+
+Expected: FAIL because `agent_pane` does not exist or `ui` is not exported.
+
+- [ ] **Step 3: Implement agent pane skeleton**
+
+Create `src/ui/agent_pane.rs`:
+
+```rust
+use crate::{agent::{AgentThreadState, AgentThreadStatus, AgentTranscriptRole}, ui::theme::{DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED}};
+use gpui::{div, AnyElement, IntoElement, ParentElement, SharedString, Styled, prelude::*};
+
+pub fn agent_status_label(thread: &AgentThreadState) -> String {
+    match &thread.status {
+        AgentThreadStatus::Disconnected => "Disconnected".to_string(),
+        AgentThreadStatus::Starting => "Starting".to_string(),
+        AgentThreadStatus::AuthRequired => "Authentication required".to_string(),
+        AgentThreadStatus::Ready => "Ready".to_string(),
+        AgentThreadStatus::Running => "Running".to_string(),
+        AgentThreadStatus::Failed { message } => format!("Failed: {message}"),
+        AgentThreadStatus::ReadOnly { reason } => format!("Read-only: {reason}"),
+    }
+}
+
+pub fn render_agent_pane(thread: &AgentThreadState) -> impl IntoElement {
+    div()
+        .id("agent-chat-pane")
+        .flex()
+        .flex_col()
+        .flex_1()
+        .size_full()
+        .bg(PANEL_BG)
+        .text_color(TEXT)
+        .child(render_agent_header(thread))
+        .child(render_transcript(thread))
+        .child(render_composer(thread))
+}
+
+fn render_agent_header(thread: &AgentThreadState) -> impl IntoElement {
+    div()
+        .flex()
+        .items_center()
+        .justify_between()
+        .px_3()
+        .py_2()
+        .border_b_1()
+        .border_color(PANEL_BORDER)
+        .child(div().text_sm().font_weight(gpui::FontWeight::SEMIBOLD).child(SharedString::from(thread.title.clone())))
+        .child(div().text_xs().text_color(TEXT_MUTED).child(SharedString::from(agent_status_label(thread))))
+}
+
+fn render_transcript(thread: &AgentThreadState) -> impl IntoElement {
+    div()
+        .id("agent-chat-transcript")
+        .flex()
+        .flex_col()
+        .flex_1()
+        .overflow_scroll()
+        .p_3()
+        .gap_2()
+        .children(thread.transcript.iter().map(|entry| {
+            let label = match entry.role { AgentTranscriptRole::User => "You", AgentTranscriptRole::Agent => "Agent", AgentTranscriptRole::Thought => "Thought", AgentTranscriptRole::System => "System", AgentTranscriptRole::Tool => "Tool" };
+            div().flex().flex_col().gap_1().child(div().text_xs().text_color(TEXT_MUTED).child(label)).child(div().text_sm().child(SharedString::from(entry.text.clone()))).into_any_element()
+        }))
+}
+
+fn render_composer(thread: &AgentThreadState) -> AnyElement {
+    let read_only = matches!(thread.status, AgentThreadStatus::ReadOnly { .. });
+    div()
+        .border_t_1()
+        .border_color(PANEL_BORDER)
+        .p_3()
+        .text_sm()
+        .text_color(if read_only { DANGER } else { TEXT_MUTED })
+        .child(if read_only { "This restored ACP session cannot continue. Start a new session to send prompts." } else { "Prompt input will appear here." })
+        .into_any_element()
+}
+```
+
+Modify `src/ui/mod.rs`:
+
+```rust
+pub mod agent_pane;
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test agent_ui_view_model_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/agent_pane.rs src/ui/mod.rs tests/agent_ui_view_model_tests.rs
+git commit -m "feat: add agent chat pane renderer"
+```
+
+---
+
+### Task 13: Wire Agent Chat Rendering into Shell
+
+**Files:**
+- Modify: `src/ui/shell.rs`
+- Modify: `src/ui/workspace.rs`
+- Test: `tests/agent_workspace_tests.rs`
+- Test: `tests/ui_view_model_tests.rs` if affected
+
+- [ ] **Step 1: Add failing workspace tab picker state tests**
+
+If Shell state is hard to instantiate in tests, add pure enum/state helpers under `src/ui/workspace.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum NewWorkspaceTabChoice { Terminal, AgentChat }
+```
+
+Add tests to `tests/agent_workspace_tests.rs` or `tests/ui_view_model_tests.rs` that verify:
+
+- choice labels include Terminal and Agent Chat;
+- zero enabled providers opens provider settings;
+- one enabled provider creates a tab directly;
+- multiple enabled providers opens a provider picker instead of silently choosing one.
+
+- [ ] **Step 2: Run targeted tests to verify failure**
+
+Run: `cargo test --test agent_workspace_tests --all-features`
+
+Expected: FAIL if helper does not exist.
+
+- [ ] **Step 3: Implement picker model and shell fields**
+
+Modify `src/ui/workspace.rs` to export `NewWorkspaceTabChoice` and a helper:
+
+```rust
+pub fn new_workspace_tab_choices() -> [NewWorkspaceTabChoice; 2] {
+    [NewWorkspaceTabChoice::Terminal, NewWorkspaceTabChoice::AgentChat]
+}
+```
+
+Modify `AlasShell` in `src/ui/shell.rs`:
+
+- add a `new_tab_picker_open: bool` field;
+- change existing `on_new_terminal_tab` behavior to open the picker;
+- add callbacks for Terminal and Agent Chat choices;
+- add `agent_provider_picker: Option<Vec<AgentProviderConfig>>` or equivalent shell state;
+- when Terminal is chosen, call existing command picker flow;
+- when Agent Chat is chosen:
+  - open provider settings if there are no enabled providers,
+  - create an Agent Chat tab directly if exactly one provider is enabled,
+  - open the provider picker if multiple providers are enabled;
+- when the user selects a provider from the picker, create the Agent Chat tab for that provider.
+
+- [ ] **Step 4: Route AgentChat active tab to renderer**
+
+In the `workspace_body` match in `src/ui/shell.rs`, add:
+
+```rust
+Some(WorkspaceTabContent::AgentChat(state)) => {
+    render_agent_pane(state).into_any_element()
+}
+```
+
+Update imports for `agent_pane::render_agent_pane`.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run: `cargo test --test agent_workspace_tests --test ui_view_model_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/shell.rs src/ui/workspace.rs tests/agent_workspace_tests.rs tests/ui_view_model_tests.rs
+git commit -m "feat: render agent chat tabs in workspace"
+```
+
+---
+
+### Task 14: Wire Provider Settings to App Config
+
+**Files:**
+- Modify: `src/ui/shell.rs`
+- Modify: `src/ui/provider_settings.rs`
+- Test: `tests/config_tests.rs`
+- Test: `tests/agent_provider_config_tests.rs`
+
+- [ ] **Step 1: Add config persistence test for provider edits**
+
+In `tests/config_tests.rs`, add a test using `AppConfigStore::new(temp_path)` that saves and loads `agent_providers` with no secrets.
+
+In `tests/agent_ui_view_model_tests.rs`, add a provider settings state test that edits all required provider fields:
+
+```rust
+use alas::agent::{AgentAuthStatus, AgentProviderConfig, AgentTrustMode, ProviderSettingsState};
+
+#[test]
+fn provider_settings_state_edits_required_provider_fields() {
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(AgentProviderConfig::new("opencode", "OpenCode", "opencode"));
+    state.update_command("opencode", "opencode");
+    state.update_args("opencode", vec!["acp".to_string()]);
+    state.update_plain_env("opencode", "OPENCODE_CONFIG", "dev");
+    state.update_enabled("opencode", false);
+    state.update_trust_mode("opencode", AgentTrustMode::Ask);
+    state.update_auth_status("opencode", AgentAuthStatus::Required { instructions: Some("Run login".to_string()) });
+
+    assert_eq!(state.auth_status_label("opencode"), Some("Auth Required".to_string()));
+    let provider = &state.providers[0];
+    assert_eq!(provider.args, vec!["acp".to_string()]);
+    assert!(!provider.enabled);
+    assert_eq!(provider.trust_mode, AgentTrustMode::Ask);
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure or missing coverage**
+
+Run: `cargo test --test config_tests --all-features`
+
+Expected: PASS after Task 1 may already serialize. If it passes, keep this as regression coverage.
+
+- [ ] **Step 3: Add Shell provider settings state**
+
+Modify `src/agent/provider.rs` before Shell wiring:
+
+- add `AgentAuthStatus` with `Unknown`, `Authenticated`, `Required { instructions }`, and `Failed { message, instructions }`;
+- add `AgentAuthStatus::instructions()` and a status-label helper;
+- add `ProviderSettingsState` methods required by the test: `update_command`, `update_args`, `update_plain_env`, `update_enabled`, `update_trust_mode`, `update_auth_status`, and `auth_status_label`.
+
+Modify `AlasShell`:
+
+- add `provider_settings: Option<ProviderSettingsState>`;
+- add methods:
+  - `open_provider_settings`,
+  - `close_provider_settings`,
+  - `save_provider_settings`,
+  - `create_agent_chat_from_provider`.
+
+`save_provider_settings` must update `self.config.agent_providers`, call `self.app_config_store.save(&self.config)`, and show errors in settings state.
+
+- [ ] **Step 4: Extend provider settings renderer with minimal controls**
+
+Add visible fields and handlers for editing:
+
+- display name,
+- command,
+- args,
+- env metadata/secure refs,
+- enabled/disabled state,
+- trust mode.
+
+Add buttons/handlers for:
+
+- Add Provider,
+- Save,
+- Cancel,
+- Remove,
+- Authenticate,
+- Run Terminal Auth,
+- Clear Stored Credentials,
+- View Auth Instructions.
+
+The Authenticate controls should be disabled until Task 15 wires the concrete auth actions, but the UI state must already expose real auth status labels (`Unknown`, `Authenticated`, `Auth Required`, `Failed`) using `AgentAuthStatus`. Use existing dialog patterns from command settings in `src/ui/shell.rs`. Keep text editing simple and consistent with existing command settings fields.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --test config_tests --test agent_provider_config_tests --test agent_ui_view_model_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent/provider.rs src/agent/mod.rs src/ui/shell.rs src/ui/provider_settings.rs tests/config_tests.rs tests/agent_ui_view_model_tests.rs
+git commit -m "feat: manage ACP providers in app config"
+```
+
+---
+
+### Task 15: Add Auth Flow State, ACP Auth Actions, and Credential Injection
+
+**Files:**
+- Modify: `src/agent/provider.rs`
+- Modify: `src/agent/credentials.rs`
+- Modify: `src/agent/runtime.rs`
+- Modify: `src/ui/provider_settings.rs`
+- Test: `tests/agent_provider_config_tests.rs`
+- Test: `tests/agent_runtime_tests.rs`
+
+- [ ] **Step 1: Add failing auth metadata and status tests**
+
+Add tests that model ACP-advertised auth methods, provider-supplied instructions, env-var auth without storing raw secret in config, and terminal auth actions:
+
+```rust
+use alas::agent::{AgentAuthField, AgentAuthMethod};
+
+#[test]
+fn env_var_auth_method_builds_secure_env_refs() {
+    let method = AgentAuthMethod::EnvVar { fields: vec![AgentAuthField::secret("API Key", "OPENAI_API_KEY")], link: None };
+    let refs = method.secure_env_refs("opencode");
+    assert_eq!(refs[0].name, "OPENAI_API_KEY");
+    assert_eq!(refs[0].secure_ref.as_deref(), Some("opencode/OPENAI_API_KEY"));
+}
+
+#[test]
+fn terminal_auth_method_keeps_setup_args() {
+    let method = AgentAuthMethod::Terminal { args: vec!["login".to_string()], env: vec![] };
+    assert!(matches!(method, AgentAuthMethod::Terminal { .. }));
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cargo test --test agent_provider_config_tests --all-features`
+
+Expected: FAIL because auth metadata types do not exist.
+
+- [ ] **Step 3: Implement auth metadata and credential resolution**
+
+Add to `src/agent/provider.rs`:
+
+```rust
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentAuthMethod {
+    Agent { instructions: Option<String> },
+    EnvVar { fields: Vec<AgentAuthField>, link: Option<String> },
+    Terminal { args: Vec<String>, env: Vec<(String, String)> },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentAuthField {
+    pub label: String,
+    pub env_name: String,
+    pub secret: bool,
+    pub optional: bool,
+}
+
+impl AgentAuthField {
+    pub fn secret(label: impl Into<String>, env_name: impl Into<String>) -> Self {
+        Self { label: label.into(), env_name: env_name.into(), secret: true, optional: false }
+    }
+}
+```
+
+Extend the `AgentAuthStatus` introduced in Task 14 only if needed by runtime auth results.
+
+Add helpers to:
+
+- convert ACP-advertised auth methods into `AgentAuthMethod` values;
+- expose provider instructions/status to the provider settings UI;
+- resolve secure env values into process env with a `CredentialStore`;
+- build terminal-auth command args/env from a `Terminal` auth method.
+
+- [ ] **Step 4: Wire credential injection into `AcpProcessConnection::spawn`**
+
+Add a spawn variant:
+
+```rust
+pub fn spawn_with_env(provider: &AgentProviderConfig, cwd: PathBuf, env: &[(String, String)]) -> anyhow::Result<Self>
+```
+
+It should call `.env(key, value)` for resolved values and never log values.
+
+- [ ] **Step 5: Add agent-handled ACP authenticate action**
+
+Add `AgentRuntime::authenticate(method_id)` or equivalent, backed by the real ACP crate when available and by `FakeAcpConnection` in tests. It should:
+
+- call the provider's ACP authenticate method for agent-handled auth;
+- update `AgentAuthStatus` from success/failure;
+- preserve provider-supplied instructions in thread/provider settings state;
+- append redacted debug events.
+
+- [ ] **Step 6: Add env-var auth UI fields and storage**
+
+Provider settings should allow entering env-var auth values and saving them via `CredentialStore`, not into config. Saving env-var auth should restart/reinitialize the provider with the resolved env and retry authenticate when required.
+
+- [ ] **Step 7: Add terminal auth action**
+
+Implement a terminal-auth launcher that runs the configured provider command plus advertised terminal auth args/env from Alas. In this task it may use the existing terminal/session infrastructure or a protocol-only command with captured output, but it must expose success/failure/instructions in provider settings. Do not allow arbitrary command substitution from the provider; only append advertised args/env to the configured provider command.
+
+- [ ] **Step 8: Run tests**
+
+Run: `cargo test --test agent_provider_config_tests --test agent_runtime_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/agent/provider.rs src/agent/credentials.rs src/agent/runtime.rs src/ui/provider_settings.rs tests/agent_provider_config_tests.rs tests/agent_runtime_tests.rs
+git commit -m "feat: add ACP provider auth flows"
+```
+
+---
+
+### Task 16: Map Real ACP Session Updates Into Thread State
+
+**Files:**
+- Modify: `src/agent/runtime.rs`
+- Modify: `src/agent/types.rs`
+- Test: `tests/agent_runtime_tests.rs`
+
+- [ ] **Step 1: Add failing update mapping tests independent of real crate transport**
+
+Add tests for an Alas-owned update enum:
+
+```rust
+use alas::agent::{AgentConfigOption, AgentModeOption, AgentSlashCommand, AgentUpdate, apply_agent_update};
+
+#[test]
+fn agent_message_update_appends_agent_transcript_entry() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/a"));
+    apply_agent_update(&mut thread, AgentUpdate::AgentMessageChunk("hello".to_string()));
+    assert!(thread.transcript.iter().any(|entry| entry.text == "hello"));
+}
+
+#[test]
+fn plan_update_replaces_plan_state() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/a"));
+    apply_agent_update(&mut thread, AgentUpdate::Plan(vec!["step one".to_string()]));
+    assert_eq!(thread.plans[0].entries, vec!["step one".to_string()]);
+}
+
+#[test]
+fn advertised_commands_modes_and_config_options_update_thread_state() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/a"));
+    apply_agent_update(&mut thread, AgentUpdate::AvailableCommands(vec![AgentSlashCommand { name: "/test".to_string(), description: Some("Run tests".to_string()) }]));
+    apply_agent_update(&mut thread, AgentUpdate::AvailableModes { modes: vec![AgentModeOption { id: "plan".to_string(), name: "Plan".to_string() }], current: Some("plan".to_string()) });
+    apply_agent_update(&mut thread, AgentUpdate::ConfigOptions(vec![AgentConfigOption { id: "model".to_string(), label: "Model".to_string(), value: Some("sonnet".to_string()) }]));
+
+    assert_eq!(thread.available_commands[0].name, "/test");
+    assert_eq!(thread.current_mode.as_deref(), Some("plan"));
+    assert_eq!(thread.config_options[0].id, "model");
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement update mapper**
+
+Add to `src/agent/runtime.rs`:
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AgentUpdate {
+    UserMessageChunk(String),
+    AgentMessageChunk(String),
+    ThoughtChunk(String),
+    ToolCall { id: String, title: String, status: String },
+    Plan(Vec<String>),
+    AvailableCommands(Vec<crate::agent::AgentSlashCommand>),
+    AvailableModes { modes: Vec<crate::agent::AgentModeOption>, current: Option<String> },
+    ConfigOptions(Vec<crate::agent::AgentConfigOption>),
+    Error(String),
+}
+
+pub fn apply_agent_update(thread: &mut AgentThreadState, update: AgentUpdate) {
+    match update {
+        AgentUpdate::UserMessageChunk(text) => thread.transcript.push(AgentTranscriptEntry::user(text)),
+        AgentUpdate::AgentMessageChunk(text) => thread.transcript.push(AgentTranscriptEntry::agent(text)),
+        AgentUpdate::ThoughtChunk(text) => thread.transcript.push(AgentTranscriptEntry { role: crate::agent::AgentTranscriptRole::Thought, text }),
+        AgentUpdate::ToolCall { id, title, status } => thread.tool_calls.push(crate::agent::AgentToolCallState { id, title, status }),
+        AgentUpdate::Plan(entries) => thread.plans.push(crate::agent::AgentPlanState { entries }),
+        AgentUpdate::AvailableCommands(commands) => thread.available_commands = commands,
+        AgentUpdate::AvailableModes { modes, current } => { thread.available_modes = modes; thread.current_mode = current; },
+        AgentUpdate::ConfigOptions(options) => thread.config_options = options,
+        AgentUpdate::Error(message) => thread.debug_log.push(crate::agent::AgentDebugEvent { message }),
+    }
+}
+```
+
+- [ ] **Step 4: Add real ACP conversion function**
+
+Add a function such as `fn convert_acp_update(update: agent_client_protocol::SessionUpdate) -> Vec<AgentUpdate>`. Check the actual crate docs/API before writing exact matches. Keep the conversion isolated here so UI and tests stay stable.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent/runtime.rs src/agent/types.rs tests/agent_runtime_tests.rs
+git commit -m "feat: map ACP updates into agent thread state"
+```
+
+---
+
+### Task 17: Implement Real ACP Initialize/New/Resume/Prompt/Cancel
+
+**Files:**
+- Modify: `src/agent/runtime.rs`
+- Test: `tests/agent_runtime_tests.rs`
+
+- [ ] **Step 1: Add an ignored/manual fake-provider integration test**
+
+Create an ignored test that can run against a small test ACP server or provider command later:
+
+```rust
+#[test]
+#[ignore = "requires installed ACP provider test command"]
+fn real_acp_provider_can_initialize_and_create_session() {
+    // Use ALAS_TEST_ACP_COMMAND and ALAS_TEST_ACP_ARGS from env.
+}
+```
+
+- [ ] **Step 2: Inspect crate API and replace skeleton methods**
+
+Use local docs/source:
+
+```bash
+cargo doc -p agent-client-protocol --no-deps --open
+```
+
+Then implement `AcpProcessConnection` with the crate-supported client-side connection over child stdio. Shell/runtime launch must compute cwd through `resolve_provider_cwd(provider, selected_worktree, repository_root)` before spawning. The methods must:
+
+- send initialize with Alas client info/capabilities;
+- call the crate's session new/load/resume APIs;
+- call prompt and forward every streamed `session/update` into `AgentEventSink` as it arrives;
+- keep callbacks responsive while a prompt is running;
+- call cancel through the same live connection so an in-flight prompt can stop promptly.
+
+If the crate requires async, expose an async/event-loop implementation internally and keep the Shell boundary as a background task that sends `AgentRuntimeEvent` values back to the GPUI entity. Do not collapse streaming into a final `Vec` in the real implementation.
+
+- [ ] **Step 3: Preserve fake tests**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run ignored test manually when a provider is available**
+
+Run, for example:
+
+```bash
+ALAS_TEST_ACP_COMMAND=opencode ALAS_TEST_ACP_ARGS=acp cargo test --test agent_runtime_tests real_acp_provider_can_initialize_and_create_session --all-features -- --ignored
+```
+
+Expected: PASS when the provider is installed and authenticated, or a clear auth-required error if not.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/runtime.rs tests/agent_runtime_tests.rs
+git commit -m "feat: wire ACP runtime protocol calls"
+```
+
+---
+
+### Task 18: Connect Runtime Actions to Agent Chat UI
+
+**Files:**
+- Modify: `src/ui/agent_pane.rs`
+- Modify: `src/ui/shell.rs`
+- Modify: `src/agent/runtime.rs`
+- Test: `tests/agent_ui_view_model_tests.rs`
+
+- [ ] **Step 1: Add view-model tests for composer state**
+
+Add tests for helpers such as `agent_composer_enabled(thread)` and `agent_primary_action_label(thread)`.
+
+Expected behavior:
+
+- Ready => composer enabled, Send;
+- Running => composer disabled for editing, Cancel visible;
+- ReadOnly => composer disabled;
+- AuthRequired => composer disabled and auth action visible;
+- advertised modes/config options produce visible selector labels in the header;
+- advertised slash commands are available to the composer helper.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cargo test --test agent_ui_view_model_tests --all-features`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement UI helpers and callbacks**
+
+Update `render_agent_pane` signature to accept callbacks:
+
+```rust
+pub fn render_agent_pane(
+    thread: &AgentThreadState,
+    on_send: impl Fn(String, &gpui::ClickEvent, &mut gpui::Window, &mut gpui::App) + Clone + 'static,
+    on_cancel: impl Fn(&gpui::ClickEvent, &mut gpui::Window, &mut gpui::App) + Clone + 'static,
+) -> impl IntoElement
+```
+
+Render advertised mode/model/config selectors in the compact header from `thread.available_modes`, `thread.current_mode`, and `thread.config_options`. Expose slash commands from `thread.available_commands` in the composer helper even if autocomplete UI remains minimal. If text input is not straightforward in current GPUI code, follow existing command settings field patterns from `src/ui/shell.rs` for draft editing.
+
+- [ ] **Step 4: Add Shell runtime storage**
+
+In `AlasShell`, add runtime state keyed by `WorkspaceTabId`, for example:
+
+```rust
+agent_runtimes: std::collections::HashMap<WorkspaceTabId, AgentRuntime<AcpProcessConnection>>,
+```
+
+If generic storage is difficult because fake/runtime types differ, introduce an `AgentRuntimeHandle` enum or trait object facade.
+
+- [ ] **Step 5: Implement send/cancel methods**
+
+Add methods:
+
+- `start_agent_runtime_for_tab`,
+- `send_agent_prompt`,
+- `cancel_agent_prompt`,
+- `sync_agent_thread_from_runtime`.
+
+Run protocol work on the background executor and update tab state for every streamed `AgentRuntimeEvent`, not only at prompt completion. The Shell should keep enough handle state to send cancel while streaming is active.
+
+- [ ] **Step 6: Run UI tests**
+
+Run: `cargo test --test agent_ui_view_model_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/agent_pane.rs src/ui/shell.rs src/agent/runtime.rs tests/agent_ui_view_model_tests.rs
+git commit -m "feat: connect agent chat UI to runtime actions"
+```
+
+---
+
+### Task 19: Wire Filesystem and Terminal Callbacks Into Runtime
+
+**Files:**
+- Modify: `src/agent/runtime.rs`
+- Modify: `src/agent/filesystem.rs`
+- Modify: `src/agent/terminal.rs`
+- Test: `tests/agent_runtime_tests.rs`
+- Test: `tests/agent_filesystem_tests.rs`
+- Test: `tests/agent_terminal_tests.rs`
+
+- [ ] **Step 1: Add runtime callback dispatch tests**
+
+Use fake connection events or direct runtime callback methods:
+
+```rust
+#[test]
+fn runtime_filesystem_callback_records_tool_error_when_denied() {
+    // Construct runtime with Deny policy, call read/write callback, assert error/debug entry.
+}
+
+#[test]
+fn runtime_terminal_callback_records_output_in_tool_state() {
+    // Construct runtime with AllowEverything, run printf command, assert output appears in transcript/tool state.
+}
+
+#[test]
+fn ask_mode_callback_creates_pending_permission_and_resumes_after_decision() {
+    // Construct runtime with Ask policy, request a write/terminal callback,
+    // assert pending_permissions contains the request, then approve it and assert callback completes.
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add callback dispatcher to runtime**
+
+Runtime should own or receive:
+
+- `FilesystemCallbackService`,
+- `AgentTerminalService`,
+- `PermissionPolicy`.
+
+Add methods that the real ACP client handler and permission UI can call:
+
+- `handle_request_permission`,
+- `resolve_permission_request`,
+- `handle_read_text_file`,
+- `handle_write_text_file`,
+- `handle_terminal_create`,
+- `handle_terminal_output`,
+- `handle_terminal_wait_for_exit`,
+- `handle_terminal_kill`,
+- `handle_terminal_release`.
+
+Each method should append redacted debug/tool entries and return ACP-compatible success/error values. For `Ask` decisions, callbacks must create an `AgentPermissionRequest`, return or await a pending decision according to the ACP handler shape, and continue only after `resolve_permission_request` records Allow/Deny. Do not simply bail on `Ask` inside runtime dispatch.
+
+- [ ] **Step 4: Connect real ACP client handlers**
+
+In `AcpProcessConnection`, wire the crate's client callback hooks to the runtime dispatcher. If crate ownership makes direct calls awkward, use channels from callback handlers into the runtime event loop. The UI must render pending permission cards in `render_agent_pane` with Allow/Deny actions, even though the default Allow Everything mode normally bypasses them.
+
+- [ ] **Step 5: Run callback and runtime tests**
+
+Run:
+
+```bash
+cargo test --test agent_runtime_tests --test agent_filesystem_tests --test agent_terminal_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent/runtime.rs src/agent/filesystem.rs src/agent/terminal.rs tests/agent_runtime_tests.rs
+git commit -m "feat: handle ACP filesystem and terminal callbacks"
+```
+
+---
+
+### Task 20: Persist and Restore Agent Chat Tabs
+
+**Files:**
+- Modify: `src/ui/shell.rs`
+- Modify: `src/agent/persistence.rs`
+- Modify: `src/app/workspace.rs`
+- Test: `tests/agent_persistence_tests.rs`
+- Test: `tests/agent_workspace_tests.rs`
+
+- [ ] **Step 1: Add tests for stable thread identity**
+
+Add a stable `thread_id` to `AgentThreadState` or `AgentThreadRecord`. Prefer stable thread id over tab id so persisted records survive tab id allocation changes.
+
+Test:
+
+```rust
+#[test]
+fn persisted_thread_record_uses_stable_thread_id_not_workspace_tab_id() {
+    // Create record, assert thread_id remains the same after state clone/save/load.
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cargo test --test agent_persistence_tests --all-features`
+
+Expected: FAIL if stable thread id not implemented.
+
+- [ ] **Step 3: Implement stable thread ids**
+
+Add `thread_id: String` to `AgentThreadState` or keep it in `AgentThreadRecord` and ensure `WorkspaceSession` can restore Agent Chat tabs from records.
+
+Use simple deterministic ids for tests; use incrementing or timestamp/uuid-like ids for runtime. If adding a UUID dependency, use `uuid = { version = "1", features = ["v4", "serde"] }`.
+
+- [ ] **Step 4: Add Shell store path**
+
+Use `directories::ProjectDirs::from("dev", "alas", "Alas")` data dir and store records in `agent_threads.json`.
+
+Add `agent_thread_store: AgentThreadStore` to `AlasShell`.
+
+- [ ] **Step 5: Restore persisted Agent Chat tabs on startup or worktree selection**
+
+On `AlasShell::new`, load records. On worktree selection, restore records matching selected worktree into `WorkspaceSession` if they are not already open. Mark them `Pending`/`ReadOnly` until runtime resume completes.
+
+- [ ] **Step 6: Persist after thread changes**
+
+After prompt updates, draft changes, resume state changes, and tab close, save current Agent Chat records.
+
+- [ ] **Step 7: Run tests**
+
+Run:
+
+```bash
+cargo test --test agent_persistence_tests --test agent_workspace_tests --all-features
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/ui/shell.rs src/agent/persistence.rs src/app/workspace.rs tests/agent_persistence_tests.rs tests/agent_workspace_tests.rs
+git commit -m "feat: persist and restore agent chat tabs"
+```
+
+---
+
+### Task 21: Enforce Durable Resume Read-Only Behavior
+
+**Files:**
+- Modify: `src/agent/runtime.rs`
+- Modify: `src/ui/agent_pane.rs`
+- Modify: `src/ui/shell.rs`
+- Test: `tests/agent_runtime_tests.rs`
+- Test: `tests/agent_ui_view_model_tests.rs`
+
+- [ ] **Step 1: Add failing read-only prompt tests**
+
+Add runtime test:
+
+```rust
+#[test]
+fn runtime_rejects_prompt_when_thread_is_read_only() {
+    let fake = FakeAcpConnection::new();
+    let mut runtime = AgentRuntime::with_connection("opencode", PathBuf::from("/repo/a"), fake);
+    runtime.thread_mut().status = AgentThreadStatus::ReadOnly { reason: "resume unsupported".to_string() };
+
+    let error = runtime.prompt("hello").expect_err("read-only prompt should fail").to_string();
+    assert!(error.contains("read-only"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: FAIL if prompts are allowed in read-only state.
+
+- [ ] **Step 3: Guard runtime and UI send paths**
+
+- `AgentRuntime::prompt` returns an error for `ReadOnly`.
+- Agent pane disables composer for `ReadOnly`.
+- Shell send handler no-ops and records a debug error if a stale UI event tries to send.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --test agent_runtime_tests --test agent_ui_view_model_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agent/runtime.rs src/ui/agent_pane.rs src/ui/shell.rs tests/agent_runtime_tests.rs tests/agent_ui_view_model_tests.rs
+git commit -m "feat: enforce ACP resume read-only sessions"
+```
+
+---
+
+### Task 22: Add Debug Log Redaction
+
+**Files:**
+- Modify: `src/agent/types.rs`
+- Modify: `src/agent/runtime.rs`
+- Test: `tests/agent_runtime_tests.rs`
+
+- [ ] **Step 1: Add failing redaction tests**
+
+```rust
+use alas::agent::redact_debug_value;
+
+#[test]
+fn debug_redaction_removes_secret_values() {
+    assert_eq!(redact_debug_value("OPENAI_API_KEY", "abc123"), "[redacted]");
+    assert_eq!(redact_debug_value("PATH", "/usr/bin"), "/usr/bin");
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement redaction helper and bounded log**
+
+Add helper that redacts keys containing `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, or auth fields marked secret. Add `push_debug_event` on `AgentThreadState` that caps entries, e.g. 500.
+
+- [ ] **Step 4: Use redaction in runtime/provider launch/auth paths**
+
+Ensure debug events include method names and safe metadata but no raw env values.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test --test agent_runtime_tests --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent/types.rs src/agent/runtime.rs tests/agent_runtime_tests.rs
+git commit -m "feat: redact ACP debug logs"
+```
+
+---
+
+### Task 23: Add Manual Test Documentation
+
+**Files:**
+- Modify: `docs/manual-test.md`
+
+- [ ] **Step 1: Add ACP manual acceptance section**
+
+Append a section with these steps:
+
+```markdown
+## ACP Agent Chat
+
+1. Ensure an ACP provider is installed, for example `opencode acp` or another provider command.
+2. Open Alas and select a worktree.
+3. Open provider settings and add a global provider with command/args.
+4. Authenticate from Alas if the provider reports auth is required.
+5. Use `+ → Agent Chat` and select the provider.
+6. Send a prompt and confirm streamed transcript updates appear.
+7. Trigger a file read/write or terminal command and confirm the tool card shows the side effect under Allow Everything.
+8. Restart Alas and confirm the chat returns.
+9. Confirm the composer is enabled only if ACP resume succeeds; otherwise the transcript is read-only.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/manual-test.md
+git commit -m "docs: add ACP agent chat manual test"
+```
+
+---
+
+### Task 24: Run Full Verification
+
+**Files:**
+- No code changes expected unless checks fail.
+
+- [ ] **Step 1: Run formatting check**
+
+Run: `cargo fmt --all -- --check`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run clippy**
+
+Run: `cargo clippy --all-targets --all-features -- -D warnings`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run build**
+
+Run: `cargo build --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --all-features`
+
+Expected: PASS.
+
+- [ ] **Step 5: Fix any failures with focused commits**
+
+For each failure:
+
+1. write or update a targeted regression test if missing;
+2. fix the issue;
+3. rerun the failing command;
+4. commit with a focused message.
+
+- [ ] **Step 6: Final status**
+
+Run: `git status --short`
+
+Expected: clean working tree.
+
+---
+
+## Implementation Handoff Notes
+
+- Start with Tasks 1-9 to build a testable non-UI foundation before heavy GPUI wiring.
+- Do not wire real ACP subprocess protocol calls until fake-backed state, persistence, and UI seams are stable.
+- Keep provider install/update/registry work out of this branch.
+- Preserve existing terminal behavior. Terminal-specific input/rendering paths should remain gated on terminal tabs.
+- The default trust mode is intentionally powerful: Allow Everything across the whole machine. Keep tests explicit so future safer defaults are a conscious product change.

--- a/docs/superpowers/specs/2026-05-01-acp-provider-auto-discovery-design.md
+++ b/docs/superpowers/specs/2026-05-01-acp-provider-auto-discovery-design.md
@@ -1,0 +1,226 @@
+# ACP Provider Auto-Discovery Design
+
+Date: 2026-05-01
+
+## Goal
+
+Add lightweight ACP provider auto-discovery so Alas can silently configure known installed ACP providers when possible, while preserving all user-edited provider configuration and avoiding broken guesses.
+
+The first target is OpenCode via `opencode acp`. Claude Code and Codex should be detected as suggestions until their ACP command shapes are verified.
+
+## Context
+
+Alas currently supports manual global ACP provider configuration. Provider install/update/registry management was intentionally out of scope for the initial center-pane ACP implementation. This feature adds a small, safe discovery layer on top of the existing manual provider model.
+
+Relevant existing areas:
+
+- `src/agent/provider.rs`: provider config and settings state.
+- `src/config/types.rs`: persisted app config.
+- `src/config/app_config.rs`: app config load/save.
+- `src/ui/shell.rs`: startup config loading and provider settings state.
+- `src/ui/provider_settings.rs`: provider settings UI.
+
+## Product Decisions
+
+- Discovery runs on every startup.
+- Verified providers are silently added when missing.
+- Existing providers are never overwritten by discovery.
+- Disabled providers are not re-enabled.
+- Deleted auto-discovered providers should stay deleted by recording an ignored provider id.
+- Suggestions are non-invasive and are not active providers.
+- V1 should avoid launching ACP servers for probing.
+- OpenCode is the first verified silent provider: `opencode acp`.
+- Claude Code and Codex are suggestions only until their ACP command shapes are confirmed.
+
+## Scope
+
+### In scope
+
+- Scan `PATH` for known provider binaries.
+- Add verified missing providers to global app config.
+- Preserve existing user provider config unchanged.
+- Persist ignored discovery ids for deleted providers.
+- Surface unverified detections as Provider Settings suggestions.
+- Add unit tests for discovery and merge behavior.
+
+### Out of scope
+
+- Installing providers.
+- Updating providers.
+- Downloading remote provider registries.
+- Running long-lived ACP server processes as startup probes.
+- Automatically adding unverified Claude/Codex command guesses.
+- Credential discovery or migration.
+
+## Architecture
+
+Add a provider discovery layer separate from provider configuration.
+
+### Known provider registry
+
+The registry is a small built-in table of known candidates. Each entry should describe:
+
+- stable provider id,
+- display name,
+- executable name,
+- verified ACP args when known,
+- suggestion message when unverified.
+
+Initial registry:
+
+| Provider | Binary | Verified command | Discovery result |
+| --- | --- | --- | --- |
+| OpenCode | `opencode` | `opencode acp` | verified provider |
+| Claude Code | `claude` | unknown in V1 | suggestion |
+| Codex | `codex` | unknown in V1 | suggestion |
+
+Provider ids are stable and predictable: `opencode`, `claude`, and `codex`.
+
+### Discovery result
+
+Discovery should produce:
+
+- `verified_providers`: providers safe to auto-add,
+- `suggestions`: detected tools that may support ACP but are not auto-configured.
+
+Suggested types:
+
+- `KnownAgentProvider`
+- `AgentProviderDiscovery`
+- `DiscoveredAgentProvider`
+- `AgentProviderSuggestion`
+- `ProviderDiscoveryResult`
+
+These names are suggestions; implementation may adjust them to match existing module style.
+
+### PATH scanning
+
+Discovery scans the process `PATH` for known executable names. It should tolerate:
+
+- missing `PATH`,
+- empty path segments,
+- non-existent directories,
+- unreadable directories,
+- duplicate matches.
+
+Discovery should not fail app startup. Unexpected filesystem errors should produce no provider for that candidate or a non-fatal diagnostic, not a hard error.
+
+Discovery must be conservative about PATH safety because verified providers are added silently and use the existing default trust mode. It must ignore:
+
+- empty PATH segments,
+- relative PATH segments, including current-directory entries,
+- non-directory PATH entries,
+- matching files that are not executable.
+
+For V1, do not execute `opencode acp`, `claude`, or `codex` during startup. Running an ACP command may start a server and hang. Safe version probes may be added later only when bounded and known to exit quickly.
+
+## Config Model
+
+Extend app config with an agent provider discovery section, for example:
+
+```toml
+[agent_provider_discovery]
+ignored_provider_ids = ["opencode"]
+```
+
+Equivalent Rust model:
+
+```rust
+pub struct AgentProviderDiscoveryConfig {
+    pub ignored_provider_ids: Vec<String>,
+}
+```
+
+Defaults must preserve existing config compatibility.
+
+## Merge Behavior
+
+Add a pure merge function, for example:
+
+```rust
+merge_discovered_agent_providers(config, discovery_result) -> bool
+```
+
+The function appends verified providers and returns whether config changed.
+
+Rules:
+
+1. If a provider id already exists in `config.agent_providers`, do nothing.
+2. If a provider id is in `agent_provider_discovery.ignored_provider_ids`, do nothing.
+3. If a verified provider is missing and not ignored, append it.
+4. Appended provider defaults:
+   - `id`: stable id,
+   - `display_name`: registry display name,
+   - `command`: executable name, not absolute path,
+   - `args`: verified ACP args,
+   - `enabled`: true,
+   - `trust_mode`: the existing provider default, Allow Everything,
+   - `cwd_policy`: existing default,
+   - `env` and `auth_methods`: empty unless a future verified provider requires metadata.
+
+Allow Everything remains the default for consistency with the approved ACP trust-mode design. The PATH safety rules above are required so silent auto-enablement does not come from current-directory or non-executable spoofing. Users can still change trust mode or disable the provider in Provider Settings.
+5. Never mutate existing command, args, env, trust mode, enabled state, auth methods, or display name.
+
+Storing the command name instead of the absolute path lets normal PATH changes continue to work.
+
+## Startup Flow
+
+On startup:
+
+1. Load app config.
+2. Run provider discovery.
+3. Merge verified providers into config.
+4. Save config only if merge changed it.
+5. Continue app startup even if discovery or save has a non-fatal error.
+6. Store filtered suggestions in Shell/provider settings state so Provider Settings can display them.
+
+If config save fails after adding providers, Alas should still start. The in-memory config may contain the discovered provider for the current session, but the provider settings state should record a deterministic non-fatal error explaining that auto-discovered providers could not be persisted.
+
+## Provider Settings UX
+
+Provider Settings continues to show configured providers as editable entries. Auto-configured providers appear as normal configured providers.
+
+Add a small suggestions area when unverified tools are detected, for example:
+
+- “Claude Code found, but ACP command is not verified yet.”
+- “Codex found, but ACP command is not verified yet.”
+
+For V1, suggestions may be informational only. A later enhancement can add an “Add manually” action that pre-fills provider name and command while leaving args editable.
+
+Suggestions must be filtered before display:
+
+- Do not show a suggestion when the same provider id already exists in configured providers.
+- Do not show a suggestion when the provider id is in `ignored_provider_ids`.
+
+Deleting a provider whose id matches a known discovery registry entry should append that id to `ignored_provider_ids` before saving provider settings. This applies whether the provider was originally auto-discovered or manually added with the same known id; the user action means “do not recreate this known provider automatically.” Disabling a provider should simply keep the existing disabled provider entry; discovery will not re-enable it because existing providers are never overwritten.
+
+## Error Handling
+
+- Missing binaries are normal and not errors.
+- Missing or malformed PATH is not fatal.
+- Discovery must avoid blocking startup.
+- Config save failures after discovery are non-fatal and should be surfaced as deterministic settings/debug state.
+- Suggestions should not imply Claude or Codex are ready to use as ACP providers.
+- Unsafe PATH entries, relative directories, and non-executable matches are ignored rather than warned about during normal startup.
+
+## Testing
+
+Add tests for:
+
+- `opencode` on a fake PATH produces a verified provider with command `opencode` and args `["acp"]`.
+- `claude` on a fake PATH produces a suggestion only.
+- `codex` on a fake PATH produces a suggestion only.
+- Existing provider config is not overwritten.
+- Disabled existing provider is not re-enabled.
+- Ignored provider id is not re-added.
+- Merge reports `changed == true` only when providers are appended.
+- Missing or empty PATH does not error.
+- Empty PATH segments and relative/current-directory entries are ignored.
+- Matching non-executable files are ignored.
+- Duplicate PATH matches do not create duplicate providers or suggestions.
+- Suggestions are not shown for already configured provider ids.
+- Suggestions are not shown for ignored provider ids.
+- Removing a known provider id records it in `ignored_provider_ids` before saving.
+- Startup continues with deterministic error state when discovery merge changes config but save fails.
+
+Shell-level behavior should be covered where practical, but pure discovery and merge tests are the priority.

--- a/docs/superpowers/specs/2026-05-01-center-pane-acp-design.md
+++ b/docs/superpowers/specs/2026-05-01-center-pane-acp-design.md
@@ -1,0 +1,371 @@
+# Center Pane ACP Support Design
+
+Date: 2026-05-01
+
+## Goal
+
+Add Agent Client Protocol (ACP) support to Alas as a first-class center-pane tab. The new Agent Chat tab lets users configure installed ACP providers, authenticate them from Alas, create and resume durable agent sessions, send prompts, view streamed transcript/tool updates, and service ACP filesystem and terminal callbacks.
+
+The first implementation should establish the full contracts needed for Claude, Codex, OpenCode, and other ACP-compatible providers, while keeping provider installation, update, and registry management out of scope.
+
+## Context
+
+Previous research in commit `0d5047c80b6ceb6720594ee8be3bf44d8c8ef9b9` found that ACP support is feasible but should be implemented as a center-tab surface rather than layered onto terminal state. Since that research, Alas already has a generic center tab model with Terminal, File, and Markdown content. ACP should extend that model with Agent Chat content.
+
+Relevant current code areas:
+
+- `src/app/workspace.rs`: `WorkspaceTab`, `WorkspaceTabKind`, `WorkspaceTabContent`, tab lifecycle.
+- `src/ui/workspace.rs`: center workspace tab bar and `+` action.
+- `src/ui/shell.rs`: active tab routing and terminal/file/markdown pane selection.
+- `src/terminal/*`: existing terminal process and Ghostty rendering infrastructure.
+- `src/config/*`: global app config and repository config persistence.
+
+## Scope
+
+### In scope
+
+- Add an Agent Chat center tab kind.
+- Add global manual ACP provider configuration.
+- Add provider settings and in-app auth surfaces.
+- Store provider credentials in OS secure storage only.
+- Launch configured providers as ACP stdio subprocesses.
+- Implement the ACP lifecycle: initialize, authenticate, session creation, session load/resume, prompt, cancel, and streamed updates.
+- Implement core client callbacks:
+  - `session/request_permission`,
+  - filesystem read/write callbacks,
+  - terminal create/output/wait/kill/release callbacks.
+- Use protocol-only terminal command execution in the first implementation.
+- Persist local chat metadata, transcript snapshots, drafts, debug metadata, and ACP session ids.
+- Require durable ACP resume for continued prompting after app restart.
+- Fall back to read-only local transcript display when a provider cannot resume a restored session.
+- Add configurable trust modes with **Allow Everything** as the default across the whole machine.
+
+### Out of scope
+
+- ACP registry integration.
+- Provider installation or update management.
+- Full provider-specific install flows for Claude, Codex, or OpenCode.
+- Editor buffer integration or unsaved-file semantics.
+- Ghostty-backed interactive ACP terminals in V1.
+- Diff/editor review surfaces beyond transcript/tool-call rendering.
+
+## Product Decisions
+
+- Provider support targets multiple ACP providers equally from day one, but providers must already be installed.
+- Manual providers live in global app config first.
+- New Agent Chat tabs are created from the existing `+` tab control through a Terminal vs Agent Chat picker.
+- The default Agent Chat layout is a single vertical chat surface.
+- Terminal callbacks are protocol-only in V1, with interfaces designed for future Ghostty-backed terminal tabs.
+- Persistence is local, but continuing an old session requires ACP session load/resume success.
+- If resume is unsupported or fails, Alas shows the transcript read-only and disables the composer.
+- Trust mode defaults to Allow Everything for filesystem and terminal callbacks across the whole local machine.
+- Credentials and tokens are stored only through OS secure storage, such as macOS Keychain or the platform credential store.
+
+## Architecture
+
+ACP is added as a new center-tab content type, not as a terminal feature.
+
+### Workspace tab model
+
+Extend the workspace model with Agent Chat state:
+
+- `WorkspaceTabKind::AgentChat`
+- `WorkspaceTabContent::AgentChat(AgentThreadState)`
+
+`AgentThreadState` should track:
+
+- provider id,
+- ACP session id when available,
+- selected worktree path,
+- title,
+- lifecycle status,
+- transcript entries,
+- plan state,
+- tool-call state,
+- pending permission decisions,
+- advertised slash commands,
+- advertised modes/models/config options,
+- composer draft,
+- resume capability/result,
+- bounded redacted debug log metadata.
+
+Terminal-specific state and mutations must continue to reject non-terminal tabs. Mixed-tab behavior should remain consistent for selecting, moving, and closing tabs.
+
+### Provider configuration
+
+Add global app-level provider definitions. A provider definition includes:
+
+- stable id,
+- display name,
+- command,
+- args,
+- non-secret env values or secure-store references,
+- working-directory policy,
+- enabled flag,
+- default trust mode,
+- optional provider metadata such as known provider kind.
+
+Config files must not store secrets. They may store secure credential keys or metadata needed to retrieve secrets from the OS credential store.
+
+### ACP runtime layer
+
+Introduce an ACP runtime module that owns protocol integration:
+
+- provider subprocess launch over stdio,
+- JSON-RPC/ACP connection using the official Rust `agent-client-protocol` crate where practical,
+- initialization and capability negotiation,
+- auth orchestration,
+- session new/load/resume,
+- prompt/cancel,
+- streamed `session/update` handling,
+- client callback dispatch,
+- debug logging.
+
+Separate provider process/connection state from user-visible thread state. A provider connection may fail or restart while the local Agent Chat tab retains transcript and recovery information.
+
+### Credential store adapter
+
+Add an abstraction for OS secure storage. The first implementation should support the host platform needed for development, and expose clear errors when secure storage is unavailable.
+
+The adapter stores and retrieves secrets by provider id and auth field. The app config stores only the reference metadata.
+
+### Callback services
+
+Callback handling is split into explicit services:
+
+- permission policy service,
+- filesystem callback service,
+- protocol-only terminal callback service.
+
+The terminal callback service should expose internal command handles and streamed output events. This keeps Agent Chat state independent from the V1 execution backend and leaves room for replacing command execution with Ghostty-backed terminal tabs later.
+
+### Persistence store
+
+Persist local Agent Chat records separately from transient runtime connections. Persisted records include:
+
+- tab id or stable thread id,
+- provider id,
+- worktree path,
+- ACP session id,
+- title,
+- transcript snapshot,
+- draft text,
+- last known lifecycle state,
+- resume status,
+- redacted debug/error metadata.
+
+A persisted tab is not considered live until the provider reconnects and ACP resume succeeds.
+
+## UI and User Flow
+
+### New tab flow
+
+The existing `+` workspace tab button opens a small picker with at least:
+
+- Terminal,
+- Agent Chat.
+
+Selecting Agent Chat opens a provider picker when multiple enabled providers exist. If no providers exist, Alas opens provider settings with an empty-state explanation.
+
+### Provider settings
+
+A global provider settings surface supports daily manual provider use:
+
+- add provider,
+- edit provider command/args/env metadata,
+- remove provider,
+- enable/disable provider,
+- select trust mode,
+- view auth status,
+- run auth actions,
+- view recent provider errors/debug log.
+
+Provider installation and updates are intentionally deferred.
+
+### Authentication UX
+
+Alas supports in-app auth surfaces for ACP-advertised auth methods and provider metadata:
+
+- **Agent-handled auth**: call the provider's ACP auth method and show provider-supplied instructions/status.
+- **Env-var auth**: collect required values in Alas, store secrets in OS secure storage, restart the provider with injected env, and retry auth.
+- **Terminal auth**: run the provider's setup/login flow from Alas when the provider advertises terminal auth support.
+
+Provider-specific polish for Claude, Codex, and OpenCode can be implemented behind the same auth interface. The design does not require install/update flows.
+
+### Agent Chat tab
+
+The tab is a single vertical chat surface:
+
+- compact header with provider name, session status, auth/resume state, and advertised mode/model/config selectors,
+- scrollable transcript,
+- visible user messages,
+- streamed agent message chunks,
+- thoughts when available,
+- plans,
+- tool-call cards,
+- permission decisions,
+- errors,
+- bottom composer with draft, Send, and Cancel while running,
+- debug log accessible from the tab/provider UI but hidden by default.
+
+### Resume UX
+
+On app restart, persisted Agent Chat tabs reappear.
+
+- If ACP resume succeeds, transcript is restored and composer is enabled.
+- If ACP resume fails or the provider does not support durable resume, transcript remains visible but composer is disabled with a clear read-only message.
+- The user may start a new session from the read-only tab.
+
+## Data Flow and ACP Lifecycle
+
+### Provider launch
+
+1. Resolve global provider config.
+2. Resolve non-secret env values and secure-store secrets.
+3. Start the provider subprocess over stdio.
+4. Use the selected worktree as workspace root or cwd according to provider policy.
+5. Attach redacted lifecycle/debug logging.
+
+### Initialize
+
+Send ACP `initialize` with Alas client info and supported capabilities, including filesystem callbacks, terminal callbacks, permission handling, and terminal auth support when implemented.
+
+### Authenticate
+
+1. Inspect provider auth status and advertised methods.
+2. Route missing auth through the in-app auth UI.
+3. Store required secrets only in OS secure storage.
+4. Restart and reinitialize the provider when env-var auth changes process environment.
+
+### Session setup
+
+- For new chats, call `session/new`.
+- For restored chats, prefer `session/load` or `session/resume` according to provider capability.
+- Register local thread state before load/resume completes so replayed updates attach to the correct tab.
+
+### Prompt turn
+
+1. User sends composer text through `session/prompt`.
+2. Stream `session/update` notifications into transcript, tool-call, plan, mode, and config state.
+3. While running, `Cancel` calls `session/cancel` and marks the local turn interrupted.
+
+### Client callbacks
+
+- `session/request_permission` consults the configured trust mode. The default Allow Everything mode approves without prompting across the whole machine.
+- Filesystem read/write callbacks operate on disk paths after policy approval.
+- Terminal callbacks run background protocol-only commands in V1 and stream output/status into tool-call cards.
+- Terminal callbacks expose command handles that support output, wait, kill, and release semantics.
+
+### Persistence
+
+After meaningful thread changes, persist local metadata and transcript snapshots. Do not persist live connection state. After restart, restored tabs must reconnect to the provider and resume through ACP before accepting new prompts.
+
+## Error Handling and Safety
+
+### Provider errors
+
+Startup failure, stdio disconnect, invalid JSON-RPC, and protocol errors put the tab in a recoverable failed state with actions:
+
+- Retry,
+- Edit Provider,
+- View Debug Log.
+
+### Auth errors
+
+Auth errors show provider-supplied instructions when available. Env-var auth validates required fields before restart. Secrets remain in OS secure storage and are redacted from logs.
+
+### Resume errors
+
+Resume errors preserve local transcript history, disable the composer, and label the session read-only unless the user starts a new session.
+
+### Callback errors
+
+- File read/write errors return ACP errors and append transcript/debug entries.
+- Terminal command failures include exit status and captured output.
+- Callback failures should not crash the app or corrupt unrelated tabs.
+
+### Trust modes
+
+The policy model should support at least:
+
+- Allow Everything,
+- Ask,
+- Worktree-only,
+- Deny.
+
+The chosen default is Allow Everything across the whole machine. Even when a callback is auto-approved, file and terminal side effects must be visible in transcript/tool-call cards.
+
+### Debug logging
+
+Each provider/thread stores a bounded redacted debug log containing lifecycle events, protocol method names, errors, and redacted parameters. Logs must not include secrets, tokens, or raw secure env values.
+
+## Testing Strategy
+
+### Workspace model tests
+
+- Agent Chat tabs coexist with Terminal/File/Markdown tabs.
+- Tab selection, closing, moving, and fallback behavior work across mixed tab kinds.
+- Terminal-specific mutations reject Agent Chat tabs.
+
+### Provider config tests
+
+- Global provider config serializes and deserializes.
+- Secrets are not written to config files.
+- Trust mode defaults to Allow Everything.
+- Secure-store references remain stable across provider edits.
+
+### ACP runtime tests
+
+Use fake ACP providers where possible.
+
+- Lifecycle transitions: uninitialized, auth needed, ready, running, failed.
+- New session vs load/resume behavior.
+- Resume failure produces read-only transcript state.
+- Streamed updates append to transcript/tool/plan state.
+- Cancel maps to ACP cancellation and local interrupted state.
+
+### Callback tests
+
+- Allow Everything auto-approves permission requests.
+- Filesystem read/write callbacks handle success and disk errors.
+- Protocol-only terminal callbacks stream output, report exit status, and support kill/release.
+- Callback errors are scoped to the active tool call/thread.
+
+### UI/view-model tests
+
+- Provider empty state.
+- Provider auth states.
+- Agent tab failed state.
+- Read-only resume-failed state.
+- Running/cancel state.
+- Transcript/composer updates.
+
+## Manual Acceptance
+
+The first implementation is accepted when a user can:
+
+1. Add a global provider for an already installed ACP agent.
+2. Authenticate it from Alas using a supported in-app auth flow.
+3. Open `+ → Agent Chat`.
+4. Send prompts and see streamed transcript/tool/plan updates.
+5. Let the agent perform filesystem and terminal callbacks under Allow Everything.
+6. Restart Alas.
+7. See existing chats restored.
+8. Continue restored chats only when ACP resume succeeds.
+9. Use provider settings/auth UI comfortably for daily manual provider use.
+
+## Risks and Mitigations
+
+- **Provider auth variability**: use an auth-method abstraction and keep provider-specific behavior behind it.
+- **Durable resume variability**: make unsupported resume explicit and safe by restoring transcript read-only.
+- **Powerful default trust mode**: document Allow Everything clearly and keep policy hooks for safer modes.
+- **External process opacity**: add redacted debug logging early.
+- **Terminal callback complexity**: start with protocol-only execution but keep backend boundaries clear for future Ghostty integration.
+- **Large UI surface**: keep Agent Chat as one vertical surface and avoid split/diff/editor UI in this subproject.
+
+## References
+
+- Research commit: `0d5047c80b6ceb6720594ee8be3bf44d8c8ef9b9`.
+- ACP docs: initialization, session setup, prompt turn, tool calls, filesystem, terminals, Rust library.
+- ACP RFD: authentication methods.
+- Zed external-agent architecture patterns noted in prior research.

--- a/src/agent/credentials.rs
+++ b/src/agent/credentials.rs
@@ -1,0 +1,126 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use anyhow::{Context, anyhow};
+
+use super::AgentProviderEnvVar;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct CredentialStoreKey {
+    pub provider_id: String,
+    pub field: String,
+}
+
+impl CredentialStoreKey {
+    pub fn new(provider_id: impl Into<String>, field: impl Into<String>) -> Self {
+        Self {
+            provider_id: provider_id.into(),
+            field: field.into(),
+        }
+    }
+
+    fn service(&self) -> String {
+        format!("alas.agent.{}", self.provider_id)
+    }
+
+    fn username(&self) -> &str {
+        &self.field
+    }
+}
+
+pub trait CredentialStore: Send + Sync {
+    fn read_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<Option<String>>;
+    fn write_secret(&self, key: &CredentialStoreKey, value: &str) -> anyhow::Result<()>;
+    fn delete_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<()>;
+}
+
+#[derive(Clone, Default)]
+pub struct MemoryCredentialStore {
+    secrets: Arc<Mutex<HashMap<CredentialStoreKey, String>>>,
+}
+
+impl CredentialStore for MemoryCredentialStore {
+    fn read_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<Option<String>> {
+        Ok(self
+            .secrets
+            .lock()
+            .expect("credential lock")
+            .get(key)
+            .cloned())
+    }
+
+    fn write_secret(&self, key: &CredentialStoreKey, value: &str) -> anyhow::Result<()> {
+        self.secrets
+            .lock()
+            .expect("credential lock")
+            .insert(key.clone(), value.to_string());
+        Ok(())
+    }
+
+    fn delete_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<()> {
+        self.secrets.lock().expect("credential lock").remove(key);
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OsCredentialStore;
+
+pub fn resolve_secure_env_values(
+    provider_id: &str,
+    env: &[AgentProviderEnvVar],
+    store: &dyn CredentialStore,
+) -> anyhow::Result<Vec<(String, String)>> {
+    env.iter()
+        .map(|entry| {
+            if let Some(value) = &entry.value {
+                Ok((entry.name.clone(), value.clone()))
+            } else if let Some(secure_ref) = &entry.secure_ref {
+                let field = secure_ref
+                    .strip_prefix(&format!("{provider_id}/"))
+                    .unwrap_or(secure_ref);
+                let key = CredentialStoreKey::new(provider_id, field);
+                let value = store.read_secret(&key)?.ok_or_else(|| {
+                    anyhow!(
+                        "missing credential for provider '{}' env var '{}'",
+                        provider_id,
+                        entry.name
+                    )
+                })?;
+                Ok((entry.name.clone(), value))
+            } else {
+                Ok((entry.name.clone(), String::new()))
+            }
+        })
+        .collect()
+}
+
+impl CredentialStore for OsCredentialStore {
+    fn read_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<Option<String>> {
+        let entry = keyring::Entry::new(&key.service(), key.username())
+            .context("failed to create keyring entry")?;
+        match entry.get_password() {
+            Ok(secret) => Ok(Some(secret)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(error).context("failed to read secret from OS credential store"),
+        }
+    }
+
+    fn write_secret(&self, key: &CredentialStoreKey, value: &str) -> anyhow::Result<()> {
+        keyring::Entry::new(&key.service(), key.username())
+            .context("failed to create keyring entry")?
+            .set_password(value)
+            .context("failed to write secret to OS credential store")
+    }
+
+    fn delete_secret(&self, key: &CredentialStoreKey) -> anyhow::Result<()> {
+        let entry = keyring::Entry::new(&key.service(), key.username())
+            .context("failed to create keyring entry")?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(error).context("failed to delete secret from OS credential store"),
+        }
+    }
+}

--- a/src/agent/discovery.rs
+++ b/src/agent/discovery.rs
@@ -1,0 +1,399 @@
+use std::{
+    collections::HashSet,
+    env,
+    ffi::{OsStr, OsString},
+    path::Path,
+};
+
+use crate::{
+    agent::{AgentProviderConfig, ProviderSettingsState},
+    config::AppConfig,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentProviderSuggestion {
+    pub id: String,
+    pub display_name: String,
+    pub command: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ProviderDiscoveryResult {
+    pub verified_providers: Vec<AgentProviderConfig>,
+    pub suggestions: Vec<AgentProviderSuggestion>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderDiscoveryStartupResult {
+    pub changed: bool,
+    pub suggestions: Vec<AgentProviderSuggestion>,
+    pub error: Option<String>,
+}
+
+struct KnownDiscoverableProvider {
+    id: &'static str,
+    display_name: &'static str,
+    probe_commands: &'static [&'static str],
+    provider_command: &'static str,
+    verified_args: &'static [&'static str],
+    required_commands: &'static [&'static str],
+}
+
+const KNOWN_PROVIDERS: &[KnownDiscoverableProvider] = &[
+    KnownDiscoverableProvider {
+        id: "opencode",
+        display_name: "OpenCode",
+        probe_commands: &["opencode"],
+        provider_command: "opencode",
+        verified_args: &["acp"],
+        required_commands: &[],
+    },
+    KnownDiscoverableProvider {
+        id: "claude",
+        display_name: "Claude Code",
+        probe_commands: &["claude"],
+        provider_command: "npx",
+        verified_args: &["-y", "@agentclientprotocol/claude-agent-acp"],
+        required_commands: &["npx"],
+    },
+    KnownDiscoverableProvider {
+        id: "codex",
+        display_name: "Codex",
+        probe_commands: &["codex"],
+        provider_command: "npx",
+        verified_args: &["-y", "@zed-industries/codex-acp"],
+        required_commands: &["npx"],
+    },
+];
+
+pub fn discover_agent_providers() -> ProviderDiscoveryResult {
+    discover_agent_providers_from_path_os(env::var_os("PATH").as_deref())
+}
+
+pub fn discover_agent_providers_from_path(path_env: Option<&str>) -> ProviderDiscoveryResult {
+    discover_agent_providers_from_path_os(path_env.map(OsStr::new))
+}
+
+fn discover_agent_providers_from_path_os(path_env: Option<&OsStr>) -> ProviderDiscoveryResult {
+    let Some(path_env) = path_env else {
+        return ProviderDiscoveryResult::default();
+    };
+
+    if path_env.is_empty() {
+        return ProviderDiscoveryResult::default();
+    }
+
+    let available_commands = available_commands_from_path(path_env);
+    let mut result = ProviderDiscoveryResult::default();
+
+    for provider in KNOWN_PROVIDERS {
+        let has_provider_binary = provider
+            .probe_commands
+            .iter()
+            .any(|command| available_commands.contains(*command));
+        if !has_provider_binary {
+            continue;
+        }
+
+        let missing_required = provider
+            .required_commands
+            .iter()
+            .find(|command| !available_commands.contains(**command));
+        if let Some(missing) = missing_required {
+            result.suggestions.push(AgentProviderSuggestion {
+                id: provider.id.to_string(),
+                display_name: provider.display_name.to_string(),
+                command: provider.probe_commands[0].to_string(),
+                message: format!(
+                    "{} was found on PATH, but '{}' is required to launch its ACP adapter.",
+                    provider.display_name, missing
+                ),
+            });
+            continue;
+        }
+
+        let mut config = AgentProviderConfig::new(
+            provider.id,
+            provider.display_name,
+            provider.provider_command,
+        );
+        config.args = provider
+            .verified_args
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect();
+        result.verified_providers.push(config);
+    }
+
+    result
+}
+
+fn available_commands_from_path(path_env: &OsStr) -> HashSet<String> {
+    let mut commands = HashSet::new();
+
+    for path_entry in env::split_paths(path_env) {
+        if path_entry.as_os_str().is_empty() || path_entry.is_relative() || !path_entry.is_dir() {
+            continue;
+        }
+
+        for provider in KNOWN_PROVIDERS {
+            for command in provider
+                .probe_commands
+                .iter()
+                .chain(std::iter::once(&provider.provider_command))
+            {
+                if command_file_candidates(command, should_use_windows_command_extensions())
+                    .iter()
+                    .any(|candidate| is_executable_file(&path_entry.join(candidate)))
+                {
+                    commands.insert((*command).to_string());
+                }
+            }
+            for command in provider.required_commands {
+                if command_file_candidates(command, should_use_windows_command_extensions())
+                    .iter()
+                    .any(|candidate| is_executable_file(&path_entry.join(candidate)))
+                {
+                    commands.insert((*command).to_string());
+                }
+            }
+        }
+    }
+
+    commands
+}
+
+pub fn merge_discovered_agent_providers(
+    config: &mut AppConfig,
+    discovery: &ProviderDiscoveryResult,
+) -> bool {
+    let mut configured_provider_ids = config
+        .agent_providers
+        .iter()
+        .map(|provider| provider.id.clone())
+        .collect::<HashSet<_>>();
+    let ignored_provider_ids = config
+        .agent_provider_discovery
+        .ignored_provider_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+
+    let mut providers_to_append = discovery
+        .verified_providers
+        .iter()
+        .filter(|provider| {
+            !ignored_provider_ids.contains(provider.id.as_str())
+                && configured_provider_ids.insert(provider.id.clone())
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if providers_to_append.is_empty() {
+        return false;
+    }
+
+    config.agent_providers.append(&mut providers_to_append);
+    true
+}
+
+pub fn apply_provider_discovery_to_config(
+    config: &mut AppConfig,
+    discovery: &ProviderDiscoveryResult,
+    save: impl FnOnce(&AppConfig) -> anyhow::Result<()>,
+) -> ProviderDiscoveryStartupResult {
+    let changed = merge_discovered_agent_providers(config, discovery);
+    let error = if changed {
+        save(config)
+            .err()
+            .map(|error| format!("failed to persist auto-discovered providers: {error}"))
+    } else {
+        None
+    };
+
+    ProviderDiscoveryStartupResult {
+        changed,
+        suggestions: filtered_provider_suggestions(config, discovery),
+        error,
+    }
+}
+
+pub fn filtered_provider_suggestions(
+    config: &AppConfig,
+    discovery: &ProviderDiscoveryResult,
+) -> Vec<AgentProviderSuggestion> {
+    let configured_provider_ids = config
+        .agent_providers
+        .iter()
+        .map(|provider| provider.id.as_str())
+        .collect::<HashSet<_>>();
+    let ignored_provider_ids = config
+        .agent_provider_discovery
+        .ignored_provider_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+
+    discovery
+        .suggestions
+        .iter()
+        .filter(|suggestion| {
+            !configured_provider_ids.contains(suggestion.id.as_str())
+                && !ignored_provider_ids.contains(suggestion.id.as_str())
+        })
+        .cloned()
+        .collect()
+}
+
+pub fn ignore_discovered_provider_id(config: &mut AppConfig, provider_id: &str) -> bool {
+    if !is_known_discoverable_provider_id(provider_id) {
+        return false;
+    }
+
+    if config
+        .agent_provider_discovery
+        .ignored_provider_ids
+        .iter()
+        .any(|ignored_provider_id| ignored_provider_id == provider_id)
+    {
+        return false;
+    }
+
+    config
+        .agent_provider_discovery
+        .ignored_provider_ids
+        .push(provider_id.to_string());
+    true
+}
+
+pub fn remove_provider_and_record_discovery_ignore(
+    config: &mut AppConfig,
+    settings: &mut ProviderSettingsState,
+    provider_id: &str,
+) -> bool {
+    let provider_was_present = settings
+        .providers
+        .iter()
+        .any(|provider| provider.id == provider_id);
+    let suggestion_count = settings.discovery_suggestions.len();
+
+    settings.remove_provider(provider_id);
+    settings
+        .discovery_suggestions
+        .retain(|suggestion| suggestion.id != provider_id);
+
+    let ignored_changed = if provider_was_present {
+        ignore_discovered_provider_id(config, provider_id)
+    } else {
+        false
+    };
+
+    provider_was_present
+        || ignored_changed
+        || settings.discovery_suggestions.len() != suggestion_count
+}
+
+pub fn is_known_discoverable_provider_id(provider_id: &str) -> bool {
+    KNOWN_PROVIDERS
+        .iter()
+        .any(|provider| provider.id == provider_id)
+}
+
+fn should_use_windows_command_extensions() -> bool {
+    cfg!(windows)
+}
+
+fn command_file_candidates(command: &str, include_windows_extensions: bool) -> Vec<OsString> {
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+
+    push_command_candidate(&mut candidates, &mut seen, OsString::from(command));
+
+    if include_windows_extensions && Path::new(command).extension().is_none() {
+        for extension in windows_command_extensions(env::var_os("PATHEXT").as_deref()) {
+            let mut candidate = OsString::from(command);
+            candidate.push(extension);
+            push_command_candidate(&mut candidates, &mut seen, candidate);
+        }
+    }
+
+    candidates
+}
+
+fn push_command_candidate(
+    candidates: &mut Vec<OsString>,
+    seen: &mut HashSet<OsString>,
+    candidate: OsString,
+) {
+    if seen.insert(candidate.clone()) {
+        candidates.push(candidate);
+    }
+}
+
+fn windows_command_extensions(path_ext: Option<&OsStr>) -> Vec<OsString> {
+    let mut extensions = Vec::new();
+    let mut seen = HashSet::new();
+
+    if let Some(path_ext) = path_ext {
+        for extension in path_ext.to_string_lossy().split(';') {
+            if !extension.is_empty() {
+                push_command_candidate(&mut extensions, &mut seen, OsString::from(extension));
+            }
+        }
+    }
+
+    for extension in [".exe", ".cmd", ".bat"] {
+        push_command_candidate(&mut extensions, &mut seen, OsString::from(extension));
+    }
+
+    extensions
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.metadata()
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_file_candidates_include_windows_suffixes_when_requested() {
+        let candidates = command_file_candidates("opencode", true);
+
+        assert!(candidates.contains(&OsString::from("opencode")));
+        assert!(candidates.contains(&OsString::from("opencode.exe")));
+        assert!(candidates.contains(&OsString::from("opencode.cmd")));
+        assert!(candidates.contains(&OsString::from("opencode.bat")));
+    }
+
+    #[test]
+    fn command_file_candidates_do_not_append_suffixes_to_explicit_extension() {
+        let candidates = command_file_candidates("opencode.exe", true);
+
+        assert_eq!(candidates, vec![OsString::from("opencode.exe")]);
+    }
+
+    #[test]
+    fn windows_command_extensions_use_pathext_before_defaults() {
+        let extensions = windows_command_extensions(Some(OsStr::new(".COM;.EXE;.CMD")));
+
+        assert_eq!(extensions[0], OsString::from(".COM"));
+        assert_eq!(extensions[1], OsString::from(".EXE"));
+        assert_eq!(extensions[2], OsString::from(".CMD"));
+        assert!(extensions.contains(&OsString::from(".exe")));
+        assert!(extensions.contains(&OsString::from(".cmd")));
+        assert!(extensions.contains(&OsString::from(".bat")));
+    }
+}

--- a/src/agent/fake.rs
+++ b/src/agent/fake.rs
@@ -1,0 +1,176 @@
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+
+use super::{AcpConnection, AgentEventSink, AgentRuntimeEvent};
+
+#[derive(Clone, Debug, Default)]
+pub struct FakeAcpConnection {
+    new_session_id: Option<String>,
+    new_session_events: Vec<AgentRuntimeEvent>,
+    prompt_events: Vec<AgentRuntimeEvent>,
+    prompt_error: Option<String>,
+    resume_error: Option<String>,
+    resume_events: Vec<AgentRuntimeEvent>,
+    cancelled_sessions: Vec<String>,
+    set_modes: Vec<(String, String)>,
+    set_mode_error: Option<String>,
+    set_config_options: Vec<(String, String, String)>,
+    set_config_option_error: Option<String>,
+    auth_error: Option<String>,
+    authenticated_methods: Vec<String>,
+}
+
+impl FakeAcpConnection {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_new_session(
+        mut self,
+        session_id: impl Into<String>,
+        events: Vec<AgentRuntimeEvent>,
+    ) -> Self {
+        self.new_session_id = Some(session_id.into());
+        self.new_session_events = events;
+        self
+    }
+
+    pub fn with_prompt_update(mut self, events: Vec<AgentRuntimeEvent>) -> Self {
+        self.prompt_events = events;
+        self
+    }
+
+    pub fn with_prompt_error(mut self, message: impl Into<String>) -> Self {
+        self.prompt_error = Some(message.into());
+        self
+    }
+
+    pub fn with_resume_update(mut self, events: Vec<AgentRuntimeEvent>) -> Self {
+        self.resume_events = events;
+        self
+    }
+
+    pub fn with_resume_error(mut self, message: impl Into<String>) -> Self {
+        self.resume_error = Some(message.into());
+        self
+    }
+
+    pub fn with_set_mode_error(mut self, message: impl Into<String>) -> Self {
+        self.set_mode_error = Some(message.into());
+        self
+    }
+
+    pub fn with_set_config_option_error(mut self, message: impl Into<String>) -> Self {
+        self.set_config_option_error = Some(message.into());
+        self
+    }
+
+    pub fn with_auth_error(mut self, message: impl Into<String>) -> Self {
+        self.auth_error = Some(message.into());
+        self
+    }
+
+    pub fn cancelled_sessions(&self) -> &[String] {
+        &self.cancelled_sessions
+    }
+
+    pub fn authenticated_methods(&self) -> &[String] {
+        &self.authenticated_methods
+    }
+
+    pub fn set_modes(&self) -> &[(String, String)] {
+        &self.set_modes
+    }
+
+    pub fn set_config_options(&self) -> &[(String, String, String)] {
+        &self.set_config_options
+    }
+}
+
+impl AcpConnection for FakeAcpConnection {
+    fn initialize(&mut self, sink: &mut dyn AgentEventSink) -> Result<()> {
+        sink.emit(AgentRuntimeEvent::Initialized);
+        Ok(())
+    }
+
+    fn new_session(
+        &mut self,
+        _worktree_path: PathBuf,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<Option<String>> {
+        for event in self.new_session_events.clone() {
+            sink.emit(event);
+        }
+        Ok(self.new_session_id.clone())
+    }
+
+    fn resume_session(&mut self, _session_id: String, sink: &mut dyn AgentEventSink) -> Result<()> {
+        if let Some(error) = &self.resume_error {
+            bail!(error.clone());
+        }
+
+        for event in self.resume_events.clone() {
+            sink.emit(event);
+        }
+        Ok(())
+    }
+
+    fn prompt(
+        &mut self,
+        _session_id: String,
+        _prompt: String,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<()> {
+        if let Some(error) = &self.prompt_error {
+            bail!(error.clone());
+        }
+
+        for event in self.prompt_events.clone() {
+            sink.emit(event);
+        }
+        Ok(())
+    }
+
+    fn cancel(&mut self, session_id: String) -> Result<()> {
+        self.cancelled_sessions.push(session_id);
+        Ok(())
+    }
+
+    fn set_mode(
+        &mut self,
+        session_id: String,
+        mode_id: String,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<()> {
+        if let Some(error) = &self.set_mode_error {
+            bail!(error.clone());
+        }
+        self.set_modes.push((session_id, mode_id.clone()));
+        sink.emit(AgentRuntimeEvent::CurrentMode(mode_id));
+        Ok(())
+    }
+
+    fn set_config_option(
+        &mut self,
+        session_id: String,
+        config_id: String,
+        value_id: String,
+        _sink: &mut dyn AgentEventSink,
+    ) -> Result<()> {
+        if let Some(error) = &self.set_config_option_error {
+            bail!(error.clone());
+        }
+        self.set_config_options
+            .push((session_id, config_id, value_id));
+        Ok(())
+    }
+
+    fn authenticate(&mut self, method_id: String, _sink: &mut dyn AgentEventSink) -> Result<()> {
+        if let Some(error) = &self.auth_error {
+            bail!(error.clone());
+        }
+        self.authenticated_methods.push(method_id);
+        Ok(())
+    }
+}

--- a/src/agent/filesystem.rs
+++ b/src/agent/filesystem.rs
@@ -1,0 +1,51 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, bail};
+
+use crate::agent::{AgentTrustMode, PermissionDecision, PermissionPolicy, PermissionRequestKind};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FilesystemCallbackService {
+    pub policy: PermissionPolicy,
+}
+
+impl FilesystemCallbackService {
+    pub fn new(trust_mode: AgentTrustMode, worktree_path: PathBuf) -> Self {
+        Self {
+            policy: PermissionPolicy::new(trust_mode, worktree_path),
+        }
+    }
+
+    pub fn read_text_file(&self, path: &Path) -> anyhow::Result<String> {
+        match self
+            .policy
+            .decide(&PermissionRequestKind::ReadFile(path.to_path_buf()))
+        {
+            PermissionDecision::Allow => std::fs::read_to_string(path)
+                .with_context(|| format!("read text file {}", path.display())),
+            PermissionDecision::Ask => bail!("permission required to read file {}", path.display()),
+            PermissionDecision::Deny => bail!("permission denied to read file {}", path.display()),
+        }
+    }
+
+    pub fn write_text_file(&self, path: &Path, content: &str) -> anyhow::Result<()> {
+        match self
+            .policy
+            .decide(&PermissionRequestKind::WriteFile(path.to_path_buf()))
+        {
+            PermissionDecision::Allow => {
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).with_context(|| {
+                        format!("create parent directories for {}", path.display())
+                    })?;
+                }
+                std::fs::write(path, content)
+                    .with_context(|| format!("write text file {}", path.display()))
+            }
+            PermissionDecision::Ask => {
+                bail!("permission required to write file {}", path.display())
+            }
+            PermissionDecision::Deny => bail!("permission denied to write file {}", path.display()),
+        }
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,0 +1,46 @@
+pub mod credentials;
+mod discovery;
+pub mod fake;
+pub mod filesystem;
+pub mod permission;
+pub mod persistence;
+pub mod provider;
+pub mod runtime;
+pub mod terminal;
+pub mod types;
+
+pub use credentials::{
+    CredentialStore, CredentialStoreKey, MemoryCredentialStore, OsCredentialStore,
+    resolve_secure_env_values,
+};
+pub use discovery::{
+    AgentProviderSuggestion, ProviderDiscoveryResult, ProviderDiscoveryStartupResult,
+    apply_provider_discovery_to_config, discover_agent_providers,
+    discover_agent_providers_from_path, filtered_provider_suggestions,
+    ignore_discovered_provider_id, is_known_discoverable_provider_id,
+    merge_discovered_agent_providers, remove_provider_and_record_discovery_ignore,
+};
+pub use fake::FakeAcpConnection;
+pub use filesystem::FilesystemCallbackService;
+pub use permission::{PermissionDecision, PermissionPolicy, PermissionRequestKind};
+pub use persistence::{
+    AgentThreadRecord, AgentThreadStore, filter_agent_thread_records, merge_agent_thread_records,
+};
+pub use provider::{
+    AgentAuthField, AgentAuthMethod, AgentAuthStatus, AgentProviderConfig, AgentProviderEnvVar,
+    ProviderCwdPolicy, ProviderSettingsState,
+};
+pub use runtime::{
+    AcpCancelHandle, AcpConnection, AcpProcessConnection, AgentEventSink, AgentRuntime,
+    AgentRuntimeEvent, AgentUpdate, agent_update_from_acp_session_update, apply_agent_update,
+    apply_runtime_event, resolve_provider_cwd,
+};
+pub use terminal::{
+    AgentTerminalHandle, AgentTerminalResult, AgentTerminalService, AgentTerminalStatus,
+};
+pub use types::{
+    AgentConfigOption, AgentConfigValueOption, AgentDebugEvent, AgentModeOption,
+    AgentPermissionRequest, AgentPlanState, AgentResumeState, AgentSlashCommand, AgentThreadState,
+    AgentThreadStatus, AgentToolCallState, AgentTranscriptEntry, AgentTranscriptRole,
+    AgentTrustMode, redact_debug_message, redact_debug_value,
+};

--- a/src/agent/permission.rs
+++ b/src/agent/permission.rs
@@ -1,0 +1,117 @@
+use std::path::{Component, Path, PathBuf};
+
+use crate::agent::AgentTrustMode;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PermissionDecision {
+    Allow,
+    Ask,
+    Deny,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PermissionRequestKind {
+    ReadFile(PathBuf),
+    WriteFile(PathBuf),
+    RunTerminal { command: String },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PermissionPolicy {
+    pub trust_mode: AgentTrustMode,
+    pub worktree_path: PathBuf,
+}
+
+impl PermissionPolicy {
+    pub fn new(trust_mode: AgentTrustMode, worktree_path: PathBuf) -> Self {
+        Self {
+            trust_mode,
+            worktree_path,
+        }
+    }
+
+    pub fn decide(&self, request: &PermissionRequestKind) -> PermissionDecision {
+        match self.trust_mode {
+            AgentTrustMode::AllowEverything => PermissionDecision::Allow,
+            AgentTrustMode::Ask => PermissionDecision::Ask,
+            AgentTrustMode::Deny => PermissionDecision::Deny,
+            AgentTrustMode::WorktreeOnly => match request {
+                PermissionRequestKind::ReadFile(path) | PermissionRequestKind::WriteFile(path) => {
+                    if path_is_inside_worktree(path, &self.worktree_path) {
+                        PermissionDecision::Allow
+                    } else {
+                        PermissionDecision::Deny
+                    }
+                }
+                PermissionRequestKind::RunTerminal { .. } => PermissionDecision::Ask,
+            },
+        }
+    }
+}
+
+fn path_is_inside_worktree(path: &Path, worktree_path: &Path) -> bool {
+    let Ok(worktree_path) = canonicalize_existing_prefix(worktree_path) else {
+        return false;
+    };
+    let Ok(path) = canonicalize_existing_prefix(path) else {
+        return false;
+    };
+
+    path.starts_with(worktree_path)
+}
+
+fn canonicalize_existing_prefix(path: &Path) -> std::io::Result<PathBuf> {
+    let mut missing_components = Vec::new();
+    let mut current = path.to_path_buf();
+
+    while !current.exists() {
+        let Some(component) = current.components().next_back() else {
+            return current.canonicalize();
+        };
+        missing_components.push(component.as_os_str().to_os_string());
+        if !current.pop() {
+            return current.canonicalize();
+        }
+    }
+
+    let mut canonical = current.canonicalize()?;
+    for component in missing_components.iter().rev() {
+        match Path::new(component).components().next() {
+            Some(Component::CurDir) => {}
+            Some(Component::ParentDir) if !canonical.pop() => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "path escapes filesystem root",
+                ));
+            }
+            Some(Component::ParentDir) => {}
+            Some(Component::Normal(component)) => canonical.push(component),
+            Some(Component::RootDir | Component::Prefix(_)) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "absolute component in missing path suffix",
+                ));
+            }
+            None => {}
+        }
+    }
+
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalizes_nearest_existing_ancestor_for_missing_leaf() {
+        let temp = tempfile::tempdir().expect("create tempdir");
+        let dir = temp.path().join("dir");
+        std::fs::create_dir(&dir).expect("create dir");
+
+        let canonical = canonicalize_existing_prefix(&dir.join("missing.txt"))
+            .expect("canonicalize missing leaf");
+
+        assert_eq!(canonical, dir.canonicalize().unwrap().join("missing.txt"));
+    }
+}

--- a/src/agent/persistence.rs
+++ b/src/agent/persistence.rs
@@ -1,0 +1,113 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::AgentThreadState;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentThreadRecord {
+    pub thread_id: String,
+    pub state: AgentThreadState,
+}
+
+impl AgentThreadRecord {
+    pub fn from_state(thread_id: String, state: &AgentThreadState) -> Self {
+        let mut state = state.clone();
+        state.thread_id = thread_id.clone();
+        Self { thread_id, state }
+    }
+}
+
+pub fn merge_agent_thread_records(
+    cached_records: impl IntoIterator<Item = AgentThreadRecord>,
+    workspace_records: impl IntoIterator<Item = AgentThreadRecord>,
+    excluded_thread_ids: impl IntoIterator<Item = String>,
+) -> Vec<AgentThreadRecord> {
+    let excluded_thread_ids = excluded_thread_ids.into_iter().collect::<BTreeSet<_>>();
+    let mut records = cached_records
+        .into_iter()
+        .filter(|record| !excluded_thread_ids.contains(&record.thread_id))
+        .map(|record| (record.thread_id.clone(), record))
+        .collect::<BTreeMap<_, _>>();
+
+    for record in workspace_records {
+        if !excluded_thread_ids.contains(&record.thread_id) {
+            records.insert(record.thread_id.clone(), record);
+        }
+    }
+
+    records.into_values().collect()
+}
+
+pub fn filter_agent_thread_records(
+    records: impl IntoIterator<Item = AgentThreadRecord>,
+    excluded_thread_ids: impl IntoIterator<Item = String>,
+    removed_worktree_paths: impl IntoIterator<Item = PathBuf>,
+    removed_repo_paths: impl IntoIterator<Item = PathBuf>,
+) -> Vec<AgentThreadRecord> {
+    let excluded_thread_ids = excluded_thread_ids.into_iter().collect::<BTreeSet<_>>();
+    let removed_worktree_paths = removed_worktree_paths.into_iter().collect::<BTreeSet<_>>();
+    let removed_repo_paths = removed_repo_paths.into_iter().collect::<Vec<_>>();
+
+    records
+        .into_iter()
+        .filter(|record| {
+            !excluded_thread_ids.contains(&record.thread_id)
+                && !removed_worktree_paths.contains(&record.state.worktree_path)
+                && !removed_repo_paths
+                    .iter()
+                    .any(|repo_path| record.state.worktree_path.starts_with(repo_path))
+        })
+        .collect()
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentThreadStore {
+    path: PathBuf,
+}
+
+impl AgentThreadStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn load_records(&self) -> Result<Vec<AgentThreadRecord>> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let contents = std::fs::read_to_string(&self.path).with_context(|| {
+            format!("failed to read agent thread store {}", self.path.display())
+        })?;
+        serde_json::from_str(&contents)
+            .with_context(|| format!("failed to parse agent thread store {}", self.path.display()))
+    }
+
+    pub fn save_records(&self, records: &[AgentThreadRecord]) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create agent thread store directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+
+        let contents = serde_json::to_string_pretty(records).with_context(|| {
+            format!(
+                "failed to serialize agent thread store {}",
+                self.path.display()
+            )
+        })?;
+        std::fs::write(&self.path, contents)
+            .with_context(|| format!("failed to write agent thread store {}", self.path.display()))
+    }
+}

--- a/src/agent/provider.rs
+++ b/src/agent/provider.rs
@@ -1,0 +1,660 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::agent::{AgentProviderSuggestion, AgentTrustMode, CredentialStore, CredentialStoreKey};
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentAuthStatus {
+    #[default]
+    Unknown,
+    Authenticated,
+    Required {
+        instructions: String,
+    },
+    Failed {
+        message: String,
+        instructions: String,
+    },
+}
+
+impl AgentAuthStatus {
+    pub fn instructions(&self) -> Option<&str> {
+        match self {
+            Self::Required { instructions } | Self::Failed { instructions, .. } => {
+                Some(instructions.as_str())
+            }
+            Self::Unknown | Self::Authenticated => None,
+        }
+    }
+
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Unknown => "Authentication unknown",
+            Self::Authenticated => "Authenticated",
+            Self::Required { .. } => "Authentication required",
+            Self::Failed { .. } => "Authentication failed",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ProviderSettingsState {
+    pub providers: Vec<AgentProviderConfig>,
+    pub selected_provider_id: Option<String>,
+    pub error: Option<String>,
+    pub discovery_suggestions: Vec<AgentProviderSuggestion>,
+    pub auth_statuses: HashMap<String, AgentAuthStatus>,
+    pub auth_env_values: HashMap<(String, String), String>,
+}
+
+impl ProviderSettingsState {
+    pub fn add_provider(&mut self, provider: AgentProviderConfig) {
+        let provider_id = provider.id.clone();
+        if let Some(existing) = self
+            .providers
+            .iter_mut()
+            .find(|existing| existing.id == provider_id)
+        {
+            *existing = provider;
+        } else {
+            self.providers.push(provider);
+        }
+        self.selected_provider_id = Some(provider_id);
+        self.error = None;
+    }
+
+    pub fn remove_provider(&mut self, provider_id: &str) {
+        let Some(provider_index) = self
+            .providers
+            .iter()
+            .position(|provider| provider.id == provider_id)
+        else {
+            return;
+        };
+
+        let was_selected = self.selected_provider_id.as_deref() == Some(provider_id);
+        self.providers.remove(provider_index);
+        self.auth_statuses.remove(provider_id);
+        if was_selected {
+            self.selected_provider_id = self.providers.first().map(|provider| provider.id.clone());
+        }
+        self.error = None;
+    }
+
+    pub fn update_display_name(&mut self, provider_id: &str, display_name: impl Into<String>) {
+        if let Some(provider) = self.provider_mut(provider_id) {
+            provider.display_name = display_name.into();
+            self.error = None;
+        }
+    }
+
+    pub fn update_command(&mut self, provider_id: &str, command: impl Into<String>) {
+        if let Some(provider) = self.provider_mut(provider_id) {
+            provider.command = command.into();
+            self.error = None;
+        }
+    }
+
+    pub fn update_args(&mut self, provider_id: &str, args: Vec<String>) {
+        if let Some(provider) = self.provider_mut(provider_id) {
+            provider.args = args;
+            self.error = None;
+        }
+    }
+
+    pub fn edit_args_json(
+        &mut self,
+        provider_id: &str,
+        edit: impl FnOnce(&mut String),
+    ) -> Result<(), serde_json::Error> {
+        let Some(provider) = self
+            .providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+        else {
+            return Ok(());
+        };
+
+        let mut value = serde_json::to_string(&provider.args).unwrap_or_else(|_| "[]".to_string());
+        edit(&mut value);
+        match serde_json::from_str::<Vec<String>>(&value) {
+            Ok(args) => {
+                self.update_args(provider_id, args);
+                Ok(())
+            }
+            Err(error) => {
+                self.error = Some(format!("Args must be a JSON array of strings: {error}"));
+                Err(error)
+            }
+        }
+    }
+
+    pub fn args_json(&self, provider_id: &str) -> Option<String> {
+        self.providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+            .map(|provider| {
+                serde_json::to_string(&provider.args).unwrap_or_else(|_| "[]".to_string())
+            })
+    }
+
+    pub fn update_plain_env(&mut self, provider_id: &str, env: Vec<(String, String)>) {
+        if let Some(provider) = self.provider_mut(provider_id) {
+            let mut updated_env = env
+                .into_iter()
+                .filter(|(name, _)| !name.trim().is_empty())
+                .map(|(name, value)| AgentProviderEnvVar {
+                    name,
+                    value: Some(value),
+                    secure_ref: None,
+                })
+                .collect::<Vec<_>>();
+            updated_env.extend(
+                provider
+                    .env
+                    .iter()
+                    .filter(|entry| entry.secure_ref.is_some())
+                    .cloned(),
+            );
+            provider.env = updated_env;
+            self.error = None;
+        }
+    }
+
+    pub fn update_enabled(&mut self, provider_id: &str, enabled: bool) {
+        if let Some(provider) = self.provider_mut(provider_id) {
+            provider.enabled = enabled;
+            self.error = None;
+        }
+    }
+
+    pub fn update_trust_mode(&mut self, provider_id: &str, trust_mode: AgentTrustMode) {
+        if let Some(provider) = self.provider_mut(provider_id) {
+            provider.trust_mode = trust_mode;
+            self.error = None;
+        }
+    }
+
+    pub fn update_auth_status(&mut self, provider_id: &str, status: AgentAuthStatus) {
+        self.auth_statuses.insert(provider_id.to_string(), status);
+        self.error = None;
+    }
+
+    pub fn update_auth_env_value(
+        &mut self,
+        provider_id: &str,
+        env_name: &str,
+        value: impl Into<String>,
+    ) {
+        self.auth_env_values.insert(
+            (provider_id.to_string(), env_name.to_string()),
+            value.into(),
+        );
+        self.error = None;
+    }
+
+    pub fn auth_env_value(&self, provider_id: &str, env_name: &str) -> String {
+        self.auth_env_values
+            .get(&(provider_id.to_string(), env_name.to_string()))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn auth_env_display_value(&self, provider_id: &str, field: &AgentAuthField) -> String {
+        let value = self.auth_env_value(provider_id, &field.env_name);
+        if field.secret && !value.is_empty() {
+            "••••••••".to_string()
+        } else {
+            value
+        }
+    }
+
+    pub fn save_pending_env_auth_values(
+        &mut self,
+        provider_id: &str,
+        store: &dyn CredentialStore,
+    ) -> anyhow::Result<()> {
+        let values = self
+            .auth_env_values
+            .iter()
+            .filter(|((saved_provider_id, _), _)| saved_provider_id == provider_id)
+            .map(|((_, field), value)| (field.clone(), value.clone()))
+            .collect::<Vec<_>>();
+        self.save_env_auth_values(provider_id, &values, store)
+    }
+
+    pub fn save_env_auth_values(
+        &mut self,
+        provider_id: &str,
+        values: &[(String, String)],
+        store: &dyn CredentialStore,
+    ) -> anyhow::Result<()> {
+        let fields = self.env_auth_fields(provider_id);
+        for field in fields.iter().filter(|field| !field.optional) {
+            let value = values
+                .iter()
+                .find(|(name, _)| name == &field.env_name)
+                .map(|(_, value)| value.as_str())
+                .unwrap_or_default();
+            if value.is_empty() {
+                let message = format!("Missing required auth env value for {}", field.env_name);
+                self.update_auth_status(
+                    provider_id,
+                    AgentAuthStatus::Failed {
+                        message: message.clone(),
+                        instructions: field.label.clone(),
+                    },
+                );
+                anyhow::bail!(message);
+            }
+        }
+
+        for (field, value) in values {
+            let key = CredentialStoreKey::new(provider_id, field);
+            if value.is_empty() {
+                store.delete_secret(&key)?;
+            } else {
+                store.write_secret(&key, value)?;
+            }
+        }
+        if let Some(provider) = self.provider_mut(provider_id) {
+            let value_names = values
+                .iter()
+                .filter(|(_, value)| !value.is_empty())
+                .map(|(name, _)| name.as_str())
+                .collect::<std::collections::HashSet<_>>();
+            let mut refs = provider
+                .auth_methods
+                .iter()
+                .flat_map(|method| method.secure_env_refs(provider_id))
+                .filter(|entry| value_names.contains(entry.name.as_str()))
+                .collect::<Vec<_>>();
+            provider.env.retain(|entry| entry.secure_ref.is_none());
+            provider.env.append(&mut refs);
+        }
+        self.update_auth_status(provider_id, AgentAuthStatus::Authenticated);
+        Ok(())
+    }
+
+    pub fn clear_env_auth_values(
+        &mut self,
+        provider_id: &str,
+        store: &dyn CredentialStore,
+    ) -> anyhow::Result<()> {
+        let fields = self.env_auth_fields(provider_id);
+        let auth_env_names = fields
+            .iter()
+            .map(|field| field.env_name.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        for field in &fields {
+            store.delete_secret(&CredentialStoreKey::new(provider_id, &field.env_name))?;
+            self.auth_env_values
+                .remove(&(provider_id.to_string(), field.env_name.clone()));
+        }
+        if let Some(provider) = self.provider_mut(provider_id) {
+            provider.env.retain(|entry| {
+                entry.secure_ref.is_none() || !auth_env_names.contains(entry.name.as_str())
+            });
+        }
+        self.update_auth_status(
+            provider_id,
+            AgentAuthStatus::Required {
+                instructions: "Credentials cleared. Enter credentials and authenticate again."
+                    .to_string(),
+            },
+        );
+        Ok(())
+    }
+
+    pub fn authenticate_with_available_method(
+        &mut self,
+        provider_id: &str,
+        store: &dyn CredentialStore,
+    ) -> anyhow::Result<()> {
+        let Some(provider) = self
+            .providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+        else {
+            return Ok(());
+        };
+        if provider
+            .auth_methods
+            .iter()
+            .any(|method| matches!(method, AgentAuthMethod::EnvVar { .. }))
+        {
+            self.save_pending_env_auth_values(provider_id, store)?;
+            return Ok(());
+        }
+        if let Some(instructions) = provider
+            .auth_methods
+            .iter()
+            .find_map(|method| method.instructions())
+        {
+            self.update_auth_status(
+                provider_id,
+                AgentAuthStatus::Required {
+                    instructions: instructions.to_string(),
+                },
+            );
+        } else {
+            self.update_auth_status(provider_id, AgentAuthStatus::Authenticated);
+        }
+        Ok(())
+    }
+
+    pub fn show_auth_instructions(&mut self, provider_id: &str) {
+        let instructions = self
+            .providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+            .and_then(|provider| {
+                provider
+                    .auth_methods
+                    .iter()
+                    .find_map(|method| method.instructions())
+            })
+            .unwrap_or("No authentication instructions are advertised by this provider.")
+            .to_string();
+        self.update_auth_status(provider_id, AgentAuthStatus::Required { instructions });
+    }
+
+    pub fn apply_auth_io_result(&mut self, provider_id: &str, result: &ProviderSettingsState) {
+        if let Some(status) = result.auth_statuses.get(provider_id).cloned() {
+            self.auth_statuses.insert(provider_id.to_string(), status);
+        }
+        self.error = result.error.clone();
+
+        let auth_env_names = self
+            .env_auth_fields(provider_id)
+            .into_iter()
+            .map(|field| field.env_name)
+            .collect::<std::collections::HashSet<_>>();
+        if auth_env_names.is_empty() {
+            return;
+        }
+
+        let Some(current_provider) = self.provider_mut(provider_id) else {
+            return;
+        };
+        current_provider.env.retain(|entry| {
+            entry.secure_ref.is_none() || !auth_env_names.contains(entry.name.as_str())
+        });
+        if let Some(result_provider) = result
+            .providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+        {
+            current_provider.env.extend(
+                result_provider
+                    .env
+                    .iter()
+                    .filter(|entry| {
+                        entry.secure_ref.is_some() && auth_env_names.contains(entry.name.as_str())
+                    })
+                    .cloned(),
+            );
+        }
+    }
+
+    pub fn apply_clear_auth_io_result(
+        &mut self,
+        provider_id: &str,
+        result: &ProviderSettingsState,
+    ) {
+        if let Some(status) = result.auth_statuses.get(provider_id).cloned() {
+            self.auth_statuses.insert(provider_id.to_string(), status);
+        }
+        self.error = result.error.clone();
+
+        let auth_env_names = self
+            .env_auth_fields(provider_id)
+            .into_iter()
+            .map(|field| field.env_name)
+            .collect::<std::collections::HashSet<_>>();
+        if let Some(current_provider) = self.provider_mut(provider_id) {
+            current_provider.env.retain(|entry| {
+                entry.secure_ref.is_none() || !auth_env_names.contains(entry.name.as_str())
+            });
+        }
+        for field in auth_env_names {
+            self.auth_env_values
+                .remove(&(provider_id.to_string(), field));
+        }
+    }
+
+    pub fn mark_terminal_auth_unavailable(&mut self, provider_id: &str) {
+        if let Some((command, args, env)) = self.terminal_auth_command(provider_id) {
+            let env_names = env.into_iter().map(|entry| entry.name).collect::<Vec<_>>();
+            self.update_auth_status(
+                provider_id,
+                AgentAuthStatus::Failed {
+                    message: "Terminal auth runtime is not connected from provider settings."
+                        .to_string(),
+                    instructions: format!(
+                        "Run terminal auth manually: {} {}{}",
+                        command,
+                        args.join(" "),
+                        if env_names.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" (with env: {})", env_names.join(", "))
+                        }
+                    ),
+                },
+            );
+        } else {
+            self.update_auth_status(
+                provider_id,
+                AgentAuthStatus::Failed {
+                    message: "Provider does not advertise terminal authentication.".to_string(),
+                    instructions: "Use another advertised authentication method.".to_string(),
+                },
+            );
+        }
+    }
+
+    pub fn env_auth_fields(&self, provider_id: &str) -> Vec<AgentAuthField> {
+        self.providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+            .map(|provider| {
+                provider
+                    .auth_methods
+                    .iter()
+                    .flat_map(|method| match method {
+                        AgentAuthMethod::EnvVar { fields, .. } => fields.clone(),
+                        AgentAuthMethod::Agent { .. } | AgentAuthMethod::Terminal { .. } => {
+                            Vec::new()
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn terminal_auth_command(
+        &self,
+        provider_id: &str,
+    ) -> Option<(String, Vec<String>, Vec<AgentProviderEnvVar>)> {
+        let provider = self
+            .providers
+            .iter()
+            .find(|provider| provider.id == provider_id)?;
+        let method = provider
+            .auth_methods
+            .iter()
+            .find(|method| matches!(method, AgentAuthMethod::Terminal { .. }))?;
+        let (auth_args, auth_env) = method.terminal_args_env()?;
+        let mut args = provider.args.clone();
+        args.extend(auth_args.iter().cloned());
+        Some((provider.command.clone(), args, auth_env.to_vec()))
+    }
+
+    pub fn auth_status_label(&self, provider_id: &str) -> String {
+        self.auth_statuses
+            .get(provider_id)
+            .unwrap_or(&AgentAuthStatus::Unknown)
+            .label()
+            .to_string()
+    }
+
+    fn provider_mut(&mut self, provider_id: &str) -> Option<&mut AgentProviderConfig> {
+        self.providers
+            .iter_mut()
+            .find(|provider| provider.id == provider_id)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentProviderConfig {
+    pub id: String,
+    pub display_name: String,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub env: Vec<AgentProviderEnvVar>,
+    #[serde(default)]
+    pub auth_methods: Vec<AgentAuthMethod>,
+    #[serde(default)]
+    pub cwd_policy: ProviderCwdPolicy,
+    #[serde(default)]
+    pub trust_mode: AgentTrustMode,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+impl AgentProviderConfig {
+    pub fn new(
+        id: impl Into<String>,
+        display_name: impl Into<String>,
+        command: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            display_name: display_name.into(),
+            command: command.into(),
+            args: Vec::new(),
+            env: Vec::new(),
+            auth_methods: Vec::new(),
+            cwd_policy: ProviderCwdPolicy::default(),
+            trust_mode: AgentTrustMode::default(),
+            enabled: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentProviderEnvVar {
+    pub name: String,
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default)]
+    pub secure_ref: Option<String>,
+}
+
+impl AgentProviderEnvVar {
+    pub fn secure_ref(name: impl Into<String>, secure_ref: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: None,
+            secure_ref: Some(secure_ref.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case", tag = "type")]
+pub enum AgentAuthMethod {
+    Agent {
+        instructions: String,
+    },
+    EnvVar {
+        fields: Vec<AgentAuthField>,
+        #[serde(default)]
+        link: Option<String>,
+    },
+    Terminal {
+        args: Vec<String>,
+        env: Vec<AgentProviderEnvVar>,
+    },
+}
+
+impl Default for AgentAuthMethod {
+    fn default() -> Self {
+        Self::Agent {
+            instructions: String::new(),
+        }
+    }
+}
+
+impl AgentAuthMethod {
+    pub fn secure_env_refs(&self, provider_id: &str) -> Vec<AgentProviderEnvVar> {
+        match self {
+            Self::EnvVar { fields, .. } => fields
+                .iter()
+                .map(|field| {
+                    AgentProviderEnvVar::secure_ref(
+                        field.env_name.clone(),
+                        format!("{provider_id}/{}", field.env_name),
+                    )
+                })
+                .collect(),
+            Self::Agent { .. } | Self::Terminal { .. } => Vec::new(),
+        }
+    }
+
+    pub fn terminal_args_env(&self) -> Option<(&[String], &[AgentProviderEnvVar])> {
+        match self {
+            Self::Terminal { args, env } => Some((args.as_slice(), env.as_slice())),
+            Self::Agent { .. } | Self::EnvVar { .. } => None,
+        }
+    }
+
+    pub fn instructions(&self) -> Option<&str> {
+        match self {
+            Self::Agent { instructions } if !instructions.is_empty() => Some(instructions),
+            Self::EnvVar {
+                link: Some(link), ..
+            } if !link.is_empty() => Some(link),
+            Self::Agent { .. } | Self::EnvVar { .. } | Self::Terminal { .. } => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentAuthField {
+    pub label: String,
+    pub env_name: String,
+    #[serde(default)]
+    pub secret: bool,
+    #[serde(default)]
+    pub optional: bool,
+}
+
+impl AgentAuthField {
+    pub fn secret(label: impl Into<String>, env_name: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            env_name: env_name.into(),
+            secret: true,
+            optional: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProviderCwdPolicy {
+    #[default]
+    SelectedWorktree,
+    RepositoryRoot,
+    Fixed(std::path::PathBuf),
+}
+
+fn default_enabled() -> bool {
+    true
+}

--- a/src/agent/runtime.rs
+++ b/src/agent/runtime.rs
@@ -1,0 +1,1498 @@
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol::{JsonRpcMessage, JsonRpcRequest, JsonRpcResponse};
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use serde_json::json;
+
+use super::{
+    AgentAuthStatus, AgentConfigOption, AgentConfigValueOption, AgentDebugEvent, AgentModeOption,
+    AgentPermissionRequest, AgentPlanState, AgentProviderConfig, AgentSlashCommand,
+    AgentTerminalHandle, AgentTerminalResult, AgentTerminalService, AgentTerminalStatus,
+    AgentThreadState, AgentThreadStatus, AgentToolCallState, AgentTranscriptEntry,
+    AgentTranscriptRole, CredentialStore, FilesystemCallbackService, PermissionDecision,
+    PermissionPolicy, PermissionRequestKind, ProviderCwdPolicy, resolve_secure_env_values,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AgentUpdate {
+    AgentMessageChunk(String),
+    ThoughtChunk(String),
+    ToolCall {
+        id: String,
+        title: String,
+        status: String,
+    },
+    ToolCallUpdate {
+        id: String,
+        title: Option<String>,
+        status: Option<String>,
+    },
+    Plan(Vec<String>),
+    AvailableCommands(Vec<AgentSlashCommand>),
+    AvailableModes {
+        modes: Vec<AgentModeOption>,
+        current: Option<String>,
+    },
+    CurrentMode(String),
+    ConfigOptions(Vec<AgentConfigOption>),
+    NeedsPermission {
+        id: String,
+        description: String,
+    },
+    Error(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AgentRuntimeEvent {
+    Initialized,
+    AuthRequired {
+        instructions: String,
+    },
+    Ready,
+    AgentMessageChunk(String),
+    ThoughtChunk(String),
+    ToolCall {
+        id: String,
+        title: String,
+        status: String,
+    },
+    Plan(Vec<String>),
+    AvailableCommands(Vec<AgentSlashCommand>),
+    AvailableModes {
+        modes: Vec<AgentModeOption>,
+        current: Option<String>,
+    },
+    ConfigOptions(Vec<AgentConfigOption>),
+    CurrentMode(String),
+    NeedsPermission {
+        id: String,
+        description: String,
+    },
+    Failed(String),
+}
+
+pub trait AgentEventSink {
+    fn emit(&mut self, event: AgentRuntimeEvent);
+}
+
+pub trait AcpConnection {
+    fn initialize(&mut self, sink: &mut dyn AgentEventSink) -> Result<()>;
+
+    fn new_session(
+        &mut self,
+        worktree_path: PathBuf,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<Option<String>>;
+
+    fn resume_session(&mut self, session_id: String, sink: &mut dyn AgentEventSink) -> Result<()>;
+
+    fn prompt(
+        &mut self,
+        session_id: String,
+        prompt: String,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<()>;
+
+    fn cancel(&mut self, session_id: String) -> Result<()>;
+
+    fn set_mode(
+        &mut self,
+        session_id: String,
+        mode_id: String,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<()>;
+
+    fn set_config_option(
+        &mut self,
+        session_id: String,
+        config_id: String,
+        value_id: String,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<()>;
+
+    fn authenticate(&mut self, method_id: String, sink: &mut dyn AgentEventSink) -> Result<()>;
+}
+
+#[derive(Debug)]
+pub struct AcpProcessConnection {
+    child: Child,
+    stdin: Arc<Mutex<ChildStdin>>,
+    stdout: BufReader<ChildStdout>,
+    next_request_id: u64,
+    cwd: PathBuf,
+    filesystem: Option<FilesystemCallbackService>,
+    terminal: Option<AgentTerminalService>,
+    permission_policy: Option<PermissionPolicy>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AcpCancelHandle {
+    stdin: Arc<Mutex<ChildStdin>>,
+}
+
+impl AcpCancelHandle {
+    pub fn cancel(&self, session_id: String) -> Result<()> {
+        let notification = agent_client_protocol::schema::CancelNotification::new(session_id);
+        let message = json!({
+            "jsonrpc": "2.0",
+            "method": notification.method(),
+            "params": notification,
+        });
+        write_acp_notification(&self.stdin, message, "ACP cancel notification")
+    }
+}
+
+fn write_acp_notification(
+    stdin: &Arc<Mutex<ChildStdin>>,
+    message: serde_json::Value,
+    context: &str,
+) -> Result<()> {
+    let mut stdin = stdin.lock().expect("ACP stdin mutex poisoned");
+    writeln!(stdin, "{message}").with_context(|| format!("failed to write {context}"))?;
+    stdin
+        .flush()
+        .with_context(|| format!("failed to flush {context}"))?;
+    Ok(())
+}
+
+pub fn resolve_provider_cwd(
+    provider: &AgentProviderConfig,
+    selected_worktree: &Path,
+    repository_root: &Path,
+) -> PathBuf {
+    match &provider.cwd_policy {
+        ProviderCwdPolicy::SelectedWorktree => selected_worktree.to_path_buf(),
+        ProviderCwdPolicy::RepositoryRoot => repository_root.to_path_buf(),
+        ProviderCwdPolicy::Fixed(path) => path.clone(),
+    }
+}
+
+impl Drop for AcpProcessConnection {
+    fn drop(&mut self) {
+        match self.child.try_wait() {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+            }
+            Err(_) => {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+            }
+        }
+    }
+}
+
+impl AcpProcessConnection {
+    pub fn spawn(provider: &AgentProviderConfig, cwd: PathBuf) -> Result<Self> {
+        Self::spawn_with_env(provider, cwd, &[])
+    }
+
+    pub fn spawn_with_credentials(
+        provider: &AgentProviderConfig,
+        cwd: PathBuf,
+        credential_store: &dyn CredentialStore,
+    ) -> Result<Self> {
+        let env = resolve_secure_env_values(&provider.id, &provider.env, credential_store)?;
+        Self::spawn_with_resolved_provider_env(provider, cwd, &[], &env)
+    }
+
+    pub fn spawn_with_env(
+        provider: &AgentProviderConfig,
+        cwd: PathBuf,
+        env: &[(String, String)],
+    ) -> Result<Self> {
+        Self::spawn_with_resolved_provider_env(provider, cwd, env, &[])
+    }
+
+    fn spawn_with_resolved_provider_env(
+        provider: &AgentProviderConfig,
+        cwd: PathBuf,
+        env: &[(String, String)],
+        resolved_provider_env: &[(String, String)],
+    ) -> Result<Self> {
+        let mut command = Command::new(&provider.command);
+        command
+            .args(&provider.args)
+            .current_dir(&cwd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        for (name, value) in env {
+            command.env(name, value);
+        }
+
+        for (name, value) in resolved_provider_env {
+            command.env(name, value);
+        }
+
+        for env_var in &provider.env {
+            if let Some(value) = &env_var.value {
+                command.env(&env_var.name, value);
+            } else if env_var.secure_ref.is_some()
+                && !resolved_provider_env
+                    .iter()
+                    .any(|(name, _)| name == &env_var.name)
+            {
+                anyhow::bail!(
+                    "provider '{}' env var '{}' requires credential resolution before launch",
+                    provider.id,
+                    env_var.name
+                );
+            }
+        }
+
+        let mut child = command.spawn().with_context(|| {
+            format!(
+                "failed to spawn ACP provider '{}' with command '{}' in '{}'",
+                provider.id,
+                provider.command,
+                cwd.display()
+            )
+        })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .context("spawned ACP provider without stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .context("spawned ACP provider without stdout")?;
+
+        Ok(Self {
+            child,
+            stdin: Arc::new(Mutex::new(stdin)),
+            stdout: BufReader::new(stdout),
+            next_request_id: 1,
+            cwd,
+            filesystem: None,
+            terminal: None,
+            permission_policy: None,
+        })
+    }
+
+    pub fn cancel_handle(&self) -> AcpCancelHandle {
+        AcpCancelHandle {
+            stdin: Arc::clone(&self.stdin),
+        }
+    }
+
+    pub fn with_callback_services(
+        mut self,
+        filesystem: FilesystemCallbackService,
+        terminal: AgentTerminalService,
+    ) -> Self {
+        self.permission_policy = Some(filesystem.policy.clone());
+        self.filesystem = Some(filesystem);
+        self.terminal = Some(terminal);
+        self
+    }
+
+    fn send_request<T>(&mut self, request: T, sink: &mut dyn AgentEventSink) -> Result<T::Response>
+    where
+        T: JsonRpcRequest + serde::Serialize,
+        T::Response: JsonRpcResponse + DeserializeOwned,
+    {
+        let id = self.next_request_id;
+        self.next_request_id += 1;
+        let message = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": request.method(),
+            "params": request,
+        });
+        {
+            let mut stdin = self.stdin.lock().expect("ACP stdin mutex poisoned");
+            writeln!(stdin, "{message}").context("failed to write ACP request")?;
+            stdin.flush().context("failed to flush ACP request")?;
+        }
+        self.read_response::<T>(id, sink)
+    }
+
+    fn send_notification<T>(&mut self, notification: T) -> Result<()>
+    where
+        T: JsonRpcMessage + serde::Serialize,
+    {
+        let message = json!({
+            "jsonrpc": "2.0",
+            "method": notification.method(),
+            "params": notification,
+        });
+        write_acp_notification(&self.stdin, message, "ACP notification")
+    }
+
+    fn read_response<T>(&mut self, id: u64, sink: &mut dyn AgentEventSink) -> Result<T::Response>
+    where
+        T: JsonRpcRequest,
+        T::Response: JsonRpcResponse + DeserializeOwned,
+    {
+        loop {
+            let mut line = String::new();
+            let bytes = self
+                .stdout
+                .read_line(&mut line)
+                .context("failed to read ACP message")?;
+            if bytes == 0 {
+                anyhow::bail!("ACP provider closed stdout while waiting for response");
+            }
+            let value: serde_json::Value = serde_json::from_str(line.trim())
+                .with_context(|| format!("failed to parse ACP JSON-RPC message: {line}"))?;
+            if value.get("id").and_then(|value| value.as_u64()) == Some(id) {
+                if let Some(error) = value.get("error") {
+                    anyhow::bail!("ACP request failed: {error}");
+                }
+                let result = value
+                    .get("result")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                return serde_json::from_value(result).context("failed to decode ACP response");
+            }
+            self.handle_incoming(value, sink)?;
+        }
+    }
+
+    fn handle_incoming(
+        &mut self,
+        value: serde_json::Value,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<()> {
+        let Some(method) = value.get("method").and_then(|method| method.as_str()) else {
+            return Ok(());
+        };
+        let params = value
+            .get("params")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        if method == "session/update" {
+            let notification: agent_client_protocol::schema::SessionNotification =
+                serde_json::from_value(params).context("failed to decode ACP session update")?;
+            if let Some(update) = agent_update_from_acp_session_update(notification.update) {
+                sink.emit(agent_runtime_event_from_update(update));
+            }
+        } else if let Some(request_id) = value.get("id").cloned() {
+            let response = match self.dispatch_client_request(method, params) {
+                Ok(result) => json!({ "jsonrpc": "2.0", "id": request_id, "result": result }),
+                Err(error) => {
+                    let code = if is_client_callback_method(method) {
+                        -32000
+                    } else {
+                        -32601
+                    };
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": { "code": code, "message": error.to_string() }
+                    })
+                }
+            };
+            write_acp_notification(&self.stdin, response, "ACP client response")?;
+        }
+        Ok(())
+    }
+
+    pub fn dispatch_client_request(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        use agent_client_protocol::schema as acp;
+
+        match method {
+            "session/request_permission" => {
+                let request: acp::RequestPermissionRequest = serde_json::from_value(params)
+                    .context("failed to decode session/request_permission")?;
+                let allow = matches!(
+                    self.permission_policy
+                        .as_ref()
+                        .map(|policy| &policy.trust_mode),
+                    Some(super::AgentTrustMode::AllowEverything)
+                );
+                if request.options.is_empty() {
+                    anyhow::bail!("permission request did not include options");
+                }
+                let preferred = request.options.iter().find(|option| {
+                    matches!(
+                        (allow, option.kind),
+                        (
+                            true,
+                            acp::PermissionOptionKind::AllowOnce
+                                | acp::PermissionOptionKind::AllowAlways
+                        ) | (
+                            false,
+                            acp::PermissionOptionKind::RejectOnce
+                                | acp::PermissionOptionKind::RejectAlways
+                        )
+                    )
+                });
+                let option_id = preferred
+                    .map(|option| option.option_id.clone())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("permission request did not include a compatible option")
+                    })?;
+                Ok(serde_json::to_value(acp::RequestPermissionResponse::new(
+                    acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(
+                        option_id,
+                    )),
+                ))?)
+            }
+            "fs/read_text_file" => {
+                let request: acp::ReadTextFileRequest =
+                    serde_json::from_value(params).context("failed to decode fs/read_text_file")?;
+                self.ensure_permission(PermissionRequestKind::ReadFile(request.path.clone()))?;
+                let content = self
+                    .filesystem
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("filesystem callback service is not configured")
+                    })?
+                    .read_text_file(&request.path)?;
+                Ok(serde_json::to_value(acp::ReadTextFileResponse::new(
+                    content,
+                ))?)
+            }
+            "fs/write_text_file" => {
+                let request: acp::WriteTextFileRequest = serde_json::from_value(params)
+                    .context("failed to decode fs/write_text_file")?;
+                self.ensure_permission(PermissionRequestKind::WriteFile(request.path.clone()))?;
+                self.filesystem
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("filesystem callback service is not configured")
+                    })?
+                    .write_text_file(&request.path, &request.content)?;
+                Ok(serde_json::to_value(acp::WriteTextFileResponse::new())?)
+            }
+            "terminal/create" => {
+                let request: acp::CreateTerminalRequest =
+                    serde_json::from_value(params).context("failed to decode terminal/create")?;
+                let command = terminal_command(&request.command, &request.args);
+                self.ensure_permission(PermissionRequestKind::RunTerminal {
+                    command: command.clone(),
+                })?;
+                let cwd = request.cwd.as_deref().unwrap_or(&self.cwd);
+                let handle = self
+                    .terminal
+                    .as_mut()
+                    .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+                    .create(&command, cwd)?;
+                Ok(serde_json::to_value(acp::CreateTerminalResponse::new(
+                    handle.0.to_string(),
+                ))?)
+            }
+            "terminal/output" => {
+                let request: acp::TerminalOutputRequest =
+                    serde_json::from_value(params).context("failed to decode terminal/output")?;
+                let output = self
+                    .terminal
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+                    .output(parse_terminal_id(&request.terminal_id.0)?)?;
+                Ok(serde_json::to_value(acp::TerminalOutputResponse::new(
+                    output, false,
+                ))?)
+            }
+            "terminal/wait_for_exit" => {
+                let request: acp::WaitForTerminalExitRequest = serde_json::from_value(params)
+                    .context("failed to decode terminal/wait_for_exit")?;
+                let result = self
+                    .terminal
+                    .as_mut()
+                    .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+                    .wait_for_exit(parse_terminal_id(&request.terminal_id.0)?)?;
+                Ok(serde_json::to_value(
+                    acp::WaitForTerminalExitResponse::new(terminal_exit_status(result.status)),
+                )?)
+            }
+            "terminal/kill" => {
+                let request: acp::KillTerminalRequest =
+                    serde_json::from_value(params).context("failed to decode terminal/kill")?;
+                self.terminal
+                    .as_mut()
+                    .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+                    .kill(parse_terminal_id(&request.terminal_id.0)?)?;
+                Ok(serde_json::to_value(acp::KillTerminalResponse::new())?)
+            }
+            "terminal/release" => {
+                let request: acp::ReleaseTerminalRequest =
+                    serde_json::from_value(params).context("failed to decode terminal/release")?;
+                self.terminal
+                    .as_mut()
+                    .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+                    .release(parse_terminal_id(&request.terminal_id.0)?)?;
+                Ok(serde_json::to_value(acp::ReleaseTerminalResponse::new())?)
+            }
+            _ => anyhow::bail!("ACP client method not implemented: {method}"),
+        }
+    }
+
+    fn ensure_permission(&self, request: PermissionRequestKind) -> Result<()> {
+        match self
+            .permission_policy
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("permission callback service is not configured"))?
+            .decide(&request)
+        {
+            PermissionDecision::Allow => Ok(()),
+            PermissionDecision::Deny => {
+                anyhow::bail!("permission denied: {}", permission_description(&request))
+            }
+            PermissionDecision::Ask => anyhow::bail!(
+                "permission requires user approval and cannot be continued in process callbacks: {}",
+                permission_description(&request)
+            ),
+        }
+    }
+
+    fn emit_session_metadata(
+        &self,
+        modes: Option<agent_client_protocol::schema::SessionModeState>,
+        config_options: Option<Vec<agent_client_protocol::schema::SessionConfigOption>>,
+        sink: &mut dyn AgentEventSink,
+    ) {
+        if let Some(modes) = modes {
+            sink.emit(AgentRuntimeEvent::AvailableModes {
+                modes: modes
+                    .available_modes
+                    .into_iter()
+                    .map(|mode| AgentModeOption {
+                        id: mode.id.0.to_string(),
+                        name: mode.name,
+                    })
+                    .collect(),
+                current: Some(modes.current_mode_id.0.to_string()),
+            });
+        }
+        if let Some(config_options) = config_options {
+            sink.emit(AgentRuntimeEvent::ConfigOptions(
+                config_options
+                    .into_iter()
+                    .map(agent_config_option_from_acp)
+                    .collect(),
+            ));
+        }
+    }
+}
+
+impl AcpConnection for AcpProcessConnection {
+    fn initialize(&mut self, sink: &mut dyn AgentEventSink) -> Result<()> {
+        let request = agent_client_protocol::schema::InitializeRequest::new(
+            agent_client_protocol::schema::ProtocolVersion::LATEST,
+        )
+        .client_capabilities(agent_client_protocol::schema::ClientCapabilities::new())
+        .client_info(
+            agent_client_protocol::schema::Implementation::new("alas", env!("CARGO_PKG_VERSION"))
+                .title("Alas"),
+        );
+        let response = self.send_request(request, sink)?;
+        if !response.auth_methods.is_empty() {
+            sink.emit(AgentRuntimeEvent::AuthRequired {
+                instructions: "ACP provider requires authentication".to_string(),
+            });
+        } else {
+            sink.emit(AgentRuntimeEvent::Initialized);
+        }
+        Ok(())
+    }
+
+    fn new_session(
+        &mut self,
+        worktree_path: PathBuf,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<Option<String>> {
+        let request = agent_client_protocol::schema::NewSessionRequest::new(worktree_path);
+        let response = self.send_request(request, sink)?;
+        let session_id = response.session_id.0.to_string();
+        self.emit_session_metadata(response.modes, response.config_options, sink);
+        sink.emit(AgentRuntimeEvent::Ready);
+        Ok(Some(session_id))
+    }
+
+    fn resume_session(&mut self, session_id: String, sink: &mut dyn AgentEventSink) -> Result<()> {
+        let request =
+            agent_client_protocol::schema::LoadSessionRequest::new(session_id, self.cwd.clone());
+        let response = self.send_request(request, sink)?;
+        self.emit_session_metadata(response.modes, response.config_options, sink);
+        sink.emit(AgentRuntimeEvent::Ready);
+        Ok(())
+    }
+
+    fn prompt(
+        &mut self,
+        session_id: String,
+        prompt: String,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<()> {
+        let request = agent_client_protocol::schema::PromptRequest::new(
+            session_id,
+            vec![agent_client_protocol::schema::ContentBlock::Text(
+                agent_client_protocol::schema::TextContent::new(prompt),
+            )],
+        );
+        let _response: agent_client_protocol::schema::PromptResponse =
+            self.send_request(request, sink)?;
+        sink.emit(AgentRuntimeEvent::Ready);
+        Ok(())
+    }
+
+    fn cancel(&mut self, session_id: String) -> Result<()> {
+        self.send_notification(agent_client_protocol::schema::CancelNotification::new(
+            session_id,
+        ))
+    }
+
+    fn set_mode(
+        &mut self,
+        session_id: String,
+        mode_id: String,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<()> {
+        let request =
+            agent_client_protocol::schema::SetSessionModeRequest::new(session_id, mode_id.clone());
+        let _response: agent_client_protocol::schema::SetSessionModeResponse =
+            self.send_request(request, sink)?;
+        sink.emit(AgentRuntimeEvent::CurrentMode(mode_id));
+        Ok(())
+    }
+
+    fn set_config_option(
+        &mut self,
+        session_id: String,
+        config_id: String,
+        value_id: String,
+        sink: &mut dyn AgentEventSink,
+    ) -> Result<()> {
+        let request = agent_client_protocol::schema::SetSessionConfigOptionRequest::new(
+            session_id, config_id, value_id,
+        );
+        let response: agent_client_protocol::schema::SetSessionConfigOptionResponse =
+            self.send_request(request, sink)?;
+        sink.emit(AgentRuntimeEvent::ConfigOptions(
+            response
+                .config_options
+                .into_iter()
+                .map(agent_config_option_from_acp)
+                .collect(),
+        ));
+        Ok(())
+    }
+
+    fn authenticate(&mut self, method_id: String, sink: &mut dyn AgentEventSink) -> Result<()> {
+        let request = agent_client_protocol::schema::AuthenticateRequest::new(method_id);
+        let _response: agent_client_protocol::schema::AuthenticateResponse =
+            self.send_request(request, sink)?;
+        sink.emit(AgentRuntimeEvent::Ready);
+        Ok(())
+    }
+}
+
+pub struct AgentRuntime<C> {
+    thread: AgentThreadState,
+    connection: C,
+    filesystem: Option<FilesystemCallbackService>,
+    terminal: Option<AgentTerminalService>,
+    permission_policy: Option<PermissionPolicy>,
+    next_permission_request_id: u64,
+}
+
+impl<C> AgentRuntime<C> {
+    pub fn with_connection(thread: AgentThreadState, connection: C) -> Self {
+        Self {
+            thread,
+            connection,
+            filesystem: None,
+            terminal: None,
+            permission_policy: None,
+            next_permission_request_id: 1,
+        }
+    }
+
+    pub fn with_callback_services(
+        mut self,
+        filesystem: FilesystemCallbackService,
+        terminal: AgentTerminalService,
+    ) -> Self {
+        self.permission_policy = Some(filesystem.policy.clone());
+        self.filesystem = Some(filesystem);
+        self.terminal = Some(terminal);
+        self
+    }
+
+    pub fn handle_request_permission(&mut self, request: PermissionRequestKind) -> Result<bool> {
+        let policy = self
+            .permission_policy
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("permission callback service is not configured"))?;
+        let description = permission_description(&request);
+        match policy.decide(&request) {
+            PermissionDecision::Allow => {
+                self.thread.push_debug_event(AgentDebugEvent {
+                    message: format!("Permission allowed: {description}"),
+                });
+                Ok(true)
+            }
+            PermissionDecision::Deny => {
+                let message = format!("permission denied: {description}");
+                self.thread.push_debug_event(AgentDebugEvent {
+                    message: message.clone(),
+                });
+                Err(anyhow::anyhow!(message))
+            }
+            PermissionDecision::Ask => {
+                let id = format!("permission-{}", self.next_permission_request_id);
+                self.next_permission_request_id = self
+                    .next_permission_request_id
+                    .checked_add(1)
+                    .ok_or_else(|| anyhow::anyhow!("permission request id overflow"))?;
+                self.thread.push_debug_event(AgentDebugEvent {
+                    message: format!("Permission requested: {description}"),
+                });
+                self.thread
+                    .pending_permissions
+                    .push(AgentPermissionRequest {
+                        id: id.clone(),
+                        description,
+                    });
+                Err(anyhow::anyhow!("permission request pending: {id}"))
+            }
+        }
+    }
+
+    pub fn resolve_permission_request(&mut self, id: &str, allow: bool) -> Result<bool> {
+        let Some(index) = self
+            .thread
+            .pending_permissions
+            .iter()
+            .position(|request| request.id == id)
+        else {
+            anyhow::bail!("permission request {id} not found");
+        };
+        let request = self.thread.pending_permissions.remove(index);
+        self.thread.push_debug_event(AgentDebugEvent {
+            message: format!(
+                "Permission {}: {}",
+                if allow { "allowed" } else { "denied" },
+                request.description
+            ),
+        });
+        Ok(allow)
+    }
+
+    pub fn handle_read_text_file(&mut self, path: &Path) -> Result<String> {
+        if let Err(error) =
+            self.handle_request_permission(PermissionRequestKind::ReadFile(path.to_path_buf()))
+        {
+            self.record_callback_error("read_text_file", error.to_string());
+            return Err(error);
+        }
+        let result = self
+            .filesystem
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("filesystem callback service is not configured"))?
+            .read_text_file(path);
+        match result {
+            Ok(content) => {
+                self.record_tool_entry("read_text_file", format!("Read {}", path.display()));
+                Ok(content)
+            }
+            Err(error) => {
+                self.record_callback_error("read_text_file", error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    pub fn handle_write_text_file(&mut self, path: &Path, content: &str) -> Result<()> {
+        if let Err(error) =
+            self.handle_request_permission(PermissionRequestKind::WriteFile(path.to_path_buf()))
+        {
+            self.record_callback_error("write_text_file", error.to_string());
+            return Err(error);
+        }
+        let result = self
+            .filesystem
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("filesystem callback service is not configured"))?
+            .write_text_file(path, content);
+        match result {
+            Ok(()) => {
+                self.record_tool_entry("write_text_file", format!("Wrote {}", path.display()));
+                Ok(())
+            }
+            Err(error) => {
+                self.record_callback_error("write_text_file", error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    pub fn handle_terminal_create(
+        &mut self,
+        command: &str,
+        cwd: &Path,
+    ) -> Result<AgentTerminalHandle> {
+        if let Err(error) = self.handle_request_permission(PermissionRequestKind::RunTerminal {
+            command: command.to_string(),
+        }) {
+            self.record_callback_error("terminal_create", error.to_string());
+            return Err(error);
+        }
+        let result = self
+            .terminal
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+            .create(command, cwd);
+        match result {
+            Ok(handle) => {
+                self.record_tool_entry(
+                    "terminal_create",
+                    format!("Started terminal command: {command}"),
+                );
+                Ok(handle)
+            }
+            Err(error) => {
+                self.record_callback_error("terminal_create", error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    pub fn handle_terminal_output(&mut self, handle: AgentTerminalHandle) -> Result<String> {
+        let result = self
+            .terminal
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+            .output(handle);
+        match result {
+            Ok(output) => {
+                self.record_tool_entry("terminal_output", output.clone());
+                Ok(output)
+            }
+            Err(error) => {
+                self.record_callback_error("terminal_output", error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    pub fn handle_terminal_wait_for_exit(
+        &mut self,
+        handle: AgentTerminalHandle,
+    ) -> Result<AgentTerminalResult> {
+        let result = self
+            .terminal
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+            .wait_for_exit(handle);
+        match result {
+            Ok(result) => {
+                self.record_tool_entry(
+                    "terminal_wait_for_exit",
+                    format!("Terminal exited: {:?}", result.status),
+                );
+                Ok(result)
+            }
+            Err(error) => {
+                self.record_callback_error("terminal_wait_for_exit", error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    pub fn handle_terminal_kill(
+        &mut self,
+        handle: AgentTerminalHandle,
+    ) -> Result<AgentTerminalResult> {
+        let result = self
+            .terminal
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+            .kill(handle);
+        match result {
+            Ok(result) => {
+                self.record_tool_entry(
+                    "terminal_kill",
+                    format!("Terminal killed: {:?}", result.status),
+                );
+                Ok(result)
+            }
+            Err(error) => {
+                self.record_callback_error("terminal_kill", error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    pub fn handle_terminal_release(&mut self, handle: AgentTerminalHandle) -> Result<()> {
+        let result = self
+            .terminal
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("terminal callback service is not configured"))?
+            .release(handle);
+        match result {
+            Ok(()) => {
+                self.record_tool_entry(
+                    "terminal_release",
+                    format!("Released terminal {}", handle.0),
+                );
+                Ok(())
+            }
+            Err(error) => {
+                self.record_callback_error("terminal_release", error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    fn record_tool_entry(&mut self, id: &str, text: String) {
+        self.thread.tool_calls.push(AgentToolCallState {
+            id: format!("{id}-{}", self.thread.tool_calls.len() + 1),
+            title: id.replace('_', " "),
+            status: "completed".to_string(),
+        });
+        self.thread.transcript.push(AgentTranscriptEntry {
+            role: AgentTranscriptRole::Tool,
+            text,
+        });
+    }
+
+    fn record_callback_error(&mut self, callback: &str, message: String) {
+        self.thread.push_debug_event(AgentDebugEvent {
+            message: format!("{callback} failed: {message}"),
+        });
+    }
+
+    pub fn thread(&self) -> &AgentThreadState {
+        &self.thread
+    }
+
+    pub fn thread_mut(&mut self) -> &mut AgentThreadState {
+        &mut self.thread
+    }
+
+    pub fn connection(&self) -> &C {
+        &self.connection
+    }
+}
+
+impl<C: AcpConnection> AgentRuntime<C> {
+    pub fn initialize(&mut self) -> Result<()> {
+        self.thread.status = AgentThreadStatus::Starting;
+        let thread = &mut self.thread;
+        let mut sink = ThreadEventSink { thread };
+        self.connection.initialize(&mut sink)?;
+        if matches!(sink.thread.status, AgentThreadStatus::Starting) {
+            sink.thread.status = AgentThreadStatus::Ready;
+        }
+        Ok(())
+    }
+
+    pub fn create_session(&mut self) -> Result<()> {
+        self.thread.status = AgentThreadStatus::Starting;
+        let worktree_path = self.thread.worktree_path.clone();
+        let thread = &mut self.thread;
+        let mut sink = ThreadEventSink { thread };
+        let session_id = self.connection.new_session(worktree_path, &mut sink)?;
+        sink.thread.acp_session_id = session_id;
+        Ok(())
+    }
+
+    pub fn resume_existing_session(&mut self, session_id: impl Into<String>) -> Result<()> {
+        self.thread.status = AgentThreadStatus::Starting;
+        let session_id = session_id.into();
+        self.thread.acp_session_id = Some(session_id.clone());
+        let thread = &mut self.thread;
+        let mut sink = ThreadEventSink { thread };
+        match self.connection.resume_session(session_id, &mut sink) {
+            Ok(()) => {
+                sink.thread.resume = super::AgentResumeState::Resumed;
+                if matches!(sink.thread.status, AgentThreadStatus::Starting) {
+                    sink.thread.status = AgentThreadStatus::Ready;
+                }
+                Ok(())
+            }
+            Err(error) => {
+                let message = error.to_string();
+                sink.thread.resume = super::AgentResumeState::Failed {
+                    message: message.clone(),
+                };
+                sink.thread.status = AgentThreadStatus::ReadOnly { reason: message };
+                Ok(())
+            }
+        }
+    }
+
+    pub fn prompt(&mut self, prompt: impl Into<String>) -> Result<()> {
+        if let AgentThreadStatus::ReadOnly { reason } = &self.thread.status {
+            anyhow::bail!("cannot prompt read-only ACP session: {reason}");
+        }
+        let session_id = self
+            .thread
+            .acp_session_id
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("cannot prompt without an active ACP session"))?;
+        self.thread.status = AgentThreadStatus::Running;
+        self.thread
+            .transcript
+            .push(AgentTranscriptEntry::user(prompt.into()));
+        let prompt = self
+            .thread
+            .transcript
+            .last()
+            .map(|entry| entry.text.clone())
+            .unwrap_or_default();
+        let thread = &mut self.thread;
+        let mut sink = ThreadEventSink { thread };
+        match self.connection.prompt(session_id, prompt, &mut sink) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                let message = error.to_string();
+                sink.thread.status = AgentThreadStatus::Failed { message };
+                Err(error)
+            }
+        }
+    }
+
+    pub fn cancel(&mut self) -> Result<()> {
+        let session_id = self
+            .thread
+            .acp_session_id
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("cannot cancel without an active ACP session"))?;
+        self.connection.cancel(session_id)?;
+        self.thread.status = AgentThreadStatus::Ready;
+        Ok(())
+    }
+
+    pub fn set_mode(&mut self, mode_id: impl Into<String>) -> Result<()> {
+        if let AgentThreadStatus::ReadOnly { reason } = &self.thread.status {
+            anyhow::bail!("cannot change mode for read-only ACP session: {reason}");
+        }
+        let session_id =
+            self.thread.acp_session_id.clone().ok_or_else(|| {
+                anyhow::anyhow!("cannot change mode without an active ACP session")
+            })?;
+        let mode_id = mode_id.into();
+        let previous_mode = self.thread.current_mode.clone();
+        let thread = &mut self.thread;
+        let mut sink = ThreadEventSink { thread };
+        match self
+            .connection
+            .set_mode(session_id, mode_id.clone(), &mut sink)
+        {
+            Ok(()) => {
+                if sink.thread.current_mode == previous_mode {
+                    sink.thread.current_mode = Some(mode_id);
+                }
+                Ok(())
+            }
+            Err(error) => {
+                sink.thread.current_mode = previous_mode;
+                Err(error)
+            }
+        }
+    }
+
+    pub fn set_config_option(
+        &mut self,
+        config_id: impl Into<String>,
+        value_id: impl Into<String>,
+    ) -> Result<()> {
+        if let AgentThreadStatus::ReadOnly { reason } = &self.thread.status {
+            anyhow::bail!("cannot change config for read-only ACP session: {reason}");
+        }
+        let session_id =
+            self.thread.acp_session_id.clone().ok_or_else(|| {
+                anyhow::anyhow!("cannot change config without an active ACP session")
+            })?;
+        let config_id = config_id.into();
+        let value_id = value_id.into();
+        let previous_value = self
+            .thread
+            .config_options
+            .iter()
+            .find(|option| option.id == config_id)
+            .and_then(|option| option.value.clone());
+        let thread = &mut self.thread;
+        let mut sink = ThreadEventSink { thread };
+        match self.connection.set_config_option(
+            session_id,
+            config_id.clone(),
+            value_id.clone(),
+            &mut sink,
+        ) {
+            Ok(()) => {
+                if let Some(option) = sink
+                    .thread
+                    .config_options
+                    .iter_mut()
+                    .find(|option| option.id == config_id)
+                    && option.value == previous_value
+                {
+                    option.value = Some(value_id);
+                }
+                Ok(())
+            }
+            Err(error) => {
+                if let Some(option) = sink
+                    .thread
+                    .config_options
+                    .iter_mut()
+                    .find(|option| option.id == config_id)
+                {
+                    option.value = previous_value;
+                }
+                Err(error)
+            }
+        }
+    }
+
+    pub fn authenticate(&mut self, method_id: impl Into<String>) -> Result<()> {
+        let method_id = method_id.into();
+        self.thread.push_debug_event(AgentDebugEvent {
+            message: format!("Authenticating with auth method '{method_id}'"),
+        });
+        let thread = &mut self.thread;
+        let mut sink = ThreadEventSink { thread };
+        match self.connection.authenticate(method_id, &mut sink) {
+            Ok(()) => {
+                sink.thread.auth_status = AgentAuthStatus::Authenticated;
+                sink.thread.status = AgentThreadStatus::Ready;
+                sink.thread.push_debug_event(AgentDebugEvent {
+                    message: "Authentication succeeded".to_string(),
+                });
+                Ok(())
+            }
+            Err(error) => {
+                let message = error.to_string();
+                let instructions = sink
+                    .thread
+                    .auth_status
+                    .instructions()
+                    .unwrap_or_default()
+                    .to_string();
+                sink.thread.auth_status = AgentAuthStatus::Failed {
+                    message: message.clone(),
+                    instructions,
+                };
+                sink.thread.push_debug_event(AgentDebugEvent {
+                    message: "Authentication failed".to_string(),
+                });
+                Err(error)
+            }
+        }
+    }
+}
+
+struct ThreadEventSink<'a> {
+    thread: &'a mut AgentThreadState,
+}
+
+impl AgentEventSink for ThreadEventSink<'_> {
+    fn emit(&mut self, event: AgentRuntimeEvent) {
+        apply_runtime_event(self.thread, event);
+    }
+}
+
+pub fn apply_runtime_event(thread: &mut AgentThreadState, event: AgentRuntimeEvent) {
+    match event {
+        AgentRuntimeEvent::Initialized => thread.status = AgentThreadStatus::Starting,
+        AgentRuntimeEvent::AuthRequired { instructions } => {
+            thread.status = AgentThreadStatus::AuthRequired;
+            thread.auth_status = AgentAuthStatus::Required {
+                instructions: instructions.clone(),
+            };
+            thread.push_debug_event(AgentDebugEvent {
+                message: "Authentication required".to_string(),
+            });
+            thread
+                .transcript
+                .push(AgentTranscriptEntry::agent(instructions));
+        }
+        AgentRuntimeEvent::Ready => {
+            thread.status = AgentThreadStatus::Ready;
+            thread.auth_status = AgentAuthStatus::Authenticated;
+        }
+        AgentRuntimeEvent::AgentMessageChunk(text) => {
+            apply_agent_update(thread, AgentUpdate::AgentMessageChunk(text));
+        }
+        AgentRuntimeEvent::ThoughtChunk(text) => {
+            apply_agent_update(thread, AgentUpdate::ThoughtChunk(text));
+        }
+        AgentRuntimeEvent::ToolCall { id, title, status } => {
+            apply_agent_update(thread, AgentUpdate::ToolCall { id, title, status });
+        }
+        AgentRuntimeEvent::Plan(entries) => apply_agent_update(thread, AgentUpdate::Plan(entries)),
+        AgentRuntimeEvent::AvailableCommands(commands) => {
+            apply_agent_update(thread, AgentUpdate::AvailableCommands(commands));
+        }
+        AgentRuntimeEvent::AvailableModes { modes, current } => {
+            apply_agent_update(thread, AgentUpdate::AvailableModes { modes, current });
+        }
+        AgentRuntimeEvent::ConfigOptions(options) => {
+            apply_agent_update(thread, AgentUpdate::ConfigOptions(options));
+        }
+        AgentRuntimeEvent::CurrentMode(current) => {
+            apply_agent_update(thread, AgentUpdate::CurrentMode(current));
+        }
+        AgentRuntimeEvent::NeedsPermission { id, description } => {
+            apply_agent_update(thread, AgentUpdate::NeedsPermission { id, description });
+        }
+        AgentRuntimeEvent::Failed(message) => {
+            thread.status = AgentThreadStatus::Failed { message };
+        }
+    }
+}
+
+pub fn apply_agent_update(thread: &mut AgentThreadState, update: AgentUpdate) {
+    match update {
+        AgentUpdate::AgentMessageChunk(text) => {
+            thread.transcript.push(AgentTranscriptEntry::agent(text));
+        }
+        AgentUpdate::ThoughtChunk(text) => {
+            thread.transcript.push(AgentTranscriptEntry {
+                role: super::AgentTranscriptRole::Thought,
+                text,
+            });
+        }
+        AgentUpdate::ToolCall { id, title, status } => {
+            if let Some(tool_call) = thread.tool_calls.iter_mut().find(|call| call.id == id) {
+                tool_call.title = title;
+                tool_call.status = status;
+            } else {
+                thread
+                    .tool_calls
+                    .push(AgentToolCallState { id, title, status });
+            }
+        }
+        AgentUpdate::ToolCallUpdate { id, title, status } => {
+            if let Some(tool_call) = thread.tool_calls.iter_mut().find(|call| call.id == id) {
+                if let Some(title) = title {
+                    tool_call.title = title;
+                }
+                if let Some(status) = status {
+                    tool_call.status = status;
+                }
+            } else {
+                thread.tool_calls.push(AgentToolCallState {
+                    id,
+                    title: title.unwrap_or_default(),
+                    status: status.unwrap_or_default(),
+                });
+            }
+        }
+        AgentUpdate::Plan(entries) => thread.plans.push(AgentPlanState { entries }),
+        AgentUpdate::AvailableCommands(commands) => thread.available_commands = commands,
+        AgentUpdate::AvailableModes { modes, current } => {
+            thread.available_modes = modes;
+            thread.current_mode = current;
+        }
+        AgentUpdate::CurrentMode(current) => thread.current_mode = Some(current),
+        AgentUpdate::ConfigOptions(options) => thread.config_options = options,
+        AgentUpdate::NeedsPermission { id, description } => {
+            thread
+                .pending_permissions
+                .push(AgentPermissionRequest { id, description });
+        }
+        AgentUpdate::Error(message) => {
+            thread.push_debug_event(AgentDebugEvent { message });
+        }
+    }
+}
+
+fn is_client_callback_method(method: &str) -> bool {
+    matches!(
+        method,
+        "session/request_permission"
+            | "fs/read_text_file"
+            | "fs/write_text_file"
+            | "terminal/create"
+            | "terminal/output"
+            | "terminal/wait_for_exit"
+            | "terminal/kill"
+            | "terminal/release"
+    )
+}
+
+fn terminal_command(command: &str, args: &[String]) -> String {
+    if args.is_empty() {
+        command.to_string()
+    } else {
+        // TODO: Quote arguments for display/permission prompts instead of flattening with spaces.
+        std::iter::once(command)
+            .chain(args.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+fn parse_terminal_id(id: &str) -> Result<AgentTerminalHandle> {
+    Ok(AgentTerminalHandle(
+        id.parse()
+            .with_context(|| format!("invalid terminal id '{id}'"))?,
+    ))
+}
+
+fn terminal_exit_status(
+    status: AgentTerminalStatus,
+) -> agent_client_protocol::schema::TerminalExitStatus {
+    let acp_status = agent_client_protocol::schema::TerminalExitStatus::new();
+    match status {
+        AgentTerminalStatus::Running => acp_status,
+        AgentTerminalStatus::Exited(code) => acp_status.exit_code(code.map(|code| code as u32)),
+        AgentTerminalStatus::Failed => acp_status.signal("failed"),
+    }
+}
+
+fn permission_description(request: &PermissionRequestKind) -> String {
+    match request {
+        PermissionRequestKind::ReadFile(path) => format!("read file {}", path.display()),
+        PermissionRequestKind::WriteFile(path) => format!("write file {}", path.display()),
+        PermissionRequestKind::RunTerminal { command } => format!("run terminal command {command}"),
+    }
+}
+
+fn agent_runtime_event_from_update(update: AgentUpdate) -> AgentRuntimeEvent {
+    match update {
+        AgentUpdate::AgentMessageChunk(text) => AgentRuntimeEvent::AgentMessageChunk(text),
+        AgentUpdate::ThoughtChunk(text) => AgentRuntimeEvent::ThoughtChunk(text),
+        AgentUpdate::ToolCall { id, title, status }
+        | AgentUpdate::ToolCallUpdate {
+            id,
+            title: Some(title),
+            status: Some(status),
+        } => AgentRuntimeEvent::ToolCall { id, title, status },
+        AgentUpdate::ToolCallUpdate { id, title, status } => AgentRuntimeEvent::ToolCall {
+            id,
+            title: title.unwrap_or_default(),
+            status: status.unwrap_or_default(),
+        },
+        AgentUpdate::Plan(entries) => AgentRuntimeEvent::Plan(entries),
+        AgentUpdate::AvailableCommands(commands) => AgentRuntimeEvent::AvailableCommands(commands),
+        AgentUpdate::AvailableModes { modes, current } => {
+            AgentRuntimeEvent::AvailableModes { modes, current }
+        }
+        AgentUpdate::CurrentMode(current) => AgentRuntimeEvent::CurrentMode(current),
+        AgentUpdate::ConfigOptions(options) => AgentRuntimeEvent::ConfigOptions(options),
+        AgentUpdate::NeedsPermission { id, description } => {
+            AgentRuntimeEvent::NeedsPermission { id, description }
+        }
+        AgentUpdate::Error(message) => AgentRuntimeEvent::Failed(message),
+    }
+}
+
+fn agent_config_option_from_acp(
+    option: agent_client_protocol::schema::SessionConfigOption,
+) -> AgentConfigOption {
+    use agent_client_protocol::schema::SessionConfigKind;
+
+    let mut value = None;
+    let mut options = Vec::new();
+    if let SessionConfigKind::Select(select) = option.kind {
+        value = Some(select.current_value.0.to_string());
+        options = match select.options {
+            agent_client_protocol::schema::SessionConfigSelectOptions::Ungrouped(options) => {
+                options
+                    .into_iter()
+                    .map(|option| AgentConfigValueOption {
+                        id: option.value.0.to_string(),
+                        label: option.name,
+                    })
+                    .collect()
+            }
+            agent_client_protocol::schema::SessionConfigSelectOptions::Grouped(groups) => groups
+                .into_iter()
+                .flat_map(|group| group.options)
+                .map(|option| AgentConfigValueOption {
+                    id: option.value.0.to_string(),
+                    label: option.name,
+                })
+                .collect(),
+            #[allow(unreachable_patterns)]
+            _ => Vec::new(),
+        };
+    }
+
+    AgentConfigOption {
+        id: option.id.0.to_string(),
+        label: option.name,
+        value,
+        options,
+    }
+}
+
+/// Converts ACP `SessionUpdate` notifications into Alas-owned updates.
+///
+/// ACP 0.11 sends available modes on session creation/resume responses and only sends current mode
+/// changes through `SessionUpdate`, so callers should map response `modes` separately into
+/// `AgentUpdate::AvailableModes` when wiring the real process connection.
+pub fn agent_update_from_acp_session_update(
+    update: agent_client_protocol::schema::SessionUpdate,
+) -> Option<AgentUpdate> {
+    use agent_client_protocol::schema::{ContentBlock, SessionUpdate};
+
+    match update {
+        SessionUpdate::AgentMessageChunk(chunk) => match chunk.content {
+            ContentBlock::Text(text) => Some(AgentUpdate::AgentMessageChunk(text.text)),
+            other => Some(AgentUpdate::Error(format!(
+                "Unsupported ACP agent message content: {other:?}"
+            ))),
+        },
+        SessionUpdate::AgentThoughtChunk(chunk) => match chunk.content {
+            ContentBlock::Text(text) => Some(AgentUpdate::ThoughtChunk(text.text)),
+            other => Some(AgentUpdate::Error(format!(
+                "Unsupported ACP thought content: {other:?}"
+            ))),
+        },
+        SessionUpdate::ToolCall(tool_call) => Some(AgentUpdate::ToolCall {
+            id: tool_call.tool_call_id.0.to_string(),
+            title: tool_call.title,
+            status: format!("{:?}", tool_call.status),
+        }),
+        SessionUpdate::ToolCallUpdate(update) => Some(AgentUpdate::ToolCallUpdate {
+            id: update.tool_call_id.0.to_string(),
+            title: update.fields.title,
+            status: update.fields.status.map(|status| format!("{status:?}")),
+        }),
+        SessionUpdate::Plan(plan) => Some(AgentUpdate::Plan(
+            plan.entries
+                .into_iter()
+                .map(|entry| entry.content)
+                .collect(),
+        )),
+        SessionUpdate::AvailableCommandsUpdate(update) => Some(AgentUpdate::AvailableCommands(
+            update
+                .available_commands
+                .into_iter()
+                .map(|command| AgentSlashCommand {
+                    name: command.name,
+                    description: Some(command.description),
+                })
+                .collect(),
+        )),
+        SessionUpdate::CurrentModeUpdate(update) => Some(AgentUpdate::CurrentMode(
+            update.current_mode_id.0.to_string(),
+        )),
+        SessionUpdate::ConfigOptionUpdate(update) => Some(AgentUpdate::ConfigOptions(
+            update
+                .config_options
+                .into_iter()
+                .map(agent_config_option_from_acp)
+                .collect(),
+        )),
+        SessionUpdate::UserMessageChunk(_) => None,
+        SessionUpdate::SessionInfoUpdate(update) => update
+            .title
+            .take()
+            .map(|title| AgentUpdate::Error(format!("ACP session title update ignored: {title}"))),
+        #[allow(unreachable_patterns)]
+        other => Some(AgentUpdate::Error(format!(
+            "Unsupported ACP session update: {other:?}"
+        ))),
+    }
+}

--- a/src/agent/terminal.rs
+++ b/src/agent/terminal.rs
@@ -1,0 +1,297 @@
+use std::{
+    collections::HashMap,
+    io::Read,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::{Arc, Mutex},
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+use anyhow::{Context, bail};
+
+use crate::agent::{AgentTrustMode, PermissionDecision, PermissionPolicy, PermissionRequestKind};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct AgentTerminalHandle(pub u64);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AgentTerminalStatus {
+    Running,
+    Exited(Option<i32>),
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentTerminalResult {
+    pub status: AgentTerminalStatus,
+}
+
+#[derive(Debug)]
+struct AgentTerminalProcess {
+    child: Option<Child>,
+    output: Arc<Mutex<String>>,
+    readers: Vec<JoinHandle<()>>,
+    status: AgentTerminalStatus,
+}
+
+#[derive(Debug)]
+pub struct AgentTerminalService {
+    pub policy: PermissionPolicy,
+    next_handle: u64,
+    processes: HashMap<AgentTerminalHandle, AgentTerminalProcess>,
+}
+
+impl AgentTerminalService {
+    pub fn new(trust_mode: AgentTrustMode, worktree_path: PathBuf) -> Self {
+        Self {
+            policy: PermissionPolicy::new(trust_mode, worktree_path),
+            next_handle: 1,
+            processes: HashMap::new(),
+        }
+    }
+
+    pub fn create(&mut self, command: &str, cwd: &Path) -> anyhow::Result<AgentTerminalHandle> {
+        match self.policy.decide(&PermissionRequestKind::RunTerminal {
+            command: command.to_string(),
+        }) {
+            PermissionDecision::Allow => {}
+            PermissionDecision::Ask => {
+                bail!("permission required to run terminal command {command}")
+            }
+            PermissionDecision::Deny => {
+                bail!("permission denied to run terminal command {command}")
+            }
+        }
+
+        let handle = AgentTerminalHandle(self.next_handle);
+        self.next_handle = self
+            .next_handle
+            .checked_add(1)
+            .context("terminal handle counter overflow")?;
+
+        let output = Arc::new(Mutex::new(String::new()));
+        let mut shell = Command::new(shell_program());
+        shell
+            .args(shell_args(command))
+            .current_dir(cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        configure_process_group(&mut shell);
+
+        let mut child = shell
+            .spawn()
+            .with_context(|| format!("spawn terminal command {command}"))?;
+
+        let mut readers = Vec::new();
+        if let Some(stdout) = child.stdout.take() {
+            readers.push(stream_output(stdout, Arc::clone(&output)));
+        }
+        if let Some(stderr) = child.stderr.take() {
+            readers.push(stream_output(stderr, Arc::clone(&output)));
+        }
+
+        self.processes.insert(
+            handle,
+            AgentTerminalProcess {
+                child: Some(child),
+                output,
+                readers,
+                status: AgentTerminalStatus::Running,
+            },
+        );
+
+        Ok(handle)
+    }
+
+    pub fn wait_for_exit(
+        &mut self,
+        handle: AgentTerminalHandle,
+    ) -> anyhow::Result<AgentTerminalResult> {
+        let process = self
+            .processes
+            .get_mut(&handle)
+            .with_context(|| format!("terminal handle {} not found", handle.0))?;
+
+        if process.status != AgentTerminalStatus::Running {
+            return Ok(AgentTerminalResult {
+                status: process.status.clone(),
+            });
+        }
+
+        let Some(mut child) = process.child.take() else {
+            process.status = AgentTerminalStatus::Failed;
+            join_readers(process);
+            return Ok(AgentTerminalResult {
+                status: AgentTerminalStatus::Failed,
+            });
+        };
+
+        let exit_status = child
+            .wait()
+            .with_context(|| format!("wait for terminal handle {}", handle.0))?;
+        process.status = AgentTerminalStatus::Exited(exit_status.code());
+        join_readers(process);
+
+        Ok(AgentTerminalResult {
+            status: process.status.clone(),
+        })
+    }
+
+    pub fn output(&self, handle: AgentTerminalHandle) -> anyhow::Result<String> {
+        let process = self
+            .processes
+            .get(&handle)
+            .with_context(|| format!("terminal handle {} not found", handle.0))?;
+        let output = process
+            .output
+            .lock()
+            .map_err(|_| anyhow::anyhow!("terminal output buffer poisoned"))?;
+        Ok(output.clone())
+    }
+
+    pub fn kill(&mut self, handle: AgentTerminalHandle) -> anyhow::Result<AgentTerminalResult> {
+        let process = self
+            .processes
+            .get_mut(&handle)
+            .with_context(|| format!("terminal handle {} not found", handle.0))?;
+
+        if let Some(mut child) = process.child.take() {
+            terminate_child(&mut child);
+        }
+        process.status = AgentTerminalStatus::Failed;
+        join_readers(process);
+
+        Ok(AgentTerminalResult {
+            status: AgentTerminalStatus::Failed,
+        })
+    }
+
+    pub fn release(&mut self, handle: AgentTerminalHandle) -> anyhow::Result<()> {
+        let Some(mut process) = self.processes.remove(&handle) else {
+            bail!("terminal handle {} not found", handle.0);
+        };
+
+        if process.status == AgentTerminalStatus::Running
+            && let Some(mut child) = process.child.take()
+        {
+            terminate_child(&mut child);
+        }
+        join_readers(&mut process);
+
+        Ok(())
+    }
+}
+
+fn stream_output<R>(mut reader: R, output: Arc<Mutex<String>>) -> JoinHandle<()>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut buffer = [0_u8; 4096];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(bytes_read) => {
+                    let chunk = String::from_utf8_lossy(&buffer[..bytes_read]);
+                    if let Ok(mut output) = output.lock() {
+                        output.push_str(&chunk);
+                    } else {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    })
+}
+
+fn join_readers(process: &mut AgentTerminalProcess) {
+    for reader in process.readers.drain(..) {
+        let _ = reader.join();
+    }
+}
+
+fn terminate_child(child: &mut Child) {
+    #[cfg(unix)]
+    {
+        terminate_child_unix(child);
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+#[cfg(unix)]
+fn terminate_child_unix(child: &mut Child) {
+    const TERM_TIMEOUT: Duration = Duration::from_millis(750);
+    const POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+    let pgid = child.id() as libc::pid_t;
+    unsafe {
+        let _ = libc::kill(-pgid, libc::SIGTERM);
+    }
+
+    let deadline = Instant::now() + TERM_TIMEOUT;
+    while Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                let _ = child.wait();
+                return;
+            }
+            Ok(None) => thread::sleep(POLL_INTERVAL),
+            Err(_) => return,
+        }
+    }
+
+    unsafe {
+        let _ = libc::kill(-pgid, libc::SIGKILL);
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+fn configure_process_group(command: &mut Command) {
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setpgid(0, 0) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+}
+
+#[cfg(not(unix))]
+fn configure_process_group(_command: &mut Command) {}
+
+fn shell_program() -> &'static str {
+    #[cfg(windows)]
+    {
+        "cmd"
+    }
+    #[cfg(not(windows))]
+    {
+        "/bin/sh"
+    }
+}
+
+fn shell_args(command: &str) -> [&str; 2] {
+    #[cfg(windows)]
+    {
+        ["/C", command]
+    }
+    #[cfg(not(windows))]
+    {
+        ["-lc", command]
+    }
+}

--- a/src/agent/types.rs
+++ b/src/agent/types.rs
@@ -1,0 +1,337 @@
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::AgentAuthStatus;
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentTrustMode {
+    #[default]
+    AllowEverything,
+    Ask,
+    WorktreeOnly,
+    Deny,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentThreadState {
+    #[serde(default = "new_agent_thread_id")]
+    pub thread_id: String,
+    pub provider_id: String,
+    pub acp_session_id: Option<String>,
+    pub worktree_path: PathBuf,
+    pub title: String,
+    pub status: AgentThreadStatus,
+    #[serde(default)]
+    pub auth_status: AgentAuthStatus,
+    pub transcript: Vec<AgentTranscriptEntry>,
+    pub tool_calls: Vec<AgentToolCallState>,
+    pub plans: Vec<AgentPlanState>,
+    pub pending_permissions: Vec<AgentPermissionRequest>,
+    pub available_commands: Vec<AgentSlashCommand>,
+    pub available_modes: Vec<AgentModeOption>,
+    pub current_mode: Option<String>,
+    pub config_options: Vec<AgentConfigOption>,
+    pub draft: String,
+    pub resume: AgentResumeState,
+    pub debug_log: Vec<AgentDebugEvent>,
+}
+
+fn new_agent_thread_id() -> String {
+    static NEXT_THREAD_ID: AtomicU64 = AtomicU64::new(1);
+    let sequence = NEXT_THREAD_ID.fetch_add(1, Ordering::Relaxed);
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default();
+    format!("agent-thread-{millis}-{sequence}")
+}
+
+const MAX_DEBUG_LOG_ENTRIES: usize = 500;
+
+pub fn redact_debug_value(key: &str, value: &str) -> String {
+    if is_sensitive_debug_key(key) {
+        "[redacted]".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+pub fn redact_debug_message(message: &str) -> String {
+    let mut redacted = String::with_capacity(message.len());
+    let mut index = 0;
+
+    while index < message.len() {
+        let Some((key_start, key)) = next_debug_key(message, index) else {
+            redacted.push_str(&message[index..]);
+            break;
+        };
+
+        let key_end = key_start + key.len();
+        let separator_start = next_debug_separator_start(message, key_end);
+
+        let Some(separator) = message[separator_start..].chars().next() else {
+            redacted.push_str(&message[index..]);
+            break;
+        };
+
+        if is_sensitive_debug_key(key) && matches!(separator, '=' | ':') {
+            let value_start = separator_start
+                + separator.len_utf8()
+                + message[separator_start + separator.len_utf8()..]
+                    .char_indices()
+                    .find(|(_, ch)| !ch.is_ascii_whitespace())
+                    .map(|(offset, _)| offset)
+                    .unwrap_or(message.len() - separator_start - separator.len_utf8());
+            let (redacted_start, value_end) = debug_value_bounds(message, value_start);
+
+            redacted.push_str(&message[index..redacted_start]);
+            redacted.push_str("[redacted]");
+            index = value_end;
+        } else {
+            redacted.push_str(&message[index..key_end]);
+            index = key_end;
+        }
+    }
+
+    redacted
+}
+
+fn is_sensitive_debug_key(key: &str) -> bool {
+    let key = key.to_ascii_uppercase();
+    key.contains("KEY")
+        || key.contains("TOKEN")
+        || key.contains("SECRET")
+        || key.contains("PASSWORD")
+}
+
+fn next_debug_separator_start(message: &str, key_end: usize) -> usize {
+    let mut cursor = key_end;
+
+    if let Some((offset, quote)) = message[cursor..]
+        .char_indices()
+        .find(|(_, ch)| !ch.is_ascii_whitespace())
+        .filter(|(_, ch)| matches!(ch, '"' | '\''))
+    {
+        cursor += offset + quote.len_utf8();
+    }
+
+    message[cursor..]
+        .char_indices()
+        .find(|(_, ch)| !ch.is_ascii_whitespace())
+        .map(|(offset, _)| cursor + offset)
+        .unwrap_or(message.len())
+}
+
+fn debug_value_bounds(message: &str, value_start: usize) -> (usize, usize) {
+    let Some(quote) = message[value_start..]
+        .chars()
+        .next()
+        .filter(|ch| matches!(ch, '"' | '\''))
+    else {
+        let value_end = message[value_start..]
+            .char_indices()
+            .find(|(_, ch)| ch.is_ascii_whitespace() || matches!(ch, ',' | ';'))
+            .map(|(offset, _)| value_start + offset)
+            .unwrap_or(message.len());
+        return (value_start, value_end);
+    };
+
+    let redacted_start = value_start + quote.len_utf8();
+    let value_end = quoted_debug_value_end(message, redacted_start, quote);
+
+    (redacted_start, value_end)
+}
+
+fn quoted_debug_value_end(message: &str, start: usize, quote: char) -> usize {
+    let mut escaped = false;
+
+    for (offset, ch) in message[start..].char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+
+        if ch == quote {
+            return start + offset;
+        }
+    }
+
+    message.len()
+}
+
+fn next_debug_key(message: &str, start: usize) -> Option<(usize, &str)> {
+    let mut key_start = None;
+
+    for (offset, ch) in message[start..].char_indices() {
+        let index = start + offset;
+        if is_debug_key_char(ch) {
+            key_start.get_or_insert(index);
+        } else if let Some(found_start) = key_start {
+            return Some((found_start, &message[found_start..index]));
+        }
+    }
+
+    key_start.map(|found_start| (found_start, &message[found_start..]))
+}
+
+fn is_debug_key_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')
+}
+
+impl AgentThreadState {
+    pub fn new(provider_id: impl Into<String>, worktree_path: PathBuf) -> Self {
+        Self {
+            thread_id: new_agent_thread_id(),
+            provider_id: provider_id.into(),
+            acp_session_id: None,
+            worktree_path,
+            title: "Agent Chat".to_string(),
+            status: AgentThreadStatus::Disconnected,
+            auth_status: AgentAuthStatus::Unknown,
+            transcript: Vec::new(),
+            tool_calls: Vec::new(),
+            plans: Vec::new(),
+            pending_permissions: Vec::new(),
+            available_commands: Vec::new(),
+            available_modes: Vec::new(),
+            current_mode: None,
+            config_options: Vec::new(),
+            draft: String::new(),
+            resume: AgentResumeState::NotRestored,
+            debug_log: Vec::new(),
+        }
+    }
+
+    pub fn push_debug_event(&mut self, event: AgentDebugEvent) {
+        if self.debug_log.len() >= MAX_DEBUG_LOG_ENTRIES {
+            let excess = self.debug_log.len() + 1 - MAX_DEBUG_LOG_ENTRIES;
+            self.debug_log.drain(0..excess);
+        }
+        self.debug_log.push(AgentDebugEvent {
+            message: redact_debug_message(&event.message),
+        });
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentThreadStatus {
+    #[default]
+    Disconnected,
+    Starting,
+    AuthRequired,
+    Ready,
+    Running,
+    Failed {
+        message: String,
+    },
+    ReadOnly {
+        reason: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentTranscriptEntry {
+    pub role: AgentTranscriptRole,
+    pub text: String,
+}
+
+impl AgentTranscriptEntry {
+    pub fn user(text: impl Into<String>) -> Self {
+        Self {
+            role: AgentTranscriptRole::User,
+            text: text.into(),
+        }
+    }
+
+    pub fn agent(text: impl Into<String>) -> Self {
+        Self {
+            role: AgentTranscriptRole::Agent,
+            text: text.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentTranscriptRole {
+    User,
+    Agent,
+    Thought,
+    System,
+    Tool,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentToolCallState {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentPlanState {
+    pub entries: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentPermissionRequest {
+    pub id: String,
+    pub description: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentSlashCommand {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentModeOption {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentConfigValueOption {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentConfigOption {
+    pub id: String,
+    pub label: String,
+    pub value: Option<String>,
+    #[serde(default)]
+    pub options: Vec<AgentConfigValueOption>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentResumeState {
+    #[default]
+    NotRestored,
+    Pending,
+    Resumed,
+    Unsupported,
+    Failed {
+        message: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentDebugEvent {
+    pub message: String,
+}

--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
+use crate::agent::{AgentResumeState, AgentThreadRecord, AgentThreadState, AgentThreadStatus};
 use crate::app::{DetectedLanguage, HighlightedSource, detect_language};
 use crate::terminal::{CommandSpec, TerminalBackendSession};
 
@@ -25,6 +26,7 @@ pub enum WorkspaceTabKind {
     Terminal(TerminalTabKind),
     File,
     Image,
+    AgentChat,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -192,6 +194,7 @@ pub enum WorkspaceTabContent {
     File(FileTabState),
     Markdown(MarkdownTabState),
     Image(ImageTabState),
+    AgentChat(Box<AgentThreadState>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -208,7 +211,8 @@ impl WorkspaceTab {
             WorkspaceTabContent::Terminal(state) => Some(state),
             WorkspaceTabContent::File(_)
             | WorkspaceTabContent::Markdown(_)
-            | WorkspaceTabContent::Image(_) => None,
+            | WorkspaceTabContent::Image(_)
+            | WorkspaceTabContent::AgentChat(_) => None,
         }
     }
 
@@ -217,14 +221,15 @@ impl WorkspaceTab {
             WorkspaceTabContent::Terminal(state) => Some(state),
             WorkspaceTabContent::File(_)
             | WorkspaceTabContent::Markdown(_)
-            | WorkspaceTabContent::Image(_) => None,
+            | WorkspaceTabContent::Image(_)
+            | WorkspaceTabContent::AgentChat(_) => None,
         }
     }
 
     pub fn terminal_kind(&self) -> Option<TerminalTabKind> {
         match self.kind {
             WorkspaceTabKind::Terminal(kind) => Some(kind),
-            WorkspaceTabKind::File | WorkspaceTabKind::Image => None,
+            WorkspaceTabKind::File | WorkspaceTabKind::Image | WorkspaceTabKind::AgentChat => None,
         }
     }
 
@@ -240,12 +245,27 @@ impl WorkspaceTab {
         matches!(self.kind, WorkspaceTabKind::Image)
     }
 
+    pub fn is_agent_chat(&self) -> bool {
+        matches!(self.kind, WorkspaceTabKind::AgentChat)
+    }
+
     pub fn image_tab_state(&self) -> Option<&ImageTabState> {
         match &self.content {
             WorkspaceTabContent::Image(state) => Some(state),
             WorkspaceTabContent::Terminal(_)
             | WorkspaceTabContent::File(_)
-            | WorkspaceTabContent::Markdown(_) => None,
+            | WorkspaceTabContent::Markdown(_)
+            | WorkspaceTabContent::AgentChat(_) => None,
+        }
+    }
+
+    pub fn agent_thread_state(&self) -> Option<&AgentThreadState> {
+        match &self.content {
+            WorkspaceTabContent::AgentChat(state) => Some(state.as_ref()),
+            WorkspaceTabContent::Terminal(_)
+            | WorkspaceTabContent::File(_)
+            | WorkspaceTabContent::Markdown(_)
+            | WorkspaceTabContent::Image(_) => None,
         }
     }
 
@@ -254,7 +274,18 @@ impl WorkspaceTab {
             WorkspaceTabContent::Image(state) => Some(state),
             WorkspaceTabContent::Terminal(_)
             | WorkspaceTabContent::File(_)
-            | WorkspaceTabContent::Markdown(_) => None,
+            | WorkspaceTabContent::Markdown(_)
+            | WorkspaceTabContent::AgentChat(_) => None,
+        }
+    }
+
+    pub fn agent_thread_state_mut(&mut self) -> Option<&mut AgentThreadState> {
+        match &mut self.content {
+            WorkspaceTabContent::AgentChat(state) => Some(state.as_mut()),
+            WorkspaceTabContent::Terminal(_)
+            | WorkspaceTabContent::File(_)
+            | WorkspaceTabContent::Markdown(_)
+            | WorkspaceTabContent::Image(_) => None,
         }
     }
 
@@ -262,7 +293,9 @@ impl WorkspaceTab {
         match &self.content {
             WorkspaceTabContent::File(state) => Some(&state.file_path),
             WorkspaceTabContent::Markdown(state) => Some(&state.file.file_path),
-            WorkspaceTabContent::Terminal(_) | WorkspaceTabContent::Image(_) => None,
+            WorkspaceTabContent::Terminal(_)
+            | WorkspaceTabContent::Image(_)
+            | WorkspaceTabContent::AgentChat(_) => None,
         }
     }
 }
@@ -339,6 +372,135 @@ impl WorkspaceSession {
         self.tabs.entry(key.clone()).or_default().push(tab);
         self.active_tabs.insert(key, id);
         id
+    }
+
+    pub fn create_agent_chat_tab(
+        &mut self,
+        repo_id: impl Into<String>,
+        path: PathBuf,
+        provider_id: String,
+    ) -> WorkspaceTabId {
+        let state = AgentThreadState::new(provider_id, path.clone());
+        self.create_agent_chat_tab_from_state(repo_id, path, state)
+    }
+
+    pub fn create_agent_chat_tab_from_state(
+        &mut self,
+        repo_id: impl Into<String>,
+        path: PathBuf,
+        state: AgentThreadState,
+    ) -> WorkspaceTabId {
+        let key = WorktreeKey::new(repo_id, path);
+        self.next_tab_id += 1;
+        let id = WorkspaceTabId(self.next_tab_id);
+        let tab = WorkspaceTab {
+            id,
+            name: state.title.clone(),
+            kind: WorkspaceTabKind::AgentChat,
+            content: WorkspaceTabContent::AgentChat(Box::new(state)),
+        };
+
+        self.tabs.entry(key.clone()).or_default().push(tab);
+        self.active_tabs.insert(key, id);
+        id
+    }
+
+    pub fn restore_agent_chat_tabs(
+        &mut self,
+        repo_id: impl Into<String>,
+        path: &Path,
+        records: &[AgentThreadRecord],
+    ) -> Vec<WorkspaceTabId> {
+        let repo_id = repo_id.into();
+        self.restore_agent_chat_tabs_for_key(
+            &WorktreeKey::new(repo_id, path.to_path_buf()),
+            records,
+        )
+    }
+
+    pub fn restore_agent_chat_tabs_for_worktrees(
+        &mut self,
+        worktrees: impl IntoIterator<Item = (String, PathBuf)>,
+        records: &[AgentThreadRecord],
+    ) -> Vec<WorkspaceTabId> {
+        let mut restored = Vec::new();
+        let mut restored_thread_ids = HashSet::new();
+        for (repo_id, path) in worktrees {
+            let key = WorktreeKey::new(repo_id, path);
+            let matching_records = records
+                .iter()
+                .filter(|record| !restored_thread_ids.contains(&record.thread_id))
+                .cloned()
+                .collect::<Vec<_>>();
+            let restored_for_key = self.restore_agent_chat_tabs_for_key(&key, &matching_records);
+            for tab_id in &restored_for_key {
+                if let Some(thread_id) = self
+                    .tab(&key.repo_id, &key.path, *tab_id)
+                    .and_then(|tab| tab.agent_thread_state())
+                    .map(|state| state.thread_id.clone())
+                {
+                    restored_thread_ids.insert(thread_id);
+                }
+            }
+            restored.extend(restored_for_key);
+        }
+        restored
+    }
+
+    fn restore_agent_chat_tabs_for_key(
+        &mut self,
+        key: &WorktreeKey,
+        records: &[AgentThreadRecord],
+    ) -> Vec<WorkspaceTabId> {
+        let mut existing_thread_ids = self
+            .tabs
+            .get(key)
+            .into_iter()
+            .flat_map(|tabs| tabs.iter())
+            .filter_map(|tab| {
+                tab.agent_thread_state()
+                    .map(|state| state.thread_id.clone())
+            })
+            .collect::<HashSet<_>>();
+
+        let mut restored = Vec::new();
+        for record in records {
+            if record.state.worktree_path != key.path
+                || existing_thread_ids.contains(&record.thread_id)
+            {
+                continue;
+            }
+            existing_thread_ids.insert(record.thread_id.clone());
+            let mut state = record.state.clone();
+            state.thread_id = record.thread_id.clone();
+            if matches!(
+                state.status,
+                AgentThreadStatus::Running | AgentThreadStatus::Starting
+            ) {
+                state.status = AgentThreadStatus::ReadOnly {
+                    reason: "Waiting for agent session resume".to_string(),
+                };
+            }
+            if state.acp_session_id.is_some() && !matches!(state.resume, AgentResumeState::Resumed)
+            {
+                state.resume = AgentResumeState::Pending;
+            }
+            restored.push(self.create_agent_chat_tab_from_state(
+                key.repo_id.clone(),
+                key.path.clone(),
+                state,
+            ));
+        }
+        restored
+    }
+
+    pub fn agent_thread_records(&self) -> Vec<AgentThreadRecord> {
+        self.tabs
+            .values()
+            .flat_map(|tabs| tabs.iter())
+            .filter_map(|tab| tab.agent_thread_state())
+            .map(|state| AgentThreadRecord::from_state(state.thread_id.clone(), state))
+            .collect()
     }
 
     pub fn open_file_tab(
@@ -775,7 +937,9 @@ impl WorkspaceSession {
         match &mut tab.content {
             WorkspaceTabContent::File(state) => Ok(FileTabHandle::Text(state)),
             WorkspaceTabContent::Markdown(state) => Ok(FileTabHandle::Markdown(state)),
-            WorkspaceTabContent::Terminal(_) | WorkspaceTabContent::Image(_) => {
+            WorkspaceTabContent::Terminal(_)
+            | WorkspaceTabContent::Image(_)
+            | WorkspaceTabContent::AgentChat(_) => {
                 anyhow::bail!("workspace tab {:?} is not a file tab", tab_id)
             }
         }
@@ -799,7 +963,8 @@ impl WorkspaceSession {
             WorkspaceTabContent::Markdown(state) => Ok(state),
             WorkspaceTabContent::File(_)
             | WorkspaceTabContent::Terminal(_)
-            | WorkspaceTabContent::Image(_) => {
+            | WorkspaceTabContent::Image(_)
+            | WorkspaceTabContent::AgentChat(_) => {
                 anyhow::bail!("workspace tab {:?} is not a markdown tab", tab_id)
             }
         }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -10,6 +10,16 @@ pub struct AppConfig {
     pub archived_worktrees: IndexMap<String, Vec<PathBuf>>,
     #[serde(default)]
     pub notifications: NotificationPrefs,
+    #[serde(default)]
+    pub agent_providers: Vec<crate::agent::AgentProviderConfig>,
+    #[serde(default)]
+    pub agent_provider_discovery: AgentProviderDiscoveryConfig,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AgentProviderDiscoveryConfig {
+    #[serde(default)]
+    pub ignored_provider_ids: Vec<String>,
 }
 
 impl AppConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod app;
 pub mod config;
 pub mod git;

--- a/src/ui/agent_pane.rs
+++ b/src/ui/agent_pane.rs
@@ -1,0 +1,428 @@
+use std::sync::Arc;
+
+use crate::{
+    agent::{AgentThreadState, AgentThreadStatus, AgentTranscriptEntry, AgentTranscriptRole},
+    ui::theme::{DANGER, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
+};
+use gpui::{
+    AnyElement, App, InteractiveElement, IntoElement, ParentElement, SharedString,
+    StatefulInteractiveElement, Styled, Window, div, prelude::*, rgb,
+};
+
+type ClickHandler = Arc<dyn Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static>;
+type PermissionClickHandler =
+    Arc<dyn Fn(String, &gpui::ClickEvent, &mut Window, &mut App) + 'static>;
+type ConfigClickHandler = Arc<dyn Fn(String, &gpui::ClickEvent, &mut Window, &mut App) + 'static>;
+
+pub struct AgentPaneHandlers {
+    pub on_send: ClickHandler,
+    pub on_cancel: ClickHandler,
+    pub on_focus_composer: ClickHandler,
+    pub on_allow_permission: PermissionClickHandler,
+    pub on_deny_permission: PermissionClickHandler,
+    pub on_cycle_mode: ClickHandler,
+    pub on_cycle_config: ConfigClickHandler,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentComposerViewModel {
+    pub enabled: bool,
+    pub action_enabled: bool,
+    pub action_label: &'static str,
+    pub auth_action: bool,
+    pub display_text: String,
+    pub showing_placeholder: bool,
+    pub slash_commands: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentHeaderViewModel {
+    pub status_label: String,
+    pub provider_label: String,
+    pub mode_label: Option<String>,
+    pub mode_interactive: bool,
+    pub config_labels: Vec<AgentConfigLabelViewModel>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentConfigLabelViewModel {
+    pub id: String,
+    pub label: String,
+    pub interactive: bool,
+}
+
+pub fn agent_status_label(thread: &AgentThreadState) -> String {
+    match &thread.status {
+        AgentThreadStatus::Disconnected => "Disconnected".to_string(),
+        AgentThreadStatus::Starting => "Starting".to_string(),
+        AgentThreadStatus::AuthRequired => "Authentication required".to_string(),
+        AgentThreadStatus::Ready => "Ready".to_string(),
+        AgentThreadStatus::Running => "Running".to_string(),
+        AgentThreadStatus::Failed { message } => format!("Failed: {message}"),
+        AgentThreadStatus::ReadOnly { reason } => format!("Read-only: {reason}"),
+    }
+}
+
+pub fn agent_composer_view_model(thread: &AgentThreadState) -> AgentComposerViewModel {
+    let is_running = matches!(thread.status, AgentThreadStatus::Running);
+    let has_draft = !thread.draft.trim().is_empty();
+
+    AgentComposerViewModel {
+        enabled: matches!(thread.status, AgentThreadStatus::Ready),
+        action_enabled: is_running
+            || (matches!(thread.status, AgentThreadStatus::Ready) && has_draft),
+        action_label: match thread.status {
+            AgentThreadStatus::Running => "Cancel",
+            _ => "Send",
+        },
+        auth_action: matches!(thread.status, AgentThreadStatus::AuthRequired),
+        display_text: if thread.draft.is_empty() {
+            "Type a prompt for the agent…".to_string()
+        } else {
+            thread.draft.clone()
+        },
+        showing_placeholder: thread.draft.is_empty(),
+        slash_commands: thread
+            .available_commands
+            .iter()
+            .map(|command| format!("/{}", command.name))
+            .collect(),
+    }
+}
+
+pub fn agent_header_view_model(thread: &AgentThreadState) -> AgentHeaderViewModel {
+    let current_mode_name = thread.current_mode.as_ref().and_then(|current| {
+        thread
+            .available_modes
+            .iter()
+            .find(|mode| &mode.id == current)
+            .map(|mode| mode.name.clone())
+            .or_else(|| Some(current.clone()))
+    });
+
+    AgentHeaderViewModel {
+        status_label: agent_status_label(thread),
+        provider_label: format!("Provider: {}", thread.provider_id),
+        mode_label: current_mode_name.map(|mode| {
+            if thread.available_modes.len() > 1 {
+                format!("Mode: {mode} ▾")
+            } else {
+                format!("Mode: {mode}")
+            }
+        }),
+        mode_interactive: thread.available_modes.len() > 1,
+        config_labels: thread
+            .config_options
+            .iter()
+            .map(|option| {
+                let value_label = option.value.as_ref().and_then(|value| {
+                    option
+                        .options
+                        .iter()
+                        .find(|candidate| &candidate.id == value)
+                        .map(|candidate| candidate.label.clone())
+                        .or_else(|| Some(value.clone()))
+                });
+                let mut label = match value_label {
+                    Some(value) if !value.is_empty() => format!("{}: {value}", option.label),
+                    _ => option.label.clone(),
+                };
+                let interactive = option.options.len() > 1;
+                if interactive {
+                    label.push_str(" ▾");
+                }
+                AgentConfigLabelViewModel {
+                    id: option.id.clone(),
+                    label,
+                    interactive,
+                }
+            })
+            .collect(),
+    }
+}
+
+pub fn render_agent_pane(
+    thread: &AgentThreadState,
+    handlers: AgentPaneHandlers,
+) -> impl IntoElement {
+    div()
+        .id("agent-pane")
+        .flex()
+        .flex_col()
+        .flex_1()
+        .size_full()
+        .bg(PANEL_BG)
+        .text_color(TEXT)
+        .child(render_header(
+            thread,
+            handlers.on_cycle_mode,
+            handlers.on_cycle_config,
+        ))
+        .child(render_permissions(
+            thread,
+            handlers.on_allow_permission,
+            handlers.on_deny_permission,
+        ))
+        .child(render_transcript(thread))
+        .child(render_composer(
+            thread,
+            handlers.on_send,
+            handlers.on_cancel,
+            handlers.on_focus_composer,
+        ))
+}
+
+fn render_header(
+    thread: &AgentThreadState,
+    on_cycle_mode: ClickHandler,
+    on_cycle_config: ConfigClickHandler,
+) -> impl IntoElement {
+    let vm = agent_header_view_model(thread);
+    div()
+        .flex()
+        .items_center()
+        .justify_between()
+        .px_3()
+        .py_2()
+        .border_b_1()
+        .border_color(PANEL_BORDER)
+        .child(
+            div()
+                .text_sm()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .child(SharedString::from(thread.title.clone())),
+        )
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap_2()
+                .text_xs()
+                .text_color(TEXT_MUTED)
+                .child(vm.status_label)
+                .child(vm.provider_label)
+                .children(vm.mode_label.map(|label| {
+                    if vm.mode_interactive {
+                        div()
+                            .id("agent-mode-selector")
+                            .cursor_pointer()
+                            .on_click(move |event, window, cx| {
+                                on_cycle_mode(event, window, cx);
+                            })
+                            .child(label)
+                            .into_any_element()
+                    } else {
+                        div().child(label).into_any_element()
+                    }
+                }))
+                .children(vm.config_labels.into_iter().map(|config| {
+                    if config.interactive {
+                        let handler = Arc::clone(&on_cycle_config);
+                        let config_id = config.id.clone();
+                        div()
+                            .id(SharedString::from(format!(
+                                "agent-config-selector-{}",
+                                config.id
+                            )))
+                            .cursor_pointer()
+                            .on_click(move |event, window, cx| {
+                                handler(config_id.clone(), event, window, cx);
+                            })
+                            .child(config.label)
+                            .into_any_element()
+                    } else {
+                        div().child(config.label).into_any_element()
+                    }
+                })),
+        )
+}
+
+fn render_permissions(
+    thread: &AgentThreadState,
+    on_allow_permission: PermissionClickHandler,
+    on_deny_permission: PermissionClickHandler,
+) -> impl IntoElement {
+    div()
+        .id("agent-permissions")
+        .flex()
+        .flex_col()
+        .gap_2()
+        .px_3()
+        .py_2()
+        .children(thread.pending_permissions.iter().map(|request| {
+            let allow_id = request.id.clone();
+            let deny_id = request.id.clone();
+            let on_allow_permission = Arc::clone(&on_allow_permission);
+            let on_deny_permission = Arc::clone(&on_deny_permission);
+            div()
+                .border_1()
+                .border_color(PANEL_BORDER)
+                .rounded_md()
+                .p_2()
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap_2()
+                .child(
+                    div()
+                        .text_sm()
+                        .child(SharedString::from(request.description.clone())),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .gap_2()
+                        .child(
+                            div()
+                                .id(SharedString::from(format!("allow-{allow_id}")))
+                                .px_2()
+                                .py_1()
+                                .rounded_md()
+                                .text_sm()
+                                .bg(rgb(0x2563eb))
+                                .text_color(rgb(0xffffff))
+                                .child("Allow")
+                                .on_click(move |event, window, app| {
+                                    on_allow_permission(allow_id.clone(), event, window, app)
+                                }),
+                        )
+                        .child(
+                            div()
+                                .id(SharedString::from(format!("deny-{deny_id}")))
+                                .px_2()
+                                .py_1()
+                                .rounded_md()
+                                .text_sm()
+                                .bg(rgb(0xe5e7eb))
+                                .text_color(rgb(0x111827))
+                                .child("Deny")
+                                .on_click(move |event, window, app| {
+                                    on_deny_permission(deny_id.clone(), event, window, app)
+                                }),
+                        ),
+                )
+        }))
+}
+
+fn render_transcript(thread: &AgentThreadState) -> impl IntoElement {
+    div()
+        .id("agent-transcript")
+        .flex()
+        .flex_col()
+        .flex_1()
+        .min_h(gpui::px(0.0))
+        .overflow_scroll()
+        .p_3()
+        .gap_3()
+        .children(thread.transcript.iter().map(render_transcript_entry))
+}
+
+fn render_transcript_entry(entry: &AgentTranscriptEntry) -> AnyElement {
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .child(
+            div()
+                .text_xs()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(TEXT_MUTED)
+                .child(role_label(&entry.role)),
+        )
+        .child(
+            div()
+                .text_sm()
+                .line_height(gpui::px(21.0))
+                .child(SharedString::from(entry.text.clone())),
+        )
+        .into_any_element()
+}
+
+fn render_composer(
+    thread: &AgentThreadState,
+    on_send: ClickHandler,
+    on_cancel: ClickHandler,
+    on_focus_composer: ClickHandler,
+) -> impl IntoElement {
+    let vm = agent_composer_view_model(thread);
+    let action = if vm.action_label == "Cancel" {
+        on_cancel
+    } else {
+        on_send
+    };
+    div()
+        .id("agent-composer")
+        .border_t_1()
+        .border_color(PANEL_BORDER)
+        .px_3()
+        .py_2()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .on_click(move |event, window, app| on_focus_composer(event, window, app))
+        .child(match &thread.status {
+            AgentThreadStatus::ReadOnly { reason } => div()
+                .text_sm()
+                .text_color(DANGER)
+                .child(format!("Read-only: {reason}"))
+                .into_any_element(),
+            AgentThreadStatus::AuthRequired => div()
+                .text_sm()
+                .text_color(DANGER)
+                .child("Authentication required")
+                .into_any_element(),
+            _ => div()
+                .text_sm()
+                .text_color(if vm.showing_placeholder {
+                    TEXT_MUTED
+                } else {
+                    TEXT
+                })
+                .child(vm.display_text.clone())
+                .into_any_element(),
+        })
+        .when(!vm.slash_commands.is_empty(), |element| {
+            element.child(
+                div()
+                    .id("agent-slash-commands")
+                    .flex()
+                    .gap_2()
+                    .text_xs()
+                    .text_color(TEXT_MUTED)
+                    .children(vm.slash_commands),
+            )
+        })
+        .child(
+            div()
+                .id("agent-composer-action")
+                .px_3()
+                .py_2()
+                .rounded_md()
+                .text_sm()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .text_color(if vm.action_enabled {
+                    rgb(0xffffff)
+                } else {
+                    TEXT_MUTED
+                })
+                .bg(if vm.action_enabled {
+                    rgb(0x2563eb)
+                } else {
+                    rgb(0xe5e7eb)
+                })
+                .child(vm.action_label)
+                .when(vm.action_enabled, |element| {
+                    element.on_click(move |event, window, app| action(event, window, app))
+                }),
+        )
+}
+
+fn role_label(role: &AgentTranscriptRole) -> &'static str {
+    match role {
+        AgentTranscriptRole::User => "You",
+        AgentTranscriptRole::Agent => "Agent",
+        AgentTranscriptRole::Thought => "Thought",
+        AgentTranscriptRole::System => "System",
+        AgentTranscriptRole::Tool => "Tool",
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_pane;
 pub mod chrome;
 pub mod command_picker;
 pub mod dialogs;
@@ -7,6 +8,7 @@ pub mod inspector;
 pub mod lifecycle;
 pub mod markdown_pane;
 pub mod markdown_preview;
+pub mod provider_settings;
 pub mod shell;
 pub mod sidebar;
 pub mod source_viewer;

--- a/src/ui/provider_settings.rs
+++ b/src/ui/provider_settings.rs
@@ -1,0 +1,581 @@
+use std::sync::Arc;
+
+use crate::{
+    agent::{
+        AgentAuthField, AgentProviderConfig, AgentProviderEnvVar, AgentTrustMode,
+        ProviderSettingsState,
+    },
+    ui::theme::{DANGER, PANEL_BORDER, TEXT, TEXT_MUTED, sidebar_background},
+};
+
+use gpui::{
+    App, FontWeight, InteractiveElement, IntoElement, ParentElement, SharedString,
+    StatefulInteractiveElement, Styled, Window, div, prelude::FluentBuilder, px, rgb,
+};
+
+type ClickHandler = Arc<dyn Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static>;
+type ProviderClickHandler = Arc<dyn Fn(String, &gpui::ClickEvent, &mut Window, &mut App) + 'static>;
+type ProviderFieldHandler =
+    Arc<dyn Fn(ProviderSettingsField, &gpui::ClickEvent, &mut Window, &mut App) + 'static>;
+type ProviderToggleHandler =
+    Arc<dyn Fn(String, &gpui::ClickEvent, &mut Window, &mut App) + 'static>;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ProviderSettingsField {
+    DisplayName(String),
+    Command(String),
+    Args(String),
+    EnvKey(String),
+    EnvValue(String),
+    AuthEnvValue {
+        provider_id: String,
+        env_name: String,
+    },
+}
+
+pub struct ProviderSettingsHandlers {
+    pub on_close: ClickHandler,
+    pub on_add_provider: ClickHandler,
+    pub on_save: ClickHandler,
+    pub on_cancel: ClickHandler,
+    pub on_select_field: ProviderFieldHandler,
+    pub on_toggle_enabled: ProviderToggleHandler,
+    pub on_cycle_trust_mode: ProviderToggleHandler,
+    pub on_remove_provider: ProviderClickHandler,
+    pub on_authenticate: ProviderClickHandler,
+    pub on_run_terminal_auth: ProviderClickHandler,
+    pub on_clear_credentials: ProviderClickHandler,
+    pub on_view_auth_instructions: ProviderClickHandler,
+}
+
+pub fn render_provider_settings(
+    state: &ProviderSettingsState,
+    active_field: Option<&ProviderSettingsField>,
+    handlers: ProviderSettingsHandlers,
+) -> impl IntoElement {
+    div()
+        .id("provider-settings")
+        .flex()
+        .flex_col()
+        .size_full()
+        .w(px(360.0))
+        .px_4()
+        .py_3()
+        .gap_3()
+        .border_l_1()
+        .border_color(PANEL_BORDER)
+        .bg(sidebar_background())
+        .text_color(TEXT)
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .child(
+                    div()
+                        .text_lg()
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .child("Provider Settings"),
+                )
+                .child(
+                    div()
+                        .id("close-provider-settings")
+                        .text_sm()
+                        .text_color(TEXT_MUTED)
+                        .child("Close")
+                        .on_click({
+                            let handler = Arc::clone(&handlers.on_close);
+                            move |event, window, app| handler(event, window, app)
+                        }),
+                ),
+        )
+        .when_some(state.error.as_ref(), |this, error| {
+            this.child(
+                div()
+                    .text_sm()
+                    .text_color(DANGER)
+                    .child(SharedString::from(error.clone())),
+            )
+        })
+        .child(render_provider_rows(state, active_field, &handlers))
+        .when(!state.discovery_suggestions.is_empty(), |this| {
+            this.child(render_discovery_suggestions(state))
+        })
+        .child(
+            div()
+                .flex()
+                .gap_2()
+                .child(button(
+                    "add-provider",
+                    "Add Provider",
+                    handlers.on_add_provider,
+                ))
+                .child(primary_button(
+                    "save-provider-settings",
+                    "Save",
+                    handlers.on_save,
+                ))
+                .child(button(
+                    "cancel-provider-settings",
+                    "Cancel",
+                    handlers.on_cancel,
+                )),
+        )
+}
+
+fn render_provider_rows(
+    state: &ProviderSettingsState,
+    active_field: Option<&ProviderSettingsField>,
+    handlers: &ProviderSettingsHandlers,
+) -> impl IntoElement {
+    if state.providers.is_empty() {
+        return div()
+            .text_sm()
+            .text_color(TEXT_MUTED)
+            .child("No providers configured.");
+    }
+
+    div().flex().flex_col().gap_3().children(
+        state
+            .providers
+            .iter()
+            .map(|provider| render_provider_card(state, provider, active_field, handlers))
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn render_discovery_suggestions(state: &ProviderSettingsState) -> impl IntoElement {
+    div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(
+            div()
+                .text_sm()
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(TEXT)
+                .child("Discovered tools"),
+        )
+        .children(state.discovery_suggestions.iter().map(|suggestion| {
+            div()
+                .id(SharedString::from(format!(
+                    "provider-discovery-suggestion-{}",
+                    suggestion.id
+                )))
+                .flex()
+                .flex_col()
+                .gap_1()
+                .p_3()
+                .rounded_md()
+                .border_1()
+                .border_color(PANEL_BORDER)
+                .child(
+                    div()
+                        .text_sm()
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(TEXT)
+                        .child(SharedString::from(format!(
+                            "{} found",
+                            suggestion.display_name
+                        ))),
+                )
+                .child(
+                    div()
+                        .text_sm()
+                        .text_color(TEXT_MUTED)
+                        .child(SharedString::from(suggestion.message.clone())),
+                )
+                .child(
+                    div()
+                        .text_xs()
+                        .text_color(TEXT_MUTED)
+                        .child(SharedString::from(format!(
+                            "Command: {}",
+                            suggestion.command
+                        ))),
+                )
+        }))
+}
+
+fn render_provider_card(
+    state: &ProviderSettingsState,
+    provider: &AgentProviderConfig,
+    active_field: Option<&ProviderSettingsField>,
+    handlers: &ProviderSettingsHandlers,
+) -> impl IntoElement {
+    let provider_id = provider.id.clone();
+    let (plain_env_key, plain_env_value) = first_plain_env(provider);
+    div()
+        .id(SharedString::from(format!("provider-row-{}", provider.id)))
+        .flex()
+        .flex_col()
+        .gap_2()
+        .p_3()
+        .rounded_md()
+        .border_1()
+        .border_color(PANEL_BORDER)
+        .child(editable_field(
+            format!("provider-display-name-{}", provider.id),
+            "Display name",
+            &provider.display_name,
+            ProviderSettingsField::DisplayName(provider.id.clone()),
+            active_field,
+            &handlers.on_select_field,
+        ))
+        .child(editable_field(
+            format!("provider-command-{}", provider.id),
+            "Command",
+            &provider.command,
+            ProviderSettingsField::Command(provider.id.clone()),
+            active_field,
+            &handlers.on_select_field,
+        ))
+        .child(editable_field(
+            format!("provider-args-{}", provider.id),
+            "Args (JSON array)",
+            &serde_json::to_string(&provider.args).unwrap_or_else(|_| "[]".to_string()),
+            ProviderSettingsField::Args(provider.id.clone()),
+            active_field,
+            &handlers.on_select_field,
+        ))
+        .child(
+            div()
+                .flex()
+                .gap_2()
+                .child(editable_field(
+                    format!("provider-env-key-{}", provider.id),
+                    "Plain env key",
+                    &plain_env_key,
+                    ProviderSettingsField::EnvKey(provider.id.clone()),
+                    active_field,
+                    &handlers.on_select_field,
+                ))
+                .child(editable_field(
+                    format!("provider-env-value-{}", provider.id),
+                    "Plain env value",
+                    &plain_env_value,
+                    ProviderSettingsField::EnvValue(provider.id.clone()),
+                    active_field,
+                    &handlers.on_select_field,
+                )),
+        )
+        .child(field("Secure env refs", &secure_env_summary(&provider.env)))
+        .child(render_auth_env_fields(
+            state,
+            provider,
+            active_field,
+            handlers,
+        ))
+        .child(toggle_row(
+            format!("provider-enabled-{}", provider.id),
+            "Enabled",
+            if provider.enabled { "Yes" } else { "No" },
+            provider_id.clone(),
+            &handlers.on_toggle_enabled,
+        ))
+        .child(toggle_row(
+            format!("provider-trust-mode-{}", provider.id),
+            "Trust mode",
+            trust_mode_label(&provider.trust_mode),
+            provider_id.clone(),
+            &handlers.on_cycle_trust_mode,
+        ))
+        .child(field("Auth status", &state.auth_status_label(&provider.id)))
+        .child(
+            div()
+                .flex()
+                .flex_wrap()
+                .gap_2()
+                .child(provider_button(
+                    format!("remove-provider-{}", provider.id),
+                    "Remove",
+                    provider_id.clone(),
+                    &handlers.on_remove_provider,
+                ))
+                .child(provider_button(
+                    format!("authenticate-provider-{}", provider.id),
+                    "Authenticate",
+                    provider_id.clone(),
+                    &handlers.on_authenticate,
+                ))
+                .child(provider_button(
+                    format!("terminal-auth-provider-{}", provider.id),
+                    "Terminal Auth",
+                    provider_id.clone(),
+                    &handlers.on_run_terminal_auth,
+                ))
+                .child(provider_button(
+                    format!("clear-credentials-provider-{}", provider.id),
+                    "Clear Credentials",
+                    provider_id.clone(),
+                    &handlers.on_clear_credentials,
+                ))
+                .child(provider_button(
+                    format!("auth-instructions-provider-{}", provider.id),
+                    "Auth Instructions",
+                    provider_id,
+                    &handlers.on_view_auth_instructions,
+                )),
+        )
+}
+
+pub fn auth_env_field_render_value(
+    state: &ProviderSettingsState,
+    provider_id: &str,
+    field: &AgentAuthField,
+    _active: bool,
+) -> String {
+    state.auth_env_display_value(provider_id, field)
+}
+
+fn render_auth_env_fields(
+    state: &ProviderSettingsState,
+    provider: &AgentProviderConfig,
+    active_field: Option<&ProviderSettingsField>,
+    handlers: &ProviderSettingsHandlers,
+) -> impl IntoElement {
+    let fields = state.env_auth_fields(&provider.id);
+    if fields.is_empty() {
+        return div().flex().flex_col().gap_1();
+    }
+    div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(
+            div()
+                .text_xs()
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(TEXT_MUTED)
+                .child("Authentication env fields"),
+        )
+        .children(fields.into_iter().map(|field| {
+            let label = format!(
+                "{} ({}){}{}",
+                field.label,
+                field.env_name,
+                if field.optional { " optional" } else { "" },
+                if field.secret { " secret" } else { "" }
+            );
+            let field_id = ProviderSettingsField::AuthEnvValue {
+                provider_id: provider.id.clone(),
+                env_name: field.env_name.clone(),
+            };
+            let value = auth_env_field_render_value(
+                state,
+                &provider.id,
+                &field,
+                active_field == Some(&field_id),
+            );
+            editable_field(
+                format!("provider-auth-env-{}-{}", provider.id, field.env_name),
+                SharedString::from(label),
+                value,
+                field_id,
+                active_field,
+                &handlers.on_select_field,
+            )
+        }))
+}
+
+fn editable_field(
+    id: String,
+    label: impl Into<SharedString>,
+    value: impl Into<SharedString>,
+    field: ProviderSettingsField,
+    active_field: Option<&ProviderSettingsField>,
+    on_select_field: &ProviderFieldHandler,
+) -> impl IntoElement {
+    let is_active = active_field == Some(&field);
+    let label = label.into();
+    let value = value.into();
+    let handler = Arc::clone(on_select_field);
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .child(
+            div()
+                .text_xs()
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(TEXT_MUTED)
+                .child(label),
+        )
+        .child(
+            div()
+                .id(SharedString::from(id))
+                .px_2()
+                .py_1()
+                .min_h(px(28.0))
+                .rounded_md()
+                .border_1()
+                .border_color(if is_active {
+                    rgb(0x2563eb)
+                } else {
+                    PANEL_BORDER
+                })
+                .bg(rgb(0xffffff))
+                .text_sm()
+                .child(if value.is_empty() {
+                    SharedString::from(" ")
+                } else {
+                    value.clone()
+                })
+                .on_click(move |event, window, app| {
+                    handler(field.clone(), event, window, app);
+                }),
+        )
+}
+
+fn toggle_row(
+    id: String,
+    label: &'static str,
+    value: &'static str,
+    provider_id: String,
+    on_click: &ProviderToggleHandler,
+) -> impl IntoElement {
+    let handler = Arc::clone(on_click);
+    div()
+        .flex()
+        .items_center()
+        .justify_between()
+        .child(
+            div()
+                .text_xs()
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(TEXT_MUTED)
+                .child(label),
+        )
+        .child(
+            div()
+                .id(SharedString::from(id))
+                .px_2()
+                .py_1()
+                .rounded_md()
+                .border_1()
+                .border_color(PANEL_BORDER)
+                .text_sm()
+                .child(value)
+                .on_click(move |event, window, app| {
+                    handler(provider_id.clone(), event, window, app);
+                }),
+        )
+}
+
+fn field(label: &'static str, value: &str) -> impl IntoElement {
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .child(
+            div()
+                .text_xs()
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(TEXT_MUTED)
+                .child(label),
+        )
+        .child(div().text_sm().child(SharedString::from(value.to_string())))
+}
+
+fn first_plain_env(provider: &AgentProviderConfig) -> (String, String) {
+    provider
+        .env
+        .iter()
+        .find(|entry| entry.secure_ref.is_none())
+        .map(|entry| {
+            (
+                entry.name.clone(),
+                entry.value.clone().unwrap_or_else(String::new),
+            )
+        })
+        .unwrap_or_else(|| (String::new(), String::new()))
+}
+
+fn secure_env_summary(env: &[AgentProviderEnvVar]) -> String {
+    let refs = env
+        .iter()
+        .filter_map(|entry| {
+            entry
+                .secure_ref
+                .as_ref()
+                .map(|secure_ref| format!("{}=<secure:{}>", entry.name, secure_ref))
+        })
+        .collect::<Vec<_>>();
+    if refs.is_empty() {
+        "None".to_string()
+    } else {
+        refs.join(", ")
+    }
+}
+
+fn trust_mode_label(trust_mode: &AgentTrustMode) -> &'static str {
+    match trust_mode {
+        AgentTrustMode::AllowEverything => "Allow everything",
+        AgentTrustMode::Ask => "Ask",
+        AgentTrustMode::WorktreeOnly => "Worktree only",
+        AgentTrustMode::Deny => "Deny",
+    }
+}
+
+fn button(id: &'static str, label: &'static str, on_click: ClickHandler) -> impl IntoElement {
+    div()
+        .id(id)
+        .px_3()
+        .py_2()
+        .rounded_md()
+        .text_sm()
+        .font_weight(FontWeight::SEMIBOLD)
+        .text_color(rgb(0x374151))
+        .bg(rgb(0xe5e7eb))
+        .child(label)
+        .on_click({
+            let handler = Arc::clone(&on_click);
+            move |event, window, app| handler(event, window, app)
+        })
+}
+
+fn primary_button(
+    id: &'static str,
+    label: &'static str,
+    on_click: ClickHandler,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .px_3()
+        .py_2()
+        .rounded_md()
+        .text_sm()
+        .font_weight(FontWeight::SEMIBOLD)
+        .text_color(rgb(0xffffff))
+        .bg(rgb(0x2563eb))
+        .child(label)
+        .on_click({
+            let handler = Arc::clone(&on_click);
+            move |event, window, app| handler(event, window, app)
+        })
+}
+
+fn provider_button(
+    id: String,
+    label: &'static str,
+    provider_id: String,
+    on_click: &ProviderClickHandler,
+) -> impl IntoElement {
+    let on_click = {
+        let provider_id = provider_id.clone();
+        let handler = Arc::clone(on_click);
+        move |event: &gpui::ClickEvent, window: &mut Window, app: &mut App| {
+            handler(provider_id.clone(), event, window, app);
+        }
+    };
+    div()
+        .id(SharedString::from(id))
+        .px_2()
+        .py_1()
+        .rounded_md()
+        .text_xs()
+        .text_color(TEXT_MUTED)
+        .bg(rgb(0xf3f4f6))
+        .child(label)
+        .on_click(on_click)
+}

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -3,7 +3,17 @@ use std::{
     time::Duration,
 };
 
+use directories::ProjectDirs;
+
 use crate::{
+    agent::{
+        AcpCancelHandle, AcpProcessConnection, AgentDebugEvent, AgentProviderConfig,
+        AgentProviderSuggestion, AgentRuntime, AgentThreadRecord, AgentThreadState,
+        AgentThreadStatus, AgentThreadStore, AgentTranscriptEntry, AgentTrustMode,
+        OsCredentialStore, ProviderSettingsState, apply_provider_discovery_to_config,
+        discover_agent_providers, filter_agent_thread_records, merge_agent_thread_records,
+        remove_provider_and_record_discovery_ignore, resolve_provider_cwd,
+    },
     app::{
         ActionId, AlasModel, FileLoader, FileTabLoadState, HighlightError, ImageZoom,
         InspectorPaneState, MarkdownViewMode, RepositoryNode, TerminalTabKind, TerminalTabStatus,
@@ -27,6 +37,7 @@ use crate::{
         },
     },
     ui::{
+        agent_pane::{AgentPaneHandlers, render_agent_pane},
         chrome::{alas_window_options, apply_window_background_appearance},
         command_picker::render_command_picker,
         dialogs::{
@@ -37,6 +48,9 @@ use crate::{
         image_view::render_image_view,
         inspector::render_project_inspector,
         markdown_pane::render_markdown_pane,
+        provider_settings::{
+            ProviderSettingsField, ProviderSettingsHandlers, render_provider_settings,
+        },
         sidebar::{SidebarMenuState, render_sidebar},
         source_viewer::render_source_viewer,
         terminal_canvas::measure_terminal_metrics,
@@ -46,17 +60,27 @@ use crate::{
         },
         theme::{DANGER, PANEL_BG, PANEL_BORDER, SUCCESS, TEXT, TEXT_MUTED, root_background},
         view_models::TreeExpansionState,
-        workspace::render_workspace,
+        workspace::{
+            AgentChatProviderFlow, NewWorkspaceTabChoice, agent_chat_provider_flow,
+            new_workspace_tab_choice_label, new_workspace_tab_choices, render_workspace,
+        },
     },
 };
 use gpui::{
     App, Application, Bounds, ClipboardItem, Context, FocusHandle, IntoElement, KeyDownEvent,
     MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PathPromptOptions, Pixels,
-    PromptLevel, Render, ScrollDelta, ScrollWheelEvent, SharedString, Window, div, prelude::*, px,
-    rgb,
+    PromptLevel, Render, ScrollDelta, ScrollWheelEvent, SharedString, Task, Window, div,
+    prelude::*, px, rgb,
 };
 use indexmap::IndexMap;
-use std::borrow::BorrowMut;
+use std::{
+    borrow::BorrowMut,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum CommandSettingsField {
@@ -76,6 +100,33 @@ const INSPECTOR_FILE_TREE_MAX_DEPTH: usize = 3;
 
 fn terminal_refresh_interval() -> Duration {
     Duration::from_millis(16)
+}
+
+fn agent_thread_persist_debounce_interval() -> Duration {
+    Duration::from_millis(400)
+}
+
+fn provider_plain_env(
+    settings: &ProviderSettingsState,
+    provider_id: &str,
+) -> Option<(String, String)> {
+    let provider = settings
+        .providers
+        .iter()
+        .find(|provider| provider.id == provider_id)?;
+    Some(
+        provider
+            .env
+            .iter()
+            .find(|entry| entry.secure_ref.is_none())
+            .map(|entry| {
+                (
+                    entry.name.clone(),
+                    entry.value.clone().unwrap_or_else(String::new),
+                )
+            })
+            .unwrap_or_else(|| (String::new(), String::new())),
+    )
 }
 
 fn terminal_should_intercept_key(terminal_focused: bool) -> bool {
@@ -115,6 +166,13 @@ pub struct AlasShell {
     notification_preferences_dialog: Option<NotificationPreferencesDialogState>,
     notification_controller: NotificationController<NotificationService>,
     command_picker: Option<CommandPickerState>,
+    new_tab_picker_open: bool,
+    agent_provider_picker: Option<Vec<AgentProviderConfig>>,
+    provider_discovery_suggestions: Vec<AgentProviderSuggestion>,
+    provider_discovery_error: Option<String>,
+    provider_settings: Option<ProviderSettingsState>,
+    provider_settings_focus: FocusHandle,
+    provider_settings_active_field: Option<ProviderSettingsField>,
     sidebar_menu: Option<SidebarMenuState>,
     confirm_remove_repository_dialog: Option<ConfirmRemoveRepositoryDialog>,
     confirm_remove_worktree_dialog: Option<ConfirmRemoveWorktreeDialog>,
@@ -131,17 +189,42 @@ pub struct AlasShell {
     terminal_body_size_px: Option<(f32, f32)>,
     terminal_body_bounds: Option<Bounds<Pixels>>,
     terminal_scroll_offset_rows: usize,
+    agent_composer_focus: FocusHandle,
+    active_agent_composer_tab: Option<WorkspaceTabId>,
     inspector_state: InspectorPaneState,
     inspector_request_generation: u64,
     file_tree_expansion: TreeExpansionState,
+    agent_runtimes: HashMap<WorkspaceTabId, AgentRuntime<AcpProcessConnection>>,
+    agent_cancel_handles: HashMap<WorkspaceTabId, AcpCancelHandle>,
+    agent_thread_store: AgentThreadStore,
+    agent_thread_records_cache: BTreeMap<String, AgentThreadRecord>,
+    agent_thread_records_loaded: bool,
+    pending_agent_thread_exclusions: BTreeSet<String>,
+    pending_removed_agent_worktrees: BTreeSet<PathBuf>,
+    pending_removed_agent_repos: BTreeSet<PathBuf>,
+    agent_thread_persist_generation: Arc<AtomicU64>,
+    agent_thread_persist_lock: Arc<Mutex<()>>,
 }
 
 impl AlasShell {
     fn new(cx: &mut Context<Self>) -> Self {
         let app_config_store =
             AppConfigStore::default_store().expect("failed to resolve app config store");
-        let config = app_config_store.load().unwrap_or_default();
+        let mut config = app_config_store.load().unwrap_or_default();
         let notification_preferences = config.notifications.clone();
+        let provider_discovery = discover_agent_providers();
+        let provider_discovery_startup =
+            apply_provider_discovery_to_config(&mut config, &provider_discovery, |config| {
+                app_config_store.save(config)
+            });
+
+        let agent_thread_store = AgentThreadStore::new(
+            ProjectDirs::from("dev", "alas", "Alas")
+                .expect("failed to resolve app data directory")
+                .data_dir()
+                .join("agent_threads.json"),
+        );
+        let agent_thread_records_cache = BTreeMap::new();
 
         let mut shell = Self {
             model: AlasModel::default(),
@@ -159,6 +242,13 @@ impl AlasShell {
                 notification_preferences,
             ),
             command_picker: None,
+            new_tab_picker_open: false,
+            agent_provider_picker: None,
+            provider_discovery_suggestions: provider_discovery_startup.suggestions,
+            provider_discovery_error: provider_discovery_startup.error,
+            provider_settings: None,
+            provider_settings_focus: cx.focus_handle(),
+            provider_settings_active_field: None,
             sidebar_menu: None,
             confirm_remove_repository_dialog: None,
             confirm_remove_worktree_dialog: None,
@@ -175,14 +265,70 @@ impl AlasShell {
             terminal_body_size_px: None,
             terminal_body_bounds: None,
             terminal_scroll_offset_rows: 0,
+            agent_composer_focus: cx.focus_handle(),
+            active_agent_composer_tab: None,
             inspector_state: InspectorPaneState::default(),
             inspector_request_generation: 0,
             file_tree_expansion: TreeExpansionState::default(),
+            agent_runtimes: HashMap::new(),
+            agent_cancel_handles: HashMap::new(),
+            agent_thread_store,
+            agent_thread_records_cache,
+            agent_thread_records_loaded: false,
+            pending_agent_thread_exclusions: BTreeSet::new(),
+            pending_removed_agent_worktrees: BTreeSet::new(),
+            pending_removed_agent_repos: BTreeSet::new(),
+            agent_thread_persist_generation: Arc::new(AtomicU64::new(0)),
+            agent_thread_persist_lock: Arc::new(Mutex::new(())),
         };
-        shell.refresh_repositories();
+        shell.start_agent_thread_record_load(cx);
+        shell.refresh_repositories_and_restore_agent_threads(cx);
         shell.start_terminal_refresh(cx);
         shell.register_app_quit_cleanup(cx);
         shell
+    }
+
+    fn start_agent_thread_record_load(&self, cx: &mut Context<Self>) {
+        let store = self.agent_thread_store.clone();
+        let task = cx
+            .background_executor()
+            .spawn(async move { store.load_records() });
+
+        cx.spawn(async move |this, cx| {
+            let result = task.await;
+            this.update(cx, |shell, cx| {
+                let loaded_records = match result {
+                    Ok(records) => records,
+                    Err(error) => {
+                        eprintln!("failed to load agent threads: {error:#}");
+                        Vec::new()
+                    }
+                };
+                let loaded_records = filter_agent_thread_records(
+                    loaded_records,
+                    shell.pending_agent_thread_exclusions.iter().cloned(),
+                    shell.pending_removed_agent_worktrees.iter().cloned(),
+                    shell.pending_removed_agent_repos.iter().cloned(),
+                );
+                let records = merge_agent_thread_records(
+                    loaded_records,
+                    shell.workspace_session.agent_thread_records(),
+                    Vec::<String>::new(),
+                );
+                shell.agent_thread_records_cache = records
+                    .iter()
+                    .cloned()
+                    .map(|record| (record.thread_id.clone(), record))
+                    .collect();
+                shell.agent_thread_records_loaded = true;
+                shell.pending_agent_thread_exclusions.clear();
+                shell.pending_removed_agent_worktrees.clear();
+                shell.pending_removed_agent_repos.clear();
+                shell.restore_agent_threads_for_known_worktrees(cx);
+            })
+            .ok();
+        })
+        .detach();
     }
 
     fn start_terminal_refresh(&self, cx: &mut Context<Self>) {
@@ -646,7 +792,7 @@ impl AlasShell {
                 if let Some(path) = paths.into_iter().next() {
                     this.update(cx, |shell, cx| {
                         shell.set_add_repository_path(path);
-                        shell.add_repository_from_dialog();
+                        shell.add_repository_from_dialog(cx);
                         cx.notify();
                     })
                     .ok();
@@ -687,7 +833,7 @@ impl AlasShell {
         dialog.error = None;
     }
 
-    fn add_repository_from_dialog(&mut self) {
+    fn add_repository_from_dialog(&mut self, cx: &mut Context<Self>) {
         let Some(path) = self
             .add_repository_dialog
             .as_ref()
@@ -727,7 +873,7 @@ impl AlasShell {
 
         self.config = next_config;
         self.add_repository_dialog = None;
-        self.refresh_repositories();
+        self.refresh_repositories_and_restore_agent_threads(cx);
     }
 
     fn set_add_repository_error(&mut self, error: impl Into<String>) {
@@ -1105,7 +1251,7 @@ impl AlasShell {
             return;
         }
 
-        self.refresh_repositories();
+        self.refresh_repositories_and_restore_agent_threads(cx);
         self.create_worktree_dialog = None;
         self.select_worktree(dialog.repo_id.clone(), target_path, cx);
     }
@@ -1138,7 +1284,8 @@ impl AlasShell {
             path.clone(),
             default_command,
         );
-        self.start_or_reuse_terminal_tab(repo_id, path, tab_id);
+        self.start_or_reuse_terminal_tab(repo_id.clone(), path.clone(), tab_id);
+        self.restore_agent_threads_for_selected_worktree(cx);
     }
 
     fn select_workspace_tab(&mut self, tab_id: WorkspaceTabId) {
@@ -1164,6 +1311,7 @@ impl AlasShell {
         } else {
             self.active_terminal_tab = Some(tab_id);
             self.active_terminal = None;
+            self.active_agent_composer_tab = None;
             self.terminal_scroll_offset_rows = 0;
             self.terminal_error = None;
         }
@@ -1334,15 +1482,24 @@ impl AlasShell {
         }
     }
 
-    fn close_workspace_tab(&mut self, tab_id: WorkspaceTabId) {
+    fn close_workspace_tab(&mut self, tab_id: WorkspaceTabId, cx: &mut Context<Self>) {
         let Some(selected) = self.model.selected_worktree().cloned() else {
             return;
         };
 
-        let is_terminal = self
+        let tab = self
             .workspace_session
-            .tab(&selected.repo_id, &selected.path, tab_id)
-            .is_some_and(|t| t.is_terminal());
+            .tab(&selected.repo_id, &selected.path, tab_id);
+        let is_terminal = tab.is_some_and(|t| t.is_terminal());
+        let closed_agent_thread_id = tab
+            .and_then(|tab| tab.agent_thread_state())
+            .map(|thread| thread.thread_id.clone());
+
+        self.agent_runtimes.remove(&tab_id);
+        self.agent_cancel_handles.remove(&tab_id);
+        if self.active_agent_composer_tab == Some(tab_id) {
+            self.active_agent_composer_tab = None;
+        }
 
         if is_terminal {
             let session_id =
@@ -1373,6 +1530,7 @@ impl AlasShell {
             } else {
                 self.active_terminal_tab = Some(fallback_id);
                 self.active_terminal = None;
+                self.active_agent_composer_tab = None;
                 self.terminal_error = None;
             }
         } else {
@@ -1380,6 +1538,7 @@ impl AlasShell {
             self.active_terminal = None;
             self.terminal_error = None;
         }
+        self.persist_agent_threads_excluding(closed_agent_thread_id.as_deref(), cx);
     }
 
     fn open_file_from_inspector(&mut self, file_path: PathBuf, cx: &mut Context<Self>) {
@@ -1432,7 +1591,9 @@ impl AlasShell {
             .and_then(|tab| match &tab.content {
                 WorkspaceTabContent::File(state) => Some(state.load_state.clone()),
                 WorkspaceTabContent::Markdown(state) => Some(state.file.load_state.clone()),
-                WorkspaceTabContent::Terminal(_) | WorkspaceTabContent::Image(_) => None,
+                WorkspaceTabContent::Terminal(_)
+                | WorkspaceTabContent::Image(_)
+                | WorkspaceTabContent::AgentChat(_) => None,
             })
             .is_some_and(|state| matches!(state, FileTabLoadState::Loaded { .. }));
 
@@ -1483,6 +1644,7 @@ impl AlasShell {
     }
 
     fn open_command_picker(&mut self, cx: &mut Context<Self>) {
+        self.provider_settings = None;
         let Some(selected) = self.model.selected_worktree().cloned() else {
             return;
         };
@@ -1501,6 +1663,1143 @@ impl AlasShell {
 
     fn close_command_picker(&mut self) {
         self.command_picker = None;
+    }
+
+    fn open_new_tab_picker(&mut self, cx: &mut Context<Self>) {
+        self.new_tab_picker_open = true;
+        self.command_picker = None;
+        self.agent_provider_picker = None;
+        self.provider_settings = None;
+        cx.notify();
+    }
+
+    fn close_new_tab_picker(&mut self) {
+        self.new_tab_picker_open = false;
+    }
+
+    fn open_provider_settings(&mut self, cx: &mut Context<Self>) {
+        self.new_tab_picker_open = false;
+        self.agent_provider_picker = None;
+        let mut settings = ProviderSettingsState {
+            providers: self.config.agent_providers.clone(),
+            selected_provider_id: self
+                .config
+                .agent_providers
+                .first()
+                .map(|provider| provider.id.clone()),
+            discovery_suggestions: self.provider_discovery_suggestions.clone(),
+            ..ProviderSettingsState::default()
+        };
+        if let Some(error) = self.provider_discovery_error.as_ref() {
+            settings.error = Some(error.clone());
+        }
+        self.provider_settings = Some(settings);
+        self.provider_settings_active_field = None;
+        cx.notify();
+    }
+
+    fn close_provider_settings(&mut self) {
+        self.provider_settings = None;
+        self.provider_settings_active_field = None;
+    }
+
+    fn add_provider_settings_entry(&mut self) {
+        let Some(settings) = self.provider_settings.as_mut() else {
+            return;
+        };
+        let mut index = settings.providers.len() + 1;
+        let provider_id = loop {
+            let candidate = format!("provider-{index}");
+            if !settings
+                .providers
+                .iter()
+                .any(|provider| provider.id == candidate)
+            {
+                break candidate;
+            }
+            index += 1;
+        };
+        settings.add_provider(AgentProviderConfig::new(
+            provider_id.clone(),
+            "New Provider",
+            "agent-acp",
+        ));
+        self.provider_settings_active_field = Some(ProviderSettingsField::DisplayName(provider_id));
+    }
+
+    fn set_provider_settings_field(&mut self, field: ProviderSettingsField) {
+        self.provider_settings_active_field = Some(field);
+        if let Some(settings) = self.provider_settings.as_mut() {
+            settings.error = None;
+        }
+    }
+
+    fn edit_provider_settings_field(
+        &mut self,
+        event: &KeyDownEvent,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.provider_settings.is_none() || self.provider_settings_active_field.is_none() {
+            return false;
+        }
+
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                self.provider_settings_active_field = None;
+                return true;
+            }
+            "enter" => {
+                self.save_provider_settings(cx);
+                return true;
+            }
+            "tab" => {
+                self.advance_provider_settings_field();
+                return true;
+            }
+            "backspace" => {
+                self.edit_active_provider_settings_text(|text| {
+                    text.pop();
+                });
+                return true;
+            }
+            _ => {}
+        }
+
+        if event.keystroke.modifiers.control || event.keystroke.modifiers.platform {
+            return false;
+        }
+        if let Some(text) = event.keystroke.key_char.as_deref() {
+            self.edit_active_provider_settings_text(|active_text| active_text.push_str(text));
+            return true;
+        }
+
+        false
+    }
+
+    fn edit_active_provider_settings_text(&mut self, edit: impl FnOnce(&mut String)) {
+        let Some(field) = self.provider_settings_active_field.clone() else {
+            return;
+        };
+        let Some(settings) = self.provider_settings.as_mut() else {
+            return;
+        };
+        match field {
+            ProviderSettingsField::DisplayName(provider_id) => {
+                if let Some(provider) = settings
+                    .providers
+                    .iter()
+                    .find(|provider| provider.id == provider_id)
+                {
+                    let mut value = provider.display_name.clone();
+                    edit(&mut value);
+                    settings.update_display_name(&provider_id, value);
+                }
+            }
+            ProviderSettingsField::Command(provider_id) => {
+                if let Some(provider) = settings
+                    .providers
+                    .iter()
+                    .find(|provider| provider.id == provider_id)
+                {
+                    let mut value = provider.command.clone();
+                    edit(&mut value);
+                    settings.update_command(&provider_id, value);
+                }
+            }
+            ProviderSettingsField::Args(provider_id) => {
+                let _ = settings.edit_args_json(&provider_id, edit);
+            }
+            ProviderSettingsField::EnvKey(provider_id) => {
+                if let Some((mut key, value)) = provider_plain_env(settings, &provider_id) {
+                    edit(&mut key);
+                    settings.update_plain_env(&provider_id, vec![(key, value)]);
+                }
+            }
+            ProviderSettingsField::EnvValue(provider_id) => {
+                if let Some((key, mut value)) = provider_plain_env(settings, &provider_id) {
+                    edit(&mut value);
+                    settings.update_plain_env(&provider_id, vec![(key, value)]);
+                }
+            }
+            ProviderSettingsField::AuthEnvValue {
+                provider_id,
+                env_name,
+            } => {
+                let mut value = settings.auth_env_value(&provider_id, &env_name);
+                edit(&mut value);
+                settings.update_auth_env_value(&provider_id, &env_name, value);
+            }
+        }
+    }
+
+    fn authenticate_provider_settings(&mut self, provider_id: &str, cx: &mut Context<Self>) {
+        let Some(settings) = self.provider_settings.as_ref() else {
+            return;
+        };
+        let provider_id = provider_id.to_string();
+        let original_provider = settings
+            .providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+            .cloned();
+        let mut next_settings = settings.clone();
+        let task = cx.background_executor().spawn(async move {
+            let result = next_settings
+                .authenticate_with_available_method(&provider_id, &OsCredentialStore)
+                .map_err(|error| error.to_string());
+            (provider_id, original_provider, next_settings, result)
+        });
+
+        cx.spawn(async move |this, cx| {
+            let (provider_id, original_provider, mut next_settings, result) = task.await;
+            this.update(cx, |shell, cx| {
+                let Some(current_settings) = shell.provider_settings.as_mut() else {
+                    return;
+                };
+                let provider_unchanged = current_settings
+                    .providers
+                    .iter()
+                    .find(|provider| provider.id == provider_id)
+                    == original_provider.as_ref();
+                if !provider_unchanged {
+                    return;
+                }
+                if let Err(error) = result {
+                    next_settings.error = Some(error);
+                }
+                current_settings.apply_auth_io_result(&provider_id, &next_settings);
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn run_provider_settings_terminal_auth(&mut self, provider_id: &str) {
+        if let Some(settings) = self.provider_settings.as_mut() {
+            settings.mark_terminal_auth_unavailable(provider_id);
+        }
+    }
+
+    fn clear_provider_settings_credentials(&mut self, provider_id: &str, cx: &mut Context<Self>) {
+        let Some(settings) = self.provider_settings.as_ref() else {
+            return;
+        };
+        let provider_id = provider_id.to_string();
+        let original_provider = settings
+            .providers
+            .iter()
+            .find(|provider| provider.id == provider_id)
+            .cloned();
+        let mut next_settings = settings.clone();
+        let task = cx.background_executor().spawn(async move {
+            let result = next_settings
+                .clear_env_auth_values(&provider_id, &OsCredentialStore)
+                .map_err(|error| error.to_string());
+            (provider_id, original_provider, next_settings, result)
+        });
+
+        cx.spawn(async move |this, cx| {
+            let (provider_id, original_provider, mut next_settings, result) = task.await;
+            this.update(cx, |shell, cx| {
+                let Some(current_settings) = shell.provider_settings.as_mut() else {
+                    return;
+                };
+                let provider_unchanged = current_settings
+                    .providers
+                    .iter()
+                    .find(|provider| provider.id == provider_id)
+                    == original_provider.as_ref();
+                if !provider_unchanged {
+                    return;
+                }
+                if let Err(error) = result {
+                    next_settings.error = Some(error);
+                }
+                current_settings.apply_clear_auth_io_result(&provider_id, &next_settings);
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn view_provider_settings_auth_instructions(&mut self, provider_id: &str) {
+        if let Some(settings) = self.provider_settings.as_mut() {
+            settings.show_auth_instructions(provider_id);
+        }
+    }
+
+    fn advance_provider_settings_field(&mut self) {
+        let Some(settings) = self.provider_settings.as_ref() else {
+            return;
+        };
+        if settings.providers.is_empty() {
+            self.provider_settings_active_field = None;
+            return;
+        }
+        let fields = settings
+            .providers
+            .iter()
+            .flat_map(|provider| {
+                [
+                    ProviderSettingsField::DisplayName(provider.id.clone()),
+                    ProviderSettingsField::Command(provider.id.clone()),
+                    ProviderSettingsField::Args(provider.id.clone()),
+                    ProviderSettingsField::EnvKey(provider.id.clone()),
+                    ProviderSettingsField::EnvValue(provider.id.clone()),
+                ]
+                .into_iter()
+                .chain(provider.auth_methods.iter().flat_map(|method| {
+                    match method {
+                        crate::agent::AgentAuthMethod::EnvVar { fields, .. } => fields
+                            .iter()
+                            .map(|field| ProviderSettingsField::AuthEnvValue {
+                                provider_id: provider.id.clone(),
+                                env_name: field.env_name.clone(),
+                            })
+                            .collect::<Vec<_>>(),
+                        crate::agent::AgentAuthMethod::Agent { .. }
+                        | crate::agent::AgentAuthMethod::Terminal { .. } => Vec::new(),
+                    }
+                }))
+            })
+            .collect::<Vec<_>>();
+        let next_index = self
+            .provider_settings_active_field
+            .as_ref()
+            .and_then(|active| fields.iter().position(|field| field == active))
+            .map(|index| (index + 1) % fields.len())
+            .unwrap_or(0);
+        self.provider_settings_active_field = fields.get(next_index).cloned();
+    }
+
+    fn toggle_provider_settings_enabled(&mut self, provider_id: &str) {
+        if let Some(settings) = self.provider_settings.as_mut()
+            && let Some(provider) = settings
+                .providers
+                .iter()
+                .find(|provider| provider.id == provider_id)
+        {
+            settings.update_enabled(provider_id, !provider.enabled);
+        }
+    }
+
+    fn cycle_provider_settings_trust_mode(&mut self, provider_id: &str) {
+        if let Some(settings) = self.provider_settings.as_mut()
+            && let Some(provider) = settings
+                .providers
+                .iter()
+                .find(|provider| provider.id == provider_id)
+        {
+            let next = match provider.trust_mode {
+                AgentTrustMode::AllowEverything => AgentTrustMode::Ask,
+                AgentTrustMode::Ask => AgentTrustMode::WorktreeOnly,
+                AgentTrustMode::WorktreeOnly => AgentTrustMode::Deny,
+                AgentTrustMode::Deny => AgentTrustMode::AllowEverything,
+            };
+            settings.update_trust_mode(provider_id, next);
+        }
+    }
+
+    fn save_provider_settings(&mut self, cx: &mut Context<Self>) {
+        let Some(settings) = self.provider_settings.as_ref() else {
+            return;
+        };
+        let providers = settings.providers.clone();
+        self.config.agent_providers = providers.clone();
+        let config = self.config.clone();
+        let app_config_store = self.app_config_store.clone();
+        let task = cx.background_executor().spawn(async move {
+            app_config_store
+                .save(&config)
+                .map(|_| providers)
+                .map_err(|error| error.to_string())
+        });
+
+        cx.spawn(async move |this, cx| {
+            let result = task.await;
+            this.update(cx, |shell, cx| {
+                match result {
+                    Ok(saved_providers) => {
+                        if shell
+                            .provider_settings
+                            .as_ref()
+                            .is_some_and(|settings| settings.providers == saved_providers)
+                        {
+                            shell.provider_settings = None;
+                        }
+                    }
+                    Err(error) => {
+                        if let Some(settings) = shell.provider_settings.as_mut() {
+                            settings.error = Some(error);
+                        }
+                    }
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn remove_provider_settings_entry(&mut self, provider_id: &str) {
+        if let Some(settings) = self.provider_settings.as_mut()
+            && remove_provider_and_record_discovery_ignore(&mut self.config, settings, provider_id)
+        {
+            self.provider_discovery_suggestions
+                .retain(|suggestion| suggestion.id != provider_id);
+        }
+    }
+
+    fn create_agent_chat_from_provider(&mut self, provider_id: &str, cx: &mut Context<Self>) {
+        let Some(provider) = self
+            .config
+            .agent_providers
+            .iter()
+            .find(|provider| provider.id == provider_id && provider.enabled)
+            .cloned()
+        else {
+            if let Some(settings) = self.provider_settings.as_mut() {
+                settings.error = Some("Provider is not enabled or no longer exists".to_string());
+            }
+            cx.notify();
+            return;
+        };
+        self.create_agent_chat_tab(provider, cx);
+    }
+
+    fn handle_new_workspace_tab_choice(
+        &mut self,
+        choice: NewWorkspaceTabChoice,
+        cx: &mut Context<Self>,
+    ) {
+        self.close_new_tab_picker();
+        match choice {
+            NewWorkspaceTabChoice::Terminal => self.open_command_picker(cx),
+            NewWorkspaceTabChoice::AgentChat => {
+                match agent_chat_provider_flow(&self.config.agent_providers) {
+                    AgentChatProviderFlow::ProviderSettings => {
+                        self.open_provider_settings(cx);
+                        if let Some(settings) = self.provider_settings.as_mut() {
+                            settings.error = Some(
+                                "Add or enable an agent provider to start a chat.".to_string(),
+                            );
+                        }
+                        cx.notify();
+                    }
+                    AgentChatProviderFlow::CreateTab(provider) => {
+                        self.create_agent_chat_tab(provider, cx)
+                    }
+                    AgentChatProviderFlow::ProviderPicker(providers) => {
+                        self.provider_settings = None;
+                        self.agent_provider_picker = Some(providers);
+                        cx.notify();
+                    }
+                }
+            }
+        }
+    }
+
+    fn create_agent_chat_tab(&mut self, provider: AgentProviderConfig, cx: &mut Context<Self>) {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return;
+        };
+        self.agent_provider_picker = None;
+        self.provider_settings = None;
+        let tab_id = self.workspace_session.create_agent_chat_tab(
+            selected.repo_id,
+            selected.path,
+            provider.id.clone(),
+        );
+        self.start_agent_runtime_for_tab(tab_id, provider, cx);
+        self.persist_agent_threads(cx);
+        cx.notify();
+    }
+
+    fn start_agent_runtime_for_tab(
+        &mut self,
+        tab_id: WorkspaceTabId,
+        provider: AgentProviderConfig,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return;
+        };
+        let repository_root = self
+            .model
+            .repositories()
+            .iter()
+            .find(|repo| repo.id == selected.repo_id)
+            .map(|repo| repo.path.as_path())
+            .unwrap_or(selected.path.as_path());
+        let cwd = resolve_provider_cwd(&provider, &selected.path, repository_root);
+        let Some(tab) =
+            self.workspace_session
+                .tab_mut(selected.repo_id.clone(), &selected.path, tab_id)
+        else {
+            return;
+        };
+        let Some(thread) = tab.agent_thread_state_mut() else {
+            return;
+        };
+        thread.status = AgentThreadStatus::Starting;
+        let initial_thread = thread.clone();
+        self.persist_agent_threads(cx);
+        cx.notify();
+
+        let repo_id = selected.repo_id.clone();
+        let worktree_path = selected.path.clone();
+        let task = cx.background_executor().spawn(async move {
+            let mut thread = initial_thread;
+            match AcpProcessConnection::spawn_with_credentials(&provider, cwd, &OsCredentialStore) {
+                Ok(connection) => {
+                    let cancel_handle = connection.cancel_handle();
+                    let connection = connection.with_callback_services(
+                        crate::agent::FilesystemCallbackService::new(
+                            provider.trust_mode.clone(),
+                            worktree_path.clone(),
+                        ),
+                        crate::agent::AgentTerminalService::new(
+                            provider.trust_mode.clone(),
+                            worktree_path.clone(),
+                        ),
+                    );
+                    let filesystem = crate::agent::FilesystemCallbackService::new(
+                        provider.trust_mode.clone(),
+                        worktree_path.clone(),
+                    );
+                    let terminal = crate::agent::AgentTerminalService::new(
+                        provider.trust_mode.clone(),
+                        worktree_path.clone(),
+                    );
+                    let mut runtime = AgentRuntime::with_connection(thread, connection)
+                        .with_callback_services(filesystem, terminal);
+                    let start_result = runtime.initialize().and_then(|_| runtime.create_session());
+                    let (thread, runtime_with_cancel) =
+                        finish_agent_runtime_start(runtime, cancel_handle, start_result);
+                    (repo_id, worktree_path, tab_id, thread, runtime_with_cancel)
+                }
+                Err(error) => {
+                    thread.status = AgentThreadStatus::Failed {
+                        message: error.to_string(),
+                    };
+                    (repo_id, worktree_path, tab_id, thread, None)
+                }
+            }
+        });
+
+        cx.spawn(async move |this, cx| {
+            let (repo_id, worktree_path, tab_id, updated_thread, runtime_with_cancel) = task.await;
+            this.update(cx, |shell, cx| {
+                if let Some(tab) = shell
+                    .workspace_session
+                    .tab_mut(repo_id, &worktree_path, tab_id)
+                    && let Some(thread) = tab.agent_thread_state_mut()
+                {
+                    *thread = updated_thread;
+                    if let Some((runtime, cancel_handle)) = runtime_with_cancel {
+                        shell.agent_cancel_handles.insert(tab_id, cancel_handle);
+                        shell.agent_runtimes.insert(tab_id, runtime);
+                    } else {
+                        shell.agent_cancel_handles.remove(&tab_id);
+                    }
+                    shell.persist_agent_threads(cx);
+                    cx.notify();
+                }
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn send_agent_prompt(&mut self, tab_id: WorkspaceTabId, cx: &mut Context<Self>) {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return;
+        };
+        let prompt = self
+            .workspace_session
+            .tab(selected.repo_id.clone(), &selected.path, tab_id)
+            .and_then(|tab| tab.agent_thread_state())
+            .map(|thread| thread.draft.clone())
+            .unwrap_or_default();
+        if prompt.trim().is_empty() {
+            return;
+        }
+        if let Some(mut runtime) = self.agent_runtimes.remove(&tab_id) {
+            if matches!(runtime.thread().status, AgentThreadStatus::ReadOnly { .. }) {
+                runtime.thread_mut().push_debug_event(AgentDebugEvent {
+                    message: "Ignored stale prompt send for read-only ACP session".to_string(),
+                });
+                self.agent_runtimes.insert(tab_id, runtime);
+                self.sync_agent_thread_from_runtime(tab_id);
+                self.persist_agent_threads(cx);
+                cx.notify();
+                return;
+            }
+
+            if let Some(tab) =
+                self.workspace_session
+                    .tab_mut(selected.repo_id.clone(), &selected.path, tab_id)
+                && let Some(thread) = tab.agent_thread_state_mut()
+            {
+                thread.status = AgentThreadStatus::Running;
+                thread.draft.clear();
+            }
+            self.persist_agent_threads(cx);
+            cx.notify();
+
+            let repo_id = selected.repo_id.clone();
+            let worktree_path = selected.path.clone();
+            let task = cx.background_executor().spawn(async move {
+                if let Err(error) = runtime.prompt(prompt) {
+                    runtime.thread_mut().status = AgentThreadStatus::Failed {
+                        message: error.to_string(),
+                    };
+                }
+                runtime.thread_mut().draft.clear();
+                (repo_id, worktree_path, tab_id, runtime)
+            });
+
+            cx.spawn(async move |this, cx| {
+                let (repo_id, worktree_path, tab_id, runtime) = task.await;
+                this.update(cx, |shell, cx| {
+                    let updated = runtime.thread().clone();
+                    if let Some(tab) =
+                        shell
+                            .workspace_session
+                            .tab_mut(repo_id, &worktree_path, tab_id)
+                        && let Some(thread) = tab.agent_thread_state_mut()
+                    {
+                        *thread = updated;
+                        shell.agent_runtimes.insert(tab_id, runtime);
+                        shell.persist_agent_threads(cx);
+                        cx.notify();
+                    }
+                })
+                .ok();
+            })
+            .detach();
+            return;
+        } else if let Some(tab) =
+            self.workspace_session
+                .tab_mut(selected.repo_id, &selected.path, tab_id)
+            && let Some(thread) = tab.agent_thread_state_mut()
+        {
+            if matches!(thread.status, AgentThreadStatus::ReadOnly { .. }) {
+                thread.push_debug_event(AgentDebugEvent {
+                    message: "Ignored stale prompt send for read-only ACP session".to_string(),
+                });
+            } else if matches!(
+                thread.status,
+                AgentThreadStatus::Starting | AgentThreadStatus::Running
+            ) {
+                thread.push_debug_event(AgentDebugEvent {
+                    message: "Ignored prompt send while ACP runtime is busy".to_string(),
+                });
+            } else {
+                thread.transcript.push(AgentTranscriptEntry::user(prompt));
+                thread.draft.clear();
+                thread.status = AgentThreadStatus::Failed {
+                    message: "Agent runtime is not connected".to_string(),
+                };
+            }
+            self.persist_agent_threads(cx);
+        }
+        cx.notify();
+    }
+
+    fn cycle_agent_mode(&mut self, tab_id: WorkspaceTabId, cx: &mut Context<Self>) {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return;
+        };
+        let Some(tab) = self
+            .workspace_session
+            .tab_mut(&selected.repo_id, &selected.path, tab_id)
+        else {
+            return;
+        };
+        let Some(thread) = tab.agent_thread_state_mut() else {
+            return;
+        };
+        if thread.available_modes.len() < 2 {
+            return;
+        }
+        let current = thread.current_mode.as_deref();
+        let index = thread
+            .available_modes
+            .iter()
+            .position(|mode| Some(mode.id.as_str()) == current)
+            .unwrap_or(0);
+        let next_mode = thread.available_modes[(index + 1) % thread.available_modes.len()]
+            .id
+            .clone();
+        self.run_agent_selector_update(
+            tab_id,
+            selected.repo_id,
+            selected.path,
+            move |runtime| runtime.set_mode(next_mode),
+            cx,
+        );
+    }
+
+    fn cycle_agent_config_option(
+        &mut self,
+        tab_id: WorkspaceTabId,
+        config_id: String,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return;
+        };
+        let Some(tab) = self
+            .workspace_session
+            .tab_mut(&selected.repo_id, &selected.path, tab_id)
+        else {
+            return;
+        };
+        let Some(thread) = tab.agent_thread_state_mut() else {
+            return;
+        };
+        let Some(option) = thread
+            .config_options
+            .iter_mut()
+            .find(|option| option.id == config_id)
+        else {
+            return;
+        };
+        if option.options.len() < 2 {
+            return;
+        }
+        let current = option.value.as_deref();
+        let index = option
+            .options
+            .iter()
+            .position(|value| Some(value.id.as_str()) == current)
+            .unwrap_or(0);
+        let next_value = option.options[(index + 1) % option.options.len()]
+            .id
+            .clone();
+        self.run_agent_selector_update(
+            tab_id,
+            selected.repo_id,
+            selected.path,
+            move |runtime| runtime.set_config_option(config_id, next_value),
+            cx,
+        );
+    }
+
+    fn run_agent_selector_update(
+        &mut self,
+        tab_id: WorkspaceTabId,
+        repo_id: String,
+        worktree_path: PathBuf,
+        update: impl FnOnce(&mut AgentRuntime<AcpProcessConnection>) -> anyhow::Result<()>
+        + Send
+        + 'static,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(mut runtime) = self.agent_runtimes.remove(&tab_id) else {
+            if let Some(tab) = self
+                .workspace_session
+                .tab_mut(&repo_id, &worktree_path, tab_id)
+                && let Some(thread) = tab.agent_thread_state_mut()
+            {
+                thread.push_debug_event(AgentDebugEvent {
+                    message: "Ignored selector change while ACP runtime is busy or disconnected"
+                        .to_string(),
+                });
+                self.persist_agent_threads(cx);
+            }
+            return;
+        };
+        let task = cx.background_executor().spawn(async move {
+            if let Err(error) = update(&mut runtime) {
+                runtime.thread_mut().push_debug_event(AgentDebugEvent {
+                    message: error.to_string(),
+                });
+            }
+            (repo_id, worktree_path, tab_id, runtime)
+        });
+        cx.spawn(async move |this, cx| {
+            let (repo_id, worktree_path, tab_id, runtime) = task.await;
+            this.update(cx, |shell, cx| {
+                let updated = runtime.thread().clone();
+                if let Some(tab) = shell
+                    .workspace_session
+                    .tab_mut(repo_id, &worktree_path, tab_id)
+                    && let Some(thread) = tab.agent_thread_state_mut()
+                {
+                    *thread = updated;
+                    shell.agent_runtimes.insert(tab_id, runtime);
+                    shell.persist_agent_threads(cx);
+                    cx.notify();
+                }
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn focus_agent_composer(
+        &mut self,
+        tab_id: WorkspaceTabId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.active_agent_composer_tab = Some(tab_id);
+        window.focus(&self.agent_composer_focus);
+        cx.notify();
+    }
+
+    fn handle_agent_composer_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(tab_id) = self.active_agent_composer_tab else {
+            return false;
+        };
+
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                self.active_agent_composer_tab = None;
+                return true;
+            }
+            "enter" => {
+                self.send_agent_prompt(tab_id, cx);
+                return true;
+            }
+            "backspace" => {
+                self.edit_agent_draft(
+                    tab_id,
+                    |draft| {
+                        draft.pop();
+                    },
+                    cx,
+                );
+                cx.notify();
+                return true;
+            }
+            _ => {}
+        }
+
+        if event.keystroke.modifiers.control || event.keystroke.modifiers.platform {
+            return false;
+        }
+
+        if let Some(text) = event.keystroke.key_char.as_deref() {
+            self.edit_agent_draft(tab_id, |draft| draft.push_str(text), cx);
+            cx.notify();
+            return true;
+        }
+
+        false
+    }
+
+    fn edit_agent_draft(
+        &mut self,
+        tab_id: WorkspaceTabId,
+        edit: impl FnOnce(&mut String),
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return false;
+        };
+        let Some(tab) = self
+            .workspace_session
+            .tab_mut(&selected.repo_id, &selected.path, tab_id)
+        else {
+            return false;
+        };
+        let Some(thread) = tab.agent_thread_state_mut() else {
+            return false;
+        };
+
+        edit(&mut thread.draft);
+        if let Some(runtime) = self.agent_runtimes.get_mut(&tab_id) {
+            runtime.thread_mut().draft = thread.draft.clone();
+        }
+        self.persist_agent_threads(cx);
+        true
+    }
+
+    fn cancel_agent_prompt(&mut self, tab_id: WorkspaceTabId, cx: &mut Context<Self>) {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return;
+        };
+        let Some(tab) = self
+            .workspace_session
+            .tab_mut(&selected.repo_id, &selected.path, tab_id)
+        else {
+            return;
+        };
+        let Some(thread) = tab.agent_thread_state_mut() else {
+            return;
+        };
+        let Some(session_id) = thread.acp_session_id.clone() else {
+            thread.push_debug_event(AgentDebugEvent {
+                message: "Cannot cancel ACP prompt without an active session".to_string(),
+            });
+            self.persist_agent_threads(cx);
+            cx.notify();
+            return;
+        };
+        let Some(cancel_handle) = self.agent_cancel_handles.get(&tab_id).cloned() else {
+            thread.push_debug_event(AgentDebugEvent {
+                message: "Cannot cancel ACP prompt because the runtime is not connected"
+                    .to_string(),
+            });
+            self.persist_agent_threads(cx);
+            cx.notify();
+            return;
+        };
+
+        let repo_id = selected.repo_id.clone();
+        let worktree_path = selected.path.clone();
+        let task = cx
+            .background_executor()
+            .spawn(async move { cancel_handle.cancel(session_id) });
+
+        cx.spawn(async move |this, cx| {
+            let result = task.await;
+            this.update(cx, |shell, cx| {
+                if let Some(tab) = shell
+                    .workspace_session
+                    .tab_mut(repo_id, &worktree_path, tab_id)
+                    && let Some(thread) = tab.agent_thread_state_mut()
+                {
+                    match result {
+                        Ok(()) => {
+                            thread.status = AgentThreadStatus::Ready;
+                            if let Some(runtime) = shell.agent_runtimes.get_mut(&tab_id) {
+                                runtime.thread_mut().status = AgentThreadStatus::Ready;
+                            }
+                        }
+                        Err(error) => {
+                            let message = error.to_string();
+                            thread.push_debug_event(AgentDebugEvent {
+                                message: message.clone(),
+                            });
+                            if let Some(runtime) = shell.agent_runtimes.get_mut(&tab_id) {
+                                runtime
+                                    .thread_mut()
+                                    .push_debug_event(AgentDebugEvent { message });
+                            }
+                        }
+                    }
+                    shell.persist_agent_threads(cx);
+                    cx.notify();
+                }
+            })
+            .ok();
+        })
+        .detach();
+        cx.notify();
+    }
+
+    fn resolve_agent_permission(
+        &mut self,
+        tab_id: WorkspaceTabId,
+        request_id: &str,
+        allow: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(runtime) = self.agent_runtimes.get_mut(&tab_id) {
+            if let Err(error) = runtime.resolve_permission_request(request_id, allow) {
+                runtime
+                    .thread_mut()
+                    .push_debug_event(crate::agent::AgentDebugEvent {
+                        message: error.to_string(),
+                    });
+            }
+            self.sync_agent_thread_from_runtime(tab_id);
+            self.persist_agent_threads(cx);
+        }
+    }
+
+    fn persist_agent_threads(&mut self, cx: &mut Context<Self>) {
+        self.persist_agent_threads_with_exclusions(
+            Vec::new(),
+            agent_thread_persist_debounce_interval(),
+            cx,
+        )
+        .detach();
+    }
+
+    fn persist_agent_threads_excluding(
+        &mut self,
+        excluded_thread_id: Option<&str>,
+        cx: &mut Context<Self>,
+    ) {
+        let excluded_thread_ids = excluded_thread_id
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        self.persist_agent_threads_immediately_excluding(excluded_thread_ids, cx);
+    }
+
+    fn persist_agent_threads_immediately_excluding(
+        &mut self,
+        excluded_thread_ids: Vec<String>,
+        cx: &mut Context<Self>,
+    ) {
+        self.persist_agent_threads_with_exclusions(excluded_thread_ids, Duration::ZERO, cx)
+            .detach();
+    }
+
+    fn persist_agent_threads_with_exclusions(
+        &mut self,
+        excluded_thread_ids: Vec<String>,
+        delay: Duration,
+        cx: &mut Context<Self>,
+    ) -> Task<()> {
+        if !self.agent_thread_records_loaded {
+            self.pending_agent_thread_exclusions
+                .extend(excluded_thread_ids.iter().cloned());
+        }
+        let records = merge_agent_thread_records(
+            self.agent_thread_records_cache.values().cloned(),
+            self.workspace_session.agent_thread_records(),
+            excluded_thread_ids,
+        );
+        self.agent_thread_records_cache = records
+            .iter()
+            .cloned()
+            .map(|record| (record.thread_id.clone(), record))
+            .collect();
+        self.spawn_agent_thread_records_save(records, delay, cx)
+    }
+
+    fn spawn_agent_thread_records_save(
+        &self,
+        records: Vec<AgentThreadRecord>,
+        delay: Duration,
+        cx: &mut Context<Self>,
+    ) -> Task<()> {
+        let store = self.agent_thread_store.clone();
+        let latest_generation = self.agent_thread_persist_generation.clone();
+        let generation = latest_generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let save_lock = self.agent_thread_persist_lock.clone();
+        let executor = cx.background_executor().clone();
+        let timer_executor = executor.clone();
+
+        executor.spawn(async move {
+            timer_executor.timer(delay).await;
+            let _guard = match save_lock.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            if generation != latest_generation.load(Ordering::SeqCst) {
+                return;
+            }
+            if let Err(error) = store.save_records(&records) {
+                eprintln!("failed to persist agent threads: {error:#}");
+            }
+        })
+    }
+
+    fn cached_agent_thread_records(&self) -> Vec<AgentThreadRecord> {
+        self.agent_thread_records_cache.values().cloned().collect()
+    }
+
+    fn agent_thread_ids_for_worktree(&self, path: &Path) -> Vec<String> {
+        let workspace_records = self.workspace_session.agent_thread_records();
+        self.agent_thread_records_cache
+            .values()
+            .chain(workspace_records.iter())
+            .filter(|record| record.state.worktree_path == path)
+            .map(|record| record.thread_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn agent_thread_ids_for_repo(&self, repo_id: &str) -> Vec<String> {
+        let repository_path = self.repository_path(repo_id);
+        let worktree_paths = self
+            .model
+            .repositories()
+            .iter()
+            .find(|repository| repository.id == repo_id)
+            .map(|repository| {
+                repository
+                    .worktrees
+                    .iter()
+                    .map(|worktree| worktree.path.clone())
+                    .collect::<BTreeSet<_>>()
+            })
+            .unwrap_or_default();
+        let workspace_records = self.workspace_session.agent_thread_records();
+        self.agent_thread_records_cache
+            .values()
+            .chain(workspace_records.iter())
+            .filter(|record| {
+                worktree_paths.contains(&record.state.worktree_path)
+                    || repository_path
+                        .as_ref()
+                        .is_some_and(|path| record.state.worktree_path.starts_with(path))
+            })
+            .map(|record| record.thread_id.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn restore_agent_threads_for_selected_worktree(&mut self, cx: &mut Context<Self>) {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return;
+        };
+        let records = self.cached_agent_thread_records();
+        if !self
+            .workspace_session
+            .restore_agent_chat_tabs(&selected.repo_id, &selected.path, &records)
+            .is_empty()
+        {
+            cx.notify();
+        }
+    }
+
+    fn restore_agent_threads_for_known_worktrees(&mut self, cx: &mut Context<Self>) {
+        let records = self.cached_agent_thread_records();
+        let worktrees = self
+            .model
+            .repositories()
+            .iter()
+            .flat_map(|repository| {
+                repository
+                    .worktrees
+                    .iter()
+                    .map(|worktree| (repository.id.clone(), worktree.path.clone()))
+            })
+            .collect::<Vec<_>>();
+        if !self
+            .workspace_session
+            .restore_agent_chat_tabs_for_worktrees(worktrees, &records)
+            .is_empty()
+        {
+            cx.notify();
+        }
+    }
+
+    fn sync_agent_thread_from_runtime(&mut self, tab_id: WorkspaceTabId) {
+        let Some(selected) = self.model.selected_worktree().cloned() else {
+            return;
+        };
+        let Some(runtime_thread) = self
+            .agent_runtimes
+            .get(&tab_id)
+            .map(|runtime| runtime.thread().clone())
+        else {
+            return;
+        };
+        if let Some(tab) = self
+            .workspace_session
+            .tab_mut(selected.repo_id, &selected.path, tab_id)
+            && let Some(thread) = tab.agent_thread_state_mut()
+        {
+            *thread = runtime_thread;
+        }
     }
 
     fn handle_sidebar_menu_action(
@@ -1787,7 +3086,8 @@ impl AlasShell {
         cx.spawn(async move |this, cx| {
             let should_remove = answer.await.unwrap_or(1) == 0;
             this.update(cx, |shell, cx| {
-                if should_remove && let Err(error) = shell.remove_repository_from_alas(&repo_id) {
+                if should_remove && let Err(error) = shell.remove_repository_from_alas(&repo_id, cx)
+                {
                     shell.set_add_repository_error(error.to_string());
                 }
                 shell.confirm_remove_repository_dialog = None;
@@ -1800,17 +3100,45 @@ impl AlasShell {
         cx.notify();
     }
 
-    fn remove_repository_from_alas(&mut self, repo_id: &str) -> anyhow::Result<()> {
+    fn remove_repository_from_alas(
+        &mut self,
+        repo_id: &str,
+        cx: &mut Context<Self>,
+    ) -> anyhow::Result<()> {
         let mut next_config = self.config.clone();
         next_config
             .repositories
             .retain(|repository| repository.id != repo_id);
         next_config.archived_worktrees.shift_remove(repo_id);
 
+        let excluded_thread_ids = self.agent_thread_ids_for_repo(repo_id);
+        let pending_removed_repo = self.repository_path(repo_id);
+        let pending_removed_worktrees = self
+            .model
+            .repositories()
+            .iter()
+            .find(|repository| repository.id == repo_id)
+            .map(|repository| {
+                repository
+                    .worktrees
+                    .iter()
+                    .map(|worktree| worktree.path.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
         self.app_config_store.save(&next_config)?;
+        if !self.agent_thread_records_loaded {
+            if let Some(path) = pending_removed_repo {
+                self.pending_removed_agent_repos.insert(path);
+            }
+            self.pending_removed_agent_worktrees
+                .extend(pending_removed_worktrees);
+        }
         self.config = next_config;
         self.cleanup_repository_sessions(repo_id);
         self.workspace_session.remove_repository(repo_id);
+        self.persist_agent_threads_immediately_excluding(excluded_thread_ids, cx);
 
         if self
             .model
@@ -1820,7 +3148,7 @@ impl AlasShell {
             self.clear_selection_and_active_terminal();
         }
 
-        self.refresh_repositories();
+        self.refresh_repositories_and_restore_agent_threads(cx);
         Ok(())
     }
 
@@ -1862,7 +3190,7 @@ impl AlasShell {
         cx.spawn(async move |this, cx| {
             let should_remove = answer.await.unwrap_or(1) == 0;
             this.update(cx, |shell, cx| {
-                if should_remove && let Err(error) = shell.remove_worktree(&repo_id, &path) {
+                if should_remove && let Err(error) = shell.remove_worktree(&repo_id, &path, cx) {
                     shell.set_add_repository_error(error.to_string());
                 }
                 shell.confirm_remove_worktree_dialog = None;
@@ -1875,14 +3203,26 @@ impl AlasShell {
         cx.notify();
     }
 
-    fn remove_worktree(&mut self, repo_id: &str, path: &Path) -> anyhow::Result<()> {
+    fn remove_worktree(
+        &mut self,
+        repo_id: &str,
+        path: &Path,
+        cx: &mut Context<Self>,
+    ) -> anyhow::Result<()> {
         let repo_path = self
             .repository_path(repo_id)
             .ok_or_else(|| anyhow::anyhow!("Repository not found"))?;
 
+        let excluded_thread_ids = self.agent_thread_ids_for_worktree(path);
+
         GitWorktreeService::new(GitRunner::new()).remove_worktree(&repo_path, path)?;
+        if !self.agent_thread_records_loaded {
+            self.pending_removed_agent_worktrees
+                .insert(path.to_path_buf());
+        }
         self.cleanup_worktree_sessions(repo_id, path);
         self.workspace_session.remove_worktree(repo_id, path);
+        self.persist_agent_threads_immediately_excluding(excluded_thread_ids, cx);
 
         if self
             .model
@@ -1892,7 +3232,7 @@ impl AlasShell {
             self.clear_selection_and_active_terminal();
         }
 
-        self.refresh_repositories();
+        self.refresh_repositories_and_restore_agent_threads(cx);
         Ok(())
     }
 
@@ -1987,9 +3327,12 @@ impl AlasShell {
     }
 
     fn register_app_quit_cleanup(&self, cx: &mut Context<Self>) {
-        cx.on_app_quit(|shell, _cx| {
+        cx.on_app_quit(|shell, cx| {
+            let save = shell.persist_agent_threads_with_exclusions(Vec::new(), Duration::ZERO, cx);
             shell.shutdown();
-            async {}
+            async move {
+                save.await;
+            }
         })
         .detach();
     }
@@ -2054,6 +3397,11 @@ impl AlasShell {
         }
 
         self.model.set_repositories(nodes);
+    }
+
+    fn refresh_repositories_and_restore_agent_threads(&mut self, cx: &mut Context<Self>) {
+        self.refresh_repositories();
+        self.restore_agent_threads_for_known_worktrees(cx);
     }
 
     fn add_repository_error(&self) -> Option<&str> {
@@ -2306,6 +3654,107 @@ fn render_status_bar(
         )
 }
 
+fn render_new_tab_picker(
+    on_select: impl Fn(NewWorkspaceTabChoice, &gpui::ClickEvent, &mut Window, &mut App)
+    + Clone
+    + 'static,
+    on_cancel: impl Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    div()
+        .id("new-tab-picker")
+        .m_3()
+        .p_3()
+        .rounded_md()
+        .border_1()
+        .border_color(PANEL_BORDER)
+        .bg(PANEL_BG)
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(
+            div()
+                .text_sm()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .child("New Workspace Tab"),
+        )
+        .children(new_workspace_tab_choices().into_iter().map(|choice| {
+            let on_select = on_select.clone();
+            div()
+                .id(SharedString::from(format!("new-tab-choice-{choice:?}")))
+                .px_3()
+                .py_2()
+                .rounded_md()
+                .text_sm()
+                .text_color(rgb(0x111827))
+                .bg(rgb(0xe5e7eb))
+                .child(new_workspace_tab_choice_label(choice))
+                .on_click(move |event, window, cx| on_select(choice, event, window, cx))
+        }))
+        .child(
+            div()
+                .id("cancel-new-tab-picker")
+                .px_3()
+                .py_2()
+                .rounded_md()
+                .text_sm()
+                .text_color(TEXT_MUTED)
+                .child("Cancel")
+                .on_click(on_cancel),
+        )
+}
+
+fn render_agent_provider_picker(
+    providers: &[AgentProviderConfig],
+    on_select: impl Fn(AgentProviderConfig, &gpui::ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    on_cancel: impl Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    div()
+        .id("agent-provider-picker")
+        .m_3()
+        .p_3()
+        .rounded_md()
+        .border_1()
+        .border_color(PANEL_BORDER)
+        .bg(PANEL_BG)
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(
+            div()
+                .text_sm()
+                .font_weight(gpui::FontWeight::SEMIBOLD)
+                .child("Choose Agent Provider"),
+        )
+        .children(providers.iter().map(|provider| {
+            let on_select = on_select.clone();
+            let provider = provider.clone();
+            div()
+                .id(SharedString::from(format!(
+                    "agent-provider-{}",
+                    provider.id
+                )))
+                .px_3()
+                .py_2()
+                .rounded_md()
+                .text_sm()
+                .text_color(rgb(0x111827))
+                .bg(rgb(0xe5e7eb))
+                .child(SharedString::from(provider.display_name.clone()))
+                .on_click(move |event, window, cx| on_select(provider.clone(), event, window, cx))
+        }))
+        .child(
+            div()
+                .id("cancel-agent-provider-picker")
+                .px_3()
+                .py_2()
+                .rounded_md()
+                .text_sm()
+                .text_color(TEXT_MUTED)
+                .child("Cancel")
+                .on_click(on_cancel),
+        )
+}
+
 impl Render for AlasShell {
     fn render(&mut self, window: &mut gpui::Window, cx: &mut Context<Self>) -> impl IntoElement {
         let measured_metrics =
@@ -2442,6 +3891,11 @@ impl Render for AlasShell {
                 cx.stop_propagation();
             }
         });
+        let on_agent_composer_key_down = cx.listener(|shell, event: &KeyDownEvent, _window, cx| {
+            if shell.handle_agent_composer_key_down(event, cx) {
+                cx.stop_propagation();
+            }
+        });
         let on_retry_terminal = cx.listener(|shell, _event, _window, cx| {
             shell.retry_active_terminal();
             cx.notify();
@@ -2546,13 +4000,13 @@ impl Render for AlasShell {
                                            _window: &mut Window,
                                            app: &mut App| {
             view.update(app, |shell, cx| {
-                shell.close_workspace_tab(tab_id);
+                shell.close_workspace_tab(tab_id, cx);
                 cx.notify();
             })
             .ok();
         };
-        let on_new_terminal_tab = cx.listener(|shell, _event, _window, cx| {
-            shell.open_command_picker(cx);
+        let on_new_workspace_tab = cx.listener(|shell, _event, _window, cx| {
+            shell.open_new_tab_picker(cx);
         });
         let view = cx.entity().downgrade();
         let on_image_fit = move |tab_id: WorkspaceTabId,
@@ -2633,6 +4087,163 @@ impl Render for AlasShell {
             shell.close_command_picker();
             cx.notify();
         });
+        let view = cx.entity().downgrade();
+        let on_select_new_tab_choice = move |choice: NewWorkspaceTabChoice,
+                                             _event: &gpui::ClickEvent,
+                                             _window: &mut Window,
+                                             app: &mut App| {
+            view.update(app, |shell, cx| {
+                shell.handle_new_workspace_tab_choice(choice, cx);
+            })
+            .ok();
+        };
+        let on_cancel_new_tab_picker = cx.listener(|shell, _event, _window, cx| {
+            shell.close_new_tab_picker();
+            cx.notify();
+        });
+        let view = cx.entity().downgrade();
+        let on_select_agent_provider = move |provider: AgentProviderConfig,
+                                             _event: &gpui::ClickEvent,
+                                             _window: &mut Window,
+                                             app: &mut App| {
+            view.update(app, |shell, cx| {
+                shell.create_agent_chat_from_provider(&provider.id, cx);
+            })
+            .ok();
+        };
+        let on_cancel_agent_provider_picker = cx.listener(|shell, _event, _window, cx| {
+            shell.agent_provider_picker = None;
+            cx.notify();
+        });
+        let on_close_provider_settings = cx.listener(|shell, _event, _window, cx| {
+            shell.close_provider_settings();
+            cx.notify();
+        });
+        let on_add_provider = cx.listener(|shell, _event, window, cx| {
+            shell.add_provider_settings_entry();
+            window.focus(&shell.provider_settings_focus);
+            cx.notify();
+        });
+        let on_save_provider_settings = cx.listener(|shell, _event, _window, cx| {
+            shell.save_provider_settings(cx);
+            cx.notify();
+        });
+        let on_cancel_provider_settings = cx.listener(|shell, _event, _window, cx| {
+            shell.close_provider_settings();
+            cx.notify();
+        });
+        let on_provider_settings_key_down =
+            cx.listener(|shell, event: &KeyDownEvent, _window, cx| {
+                if shell.edit_provider_settings_field(event, cx) {
+                    cx.stop_propagation();
+                    cx.notify();
+                }
+            });
+        let view = cx.entity().downgrade();
+        let on_select_provider_settings_field = Arc::new(
+            move |field: ProviderSettingsField,
+                  _event: &gpui::ClickEvent,
+                  window: &mut Window,
+                  app: &mut App| {
+                view.update(app, |shell, cx| {
+                    shell.set_provider_settings_field(field);
+                    window.focus(&shell.provider_settings_focus);
+                    cx.notify();
+                })
+                .ok();
+            },
+        );
+        let view = cx.entity().downgrade();
+        let on_toggle_provider_enabled = Arc::new(
+            move |provider_id: String,
+                  _event: &gpui::ClickEvent,
+                  _window: &mut Window,
+                  app: &mut App| {
+                view.update(app, |shell, cx| {
+                    shell.toggle_provider_settings_enabled(&provider_id);
+                    cx.notify();
+                })
+                .ok();
+            },
+        );
+        let view = cx.entity().downgrade();
+        let on_cycle_provider_trust_mode = Arc::new(
+            move |provider_id: String,
+                  _event: &gpui::ClickEvent,
+                  _window: &mut Window,
+                  app: &mut App| {
+                view.update(app, |shell, cx| {
+                    shell.cycle_provider_settings_trust_mode(&provider_id);
+                    cx.notify();
+                })
+                .ok();
+            },
+        );
+        let view = cx.entity().downgrade();
+        let on_remove_provider = Arc::new(
+            move |provider_id: String,
+                  _event: &gpui::ClickEvent,
+                  _window: &mut Window,
+                  app: &mut App| {
+                view.update(app, |shell, cx| {
+                    shell.remove_provider_settings_entry(&provider_id);
+                    cx.notify();
+                })
+                .ok();
+            },
+        );
+        let view = cx.entity().downgrade();
+        let on_authenticate_provider = Arc::new(
+            move |provider_id: String,
+                  _event: &gpui::ClickEvent,
+                  _window: &mut Window,
+                  app: &mut App| {
+                view.update(app, |shell, cx| {
+                    shell.authenticate_provider_settings(&provider_id, cx);
+                    cx.notify();
+                })
+                .ok();
+            },
+        );
+        let view = cx.entity().downgrade();
+        let on_run_terminal_auth = Arc::new(
+            move |provider_id: String,
+                  _event: &gpui::ClickEvent,
+                  _window: &mut Window,
+                  app: &mut App| {
+                view.update(app, |shell, cx| {
+                    shell.run_provider_settings_terminal_auth(&provider_id);
+                    cx.notify();
+                })
+                .ok();
+            },
+        );
+        let view = cx.entity().downgrade();
+        let on_clear_credentials = Arc::new(
+            move |provider_id: String,
+                  _event: &gpui::ClickEvent,
+                  _window: &mut Window,
+                  app: &mut App| {
+                view.update(app, |shell, cx| {
+                    shell.clear_provider_settings_credentials(&provider_id, cx);
+                    cx.notify();
+                })
+                .ok();
+            },
+        );
+        let view = cx.entity().downgrade();
+        let on_view_auth_instructions = Arc::new(
+            move |provider_id: String,
+                  _event: &gpui::ClickEvent,
+                  _window: &mut Window,
+                  app: &mut App| {
+                view.update(app, |shell, cx| {
+                    shell.view_provider_settings_auth_instructions(&provider_id);
+                    cx.notify();
+                })
+                .ok();
+            },
+        );
         let view = cx.entity().downgrade();
         let on_sidebar_menu_action = move |menu: SidebarMenuState,
                                            action_id: ActionId,
@@ -2723,6 +4334,107 @@ impl Render for AlasShell {
 
         let selected_worktree = self.model.selected_worktree();
         let terminal_state = active_tab.and_then(|t| t.terminal_tab_state());
+        let on_send_agent_prompt = {
+            let tab_id = active_tab.map(|tab| tab.id);
+            let view = cx.entity().downgrade();
+            Arc::new(
+                move |_event: &gpui::ClickEvent, _window: &mut Window, app: &mut App| {
+                    if let Some(tab_id) = tab_id {
+                        view.update(app, |shell, cx| shell.send_agent_prompt(tab_id, cx))
+                            .ok();
+                    }
+                },
+            )
+        };
+        let on_cancel_agent_prompt = {
+            let tab_id = active_tab.map(|tab| tab.id);
+            let view = cx.entity().downgrade();
+            Arc::new(
+                move |_event: &gpui::ClickEvent, _window: &mut Window, app: &mut App| {
+                    if let Some(tab_id) = tab_id {
+                        view.update(app, |shell, cx| shell.cancel_agent_prompt(tab_id, cx))
+                            .ok();
+                    }
+                },
+            )
+        };
+        let on_focus_agent_composer = {
+            let tab_id = active_tab.map(|tab| tab.id);
+            let view = cx.entity().downgrade();
+            Arc::new(
+                move |_event: &gpui::ClickEvent, window: &mut Window, app: &mut App| {
+                    if let Some(tab_id) = tab_id {
+                        view.update(app, |shell, cx| {
+                            shell.focus_agent_composer(tab_id, window, cx)
+                        })
+                        .ok();
+                    }
+                },
+            )
+        };
+        let on_allow_agent_permission = {
+            let tab_id = active_tab.map(|tab| tab.id);
+            let view = cx.entity().downgrade();
+            Arc::new(
+                move |request_id: String,
+                      _event: &gpui::ClickEvent,
+                      _window: &mut Window,
+                      app: &mut App| {
+                    if let Some(tab_id) = tab_id {
+                        view.update(app, |shell, cx| {
+                            shell.resolve_agent_permission(tab_id, &request_id, true, cx)
+                        })
+                        .ok();
+                    }
+                },
+            )
+        };
+        let on_deny_agent_permission = {
+            let tab_id = active_tab.map(|tab| tab.id);
+            let view = cx.entity().downgrade();
+            Arc::new(
+                move |request_id: String,
+                      _event: &gpui::ClickEvent,
+                      _window: &mut Window,
+                      app: &mut App| {
+                    if let Some(tab_id) = tab_id {
+                        view.update(app, |shell, cx| {
+                            shell.resolve_agent_permission(tab_id, &request_id, false, cx)
+                        })
+                        .ok();
+                    }
+                },
+            )
+        };
+        let on_cycle_agent_mode = {
+            let tab_id = active_tab.map(|tab| tab.id);
+            let view = cx.entity().downgrade();
+            Arc::new(
+                move |_event: &gpui::ClickEvent, _window: &mut Window, app: &mut App| {
+                    if let Some(tab_id) = tab_id {
+                        view.update(app, |shell, cx| shell.cycle_agent_mode(tab_id, cx))
+                            .ok();
+                    }
+                },
+            )
+        };
+        let on_cycle_agent_config = {
+            let tab_id = active_tab.map(|tab| tab.id);
+            let view = cx.entity().downgrade();
+            Arc::new(
+                move |config_id: String,
+                      _event: &gpui::ClickEvent,
+                      _window: &mut Window,
+                      app: &mut App| {
+                    if let Some(tab_id) = tab_id {
+                        view.update(app, |shell, cx| {
+                            shell.cycle_agent_config_option(tab_id, config_id, cx)
+                        })
+                        .ok();
+                    }
+                },
+            )
+        };
         let workspace_body = match active_tab.map(|tab| &tab.content) {
             Some(WorkspaceTabContent::File(state)) => render_source_viewer(state),
             Some(WorkspaceTabContent::Markdown(state)) => render_markdown_pane(
@@ -2761,6 +4473,22 @@ impl Render for AlasShell {
                 on_terminal_body_bounds,
             )
             .into_any_element(),
+            Some(WorkspaceTabContent::AgentChat(state)) => div()
+                .track_focus(&self.agent_composer_focus)
+                .on_key_down(on_agent_composer_key_down)
+                .child(render_agent_pane(
+                    state,
+                    AgentPaneHandlers {
+                        on_send: on_send_agent_prompt,
+                        on_cancel: on_cancel_agent_prompt,
+                        on_focus_composer: on_focus_agent_composer,
+                        on_allow_permission: on_allow_agent_permission,
+                        on_deny_permission: on_deny_agent_permission,
+                        on_cycle_mode: on_cycle_agent_mode,
+                        on_cycle_config: on_cycle_agent_config,
+                    },
+                ))
+                .into_any_element(),
         };
         div()
             .on_action(cx.listener(|_shell, _: &crate::ui::lifecycle::Quit, _window, cx| {
@@ -2792,6 +4520,17 @@ impl Render for AlasShell {
                     .flex_col()
                     .flex_1()
                     .min_w(px(0.0))
+                    .child(
+                        div()
+                            .flex()
+                            .flex_1()
+                            .min_h(px(0.0))
+                            .child(
+                                div()
+                                    .flex()
+                                    .flex_col()
+                                    .flex_1()
+                                    .min_w(px(0.0))
                     .when(self.command_picker.is_some(), |element| {
                         let picker = self.command_picker.as_ref().unwrap();
                         element.child(render_command_picker(
@@ -2884,6 +4623,44 @@ impl Render for AlasShell {
                                                 .on_click(on_cancel_notification_preferences),
                                         ),
                                 ),
+                        )
+                    })
+                    .when(self.new_tab_picker_open, |element| {
+                        element.child(render_new_tab_picker(
+                            on_select_new_tab_choice,
+                            on_cancel_new_tab_picker,
+                        ))
+                    })
+                    .when(self.agent_provider_picker.is_some(), |element| {
+                        element.child(render_agent_provider_picker(
+                            self.agent_provider_picker.as_deref().unwrap_or(&[]),
+                            on_select_agent_provider,
+                            on_cancel_agent_provider_picker,
+                        ))
+                    })
+                    .when(self.provider_settings.is_some(), |element| {
+                        element.child(
+                            div()
+                                .track_focus(&self.provider_settings_focus)
+                                .on_key_down(on_provider_settings_key_down)
+                                .child(render_provider_settings(
+                                    self.provider_settings.as_ref().unwrap(),
+                                    self.provider_settings_active_field.as_ref(),
+                                    ProviderSettingsHandlers {
+                                        on_close: Arc::new(on_close_provider_settings),
+                                        on_add_provider: Arc::new(on_add_provider),
+                                        on_save: Arc::new(on_save_provider_settings),
+                                        on_cancel: Arc::new(on_cancel_provider_settings),
+                                        on_select_field: on_select_provider_settings_field,
+                                        on_toggle_enabled: on_toggle_provider_enabled,
+                                        on_cycle_trust_mode: on_cycle_provider_trust_mode,
+                                        on_remove_provider,
+                                        on_authenticate: on_authenticate_provider,
+                                        on_run_terminal_auth,
+                                        on_clear_credentials,
+                                        on_view_auth_instructions,
+                                    },
+                                )),
                         )
                     })
                     .when(self.command_settings_dialog.is_some(), |element| {
@@ -3145,24 +4922,26 @@ impl Render for AlasShell {
                                 active_workspace_tab,
                                 on_select_workspace_tab,
                                 on_close_workspace_tab,
-                                on_new_terminal_tab,
+                                on_new_workspace_tab,
                                 workspace_body,
                             )),
                     ),
+                            )
+                            .child(render_project_inspector(
+                                self.model.selected_worktree(),
+                                &self.inspector_state,
+                                &self.file_tree_expansion,
+                                on_toggle_file_tree_node,
+                                on_open_file_from_inspector,
+                            )),
+                    )
+                    .child(render_status_bar(
+                        status_bar_repo,
+                        status_bar_tab,
+                        status_bar_terminal_status.as_ref(),
+                        active_tab.map(|tab| tab.kind),
+                    )),
             )
-            .child(render_project_inspector(
-                self.model.selected_worktree(),
-                &self.inspector_state,
-                &self.file_tree_expansion,
-                on_toggle_file_tree_node,
-                on_open_file_from_inspector,
-            ))
-            .child(render_status_bar(
-                status_bar_repo,
-                status_bar_tab,
-                status_bar_terminal_status.as_ref(),
-                active_tab.map(|tab| tab.kind),
-            ))
     }
 }
 
@@ -3216,6 +4995,25 @@ fn infer_repository_name(path: &Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
+fn finish_agent_runtime_start<C, H>(
+    mut runtime: AgentRuntime<C>,
+    cancel_handle: H,
+    start_result: anyhow::Result<()>,
+) -> (AgentThreadState, Option<(AgentRuntime<C>, H)>) {
+    match start_result {
+        Ok(()) => {
+            let thread = runtime.thread().clone();
+            (thread, Some((runtime, cancel_handle)))
+        }
+        Err(error) => {
+            runtime.thread_mut().status = AgentThreadStatus::Failed {
+                message: error.to_string(),
+            };
+            (runtime.thread().clone(), None)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3223,6 +5021,25 @@ mod tests {
     #[test]
     fn terminal_refresh_interval_targets_sixty_fps_input_echo() {
         assert!(terminal_refresh_interval() <= Duration::from_millis(16));
+    }
+
+    #[test]
+    fn failed_agent_runtime_start_drops_runtime_and_cancel_handle() {
+        let thread = AgentThreadState::new("provider", PathBuf::from("/repo/worktree"));
+        let runtime =
+            AgentRuntime::with_connection(thread, crate::agent::fake::FakeAcpConnection::new());
+
+        let (thread, runtime_with_cancel) = finish_agent_runtime_start::<_, String>(
+            runtime,
+            "cancel-handle".to_string(),
+            Err(anyhow::anyhow!("create session failed")),
+        );
+
+        assert!(runtime_with_cancel.is_none());
+        assert!(matches!(
+            thread.status,
+            AgentThreadStatus::Failed { ref message } if message == "create session failed"
+        ));
     }
 
     #[test]

--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -1,10 +1,51 @@
 use crate::{
+    agent::AgentProviderConfig,
     app::{TerminalTabKind, WorkspaceTab, WorkspaceTabId, WorkspaceTabKind},
     ui::theme::{ACCENT, ACTIVE_TAB_BG, APP_BG, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
 };
 use gpui::{
     App, ClickEvent, IntoElement, ParentElement, SharedString, Styled, Window, div, prelude::*,
 };
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum NewWorkspaceTabChoice {
+    Terminal,
+    AgentChat,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum AgentChatProviderFlow {
+    ProviderSettings,
+    CreateTab(AgentProviderConfig),
+    ProviderPicker(Vec<AgentProviderConfig>),
+}
+
+pub fn new_workspace_tab_choices() -> [NewWorkspaceTabChoice; 2] {
+    [
+        NewWorkspaceTabChoice::Terminal,
+        NewWorkspaceTabChoice::AgentChat,
+    ]
+}
+
+pub fn new_workspace_tab_choice_label(choice: NewWorkspaceTabChoice) -> &'static str {
+    match choice {
+        NewWorkspaceTabChoice::Terminal => "Terminal",
+        NewWorkspaceTabChoice::AgentChat => "Agent Chat",
+    }
+}
+
+pub fn agent_chat_provider_flow(providers: &[AgentProviderConfig]) -> AgentChatProviderFlow {
+    let enabled = providers
+        .iter()
+        .filter(|provider| provider.enabled)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    match enabled.as_slice() {
+        [] => AgentChatProviderFlow::ProviderSettings,
+        _ => AgentChatProviderFlow::ProviderPicker(enabled),
+    }
+}
 
 pub fn render_workspace(
     tabs: &[WorkspaceTab],
@@ -131,5 +172,6 @@ fn tab_label(tab: &WorkspaceTab) -> String {
         },
         WorkspaceTabKind::File => tab.name.clone(),
         WorkspaceTabKind::Image => format!("▧ {}", tab.name),
+        WorkspaceTabKind::AgentChat => format!("◇ {}", tab.name),
     }
 }

--- a/tests/agent_filesystem_tests.rs
+++ b/tests/agent_filesystem_tests.rs
@@ -1,0 +1,126 @@
+use alas::agent::{AgentTrustMode, FilesystemCallbackService};
+
+#[test]
+fn allowed_service_reads_and_writes_text_file() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let path = worktree.join("nested").join("file.txt");
+
+    let service = FilesystemCallbackService::new(AgentTrustMode::AllowEverything, worktree);
+
+    service
+        .write_text_file(&path, "hello from agent")
+        .expect("write text file");
+
+    let contents = service.read_text_file(&path).expect("read text file");
+    assert_eq!(contents, "hello from agent");
+}
+
+#[test]
+fn worktree_only_service_denies_write_outside_via_missing_path_traversal() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let traversal_path = worktree
+        .join("missing")
+        .join("..")
+        .join("..")
+        .join("outside.txt");
+    let outside = temp.path().join("outside.txt");
+
+    let service = FilesystemCallbackService::new(AgentTrustMode::WorktreeOnly, worktree);
+
+    let error = service
+        .write_text_file(&traversal_path, "should not be written")
+        .expect_err("write should be denied");
+
+    assert!(
+        error.to_string().contains("permission denied"),
+        "unexpected error: {error:#}"
+    );
+    assert!(!outside.exists());
+}
+
+#[test]
+fn worktree_only_service_allows_write_and_read_inside_worktree() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let path = worktree.join("nested").join("file.txt");
+
+    let service = FilesystemCallbackService::new(AgentTrustMode::WorktreeOnly, worktree);
+
+    service
+        .write_text_file(&path, "inside worktree")
+        .expect("write inside worktree");
+    let contents = service.read_text_file(&path).expect("read inside worktree");
+
+    assert_eq!(contents, "inside worktree");
+}
+
+#[test]
+fn ask_service_requires_permission_for_read_and_write() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let path = worktree.join("file.txt");
+    std::fs::write(&path, "contents").expect("write fixture");
+
+    let service = FilesystemCallbackService::new(AgentTrustMode::Ask, worktree);
+
+    let read_error = service
+        .read_text_file(&path)
+        .expect_err("read should require permission");
+    assert!(
+        read_error.to_string().contains("permission required"),
+        "unexpected error: {read_error:#}"
+    );
+    let write_error = service
+        .write_text_file(&path, "new contents")
+        .expect_err("write should require permission");
+    assert!(
+        write_error.to_string().contains("permission required"),
+        "unexpected error: {write_error:#}"
+    );
+}
+
+#[test]
+fn denied_service_denies_write_and_does_not_create_file() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let path = worktree.join("file.txt");
+
+    let service = FilesystemCallbackService::new(AgentTrustMode::Deny, worktree);
+
+    let error = service
+        .write_text_file(&path, "should not be written")
+        .expect_err("write should be denied");
+
+    assert!(
+        error.to_string().contains("permission denied"),
+        "unexpected error: {error:#}"
+    );
+    assert!(!path.exists());
+}
+
+#[test]
+fn denied_service_denies_read() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let path = worktree.join("file.txt");
+    std::fs::write(&path, "contents").expect("write fixture");
+
+    let service = FilesystemCallbackService::new(AgentTrustMode::Deny, worktree);
+
+    let error = service
+        .read_text_file(&path)
+        .expect_err("read should be denied");
+
+    assert!(
+        error.to_string().contains("permission denied"),
+        "unexpected error: {error:#}"
+    );
+}

--- a/tests/agent_permission_tests.rs
+++ b/tests/agent_permission_tests.rs
@@ -1,0 +1,188 @@
+use alas::agent::{AgentTrustMode, PermissionDecision, PermissionPolicy, PermissionRequestKind};
+
+#[test]
+fn allow_everything_approves_file_writes_outside_worktree_and_terminal_commands() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let outside = temp.path().join("outside.txt");
+
+    let policy = PermissionPolicy::new(AgentTrustMode::AllowEverything, worktree);
+
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::WriteFile(outside)),
+        PermissionDecision::Allow
+    );
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::RunTerminal {
+            command: "touch /tmp/outside".to_string(),
+        }),
+        PermissionDecision::Allow
+    );
+}
+
+#[test]
+fn ask_prompts_for_file_reads_file_writes_and_terminal_commands() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+
+    let policy = PermissionPolicy::new(AgentTrustMode::Ask, worktree.clone());
+
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::ReadFile(worktree.join("file.txt"))),
+        PermissionDecision::Ask
+    );
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::WriteFile(worktree.join("file.txt"))),
+        PermissionDecision::Ask
+    );
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::RunTerminal {
+            command: "cargo test".to_string(),
+        }),
+        PermissionDecision::Ask
+    );
+}
+
+#[test]
+fn worktree_only_denies_write_outside_and_allows_missing_file_inside_canonical_worktree() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    let outside_dir = temp.path().join("outside");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    std::fs::create_dir(&outside_dir).expect("create outside dir");
+
+    let worktree_link = temp.path().join("worktree-link");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&worktree, &worktree_link).expect("create worktree symlink");
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(&worktree, &worktree_link).expect("create worktree symlink");
+
+    let outside = outside_dir.join("outside.txt");
+    let missing_inside = worktree_link.join("nested").join("missing.txt");
+    std::fs::create_dir(worktree.join("nested")).expect("create nested dir");
+
+    let policy = PermissionPolicy::new(AgentTrustMode::WorktreeOnly, worktree_link);
+
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::WriteFile(outside)),
+        PermissionDecision::Deny
+    );
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::WriteFile(missing_inside)),
+        PermissionDecision::Allow
+    );
+}
+
+#[test]
+fn worktree_only_denies_missing_path_parent_traversal_outside_worktree() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let path = worktree
+        .join("missing")
+        .join("..")
+        .join("..")
+        .join("outside.txt");
+
+    let policy = PermissionPolicy::new(AgentTrustMode::WorktreeOnly, worktree);
+
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::WriteFile(path)),
+        PermissionDecision::Deny
+    );
+}
+
+#[test]
+fn worktree_only_prompts_for_terminal_commands() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+
+    let policy = PermissionPolicy::new(AgentTrustMode::WorktreeOnly, worktree);
+
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::RunTerminal {
+            command: "cargo test".to_string(),
+        }),
+        PermissionDecision::Ask
+    );
+}
+
+#[test]
+fn worktree_only_allows_file_reads_inside_worktree() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let file = worktree.join("file.txt");
+    std::fs::write(&file, "contents").expect("write file");
+
+    let policy = PermissionPolicy::new(AgentTrustMode::WorktreeOnly, worktree);
+
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::ReadFile(file)),
+        PermissionDecision::Allow
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn worktree_only_denies_symlink_inside_worktree_pointing_outside() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    let outside = temp.path().join("outside.txt");
+    std::fs::write(&outside, "outside").expect("write outside file");
+    let link = worktree.join("outside-link.txt");
+    std::os::unix::fs::symlink(&outside, &link).expect("create file symlink");
+
+    let policy = PermissionPolicy::new(AgentTrustMode::WorktreeOnly, worktree);
+
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::ReadFile(link)),
+        PermissionDecision::Deny
+    );
+}
+
+#[test]
+fn worktree_only_denies_sibling_path_with_common_prefix() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    let sibling = temp.path().join("worktree-sibling");
+    std::fs::create_dir(&worktree).expect("create worktree");
+    std::fs::create_dir(&sibling).expect("create sibling");
+    let sibling_file = sibling.join("file.txt");
+    std::fs::write(&sibling_file, "sibling").expect("write sibling file");
+
+    let policy = PermissionPolicy::new(AgentTrustMode::WorktreeOnly, worktree);
+
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::ReadFile(sibling_file)),
+        PermissionDecision::Deny
+    );
+}
+
+#[test]
+fn deny_rejects_file_reads_file_writes_and_terminal_side_effects() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().join("worktree");
+    std::fs::create_dir(&worktree).expect("create worktree");
+
+    let policy = PermissionPolicy::new(AgentTrustMode::Deny, worktree.clone());
+
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::ReadFile(worktree.join("file.txt"))),
+        PermissionDecision::Deny
+    );
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::WriteFile(worktree.join("file.txt"))),
+        PermissionDecision::Deny
+    );
+    assert_eq!(
+        policy.decide(&PermissionRequestKind::RunTerminal {
+            command: "rm -rf target".to_string(),
+        }),
+        PermissionDecision::Deny
+    );
+}

--- a/tests/agent_persistence_tests.rs
+++ b/tests/agent_persistence_tests.rs
@@ -1,0 +1,139 @@
+use std::path::PathBuf;
+
+use alas::agent::{
+    AgentThreadRecord, AgentThreadState, AgentThreadStore, AgentTranscriptEntry,
+    filter_agent_thread_records, merge_agent_thread_records,
+};
+use tempfile::tempdir;
+
+#[test]
+fn thread_store_round_trips_persisted_thread_records() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentThreadStore::new(dir.path().join("agent_threads.json"));
+    let mut state = AgentThreadState::new("opencode", PathBuf::from("/repo/a"));
+    state.acp_session_id = Some("sess-1".to_string());
+    state.transcript.push(AgentTranscriptEntry::user("hello"));
+
+    let record = AgentThreadRecord::from_state("thread-1".to_string(), &state);
+    assert_eq!(record.state.thread_id, "thread-1");
+    store
+        .save_records(std::slice::from_ref(&record))
+        .expect("save records");
+
+    let loaded = store.load_records().expect("load records");
+    assert_eq!(loaded, vec![record]);
+}
+
+#[test]
+fn thread_store_preserves_state_thread_id_across_save_load() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentThreadStore::new(dir.path().join("agent_threads.json"));
+    let mut state = AgentThreadState::new("opencode", PathBuf::from("/repo/a"));
+    state.thread_id = "stable-thread".to_string();
+
+    store
+        .save_records(&[AgentThreadRecord::from_state(
+            state.thread_id.clone(),
+            &state,
+        )])
+        .expect("save records");
+
+    let loaded = store.load_records().expect("load records");
+    assert_eq!(loaded[0].thread_id, "stable-thread");
+    assert_eq!(loaded[0].state.thread_id, "stable-thread");
+}
+
+#[test]
+fn missing_thread_store_loads_empty_records() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentThreadStore::new(dir.path().join("missing.json"));
+    assert!(store.load_records().expect("load missing").is_empty());
+}
+
+#[test]
+fn merge_records_preserves_cached_worktrees_and_overwrites_workspace_threads() {
+    let mut cached_current = AgentThreadState::new("opencode", PathBuf::from("/repo/current"));
+    cached_current.draft = "old draft".to_string();
+    let mut workspace_current = cached_current.clone();
+    workspace_current.draft = "new draft".to_string();
+    let cached_other = AgentThreadState::new("codex", PathBuf::from("/repo/other"));
+
+    let merged = merge_agent_thread_records(
+        vec![
+            AgentThreadRecord::from_state("thread-current".to_string(), &cached_current),
+            AgentThreadRecord::from_state("thread-other".to_string(), &cached_other),
+        ],
+        vec![AgentThreadRecord::from_state(
+            "thread-current".to_string(),
+            &workspace_current,
+        )],
+        Vec::<String>::new(),
+    );
+
+    assert_eq!(merged.len(), 2);
+    assert_eq!(
+        merged
+            .iter()
+            .find(|record| record.thread_id == "thread-current")
+            .expect("current record")
+            .state
+            .draft,
+        "new draft"
+    );
+    assert!(
+        merged
+            .iter()
+            .any(|record| record.thread_id == "thread-other")
+    );
+}
+
+#[test]
+fn filter_records_excludes_pending_load_tombstones() {
+    let closed = AgentThreadState::new("opencode", PathBuf::from("/repo/current"));
+    let removed_worktree = AgentThreadState::new("opencode", PathBuf::from("/repo/removed-wt"));
+    let removed_repo = AgentThreadState::new("codex", PathBuf::from("/repo/removed/subtree"));
+    let kept = AgentThreadState::new("codex", PathBuf::from("/repo/kept"));
+
+    let filtered = filter_agent_thread_records(
+        vec![
+            AgentThreadRecord::from_state("thread-closed".to_string(), &closed),
+            AgentThreadRecord::from_state("thread-removed-wt".to_string(), &removed_worktree),
+            AgentThreadRecord::from_state("thread-removed-repo".to_string(), &removed_repo),
+            AgentThreadRecord::from_state("thread-kept".to_string(), &kept),
+        ],
+        vec!["thread-closed".to_string()],
+        vec![PathBuf::from("/repo/removed-wt")],
+        vec![PathBuf::from("/repo/removed")],
+    );
+
+    let thread_ids = filtered
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(thread_ids, vec!["thread-kept"]);
+}
+
+#[test]
+fn merge_records_excludes_closed_thread_from_cached_and_workspace_records() {
+    let closed = AgentThreadState::new("opencode", PathBuf::from("/repo/current"));
+    let open = AgentThreadState::new("opencode", PathBuf::from("/repo/current"));
+    let other = AgentThreadState::new("codex", PathBuf::from("/repo/other"));
+
+    let merged = merge_agent_thread_records(
+        vec![
+            AgentThreadRecord::from_state("thread-closed".to_string(), &closed),
+            AgentThreadRecord::from_state("thread-other".to_string(), &other),
+        ],
+        vec![
+            AgentThreadRecord::from_state("thread-closed".to_string(), &closed),
+            AgentThreadRecord::from_state("thread-open".to_string(), &open),
+        ],
+        vec!["thread-closed".to_string()],
+    );
+
+    let thread_ids = merged
+        .iter()
+        .map(|record| record.thread_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(thread_ids, vec!["thread-open", "thread-other"]);
+}

--- a/tests/agent_provider_config_tests.rs
+++ b/tests/agent_provider_config_tests.rs
@@ -1,0 +1,119 @@
+use alas::agent::{
+    AgentAuthField, AgentAuthMethod, AgentProviderConfig, AgentProviderEnvVar, AgentTrustMode,
+    CredentialStore, CredentialStoreKey, MemoryCredentialStore, ProviderCwdPolicy,
+    resolve_secure_env_values,
+};
+use alas::config::AppConfig;
+
+#[test]
+fn app_config_serializes_global_agent_providers_without_secret_values() {
+    let mut config = AppConfig::default();
+    config.agent_providers.push(AgentProviderConfig {
+        id: "opencode".to_string(),
+        display_name: "OpenCode".to_string(),
+        command: "opencode".to_string(),
+        args: vec!["acp".to_string()],
+        env: vec![AgentProviderEnvVar::secure_ref(
+            "OPENCODE_API_KEY",
+            "opencode/api-key",
+        )],
+        auth_methods: Vec::new(),
+        cwd_policy: ProviderCwdPolicy::SelectedWorktree,
+        trust_mode: AgentTrustMode::AllowEverything,
+        enabled: true,
+    });
+
+    let toml = toml::to_string(&config).expect("serialize config");
+    assert!(toml.contains("agent_providers"));
+    assert!(toml.contains("opencode/api-key"));
+    assert!(!toml.contains("value ="));
+
+    let loaded: AppConfig = toml::from_str(&toml).expect("deserialize config");
+    assert_eq!(
+        loaded.agent_providers[0].trust_mode,
+        AgentTrustMode::AllowEverything
+    );
+}
+
+#[test]
+fn provider_defaults_to_allow_everything_and_selected_worktree() {
+    let provider = AgentProviderConfig::new("codex", "Codex", "codex-acp");
+    assert_eq!(provider.trust_mode, AgentTrustMode::AllowEverything);
+    assert_eq!(provider.cwd_policy, ProviderCwdPolicy::SelectedWorktree);
+    assert!(provider.enabled);
+}
+
+#[test]
+fn env_var_auth_method_builds_secure_env_refs() {
+    let method = AgentAuthMethod::EnvVar {
+        fields: vec![AgentAuthField::secret("API token", "OPENCODE_API_KEY")],
+        link: Some("https://example.test/token".to_string()),
+    };
+
+    assert_eq!(
+        method.secure_env_refs("opencode"),
+        vec![AgentProviderEnvVar::secure_ref(
+            "OPENCODE_API_KEY",
+            "opencode/OPENCODE_API_KEY"
+        )]
+    );
+    assert_eq!(method.instructions(), Some("https://example.test/token"));
+}
+
+#[test]
+fn terminal_auth_method_preserves_setup_args_and_env() {
+    let env = vec![AgentProviderEnvVar {
+        name: "AUTH_MODE".to_string(),
+        value: Some("browser".to_string()),
+        secure_ref: None,
+    }];
+    let method = AgentAuthMethod::Terminal {
+        args: vec!["auth".to_string(), "login".to_string()],
+        env: env.clone(),
+    };
+
+    let (args, method_env) = method.terminal_args_env().expect("terminal auth");
+    assert_eq!(args, &["auth".to_string(), "login".to_string()]);
+    assert_eq!(method_env, env.as_slice());
+}
+
+#[test]
+fn secure_env_values_resolve_from_credential_store_without_serializing_secret() {
+    let store = MemoryCredentialStore::default();
+    store
+        .write_secret(
+            &CredentialStoreKey::new("opencode", "OPENCODE_API_KEY"),
+            "super-secret",
+        )
+        .unwrap();
+    let env = vec![AgentProviderEnvVar::secure_ref(
+        "OPENCODE_API_KEY",
+        "opencode/OPENCODE_API_KEY",
+    )];
+
+    assert_eq!(
+        resolve_secure_env_values("opencode", &env, &store).unwrap(),
+        vec![("OPENCODE_API_KEY".to_string(), "super-secret".to_string())]
+    );
+    assert!(
+        !serde_json::to_string(&env)
+            .unwrap()
+            .contains("super-secret")
+    );
+}
+
+#[test]
+fn memory_credential_store_round_trips_secret_by_provider_and_field() {
+    let store = MemoryCredentialStore::default();
+    let key = CredentialStoreKey::new("opencode", "OPENCODE_API_KEY");
+
+    store
+        .write_secret(&key, "super-secret")
+        .expect("write secret");
+    assert_eq!(
+        store.read_secret(&key).expect("read secret"),
+        Some("super-secret".to_string())
+    );
+    store.delete_secret(&key).expect("delete secret");
+    assert_eq!(store.read_secret(&key).expect("read after delete"), None);
+}

--- a/tests/agent_provider_discovery_tests.rs
+++ b/tests/agent_provider_discovery_tests.rs
@@ -1,0 +1,390 @@
+use std::{cell::Cell, fs, path::Path};
+
+use alas::{
+    agent::{
+        AgentProviderConfig, AgentProviderSuggestion, ProviderDiscoveryResult,
+        ProviderSettingsState, apply_provider_discovery_to_config,
+        discover_agent_providers_from_path, filtered_provider_suggestions,
+        ignore_discovered_provider_id, is_known_discoverable_provider_id,
+        merge_discovered_agent_providers, remove_provider_and_record_discovery_ignore,
+    },
+    config::{AppConfig, AppConfigStore},
+};
+use tempfile::TempDir;
+
+#[test]
+fn opencode_on_path_is_verified_provider() {
+    let dir = TempDir::new().expect("temp dir");
+    create_fake_executable(dir.path(), "opencode");
+
+    let discovery = discover_agent_providers_from_path(Some(&path_env(&[dir.path()])));
+
+    assert_eq!(discovery.verified_providers.len(), 1);
+    let provider = &discovery.verified_providers[0];
+    assert_eq!(provider.id, "opencode");
+    assert_eq!(provider.display_name, "OpenCode");
+    assert_eq!(provider.command, "opencode");
+    assert_eq!(provider.args, vec!["acp"]);
+    assert!(provider.enabled);
+    assert!(discovery.suggestions.is_empty());
+}
+
+#[test]
+fn claude_and_codex_on_path_are_verified_with_npx_adapters() {
+    let dir = TempDir::new().expect("temp dir");
+    create_fake_executable(dir.path(), "claude");
+    create_fake_executable(dir.path(), "codex");
+    create_fake_executable(dir.path(), "npx");
+
+    let discovery = discover_agent_providers_from_path(Some(&path_env(&[dir.path()])));
+
+    assert!(discovery.suggestions.is_empty());
+    assert_eq!(
+        discovery
+            .verified_providers
+            .iter()
+            .map(|provider| provider.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["claude", "codex"]
+    );
+
+    let claude = &discovery.verified_providers[0];
+    assert_eq!(claude.display_name, "Claude Code");
+    assert_eq!(claude.command, "npx");
+    assert_eq!(
+        claude.args,
+        vec!["-y", "@agentclientprotocol/claude-agent-acp"]
+    );
+
+    let codex = &discovery.verified_providers[1];
+    assert_eq!(codex.display_name, "Codex");
+    assert_eq!(codex.command, "npx");
+    assert_eq!(codex.args, vec!["-y", "@zed-industries/codex-acp"]);
+}
+
+#[test]
+fn missing_or_empty_path_does_not_error() {
+    let missing = discover_agent_providers_from_path(None);
+    assert!(missing.verified_providers.is_empty());
+    assert!(missing.suggestions.is_empty());
+
+    let empty = discover_agent_providers_from_path(Some(""));
+    assert!(empty.verified_providers.is_empty());
+    assert!(empty.suggestions.is_empty());
+}
+
+#[test]
+fn ignores_empty_relative_and_non_executable_path_entries() {
+    let dir = TempDir::new().expect("temp dir");
+    create_fake_file(dir.path(), "opencode");
+
+    let path = format!(
+        "{}relative{}{}",
+        path_list_separator(),
+        path_list_separator(),
+        path_env(&[dir.path()])
+    );
+
+    let discovery = discover_agent_providers_from_path(Some(&path));
+
+    assert!(discovery.verified_providers.is_empty());
+    assert!(discovery.suggestions.is_empty());
+}
+
+#[test]
+fn duplicate_path_matches_are_deduped() {
+    let first = TempDir::new().expect("temp dir");
+    let second = TempDir::new().expect("temp dir");
+    create_fake_executable(first.path(), "opencode");
+    create_fake_executable(second.path(), "opencode");
+
+    let discovery =
+        discover_agent_providers_from_path(Some(&path_env(&[first.path(), second.path()])));
+
+    assert_eq!(discovery.verified_providers.len(), 1);
+    assert_eq!(discovery.verified_providers[0].id, "opencode");
+}
+
+#[test]
+fn claude_without_npx_is_suggestion_only() {
+    let dir = TempDir::new().expect("temp dir");
+    create_fake_executable(dir.path(), "claude");
+
+    let discovery = discover_agent_providers_from_path(Some(&path_env(&[dir.path()])));
+
+    assert!(discovery.verified_providers.is_empty());
+    assert_eq!(discovery.suggestions.len(), 1);
+    assert_eq!(discovery.suggestions[0].id, "claude");
+    assert!(discovery.suggestions[0].message.contains("npx"));
+    assert!(discovery.suggestions[0].message.contains("ACP adapter"));
+}
+
+#[test]
+fn known_discoverable_provider_ids_are_reported() {
+    assert!(is_known_discoverable_provider_id("opencode"));
+    assert!(is_known_discoverable_provider_id("claude"));
+    assert!(is_known_discoverable_provider_id("codex"));
+    assert!(!is_known_discoverable_provider_id("unknown"));
+}
+
+#[test]
+fn merge_appends_missing_verified_provider_and_reports_changed() {
+    let mut config = AppConfig::default();
+    let discovery = ProviderDiscoveryResult {
+        verified_providers: vec![opencode_provider()],
+        suggestions: Vec::new(),
+    };
+
+    let changed = merge_discovered_agent_providers(&mut config, &discovery);
+
+    assert!(changed);
+    assert_eq!(config.agent_providers.len(), 1);
+    assert_eq!(config.agent_providers[0].id, "opencode");
+}
+
+#[test]
+fn merge_preserves_existing_provider_without_overwrite_or_reenable() {
+    let mut existing = AgentProviderConfig::new("opencode", "Custom OpenCode", "custom-opencode");
+    existing.args = vec!["custom-acp".to_string()];
+    existing.enabled = false;
+    let original = existing.clone();
+    let mut config = AppConfig {
+        agent_providers: vec![existing],
+        ..AppConfig::default()
+    };
+    let discovery = ProviderDiscoveryResult {
+        verified_providers: vec![opencode_provider()],
+        suggestions: Vec::new(),
+    };
+
+    let changed = merge_discovered_agent_providers(&mut config, &discovery);
+
+    assert!(!changed);
+    assert_eq!(config.agent_providers, vec![original]);
+    assert!(!config.agent_providers[0].enabled);
+}
+
+#[test]
+fn merge_skips_ignored_provider_id() {
+    let mut config = AppConfig::default();
+    config
+        .agent_provider_discovery
+        .ignored_provider_ids
+        .push("opencode".to_string());
+    let discovery = ProviderDiscoveryResult {
+        verified_providers: vec![opencode_provider()],
+        suggestions: Vec::new(),
+    };
+
+    let changed = merge_discovered_agent_providers(&mut config, &discovery);
+
+    assert!(!changed);
+    assert!(config.agent_providers.is_empty());
+}
+
+#[test]
+fn suggestions_are_filtered_for_configured_and_ignored_ids() {
+    let mut config = AppConfig {
+        agent_providers: vec![AgentProviderConfig::new("claude", "Claude Code", "claude")],
+        ..AppConfig::default()
+    };
+    config
+        .agent_provider_discovery
+        .ignored_provider_ids
+        .push("codex".to_string());
+    let discovery = ProviderDiscoveryResult {
+        verified_providers: Vec::new(),
+        suggestions: vec![suggestion("claude"), suggestion("codex")],
+    };
+
+    let filtered = filtered_provider_suggestions(&config, &discovery);
+
+    assert!(filtered.is_empty());
+}
+
+#[test]
+fn record_ignored_known_provider_id_dedupes() {
+    let mut config = AppConfig::default();
+
+    assert!(ignore_discovered_provider_id(&mut config, "opencode"));
+    assert!(!ignore_discovered_provider_id(&mut config, "opencode"));
+    assert!(!ignore_discovered_provider_id(&mut config, "unknown"));
+
+    assert_eq!(
+        config.agent_provider_discovery.ignored_provider_ids,
+        vec!["opencode"]
+    );
+}
+
+#[test]
+fn removing_known_discovered_provider_records_ignored_id() {
+    let mut config = AppConfig::default();
+    let mut settings = ProviderSettingsState::default();
+    settings.add_provider(AgentProviderConfig::new("opencode", "OpenCode", "opencode"));
+
+    let changed =
+        remove_provider_and_record_discovery_ignore(&mut config, &mut settings, "opencode");
+
+    assert!(changed);
+    assert!(settings.providers.is_empty());
+    assert_eq!(
+        config.agent_provider_discovery.ignored_provider_ids,
+        vec!["opencode"]
+    );
+}
+
+#[test]
+fn removing_unknown_provider_does_not_record_ignored_id() {
+    let mut config = AppConfig::default();
+    let mut settings = ProviderSettingsState::default();
+    settings.add_provider(AgentProviderConfig::new("custom", "Custom", "custom"));
+
+    let changed = remove_provider_and_record_discovery_ignore(&mut config, &mut settings, "custom");
+
+    assert!(changed);
+    assert!(settings.providers.is_empty());
+    assert!(
+        config
+            .agent_provider_discovery
+            .ignored_provider_ids
+            .is_empty()
+    );
+}
+
+#[test]
+fn saving_after_removal_persists_ignored_provider_ids() {
+    let dir = TempDir::new().expect("temp dir");
+    let store = AppConfigStore::new(dir.path().join("config.toml"));
+    let mut config = AppConfig::default();
+    let mut settings = ProviderSettingsState::default();
+    settings.add_provider(AgentProviderConfig::new("opencode", "OpenCode", "opencode"));
+
+    let changed =
+        remove_provider_and_record_discovery_ignore(&mut config, &mut settings, "opencode");
+    assert!(changed);
+    config.agent_providers = settings.providers.clone();
+    store.save(&config).expect("save config");
+
+    let reloaded = store.load().expect("load config");
+    assert_eq!(
+        reloaded.agent_provider_discovery.ignored_provider_ids,
+        vec!["opencode"]
+    );
+}
+
+#[test]
+fn startup_discovery_returns_filtered_suggestions_after_merge() {
+    let mut config = AppConfig::default();
+    let discovery = ProviderDiscoveryResult {
+        verified_providers: vec![opencode_provider()],
+        suggestions: vec![suggestion("claude")],
+    };
+    let save_called = Cell::new(false);
+
+    let result = apply_provider_discovery_to_config(&mut config, &discovery, |saved_config| {
+        save_called.set(true);
+        assert_eq!(saved_config.agent_providers.len(), 1);
+        assert_eq!(saved_config.agent_providers[0].id, "opencode");
+        Ok(())
+    });
+
+    assert!(result.changed);
+    assert!(result.error.is_none());
+    assert!(save_called.get());
+    assert_eq!(config.agent_providers.len(), 1);
+    assert_eq!(config.agent_providers[0].id, "opencode");
+    assert_eq!(
+        result
+            .suggestions
+            .iter()
+            .map(|suggestion| suggestion.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["claude"]
+    );
+}
+
+#[test]
+fn startup_discovery_save_failure_returns_deterministic_error_without_aborting() {
+    let mut config = AppConfig::default();
+    let discovery = ProviderDiscoveryResult {
+        verified_providers: vec![opencode_provider()],
+        suggestions: Vec::new(),
+    };
+
+    let result = apply_provider_discovery_to_config(&mut config, &discovery, |_config| {
+        Err(anyhow::anyhow!("disk full"))
+    });
+
+    assert!(result.changed);
+    assert_eq!(config.agent_providers.len(), 1);
+    assert_eq!(config.agent_providers[0].id, "opencode");
+    let error = result.error.expect("save error");
+    assert!(error.starts_with("failed to persist auto-discovered providers: "));
+    assert!(error.contains("disk full"));
+}
+
+#[test]
+fn startup_discovery_does_not_save_when_config_unchanged() {
+    let mut config = AppConfig {
+        agent_providers: vec![opencode_provider()],
+        ..AppConfig::default()
+    };
+    let discovery = ProviderDiscoveryResult {
+        verified_providers: vec![opencode_provider()],
+        suggestions: Vec::new(),
+    };
+
+    let result = apply_provider_discovery_to_config(&mut config, &discovery, |_config| {
+        panic!("save should not be called when config is unchanged")
+    });
+
+    assert!(!result.changed);
+    assert!(result.error.is_none());
+    assert!(result.suggestions.is_empty());
+    assert_eq!(config.agent_providers.len(), 1);
+    assert_eq!(config.agent_providers[0].id, "opencode");
+}
+
+fn opencode_provider() -> AgentProviderConfig {
+    let mut provider = AgentProviderConfig::new("opencode", "OpenCode", "opencode");
+    provider.args = vec!["acp".to_string()];
+    provider
+}
+
+fn suggestion(id: &str) -> AgentProviderSuggestion {
+    AgentProviderSuggestion {
+        id: id.to_string(),
+        display_name: id.to_string(),
+        command: id.to_string(),
+        message: format!("{id} suggestion"),
+    }
+}
+
+fn path_env(paths: &[&Path]) -> String {
+    std::env::join_paths(paths)
+        .expect("join path")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn path_list_separator() -> char {
+    if cfg!(windows) { ';' } else { ':' }
+}
+
+fn create_fake_executable(dir: &Path, command: &str) {
+    create_fake_file(dir, command);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = dir.join(command);
+        let mut permissions = fs::metadata(&path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).expect("set executable permissions");
+    }
+}
+
+fn create_fake_file(dir: &Path, command: &str) {
+    fs::write(dir.join(command), "#!/bin/sh\n").expect("write fake command");
+}

--- a/tests/agent_runtime_tests.rs
+++ b/tests/agent_runtime_tests.rs
@@ -1,0 +1,1130 @@
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use alas::agent::{
+    AcpProcessConnection, AgentAuthStatus, AgentConfigOption, AgentConfigValueOption,
+    AgentDebugEvent, AgentModeOption, AgentProviderConfig, AgentProviderEnvVar, AgentResumeState,
+    AgentRuntime, AgentRuntimeEvent, AgentSlashCommand, AgentTerminalService, AgentThreadState,
+    AgentThreadStatus, AgentTranscriptEntry, AgentTranscriptRole, AgentTrustMode, CredentialStore,
+    CredentialStoreKey, FakeAcpConnection, FilesystemCallbackService, MemoryCredentialStore,
+    ProviderCwdPolicy, apply_agent_update, redact_debug_message, redact_debug_value,
+    resolve_provider_cwd,
+};
+
+#[test]
+fn process_connection_reports_missing_provider_binary_with_context() {
+    let provider = AgentProviderConfig::new(
+        "missing-provider",
+        "Missing Provider",
+        "alas-definitely-missing-acp-provider-binary",
+    );
+
+    let error = AcpProcessConnection::spawn(&provider, PathBuf::from("/")).unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains("missing-provider"));
+    assert!(message.contains("alas-definitely-missing-acp-provider-binary"));
+}
+
+#[test]
+fn process_connection_dispatches_filesystem_callbacks() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("note.txt");
+    let provider = AgentProviderConfig::new("dispatcher", "Dispatcher", "/bin/cat");
+    let mut connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf())
+        .unwrap()
+        .with_callback_services(
+            FilesystemCallbackService::new(
+                AgentTrustMode::AllowEverything,
+                temp.path().to_path_buf(),
+            ),
+            AgentTerminalService::new(AgentTrustMode::AllowEverything, temp.path().to_path_buf()),
+        );
+
+    connection
+        .dispatch_client_request(
+            "fs/write_text_file",
+            serde_json::json!({ "sessionId": "s", "path": path, "content": "hello" }),
+        )
+        .unwrap();
+    let response = connection
+        .dispatch_client_request(
+            "fs/read_text_file",
+            serde_json::json!({ "sessionId": "s", "path": temp.path().join("note.txt") }),
+        )
+        .unwrap();
+
+    assert_eq!(response["content"], "hello");
+}
+
+#[cfg(unix)]
+#[test]
+fn process_connection_dispatches_terminal_callbacks() {
+    let temp = tempfile::tempdir().unwrap();
+    let provider = AgentProviderConfig::new("dispatcher", "Dispatcher", "/bin/cat");
+    let mut connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf())
+        .unwrap()
+        .with_callback_services(
+            FilesystemCallbackService::new(
+                AgentTrustMode::AllowEverything,
+                temp.path().to_path_buf(),
+            ),
+            AgentTerminalService::new(AgentTrustMode::AllowEverything, temp.path().to_path_buf()),
+        );
+
+    let created = connection
+        .dispatch_client_request(
+            "terminal/create",
+            serde_json::json!({ "sessionId": "s", "command": "printf", "args": ["hello"], "cwd": temp.path() }),
+        )
+        .unwrap();
+    let terminal_id = created["terminalId"].as_str().unwrap();
+    let exit = connection
+        .dispatch_client_request(
+            "terminal/wait_for_exit",
+            serde_json::json!({ "sessionId": "s", "terminalId": terminal_id }),
+        )
+        .unwrap();
+    let output = connection
+        .dispatch_client_request(
+            "terminal/output",
+            serde_json::json!({ "sessionId": "s", "terminalId": terminal_id }),
+        )
+        .unwrap();
+    connection
+        .dispatch_client_request(
+            "terminal/kill",
+            serde_json::json!({ "sessionId": "s", "terminalId": terminal_id }),
+        )
+        .unwrap();
+    connection
+        .dispatch_client_request(
+            "terminal/release",
+            serde_json::json!({ "sessionId": "s", "terminalId": terminal_id }),
+        )
+        .unwrap();
+
+    assert_eq!(exit["exitCode"], 0);
+    assert_eq!(output["output"], "hello");
+}
+
+#[test]
+fn process_connection_dispatches_permission_without_pending_continuation() {
+    let temp = tempfile::tempdir().unwrap();
+    let provider = AgentProviderConfig::new("dispatcher", "Dispatcher", "/bin/cat");
+    let mut connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf())
+        .unwrap()
+        .with_callback_services(
+            FilesystemCallbackService::new(AgentTrustMode::Ask, temp.path().to_path_buf()),
+            AgentTerminalService::new(AgentTrustMode::Ask, temp.path().to_path_buf()),
+        );
+
+    let response = connection
+        .dispatch_client_request(
+            "session/request_permission",
+            serde_json::json!({
+                "sessionId": "s",
+                "toolCall": { "toolCallId": "t", "title": "Run tool" },
+                "options": [
+                    { "optionId": "allow", "name": "Allow", "kind": "allow_once" },
+                    { "optionId": "reject", "name": "Reject", "kind": "reject_once" }
+                ]
+            }),
+        )
+        .unwrap();
+
+    assert_eq!(response["outcome"]["optionId"], "reject");
+}
+
+#[test]
+fn process_connection_does_not_select_allow_when_permission_denied() {
+    let temp = tempfile::tempdir().unwrap();
+    let provider = AgentProviderConfig::new("dispatcher", "Dispatcher", "/bin/cat");
+    let mut connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf())
+        .unwrap()
+        .with_callback_services(
+            FilesystemCallbackService::new(AgentTrustMode::Ask, temp.path().to_path_buf()),
+            AgentTerminalService::new(AgentTrustMode::Ask, temp.path().to_path_buf()),
+        );
+
+    let error = connection
+        .dispatch_client_request(
+            "session/request_permission",
+            serde_json::json!({
+                "sessionId": "s",
+                "toolCall": { "toolCallId": "t", "title": "Run tool" },
+                "options": [
+                    { "optionId": "allow", "name": "Allow", "kind": "allow_once" }
+                ]
+            }),
+        )
+        .expect_err("permission denial must not select the only allow option");
+
+    assert!(
+        error
+            .to_string()
+            .contains("permission request did not include a compatible option")
+    );
+}
+
+#[test]
+fn process_connection_ask_filesystem_returns_honest_error() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("note.txt");
+    std::fs::write(&path, "hello").unwrap();
+    let provider = AgentProviderConfig::new("dispatcher", "Dispatcher", "/bin/cat");
+    let mut connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf())
+        .unwrap()
+        .with_callback_services(
+            FilesystemCallbackService::new(AgentTrustMode::Ask, temp.path().to_path_buf()),
+            AgentTerminalService::new(AgentTrustMode::Ask, temp.path().to_path_buf()),
+        );
+
+    let error = connection
+        .dispatch_client_request(
+            "fs/read_text_file",
+            serde_json::json!({ "sessionId": "s", "path": path }),
+        )
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("cannot be continued"));
+}
+
+#[cfg(unix)]
+#[test]
+fn acp_cancel_handle_writes_session_cancel_notification() {
+    let temp = tempfile::tempdir().unwrap();
+    let output = temp.path().join("cancel.json");
+    let script = format!(
+        "IFS= read -r line; printf '%s' \"$line\" > {}; sleep 1",
+        output.display()
+    );
+    let mut provider = AgentProviderConfig::new("cancel-provider", "Cancel Provider", "/bin/sh");
+    provider.args = vec!["-c".to_string(), script];
+
+    let connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf()).unwrap();
+    let cancel_handle = connection.cancel_handle();
+    cancel_handle.cancel("session-123".to_string()).unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !output.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(output).unwrap()).unwrap();
+    assert_eq!(value["jsonrpc"], "2.0");
+    assert_eq!(value["method"], "session/cancel");
+    assert_eq!(value["params"]["sessionId"], "session-123");
+}
+
+#[test]
+fn process_connection_rejects_unresolved_secure_env_refs() {
+    let mut provider = AgentProviderConfig::new("secure-provider", "Secure Provider", "unused");
+    provider
+        .env
+        .push(AgentProviderEnvVar::secure_ref("API_TOKEN", "token-id"));
+
+    let error = AcpProcessConnection::spawn_with_env(
+        &provider,
+        PathBuf::from("/"),
+        &[("TOKEN".to_string(), "redacted".to_string())],
+    )
+    .unwrap_err();
+    let message = error.to_string();
+
+    assert!(message.contains("secure-provider"));
+    assert!(message.contains("API_TOKEN"));
+    assert!(!message.contains("token-id"));
+    assert!(message.contains("requires credential resolution before launch"));
+    assert!(!message.contains("redacted"));
+}
+
+#[cfg(unix)]
+#[test]
+fn process_connection_spawns_after_resolving_secure_env_refs() {
+    let temp = tempfile::tempdir().unwrap();
+    let output = temp.path().join("secure-spawn-output.txt");
+    let script = format!("printf '%s' \"$API_TOKEN\" > {}", output.display());
+    let mut provider = AgentProviderConfig::new("secure-provider", "Secure Provider", "/bin/sh");
+    provider.args = vec!["-c".to_string(), script];
+    provider.env.push(AgentProviderEnvVar::secure_ref(
+        "API_TOKEN",
+        "secure-provider/API_TOKEN",
+    ));
+    let store = MemoryCredentialStore::default();
+    store
+        .write_secret(
+            &CredentialStoreKey::new("secure-provider", "API_TOKEN"),
+            "resolved-secret",
+        )
+        .unwrap();
+
+    let connection =
+        AcpProcessConnection::spawn_with_credentials(&provider, temp.path().to_path_buf(), &store)
+            .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !output.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    drop(connection);
+
+    assert_eq!(std::fs::read_to_string(output).unwrap(), "resolved-secret");
+}
+
+#[test]
+#[ignore = "requires ALAS_TEST_ACP_COMMAND pointing at a real ACP provider"]
+fn real_acp_provider_can_initialize_and_create_session() {
+    let command = std::env::var("ALAS_TEST_ACP_COMMAND")
+        .expect("set ALAS_TEST_ACP_COMMAND to a real ACP provider command");
+    let args = std::env::var("ALAS_TEST_ACP_ARGS")
+        .ok()
+        .map(|args| args.split_whitespace().map(str::to_string).collect())
+        .unwrap_or_default();
+
+    let temp = tempfile::tempdir().unwrap();
+    let mut provider = AgentProviderConfig::new("real-acp", "Real ACP", command);
+    provider.args = args;
+
+    let connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf()).unwrap();
+    let thread = AgentThreadState::new("real-acp", temp.path().to_path_buf());
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.initialize().unwrap();
+    runtime.create_session().unwrap();
+
+    assert_eq!(runtime.thread().status, AgentThreadStatus::Ready);
+    assert!(runtime.thread().acp_session_id.is_some());
+}
+
+#[test]
+fn fake_authenticate_updates_auth_status_and_redacted_debug_events() {
+    let thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let connection = FakeAcpConnection::new();
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.authenticate("env-var").unwrap();
+
+    assert_eq!(runtime.thread().auth_status, AgentAuthStatus::Authenticated);
+    assert_eq!(runtime.thread().status, AgentThreadStatus::Ready);
+    assert_eq!(runtime.connection().authenticated_methods(), &["env-var"]);
+    assert!(
+        runtime
+            .thread()
+            .debug_log
+            .iter()
+            .any(|event| event.message == "Authentication succeeded")
+    );
+}
+
+#[test]
+fn fake_authenticate_failure_preserves_required_instructions() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.auth_status = AgentAuthStatus::Required {
+        instructions: "Run login".to_string(),
+    };
+    let connection = FakeAcpConnection::new().with_auth_error("denied");
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    let error = runtime.authenticate("terminal").unwrap_err();
+
+    assert_eq!(error.to_string(), "denied");
+    assert_eq!(
+        runtime.thread().auth_status,
+        AgentAuthStatus::Failed {
+            message: "denied".to_string(),
+            instructions: "Run login".to_string(),
+        }
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn process_connection_spawns_with_cwd_args_and_env() {
+    let temp = tempfile::tempdir().unwrap();
+    let output = temp.path().join("spawn-output.txt");
+    let script = format!(
+        "printf '%s|%s|%s' \"$PWD\" \"$ALAS_TEST_ENV\" \"$1\" > {}",
+        output.display()
+    );
+    let mut provider = AgentProviderConfig::new("shell-provider", "Shell Provider", "/bin/sh");
+    provider.args = vec![
+        "-c".to_string(),
+        script,
+        "alas-sh".to_string(),
+        "arg-value".to_string(),
+    ];
+    provider.env.push(AgentProviderEnvVar {
+        name: "ALAS_TEST_ENV".to_string(),
+        value: Some("env-value".to_string()),
+        secure_ref: None,
+    });
+
+    let connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf()).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !output.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    drop(connection);
+
+    assert_eq!(
+        std::fs::read_to_string(output).unwrap(),
+        format!(
+            "{}|env-value|arg-value",
+            temp.path().canonicalize().unwrap().display()
+        )
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn process_connection_drop_kills_and_reaps_running_child() {
+    let temp = tempfile::tempdir().unwrap();
+    let pid_file = temp.path().join("child.pid");
+    let script = format!("echo $$ > {}; sleep 60", pid_file.display());
+    let mut provider = AgentProviderConfig::new("sleep-provider", "Sleep Provider", "/bin/sh");
+    provider.args = vec!["-c".to_string(), script];
+
+    let connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf()).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !pid_file.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let pid: libc::pid_t = std::fs::read_to_string(&pid_file)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+
+    drop(connection);
+
+    let still_exists = unsafe { libc::kill(pid, 0) == 0 };
+    assert!(!still_exists, "child process should be reaped on drop");
+}
+
+#[test]
+fn provider_cwd_policy_resolves_launch_directory() {
+    let selected_worktree = PathBuf::from("/repo/worktrees/feature");
+    let repository_root = PathBuf::from("/repo");
+
+    let mut provider = AgentProviderConfig::new("provider", "Provider", "agent");
+    provider.cwd_policy = ProviderCwdPolicy::SelectedWorktree;
+    assert_eq!(
+        resolve_provider_cwd(&provider, &selected_worktree, &repository_root),
+        selected_worktree
+    );
+
+    let mut provider = AgentProviderConfig::new("provider", "Provider", "agent");
+    provider.cwd_policy = ProviderCwdPolicy::RepositoryRoot;
+    assert_eq!(
+        resolve_provider_cwd(&provider, &selected_worktree, &repository_root),
+        repository_root
+    );
+
+    let fixed = PathBuf::from("/tmp/provider-cwd");
+    let mut provider = AgentProviderConfig::new("provider", "Provider", "agent");
+    provider.cwd_policy = ProviderCwdPolicy::Fixed(fixed.clone());
+    assert_eq!(
+        resolve_provider_cwd(&provider, &selected_worktree, &repository_root),
+        fixed
+    );
+}
+
+#[test]
+fn initialize_sets_status_ready() {
+    let thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let connection = FakeAcpConnection::new();
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.initialize().unwrap();
+
+    assert_eq!(runtime.thread().status, AgentThreadStatus::Ready);
+}
+
+#[test]
+fn new_session_applies_streamed_update_and_sets_status_ready() {
+    let thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let connection = FakeAcpConnection::new().with_new_session(
+        "session-1",
+        vec![
+            AgentRuntimeEvent::AgentMessageChunk("hello from agent".to_string()),
+            AgentRuntimeEvent::ToolCall {
+                id: "tool-1".to_string(),
+                title: "Read file".to_string(),
+                status: "completed".to_string(),
+            },
+            AgentRuntimeEvent::Plan(vec!["Inspect files".to_string(), "Report back".to_string()]),
+            AgentRuntimeEvent::Ready,
+        ],
+    );
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.create_session().unwrap();
+
+    let thread = runtime.thread();
+    assert_eq!(thread.acp_session_id.as_deref(), Some("session-1"));
+    assert_eq!(thread.status, AgentThreadStatus::Ready);
+    assert_eq!(
+        thread.transcript,
+        vec![AgentTranscriptEntry::agent("hello from agent")]
+    );
+    assert_eq!(thread.tool_calls.len(), 1);
+    assert_eq!(thread.tool_calls[0].id, "tool-1");
+    assert_eq!(
+        thread.plans[0].entries,
+        vec!["Inspect files", "Report back"]
+    );
+}
+
+#[test]
+fn apply_agent_update_maps_message_chunk_and_plan() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::AgentMessageChunk("hello".to_string()),
+    );
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::Plan(vec!["Inspect".to_string(), "Report".to_string()]),
+    );
+
+    assert_eq!(
+        thread.transcript,
+        vec![AgentTranscriptEntry::agent("hello")]
+    );
+    assert_eq!(thread.plans[0].entries, vec!["Inspect", "Report"]);
+}
+
+#[test]
+fn apply_agent_update_preserves_tool_call_fields_on_partial_update() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::ToolCall {
+            id: "tool-1".to_string(),
+            title: "Read file".to_string(),
+            status: "Pending".to_string(),
+        },
+    );
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::ToolCallUpdate {
+            id: "tool-1".to_string(),
+            title: None,
+            status: Some("Completed".to_string()),
+        },
+    );
+
+    assert_eq!(thread.tool_calls.len(), 1);
+    assert_eq!(thread.tool_calls[0].title, "Read file");
+    assert_eq!(thread.tool_calls[0].status, "Completed");
+}
+
+#[test]
+fn apply_agent_update_maps_commands_modes_config_and_error() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::AvailableCommands(vec![AgentSlashCommand {
+            name: "plan".to_string(),
+            description: Some("Create a plan".to_string()),
+        }]),
+    );
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::AvailableModes {
+            modes: vec![AgentModeOption {
+                id: "default".to_string(),
+                name: "Default".to_string(),
+            }],
+            current: Some("default".to_string()),
+        },
+    );
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::ConfigOptions(vec![AgentConfigOption {
+            id: "model".to_string(),
+            label: "Model".to_string(),
+            value: Some("sonnet".to_string()),
+            options: Vec::new(),
+        }]),
+    );
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::Error("provider warning".to_string()),
+    );
+
+    assert_eq!(thread.available_commands[0].name, "plan");
+    assert_eq!(thread.available_modes[0].id, "default");
+    assert_eq!(thread.current_mode.as_deref(), Some("default"));
+    assert_eq!(thread.config_options[0].value.as_deref(), Some("sonnet"));
+    assert_eq!(thread.debug_log[0].message, "provider warning");
+}
+
+#[test]
+fn acp_session_update_converts_supported_updates() {
+    use agent_client_protocol::schema::{
+        AvailableCommand, AvailableCommandsUpdate, ConfigOptionUpdate, ContentChunk, Plan,
+        PlanEntry, PlanEntryPriority, PlanEntryStatus, SessionConfigOption,
+        SessionConfigSelectOption, SessionUpdate, ToolCallStatus, ToolCallUpdate,
+        ToolCallUpdateFields,
+    };
+
+    let message = alas::agent::agent_update_from_acp_session_update(
+        SessionUpdate::AgentMessageChunk(ContentChunk::new("hi".into())),
+    );
+    assert_eq!(
+        message,
+        Some(alas::agent::AgentUpdate::AgentMessageChunk(
+            "hi".to_string()
+        ))
+    );
+
+    let tool_call_update = alas::agent::agent_update_from_acp_session_update(
+        SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            "tool-1",
+            ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+        )),
+    );
+    assert_eq!(
+        tool_call_update,
+        Some(alas::agent::AgentUpdate::ToolCallUpdate {
+            id: "tool-1".to_string(),
+            title: None,
+            status: Some("Completed".to_string()),
+        })
+    );
+
+    let plan =
+        alas::agent::agent_update_from_acp_session_update(SessionUpdate::Plan(Plan::new(vec![
+            PlanEntry::new(
+                "Inspect files",
+                PlanEntryPriority::Medium,
+                PlanEntryStatus::Pending,
+            ),
+        ])));
+    assert_eq!(
+        plan,
+        Some(alas::agent::AgentUpdate::Plan(vec![
+            "Inspect files".to_string()
+        ]))
+    );
+
+    let commands =
+        alas::agent::agent_update_from_acp_session_update(SessionUpdate::AvailableCommandsUpdate(
+            AvailableCommandsUpdate::new(vec![AvailableCommand::new("plan", "Create a plan")]),
+        ));
+    assert_eq!(
+        commands,
+        Some(alas::agent::AgentUpdate::AvailableCommands(vec![
+            AgentSlashCommand {
+                name: "plan".to_string(),
+                description: Some("Create a plan".to_string()),
+            },
+        ]))
+    );
+
+    let mode = alas::agent::agent_update_from_acp_session_update(SessionUpdate::CurrentModeUpdate(
+        agent_client_protocol::schema::CurrentModeUpdate::new("default"),
+    ));
+    assert_eq!(
+        mode,
+        Some(alas::agent::AgentUpdate::CurrentMode("default".to_string()))
+    );
+
+    let config =
+        alas::agent::agent_update_from_acp_session_update(SessionUpdate::ConfigOptionUpdate(
+            ConfigOptionUpdate::new(vec![SessionConfigOption::select(
+                "model",
+                "Model",
+                "sonnet",
+                vec![
+                    SessionConfigSelectOption::new("sonnet", "Claude Sonnet"),
+                    SessionConfigSelectOption::new("opus", "Claude Opus"),
+                ],
+            )]),
+        ));
+    assert_eq!(
+        config,
+        Some(alas::agent::AgentUpdate::ConfigOptions(vec![
+            AgentConfigOption {
+                id: "model".to_string(),
+                label: "Model".to_string(),
+                value: Some("sonnet".to_string()),
+                options: vec![
+                    AgentConfigValueOption {
+                        id: "sonnet".to_string(),
+                        label: "Claude Sonnet".to_string(),
+                    },
+                    AgentConfigValueOption {
+                        id: "opus".to_string(),
+                        label: "Claude Opus".to_string(),
+                    },
+                ],
+            },
+        ]))
+    );
+}
+
+#[test]
+fn cancel_calls_connection_and_returns_ready() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.acp_session_id = Some("session-1".to_string());
+    thread.status = AgentThreadStatus::Running;
+    let connection = FakeAcpConnection::new();
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.cancel().unwrap();
+
+    assert_eq!(runtime.thread().status, AgentThreadStatus::Ready);
+    assert_eq!(
+        runtime.connection().cancelled_sessions(),
+        &["session-1".to_string()]
+    );
+}
+
+#[test]
+fn set_mode_and_config_call_fake_connection() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.acp_session_id = Some("session-1".to_string());
+    thread.status = AgentThreadStatus::Ready;
+    thread.current_mode = Some("ask".to_string());
+    thread.config_options = vec![AgentConfigOption {
+        id: "model".to_string(),
+        label: "Model".to_string(),
+        value: Some("old".to_string()),
+        options: Vec::new(),
+    }];
+    let connection = FakeAcpConnection::new();
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.set_mode("plan").unwrap();
+    runtime.set_config_option("model", "new").unwrap();
+
+    assert_eq!(runtime.thread().current_mode.as_deref(), Some("plan"));
+    assert_eq!(
+        runtime.thread().config_options[0].value.as_deref(),
+        Some("new")
+    );
+    assert_eq!(
+        runtime.connection().set_modes(),
+        &[("session-1".to_string(), "plan".to_string())]
+    );
+    assert_eq!(
+        runtime.connection().set_config_options(),
+        &[(
+            "session-1".to_string(),
+            "model".to_string(),
+            "new".to_string()
+        )]
+    );
+}
+
+#[test]
+fn failed_set_mode_keeps_previous_current_mode() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.acp_session_id = Some("session-1".to_string());
+    thread.status = AgentThreadStatus::Ready;
+    thread.current_mode = Some("ask".to_string());
+    let connection = FakeAcpConnection::new().with_set_mode_error("mode failed");
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    let error = runtime.set_mode("plan").unwrap_err();
+
+    assert_eq!(error.to_string(), "mode failed");
+    assert_eq!(runtime.thread().current_mode.as_deref(), Some("ask"));
+    assert!(runtime.connection().set_modes().is_empty());
+}
+
+#[test]
+fn failed_set_config_option_keeps_previous_value() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.acp_session_id = Some("session-1".to_string());
+    thread.status = AgentThreadStatus::Ready;
+    thread.config_options = vec![AgentConfigOption {
+        id: "model".to_string(),
+        label: "Model".to_string(),
+        value: Some("old".to_string()),
+        options: Vec::new(),
+    }];
+    let connection = FakeAcpConnection::new().with_set_config_option_error("config failed");
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    let error = runtime.set_config_option("model", "new").unwrap_err();
+
+    assert_eq!(error.to_string(), "config failed");
+    assert_eq!(
+        runtime.thread().config_options[0].value.as_deref(),
+        Some("old")
+    );
+    assert!(runtime.connection().set_config_options().is_empty());
+}
+
+#[test]
+fn failed_event_sets_failed_status() {
+    let thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let connection = FakeAcpConnection::new().with_new_session(
+        "session-1",
+        vec![AgentRuntimeEvent::Failed("provider crashed".to_string())],
+    );
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.create_session().unwrap();
+
+    assert_eq!(
+        runtime.thread().status,
+        AgentThreadStatus::Failed {
+            message: "provider crashed".to_string()
+        }
+    );
+}
+
+#[test]
+fn auth_required_event_sets_status_and_debug_instructions() {
+    let thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let connection = FakeAcpConnection::new().with_new_session(
+        "session-1",
+        vec![AgentRuntimeEvent::AuthRequired {
+            instructions: "Run auth login".to_string(),
+        }],
+    );
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.create_session().unwrap();
+
+    let thread = runtime.thread();
+    assert_eq!(thread.status, AgentThreadStatus::AuthRequired);
+    assert_eq!(thread.debug_log.len(), 1);
+    assert_eq!(thread.debug_log[0].message, "Authentication required");
+    assert_eq!(
+        thread.transcript[0],
+        AgentTranscriptEntry::agent("Run auth login")
+    );
+}
+
+#[test]
+fn tool_call_event_updates_existing_call_by_id() {
+    let thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let connection = FakeAcpConnection::new().with_new_session(
+        "session-1",
+        vec![
+            AgentRuntimeEvent::ToolCall {
+                id: "tool-1".to_string(),
+                title: "Read file".to_string(),
+                status: "running".to_string(),
+            },
+            AgentRuntimeEvent::ToolCall {
+                id: "tool-1".to_string(),
+                title: "Read src/main.rs".to_string(),
+                status: "completed".to_string(),
+            },
+            AgentRuntimeEvent::Ready,
+        ],
+    );
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.create_session().unwrap();
+
+    let thread = runtime.thread();
+    assert_eq!(thread.tool_calls.len(), 1);
+    assert_eq!(thread.tool_calls[0].id, "tool-1");
+    assert_eq!(thread.tool_calls[0].title, "Read src/main.rs");
+    assert_eq!(thread.tool_calls[0].status, "completed");
+}
+
+#[test]
+fn prompt_without_session_errors_and_does_not_set_running() {
+    let thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let connection = FakeAcpConnection::new();
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    let error = runtime.prompt("hello").unwrap_err();
+
+    assert!(error.to_string().contains("without an active ACP session"));
+    assert_eq!(runtime.thread().status, AgentThreadStatus::Disconnected);
+    assert!(runtime.thread().transcript.is_empty());
+}
+
+#[test]
+fn prompt_read_only_errors_without_mutating_thread() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.acp_session_id = Some("session-1".to_string());
+    thread.status = AgentThreadStatus::ReadOnly {
+        reason: "session is unavailable".to_string(),
+    };
+    thread.draft = "hello".to_string();
+    let connection = FakeAcpConnection::new().with_prompt_update(vec![AgentRuntimeEvent::Ready]);
+    let mut runtime = AgentRuntime::with_connection(thread.clone(), connection);
+
+    let error = runtime.prompt("hello").unwrap_err();
+
+    assert!(error.to_string().contains("read-only"));
+    assert_eq!(runtime.thread().status, thread.status);
+    assert_eq!(runtime.thread().draft, "hello");
+    assert!(runtime.thread().transcript.is_empty());
+}
+
+#[test]
+fn prompt_connection_error_sets_failed_status() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.acp_session_id = Some("session-1".to_string());
+    let connection = FakeAcpConnection::new().with_prompt_error("send failed");
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    let error = runtime.prompt("hello").unwrap_err();
+
+    assert_eq!(error.to_string(), "send failed");
+    assert_eq!(
+        runtime.thread().status,
+        AgentThreadStatus::Failed {
+            message: "send failed".to_string()
+        }
+    );
+    assert_eq!(
+        runtime.thread().transcript[0],
+        AgentTranscriptEntry::user("hello")
+    );
+}
+
+#[test]
+fn prompt_with_needs_permission_produces_pending_permission() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.acp_session_id = Some("session-1".to_string());
+    let connection = FakeAcpConnection::new().with_prompt_update(vec![
+        AgentRuntimeEvent::NeedsPermission {
+            id: "perm-1".to_string(),
+            description: "Allow reading /repo/worktree/src/main.rs".to_string(),
+        },
+        AgentRuntimeEvent::Ready,
+    ]);
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.prompt("read the main file").unwrap();
+
+    let thread = runtime.thread();
+    assert_eq!(thread.status, AgentThreadStatus::Ready);
+    assert_eq!(thread.pending_permissions.len(), 1);
+    assert_eq!(thread.pending_permissions[0].id, "perm-1");
+    assert_eq!(
+        thread.transcript[0],
+        AgentTranscriptEntry::user("read the main file")
+    );
+}
+
+#[test]
+fn successful_resume_with_update_marks_resumed_and_ready() {
+    let thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let connection =
+        FakeAcpConnection::new().with_resume_update(vec![AgentRuntimeEvent::AgentMessageChunk(
+            "restored transcript".to_string(),
+        )]);
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.resume_existing_session("session-1").unwrap();
+
+    let thread = runtime.thread();
+    assert_eq!(thread.acp_session_id.as_deref(), Some("session-1"));
+    assert_eq!(thread.resume, AgentResumeState::Resumed);
+    assert_eq!(thread.status, AgentThreadStatus::Ready);
+    assert_eq!(
+        thread.transcript,
+        vec![AgentTranscriptEntry::agent("restored transcript")]
+    );
+}
+
+#[test]
+fn resume_error_marks_thread_read_only() {
+    let thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let connection = FakeAcpConnection::new().with_resume_error("session is unavailable");
+    let mut runtime = AgentRuntime::with_connection(thread, connection);
+
+    runtime.resume_existing_session("session-1").unwrap();
+
+    assert_eq!(
+        runtime.thread().acp_session_id.as_deref(),
+        Some("session-1")
+    );
+    assert_eq!(
+        runtime.thread().status,
+        AgentThreadStatus::ReadOnly {
+            reason: "session is unavailable".to_string()
+        }
+    );
+}
+
+#[test]
+fn denied_filesystem_callback_records_debug_error() {
+    let temp = tempfile::tempdir().unwrap();
+    let thread = AgentThreadState::new("provider", temp.path().to_path_buf());
+    let connection = FakeAcpConnection::new();
+    let filesystem =
+        FilesystemCallbackService::new(AgentTrustMode::Deny, temp.path().to_path_buf());
+    let terminal = AgentTerminalService::new(AgentTrustMode::Deny, temp.path().to_path_buf());
+    let mut runtime = AgentRuntime::with_connection(thread, connection)
+        .with_callback_services(filesystem, terminal);
+
+    let error = runtime
+        .handle_read_text_file(&temp.path().join("file.txt"))
+        .unwrap_err();
+
+    assert!(error.to_string().contains("permission denied"));
+    assert!(
+        runtime
+            .thread()
+            .debug_log
+            .iter()
+            .any(|event| event.message.contains("read_text_file failed"))
+    );
+}
+
+#[test]
+fn terminal_callback_records_output_and_tool_entries() {
+    let temp = tempfile::tempdir().unwrap();
+    let thread = AgentThreadState::new("provider", temp.path().to_path_buf());
+    let connection = FakeAcpConnection::new();
+    let filesystem =
+        FilesystemCallbackService::new(AgentTrustMode::AllowEverything, temp.path().to_path_buf());
+    let terminal =
+        AgentTerminalService::new(AgentTrustMode::AllowEverything, temp.path().to_path_buf());
+    let mut runtime = AgentRuntime::with_connection(thread, connection)
+        .with_callback_services(filesystem, terminal);
+
+    let handle = runtime
+        .handle_terminal_create("printf callback-output", temp.path())
+        .unwrap();
+    runtime.handle_terminal_wait_for_exit(handle).unwrap();
+    let output = runtime.handle_terminal_output(handle).unwrap();
+
+    assert_eq!(output, "callback-output");
+    assert!(
+        runtime
+            .thread()
+            .transcript
+            .iter()
+            .any(|entry| entry.role == AgentTranscriptRole::Tool
+                && entry.text.contains("callback-output"))
+    );
+    assert!(
+        runtime
+            .thread()
+            .tool_calls
+            .iter()
+            .any(|call| call.title == "terminal output")
+    );
+}
+
+#[test]
+fn ask_permission_creates_pending_request_and_resolves() {
+    let temp = tempfile::tempdir().unwrap();
+    let thread = AgentThreadState::new("provider", temp.path().to_path_buf());
+    let connection = FakeAcpConnection::new();
+    let filesystem = FilesystemCallbackService::new(AgentTrustMode::Ask, temp.path().to_path_buf());
+    let terminal = AgentTerminalService::new(AgentTrustMode::Ask, temp.path().to_path_buf());
+    let mut runtime = AgentRuntime::with_connection(thread, connection)
+        .with_callback_services(filesystem, terminal);
+
+    let error = runtime
+        .handle_read_text_file(&temp.path().join("file.txt"))
+        .unwrap_err();
+
+    assert!(error.to_string().contains("permission request pending"));
+    assert_eq!(runtime.thread().pending_permissions.len(), 1);
+    let request_id = runtime.thread().pending_permissions[0].id.clone();
+
+    assert!(
+        runtime
+            .resolve_permission_request(&request_id, true)
+            .unwrap()
+    );
+    assert!(runtime.thread().pending_permissions.is_empty());
+    assert!(
+        runtime
+            .thread()
+            .debug_log
+            .iter()
+            .any(|event| event.message.contains("Permission allowed"))
+    );
+}
+
+#[test]
+fn redact_debug_value_redacts_sensitive_keys_case_insensitively() {
+    assert_eq!(redact_debug_value("API_KEY", "abc123"), "[redacted]");
+    assert_eq!(redact_debug_value("authToken", "abc123"), "[redacted]");
+    assert_eq!(redact_debug_value("client_secret", "abc123"), "[redacted]");
+    assert_eq!(redact_debug_value("password", "abc123"), "[redacted]");
+    assert_eq!(redact_debug_value("PATH", "/usr/bin"), "/usr/bin");
+    assert_eq!(redact_debug_value("HOME", "/home/alice"), "/home/alice");
+}
+
+#[test]
+fn redact_debug_message_redacts_sensitive_key_value_patterns() {
+    assert_eq!(
+        redact_debug_message("provider failed: API_KEY=abc123 token: abc"),
+        "provider failed: API_KEY=[redacted] token: [redacted]"
+    );
+    assert_eq!(
+        redact_debug_message("provider warning without secrets"),
+        "provider warning without secrets"
+    );
+}
+
+#[test]
+fn redact_debug_message_redacts_json_like_sensitive_values() {
+    assert_eq!(
+        redact_debug_message(r#"provider failed: {"api_key":"abc123"}"#),
+        r#"provider failed: {"api_key":"[redacted]"}"#
+    );
+    assert_eq!(
+        redact_debug_message(r#"provider failed: {"token": "abc"}"#),
+        r#"provider failed: {"token": "[redacted]"}"#
+    );
+    assert_eq!(
+        redact_debug_message("provider failed: {'password': 'pw'}"),
+        "provider failed: {'password': '[redacted]'}"
+    );
+    assert_eq!(
+        redact_debug_message(r#"provider failed: {"token":"abc\"def"}"#),
+        r#"provider failed: {"token":"[redacted]"}"#
+    );
+    assert!(!redact_debug_message(r#"{"client_secret":"shh"}"#).contains("shh"));
+}
+
+#[test]
+fn agent_update_error_redacts_debug_message_secrets() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::Error("provider failed: API_KEY=abc123".to_string()),
+    );
+    apply_agent_update(
+        &mut thread,
+        alas::agent::AgentUpdate::Error("provider warning".to_string()),
+    );
+
+    assert_eq!(
+        thread.debug_log[0].message,
+        "provider failed: API_KEY=[redacted]"
+    );
+    assert!(!thread.debug_log[0].message.contains("abc123"));
+    assert_eq!(thread.debug_log[1].message, "provider warning");
+}
+
+#[test]
+fn push_debug_event_bounds_log_to_latest_500_entries() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+
+    for index in 0..505 {
+        thread.push_debug_event(AgentDebugEvent {
+            message: format!("event-{index}"),
+        });
+    }
+
+    assert_eq!(thread.debug_log.len(), 500);
+    assert_eq!(thread.debug_log.first().unwrap().message, "event-5");
+    assert_eq!(thread.debug_log.last().unwrap().message, "event-504");
+}

--- a/tests/agent_terminal_tests.rs
+++ b/tests/agent_terminal_tests.rs
@@ -1,0 +1,267 @@
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
+
+use alas::agent::{AgentTerminalHandle, AgentTerminalService, AgentTerminalStatus, AgentTrustMode};
+
+#[test]
+fn command_runs_captures_output_and_release_removes_handle() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().to_path_buf();
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, worktree.clone());
+
+    let handle = service
+        .create(&print_command("hello terminal"), &worktree)
+        .expect("create terminal command");
+    let result = service.wait_for_exit(handle).expect("wait for exit");
+
+    assert_eq!(result.status, AgentTerminalStatus::Exited(Some(0)));
+    assert!(
+        service
+            .output(handle)
+            .expect("read output")
+            .contains("hello terminal")
+    );
+
+    service.release(handle).expect("release handle");
+    let error = service
+        .output(handle)
+        .expect_err("released handle should not have output");
+    assert!(
+        error.to_string().contains("not found"),
+        "unexpected error: {error:#}"
+    );
+}
+
+#[test]
+fn command_captures_stderr_and_tail_output_after_wait() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().to_path_buf();
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, worktree.clone());
+
+    let handle = service
+        .create(stdout_stderr_tail_command(), &worktree)
+        .expect("create terminal command");
+    let result = service.wait_for_exit(handle).expect("wait for exit");
+    let output = service.output(handle).expect("read output");
+
+    assert_eq!(result.status, AgentTerminalStatus::Exited(Some(0)));
+    assert!(output.contains("stdout"), "missing stdout in {output:?}");
+    assert!(output.contains("stderr"), "missing stderr in {output:?}");
+    assert!(output.contains("tail"), "missing tail output in {output:?}");
+}
+
+#[test]
+fn non_zero_exit_status_is_reported() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().to_path_buf();
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, worktree.clone());
+
+    let handle = service
+        .create(&exit_command(7), &worktree)
+        .expect("create terminal command");
+    let result = service.wait_for_exit(handle).expect("wait for exit");
+
+    assert_eq!(result.status, AgentTerminalStatus::Exited(Some(7)));
+}
+
+#[test]
+fn invalid_handle_errors_for_terminal_operations() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().to_path_buf();
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, worktree);
+    let handle = AgentTerminalHandle(999);
+
+    assert_not_found(service.output(handle).expect_err("output should fail"));
+    assert_not_found(service.wait_for_exit(handle).expect_err("wait should fail"));
+    assert_not_found(service.kill(handle).expect_err("kill should fail"));
+    assert_not_found(service.release(handle).expect_err("release should fail"));
+}
+
+#[test]
+fn release_running_command_removes_handle_and_stops_process() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().to_path_buf();
+    let marker = worktree.join("marker");
+    let marker_arg = marker.to_string_lossy();
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, worktree.clone());
+
+    let handle = service
+        .create(&delayed_marker_command(&marker_arg), &worktree)
+        .expect("create terminal command");
+
+    service.release(handle).expect("release running handle");
+    thread::sleep(Duration::from_millis(700));
+
+    assert!(
+        service.output(handle).is_err(),
+        "released handle should not allow later output"
+    );
+    assert!(
+        !marker.exists(),
+        "released command should have been stopped"
+    );
+}
+
+#[test]
+fn kill_running_command_marks_failed_and_later_wait_returns() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().to_path_buf();
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, worktree.clone());
+
+    let handle = service
+        .create(long_running_command(), &worktree)
+        .expect("create terminal command");
+
+    let result = service.kill(handle).expect("kill running command");
+    assert_eq!(result.status, AgentTerminalStatus::Failed);
+
+    let start = Instant::now();
+    let later_result = service.wait_for_exit(handle).expect("wait after kill");
+    assert_eq!(later_result.status, AgentTerminalStatus::Failed);
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "wait after kill should return immediately"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn kill_escalates_when_command_ignores_term() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().to_path_buf();
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, worktree.clone());
+
+    let handle = service
+        .create(term_resistant_command(), &worktree)
+        .expect("create terminal command");
+    wait_for_output(&service, handle, "ready");
+
+    let start = Instant::now();
+    let result = service.kill(handle).expect("kill TERM-resistant command");
+
+    assert_eq!(result.status, AgentTerminalStatus::Failed);
+    assert!(
+        start.elapsed() < Duration::from_secs(3),
+        "kill should escalate to SIGKILL instead of waiting for sleep"
+    );
+}
+
+#[test]
+fn output_is_visible_before_wait() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().to_path_buf();
+    let mut service = AgentTerminalService::new(AgentTrustMode::AllowEverything, worktree.clone());
+
+    let handle = service
+        .create(ready_then_sleep_command(), &worktree)
+        .expect("create terminal command");
+
+    wait_for_output(&service, handle, "ready");
+
+    let result = service.wait_for_exit(handle).expect("wait for exit");
+    assert_eq!(result.status, AgentTerminalStatus::Exited(Some(0)));
+    service.release(handle).expect("release handle");
+}
+
+#[test]
+fn deny_rejects_command() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let worktree = temp.path().to_path_buf();
+    let mut service = AgentTerminalService::new(AgentTrustMode::Deny, worktree.clone());
+
+    let error = service
+        .create(&print_command("should not run"), &worktree)
+        .expect_err("command should be denied");
+
+    assert!(
+        error.to_string().contains("permission denied"),
+        "unexpected error: {error:#}"
+    );
+}
+
+fn wait_for_output(service: &AgentTerminalService, handle: AgentTerminalHandle, expected: &str) {
+    let mut output = String::new();
+    for _ in 0..20 {
+        output = service.output(handle).expect("read output");
+        if output.contains(expected) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    panic!("expected {expected:?} in terminal output, got {output:?}");
+}
+
+fn assert_not_found(error: anyhow::Error) {
+    assert!(
+        error.to_string().contains("not found"),
+        "unexpected error: {error:#}"
+    );
+}
+
+#[cfg(windows)]
+fn print_command(message: &str) -> String {
+    format!("echo {message}")
+}
+
+#[cfg(not(windows))]
+fn print_command(message: &str) -> String {
+    format!("printf '{message}'")
+}
+
+#[cfg(windows)]
+fn stdout_stderr_tail_command() -> &'static str {
+    "echo stdout && echo stderr 1>&2 && echo tail"
+}
+
+#[cfg(not(windows))]
+fn stdout_stderr_tail_command() -> &'static str {
+    "printf stdout; printf stderr >&2; printf tail"
+}
+
+#[cfg(windows)]
+fn exit_command(code: i32) -> String {
+    format!("exit /B {code}")
+}
+
+#[cfg(not(windows))]
+fn exit_command(code: i32) -> String {
+    format!("exit {code}")
+}
+
+#[cfg(windows)]
+fn delayed_marker_command(marker: &str) -> String {
+    format!("ping -n 3 127.0.0.1 >NUL & type nul > \"{marker}\"")
+}
+
+#[cfg(not(windows))]
+fn delayed_marker_command(marker: &str) -> String {
+    format!("sleep 2; touch '{marker}'")
+}
+
+#[cfg(windows)]
+fn ready_then_sleep_command() -> &'static str {
+    "echo ready && ping -n 2 127.0.0.1 >NUL"
+}
+
+#[cfg(not(windows))]
+fn ready_then_sleep_command() -> &'static str {
+    "printf 'ready'; sleep 1"
+}
+
+#[cfg(windows)]
+fn long_running_command() -> &'static str {
+    "ping -n 6 127.0.0.1 >NUL"
+}
+
+#[cfg(not(windows))]
+fn long_running_command() -> &'static str {
+    "sleep 5"
+}
+
+#[cfg(unix)]
+fn term_resistant_command() -> &'static str {
+    "trap '' TERM; printf 'ready'; sleep 5"
+}

--- a/tests/agent_ui_view_model_tests.rs
+++ b/tests/agent_ui_view_model_tests.rs
@@ -1,0 +1,659 @@
+use alas::{
+    agent::{
+        AgentAuthField, AgentAuthMethod, AgentAuthStatus, AgentConfigOption,
+        AgentConfigValueOption, AgentModeOption, AgentProviderConfig, AgentProviderEnvVar,
+        AgentProviderSuggestion, AgentSlashCommand, AgentThreadState, AgentThreadStatus,
+        AgentTrustMode, CredentialStore, CredentialStoreKey, MemoryCredentialStore,
+        ProviderSettingsState,
+    },
+    ui::{
+        agent_pane::{agent_composer_view_model, agent_header_view_model, agent_status_label},
+        provider_settings::auth_env_field_render_value,
+    },
+};
+
+use std::path::PathBuf;
+
+fn provider(id: &str) -> AgentProviderConfig {
+    AgentProviderConfig::new(id, id.to_uppercase(), format!("{id}-acp"))
+}
+
+#[test]
+fn agent_status_label_formats_read_only_reason() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.status = AgentThreadStatus::ReadOnly {
+        reason: "worktree is locked".to_string(),
+    };
+
+    assert_eq!(agent_status_label(&thread), "Read-only: worktree is locked");
+}
+
+#[test]
+fn agent_composer_state_maps_status_to_action_availability() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+
+    thread.status = AgentThreadStatus::Ready;
+    let ready_empty = agent_composer_view_model(&thread);
+    assert!(ready_empty.enabled);
+    assert!(!ready_empty.action_enabled);
+    assert_eq!(ready_empty.action_label, "Send");
+    assert!(ready_empty.showing_placeholder);
+    assert_eq!(ready_empty.display_text, "Type a prompt for the agent…");
+
+    thread.draft = "Summarize changes".to_string();
+    let ready = agent_composer_view_model(&thread);
+    assert!(ready.enabled);
+    assert!(ready.action_enabled);
+    assert_eq!(ready.action_label, "Send");
+    assert!(!ready.showing_placeholder);
+    assert_eq!(ready.display_text, "Summarize changes");
+
+    thread.status = AgentThreadStatus::Running;
+    let running = agent_composer_view_model(&thread);
+    assert!(!running.enabled);
+    assert!(running.action_enabled);
+    assert_eq!(running.action_label, "Cancel");
+
+    thread.status = AgentThreadStatus::ReadOnly {
+        reason: "locked".to_string(),
+    };
+    let read_only = agent_composer_view_model(&thread);
+    assert!(!read_only.enabled);
+    assert!(!read_only.action_enabled);
+    assert_eq!(read_only.action_label, "Send");
+
+    thread.status = AgentThreadStatus::AuthRequired;
+    let auth_required = agent_composer_view_model(&thread);
+    assert!(!auth_required.enabled);
+    assert!(auth_required.auth_action);
+}
+
+#[test]
+fn agent_header_shows_interactive_mode_and_resolved_config_labels() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.available_modes = vec![
+        AgentModeOption {
+            id: "plan".to_string(),
+            name: "Plan".to_string(),
+        },
+        AgentModeOption {
+            id: "ask".to_string(),
+            name: "Ask".to_string(),
+        },
+    ];
+    thread.current_mode = Some("plan".to_string());
+    thread.config_options = vec![AgentConfigOption {
+        id: "model".to_string(),
+        label: "Model".to_string(),
+        value: Some("gpt-5".to_string()),
+        options: vec![
+            AgentConfigValueOption {
+                id: "gpt-5".to_string(),
+                label: "GPT-5".to_string(),
+            },
+            AgentConfigValueOption {
+                id: "sonnet".to_string(),
+                label: "Claude Sonnet".to_string(),
+            },
+        ],
+    }];
+
+    let header = agent_header_view_model(&thread);
+    assert_eq!(header.mode_label.as_deref(), Some("Mode: Plan ▾"));
+    assert!(header.mode_interactive);
+    assert_eq!(header.config_labels[0].label, "Model: GPT-5 ▾");
+    assert!(header.config_labels[0].interactive);
+}
+
+#[test]
+fn agent_header_and_composer_expose_runtime_advertisements() {
+    let mut thread = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    thread.available_modes = vec![AgentModeOption {
+        id: "plan".to_string(),
+        name: "Plan".to_string(),
+    }];
+    thread.current_mode = Some("plan".to_string());
+    thread.config_options = vec![AgentConfigOption {
+        id: "model".to_string(),
+        label: "Model".to_string(),
+        value: Some("gpt-5".to_string()),
+        options: Vec::new(),
+    }];
+    thread.available_commands = vec![AgentSlashCommand {
+        name: "help".to_string(),
+        description: Some("Show help".to_string()),
+    }];
+
+    let header = agent_header_view_model(&thread);
+    assert_eq!(header.provider_label, "Provider: opencode");
+    assert_eq!(header.mode_label.as_deref(), Some("Mode: Plan"));
+    assert_eq!(header.config_labels[0].label, "Model: gpt-5");
+    assert!(!header.config_labels[0].interactive);
+
+    let composer = agent_composer_view_model(&thread);
+    assert_eq!(composer.slash_commands, vec!["/help"]);
+}
+
+#[test]
+fn provider_settings_state_adds_updates_and_removes_provider() {
+    let mut state = ProviderSettingsState::default();
+
+    state.add_provider(AgentProviderConfig::new("codex", "Codex", "codex-acp"));
+
+    assert_eq!(state.providers.len(), 1);
+    assert_eq!(state.providers[0].display_name, "Codex");
+    assert_eq!(state.providers[0].command, "codex-acp");
+    assert_eq!(state.selected_provider_id.as_deref(), Some("codex"));
+    assert_eq!(state.error, None);
+
+    state.add_provider(AgentProviderConfig::new(
+        "codex",
+        "Codex Updated",
+        "codex-acp-next",
+    ));
+
+    assert_eq!(state.providers.len(), 1);
+    assert_eq!(state.providers[0].display_name, "Codex Updated");
+    assert_eq!(state.providers[0].command, "codex-acp-next");
+    assert_eq!(state.selected_provider_id.as_deref(), Some("codex"));
+
+    state.remove_provider("codex");
+
+    assert!(state.providers.is_empty());
+    assert_eq!(state.selected_provider_id, None);
+    assert_eq!(state.error, None);
+}
+
+#[test]
+fn provider_settings_state_removing_selected_provider_selects_first_remaining_provider() {
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider("codex"));
+    state.add_provider(provider("claude"));
+    state.add_provider(provider("gemini"));
+    state.selected_provider_id = Some("claude".to_string());
+
+    state.remove_provider("claude");
+
+    assert_eq!(
+        state
+            .providers
+            .iter()
+            .map(|provider| provider.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["codex", "gemini"]
+    );
+    assert_eq!(state.selected_provider_id.as_deref(), Some("codex"));
+    assert_eq!(state.error, None);
+}
+
+#[test]
+fn provider_settings_tracks_discovery_suggestions() {
+    let mut state = ProviderSettingsState::default();
+    state.discovery_suggestions.push(AgentProviderSuggestion {
+        id: "claude".to_string(),
+        display_name: "Claude Code".to_string(),
+        command: "claude".to_string(),
+        message: "Claude Code found, but ACP command is not verified yet.".to_string(),
+    });
+    assert_eq!(state.discovery_suggestions[0].id, "claude");
+}
+
+#[test]
+fn provider_settings_error_can_report_discovery_save_failure() {
+    let state = ProviderSettingsState {
+        error: Some("failed to persist auto-discovered providers".to_string()),
+        ..ProviderSettingsState::default()
+    };
+    assert!(state.error.as_deref().unwrap().contains("auto-discovered"));
+}
+
+#[test]
+fn provider_settings_state_removing_non_selected_provider_preserves_selection() {
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider("codex"));
+    state.add_provider(provider("claude"));
+    state.add_provider(provider("gemini"));
+    state.selected_provider_id = Some("gemini".to_string());
+
+    state.remove_provider("claude");
+
+    assert_eq!(
+        state
+            .providers
+            .iter()
+            .map(|provider| provider.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["codex", "gemini"]
+    );
+    assert_eq!(state.selected_provider_id.as_deref(), Some("gemini"));
+    assert_eq!(state.error, None);
+}
+
+#[test]
+fn provider_settings_state_updates_provider_fields_and_auth_status() {
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider("codex"));
+
+    state.update_display_name("codex", "Codex Next");
+    state.update_command("codex", "codex next");
+    state.update_args("codex", vec!["acp".to_string(), "--json".to_string()]);
+    state.update_plain_env(
+        "codex",
+        vec![("CODEX_HOME".to_string(), "/tmp/codex".to_string())],
+    );
+    state.update_enabled("codex", false);
+    state.update_trust_mode("codex", AgentTrustMode::WorktreeOnly);
+    state.update_auth_status(
+        "codex",
+        AgentAuthStatus::Required {
+            instructions: "Run codex login".to_string(),
+        },
+    );
+
+    let codex = &state.providers[0];
+    assert_eq!(codex.display_name, "Codex Next");
+    assert_eq!(codex.command, "codex next");
+    assert_eq!(codex.args, vec!["acp", "--json"]);
+    assert_eq!(
+        state.args_json("codex").as_deref(),
+        Some("[\"acp\",\"--json\"]")
+    );
+    assert_eq!(codex.env[0].name, "CODEX_HOME");
+    assert_eq!(codex.env[0].value.as_deref(), Some("/tmp/codex"));
+    assert_eq!(codex.env[0].secure_ref, None);
+    assert!(!codex.enabled);
+    assert_eq!(codex.trust_mode, AgentTrustMode::WorktreeOnly);
+    assert_eq!(state.auth_status_label("codex"), "Authentication required");
+    assert_eq!(
+        state.auth_statuses["codex"].instructions(),
+        Some("Run codex login")
+    );
+
+    state.update_auth_status("codex", AgentAuthStatus::Authenticated);
+    assert_eq!(state.auth_status_label("codex"), "Authenticated");
+
+    state.update_auth_status(
+        "codex",
+        AgentAuthStatus::Failed {
+            message: "expired".to_string(),
+            instructions: "Run codex login again".to_string(),
+        },
+    );
+    assert_eq!(state.auth_status_label("codex"), "Authentication failed");
+    assert_eq!(state.auth_status_label("missing"), "Authentication unknown");
+}
+
+#[test]
+fn provider_settings_state_edits_args_as_json_array() {
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider("codex"));
+
+    state
+        .edit_args_json("codex", |value| {
+            *value = serde_json::to_string(&vec![
+                "acp".to_string(),
+                "--prompt".to_string(),
+                "hello world".to_string(),
+                "".to_string(),
+                "quoted \"value\"".to_string(),
+            ])
+            .unwrap();
+        })
+        .unwrap();
+
+    assert_eq!(
+        state.providers[0].args,
+        vec!["acp", "--prompt", "hello world", "", "quoted \"value\""]
+    );
+    assert_eq!(state.error, None);
+}
+
+#[test]
+fn provider_settings_state_rejects_invalid_args_json_without_corrupting_args() {
+    let mut state = ProviderSettingsState::default();
+    let mut codex = provider("codex");
+    codex.args = vec!["hello world".to_string(), "".to_string()];
+    state.add_provider(codex);
+
+    let result = state.edit_args_json("codex", |value| {
+        value.clear();
+        value.push_str("hello world");
+    });
+
+    assert!(result.is_err());
+    assert_eq!(state.providers[0].args, vec!["hello world", ""]);
+    assert!(
+        state
+            .error
+            .as_deref()
+            .is_some_and(|error| error.starts_with("Args must be a JSON array of strings:"))
+    );
+}
+
+#[test]
+fn provider_settings_state_updates_plain_env_without_dropping_secure_refs() {
+    let mut state = ProviderSettingsState::default();
+    let mut provider = provider("codex");
+    provider.env = vec![
+        AgentProviderEnvVar {
+            name: "CODEX_HOME".to_string(),
+            value: Some("/old".to_string()),
+            secure_ref: None,
+        },
+        AgentProviderEnvVar {
+            name: "CODEX_TOKEN".to_string(),
+            value: None,
+            secure_ref: Some("codex-token".to_string()),
+        },
+    ];
+    state.add_provider(provider);
+
+    state.update_plain_env(
+        "codex",
+        vec![("CODEX_HOME".to_string(), "/new".to_string())],
+    );
+
+    let env = &state.providers[0].env;
+    assert_eq!(env.len(), 2);
+    assert_eq!(env[0].name, "CODEX_HOME");
+    assert_eq!(env[0].value.as_deref(), Some("/new"));
+    assert_eq!(env[0].secure_ref, None);
+    assert_eq!(env[1].name, "CODEX_TOKEN");
+    assert_eq!(env[1].value, None);
+    assert_eq!(env[1].secure_ref.as_deref(), Some("codex-token"));
+}
+
+#[test]
+fn provider_settings_state_removing_nonexistent_provider_leaves_state_unchanged() {
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider("codex"));
+    state.add_provider(provider("claude"));
+    state.selected_provider_id = Some("claude".to_string());
+    state.error = Some("provider missing".to_string());
+    let original_state = state.clone();
+
+    state.remove_provider("gemini");
+
+    assert_eq!(state, original_state);
+}
+
+#[test]
+fn provider_settings_env_auth_entry_saves_to_credential_store() {
+    let store = MemoryCredentialStore::default();
+    let mut provider = provider("opencode");
+    provider.auth_methods = vec![AgentAuthMethod::EnvVar {
+        fields: vec![AgentAuthField::secret("API key", "OPENCODE_API_KEY")],
+        link: Some("https://example.test/key".to_string()),
+    }];
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider);
+
+    state.update_auth_env_value("opencode", "OPENCODE_API_KEY", "super-secret");
+    state
+        .authenticate_with_available_method("opencode", &store)
+        .expect("authenticate");
+
+    assert_eq!(
+        store
+            .read_secret(&CredentialStoreKey::new("opencode", "OPENCODE_API_KEY"))
+            .expect("read secret"),
+        Some("super-secret".to_string())
+    );
+    assert_eq!(state.auth_status_label("opencode"), "Authenticated");
+    assert_eq!(
+        state.providers[0].env[0].secure_ref.as_deref(),
+        Some("opencode/OPENCODE_API_KEY")
+    );
+    assert!(
+        !serde_json::to_string(&state.providers[0])
+            .expect("serialize provider")
+            .contains("super-secret")
+    );
+}
+
+#[test]
+fn provider_settings_missing_required_env_auth_value_fails() {
+    let store = MemoryCredentialStore::default();
+    let mut provider = provider("opencode");
+    provider.auth_methods = vec![AgentAuthMethod::EnvVar {
+        fields: vec![AgentAuthField::secret("API key", "OPENCODE_API_KEY")],
+        link: None,
+    }];
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider);
+
+    let error = state
+        .authenticate_with_available_method("opencode", &store)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("OPENCODE_API_KEY"));
+    assert_eq!(state.auth_status_label("opencode"), "Authentication failed");
+    assert_eq!(
+        store
+            .read_secret(&CredentialStoreKey::new("opencode", "OPENCODE_API_KEY"))
+            .expect("read secret"),
+        None
+    );
+}
+
+#[test]
+fn provider_settings_secret_auth_env_display_is_masked() {
+    let mut state = ProviderSettingsState::default();
+    let field = AgentAuthField::secret("API key", "OPENCODE_API_KEY");
+    state.update_auth_env_value("opencode", "OPENCODE_API_KEY", "super-secret");
+
+    assert_eq!(state.auth_env_display_value("opencode", &field), "••••••••");
+    assert_eq!(
+        auth_env_field_render_value(&state, "opencode", &field, false),
+        "••••••••"
+    );
+    assert_eq!(
+        auth_env_field_render_value(&state, "opencode", &field, true),
+        "••••••••"
+    );
+    assert!(
+        !auth_env_field_render_value(&state, "opencode", &field, true).contains("super-secret")
+    );
+    assert_eq!(
+        state.auth_env_value("opencode", "OPENCODE_API_KEY"),
+        "super-secret"
+    );
+}
+
+#[test]
+fn provider_settings_clear_credentials_removes_env_auth_secrets() {
+    let store = MemoryCredentialStore::default();
+    store
+        .write_secret(
+            &CredentialStoreKey::new("opencode", "OPENCODE_API_KEY"),
+            "super-secret",
+        )
+        .expect("seed secret");
+    let mut provider = provider("opencode");
+    provider.env = vec![
+        AgentProviderEnvVar {
+            name: "PLAIN".to_string(),
+            value: Some("value".to_string()),
+            secure_ref: None,
+        },
+        AgentProviderEnvVar::secure_ref("OPENCODE_API_KEY", "opencode/OPENCODE_API_KEY"),
+    ];
+    provider.auth_methods = vec![AgentAuthMethod::EnvVar {
+        fields: vec![AgentAuthField::secret("API key", "OPENCODE_API_KEY")],
+        link: None,
+    }];
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider);
+    state.update_auth_env_value("opencode", "OPENCODE_API_KEY", "pending");
+
+    state
+        .clear_env_auth_values("opencode", &store)
+        .expect("clear credentials");
+
+    assert_eq!(
+        store
+            .read_secret(&CredentialStoreKey::new("opencode", "OPENCODE_API_KEY"))
+            .expect("read secret"),
+        None
+    );
+    assert_eq!(state.auth_env_value("opencode", "OPENCODE_API_KEY"), "");
+    assert_eq!(state.providers[0].env.len(), 1);
+    assert_eq!(state.providers[0].env[0].name, "PLAIN");
+    assert!(
+        state.providers[0]
+            .env
+            .iter()
+            .all(|entry| entry.secure_ref.as_deref() != Some("opencode/OPENCODE_API_KEY"))
+    );
+    assert_eq!(
+        state.auth_status_label("opencode"),
+        "Authentication required"
+    );
+}
+
+#[test]
+fn provider_settings_auth_io_result_merges_only_auth_fields() {
+    let mut provider = provider("opencode");
+    provider.env = vec![AgentProviderEnvVar {
+        name: "PLAIN".to_string(),
+        value: Some("old".to_string()),
+        secure_ref: None,
+    }];
+    provider.auth_methods = vec![AgentAuthMethod::EnvVar {
+        fields: vec![AgentAuthField::secret("API key", "OPENCODE_API_KEY")],
+        link: None,
+    }];
+    let mut current = ProviderSettingsState::default();
+    current.add_provider(provider.clone());
+    current.selected_provider_id = Some("other".to_string());
+    current.discovery_suggestions = vec![AgentProviderSuggestion {
+        id: "suggestion".to_string(),
+        display_name: "Suggestion".to_string(),
+        command: "suggestion".to_string(),
+        message: "test".to_string(),
+    }];
+    current.update_auth_env_value("opencode", "OPENCODE_API_KEY", "new-draft");
+
+    let mut result = ProviderSettingsState::default();
+    provider.env.push(AgentProviderEnvVar::secure_ref(
+        "OPENCODE_API_KEY",
+        "opencode/OPENCODE_API_KEY",
+    ));
+    result.add_provider(provider);
+    result.update_auth_status("opencode", AgentAuthStatus::Authenticated);
+
+    current.apply_auth_io_result("opencode", &result);
+
+    assert_eq!(current.selected_provider_id.as_deref(), Some("other"));
+    assert_eq!(current.discovery_suggestions.len(), 1);
+    assert_eq!(
+        current.auth_env_value("opencode", "OPENCODE_API_KEY"),
+        "new-draft"
+    );
+    assert_eq!(current.providers[0].env.len(), 2);
+    assert!(
+        current.providers[0]
+            .env
+            .iter()
+            .any(|entry| entry.name == "PLAIN")
+    );
+    assert!(
+        current.providers[0]
+            .env
+            .iter()
+            .any(|entry| entry.secure_ref.as_deref() == Some("opencode/OPENCODE_API_KEY"))
+    );
+    assert_eq!(current.auth_status_label("opencode"), "Authenticated");
+}
+
+#[test]
+fn provider_settings_clear_auth_io_result_preserves_unrelated_state() {
+    let mut provider = provider("opencode");
+    provider.env = vec![
+        AgentProviderEnvVar {
+            name: "PLAIN".to_string(),
+            value: Some("value".to_string()),
+            secure_ref: None,
+        },
+        AgentProviderEnvVar::secure_ref("OPENCODE_API_KEY", "opencode/OPENCODE_API_KEY"),
+    ];
+    provider.auth_methods = vec![AgentAuthMethod::EnvVar {
+        fields: vec![AgentAuthField::secret("API key", "OPENCODE_API_KEY")],
+        link: None,
+    }];
+    let mut current = ProviderSettingsState::default();
+    current.add_provider(provider.clone());
+    current.update_auth_env_value("opencode", "OPENCODE_API_KEY", "draft");
+    current.update_auth_env_value("other", "OPENCODE_API_KEY", "other-draft");
+
+    let store = MemoryCredentialStore::default();
+    let mut result = ProviderSettingsState::default();
+    result.add_provider(provider);
+    result
+        .clear_env_auth_values("opencode", &store)
+        .expect("clear credentials");
+
+    current.apply_clear_auth_io_result("opencode", &result);
+
+    assert_eq!(current.auth_env_value("opencode", "OPENCODE_API_KEY"), "");
+    assert_eq!(
+        current.auth_env_value("other", "OPENCODE_API_KEY"),
+        "other-draft"
+    );
+    assert_eq!(current.providers[0].env.len(), 1);
+    assert_eq!(current.providers[0].env[0].name, "PLAIN");
+    assert_eq!(
+        current.auth_status_label("opencode"),
+        "Authentication required"
+    );
+}
+
+#[test]
+fn provider_settings_auth_instructions_surface_advertised_text() {
+    let mut provider = provider("codex");
+    provider.auth_methods = vec![AgentAuthMethod::Agent {
+        instructions: "Run codex login".to_string(),
+    }];
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider);
+
+    state.show_auth_instructions("codex");
+
+    assert_eq!(
+        state.auth_statuses["codex"].instructions(),
+        Some("Run codex login")
+    );
+}
+
+#[test]
+fn provider_settings_terminal_auth_command_uses_only_advertised_args_and_env() {
+    let mut provider = provider("codex");
+    provider.args = vec!["acp".to_string()];
+    provider.auth_methods = vec![AgentAuthMethod::Terminal {
+        args: vec!["login".to_string(), "--device".to_string()],
+        env: vec![AgentProviderEnvVar {
+            name: "CODEX_HOME".to_string(),
+            value: Some("/tmp/codex".to_string()),
+            secure_ref: None,
+        }],
+    }];
+    let mut state = ProviderSettingsState::default();
+    state.add_provider(provider);
+
+    let (command, args, env) = state
+        .terminal_auth_command("codex")
+        .expect("terminal auth command");
+    assert_eq!(command, "codex-acp");
+    assert_eq!(args, vec!["acp", "login", "--device"]);
+    assert_eq!(env.len(), 1);
+    assert_eq!(env[0].name, "CODEX_HOME");
+
+    state.mark_terminal_auth_unavailable("codex");
+    assert_eq!(state.auth_status_label("codex"), "Authentication failed");
+    assert!(
+        state.auth_statuses["codex"]
+            .instructions()
+            .expect("instructions")
+            .contains("codex-acp acp login --device")
+    );
+}

--- a/tests/agent_workspace_tests.rs
+++ b/tests/agent_workspace_tests.rs
@@ -1,0 +1,298 @@
+use std::path::PathBuf;
+
+use alas::agent::{
+    AgentConfigOption, AgentDebugEvent, AgentModeOption, AgentPermissionRequest, AgentPlanState,
+    AgentResumeState, AgentSlashCommand, AgentThreadState, AgentThreadStatus, AgentToolCallState,
+    AgentTranscriptEntry, AgentTranscriptRole,
+};
+use alas::app::{TerminalTabKind, WorkspaceSession, WorkspaceTabContent, WorkspaceTabKind};
+use alas::terminal::CommandSpec;
+
+#[test]
+fn new_agent_thread_starts_disconnected_with_empty_transcript() {
+    let state = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+
+    assert!(!state.thread_id.is_empty());
+    assert_eq!(state.provider_id, "opencode");
+    assert_eq!(state.acp_session_id, None);
+    assert_eq!(state.worktree_path, PathBuf::from("/repo/worktree"));
+    assert_eq!(state.title, "Agent Chat");
+    assert_eq!(state.status, AgentThreadStatus::Disconnected);
+    assert!(state.transcript.is_empty());
+    assert!(state.tool_calls.is_empty());
+    assert!(state.plans.is_empty());
+    assert!(state.pending_permissions.is_empty());
+    assert!(state.available_commands.is_empty());
+    assert!(state.available_modes.is_empty());
+    assert_eq!(state.current_mode, None);
+    assert!(state.config_options.is_empty());
+    assert_eq!(state.draft, "");
+    assert_eq!(state.resume, AgentResumeState::NotRestored);
+    assert!(state.debug_log.is_empty());
+}
+
+#[test]
+fn transcript_entries_keep_role_and_text() {
+    let entry = AgentTranscriptEntry::user("hello");
+    assert_eq!(entry.text, "hello");
+}
+
+#[test]
+fn nested_agent_domain_types_match_task_contract() {
+    let roles = [
+        AgentTranscriptRole::User,
+        AgentTranscriptRole::Agent,
+        AgentTranscriptRole::Thought,
+        AgentTranscriptRole::System,
+        AgentTranscriptRole::Tool,
+    ];
+    assert_eq!(roles.len(), 5);
+
+    let tool_call = AgentToolCallState {
+        id: "tool-1".to_string(),
+        title: "Read file".to_string(),
+        status: "running".to_string(),
+    };
+    assert_eq!(tool_call.status, "running");
+
+    let plan = AgentPlanState {
+        entries: vec!["Inspect workspace".to_string()],
+    };
+    assert_eq!(plan.entries, ["Inspect workspace"]);
+
+    let permission = AgentPermissionRequest {
+        id: "perm-1".to_string(),
+        description: "Allow command".to_string(),
+    };
+    assert_eq!(permission.description, "Allow command");
+
+    let command = AgentSlashCommand {
+        name: "reset".to_string(),
+        description: Some("Reset conversation".to_string()),
+    };
+    assert_eq!(command.description.as_deref(), Some("Reset conversation"));
+
+    let mode = AgentModeOption {
+        id: "ask".to_string(),
+        name: "Ask".to_string(),
+    };
+    assert_eq!(mode.name, "Ask");
+
+    let config = AgentConfigOption {
+        id: "model".to_string(),
+        label: "Model".to_string(),
+        value: Some("fast".to_string()),
+        options: Vec::new(),
+    };
+    assert_eq!(config.value.as_deref(), Some("fast"));
+
+    let debug_event = AgentDebugEvent {
+        message: "Connected to agent".to_string(),
+    };
+    assert_eq!(debug_event.message, "Connected to agent");
+}
+
+#[test]
+fn agent_threads_get_stable_distinct_thread_ids() {
+    let first = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+    let second = AgentThreadState::new("opencode", PathBuf::from("/repo/worktree"));
+
+    assert_ne!(first.thread_id, second.thread_id);
+}
+
+#[test]
+fn worktree_can_have_agent_chat_tabs_with_other_tab_kinds() {
+    let mut session = WorkspaceSession::default();
+    let path = PathBuf::from("/repo/a");
+    let terminal = session.create_terminal_tab(
+        "repo",
+        path.clone(),
+        "Shell".to_string(),
+        TerminalTabKind::Shell,
+        CommandSpec::shell_command("$SHELL", path.clone()),
+    );
+
+    let agent = session.create_agent_chat_tab("repo", path.clone(), "opencode".to_string());
+
+    let tabs = session.tabs_for_worktree("repo", &path);
+    assert_eq!(tabs.len(), 2);
+    assert_eq!(tabs[0].id, terminal);
+    assert_eq!(tabs[1].id, agent);
+    assert_eq!(tabs[1].kind, WorkspaceTabKind::AgentChat);
+    assert!(matches!(tabs[1].content, WorkspaceTabContent::AgentChat(_)));
+    assert_eq!(
+        session.active_tab("repo", &path).map(|tab| tab.id),
+        Some(agent)
+    );
+}
+
+#[test]
+fn workspace_restores_persisted_agent_tabs_once_for_matching_worktree() {
+    let mut session = WorkspaceSession::default();
+    let path = PathBuf::from("/repo/a");
+    let other_path = PathBuf::from("/repo/b");
+    let mut state = AgentThreadState::new("opencode", path.clone());
+    state.thread_id = "thread-1".to_string();
+    state.acp_session_id = Some("session-1".to_string());
+    state.status = AgentThreadStatus::Running;
+    state.resume = AgentResumeState::NotRestored;
+    state.draft = "saved draft".to_string();
+    let mut other = AgentThreadState::new("opencode", other_path);
+    other.thread_id = "thread-2".to_string();
+
+    let restored = session.restore_agent_chat_tabs(
+        "repo",
+        &path,
+        &[
+            alas::agent::AgentThreadRecord::from_state("thread-1".to_string(), &state),
+            alas::agent::AgentThreadRecord::from_state("thread-2".to_string(), &other),
+        ],
+    );
+    let duplicate_restore = session.restore_agent_chat_tabs(
+        "repo",
+        &path,
+        &[alas::agent::AgentThreadRecord::from_state(
+            "thread-1".to_string(),
+            &state,
+        )],
+    );
+
+    assert_eq!(restored.len(), 1);
+    assert!(duplicate_restore.is_empty());
+    let tabs = session.tabs_for_worktree("repo", &path);
+    assert_eq!(tabs.len(), 1);
+    let thread = tabs[0].agent_thread_state().expect("agent thread");
+    assert_eq!(thread.thread_id, "thread-1");
+    assert_eq!(thread.draft, "saved draft");
+    assert_eq!(thread.resume, AgentResumeState::Pending);
+    assert_eq!(
+        thread.status,
+        AgentThreadStatus::ReadOnly {
+            reason: "Waiting for agent session resume".to_string()
+        }
+    );
+}
+
+#[test]
+fn workspace_restores_persisted_agent_tabs_for_known_worktrees_without_selection() {
+    let mut session = WorkspaceSession::default();
+    let path_a = PathBuf::from("/repo/a");
+    let path_b = PathBuf::from("/repo/b");
+    let mut state_a = AgentThreadState::new("opencode", path_a.clone());
+    state_a.thread_id = "thread-a".to_string();
+    let mut state_b = AgentThreadState::new("codex", path_b.clone());
+    state_b.thread_id = "thread-b".to_string();
+
+    let restored = session.restore_agent_chat_tabs_for_worktrees(
+        vec![
+            ("repo".to_string(), path_a.clone()),
+            ("repo".to_string(), path_b.clone()),
+        ],
+        &[
+            alas::agent::AgentThreadRecord::from_state("thread-a".to_string(), &state_a),
+            alas::agent::AgentThreadRecord::from_state("thread-b".to_string(), &state_b),
+        ],
+    );
+
+    assert_eq!(restored.len(), 2);
+    assert_eq!(session.tabs_for_worktree("repo", &path_a).len(), 1);
+    assert_eq!(session.tabs_for_worktree("repo", &path_b).len(), 1);
+    assert_eq!(
+        session
+            .active_tab("repo", &path_a)
+            .and_then(|tab| tab.agent_thread_state())
+            .map(|thread| thread.thread_id.as_str()),
+        Some("thread-a")
+    );
+    assert_eq!(
+        session
+            .active_tab("repo", &path_b)
+            .and_then(|tab| tab.agent_thread_state())
+            .map(|thread| thread.thread_id.as_str()),
+        Some("thread-b")
+    );
+}
+
+#[test]
+fn workspace_restore_for_known_worktrees_dedupes_by_thread_id() {
+    let mut session = WorkspaceSession::default();
+    let path_a = PathBuf::from("/repo/a");
+    let path_b = PathBuf::from("/repo/b");
+    let mut state_a = AgentThreadState::new("opencode", path_a.clone());
+    state_a.thread_id = "thread-1".to_string();
+    let mut state_b = AgentThreadState::new("opencode", path_b.clone());
+    state_b.thread_id = "thread-1".to_string();
+
+    let restored = session.restore_agent_chat_tabs_for_worktrees(
+        vec![
+            ("repo".to_string(), path_a.clone()),
+            ("repo".to_string(), path_b.clone()),
+        ],
+        &[
+            alas::agent::AgentThreadRecord::from_state("thread-1".to_string(), &state_a),
+            alas::agent::AgentThreadRecord::from_state("thread-1".to_string(), &state_b),
+        ],
+    );
+
+    assert_eq!(restored.len(), 1);
+    let restored_count = session.tabs_for_worktree("repo", &path_a).len()
+        + session.tabs_for_worktree("repo", &path_b).len();
+    assert_eq!(restored_count, 1);
+}
+
+#[test]
+fn terminal_specific_mutation_rejects_agent_chat_tabs() {
+    let mut session = WorkspaceSession::default();
+    let path = PathBuf::from("/repo/a");
+    let agent = session.create_agent_chat_tab("repo", path.clone(), "opencode".to_string());
+
+    let error = session
+        .set_tab_scroll_offset("repo", &path, agent, 12)
+        .expect_err("agent tab should reject terminal mutation")
+        .to_string();
+
+    assert!(error.contains("not a terminal tab"));
+}
+
+#[test]
+fn new_workspace_tab_choice_labels_include_terminal_and_agent_chat() {
+    let labels = alas::ui::workspace::new_workspace_tab_choices()
+        .into_iter()
+        .map(alas::ui::workspace::new_workspace_tab_choice_label)
+        .collect::<Vec<_>>();
+
+    assert!(labels.contains(&"Terminal"));
+    assert!(labels.contains(&"Agent Chat"));
+}
+
+#[test]
+fn agent_chat_provider_flow_uses_settings_when_no_provider_enabled() {
+    let mut disabled = alas::agent::AgentProviderConfig::new("codex", "Codex", "codex-acp");
+    disabled.enabled = false;
+
+    assert_eq!(
+        alas::ui::workspace::agent_chat_provider_flow(&[disabled]),
+        alas::ui::workspace::AgentChatProviderFlow::ProviderSettings
+    );
+}
+
+#[test]
+fn agent_chat_provider_flow_opens_picker_for_one_enabled_provider() {
+    let provider = alas::agent::AgentProviderConfig::new("codex", "Codex", "codex-acp");
+
+    assert_eq!(
+        alas::ui::workspace::agent_chat_provider_flow(std::slice::from_ref(&provider)),
+        alas::ui::workspace::AgentChatProviderFlow::ProviderPicker(vec![provider])
+    );
+}
+
+#[test]
+fn agent_chat_provider_flow_opens_picker_for_multiple_enabled_providers() {
+    let codex = alas::agent::AgentProviderConfig::new("codex", "Codex", "codex-acp");
+    let opencode = alas::agent::AgentProviderConfig::new("opencode", "OpenCode", "opencode-acp");
+
+    assert_eq!(
+        alas::ui::workspace::agent_chat_provider_flow(&[codex.clone(), opencode.clone()]),
+        alas::ui::workspace::AgentChatProviderFlow::ProviderPicker(vec![codex, opencode])
+    );
+}

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,8 +1,11 @@
-use alas::config::{
-    AppConfig, AppConfigStore, AppRepository, CommandConfig, CommandEntry, RepoConfigFile,
-    RepoConfigStore, ResolvedRepoConfig,
-};
 use alas::ui::dialogs::{CommandSettingsDialogState, NotificationPreferencesDialogState};
+use alas::{
+    agent::{AgentProviderConfig, AgentProviderEnvVar, AgentTrustMode, ProviderCwdPolicy},
+    config::{
+        AppConfig, AppConfigStore, AppRepository, CommandConfig, CommandEntry, RepoConfigFile,
+        RepoConfigStore, ResolvedRepoConfig,
+    },
+};
 use indexmap::IndexMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
@@ -95,6 +98,63 @@ fn app_config_round_trips_notification_preferences() {
 
     store.save(&config).unwrap();
 
+    assert_eq!(store.load().unwrap(), config);
+}
+
+#[test]
+fn app_config_defaults_provider_discovery_config() {
+    let config: AppConfig = toml::from_str("").expect("empty config");
+    assert!(
+        config
+            .agent_provider_discovery
+            .ignored_provider_ids
+            .is_empty()
+    );
+}
+
+#[test]
+fn app_config_round_trips_provider_discovery_ignored_ids() {
+    let mut config = AppConfig::default();
+    config
+        .agent_provider_discovery
+        .ignored_provider_ids
+        .push("opencode".to_string());
+    let toml = toml::to_string(&config).expect("serialize config");
+    assert!(toml.contains("agent_provider_discovery"));
+    assert!(toml.contains("opencode"));
+    let loaded: AppConfig = toml::from_str(&toml).expect("deserialize config");
+    assert_eq!(loaded, config);
+}
+
+#[test]
+fn app_config_store_persists_agent_providers_without_inline_secrets() {
+    let temp = tempdir().unwrap();
+    let config_path = temp.path().join("alas").join("config.toml");
+    let store = AppConfigStore::new(config_path.clone());
+
+    let mut config = AppConfig::default();
+    config.agent_providers.push(AgentProviderConfig {
+        id: "opencode".to_string(),
+        display_name: "OpenCode".to_string(),
+        command: "opencode".to_string(),
+        args: vec!["acp".to_string()],
+        env: vec![AgentProviderEnvVar::secure_ref(
+            "OPENCODE_API_KEY",
+            "opencode/api-key",
+        )],
+        auth_methods: Vec::new(),
+        cwd_policy: ProviderCwdPolicy::SelectedWorktree,
+        trust_mode: AgentTrustMode::Ask,
+        enabled: true,
+    });
+
+    store.save(&config).unwrap();
+
+    let saved = std::fs::read_to_string(config_path).unwrap();
+    assert!(saved.contains("agent_providers"));
+    assert!(saved.contains("opencode/api-key"));
+    assert!(!saved.contains("super-secret"));
+    assert!(!saved.contains("value ="));
     assert_eq!(store.load().unwrap(), config);
 }
 

--- a/tests/workspace_session_tests.rs
+++ b/tests/workspace_session_tests.rs
@@ -495,7 +495,8 @@ fn file_tab_load_state_can_be_updated() {
         )),
         WorkspaceTabContent::Markdown(_)
         | WorkspaceTabContent::Terminal(_)
-        | WorkspaceTabContent::Image(_) => {
+        | WorkspaceTabContent::Image(_)
+        | WorkspaceTabContent::AgentChat(_) => {
             panic!("expected file tab")
         }
     }
@@ -520,7 +521,8 @@ fn markdown_files_open_in_split_mode_by_default() {
         }
         WorkspaceTabContent::File(_)
         | WorkspaceTabContent::Terminal(_)
-        | WorkspaceTabContent::Image(_) => {
+        | WorkspaceTabContent::Image(_)
+        | WorkspaceTabContent::AgentChat(_) => {
             panic!("expected markdown tab")
         }
     }
@@ -551,7 +553,8 @@ fn markdown_mode_can_switch_between_code_preview_and_split() {
         }
         WorkspaceTabContent::File(_)
         | WorkspaceTabContent::Terminal(_)
-        | WorkspaceTabContent::Image(_) => {
+        | WorkspaceTabContent::Image(_)
+        | WorkspaceTabContent::AgentChat(_) => {
             panic!("expected markdown tab")
         }
     }


### PR DESCRIPTION
## Summary
- Adds ACP provider configuration, secure credentials, provider discovery, and stdio runtime support.
- Adds Agent Chat workspace tabs with persisted/resumable sessions, transcript/tool rendering, callbacks, permissions, and model/mode/config controls.
- Moves Agent Chat persistence, provider settings IO, startup, prompt, and cancel paths off the UI thread where practical.

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
