### PR TITLE
Fix ACP review feedback

### DIFF
--- a/src/agent/runtime.rs
+++ b/src/agent/runtime.rs
@@ -60,6 +60,11 @@ pub enum AgentRuntimeEvent {
         title: String,
         status: String,
     },
+    ToolCallUpdate {
+        id: String,
+        title: Option<String>,
+        status: Option<String>,
+    },
     Plan(Vec<String>),
     AvailableCommands(Vec<AgentSlashCommand>),
     AvailableModes {
@@ -407,12 +412,22 @@ impl AcpProcessConnection {
             "session/request_permission" => {
                 let request: acp::RequestPermissionRequest = serde_json::from_value(params)
                     .context("failed to decode session/request_permission")?;
-                let allow = matches!(
-                    self.permission_policy
-                        .as_ref()
-                        .map(|policy| &policy.trust_mode),
-                    Some(super::AgentTrustMode::AllowEverything)
-                );
+                let trust_mode = self
+                    .permission_policy
+                    .as_ref()
+                    .map(|policy| &policy.trust_mode);
+                if matches!(trust_mode, Some(super::AgentTrustMode::Ask)) {
+                    anyhow::bail!(
+                        "permission request requires user approval and cannot be continued in process callbacks: {}",
+                        request
+                            .tool_call
+                            .fields
+                            .title
+                            .as_deref()
+                            .unwrap_or("ACP permission request")
+                    );
+                }
+                let allow = matches!(trust_mode, Some(super::AgentTrustMode::AllowEverything));
                 if request.options.is_empty() {
                     anyhow::bail!("permission request did not include options");
                 }
@@ -1227,6 +1242,9 @@ pub fn apply_runtime_event(thread: &mut AgentThreadState, event: AgentRuntimeEve
         AgentRuntimeEvent::ToolCall { id, title, status } => {
             apply_agent_update(thread, AgentUpdate::ToolCall { id, title, status });
         }
+        AgentRuntimeEvent::ToolCallUpdate { id, title, status } => {
+            apply_agent_update(thread, AgentUpdate::ToolCallUpdate { id, title, status });
+        }
         AgentRuntimeEvent::Plan(entries) => apply_agent_update(thread, AgentUpdate::Plan(entries)),
         AgentRuntimeEvent::AvailableCommands(commands) => {
             apply_agent_update(thread, AgentUpdate::AvailableCommands(commands));
@@ -1361,17 +1379,12 @@ fn agent_runtime_event_from_update(update: AgentUpdate) -> AgentRuntimeEvent {
     match update {
         AgentUpdate::AgentMessageChunk(text) => AgentRuntimeEvent::AgentMessageChunk(text),
         AgentUpdate::ThoughtChunk(text) => AgentRuntimeEvent::ThoughtChunk(text),
-        AgentUpdate::ToolCall { id, title, status }
-        | AgentUpdate::ToolCallUpdate {
-            id,
-            title: Some(title),
-            status: Some(status),
-        } => AgentRuntimeEvent::ToolCall { id, title, status },
-        AgentUpdate::ToolCallUpdate { id, title, status } => AgentRuntimeEvent::ToolCall {
-            id,
-            title: title.unwrap_or_default(),
-            status: status.unwrap_or_default(),
-        },
+        AgentUpdate::ToolCall { id, title, status } => {
+            AgentRuntimeEvent::ToolCall { id, title, status }
+        }
+        AgentUpdate::ToolCallUpdate { id, title, status } => {
+            AgentRuntimeEvent::ToolCallUpdate { id, title, status }
+        }
         AgentUpdate::Plan(entries) => AgentRuntimeEvent::Plan(entries),
         AgentUpdate::AvailableCommands(commands) => AgentRuntimeEvent::AvailableCommands(commands),
         AgentUpdate::AvailableModes { modes, current } => {

--- a/tests/agent_runtime_tests.rs
+++ b/tests/agent_runtime_tests.rs
@@ -109,7 +109,7 @@ fn process_connection_dispatches_terminal_callbacks() {
 }
 
 #[test]
-fn process_connection_dispatches_permission_without_pending_continuation() {
+fn process_connection_ask_permission_returns_honest_error() {
     let temp = tempfile::tempdir().unwrap();
     let provider = AgentProviderConfig::new("dispatcher", "Dispatcher", "/bin/cat");
     let mut connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf())
@@ -119,7 +119,7 @@ fn process_connection_dispatches_permission_without_pending_continuation() {
             AgentTerminalService::new(AgentTrustMode::Ask, temp.path().to_path_buf()),
         );
 
-    let response = connection
+    let error = connection
         .dispatch_client_request(
             "session/request_permission",
             serde_json::json!({
@@ -131,9 +131,13 @@ fn process_connection_dispatches_permission_without_pending_continuation() {
                 ]
             }),
         )
-        .unwrap();
+        .expect_err("Ask mode cannot silently choose an ACP permission option");
 
-    assert_eq!(response["outcome"]["optionId"], "reject");
+    assert!(
+        error
+            .to_string()
+            .contains("permission request requires user approval")
+    );
 }
 
 #[test]
@@ -143,8 +147,8 @@ fn process_connection_does_not_select_allow_when_permission_denied() {
     let mut connection = AcpProcessConnection::spawn(&provider, temp.path().to_path_buf())
         .unwrap()
         .with_callback_services(
-            FilesystemCallbackService::new(AgentTrustMode::Ask, temp.path().to_path_buf()),
-            AgentTerminalService::new(AgentTrustMode::Ask, temp.path().to_path_buf()),
+            FilesystemCallbackService::new(AgentTrustMode::Deny, temp.path().to_path_buf()),
+            AgentTerminalService::new(AgentTrustMode::Deny, temp.path().to_path_buf()),
         );
 
     let error = connection


### PR DESCRIPTION
## Summary
- Preserve partial ACP tool-call updates through the runtime event layer so missing fields do not overwrite existing title/status.
- Make Ask-mode ACP permission callbacks fail honestly with a user-approval-required error instead of silently selecting reject.

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features

@codex review