### PR TITLE
Fix center pane scrolling

### DIFF
--- a/src/ui/file_pane.rs
+++ b/src/ui/file_pane.rs
@@ -2,7 +2,7 @@ use crate::{
     app::FileTabLoadState,
     ui::theme::{DANGER, PANEL_BG, TEXT, TEXT_MUTED},
 };
-use gpui::{AnyElement, IntoElement, SharedString, Styled, div, prelude::*};
+use gpui::{AnyElement, IntoElement, SharedString, Styled, div, prelude::*, px};
 
 pub fn render_file_pane(load_state: &FileTabLoadState) -> impl IntoElement {
     div()
@@ -29,6 +29,7 @@ fn render_file_content(load_state: &FileTabLoadState) -> AnyElement {
             .flex()
             .flex_1()
             .size_full()
+            .min_h(px(0.0))
             .overflow_scroll()
             .p_3()
             .child(

--- a/src/ui/image_view.rs
+++ b/src/ui/image_view.rs
@@ -119,6 +119,7 @@ fn render_image_body(state: &ImageTabState) -> impl IntoElement {
         .id("image-body")
         .flex()
         .flex_1()
+        .min_h(px(0.0))
         .items_center()
         .justify_center()
         .overflow_scroll()

--- a/src/ui/workspace.rs
+++ b/src/ui/workspace.rs
@@ -4,7 +4,7 @@ use crate::{
     ui::theme::{ACCENT, ACTIVE_TAB_BG, APP_BG, PANEL_BG, PANEL_BORDER, TEXT, TEXT_MUTED},
 };
 use gpui::{
-    App, ClickEvent, IntoElement, ParentElement, SharedString, Styled, Window, div, prelude::*,
+    App, ClickEvent, IntoElement, ParentElement, SharedString, Styled, Window, div, prelude::*, px,
 };
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -68,6 +68,7 @@ pub fn render_workspace(
                 .flex()
                 .flex_col()
                 .flex_1()
+                .min_h(px(0.0))
                 .overflow_hidden()
                 .rounded_lg()
                 .border_1()
@@ -80,7 +81,14 @@ pub fn render_workspace(
                     on_close_tab,
                     on_new_tab,
                 ))
-                .child(div().flex().flex_1().overflow_hidden().child(body)),
+                .child(
+                    div()
+                        .flex()
+                        .flex_1()
+                        .min_h(px(0.0))
+                        .overflow_hidden()
+                        .child(body),
+                ),
         )
 }
 

--- a/tests/center_pane_layout_tests.rs
+++ b/tests/center_pane_layout_tests.rs
@@ -1,0 +1,41 @@
+use std::fs;
+
+fn compact(source: &str) -> String {
+    source.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[test]
+fn workspace_bounds_active_tab_body_below_fixed_tab_bar() {
+    let source =
+        fs::read_to_string("src/ui/workspace.rs").expect("workspace UI source is readable");
+    let compact = compact(&source);
+
+    assert!(compact.contains(".child(render_tab_bar("));
+    assert!(
+        compact.matches(".min_h(px(0.0))").count() >= 2,
+        "workspace panel and active body wrapper must allow scrollable tab content to shrink"
+    );
+}
+
+#[test]
+fn central_file_and_image_bodies_are_scroll_owners() {
+    let file_pane = compact(
+        &fs::read_to_string("src/ui/file_pane.rs").expect("file pane UI source is readable"),
+    );
+    let image_view = compact(
+        &fs::read_to_string("src/ui/image_view.rs").expect("image view UI source is readable"),
+    );
+
+    assert!(
+        file_pane.contains(
+            ".id(\"file-pane-content\") .flex() .flex_1() .size_full() .min_h(px(0.0)) .overflow_scroll()"
+        ),
+        "generic file pane content must be a bounded scroll container"
+    );
+    assert!(
+        image_view.contains(
+            ".id(\"image-body\") .flex() .flex_1() .min_h(px(0.0)) .items_center() .justify_center() .overflow_scroll()"
+        ),
+        "image body must be a bounded scroll container below the toolbar"
+    );
+}


### PR DESCRIPTION
## Summary
- add bounded min-height constraints through the center-pane flex chain
- make generic file and image pane scroll owners shrinkable
- add regression coverage for the center-pane scroll layout convention

## Validation
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --all-features
- cargo test --all-features