### PR TITLE
Add draggable resize handles to sidebars

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -14,6 +14,8 @@ pub struct AppConfig {
     pub agent_providers: Vec<crate::agent::AgentProviderConfig>,
     #[serde(default)]
     pub agent_provider_discovery: AgentProviderDiscoveryConfig,
+    #[serde(default)]
+    pub layout: LayoutPrefs,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -65,6 +67,31 @@ impl Default for HarnessCompletionNotificationPrefs {
 
 const fn default_true() -> bool {
     true
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct LayoutPrefs {
+    #[serde(default = "default_left_sidebar_width_px")]
+    pub left_sidebar_width_px: u32,
+    #[serde(default = "default_right_sidebar_width_px")]
+    pub right_sidebar_width_px: u32,
+}
+
+impl Default for LayoutPrefs {
+    fn default() -> Self {
+        Self {
+            left_sidebar_width_px: default_left_sidebar_width_px(),
+            right_sidebar_width_px: default_right_sidebar_width_px(),
+        }
+    }
+}
+
+const fn default_left_sidebar_width_px() -> u32 {
+    280
+}
+
+const fn default_right_sidebar_width_px() -> u32 {
+    320
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/ui/inspector.rs
+++ b/src/ui/inspector.rs
@@ -18,6 +18,7 @@ pub fn render_project_inspector(
     file_expansion: &TreeExpansionState,
     on_toggle_file: impl Fn(PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
     on_open_file: impl Fn(PathBuf, &ClickEvent, &mut Window, &mut App) + Clone + 'static,
+    width: f32,
 ) -> impl IntoElement {
     let rows = build_inspector_tree_rows(selected_worktree, state, file_expansion);
 
@@ -27,7 +28,7 @@ pub fn render_project_inspector(
         .flex_col()
         .flex_shrink_0()
         .size_full()
-        .w(px(320.0))
+        .w(px(width))
         .px_4()
         .py_3()
         .gap_2()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ pub mod lifecycle;
 pub mod markdown_pane;
 pub mod markdown_preview;
 pub mod provider_settings;
+pub mod resize_handle;
 pub mod shell;
 pub mod sidebar;
 pub mod source_viewer;

--- a/src/ui/resize_handle.rs
+++ b/src/ui/resize_handle.rs
@@ -34,6 +34,21 @@ impl SidebarLayoutState {
         }
     }
 
+    pub fn clamp_for_window(&mut self, window_width: f32) {
+        self.left_width_px = clamp_sidebar_width(
+            SidebarResizeTarget::Left,
+            self.left_width_px,
+            self.right_width_px,
+            window_width,
+        );
+        self.right_width_px = clamp_sidebar_width(
+            SidebarResizeTarget::Right,
+            self.right_width_px,
+            self.left_width_px,
+            window_width,
+        );
+    }
+
     pub fn left_width(&self) -> Pixels {
         px(self.left_width_px)
     }
@@ -113,5 +128,16 @@ mod tests {
         // left max = 1000 - 400 - 300 = 300
         let result = clamp_sidebar_width(SidebarResizeTarget::Left, 400.0, 400.0, 1000.0);
         assert_eq!(result, 300.0);
+    }
+
+    #[test]
+    fn layout_state_clamps_saved_widths_for_window() {
+        let mut layout = SidebarLayoutState::from_config(900, 900);
+
+        layout.clamp_for_window(900.0);
+
+        assert!(layout.left_width_px <= LEFT_SIDEBAR_MAX_WIDTH_PX);
+        assert!(layout.right_width_px <= RIGHT_SIDEBAR_MAX_WIDTH_PX);
+        assert!(900.0 - layout.left_width_px - layout.right_width_px >= CENTER_MIN_WIDTH_PX);
     }
 }

--- a/src/ui/resize_handle.rs
+++ b/src/ui/resize_handle.rs
@@ -29,8 +29,10 @@ pub struct SidebarLayoutState {
 impl SidebarLayoutState {
     pub fn from_config(left: u32, right: u32) -> Self {
         Self {
-            left_width_px: left as f32,
-            right_width_px: right as f32,
+            left_width_px: (left as f32)
+                .clamp(LEFT_SIDEBAR_MIN_WIDTH_PX, LEFT_SIDEBAR_MAX_WIDTH_PX),
+            right_width_px: (right as f32)
+                .clamp(RIGHT_SIDEBAR_MIN_WIDTH_PX, RIGHT_SIDEBAR_MAX_WIDTH_PX),
         }
     }
 
@@ -71,7 +73,9 @@ pub fn clamp_sidebar_width(
     };
 
     // Ensure center pane keeps minimum width
-    let effective_max = (window_width - other_sidebar_width - CENTER_MIN_WIDTH_PX).max(min);
+    let handle_widths = RESIZE_HANDLE_WIDTH_PX * 2.0;
+    let effective_max =
+        (window_width - handle_widths - other_sidebar_width - CENTER_MIN_WIDTH_PX).max(min);
     requested.clamp(min, max.min(effective_max))
 }
 
@@ -124,10 +128,10 @@ mod tests {
 
     #[test]
     fn center_preserved_when_both_sidebars_expand() {
-        // Window = 1000, right = 400, center min = 300
-        // left max = 1000 - 400 - 300 = 300
+        // Window = 1000, right = 400, handles = 12, center min = 300
+        // left max = 1000 - 400 - 12 - 300 = 288
         let result = clamp_sidebar_width(SidebarResizeTarget::Left, 400.0, 400.0, 1000.0);
-        assert_eq!(result, 300.0);
+        assert_eq!(result, 288.0);
     }
 
     #[test]
@@ -138,6 +142,9 @@ mod tests {
 
         assert!(layout.left_width_px <= LEFT_SIDEBAR_MAX_WIDTH_PX);
         assert!(layout.right_width_px <= RIGHT_SIDEBAR_MAX_WIDTH_PX);
-        assert!(900.0 - layout.left_width_px - layout.right_width_px >= CENTER_MIN_WIDTH_PX);
+        assert!(
+            900.0 - (RESIZE_HANDLE_WIDTH_PX * 2.0) - layout.left_width_px - layout.right_width_px
+                >= CENTER_MIN_WIDTH_PX
+        );
     }
 }

--- a/src/ui/resize_handle.rs
+++ b/src/ui/resize_handle.rs
@@ -1,0 +1,117 @@
+use gpui::{Pixels, px};
+
+pub const LEFT_SIDEBAR_MIN_WIDTH_PX: f32 = 180.0;
+pub const LEFT_SIDEBAR_MAX_WIDTH_PX: f32 = 480.0;
+pub const RIGHT_SIDEBAR_MIN_WIDTH_PX: f32 = 200.0;
+pub const RIGHT_SIDEBAR_MAX_WIDTH_PX: f32 = 500.0;
+pub const CENTER_MIN_WIDTH_PX: f32 = 300.0;
+pub const RESIZE_HANDLE_WIDTH_PX: f32 = 6.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SidebarResizeTarget {
+    Left,
+    Right,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SidebarResizeDrag {
+    pub target: SidebarResizeTarget,
+    pub start_x: f32,
+    pub start_width: f32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SidebarLayoutState {
+    pub left_width_px: f32,
+    pub right_width_px: f32,
+}
+
+impl SidebarLayoutState {
+    pub fn from_config(left: u32, right: u32) -> Self {
+        Self {
+            left_width_px: left as f32,
+            right_width_px: right as f32,
+        }
+    }
+
+    pub fn left_width(&self) -> Pixels {
+        px(self.left_width_px)
+    }
+
+    pub fn right_width(&self) -> Pixels {
+        px(self.right_width_px)
+    }
+}
+
+/// Clamp a sidebar width based on its own limits and the available window width.
+pub fn clamp_sidebar_width(
+    target: SidebarResizeTarget,
+    requested: f32,
+    other_sidebar_width: f32,
+    window_width: f32,
+) -> f32 {
+    let (min, max) = match target {
+        SidebarResizeTarget::Left => (LEFT_SIDEBAR_MIN_WIDTH_PX, LEFT_SIDEBAR_MAX_WIDTH_PX),
+        SidebarResizeTarget::Right => (RIGHT_SIDEBAR_MIN_WIDTH_PX, RIGHT_SIDEBAR_MAX_WIDTH_PX),
+    };
+
+    // Ensure center pane keeps minimum width
+    let effective_max = (window_width - other_sidebar_width - CENTER_MIN_WIDTH_PX).max(min);
+    requested.clamp(min, max.min(effective_max))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NORMAL_WINDOW: f32 = 1440.0;
+
+    #[test]
+    fn left_clamps_to_min() {
+        let result = clamp_sidebar_width(SidebarResizeTarget::Left, 100.0, 320.0, NORMAL_WINDOW);
+        assert_eq!(result, LEFT_SIDEBAR_MIN_WIDTH_PX);
+    }
+
+    #[test]
+    fn left_clamps_to_max() {
+        let result = clamp_sidebar_width(SidebarResizeTarget::Left, 600.0, 320.0, NORMAL_WINDOW);
+        assert_eq!(result, LEFT_SIDEBAR_MAX_WIDTH_PX);
+    }
+
+    #[test]
+    fn right_clamps_to_min() {
+        let result = clamp_sidebar_width(SidebarResizeTarget::Right, 100.0, 280.0, NORMAL_WINDOW);
+        assert_eq!(result, RIGHT_SIDEBAR_MIN_WIDTH_PX);
+    }
+
+    #[test]
+    fn right_clamps_to_max() {
+        let result = clamp_sidebar_width(SidebarResizeTarget::Right, 600.0, 280.0, NORMAL_WINDOW);
+        assert_eq!(result, RIGHT_SIDEBAR_MAX_WIDTH_PX);
+    }
+
+    #[test]
+    fn narrow_window_preserves_center_minimum() {
+        // Window = 700, other sidebar = 280, center min = 300
+        // So left max = 700 - 280 - 300 = 120 — but that's below the sidebar min of 180
+        // The effective max should be clamped to min (180)
+        let result = clamp_sidebar_width(SidebarResizeTarget::Left, 400.0, 280.0, 700.0);
+        assert_eq!(result, LEFT_SIDEBAR_MIN_WIDTH_PX);
+    }
+
+    #[test]
+    fn defaults_survive_normal_window() {
+        let left = clamp_sidebar_width(SidebarResizeTarget::Left, 280.0, 320.0, NORMAL_WINDOW);
+        let right = clamp_sidebar_width(SidebarResizeTarget::Right, 320.0, 280.0, NORMAL_WINDOW);
+        assert_eq!(left, 280.0);
+        assert_eq!(right, 320.0);
+    }
+
+    #[test]
+    fn center_preserved_when_both_sidebars_expand() {
+        // Window = 1000, right = 400, center min = 300
+        // left max = 1000 - 400 - 300 = 300
+        let result = clamp_sidebar_width(SidebarResizeTarget::Left, 400.0, 400.0, 1000.0);
+        assert_eq!(result, 300.0);
+    }
+}

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -51,6 +51,10 @@ use crate::{
         provider_settings::{
             ProviderSettingsField, ProviderSettingsHandlers, render_provider_settings,
         },
+        resize_handle::{
+            RESIZE_HANDLE_WIDTH_PX, SidebarLayoutState, SidebarResizeDrag, SidebarResizeTarget,
+            clamp_sidebar_width,
+        },
         sidebar::{SidebarMenuState, render_sidebar},
         source_viewer::render_source_viewer,
         terminal_canvas::measure_terminal_metrics,
@@ -194,6 +198,8 @@ pub struct AlasShell {
     inspector_state: InspectorPaneState,
     inspector_request_generation: u64,
     file_tree_expansion: TreeExpansionState,
+    sidebar_layout: SidebarLayoutState,
+    active_sidebar_resize: Option<SidebarResizeDrag>,
     agent_runtimes: HashMap<WorkspaceTabId, AgentRuntime<AcpProcessConnection>>,
     agent_cancel_handles: HashMap<WorkspaceTabId, AcpCancelHandle>,
     agent_thread_store: AgentThreadStore,
@@ -212,6 +218,10 @@ impl AlasShell {
             AppConfigStore::default_store().expect("failed to resolve app config store");
         let mut config = app_config_store.load().unwrap_or_default();
         let notification_preferences = config.notifications.clone();
+        let sidebar_layout = SidebarLayoutState::from_config(
+            config.layout.left_sidebar_width_px,
+            config.layout.right_sidebar_width_px,
+        );
         let provider_discovery = discover_agent_providers();
         let provider_discovery_startup =
             apply_provider_discovery_to_config(&mut config, &provider_discovery, |config| {
@@ -270,6 +280,8 @@ impl AlasShell {
             inspector_state: InspectorPaneState::default(),
             inspector_request_generation: 0,
             file_tree_expansion: TreeExpansionState::default(),
+            sidebar_layout,
+            active_sidebar_resize: None,
             agent_runtimes: HashMap::new(),
             agent_cancel_handles: HashMap::new(),
             agent_thread_store,
@@ -3409,6 +3421,96 @@ impl AlasShell {
             .as_ref()
             .and_then(|dialog| dialog.error.as_deref())
     }
+
+    fn render_resize_handle(
+        &self,
+        target: SidebarResizeTarget,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let is_active = self
+            .active_sidebar_resize
+            .as_ref()
+            .is_some_and(|drag| drag.target == target);
+
+        let handle_id = match target {
+            SidebarResizeTarget::Left => "resize-handle-left",
+            SidebarResizeTarget::Right => "resize-handle-right",
+        };
+
+        let on_mouse_down = cx.listener(move |shell, event: &MouseDownEvent, _window, cx| {
+            if event.button != MouseButton::Left {
+                return;
+            }
+            let start_width = match target {
+                SidebarResizeTarget::Left => shell.sidebar_layout.left_width_px,
+                SidebarResizeTarget::Right => shell.sidebar_layout.right_width_px,
+            };
+            shell.active_sidebar_resize = Some(SidebarResizeDrag {
+                target,
+                start_x: f32::from(event.position.x),
+                start_width,
+            });
+            cx.stop_propagation();
+            cx.notify();
+        });
+
+        let on_mouse_move = cx.listener(move |shell, event: &MouseMoveEvent, window, cx| {
+            let Some(drag) = shell.active_sidebar_resize else {
+                return;
+            };
+            if drag.target != target {
+                return;
+            }
+            let delta = f32::from(event.position.x) - drag.start_x;
+            let requested = match drag.target {
+                SidebarResizeTarget::Left => drag.start_width + delta,
+                SidebarResizeTarget::Right => drag.start_width - delta,
+            };
+            let other_width = match drag.target {
+                SidebarResizeTarget::Left => shell.sidebar_layout.right_width_px,
+                SidebarResizeTarget::Right => shell.sidebar_layout.left_width_px,
+            };
+            let window_width = f32::from(window.bounds().size.width);
+            let clamped = clamp_sidebar_width(drag.target, requested, other_width, window_width);
+            match drag.target {
+                SidebarResizeTarget::Left => shell.sidebar_layout.left_width_px = clamped,
+                SidebarResizeTarget::Right => shell.sidebar_layout.right_width_px = clamped,
+            }
+            cx.stop_propagation();
+            cx.notify();
+        });
+
+        let on_mouse_up = cx.listener(move |shell, event: &MouseUpEvent, _window, cx| {
+            if event.button != MouseButton::Left {
+                return;
+            }
+            if shell
+                .active_sidebar_resize
+                .is_some_and(|d| d.target == target)
+            {
+                shell.config.layout.left_sidebar_width_px =
+                    shell.sidebar_layout.left_width_px as u32;
+                shell.config.layout.right_sidebar_width_px =
+                    shell.sidebar_layout.right_width_px as u32;
+                let _ = shell.app_config_store.save(&shell.config);
+                shell.active_sidebar_resize = None;
+                cx.stop_propagation();
+                cx.notify();
+            }
+        });
+
+        div()
+            .id(handle_id)
+            .flex_shrink_0()
+            .w(px(RESIZE_HANDLE_WIDTH_PX))
+            .h_full()
+            .cursor_col_resize()
+            .when(is_active, |el| el.bg(PANEL_BORDER))
+            .hover(|el| el.bg(PANEL_BORDER))
+            .on_mouse_down(MouseButton::Left, on_mouse_down)
+            .on_mouse_move(on_mouse_move)
+            .on_mouse_up(MouseButton::Left, on_mouse_up)
+    }
 }
 
 fn terminal_status_from_tab_status(status: &TerminalTabStatus) -> Option<TerminalStatus> {
@@ -4513,7 +4615,9 @@ impl Render for AlasShell {
                 on_select_worktree,
                 on_sidebar_menu_action,
                 self.add_repository_error(),
+                self.sidebar_layout.left_width_px,
             ))
+            .child(self.render_resize_handle(SidebarResizeTarget::Left, cx))
             .child(
                 div()
                     .flex()
@@ -4927,12 +5031,14 @@ impl Render for AlasShell {
                             )),
                     ),
                             )
+                            .child(self.render_resize_handle(SidebarResizeTarget::Right, cx))
                             .child(render_project_inspector(
                                 self.model.selected_worktree(),
                                 &self.inspector_state,
                                 &self.file_tree_expansion,
                                 on_toggle_file_tree_node,
                                 on_open_file_from_inspector,
+                                self.sidebar_layout.right_width_px,
                             )),
                     )
                     .child(render_status_bar(

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -74,7 +74,7 @@ use gpui::{
     App, Application, Bounds, ClipboardItem, Context, FocusHandle, IntoElement, KeyDownEvent,
     MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PathPromptOptions, Pixels,
     PromptLevel, Render, ScrollDelta, ScrollWheelEvent, SharedString, Task, Window, div,
-    prelude::*, px, rgb,
+    prelude::*, px, rgb, transparent_black,
 };
 use indexmap::IndexMap;
 use std::{
@@ -3455,45 +3455,17 @@ impl AlasShell {
         });
 
         let on_mouse_move = cx.listener(move |shell, event: &MouseMoveEvent, window, cx| {
-            let Some(drag) = shell.active_sidebar_resize else {
-                return;
-            };
-            if drag.target != target {
-                return;
+            if shell.update_sidebar_resize(event, window) {
+                cx.stop_propagation();
+                cx.notify();
             }
-            let delta = f32::from(event.position.x) - drag.start_x;
-            let requested = match drag.target {
-                SidebarResizeTarget::Left => drag.start_width + delta,
-                SidebarResizeTarget::Right => drag.start_width - delta,
-            };
-            let other_width = match drag.target {
-                SidebarResizeTarget::Left => shell.sidebar_layout.right_width_px,
-                SidebarResizeTarget::Right => shell.sidebar_layout.left_width_px,
-            };
-            let window_width = f32::from(window.bounds().size.width);
-            let clamped = clamp_sidebar_width(drag.target, requested, other_width, window_width);
-            match drag.target {
-                SidebarResizeTarget::Left => shell.sidebar_layout.left_width_px = clamped,
-                SidebarResizeTarget::Right => shell.sidebar_layout.right_width_px = clamped,
-            }
-            cx.stop_propagation();
-            cx.notify();
         });
 
         let on_mouse_up = cx.listener(move |shell, event: &MouseUpEvent, _window, cx| {
             if event.button != MouseButton::Left {
                 return;
             }
-            if shell
-                .active_sidebar_resize
-                .is_some_and(|d| d.target == target)
-            {
-                shell.config.layout.left_sidebar_width_px =
-                    shell.sidebar_layout.left_width_px as u32;
-                shell.config.layout.right_sidebar_width_px =
-                    shell.sidebar_layout.right_width_px as u32;
-                let _ = shell.app_config_store.save(&shell.config);
-                shell.active_sidebar_resize = None;
+            if shell.finish_sidebar_resize() {
                 cx.stop_propagation();
                 cx.notify();
             }
@@ -3510,6 +3482,44 @@ impl AlasShell {
             .on_mouse_down(MouseButton::Left, on_mouse_down)
             .on_mouse_move(on_mouse_move)
             .on_mouse_up(MouseButton::Left, on_mouse_up)
+    }
+
+    fn update_sidebar_resize(&mut self, event: &MouseMoveEvent, window: &Window) -> bool {
+        let Some(drag) = self.active_sidebar_resize else {
+            return false;
+        };
+
+        if event.pressed_button != Some(MouseButton::Left) {
+            return self.finish_sidebar_resize();
+        }
+
+        let delta = f32::from(event.position.x) - drag.start_x;
+        let requested = match drag.target {
+            SidebarResizeTarget::Left => drag.start_width + delta,
+            SidebarResizeTarget::Right => drag.start_width - delta,
+        };
+        let other_width = match drag.target {
+            SidebarResizeTarget::Left => self.sidebar_layout.right_width_px,
+            SidebarResizeTarget::Right => self.sidebar_layout.left_width_px,
+        };
+        let window_width = f32::from(window.bounds().size.width);
+        let clamped = clamp_sidebar_width(drag.target, requested, other_width, window_width);
+        match drag.target {
+            SidebarResizeTarget::Left => self.sidebar_layout.left_width_px = clamped,
+            SidebarResizeTarget::Right => self.sidebar_layout.right_width_px = clamped,
+        }
+        true
+    }
+
+    fn finish_sidebar_resize(&mut self) -> bool {
+        if self.active_sidebar_resize.take().is_none() {
+            return false;
+        }
+
+        self.config.layout.left_sidebar_width_px = self.sidebar_layout.left_width_px as u32;
+        self.config.layout.right_sidebar_width_px = self.sidebar_layout.right_width_px as u32;
+        let _ = self.app_config_store.save(&self.config);
+        true
     }
 }
 
@@ -3864,6 +3874,8 @@ impl Render for AlasShell {
         if self.terminal_metrics != measured_metrics {
             self.terminal_metrics = measured_metrics;
         }
+        self.sidebar_layout
+            .clamp_for_window(f32::from(window.bounds().size.width));
 
         let terminal_size = self.current_terminal_size();
         self.resize_active_terminal(terminal_size);
@@ -4537,6 +4549,22 @@ impl Render for AlasShell {
                 },
             )
         };
+        let on_sidebar_resize_mouse_move =
+            cx.listener(|shell, event: &MouseMoveEvent, window, cx| {
+                if shell.update_sidebar_resize(event, window) {
+                    cx.stop_propagation();
+                    cx.notify();
+                }
+            });
+        let on_sidebar_resize_mouse_up = cx.listener(|shell, event: &MouseUpEvent, _window, cx| {
+            if event.button != MouseButton::Left {
+                return;
+            }
+            if shell.finish_sidebar_resize() {
+                cx.stop_propagation();
+                cx.notify();
+            }
+        });
         let workspace_body = match active_tab.map(|tab| &tab.content) {
             Some(WorkspaceTabContent::File(state)) => render_source_viewer(state),
             Some(WorkspaceTabContent::Markdown(state)) => render_markdown_pane(
@@ -5048,6 +5076,17 @@ impl Render for AlasShell {
                         active_tab.map(|tab| tab.kind),
                     )),
             )
+            .when(self.active_sidebar_resize.is_some(), |element| {
+                element.child(
+                    div()
+                        .absolute()
+                        .size_full()
+                        .cursor_col_resize()
+                        .bg(transparent_black())
+                        .on_mouse_move(on_sidebar_resize_mouse_move)
+                        .capture_any_mouse_up(on_sidebar_resize_mouse_up),
+                )
+            })
     }
 }
 

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -3461,16 +3461,6 @@ impl AlasShell {
             }
         });
 
-        let on_mouse_up = cx.listener(move |shell, event: &MouseUpEvent, _window, cx| {
-            if event.button != MouseButton::Left {
-                return;
-            }
-            if shell.finish_sidebar_resize() {
-                cx.stop_propagation();
-                cx.notify();
-            }
-        });
-
         div()
             .id(handle_id)
             .flex_shrink_0()
@@ -3481,7 +3471,6 @@ impl AlasShell {
             .hover(|el| el.bg(PANEL_BORDER))
             .on_mouse_down(MouseButton::Left, on_mouse_down)
             .on_mouse_move(on_mouse_move)
-            .on_mouse_up(MouseButton::Left, on_mouse_up)
     }
 
     fn update_sidebar_resize(&mut self, event: &MouseMoveEvent, window: &Window) -> bool {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -32,6 +32,7 @@ pub struct SidebarMenuState {
     pub scope: ActionScope,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn render_sidebar(
     repositories: &[RepositoryNode],
     selected_worktree: Option<&SelectedWorktree>,
@@ -42,6 +43,7 @@ pub fn render_sidebar(
     + Clone
     + 'static,
     add_repository_error: Option<&str>,
+    width: f32,
 ) -> impl IntoElement {
     let sections = build_repo_sections(repositories, selected_worktree);
 
@@ -50,7 +52,7 @@ pub fn render_sidebar(
         .flex_col()
         .flex_shrink_0()
         .size_full()
-        .w(px(280.0))
+        .w(px(width))
         .p_4()
         .gap_3()
         .border_r_1()

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -428,3 +428,48 @@ fn command_settings_dialog_rejects_blank_fields() {
         "Command value for claude cannot be empty"
     );
 }
+
+#[test]
+fn app_config_default_includes_layout_widths() {
+    let config = AppConfig::default();
+    assert_eq!(config.layout.left_sidebar_width_px, 280);
+    assert_eq!(config.layout.right_sidebar_width_px, 320);
+}
+
+#[test]
+fn app_config_loads_layout_defaults_from_existing_toml() {
+    let toml = r#"
+        [[repositories]]
+        id = "repo-1"
+        path = "/tmp/repo-1"
+    "#;
+
+    let config: AppConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.layout.left_sidebar_width_px, 280);
+    assert_eq!(config.layout.right_sidebar_width_px, 320);
+}
+
+#[test]
+fn app_config_loads_partial_layout_with_defaults() {
+    let toml = r#"
+        [layout]
+        left_sidebar_width_px = 350
+    "#;
+
+    let config: AppConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.layout.left_sidebar_width_px, 350);
+    assert_eq!(config.layout.right_sidebar_width_px, 320);
+}
+
+#[test]
+fn app_config_round_trips_layout_preferences() {
+    let temp = tempdir().unwrap();
+    let store = AppConfigStore::new(temp.path().join("config.toml"));
+    let mut config = AppConfig::default();
+    config.layout.left_sidebar_width_px = 400;
+    config.layout.right_sidebar_width_px = 250;
+
+    store.save(&config).unwrap();
+
+    assert_eq!(store.load().unwrap(), config);
+}


### PR DESCRIPTION
## Summary
- add draggable resize handles for the left repository sidebar and right project inspector
- clamp sidebar widths against safe min/max bounds and available window space
- persist sidebar widths in local layout preferences

## Validation
- cargo fmt
- cargo clippy
- cargo test
- cargo build

## Manual verification
- Hover and drag both vertical sidebar borders
- Verify resize direction, focus after drag, small/wide window clamps, and restart persistence