### PR TITLE
Add macOS harness completion notifications

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,6 +23,6 @@ pub use workspace::WorkspaceTabId as TerminalTabId;
 pub use workspace::{
     FILE_TAB_MAX_BYTES, FileTabLoadState, FileTabState, ImagePreflight, ImageTabState, ImageZoom,
     MarkdownTabState, MarkdownViewMode, TerminalTabKind, TerminalTabState, TerminalTabStatus,
-    WorkspaceSession, WorkspaceTab, WorkspaceTabContent, WorkspaceTabId, WorkspaceTabKind,
-    WorktreeKey, is_supported_image_path, preflight_image_path,
+    WorkspaceSession, WorkspaceTab, WorkspaceTabContent, WorkspaceTabContext, WorkspaceTabId,
+    WorkspaceTabKind, WorktreeKey, is_supported_image_path, preflight_image_path,
 };

--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -300,6 +300,14 @@ impl WorkspaceTab {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceTabContext {
+    pub tab_id: WorkspaceTabId,
+    pub tab_name: String,
+    pub repo_id: String,
+    pub worktree_path: PathBuf,
+}
+
 #[derive(Debug, Default)]
 pub struct WorkspaceSession {
     next_tab_id: u64,
@@ -650,6 +658,19 @@ impl WorkspaceSession {
     ) -> Option<&WorkspaceTab> {
         self.tab(repo_id, path, tab_id)
             .filter(|tab| tab.is_terminal())
+    }
+
+    pub fn terminal_tab_context(&self, tab_id: WorkspaceTabId) -> Option<WorkspaceTabContext> {
+        self.tabs.iter().find_map(|(key, tabs)| {
+            tabs.iter()
+                .find(|tab| tab.id == tab_id && tab.is_terminal())
+                .map(|tab| WorkspaceTabContext {
+                    tab_id,
+                    tab_name: tab.name.clone(),
+                    repo_id: key.repo_id.clone(),
+                    worktree_path: key.path.clone(),
+                })
+        })
     }
 
     pub fn terminal_tab_state(

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,6 +1,24 @@
+use std::path::PathBuf;
+
 use serde_json::Value;
 
-use crate::app::TerminalTabId;
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(target_os = "macos")]
+pub use macos::{MacOsAppFocusState, MacOsNotificationSink};
+
+#[cfg(target_os = "macos")]
+pub type DefaultAppFocusState = MacOsAppFocusState;
+#[cfg(target_os = "macos")]
+pub type DefaultNotificationSink = MacOsNotificationSink;
+
+#[cfg(not(target_os = "macos"))]
+pub type DefaultAppFocusState = NeverFocusedAppFocusState;
+#[cfg(not(target_os = "macos"))]
+pub type DefaultNotificationSink = NotificationService;
+
+use crate::app::{TerminalTabId, WorkspaceTabContext};
 use crate::config::NotificationPrefs;
 use crate::terminal::HarnessKind;
 
@@ -31,8 +49,44 @@ pub struct HarnessCompletionEvent {
     pub source: HarnessCompletionSource,
     pub outcome: HarnessCompletionOutcome,
     pub terminal_tab_id: Option<TerminalTabId>,
+    pub context: HarnessCompletionContext,
     pub title: String,
     pub body: String,
+    pub sound: NotificationSound,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HarnessCompletionContext {
+    pub terminal_tab_id: Option<TerminalTabId>,
+    pub tab_name: Option<String>,
+    pub repo_id: Option<String>,
+    pub worktree_path: Option<PathBuf>,
+}
+
+impl HarnessCompletionContext {
+    pub fn unresolved(terminal_tab_id: Option<TerminalTabId>) -> Self {
+        Self {
+            terminal_tab_id,
+            ..Self::default()
+        }
+    }
+}
+
+impl From<WorkspaceTabContext> for HarnessCompletionContext {
+    fn from(context: WorkspaceTabContext) -> Self {
+        Self {
+            terminal_tab_id: Some(context.tab_id),
+            tab_name: Some(context.tab_name),
+            repo_id: Some(context.repo_id),
+            worktree_path: Some(context.worktree_path),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NotificationSound {
+    Success,
+    Failure,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -70,6 +124,7 @@ pub enum NotificationDecision {
     SuccessDisabled,
     FailureDisabled,
     UnsupportedHarness,
+    Focused,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -80,10 +135,14 @@ impl NotificationService {
         &self,
         prefs: &NotificationPrefs,
         event: &HarnessCompletionNotificationEvent,
+        app_is_active: bool,
     ) -> NotificationDecision {
         let completion_prefs = &prefs.harness_completion;
         if !completion_prefs.enabled {
             return NotificationDecision::Disabled;
+        }
+        if app_is_active {
+            return NotificationDecision::Focused;
         }
         if matches!(event.source, HarnessNotificationSource::Unsupported(_)) {
             return NotificationDecision::UnsupportedHarness;
@@ -101,10 +160,47 @@ impl NotificationService {
             }
         }
     }
+
+    pub fn build_harness_completion_event(
+        &self,
+        signal: HookSignal,
+        context: HarnessCompletionContext,
+    ) -> HarnessCompletionEvent {
+        let title = completion_title(signal.harness, signal.outcome);
+        let body = completion_body(signal.source, signal.outcome, &context);
+        let sound = match signal.outcome {
+            HarnessCompletionOutcome::Success => NotificationSound::Success,
+            HarnessCompletionOutcome::Failure => NotificationSound::Failure,
+        };
+
+        HarnessCompletionEvent {
+            harness: signal.harness,
+            source: signal.source,
+            outcome: signal.outcome,
+            terminal_tab_id: signal.terminal_tab_id,
+            context,
+            title,
+            body,
+            sound,
+        }
+    }
 }
 
 pub trait NotificationSink {
     fn notify_harness_completed(&mut self, event: HarnessCompletionEvent) -> anyhow::Result<()>;
+}
+
+pub trait AppFocusState {
+    fn is_app_active(&self) -> bool;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NeverFocusedAppFocusState;
+
+impl AppFocusState for NeverFocusedAppFocusState {
+    fn is_app_active(&self) -> bool {
+        false
+    }
 }
 
 impl NotificationSink for NotificationService {
@@ -114,8 +210,9 @@ impl NotificationSink for NotificationService {
 }
 
 #[derive(Debug)]
-pub struct NotificationController<N> {
+pub struct NotificationController<N, F = NeverFocusedAppFocusState> {
     notifier: N,
+    focus_state: F,
     preferences: NotificationPrefs,
     notification_service: NotificationService,
 }
@@ -126,8 +223,19 @@ impl<N> NotificationController<N> {
     }
 
     pub fn new_with_preferences(notifier: N, preferences: NotificationPrefs) -> Self {
+        Self::new_with_preferences_and_focus(notifier, preferences, NeverFocusedAppFocusState)
+    }
+}
+
+impl<N, F> NotificationController<N, F> {
+    pub fn new_with_preferences_and_focus(
+        notifier: N,
+        preferences: NotificationPrefs,
+        focus_state: F,
+    ) -> Self {
         Self {
             notifier,
+            focus_state,
             preferences,
             notification_service: NotificationService,
         }
@@ -135,6 +243,10 @@ impl<N> NotificationController<N> {
 
     pub fn notifier(&self) -> &N {
         &self.notifier
+    }
+
+    pub fn focus_state(&self) -> &F {
+        &self.focus_state
     }
 
     pub fn preferences(&self) -> &NotificationPrefs {
@@ -150,19 +262,31 @@ impl<N> NotificationController<N> {
     }
 }
 
-impl<N: NotificationSink> NotificationController<N> {
+impl<N: NotificationSink, F: AppFocusState> NotificationController<N, F> {
     pub fn handle_hook_signal(&mut self, signal: HookSignal) -> anyhow::Result<()> {
+        let context = HarnessCompletionContext::unresolved(signal.terminal_tab_id);
+        self.handle_hook_signal_with_context(signal, context)
+    }
+
+    pub fn handle_hook_signal_with_context(
+        &mut self,
+        signal: HookSignal,
+        context: HarnessCompletionContext,
+    ) -> anyhow::Result<()> {
         let notification_event = notification_event(&signal);
-        if self
-            .notification_service
-            .harness_completion_decision(&self.preferences, &notification_event)
-            != NotificationDecision::Allowed
+        if self.notification_service.harness_completion_decision(
+            &self.preferences,
+            &notification_event,
+            self.focus_state.is_app_active(),
+        ) != NotificationDecision::Allowed
         {
             return Ok(());
         }
 
-        self.notifier
-            .notify_harness_completed(completion_event(signal))
+        self.notifier.notify_harness_completed(
+            self.notification_service
+                .build_harness_completion_event(signal, context),
+        )
     }
 
     pub fn handle_raw_hook_payload(
@@ -172,6 +296,19 @@ impl<N: NotificationSink> NotificationController<N> {
     ) -> anyhow::Result<()> {
         if let Some(signal) = parse_hook_signal(provider, payload) {
             self.handle_hook_signal(signal)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn handle_raw_hook_payload_with_context(
+        &mut self,
+        provider: HookProvider,
+        payload: &Value,
+        context: HarnessCompletionContext,
+    ) -> anyhow::Result<()> {
+        if let Some(signal) = parse_hook_signal(provider, payload) {
+            self.handle_hook_signal_with_context(signal, context)?;
         }
 
         Ok(())
@@ -261,17 +398,6 @@ fn terminal_tab_id(payload: &Value) -> Option<TerminalTabId> {
         .map(TerminalTabId)
 }
 
-fn completion_event(signal: HookSignal) -> HarnessCompletionEvent {
-    HarnessCompletionEvent {
-        harness: signal.harness,
-        source: signal.source,
-        outcome: signal.outcome,
-        terminal_tab_id: signal.terminal_tab_id,
-        title: format!("{} completed", signal.harness.display_name()),
-        body: completion_body(signal.source),
-    }
-}
-
 fn notification_event(signal: &HookSignal) -> HarnessCompletionNotificationEvent {
     HarnessCompletionNotificationEvent {
         source: HarnessNotificationSource::HookBacked(match signal.harness {
@@ -279,21 +405,84 @@ fn notification_event(signal: &HookSignal) -> HarnessCompletionNotificationEvent
             HarnessKind::Codex => HookBackedHarness::Codex,
         }),
         outcome: signal.outcome,
-        title: format!("{} completed", signal.harness.display_name()),
-        body: completion_body(signal.source),
+        title: completion_title(signal.harness, signal.outcome),
+        body: String::new(),
         repo_id: None,
         worktree_path: None,
     }
 }
 
-fn completion_body(source: HarnessCompletionSource) -> String {
+fn completion_title(harness: HarnessKind, outcome: HarnessCompletionOutcome) -> String {
+    match outcome {
+        HarnessCompletionOutcome::Success => format!("{} completed", harness.display_name()),
+        HarnessCompletionOutcome::Failure => format!("{} failed", harness.display_name()),
+    }
+}
+
+fn completion_body(
+    source: HarnessCompletionSource,
+    outcome: HarnessCompletionOutcome,
+    context: &HarnessCompletionContext,
+) -> String {
+    let context = context_display(context);
     match source {
-        HarnessCompletionSource::ClaudeCodeStop => "Claude Code stopped.".to_string(),
+        HarnessCompletionSource::ClaudeCodeStop => outcome_body("Claude Code", outcome, context),
         HarnessCompletionSource::ClaudeCodeSubagentStop => {
-            "Claude Code subagent stopped.".to_string()
+            outcome_body("Claude Code subagent", outcome, context)
         }
         HarnessCompletionSource::CodexAgentTurnComplete => {
-            "Codex agent turn completed.".to_string()
+            outcome_body("Codex agent turn", outcome, context)
         }
+    }
+}
+
+fn outcome_body(
+    source_label: &str,
+    outcome: HarnessCompletionOutcome,
+    context: Option<String>,
+) -> String {
+    let verb = match outcome {
+        HarnessCompletionOutcome::Success => "finished successfully",
+        HarnessCompletionOutcome::Failure => "failed",
+    };
+
+    match context {
+        Some(context) => format!("{source_label} {verb} in {context}."),
+        None => format!("{source_label} {verb}."),
+    }
+}
+
+fn context_display(context: &HarnessCompletionContext) -> Option<String> {
+    let tab_name = context.tab_name.as_deref()?.trim();
+    if tab_name.is_empty() {
+        return None;
+    }
+
+    let workspace = context
+        .repo_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|repo_id| !repo_id.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            context
+                .worktree_path
+                .as_ref()
+                .and_then(|path| path.file_name())
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.is_empty())
+                .map(ToOwned::to_owned)
+        })
+        .or_else(|| {
+            context
+                .worktree_path
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .filter(|path| !path.is_empty())
+        });
+
+    match workspace {
+        Some(workspace) => Some(format!("{tab_name} - {workspace}")),
+        None => Some(tab_name.to_string()),
     }
 }

--- a/src/notifications/macos.rs
+++ b/src/notifications/macos.rs
@@ -1,0 +1,159 @@
+#![allow(clashing_extern_declarations)]
+
+use std::ffi::{c_char, c_void};
+
+use crate::notifications::{
+    AppFocusState, HarnessCompletionEvent, NotificationSink, NotificationSound,
+};
+
+type ObjcId = *mut c_void;
+type Sel = *mut c_void;
+
+#[link(name = "objc")]
+unsafe extern "C" {
+    fn objc_getClass(name: *const c_char) -> ObjcId;
+    fn sel_registerName(name: *const c_char) -> Sel;
+
+    #[link_name = "objc_msgSend"]
+    fn msg_send_id(receiver: ObjcId, selector: Sel) -> ObjcId;
+
+    #[link_name = "objc_msgSend"]
+    fn msg_send_bool(receiver: ObjcId, selector: Sel) -> bool;
+
+    #[link_name = "objc_msgSend"]
+    fn msg_send_void_id(receiver: ObjcId, selector: Sel, value: ObjcId);
+
+    #[link_name = "objc_msgSend"]
+    fn msg_send_id_bytes(
+        receiver: ObjcId,
+        selector: Sel,
+        bytes: *const u8,
+        length: usize,
+        encoding: usize,
+    ) -> ObjcId;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MacOsAppFocusState;
+
+impl AppFocusState for MacOsAppFocusState {
+    fn is_app_active(&self) -> bool {
+        unsafe {
+            let app = send_id(class("NSApplication"), selector("sharedApplication"));
+            !app.is_null() && send_bool(app, selector("isActive"))
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MacOsNotificationSink;
+
+impl NotificationSink for MacOsNotificationSink {
+    fn notify_harness_completed(&mut self, event: HarnessCompletionEvent) -> anyhow::Result<()> {
+        unsafe {
+            let notification = send_id(class("NSUserNotification"), selector("new"));
+            if notification.is_null() {
+                anyhow::bail!("failed to allocate NSUserNotification");
+            }
+
+            let title = ns_string(&event.title);
+            let body = ns_string(&event.body);
+            if title.is_null() || body.is_null() {
+                release_if_present(title);
+                release_if_present(body);
+                release_if_present(notification);
+                anyhow::bail!("failed to allocate notification strings");
+            }
+
+            send_void_id(notification, selector("setTitle:"), title);
+            send_void_id(notification, selector("setInformativeText:"), body);
+
+            if let Some(sound_name) = notification_sound_name(event.sound) {
+                let sound = ns_string(sound_name);
+                if !sound.is_null() {
+                    send_void_id(notification, selector("setSoundName:"), sound);
+                    release_if_present(sound);
+                }
+            }
+
+            let center = send_id(
+                class("NSUserNotificationCenter"),
+                selector("defaultUserNotificationCenter"),
+            );
+            if center.is_null() {
+                release_if_present(title);
+                release_if_present(body);
+                release_if_present(notification);
+                anyhow::bail!("failed to resolve NSUserNotificationCenter");
+            }
+
+            send_void_id(center, selector("deliverNotification:"), notification);
+            release_if_present(title);
+            release_if_present(body);
+            release_if_present(notification);
+        }
+
+        Ok(())
+    }
+}
+
+fn notification_sound_name(sound: NotificationSound) -> Option<&'static str> {
+    match sound {
+        NotificationSound::Success => Some("Glass"),
+        NotificationSound::Failure => Some("Basso"),
+    }
+}
+
+unsafe fn class(name: &str) -> ObjcId {
+    let name = nul_terminated(name);
+    unsafe { objc_getClass(name.as_ptr().cast()) }
+}
+
+unsafe fn selector(name: &str) -> Sel {
+    let name = nul_terminated(name);
+    unsafe { sel_registerName(name.as_ptr().cast()) }
+}
+
+unsafe fn send_id(receiver: ObjcId, selector: Sel) -> ObjcId {
+    unsafe { msg_send_id(receiver, selector) }
+}
+
+unsafe fn send_bool(receiver: ObjcId, selector: Sel) -> bool {
+    unsafe { msg_send_bool(receiver, selector) }
+}
+
+unsafe fn send_void_id(receiver: ObjcId, selector: Sel, value: ObjcId) {
+    unsafe { msg_send_void_id(receiver, selector, value) }
+}
+
+unsafe fn ns_string(value: &str) -> ObjcId {
+    let string = unsafe { send_id(class("NSString"), selector("alloc")) };
+    if string.is_null() {
+        return string;
+    }
+
+    unsafe {
+        msg_send_id_bytes(
+            string,
+            selector("initWithBytes:length:encoding:"),
+            value.as_ptr(),
+            value.len(),
+            4,
+        )
+    }
+}
+
+unsafe fn release_if_present(object: ObjcId) {
+    if !object.is_null() {
+        unsafe {
+            send_id(object, selector("release"));
+        }
+    }
+}
+
+fn nul_terminated(value: &str) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(value.len() + 1);
+    bytes.extend_from_slice(value.as_bytes());
+    bytes.push(0);
+    bytes
+}

--- a/src/ui/shell.rs
+++ b/src/ui/shell.rs
@@ -25,7 +25,7 @@ use crate::{
         ResolvedRepoConfig, repository_id_for_path,
     },
     git::{GitInspectorService, GitRunner, GitWorktreeService},
-    notifications::{NotificationController, NotificationService},
+    notifications::{DefaultAppFocusState, DefaultNotificationSink, NotificationController},
     project::FileTreeService,
     terminal::{
         CommandSpec, GhosttyRenderFrame, GhosttyTerminalBackend, TerminalBackend, TerminalKeyInput,
@@ -164,7 +164,7 @@ pub struct AlasShell {
     command_settings_focus: FocusHandle,
     command_settings_active_field: CommandSettingsField,
     notification_preferences_dialog: Option<NotificationPreferencesDialogState>,
-    notification_controller: NotificationController<NotificationService>,
+    notification_controller: NotificationController<DefaultNotificationSink, DefaultAppFocusState>,
     command_picker: Option<CommandPickerState>,
     new_tab_picker_open: bool,
     agent_provider_picker: Option<Vec<AgentProviderConfig>>,
@@ -237,9 +237,10 @@ impl AlasShell {
             command_settings_focus: cx.focus_handle(),
             command_settings_active_field: CommandSettingsField::DefaultName,
             notification_preferences_dialog: None,
-            notification_controller: NotificationController::new_with_preferences(
-                NotificationService,
+            notification_controller: NotificationController::new_with_preferences_and_focus(
+                DefaultNotificationSink::default(),
                 notification_preferences,
+                DefaultAppFocusState::default(),
             ),
             command_picker: None,
             new_tab_picker_open: false,

--- a/tests/notification_hook_tests.rs
+++ b/tests/notification_hook_tests.rs
@@ -3,8 +3,9 @@ use std::path::{Path, PathBuf};
 use alas::app::{TerminalTabKind, WorkspaceSession};
 use alas::config::NotificationPrefs;
 use alas::notifications::{
-    HarnessCompletionEvent, HarnessCompletionOutcome, HarnessCompletionSource, HookProvider,
-    NotificationController, NotificationSink,
+    AppFocusState, HarnessCompletionContext, HarnessCompletionEvent, HarnessCompletionOutcome,
+    HarnessCompletionSource, HookProvider, NotificationController, NotificationSink,
+    NotificationSound,
 };
 use alas::terminal::{CommandSpec, HarnessKind};
 use serde_json::json;
@@ -21,12 +22,31 @@ impl NotificationSink for FakeNotifier {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FakeFocusState {
+    active: bool,
+}
+
+impl AppFocusState for FakeFocusState {
+    fn is_app_active(&self) -> bool {
+        self.active
+    }
+}
+
 fn controller() -> NotificationController<FakeNotifier> {
     NotificationController::new(FakeNotifier::default())
 }
 
 fn controller_with_preferences(prefs: NotificationPrefs) -> NotificationController<FakeNotifier> {
     NotificationController::new_with_preferences(FakeNotifier::default(), prefs)
+}
+
+fn controller_with_focus(active: bool) -> NotificationController<FakeNotifier, FakeFocusState> {
+    NotificationController::new_with_preferences_and_focus(
+        FakeNotifier::default(),
+        NotificationPrefs::default(),
+        FakeFocusState { active },
+    )
 }
 
 fn cwd() -> PathBuf {
@@ -146,6 +166,9 @@ fn claude_stop_hook_notifies() {
     assert_eq!(event.source, HarnessCompletionSource::ClaudeCodeStop);
     assert_eq!(event.outcome, HarnessCompletionOutcome::Success);
     assert_eq!(event.terminal_tab_id.map(|id| id.0), Some(7));
+    assert_eq!(event.title, "Claude Code completed");
+    assert_eq!(event.body, "Claude Code finished successfully.");
+    assert_eq!(event.sound, NotificationSound::Success);
 }
 
 #[test]
@@ -194,6 +217,98 @@ fn codex_agent_turn_complete_hook_notifies() {
         HarnessCompletionSource::CodexAgentTurnComplete
     );
     assert_eq!(event.terminal_tab_id.map(|id| id.0), Some(11));
+}
+
+#[test]
+fn focused_app_suppresses_hook_notifications() {
+    let mut controller = controller_with_focus(true);
+
+    controller
+        .handle_raw_hook_payload(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "success": true
+            }),
+        )
+        .expect("handle hook");
+
+    assert!(controller.notifier().completions.is_empty());
+}
+
+#[test]
+fn unfocused_app_allows_hook_notifications() {
+    let mut controller = controller_with_focus(false);
+
+    controller
+        .handle_raw_hook_payload(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "success": true
+            }),
+        )
+        .expect("handle hook");
+
+    assert_eq!(controller.notifier().completions.len(), 1);
+}
+
+#[test]
+fn hook_notification_includes_resolved_tab_context() {
+    let mut controller = controller();
+    let mut session = WorkspaceSession::default();
+    let path = PathBuf::from("/repo/alas");
+    let tab_id = session.create_terminal_tab(
+        "alas",
+        path.clone(),
+        "Tests".to_string(),
+        TerminalTabKind::Command,
+        CommandSpec::shell_command("cargo test", path),
+    );
+
+    controller
+        .handle_raw_hook_payload_with_context(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "success": false,
+                "terminal_tab_id": tab_id.0
+            }),
+            session
+                .terminal_tab_context(tab_id)
+                .expect("terminal tab context")
+                .into(),
+        )
+        .expect("handle hook");
+
+    assert_eq!(controller.notifier().completions.len(), 1);
+    let event = &controller.notifier().completions[0];
+    assert_eq!(event.title, "Claude Code failed");
+    assert_eq!(event.body, "Claude Code failed in Tests - alas.");
+    assert_eq!(event.sound, NotificationSound::Failure);
+}
+
+#[test]
+fn unresolved_hook_context_does_not_invent_context() {
+    let mut controller = controller();
+
+    controller
+        .handle_raw_hook_payload_with_context(
+            HookProvider::ClaudeCode,
+            &json!({
+                "hook_event_name": "Stop",
+                "success": true,
+                "terminal_tab_id": 7
+            }),
+            HarnessCompletionContext::unresolved(Some(alas::app::TerminalTabId(7))),
+        )
+        .expect("handle hook");
+
+    assert_eq!(controller.notifier().completions.len(), 1);
+    assert_eq!(
+        controller.notifier().completions[0].body,
+        "Claude Code finished successfully."
+    );
 }
 
 #[test]

--- a/tests/notification_service_tests.rs
+++ b/tests/notification_service_tests.rs
@@ -1,9 +1,11 @@
 use alas::{
     config::NotificationPrefs,
     notifications::{
-        HarnessCompletionNotificationEvent, HarnessCompletionOutcome, HarnessNotificationSource,
-        HookBackedHarness, NotificationDecision, NotificationService,
+        HarnessCompletionContext, HarnessCompletionNotificationEvent, HarnessCompletionOutcome,
+        HarnessCompletionSource, HarnessNotificationSource, HookBackedHarness, HookSignal,
+        NotificationDecision, NotificationService, NotificationSound,
     },
+    terminal::HarnessKind,
 };
 
 #[test]
@@ -86,12 +88,113 @@ fn unsupported_harness_is_suppressed_when_notifications_are_enabled() {
     };
 
     assert_eq!(
-        service.harness_completion_decision(&NotificationPrefs::default(), &event),
+        service.harness_completion_decision(&NotificationPrefs::default(), &event, false),
         NotificationDecision::UnsupportedHarness
     );
 }
 
+#[test]
+fn focused_app_suppresses_supported_completion() {
+    assert_eq!(
+        decision_with_focus(
+            NotificationPrefs::default(),
+            HarnessCompletionOutcome::Success,
+            true
+        ),
+        NotificationDecision::Focused
+    );
+}
+
+#[test]
+fn success_completion_format_uses_success_title_body_and_sound() {
+    let service = NotificationService;
+    let event = service.build_harness_completion_event(
+        HookSignal {
+            harness: HarnessKind::ClaudeCode,
+            source: HarnessCompletionSource::ClaudeCodeStop,
+            outcome: HarnessCompletionOutcome::Success,
+            terminal_tab_id: None,
+        },
+        HarnessCompletionContext::default(),
+    );
+
+    assert_eq!(event.title, "Claude Code completed");
+    assert_eq!(event.body, "Claude Code finished successfully.");
+    assert_eq!(event.sound, NotificationSound::Success);
+}
+
+#[test]
+fn failure_completion_format_uses_failure_title_body_and_sound() {
+    let service = NotificationService;
+    let event = service.build_harness_completion_event(
+        HookSignal {
+            harness: HarnessKind::Codex,
+            source: HarnessCompletionSource::CodexAgentTurnComplete,
+            outcome: HarnessCompletionOutcome::Failure,
+            terminal_tab_id: None,
+        },
+        HarnessCompletionContext::default(),
+    );
+
+    assert_eq!(event.title, "Codex failed");
+    assert_eq!(event.body, "Codex agent turn failed.");
+    assert_eq!(event.sound, NotificationSound::Failure);
+}
+
+#[test]
+fn completion_format_includes_tab_and_workspace_context() {
+    let service = NotificationService;
+    let event = service.build_harness_completion_event(
+        HookSignal {
+            harness: HarnessKind::ClaudeCode,
+            source: HarnessCompletionSource::ClaudeCodeSubagentStop,
+            outcome: HarnessCompletionOutcome::Success,
+            terminal_tab_id: None,
+        },
+        HarnessCompletionContext {
+            terminal_tab_id: None,
+            tab_name: Some("Review".to_string()),
+            repo_id: Some("alas".to_string()),
+            worktree_path: Some("/repo/alas".into()),
+        },
+    );
+
+    assert_eq!(
+        event.body,
+        "Claude Code subagent finished successfully in Review - alas."
+    );
+}
+
+#[test]
+fn unresolved_context_does_not_invent_tab_or_workspace() {
+    let service = NotificationService;
+    let event = service.build_harness_completion_event(
+        HookSignal {
+            harness: HarnessKind::ClaudeCode,
+            source: HarnessCompletionSource::ClaudeCodeStop,
+            outcome: HarnessCompletionOutcome::Failure,
+            terminal_tab_id: None,
+        },
+        HarnessCompletionContext {
+            terminal_tab_id: None,
+            tab_name: None,
+            repo_id: Some("alas".to_string()),
+            worktree_path: Some("/repo/alas".into()),
+        },
+    );
+
+    assert_eq!(event.body, "Claude Code failed.");
+}
+
 fn decision(prefs: NotificationPrefs, outcome: HarnessCompletionOutcome) -> NotificationDecision {
+    decision_with_focus(prefs, outcome, false)
+}
+
+fn decision_with_focus(
+    prefs: NotificationPrefs,
+    outcome: HarnessCompletionOutcome,
+    app_is_active: bool,
+) -> NotificationDecision {
     let service = NotificationService;
     service.harness_completion_decision(
         &prefs,
@@ -103,5 +206,6 @@ fn decision(prefs: NotificationPrefs, outcome: HarnessCompletionOutcome) -> Noti
             repo_id: None,
             worktree_path: None,
         },
+        app_is_active,
     )
 }

--- a/tests/workspace_session_tests.rs
+++ b/tests/workspace_session_tests.rs
@@ -73,6 +73,38 @@ fn worktree_can_have_multiple_named_terminal_tabs() {
 }
 
 #[test]
+fn terminal_tab_context_resolves_existing_terminal_tab() {
+    let mut session = WorkspaceSession::default();
+    let path = PathBuf::from("/repo/a");
+    let tab_id = session.create_terminal_tab(
+        "repo",
+        path.clone(),
+        "Tests".to_string(),
+        TerminalTabKind::Command,
+        CommandSpec::shell_command("cargo test", path.clone()),
+    );
+
+    let context = session
+        .terminal_tab_context(tab_id)
+        .expect("terminal tab context");
+
+    assert_eq!(context.tab_id, tab_id);
+    assert_eq!(context.tab_name, "Tests");
+    assert_eq!(context.repo_id, "repo");
+    assert_eq!(context.worktree_path, path);
+}
+
+#[test]
+fn terminal_tab_context_ignores_missing_or_non_terminal_tabs() {
+    let mut session = WorkspaceSession::default();
+    let path = PathBuf::from("/repo/a");
+    let file_tab = session.open_file_tab("repo", path.clone(), path.join("README.md"));
+
+    assert!(session.terminal_tab_context(file_tab).is_none());
+    assert!(session.terminal_tab_context(TerminalTabId(999)).is_none());
+}
+
+#[test]
 fn active_tab_is_scoped_per_worktree() {
     let mut session = WorkspaceSession::default();
     let path_a = PathBuf::from("/repo/a");


### PR DESCRIPTION
## Summary
- add harness completion notification policy, context, focus gating, and sound intent
- add macOS native notification delivery and app-active detection
- resolve terminal tab context for notification bodies

## Tests
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --all-features
- cargo test --all-features