### PR TITLE
Add harness completion hook ingestion

### DIFF
--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -683,6 +683,15 @@ impl WorkspaceSession {
             .and_then(|tab| tab.terminal_tab_state())
     }
 
+    pub fn terminal_tab_status_by_id(&self, tab_id: WorkspaceTabId) -> Option<&TerminalTabStatus> {
+        self.tabs
+            .values()
+            .flat_map(|tabs| tabs.iter())
+            .find(|tab| tab.id == tab_id)
+            .and_then(|tab| tab.terminal_tab_state())
+            .map(|state| &state.status)
+    }
+
     pub fn set_active_tab(
         &mut self,
         repo_id: impl Into<String>,
@@ -725,6 +734,16 @@ impl WorkspaceSession {
     ) -> anyhow::Result<()> {
         let key = WorktreeKey::new(repo_id, path.to_path_buf());
         let tab = self.known_terminal_tab_mut(&key, tab_id)?;
+        tab.status = status;
+        Ok(())
+    }
+
+    pub fn set_terminal_tab_status_by_id(
+        &mut self,
+        tab_id: WorkspaceTabId,
+        status: TerminalTabStatus,
+    ) -> anyhow::Result<()> {
+        let tab = self.known_terminal_tab_mut_by_id(tab_id)?;
         tab.status = status;
         Ok(())
     }
@@ -936,6 +955,21 @@ impl WorkspaceSession {
                 key.path.display()
             )
         })?;
+
+        tab.terminal_tab_state_mut()
+            .ok_or_else(|| anyhow::anyhow!("workspace tab {:?} is not a terminal tab", tab_id))
+    }
+
+    fn known_terminal_tab_mut_by_id(
+        &mut self,
+        tab_id: WorkspaceTabId,
+    ) -> anyhow::Result<&mut TerminalTabState> {
+        let tab = self
+            .tabs
+            .values_mut()
+            .flat_map(|tabs| tabs.iter_mut())
+            .find(|tab| tab.id == tab_id)
+            .ok_or_else(|| anyhow::anyhow!("unknown workspace tab {:?}", tab_id))?;
 
         tab.terminal_tab_state_mut()
             .ok_or_else(|| anyhow::anyhow!("workspace tab {:?} is not a terminal tab", tab_id))

--- a/src/app/workspace.rs
+++ b/src/app/workspace.rs
@@ -748,6 +748,17 @@ impl WorkspaceSession {
         Ok(())
     }
 
+    pub fn set_terminal_tab_failure_by_id(
+        &mut self,
+        tab_id: WorkspaceTabId,
+        cause: impl Into<String>,
+    ) -> anyhow::Result<()> {
+        let tab = self.known_terminal_tab_mut_by_id(tab_id)?;
+        tab.status = TerminalTabStatus::Failed;
+        tab.failure_cause = Some(cause.into());
+        Ok(())
+    }
+
     pub fn set_tab_failure(
         &mut self,
         repo_id: impl Into<String>,

--- a/src/harness_completion.rs
+++ b/src/harness_completion.rs
@@ -2,19 +2,34 @@ use serde_json::Value;
 
 use crate::app::{TerminalTabId, TerminalTabStatus, WorkspaceSession};
 use crate::notifications::{
-    AppFocusState, HarnessCompletionContext, HarnessCompletionOutcome, HookProvider,
-    NotificationController, NotificationSink, parse_hook_signal,
+    AppFocusState, HarnessCompletionContext, HarnessCompletionOutcome, HarnessCompletionSource,
+    HookProvider, NotificationController, NotificationSink, parse_hook_signal,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HarnessCompletionIngestionResult {
     IgnoredUnsupportedPayload,
     NotifiedWithoutTab,
+    IgnoredDuplicateWithoutTab,
     CompletedTab { tab_id: TerminalTabId },
     FailedTab { tab_id: TerminalTabId },
+    NotifiedWithoutTerminalTransition { tab_id: TerminalTabId },
     IgnoredUnknownTab { tab_id: TerminalTabId },
     IgnoredNonRunningTab { tab_id: TerminalTabId },
     IgnoredDuplicate { tab_id: TerminalTabId },
+}
+
+impl HarnessCompletionIngestionResult {
+    pub fn should_notify_shell(self) -> bool {
+        matches!(
+            self,
+            Self::NotifiedWithoutTab
+                | Self::CompletedTab { .. }
+                | Self::FailedTab { .. }
+                | Self::NotifiedWithoutTerminalTransition { .. }
+                | Self::IgnoredUnknownTab { .. }
+        )
+    }
 }
 
 pub fn ingest_harness_completion_hook<N: NotificationSink, F: AppFocusState>(
@@ -28,22 +43,40 @@ pub fn ingest_harness_completion_hook<N: NotificationSink, F: AppFocusState>(
     };
 
     let Some(tab_id) = signal.terminal_tab_id else {
-        notification_controller.handle_hook_signal(signal)?;
-        return Ok(HarnessCompletionIngestionResult::NotifiedWithoutTab);
+        return if notification_controller.handle_hook_signal(signal)? {
+            Ok(HarnessCompletionIngestionResult::NotifiedWithoutTab)
+        } else {
+            Ok(HarnessCompletionIngestionResult::IgnoredDuplicateWithoutTab)
+        };
     };
 
     let Some(status) = workspace_session.terminal_tab_status_by_id(tab_id) else {
-        notification_controller.handle_hook_signal(signal)?;
-        return Ok(HarnessCompletionIngestionResult::IgnoredUnknownTab { tab_id });
+        return if notification_controller.handle_hook_signal(signal)? {
+            Ok(HarnessCompletionIngestionResult::IgnoredUnknownTab { tab_id })
+        } else {
+            Ok(HarnessCompletionIngestionResult::IgnoredDuplicate { tab_id })
+        };
     };
     let context = workspace_session
         .terminal_tab_context(tab_id)
         .map(HarnessCompletionContext::from)
         .unwrap_or_else(|| HarnessCompletionContext::unresolved(Some(tab_id)));
 
+    if !is_terminal_completion_source(signal.source) {
+        return if notification_controller.handle_hook_signal_with_context(signal, context)? {
+            Ok(HarnessCompletionIngestionResult::NotifiedWithoutTerminalTransition { tab_id })
+        } else {
+            Ok(HarnessCompletionIngestionResult::IgnoredDuplicate { tab_id })
+        };
+    }
+
     match status {
         TerminalTabStatus::Exited(_) | TerminalTabStatus::Failed => {
-            Ok(HarnessCompletionIngestionResult::IgnoredDuplicate { tab_id })
+            if notification_controller.handle_hook_signal_with_context(signal, context)? {
+                Ok(HarnessCompletionIngestionResult::NotifiedWithoutTerminalTransition { tab_id })
+            } else {
+                Ok(HarnessCompletionIngestionResult::IgnoredDuplicate { tab_id })
+            }
         }
         TerminalTabStatus::NotStarted => {
             Ok(HarnessCompletionIngestionResult::IgnoredNonRunningTab { tab_id })
@@ -60,9 +93,23 @@ pub fn ingest_harness_completion_hook<N: NotificationSink, F: AppFocusState>(
                 ),
             };
 
-            workspace_session.set_terminal_tab_status_by_id(tab_id, status)?;
-            notification_controller.handle_hook_signal_with_context(signal, context)?;
-            Ok(result)
+            match status {
+                TerminalTabStatus::Failed => workspace_session
+                    .set_terminal_tab_failure_by_id(tab_id, "Harness completed with failure")?,
+                _ => workspace_session.set_terminal_tab_status_by_id(tab_id, status)?,
+            }
+            if notification_controller.handle_hook_signal_with_context(signal, context)? {
+                Ok(result)
+            } else {
+                Ok(HarnessCompletionIngestionResult::IgnoredDuplicate { tab_id })
+            }
         }
     }
+}
+
+fn is_terminal_completion_source(source: HarnessCompletionSource) -> bool {
+    matches!(
+        source,
+        HarnessCompletionSource::ClaudeCodeStop | HarnessCompletionSource::CodexAgentTurnComplete
+    )
 }

--- a/src/harness_completion.rs
+++ b/src/harness_completion.rs
@@ -1,0 +1,68 @@
+use serde_json::Value;
+
+use crate::app::{TerminalTabId, TerminalTabStatus, WorkspaceSession};
+use crate::notifications::{
+    AppFocusState, HarnessCompletionContext, HarnessCompletionOutcome, HookProvider,
+    NotificationController, NotificationSink, parse_hook_signal,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HarnessCompletionIngestionResult {
+    IgnoredUnsupportedPayload,
+    NotifiedWithoutTab,
+    CompletedTab { tab_id: TerminalTabId },
+    FailedTab { tab_id: TerminalTabId },
+    IgnoredUnknownTab { tab_id: TerminalTabId },
+    IgnoredNonRunningTab { tab_id: TerminalTabId },
+    IgnoredDuplicate { tab_id: TerminalTabId },
+}
+
+pub fn ingest_harness_completion_hook<N: NotificationSink, F: AppFocusState>(
+    provider: HookProvider,
+    payload: &Value,
+    workspace_session: &mut WorkspaceSession,
+    notification_controller: &mut NotificationController<N, F>,
+) -> anyhow::Result<HarnessCompletionIngestionResult> {
+    let Some(signal) = parse_hook_signal(provider, payload) else {
+        return Ok(HarnessCompletionIngestionResult::IgnoredUnsupportedPayload);
+    };
+
+    let Some(tab_id) = signal.terminal_tab_id else {
+        notification_controller.handle_hook_signal(signal)?;
+        return Ok(HarnessCompletionIngestionResult::NotifiedWithoutTab);
+    };
+
+    let Some(status) = workspace_session.terminal_tab_status_by_id(tab_id) else {
+        notification_controller.handle_hook_signal(signal)?;
+        return Ok(HarnessCompletionIngestionResult::IgnoredUnknownTab { tab_id });
+    };
+    let context = workspace_session
+        .terminal_tab_context(tab_id)
+        .map(HarnessCompletionContext::from)
+        .unwrap_or_else(|| HarnessCompletionContext::unresolved(Some(tab_id)));
+
+    match status {
+        TerminalTabStatus::Exited(_) | TerminalTabStatus::Failed => {
+            Ok(HarnessCompletionIngestionResult::IgnoredDuplicate { tab_id })
+        }
+        TerminalTabStatus::NotStarted => {
+            Ok(HarnessCompletionIngestionResult::IgnoredNonRunningTab { tab_id })
+        }
+        TerminalTabStatus::Running => {
+            let (status, result) = match signal.outcome {
+                HarnessCompletionOutcome::Success => (
+                    TerminalTabStatus::Exited(Some(0)),
+                    HarnessCompletionIngestionResult::CompletedTab { tab_id },
+                ),
+                HarnessCompletionOutcome::Failure => (
+                    TerminalTabStatus::Failed,
+                    HarnessCompletionIngestionResult::FailedTab { tab_id },
+                ),
+            };
+
+            workspace_session.set_terminal_tab_status_by_id(tab_id, status)?;
+            notification_controller.handle_hook_signal_with_context(signal, context)?;
+            Ok(result)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod app;
 pub mod config;
 pub mod git;
+pub mod harness_completion;
 pub mod notifications;
 pub mod project;
 pub mod terminal;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashSet, VecDeque};
 use std::path::PathBuf;
 
 use serde_json::Value;
@@ -95,7 +96,7 @@ pub enum HookBackedHarness {
     Codex,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum HarnessCompletionOutcome {
     Success,
     Failure,
@@ -215,7 +216,30 @@ pub struct NotificationController<N, F = NeverFocusedAppFocusState> {
     focus_state: F,
     preferences: NotificationPrefs,
     notification_service: NotificationService,
+    recent_hook_signals: VecDeque<HookSignalKey>,
+    seen_hook_signals: HashSet<HookSignalKey>,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct HookSignalKey {
+    harness: HarnessKind,
+    source: HarnessCompletionSource,
+    outcome: HarnessCompletionOutcome,
+    terminal_tab_id: Option<TerminalTabId>,
+}
+
+impl From<&HookSignal> for HookSignalKey {
+    fn from(signal: &HookSignal) -> Self {
+        Self {
+            harness: signal.harness,
+            source: signal.source,
+            outcome: signal.outcome,
+            terminal_tab_id: signal.terminal_tab_id,
+        }
+    }
+}
+
+const RECENT_HOOK_SIGNAL_CAPACITY: usize = 256;
 
 impl<N> NotificationController<N> {
     pub fn new(notifier: N) -> Self {
@@ -238,6 +262,8 @@ impl<N, F> NotificationController<N, F> {
             focus_state,
             preferences,
             notification_service: NotificationService,
+            recent_hook_signals: VecDeque::new(),
+            seen_hook_signals: HashSet::new(),
         }
     }
 
@@ -263,7 +289,7 @@ impl<N, F> NotificationController<N, F> {
 }
 
 impl<N: NotificationSink, F: AppFocusState> NotificationController<N, F> {
-    pub fn handle_hook_signal(&mut self, signal: HookSignal) -> anyhow::Result<()> {
+    pub fn handle_hook_signal(&mut self, signal: HookSignal) -> anyhow::Result<bool> {
         let context = HarnessCompletionContext::unresolved(signal.terminal_tab_id);
         self.handle_hook_signal_with_context(signal, context)
     }
@@ -272,7 +298,7 @@ impl<N: NotificationSink, F: AppFocusState> NotificationController<N, F> {
         &mut self,
         signal: HookSignal,
         context: HarnessCompletionContext,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         let notification_event = notification_event(&signal);
         if self.notification_service.harness_completion_decision(
             &self.preferences,
@@ -280,25 +306,31 @@ impl<N: NotificationSink, F: AppFocusState> NotificationController<N, F> {
             self.focus_state.is_app_active(),
         ) != NotificationDecision::Allowed
         {
-            return Ok(());
+            return Ok(true);
+        }
+
+        if !self.remember_hook_signal(&signal) {
+            return Ok(false);
         }
 
         self.notifier.notify_harness_completed(
             self.notification_service
                 .build_harness_completion_event(signal, context),
-        )
+        )?;
+
+        Ok(true)
     }
 
     pub fn handle_raw_hook_payload(
         &mut self,
         provider: HookProvider,
         payload: &Value,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         if let Some(signal) = parse_hook_signal(provider, payload) {
-            self.handle_hook_signal(signal)?;
+            return self.handle_hook_signal(signal);
         }
 
-        Ok(())
+        Ok(false)
     }
 
     pub fn handle_raw_hook_payload_with_context(
@@ -306,12 +338,29 @@ impl<N: NotificationSink, F: AppFocusState> NotificationController<N, F> {
         provider: HookProvider,
         payload: &Value,
         context: HarnessCompletionContext,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         if let Some(signal) = parse_hook_signal(provider, payload) {
-            self.handle_hook_signal_with_context(signal, context)?;
+            return self.handle_hook_signal_with_context(signal, context);
         }
 
-        Ok(())
+        Ok(false)
+    }
+
+    fn remember_hook_signal(&mut self, signal: &HookSignal) -> bool {
+        let key = HookSignalKey::from(signal);
+        if self.seen_hook_signals.contains(&key) {
+            return false;
+        }
+
+        self.seen_hook_signals.insert(key);
+        self.recent_hook_signals.push_back(key);
+        while self.recent_hook_signals.len() > RECENT_HOOK_SIGNAL_CAPACITY {
+            if let Some(old_key) = self.recent_hook_signals.pop_front() {
+                self.seen_hook_signals.remove(&old_key);
+            }
+        }
+
+        true
     }
 }
 

--- a/tests/notification_hook_tests.rs
+++ b/tests/notification_hook_tests.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use alas::app::{TerminalTabKind, WorkspaceSession};
+use alas::app::{TerminalTabKind, TerminalTabStatus, WorkspaceSession};
 use alas::config::NotificationPrefs;
+use alas::harness_completion::{HarnessCompletionIngestionResult, ingest_harness_completion_hook};
 use alas::notifications::{
     AppFocusState, HarnessCompletionContext, HarnessCompletionEvent, HarnessCompletionOutcome,
     HarnessCompletionSource, HookProvider, NotificationController, NotificationSink,
@@ -74,6 +75,25 @@ fn shell_tab(path: &Path) -> WorkspaceSession {
         CommandSpec::shell_command("$SHELL", path.to_path_buf()),
     );
     session
+}
+
+fn running_terminal_tab(
+    session: &mut WorkspaceSession,
+    name: &str,
+    command: &str,
+    path: &Path,
+) -> alas::app::TerminalTabId {
+    let tab_id = session.create_terminal_tab(
+        "repo",
+        path.to_path_buf(),
+        name.to_string(),
+        TerminalTabKind::Command,
+        CommandSpec::shell_command(command, path.to_path_buf()),
+    );
+    session
+        .set_tab_status("repo", path, tab_id, TerminalTabStatus::Running)
+        .expect("set tab running");
+    tab_id
 }
 
 #[test]
@@ -237,6 +257,184 @@ fn focused_app_suppresses_hook_notifications() {
 }
 
 #[test]
+fn claude_stop_hook_ingestion_marks_running_tab_completed_and_notifies() {
+    let path = cwd();
+    let mut session = WorkspaceSession::default();
+    let tab_id = running_terminal_tab(&mut session, "Claude", "claude", &path);
+    let mut controller = controller();
+
+    let result = ingest_harness_completion_hook(
+        HookProvider::ClaudeCode,
+        &json!({
+            "hook_event_name": "Stop",
+            "success": true,
+            "terminal_tab_id": tab_id.0
+        }),
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest hook");
+
+    assert_eq!(
+        result,
+        HarnessCompletionIngestionResult::CompletedTab { tab_id }
+    );
+    assert_eq!(
+        session.terminal_tab_status_by_id(tab_id),
+        Some(&TerminalTabStatus::Exited(Some(0)))
+    );
+    assert_eq!(controller.notifier().completions.len(), 1);
+    assert_eq!(
+        controller.notifier().completions[0].outcome,
+        HarnessCompletionOutcome::Success
+    );
+}
+
+#[test]
+fn codex_completion_hook_ingestion_marks_running_tab_failed_and_notifies() {
+    let path = cwd();
+    let mut session = WorkspaceSession::default();
+    let tab_id = running_terminal_tab(&mut session, "Codex", "codex", &path);
+    let mut controller = controller();
+
+    let result = ingest_harness_completion_hook(
+        HookProvider::Codex,
+        &json!({
+            "type": "agent-turn-complete",
+            "status": "failed",
+            "alas_terminal_tab_id": tab_id.0
+        }),
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest hook");
+
+    assert_eq!(
+        result,
+        HarnessCompletionIngestionResult::FailedTab { tab_id }
+    );
+    assert_eq!(
+        session.terminal_tab_status_by_id(tab_id),
+        Some(&TerminalTabStatus::Failed)
+    );
+    assert_eq!(controller.notifier().completions.len(), 1);
+    assert_eq!(
+        controller.notifier().completions[0].outcome,
+        HarnessCompletionOutcome::Failure
+    );
+}
+
+#[test]
+fn hook_ingestion_correlates_inactive_terminal_tabs() {
+    let path = cwd();
+    let mut session = WorkspaceSession::default();
+    let inactive = running_terminal_tab(&mut session, "Claude", "claude", &path);
+    let active = running_terminal_tab(&mut session, "Tests", "cargo test", &path);
+    session
+        .set_active_tab("repo", &path, active)
+        .expect("set active tab");
+    let mut controller = controller();
+
+    let result = ingest_harness_completion_hook(
+        HookProvider::ClaudeCode,
+        &json!({
+            "hook_event_name": "Stop",
+            "exit_code": 0,
+            "terminal_tab_id": inactive.0
+        }),
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest hook");
+
+    assert_eq!(
+        result,
+        HarnessCompletionIngestionResult::CompletedTab { tab_id: inactive }
+    );
+    assert_eq!(
+        session.terminal_tab_status_by_id(inactive),
+        Some(&TerminalTabStatus::Exited(Some(0)))
+    );
+    assert_eq!(
+        session.terminal_tab_status_by_id(active),
+        Some(&TerminalTabStatus::Running)
+    );
+    assert_eq!(
+        session.active_tab("repo", &path).map(|tab| tab.id),
+        Some(active)
+    );
+    assert_eq!(controller.notifier().completions.len(), 1);
+}
+
+#[test]
+fn duplicate_completed_tab_hook_is_suppressed() {
+    let path = cwd();
+    let mut session = WorkspaceSession::default();
+    let tab_id = running_terminal_tab(&mut session, "Claude", "claude", &path);
+    let mut controller = controller();
+    let payload = json!({
+        "hook_event_name": "Stop",
+        "success": true,
+        "terminal_tab_id": tab_id.0
+    });
+
+    let first = ingest_harness_completion_hook(
+        HookProvider::ClaudeCode,
+        &payload,
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest first hook");
+    let second = ingest_harness_completion_hook(
+        HookProvider::ClaudeCode,
+        &payload,
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest duplicate hook");
+
+    assert_eq!(
+        first,
+        HarnessCompletionIngestionResult::CompletedTab { tab_id }
+    );
+    assert_eq!(
+        second,
+        HarnessCompletionIngestionResult::IgnoredDuplicate { tab_id }
+    );
+    assert_eq!(controller.notifier().completions.len(), 1);
+}
+
+#[test]
+fn unsupported_hook_ingestion_does_not_notify_or_mutate_tab() {
+    let path = cwd();
+    let mut session = WorkspaceSession::default();
+    let tab_id = running_terminal_tab(&mut session, "Command", "cargo test", &path);
+    let mut controller = controller();
+
+    let result = ingest_harness_completion_hook(
+        HookProvider::ClaudeCode,
+        &json!({
+            "hook_event_name": "PreToolUse",
+            "success": true,
+            "terminal_tab_id": tab_id.0
+        }),
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest hook");
+
+    assert_eq!(
+        result,
+        HarnessCompletionIngestionResult::IgnoredUnsupportedPayload
+    );
+    assert_eq!(
+        session.terminal_tab_status_by_id(tab_id),
+        Some(&TerminalTabStatus::Running)
+    );
+    assert!(controller.notifier().completions.is_empty());
+}
+
+#[test]
 fn unfocused_app_allows_hook_notifications() {
     let mut controller = controller_with_focus(false);
 
@@ -309,6 +507,68 @@ fn unresolved_hook_context_does_not_invent_context() {
         controller.notifier().completions[0].body,
         "Claude Code finished successfully."
     );
+}
+
+#[test]
+fn hook_without_tab_id_notifies_without_mutating_tabs() {
+    let path = cwd();
+    let mut session = WorkspaceSession::default();
+    let tab_id = running_terminal_tab(&mut session, "Claude", "claude", &path);
+    let mut controller = controller();
+
+    let result = ingest_harness_completion_hook(
+        HookProvider::ClaudeCode,
+        &json!({
+            "hook_event_name": "Stop",
+            "success": true
+        }),
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest hook");
+
+    assert_eq!(result, HarnessCompletionIngestionResult::NotifiedWithoutTab);
+    assert_eq!(
+        session.terminal_tab_status_by_id(tab_id),
+        Some(&TerminalTabStatus::Running)
+    );
+    assert_eq!(controller.notifier().completions.len(), 1);
+}
+
+#[test]
+fn non_running_tab_hook_does_not_complete_or_notify() {
+    let path = cwd();
+    let mut session = WorkspaceSession::default();
+    let tab_id = session.create_terminal_tab(
+        "repo",
+        path.clone(),
+        "Claude".to_string(),
+        TerminalTabKind::Command,
+        CommandSpec::shell_command("claude", path.clone()),
+    );
+    let mut controller = controller();
+
+    let result = ingest_harness_completion_hook(
+        HookProvider::ClaudeCode,
+        &json!({
+            "hook_event_name": "Stop",
+            "success": true,
+            "terminal_tab_id": tab_id.0
+        }),
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest hook");
+
+    assert_eq!(
+        result,
+        HarnessCompletionIngestionResult::IgnoredNonRunningTab { tab_id }
+    );
+    assert_eq!(
+        session.terminal_tab_status_by_id(tab_id),
+        Some(&TerminalTabStatus::NotStarted)
+    );
+    assert!(controller.notifier().completions.is_empty());
 }
 
 #[test]

--- a/tests/notification_hook_tests.rs
+++ b/tests/notification_hook_tests.rs
@@ -405,6 +405,51 @@ fn duplicate_completed_tab_hook_is_suppressed() {
 }
 
 #[test]
+fn first_hook_for_already_exited_tab_still_notifies() {
+    let path = cwd();
+    let mut session = WorkspaceSession::default();
+    let tab_id = running_terminal_tab(&mut session, "Claude", "claude", &path);
+    session
+        .set_terminal_tab_status_by_id(tab_id, TerminalTabStatus::Exited(Some(0)))
+        .expect("mark tab exited");
+    let mut controller = controller();
+    let payload = json!({
+        "hook_event_name": "Stop",
+        "success": true,
+        "terminal_tab_id": tab_id.0
+    });
+
+    let first = ingest_harness_completion_hook(
+        HookProvider::ClaudeCode,
+        &payload,
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest first hook");
+    let second = ingest_harness_completion_hook(
+        HookProvider::ClaudeCode,
+        &payload,
+        &mut session,
+        &mut controller,
+    )
+    .expect("ingest duplicate hook");
+
+    assert_eq!(
+        first,
+        HarnessCompletionIngestionResult::NotifiedWithoutTerminalTransition { tab_id }
+    );
+    assert_eq!(
+        second,
+        HarnessCompletionIngestionResult::IgnoredDuplicate { tab_id }
+    );
+    assert_eq!(
+        session.terminal_tab_status_by_id(tab_id),
+        Some(&TerminalTabStatus::Exited(Some(0)))
+    );
+    assert_eq!(controller.notifier().completions.len(), 1);
+}
+
+#[test]
 fn unsupported_hook_ingestion_does_not_notify_or_mutate_tab() {
     let path = cwd();
     let mut session = WorkspaceSession::default();

--- a/tests/workspace_session_tests.rs
+++ b/tests/workspace_session_tests.rs
@@ -190,6 +190,72 @@ fn tab_runtime_state_can_be_updated_and_removed() {
 }
 
 #[test]
+fn terminal_tab_status_can_be_read_and_updated_by_global_id() {
+    let mut session = WorkspaceSession::default();
+    let path_a = PathBuf::from("/repo/a");
+    let path_b = PathBuf::from("/repo/b");
+    let inactive = session.create_terminal_tab(
+        "repo",
+        path_a.clone(),
+        "Shell".to_string(),
+        TerminalTabKind::Shell,
+        shell_command("/repo/a"),
+    );
+    let active = session.create_terminal_tab(
+        "repo",
+        path_a.clone(),
+        "Tests".to_string(),
+        TerminalTabKind::Command,
+        CommandSpec::shell_command("cargo test", path_a.clone()),
+    );
+    let other_worktree = session.create_terminal_tab(
+        "repo",
+        path_b.clone(),
+        "Shell".to_string(),
+        TerminalTabKind::Shell,
+        shell_command("/repo/b"),
+    );
+
+    session
+        .set_tab_status("repo", &path_a, inactive, TerminalTabStatus::Running)
+        .expect("set inactive running");
+    session
+        .set_terminal_tab_status_by_id(inactive, TerminalTabStatus::Exited(Some(0)))
+        .expect("set status by id");
+
+    assert_eq!(
+        session.terminal_tab_status_by_id(inactive),
+        Some(&TerminalTabStatus::Exited(Some(0)))
+    );
+    assert_eq!(
+        session.terminal_tab_status_by_id(active),
+        Some(&TerminalTabStatus::NotStarted)
+    );
+    assert_eq!(
+        session.terminal_tab_status_by_id(other_worktree),
+        Some(&TerminalTabStatus::NotStarted)
+    );
+    assert_eq!(
+        session.active_tab("repo", &path_a).map(|tab| tab.id),
+        Some(active)
+    );
+}
+
+#[test]
+fn terminal_tab_status_lookup_ignores_non_terminal_tabs() {
+    let mut session = WorkspaceSession::default();
+    let path = PathBuf::from("/repo/a");
+    let file = session.open_file_tab("repo", path.clone(), path.join("src/main.rs"));
+
+    assert_eq!(session.terminal_tab_status_by_id(file), None);
+    assert!(
+        session
+            .set_terminal_tab_status_by_id(file, TerminalTabStatus::Failed)
+            .is_err()
+    );
+}
+
+#[test]
 fn failed_startup_tab_preserves_failure_without_backend_session() {
     let mut session = WorkspaceSession::default();
     let path = PathBuf::from("/repo/a");


### PR DESCRIPTION
## Summary
- add hook-driven harness completion ingestion with duplicate suppression
- update terminal tabs by correlated tab ID across all worktrees, including inactive tabs
- cover supported/unsupported hook events, tab correlation, duplicate suppression, and running-to-complete/fail transitions

## Test plan
- cargo test --all-features --test notification_hook_tests
- cargo test --all-features --test workspace_session_tests
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings