### PR TITLE
Style settings window chrome and controls

### DIFF
--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -41,6 +41,7 @@ struct AlasApp: App {
         Window("Settings", id: "settings") {
             SettingsWindow(state: state)
         }
+        .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)
         .defaultSize(width: 880, height: 580)
     }

--- a/Alas/Sources/Settings/AppearancePane.swift
+++ b/Alas/Sources/Settings/AppearancePane.swift
@@ -46,7 +46,7 @@ struct AppearancePane: View {
                                 } label: {
                                     VStack(spacing: 4) {
                                         ZStack(alignment: .topLeading) {
-                                            Rectangle().fill(c1).frame(width: 80, height: 50)
+                                            Rectangle().fill(c1).frame(width: 72, height: 46)
                                             Rectangle().fill(c2).frame(width: 16, height: 4).padding(4)
                                         }
                                         .clipShape(RoundedRectangle(cornerRadius: 4))

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -32,6 +32,7 @@ struct SettingsNavView: View {
                     HStack(spacing: 9) {
                         Icon(name: section.icon, size: 14,
                              color: selection == section ? theme.color("accent") : theme.color("fg-dim"))
+                            .frame(width: 16, height: 16)
                         Text(section.label).font(.system(size: 12.5))
                             .foregroundColor(selection == section ? theme.color("fg") : theme.color("fg-muted"))
                         Spacer()

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -3,20 +3,26 @@ import SwiftUI
 struct SettingsWindow: View {
     @Bindable var state: AppState
     @State private var section: SettingsSection = .general
-    @Environment(\.theme) var theme
 
     var body: some View {
+        let theme = state.themeStore.current
+
         VStack(spacing: 0) {
             ZStack {
                 LinearGradient(
                     colors: [theme.color("bg-3"), theme.color("bg-2")],
                     startPoint: .top, endPoint: .bottom
                 )
-                .frame(height: 38)
+                HStack {
+                    TrafficLights()
+                    Spacer()
+                }
+                .padding(.leading, 16)
                 Text("Settings")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(theme.color("fg-muted"))
             }
+            .frame(height: 44)
             .overlay(Divider().opacity(0.5), alignment: .bottom)
 
             HStack(spacing: 0) {
@@ -29,7 +35,10 @@ struct SettingsWindow: View {
                     case .appearance: AppearancePane(state: state)
                     }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(width: 680)
+                .frame(maxHeight: .infinity)
+                .background(theme.color("bg-1"))
+                .clipped()
             }
 
             HStack(spacing: 8) {
@@ -42,7 +51,10 @@ struct SettingsWindow: View {
             .overlay(Divider().opacity(0.5), alignment: .top)
         }
         .frame(width: 880, height: 580)
-        .environment(\.theme, state.themeStore.current)
+        .background(theme.color("bg-1"))
+        .background(WindowConfigurator())
+        .environment(\.theme, theme)
+        .ignoresSafeArea()
     }
 
     private func closeWindow() {

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -35,6 +35,8 @@ struct TerminalPane: View {
                                 desc: "Executed in every new terminal pane after the shell starts.") {
                         TextEditor(text: bind(\.terminal.startupScript))
                             .font(.system(size: 12, design: .monospaced))
+                            .foregroundColor(theme.color("fg"))
+                            .scrollContentBackground(.hidden)
                             .frame(minHeight: 80)
                             .padding(8)
                             .background(theme.color("bg-0"))
@@ -44,6 +46,8 @@ struct TerminalPane: View {
                                 desc: "Executed once after a worktree is created.") {
                         TextEditor(text: bind(\.terminal.worktreeCreateScript))
                             .font(.system(size: 12, design: .monospaced))
+                            .foregroundColor(theme.color("fg"))
+                            .scrollContentBackground(.hidden)
                             .frame(minHeight: 60)
                             .padding(8)
                             .background(theme.color("bg-0"))

--- a/Alas/Sources/Theme/Theme.swift
+++ b/Alas/Sources/Theme/Theme.swift
@@ -37,8 +37,13 @@ struct Theme: Codable, Equatable {
     func color(_ token: String) -> Color {
         // Accent override wins over the theme JSON when set (so the
         // settings-pane picker actually changes the chrome).
-        if token == "accent", let hex = accentOverrideHex {
-            return Color(hex: hex)
+        if let hex = accentOverrideHex {
+            if token == "accent" {
+                return Color(hex: hex)
+            }
+            if token == "accent-soft" {
+                return Color(hex: hex).opacity(0.18)
+            }
         }
         guard let raw = tokens[token],
               let parsed = try? OKLCH.parse(raw) else {

--- a/AlasTests/TitlelessWindowTests.swift
+++ b/AlasTests/TitlelessWindowTests.swift
@@ -2,6 +2,7 @@ import Testing
 import AppKit
 @testable import Alas
 
+@MainActor
 struct TitlelessWindowTests {
     @Test func hidesStandardWindowButtons() {
         let window = NSWindow(


### PR DESCRIPTION
## Summary
- unify Settings window chrome with the active Alas theme
- make Settings use the transparent/custom titlebar treatment
- theme multi-line script text editors and accent-soft overrides
- stabilize settings sidebar icon sizing and Appearance pane width

## Verification
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' clean test (Swift Testing suites passed; command timed out after tests while process watchdog was terminating a git ls-files process)
