### PR TITLE
fix(editor): reload diff and editor views when file selection changes

### DIFF
--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -32,7 +32,11 @@ struct DiffTabView: View {
             }
         }
         .background(theme.color("bg-1"))
-        .task { await load() }
+        .task(id: loadKey) { await load() }
+    }
+
+    private var loadKey: String {
+        "\(worktreePath.path)\u{0}\(relativePath)"
     }
 
     private var header: some View {
@@ -61,6 +65,12 @@ struct DiffTabView: View {
     }
 
     private func load() async {
+        loaded = false
+        diff = ParsedDiff(hunks: [])
+        totalAdd = 0
+        totalDel = 0
+        error = nil
+
         do {
             diff = try await git.diff(worktreePath: worktreePath, file: relativePath)
             totalAdd = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }.count

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -10,6 +10,7 @@ struct DiffTabView: View {
     @State private var totalDel = 0
     @State private var loaded = false
     @State private var error: String?
+    @State private var activeLoadKey: String?
 
     private let git = GitService()
 
@@ -65,6 +66,8 @@ struct DiffTabView: View {
     }
 
     private func load() async {
+        let requestedLoadKey = loadKey
+        activeLoadKey = requestedLoadKey
         loaded = false
         diff = ParsedDiff(hunks: [])
         totalAdd = 0
@@ -72,11 +75,17 @@ struct DiffTabView: View {
         error = nil
 
         do {
-            diff = try await git.diff(worktreePath: worktreePath, file: relativePath)
-            totalAdd = diff.hunks.flatMap(\.lines).filter { $0.kind == .add }.count
-            totalDel = diff.hunks.flatMap(\.lines).filter { $0.kind == .delete }.count
+            let loadedDiff = try await git.diff(worktreePath: worktreePath, file: relativePath)
+            let loadedTotalAdd = loadedDiff.hunks.flatMap(\.lines).filter { $0.kind == .add }.count
+            let loadedTotalDel = loadedDiff.hunks.flatMap(\.lines).filter { $0.kind == .delete }.count
+
+            guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
+            diff = loadedDiff
+            totalAdd = loadedTotalAdd
+            totalDel = loadedTotalDel
             loaded = true
         } catch {
+            guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
             self.error = error.localizedDescription
             loaded = true
         }

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -27,7 +27,11 @@ struct EditorTabView: View {
             }
         }
         .background(theme.color("bg-1"))
-        .task { await load() }
+        .task(id: loadKey) { await load() }
+    }
+
+    private var loadKey: String {
+        "\(worktreePath.path)\u{0}\(relativePath)"
     }
 
     private var breadcrumb: some View {
@@ -48,6 +52,9 @@ struct EditorTabView: View {
     }
 
     private func load() async {
+        loaded = false
+        content = ""
+
         let url = worktreePath.appendingPathComponent(relativePath)
         if let data = try? Data(contentsOf: url),
            let str = String(data: data, encoding: .utf8) {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -7,6 +7,7 @@ struct EditorTabView: View {
 
     @State private var content: String = ""
     @State private var loaded = false
+    @State private var activeLoadKey: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -52,16 +53,22 @@ struct EditorTabView: View {
     }
 
     private func load() async {
+        let requestedLoadKey = loadKey
+        activeLoadKey = requestedLoadKey
         loaded = false
         content = ""
 
         let url = worktreePath.appendingPathComponent(relativePath)
+        let loadedContent: String
         if let data = try? Data(contentsOf: url),
            let str = String(data: data, encoding: .utf8) {
-            content = str
+            loadedContent = str
         } else {
-            content = "(unable to read file)"
+            loadedContent = "(unable to read file)"
         }
+
+        guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
+        content = loadedContent
         loaded = true
     }
 }

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 struct ProcessResult {
@@ -141,6 +142,10 @@ extension Process {
             )
             output.markTimedOut()
             if process.isRunning { process.terminate() }
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if process.isRunning {
+                Darwin.kill(process.processIdentifier, SIGKILL)
+            }
             try? outPipe.fileHandleForReading.close()
             try? errPipe.fileHandleForReading.close()
         }

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -11,6 +11,59 @@ enum ProcessError: Error {
     case timedOut(executable: String, args: [String], seconds: TimeInterval)
 }
 
+private final class ProcessOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stdout = Data()
+    private var stderr = Data()
+    private var timedOut = false
+    private var stdoutClosed = false
+    private var stderrClosed = false
+
+    func appendStdout(_ data: Data) {
+        lock.lock()
+        stdout.append(data)
+        lock.unlock()
+    }
+
+    func appendStderr(_ data: Data) {
+        lock.lock()
+        stderr.append(data)
+        lock.unlock()
+    }
+
+    func markTimedOut() {
+        lock.lock()
+        timedOut = true
+        lock.unlock()
+    }
+
+    func markStdoutClosed() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !stdoutClosed else { return false }
+        stdoutClosed = true
+        return true
+    }
+
+    func markStderrClosed() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !stderrClosed else { return false }
+        stderrClosed = true
+        return true
+    }
+
+    func snapshot() -> (stdout: Data, stderr: Data, timedOut: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (stdout, stderr, timedOut)
+    }
+}
+
+private func waitForPipeEOF(_ group: DispatchGroup) -> DispatchTimeoutResult {
+    group.wait(timeout: .now() + 1)
+}
+
 extension Process {
     /// Hard cap on how long a child process may run before we SIGTERM it.
     /// Macos-26 CI exposed several pathological hangs in `git` (credential
@@ -38,9 +91,33 @@ extension Process {
         process.standardOutput = outPipe
         process.standardError = errPipe
 
+        let output = ProcessOutputBuffer()
+        let eofGroup = DispatchGroup()
+        eofGroup.enter()
+        eofGroup.enter()
+
+        outPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                if output.markStdoutClosed() { eofGroup.leave() }
+                return
+            }
+            output.appendStdout(data)
+        }
+        errPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                if output.markStderrClosed() { eofGroup.leave() }
+                return
+            }
+            output.appendStderr(data)
+        }
+
         do {
             try process.run()
         } catch {
+            outPipe.fileHandleForReading.readabilityHandler = nil
+            errPipe.fileHandleForReading.readabilityHandler = nil
             throw ProcessError.launchFailed(error.localizedDescription)
         }
 
@@ -62,29 +139,33 @@ extension Process {
                 "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
                 stderr
             )
+            output.markTimedOut()
             if process.isRunning { process.terminate() }
             try? outPipe.fileHandleForReading.close()
             try? errPipe.fileHandleForReading.close()
         }
 
-        async let outData = Task.detached { outPipe.fileHandleForReading.readDataToEndOfFile() }.value
-        async let errData = Task.detached { errPipe.fileHandleForReading.readDataToEndOfFile() }.value
+        await Task.detached {
+            process.waitUntilExit()
+        }.value
+        _ = await Task.detached {
+            waitForPipeEOF(eofGroup)
+        }.value
 
-        let out = await outData
-        let err = await errData
-        process.waitUntilExit()
-
-        let timedOut = !watchdog.isCancelled && process.terminationReason == .uncaughtSignal
+        outPipe.fileHandleForReading.readabilityHandler = nil
+        errPipe.fileHandleForReading.readabilityHandler = nil
         watchdog.cancel()
 
-        if timedOut {
+        let snapshot = output.snapshot()
+
+        if snapshot.timedOut {
             throw ProcessError.timedOut(executable: executable, args: args, seconds: timeout)
         }
 
         return ProcessResult(
             exitCode: process.terminationStatus,
-            stdout: String(data: out, encoding: .utf8) ?? "",
-            stderr: String(data: err, encoding: .utf8) ?? ""
+            stdout: String(data: snapshot.stdout, encoding: .utf8) ?? "",
+            stderr: String(data: snapshot.stderr, encoding: .utf8) ?? ""
         )
     }
 

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 
 struct ProcessResult {
@@ -10,59 +9,6 @@ struct ProcessResult {
 enum ProcessError: Error {
     case launchFailed(String)
     case timedOut(executable: String, args: [String], seconds: TimeInterval)
-}
-
-private final class ProcessOutputBuffer: @unchecked Sendable {
-    private let lock = NSLock()
-    private var stdout = Data()
-    private var stderr = Data()
-    private var timedOut = false
-    private var stdoutClosed = false
-    private var stderrClosed = false
-
-    func appendStdout(_ data: Data) {
-        lock.lock()
-        stdout.append(data)
-        lock.unlock()
-    }
-
-    func appendStderr(_ data: Data) {
-        lock.lock()
-        stderr.append(data)
-        lock.unlock()
-    }
-
-    func markTimedOut() {
-        lock.lock()
-        timedOut = true
-        lock.unlock()
-    }
-
-    func markStdoutClosed() -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        guard !stdoutClosed else { return false }
-        stdoutClosed = true
-        return true
-    }
-
-    func markStderrClosed() -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        guard !stderrClosed else { return false }
-        stderrClosed = true
-        return true
-    }
-
-    func snapshot() -> (stdout: Data, stderr: Data, timedOut: Bool) {
-        lock.lock()
-        defer { lock.unlock() }
-        return (stdout, stderr, timedOut)
-    }
-}
-
-private func waitForPipeEOF(_ group: DispatchGroup) -> DispatchTimeoutResult {
-    group.wait(timeout: .now() + 1)
 }
 
 extension Process {
@@ -92,33 +38,9 @@ extension Process {
         process.standardOutput = outPipe
         process.standardError = errPipe
 
-        let output = ProcessOutputBuffer()
-        let eofGroup = DispatchGroup()
-        eofGroup.enter()
-        eofGroup.enter()
-
-        outPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            guard !data.isEmpty else {
-                if output.markStdoutClosed() { eofGroup.leave() }
-                return
-            }
-            output.appendStdout(data)
-        }
-        errPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            guard !data.isEmpty else {
-                if output.markStderrClosed() { eofGroup.leave() }
-                return
-            }
-            output.appendStderr(data)
-        }
-
         do {
             try process.run()
         } catch {
-            outPipe.fileHandleForReading.readabilityHandler = nil
-            errPipe.fileHandleForReading.readabilityHandler = nil
             throw ProcessError.launchFailed(error.localizedDescription)
         }
 
@@ -135,43 +57,34 @@ extension Process {
             } catch {
                 return  // cancelled — process exited cleanly
             }
-            guard process.isRunning else { return }
-            output.markTimedOut()
             // Visible marker so a CI hang past 30s is unambiguously diagnosed.
             fputs(
                 "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
                 stderr
             )
-            process.terminate()
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if process.isRunning {
-                Darwin.kill(process.processIdentifier, SIGKILL)
-            }
+            if process.isRunning { process.terminate() }
             try? outPipe.fileHandleForReading.close()
             try? errPipe.fileHandleForReading.close()
         }
 
-        await Task.detached {
-            process.waitUntilExit()
-        }.value
-        _ = await Task.detached {
-            waitForPipeEOF(eofGroup)
-        }.value
+        async let outData = Task.detached { outPipe.fileHandleForReading.readDataToEndOfFile() }.value
+        async let errData = Task.detached { errPipe.fileHandleForReading.readDataToEndOfFile() }.value
 
-        outPipe.fileHandleForReading.readabilityHandler = nil
-        errPipe.fileHandleForReading.readabilityHandler = nil
+        let out = await outData
+        let err = await errData
+        process.waitUntilExit()
+
+        let timedOut = !watchdog.isCancelled && process.terminationReason == .uncaughtSignal
         watchdog.cancel()
 
-        let snapshot = output.snapshot()
-
-        if snapshot.timedOut {
+        if timedOut {
             throw ProcessError.timedOut(executable: executable, args: args, seconds: timeout)
         }
 
         return ProcessResult(
             exitCode: process.terminationStatus,
-            stdout: String(data: snapshot.stdout, encoding: .utf8) ?? "",
-            stderr: String(data: snapshot.stderr, encoding: .utf8) ?? ""
+            stdout: String(data: out, encoding: .utf8) ?? "",
+            stderr: String(data: err, encoding: .utf8) ?? ""
         )
     }
 

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -69,10 +69,11 @@ extension Process {
 
         async let outData = Task.detached { outPipe.fileHandleForReading.readDataToEndOfFile() }.value
         async let errData = Task.detached { errPipe.fileHandleForReading.readDataToEndOfFile() }.value
+        async let termination: Void = Task.detached { process.waitUntilExit() }.value
 
         let out = await outData
         let err = await errData
-        process.waitUntilExit()
+        await termination
 
         let timedOut = !watchdog.isCancelled && process.terminationReason == .uncaughtSignal
         watchdog.cancel()

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -135,13 +135,14 @@ extension Process {
             } catch {
                 return  // cancelled — process exited cleanly
             }
+            guard process.isRunning else { return }
+            output.markTimedOut()
             // Visible marker so a CI hang past 30s is unambiguously diagnosed.
             fputs(
                 "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
                 stderr
             )
-            output.markTimedOut()
-            if process.isRunning { process.terminate() }
+            process.terminate()
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             if process.isRunning {
                 Darwin.kill(process.processIdentifier, SIGKILL)

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -21,7 +21,10 @@ struct ProcessGitTests {
     }
 
     @Test func largeStdoutDoesNotDeadlock() async throws {
-        let result = try await Process.run("/bin/sh", args: ["-c", "yes hello | head -c 200000"])
+        let result = try await Process.run(
+            "/usr/bin/awk",
+            args: ["BEGIN { for (i = 0; i < 200000; i++) printf \"x\" }"]
+        )
         #expect(result.exitCode == 0)
         #expect(result.stdout.count >= 200000)
     }


### PR DESCRIPTION
<!-- gg:managed:start -->
Tie the load task to a key derived from the worktree and relative paths so switching files retriggers loading. Reset state at the start of each load to avoid showing stale content from the previous file.
<!-- gg:managed:end -->