### PR TITLE
fix(rows): expand row click targets

### DIFF
--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -40,8 +40,10 @@ struct SettingsNavView: View {
                         Spacer()
                     }
                     .padding(.horizontal, 10).padding(.vertical, 7)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .background(selection == section ? theme.color("accent-soft") : .clear)
                     .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
             }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -23,6 +23,8 @@ struct RepoGroupView: View {
                         .foregroundColor(theme.color("fg-faint"))
                 }
                 .padding(.horizontal, 12).padding(.vertical, 5)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             if !collapsed {

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -47,6 +47,8 @@ struct WorktreeRowView: View {
                 .padding(.trailing, 10)
                 .padding(.vertical, 7)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary

This fixes row hit testing in the sidebar repository/worktree list and the settings navigation list.

The row labels now expand to the available width and declare a rectangular content shape, so selecting anywhere in the visible row activates the same action as selecting directly on the text.

## Root Cause

The SwiftUI button labels were only contributing their intrinsic hit-test area in some rows, which meant clicks on empty row space were ignored even though the row visually occupied that space.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Note: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was started locally but stayed silent for over 5 minutes, so the run was interrupted.