### PR TITLE
fix(terminal): restore missing terminal sessions in place

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -112,6 +112,15 @@ final class AppState {
         return tabs.appendTerminal(worktreeId: worktree.id, title: worktree.branch, sessionId: session.id)
     }
 
+    @discardableResult
+    func restoreTerminalTabIfNeeded(worktreeId: String, tabId: TabID, sessionId: String) throws -> Tab? {
+        guard let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
+              case .terminal(let state) = tab,
+              state.sessionId == sessionId else { return nil }
+        if terminal.registry.session(for: sessionId) != nil { return tab }
+        return try replaceMissingTerminalSession(worktreeId: worktreeId, tab: state)
+    }
+
     func closeTab(worktreeId: String, tabId: TabID) {
         if let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
            case .terminal(let s) = tab {
@@ -123,5 +132,42 @@ final class AppState {
             terminal.closeSession(id: s.sessionId)
         }
         tabs.close(worktreeId: worktreeId, tabId: tabId)
+    }
+
+    @discardableResult
+    private func replaceMissingTerminalSession(worktreeId: String, tab: TerminalTabState) throws -> Tab {
+        guard let worktree = worktree(withId: worktreeId),
+              let project = projects.first(where: { $0.id == worktree.projectId }) else {
+            throw NSError(domain: "AppState", code: 2)
+        }
+
+        let oldSessionId = tab.sessionId
+        let session = try terminal.openSession(
+            worktree: worktree, project: project,
+            cfg: config.terminal, theme: themeStore.current
+        )
+        harness.detector.unregister(sessionId: oldSessionId)
+        harness.forgetSession(oldSessionId)
+        harness.detector.register(sessionId: session.id) { [weak session] in
+            session?.surface.foregroundPid
+        }
+        guard let replacement = tabs.replaceTerminalSession(
+            worktreeId: worktreeId,
+            tabId: tab.id,
+            sessionId: session.id
+        ) else {
+            terminal.closeSession(id: session.id)
+            throw NSError(domain: "AppState", code: 3)
+        }
+        return replacement
+    }
+
+    private func worktree(withId id: String) -> Worktree? {
+        for project in projects {
+            if let worktree = projectsManager.worktrees(projectId: project.id).first(where: { $0.id == id }) {
+                return worktree
+            }
+        }
+        return nil
     }
 }

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -35,7 +35,7 @@ enum Tab: Codable, Equatable, Identifiable {
 struct TerminalTabState: Codable, Equatable, Identifiable {
     let id: TabID
     var title: String       // e.g. branch name, "main", or "+ N"
-    let sessionId: String   // matches TerminalSession.id (re-attached on launch)
+    var sessionId: String   // matches TerminalSession.id (re-attached on launch)
 }
 
 struct EditorTabState: Codable, Equatable, Identifiable {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -37,6 +37,19 @@ final class TabsManager {
     }
 
     @discardableResult
+    func replaceTerminalSession(worktreeId: String, tabId: TabID, sessionId: String) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .terminal(var state) = file.tabs[idx] else { return nil }
+        state.sessionId = sessionId
+        let tab = Tab.terminal(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
+    @discardableResult
     func appendEditor(worktreeId: String, title: String, relativePath: String) -> Tab {
         let state = EditorTabState(id: UUID().uuidString, title: title, relativePath: relativePath)
         let tab = Tab.editor(state)

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -17,6 +17,13 @@ struct TerminalTabView: View {
                 TerminalRecoverPlaceholder(state: state, worktreeId: worktreeId, tabId: tabId)
             }
         }
+        .task(id: sessionId) {
+            _ = try? state.restoreTerminalTabIfNeeded(
+                worktreeId: worktreeId,
+                tabId: tabId,
+                sessionId: sessionId
+            )
+        }
         .background(theme.color("bg-0"))
     }
 }
@@ -34,23 +41,17 @@ private struct TerminalRecoverPlaceholder: View {
                 .foregroundColor(theme.color("fg-muted"))
             AlasButton(title: "Open new terminal", style: .primary) {
                 Task {
-                    if let wt = currentWorktree() {
-                        _ = try? state.openTerminalTab(for: wt)
-                        state.closeTab(worktreeId: worktreeId, tabId: tabId)
+                    if case .terminal(let terminal) = state.tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }) {
+                        _ = try? state.restoreTerminalTabIfNeeded(
+                            worktreeId: worktreeId,
+                            tabId: tabId,
+                            sessionId: terminal.sessionId
+                        )
                     }
                 }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.color("bg-0"))
-    }
-
-    private func currentWorktree() -> Worktree? {
-        for project in state.projects {
-            if let wt = state.projectsManager.worktrees(projectId: project.id).first(where: { $0.id == worktreeId }) {
-                return wt
-            }
-        }
-        return nil
     }
 }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -4,29 +4,50 @@ import Foundation
 
 struct TabsManagerTests {
     @Test func newTerminalAppendsAndActivates() {
-        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: "w")) }
+        let worktreeId = "tabs-manager-new-terminal"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
         let mgr = TabsManager()
-        let tab = mgr.appendTerminal(worktreeId: "w", title: "main", sessionId: "s")
-        #expect(mgr.tabs(forWorktree: "w").count == 1)
-        #expect(mgr.activeTabId(forWorktree: "w") == tab.id)
+        let tab = mgr.appendTerminal(worktreeId: worktreeId, title: "main", sessionId: "s")
+        #expect(mgr.tabs(forWorktree: worktreeId).count == 1)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == tab.id)
     }
 
     @Test func closingActivatesNeighbour() {
-        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: "w")) }
+        let worktreeId = "tabs-manager-closing-neighbour"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
         let mgr = TabsManager()
-        let t1 = mgr.appendTerminal(worktreeId: "w", title: "a", sessionId: "s1")
-        let t2 = mgr.appendTerminal(worktreeId: "w", title: "b", sessionId: "s2")
-        mgr.activate(worktreeId: "w", tabId: t2.id)
-        mgr.close(worktreeId: "w", tabId: t2.id)
-        #expect(mgr.activeTabId(forWorktree: "w") == t1.id)
+        let t1 = mgr.appendTerminal(worktreeId: worktreeId, title: "a", sessionId: "s1")
+        let t2 = mgr.appendTerminal(worktreeId: worktreeId, title: "b", sessionId: "s2")
+        mgr.activate(worktreeId: worktreeId, tabId: t2.id)
+        mgr.close(worktreeId: worktreeId, tabId: t2.id)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == t1.id)
     }
 
     @Test func closingLastTabClearsActive() {
-        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: "w")) }
+        let worktreeId = "tabs-manager-closing-last"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
         let mgr = TabsManager()
-        let t = mgr.appendTerminal(worktreeId: "w", title: "x", sessionId: "s")
-        mgr.close(worktreeId: "w", tabId: t.id)
-        #expect(mgr.tabs(forWorktree: "w").isEmpty)
-        #expect(mgr.activeTabId(forWorktree: "w") == nil)
+        let t = mgr.appendTerminal(worktreeId: worktreeId, title: "x", sessionId: "s")
+        mgr.close(worktreeId: worktreeId, tabId: t.id)
+        #expect(mgr.tabs(forWorktree: worktreeId).isEmpty)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == nil)
+    }
+
+    @Test func replacingTerminalSessionKeepsTabAndActiveSelection() {
+        let worktreeId = "tabs-manager-replace-session"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let t = mgr.appendTerminal(worktreeId: worktreeId, title: "x", sessionId: "old")
+
+        let updated = mgr.replaceTerminalSession(worktreeId: worktreeId, tabId: t.id, sessionId: "new")
+
+        #expect(updated?.id == t.id)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == t.id)
+        guard case .terminal(let state) = mgr.tabs(forWorktree: worktreeId).first else {
+            Issue.record("Expected terminal tab")
+            return
+        }
+        #expect(state.sessionId == "new")
+        #expect(state.title == "x")
     }
 }


### PR DESCRIPTION
Replaces the lost terminal session for a tab when its sessionId no longer resolves in the registry, keeping the same tab id and active selection instead of closing it and opening a new one. Adds
TabsManager.replaceTerminalSession plus AppState.restoreTerminalTabIfNeeded, wires both into TerminalTabView's task and recover placeholder, and covers the new path with a TabsManagerTests case.