### PR TITLE
fix(layout): solid dividers with proper cursor restoration

### DIFF
--- a/Alas/Sources/Layout/DragHandle.swift
+++ b/Alas/Sources/Layout/DragHandle.swift
@@ -43,6 +43,11 @@ struct DragHandle: View {
                         }
                     }
             )
+            .onDisappear {
+                if cursorPushed {
+                    popCursor()
+                }
+            }
     }
 
     private func pushCursor() {

--- a/Alas/Sources/Layout/DragHandle.swift
+++ b/Alas/Sources/Layout/DragHandle.swift
@@ -7,35 +7,57 @@ struct DragHandle: View {
     /// clamps. Sums to the same total a user expects from their cursor motion.
     let onDrag: (CGFloat) -> Void
     @State private var hovering = false
+    @State private var dragging = false
+    @State private var cursorPushed = false
     @State private var lastTranslation: CGFloat = 0
 
     var body: some View {
-        Rectangle()
-            .fill(hovering ? Color.white.opacity(0.05) : Color.white.opacity(0.001))
+        VisualEffectView(material: .sidebar, blendingMode: .behindWindow)
             .frame(
                 width: axis == .horizontal ? 6 : nil,
                 height: axis == .vertical ? 6 : nil
             )
             .contentShape(Rectangle())
-            .onHover { hovering = $0 }
-            .onContinuousHover { _ in
-                switch axis {
-                case .horizontal: NSCursor.resizeLeftRight.set()
-                case .vertical:   NSCursor.resizeUpDown.set()
+            .onHover { isHovering in
+                hovering = isHovering
+                if isHovering {
+                    pushCursor()
+                } else if !dragging {
+                    popCursor()
                 }
             }
             .gesture(
                 DragGesture(coordinateSpace: .local)
                     .onChanged { value in
+                        dragging = true
                         let cumulative = axis == .horizontal ? value.translation.width : value.translation.height
                         let delta = cumulative - lastTranslation
                         lastTranslation = cumulative
                         onDrag(delta)
                     }
                     .onEnded { _ in
+                        dragging = false
                         lastTranslation = 0
+                        if !hovering {
+                            popCursor()
+                        }
                     }
             )
+    }
+
+    private func pushCursor() {
+        guard !cursorPushed else { return }
+        switch axis {
+        case .horizontal: NSCursor.resizeLeftRight.push()
+        case .vertical:   NSCursor.resizeUpDown.push()
+        }
+        cursorPushed = true
+    }
+
+    private func popCursor() {
+        guard cursorPushed else { return }
+        NSCursor.pop()
+        cursorPushed = false
     }
 
     static func clamp(value: Double, min minVal: Double, max maxVal: Double) -> Double {


### PR DESCRIPTION
## Summary

- Replace transparent `Rectangle` dividers with `VisualEffectView(material: .sidebar, blendingMode: .behindWindow)` to match sidebar appearance
- Fix stuck resize cursor by replacing `NSCursor.set()` with proper `push()`/`pop()` pattern guarded by `cursorPushed` and `dragging` state

Closes #711

## Test plan

- [ ] Verify dividers between sidebars and center pane are solid (match sidebar material)
- [ ] Hover over a divider — cursor changes to resize
- [ ] Move cursor away from divider — cursor returns to normal
- [ ] Drag a divider, release — cursor returns to normal
- [ ] Drag a divider past its bounds, release — cursor still returns to normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)