### PR TITLE
feat(search): file-name fuzzy search dialog (⌘P)

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0294EF678CFA762C8B5D381B /* HookInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */; };
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
 		043B6662FCBEC5969946D61A /* HookWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7116359F27BF0A139E0F643B /* HookWatcher.swift */; };
+		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
 		0F560F9B2458B94C807E96A1 /* CodeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */; };
@@ -31,20 +32,27 @@
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768D12909DD5233659AC4E03 /* RepoGroupView.swift */; };
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
+		3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6CCD7F7273667B5D67F821 /* SearchScope.swift */; };
 		32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */; };
+		3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36992F601C8EB6C3D45B584F /* SearchKbd.swift */; };
 		3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */; };
+		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
 		3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */; };
 		3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2498E56CBAF84CB67166C /* HarnessKind.swift */; };
 		3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B450918CC98255AD9170586 /* AppearancePane.swift */; };
+		3B34A2725C1F6B6E29C312F1 /* SearchInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */; };
+		3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */; };
 		3BA0F34C4D9EE5081736F458 /* claude-code.sh in Resources */ = {isa = PBXBuildFile; fileRef = 4501413979E60464DCE5602C /* claude-code.sh */; };
 		3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C1705E68E97111E85D83F3 /* RightPaneState.swift */; };
 		3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */; };
+		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
 		3DC6518A9050D1029D4D99A4 /* aider.sh in Resources */ = {isa = PBXBuildFile; fileRef = 2AC91D744E42A7C071268B74 /* aider.sh */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
 		41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */; };
 		41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */; };
+		42C0AE388E5CF8B2AAEADE3C /* SearchEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */; };
 		43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
 		466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0240C5961343C3042D865570 /* GeneralPane.swift */; };
@@ -65,6 +73,7 @@
 		5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE58EF9CF8EC461667D9430 /* AppConfig.swift */; };
 		5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */; };
 		671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A17A797374500E1FDD2382C /* PersistenceStore.swift */; };
+		676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4261E417947C1A21E77C1587 /* GitStatusCache.swift */; };
 		67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */; };
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
@@ -77,10 +86,12 @@
 		74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 77EF95AD63DDA8DB0504087B /* TreeSitterSwift */; };
 		74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A34259DE8E978943E8BE16 /* OKLCH.swift */; };
 		75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */; };
+		7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3855FBA3E4444960418639E9 /* FileIndexTests.swift */; };
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
 		7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159FE807399835B0821E1CAB /* EnvBuilder.swift */; };
 		7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CA79B71B4AA72697392702 /* NumstatParser.swift */; };
+		7B309C87C042B3A18AB31D0F /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49B5B544A3432F8D8105268 /* SearchModel.swift */; };
 		7B85B033B476943E77867BA3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69024633944E9FFF6DA76FAE /* RootView.swift */; };
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
@@ -103,6 +114,7 @@
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
+		A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */; };
 		A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
@@ -112,11 +124,13 @@
 		AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */; };
 		AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF8152B18C9D6290724122F /* HoverFeature.swift */; };
 		AD3469F4745DF96ED3D0E06E /* codex-cli.sh in Resources */ = {isa = PBXBuildFile; fileRef = F1524DAA94E33D2938853810 /* codex-cli.sh */; };
+		B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7159EED1183F784104B4F /* FuzzyMatch.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
 		B6C31E7AC3CE21AFEA371389 /* cool-slate.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DEB85132B767DB3B253620C /* cool-slate.json */; };
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
 		B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */; };
+		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88379ACE40F42BE4A3257659 /* ThemeTests.swift */; };
 		BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */; };
 		C1EBF68A32C7C1D61ECC89AC /* LSPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */; };
@@ -130,6 +144,7 @@
 		CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */; };
 		CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */; };
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
+		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
 		CFDD9978240DAFEC7B0CD230 /* warm-amber.json in Resources */ = {isa = PBXBuildFile; fileRef = 821B8D5125CB96997889D3B4 /* warm-amber.json */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
@@ -142,6 +157,9 @@
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
+		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
+		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
+		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
 		E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA8FEE64D73BDEBAF74878 /* Kbd.swift */; };
 		E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66950F2226F1182DCDD39A /* RightPaneView.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
@@ -152,6 +170,7 @@
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
+		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
 		F40727225EA3797436F5722B /* neutral.json in Resources */ = {isa = PBXBuildFile; fileRef = C1BE92AB2BD3552CC87670C4 /* neutral.json */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
@@ -206,20 +225,29 @@
 		2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficLights.swift; sourceTree = "<group>"; };
 		30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorCoordinator.swift; sourceTree = "<group>"; };
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
+		3375A79ACFD3567389DA855C /* FileResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileResultRow.swift; sourceTree = "<group>"; };
 		339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeBuilder.swift; sourceTree = "<group>"; };
 		3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindow.swift; sourceTree = "<group>"; };
 		345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistryTests.swift; sourceTree = "<group>"; };
+		3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputRow.swift; sourceTree = "<group>"; };
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
+		36992F601C8EB6C3D45B584F /* SearchKbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKbd.swift; sourceTree = "<group>"; };
+		36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKind.swift; sourceTree = "<group>"; };
 		38499AFE31188908546EE222 /* LSPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransport.swift; sourceTree = "<group>"; };
+		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
+		39DFD138FE855D8CFC464847 /* SearchFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFooter.swift; sourceTree = "<group>"; };
+		3A0FF718D68E15F539577F56 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
 		3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeBuilderTests.swift; sourceTree = "<group>"; };
 		3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilderTests.swift; sourceTree = "<group>"; };
 		3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
 		412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsRangeTests.swift; sourceTree = "<group>"; };
 		413CE0B0BBC96D412D048B1D /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		4261E417947C1A21E77C1587 /* GitStatusCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCache.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
 		4501413979E60464DCE5602C /* claude-code.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "claude-code.sh"; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
+		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
 		4FE58EF9CF8EC461667D9430 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
@@ -233,8 +261,10 @@
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
 		642163EB929E060A878211E2 /* HookInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstaller.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
+		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
+		6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModelTests.swift; sourceTree = "<group>"; };
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
@@ -263,6 +293,7 @@
 		932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFeature.swift; sourceTree = "<group>"; };
 		93CDC9895F48619E97461875 /* CodePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePane.swift; sourceTree = "<group>"; };
 		954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallerTests.swift; sourceTree = "<group>"; };
+		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
 		A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClient.swift; sourceTree = "<group>"; };
@@ -271,6 +302,7 @@
 		A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailView.swift; sourceTree = "<group>"; };
 		A8820E4289EEB1ADCA9E490F /* HookEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookEventTests.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
+		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		B1AA2B3E548B50097C9AF9D3 /* FilesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesSectionView.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
@@ -281,6 +313,7 @@
 		B7CE7B4DAFDB65A79308FB63 /* GitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitService.swift; sourceTree = "<group>"; };
 		B7E50B0600EF60A0D9B09877 /* HighlightCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightCapture.swift; sourceTree = "<group>"; };
 		B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderView.swift; sourceTree = "<group>"; };
+		B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCacheTests.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfig.swift; sourceTree = "<group>"; };
 		BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManager.swift; sourceTree = "<group>"; };
@@ -294,8 +327,10 @@
 		C995611A6313FABE30508248 /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
 		CA554728676F9D3B5E2C05FA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
+		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D6A9977C979705A40595FD5E /* TabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerTests.swift; sourceTree = "<group>"; };
 		D97EF761C70A3AF83C00879A /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
@@ -303,6 +338,8 @@
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
+		E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndex.swift; sourceTree = "<group>"; };
+		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClientTests.swift; sourceTree = "<group>"; };
@@ -317,6 +354,7 @@
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
+		F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchDialog.swift; sourceTree = "<group>"; };
 		F9F85B92952C963DCF136315 /* HarnessDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetector.swift; sourceTree = "<group>"; };
 		FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
@@ -359,9 +397,12 @@
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */,
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
+				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
 				3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */,
+				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
 				039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */,
+				B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */,
 				271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */,
 				F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */,
 				A8820E4289EEB1ADCA9E490F /* HookEventTests.swift */,
@@ -372,6 +413,7 @@
 				7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */,
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
+				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
@@ -465,6 +507,7 @@
 				F407DDCF720EFE97BD8DA7A8 /* Layout */,
 				8637544952A5E268387998D1 /* Persistence */,
 				413E432DDAAAE618029482C3 /* Right */,
+				986CC94FDFD6411BCED67A48 /* Search */,
 				59E804284C70FCAD77A09774 /* Settings */,
 				697AACFEA2DCEBE4CEB2CD4E /* Sidebar */,
 				F556D34B5B6FE20EA80F892A /* Terminal */,
@@ -595,6 +638,21 @@
 			path = Persistence;
 			sourceTree = "<group>";
 		};
+		986CC94FDFD6411BCED67A48 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */,
+				96E7159EED1183F784104B4F /* FuzzyMatch.swift */,
+				4261E417947C1A21E77C1587 /* GitStatusCache.swift */,
+				36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */,
+				D49B5B544A3432F8D8105268 /* SearchModel.swift */,
+				3A0FF718D68E15F539577F56 /* SearchResult.swift */,
+				CE6CCD7F7273667B5D67F821 /* SearchScope.swift */,
+				A1CA0BEB25542A9B175DBDFE /* Views */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
 		98B31DB084754D0D15591339 /* LSP */ = {
 			isa = PBXGroup;
 			children = (
@@ -615,6 +673,21 @@
 				20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */,
 			);
 			path = Highlight;
+			sourceTree = "<group>";
+		};
+		A1CA0BEB25542A9B175DBDFE /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				3375A79ACFD3567389DA855C /* FileResultRow.swift */,
+				F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */,
+				66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */,
+				4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */,
+				ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */,
+				39DFD138FE855D8CFC464847 /* SearchFooter.swift */,
+				3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */,
+				36992F601C8EB6C3D45B584F /* SearchKbd.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		A79B23DE77D9512D04B58860 /* Ghostty */ = {
@@ -951,17 +1024,23 @@
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,
 				950C937884477417569DC20B /* EmptyTabView.swift in Sources */,
 				7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */,
+				3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */,
+				E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */,
+				DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */,
 				4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */,
 				D59E731EE52408DDF87BABDA /* FilesSectionView.swift in Sources */,
+				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,
 				41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */,
 				12035048B950CE0197604F89 /* GitService.swift in Sources */,
+				676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */,
 				7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */,
 				B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */,
 				3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */,
 				90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */,
 				C512EC7827D3C46907DDB7A1 /* HighlightCapture.swift in Sources */,
+				387EF12B6875648E422956F7 /* Highlighted.swift in Sources */,
 				4BE29AA0D4CBFF3FF4B61C9F /* HookEvent.swift in Sources */,
 				EC1B515505AEC98FB199B02A /* HookInstaller.swift in Sources */,
 				043B6662FCBEC5969946D61A /* HookWatcher.swift in Sources */,
@@ -991,6 +1070,15 @@
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
 				E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */,
 				7B85B033B476943E77867BA3 /* RootView.swift in Sources */,
+				065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */,
+				42C0AE388E5CF8B2AAEADE3C /* SearchEmptyState.swift in Sources */,
+				F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */,
+				3B34A2725C1F6B6E29C312F1 /* SearchInputRow.swift in Sources */,
+				3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */,
+				CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */,
+				7B309C87C042B3A18AB31D0F /* SearchModel.swift in Sources */,
+				B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */,
+				3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */,
 				D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */,
 				9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */,
 				3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */,
@@ -1037,9 +1125,12 @@
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */,
 				C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */,
+				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
+				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */,
 				E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */,
+				A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */,
 				9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */,
 				D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */,
 				A7BDA44A8E4364C4C335C4DA /* HookEventTests.swift in Sources */,
@@ -1054,6 +1145,7 @@
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
+				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -23,6 +23,10 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasToggleRightPane, object: nil)
                 }
                 .keyboardShortcut(.return, modifiers: [.command, .option])
+                Button("Search Files…") {
+                    NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
+                }
+                .keyboardShortcut("p", modifiers: .command)
                 Button("New Worktree…") {
                     NotificationCenter.default.post(name: .alasNewWorktree, object: nil)
                 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -16,6 +16,14 @@ final class AppState {
     @ObservationIgnored
     private var lspManager: WorkspaceLSPManager?
 
+    var isSearchOpen: Bool = false
+    @ObservationIgnored
+    lazy var search: SearchModel = SearchModel(environment: makeSearchEnvironment())
+    @ObservationIgnored
+    private let fileIndex = FileIndex()
+    @ObservationIgnored
+    private let statusCache = GitStatusCache()
+
     var lsp: WorkspaceLSPManager {
         if let lspManager { return lspManager }
         let manager = WorkspaceLSPManager(registry: LanguageServerRegistry(userDefined: config.code.languageServers))
@@ -201,5 +209,62 @@ final class AppState {
             }
         }
         return nil
+    }
+
+    private func makeSearchEnvironment() -> SearchEnvironment {
+        // Invariant: the two synchronous closures below are only invoked
+        // from `SearchModel`, which is `@MainActor` — so `assumeIsolated`
+        // is sound. If a future caller invokes them off-main this will
+        // trap; keep them on main or convert to async.
+        SearchEnvironment(
+            currentWorktreeId: { [weak self] in
+                MainActor.assumeIsolated { self?.selectedWorktreeId }
+            },
+            allWorktrees: { [weak self] in
+                MainActor.assumeIsolated {
+                    guard let self else { return [] }
+                    var out: [SearchWorktree] = []
+                    for project in self.projects {
+                        for wt in self.projectsManager.worktrees(projectId: project.id) {
+                            out.append(SearchWorktree(
+                                id: wt.id,
+                                projectId: project.id,
+                                displayName: wt.branch,
+                                absolutePath: wt.path
+                            ))
+                        }
+                    }
+                    return out
+                }
+            },
+            entries: { [fileIndex] wt in
+                try await fileIndex.entries(forWorktreePath: wt.absolutePath)
+            },
+            statuses: { [statusCache] wt in
+                try await statusCache.statuses(forWorktreePath: wt.absolutePath)
+            }
+        )
+    }
+
+    /// Open a file in the right-pane code editor by routing through the
+    /// existing tabs system. Switches `selectedWorktreeId` if the file is
+    /// in a different worktree.
+    func openFile(relativePath: String, worktreeId: String) {
+        guard let worktree = worktree(withId: worktreeId) else { return }
+        if selectedWorktreeId != worktree.id { selectedWorktreeId = worktree.id }
+
+        let existing = tabs.tabs(forWorktree: worktree.id).first { tab in
+            if case .editor(let s) = tab { return s.relativePath == relativePath } else { return false }
+        }
+        if let existing {
+            tabs.activate(worktreeId: worktree.id, tabId: existing.id)
+        } else {
+            let tab = tabs.appendEditor(
+                worktreeId: worktree.id,
+                title: (relativePath as NSString).lastPathComponent,
+                relativePath: relativePath
+            )
+            tabs.activate(worktreeId: worktree.id, tabId: tab.id)
+        }
     }
 }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -8,58 +8,61 @@ struct RootView: View {
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
-        Group {
-            if state.projects.isEmpty {
-                EmptyState(
-                    canCreateWorktree: false,
-                    onAddProject: { showNewProject = true },
-                    onNewWorktree: { showNewWorktree = true }
-                )
-            } else {
-                ThreePaneLayout(
-                    sidebarWidth: Binding(
-                        get: { state.config.sidebarWidth },
-                        set: { state.config.sidebarWidth = $0 }
-                    ),
-                    rightWidth: Binding(
-                        get: { state.config.rightPaneWidth },
-                        set: { state.config.rightPaneWidth = $0 }
-                    ),
-                    rightVisible: state.config.rightPaneVisible,
-                    onWidthsChanged: { state.saveConfig() },
-                    sidebar: {
-                        SidebarView(
-                            state: state,
-                            collapsedProjects: $collapsedProjects,
-                            onSettings: { openSettingsWindow() },
-                            onNewWorktree: { showNewWorktree = true }
-                        )
-                    },
-                    center: {
-                        if let wt = selectedWorktree() {
-                            CenterPaneView(state: state, worktree: wt)
-                        } else {
-                            EmptyTabView(onNewTerminal: {})
-                        }
-                    },
-                    right: {
-                        if let wt = selectedWorktree() {
-                            RightPaneView(
+        ZStack {
+            Group {
+                if state.projects.isEmpty {
+                    EmptyState(
+                        canCreateWorktree: false,
+                        onAddProject: { showNewProject = true },
+                        onNewWorktree: { showNewWorktree = true }
+                    )
+                } else {
+                    ThreePaneLayout(
+                        sidebarWidth: Binding(
+                            get: { state.config.sidebarWidth },
+                            set: { state.config.sidebarWidth = $0 }
+                        ),
+                        rightWidth: Binding(
+                            get: { state.config.rightPaneWidth },
+                            set: { state.config.rightPaneWidth = $0 }
+                        ),
+                        rightVisible: state.config.rightPaneVisible,
+                        onWidthsChanged: { state.saveConfig() },
+                        sidebar: {
+                            SidebarView(
                                 state: state,
-                                worktree: wt,
-                                onSelectChangedFile: { file in
-                                    openOrFocusDiff(worktree: wt, path: file.path)
-                                },
-                                onSelectTreeFile: { node in
-                                    openOrFocusEditor(worktree: wt, path: node.path)
-                                }
+                                collapsedProjects: $collapsedProjects,
+                                onSettings: { openSettingsWindow() },
+                                onNewWorktree: { showNewWorktree = true }
                             )
-                        } else {
-                            EmptyView()
+                        },
+                        center: {
+                            if let wt = selectedWorktree() {
+                                CenterPaneView(state: state, worktree: wt)
+                            } else {
+                                EmptyTabView(onNewTerminal: {})
+                            }
+                        },
+                        right: {
+                            if let wt = selectedWorktree() {
+                                RightPaneView(
+                                    state: state,
+                                    worktree: wt,
+                                    onSelectChangedFile: { file in
+                                        openOrFocusDiff(worktree: wt, path: file.path)
+                                    },
+                                    onSelectTreeFile: { node in
+                                        openOrFocusEditor(worktree: wt, path: node.path)
+                                    }
+                                )
+                            } else {
+                                EmptyView()
+                            }
                         }
-                    }
-                )
+                    )
+                }
             }
+            FileSearchDialog(appState: state)
         }
         .environment(\.theme, state.themeStore.current)
         .background(WindowConfigurator())
@@ -82,6 +85,10 @@ struct RootView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .alasOpenSettings)) { _ in
             openSettingsWindow()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .alasOpenSearch)) { _ in
+            state.search.open()
+            state.isSearchOpen = true
         }
         .sheet(isPresented: $showNewProject) {
             NewProjectDialog(state: state, presented: $showNewProject)
@@ -134,19 +141,7 @@ struct RootView: View {
     }
 
     private func openOrFocusEditor(worktree: Worktree, path: String) {
-        let existing = state.tabs.tabs(forWorktree: worktree.id).first { tab in
-            if case .editor(let s) = tab { return s.relativePath == path } else { return false }
-        }
-        if let existing {
-            state.tabs.activate(worktreeId: worktree.id, tabId: existing.id)
-        } else {
-            let tab = state.tabs.appendEditor(
-                worktreeId: worktree.id,
-                title: (path as NSString).lastPathComponent,
-                relativePath: path
-            )
-            state.tabs.activate(worktreeId: worktree.id, tabId: tab.id)
-        }
+        state.openFile(relativePath: path, worktreeId: worktree.id)
     }
 }
 
@@ -156,4 +151,5 @@ extension Notification.Name {
     static let alasNewTerminalTab  = Notification.Name("AlasNewTerminalTab")
     static let alasCloseTab        = Notification.Name("AlasCloseTab")
     static let alasOpenSettings    = Notification.Name("AlasOpenSettings")
+    static let alasOpenSearch      = Notification.Name("AlasOpenSearch")
 }

--- a/Alas/Sources/Search/FileIndex.swift
+++ b/Alas/Sources/Search/FileIndex.swift
@@ -1,0 +1,70 @@
+import Foundation
+import os
+
+/// Enumerates files in a worktree using
+/// `git ls-files -co --exclude-standard`. Cached per worktree path
+/// for the lifetime of one dialog session.
+///
+/// `Entry` is intentionally minimal — it has no `worktreeId`/`projectId`
+/// because those come from the caller (SearchModel knows which worktree
+/// it asked for). The model wraps these into `FileSearchResult`s.
+actor FileIndex {
+    struct Entry: Equatable, Sendable {
+        let relativePath: String
+        let ext: String
+    }
+
+    private let logger = Logger(subsystem: "io.nlopez.alas", category: "search.fileindex")
+
+    /// In-memory cache keyed by absolute worktree path. Cleared by
+    /// `invalidate(forWorktreePath:)` and `invalidateAll()`.
+    private var cache: [String: (timestamp: Date, entries: [Entry])] = [:]
+
+    /// Cache TTL — first dialog open builds the index, subsequent opens
+    /// in the next 30s reuse it.
+    private let ttl: TimeInterval = 30
+
+    func entries(forWorktreePath worktree: URL) async throws -> [Entry] {
+        let key = worktree.path
+        if let hit = cache[key], Date().timeIntervalSince(hit.timestamp) < ttl {
+            return hit.entries
+        }
+
+        let result: ProcessResult
+        do {
+            result = try await Process.git(
+                ["-c", "core.quotePath=false", "ls-files", "-coz", "--exclude-standard"],
+                cwd: worktree
+            )
+        } catch {
+            logger.error("git ls-files failed in \(worktree.path): \(error.localizedDescription)")
+            throw error
+        }
+        guard result.exitCode == 0 else {
+            logger.error("git ls-files exit \(result.exitCode) in \(worktree.path): \(result.stderr)")
+            throw NSError(
+                domain: "FileIndex",
+                code: Int(result.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: "git ls-files failed: \(result.stderr)"]
+            )
+        }
+
+        let entries = result.stdout
+            .split(separator: "\0", omittingEmptySubsequences: true)
+            .map { line -> Entry in
+                let path = String(line)
+                let ext = (path as NSString).pathExtension.lowercased()
+                return Entry(relativePath: path, ext: ext)
+            }
+        cache[key] = (Date(), entries)
+        return entries
+    }
+
+    func invalidate(forWorktreePath worktree: URL) {
+        cache.removeValue(forKey: worktree.path)
+    }
+
+    func invalidateAll() {
+        cache.removeAll()
+    }
+}

--- a/Alas/Sources/Search/FuzzyMatch.swift
+++ b/Alas/Sources/Search/FuzzyMatch.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Subsequence fuzzy match scorer ported from the source design's `fuzzy()`
+/// in `file-search.jsx`. Pure, deterministic, no I/O.
+///
+/// Scoring rules:
+///   - Each character in `query` must appear in `target` in order
+///     (case-insensitive). If not, returns nil.
+///   - +4 bonus when a matched character starts a new segment
+///     (target index 0 or preceded by `/`, `_`, `.`, `-`).
+///   - +1 bonus when the target character at the matched index is uppercase.
+///   - +4 per contiguous pair of matches (two adjacent matched indices).
+///   - Penalty: -0.1 per unit of span between first and last matched index.
+///   - Penalty: -0.05 per unit of distance from start of target.
+///
+/// Matching strategy (greedy-contiguous, then segment-aware, then plain):
+///   For each query character we check, in order of preference:
+///   1. The immediately next position (contiguous with the previous match).
+///   2. The first segment-start or uppercase position from the current offset.
+///   3. The first plain match from the current offset.
+///   This ensures a contiguous run like "tab" beats a scattered match like
+///   "tbr" even when the scattered match would land on three segment starts.
+///
+/// An empty query returns `(score: 0, indices: [])` (matches anything).
+enum FuzzyMatch {
+    struct Result: Equatable {
+        var indices: [Int]
+        var score: Double
+    }
+
+    static func score(query: String, target: String) -> Result? {
+        if query.isEmpty { return Result(indices: [], score: 0) }
+        let q = Array(query.lowercased())
+        let t = Array(target)
+        let tLower = Array(target.lowercased())
+        if t.isEmpty { return nil }
+
+        // Verify the query is a subsequence at all.
+        guard isSubsequence(q, of: tLower) else { return nil }
+
+        // Find best positions using greedy-contiguous, then segment-aware.
+        let indices = bestIndices(q: q, t: t, tLower: tLower)
+        // bestIndices returns [] if an invariant break left a query char
+        // unplaceable. In that case treat as "no match" rather than crashing.
+        guard indices.count == q.count else { return nil }
+
+        // Score the chosen placement. `pairs` accumulates contiguous-pair
+        // count across ALL blocks of the match — earlier versions reset
+        // on each gap and only credited the final block, so a query like
+        // "abcd" against "ab_cd" (two contiguous pairs) was scored the
+        // same as a single-pair scattered match.
+        var pairs = 0
+        var lastMatchedAt = -2
+        var bonus = 0.0
+
+        for ti in indices {
+            if ti == lastMatchedAt + 1 { pairs += 1 }
+            if ti == 0 || isSegmentDelimiter(tLower[ti - 1]) { bonus += 4 }
+            let ch = t[ti]
+            if ch.isLetter && ch.isUppercase { bonus += 1 }
+            lastMatchedAt = ti
+        }
+
+        let span = Double(indices.last! - indices.first!)
+        // Run bonus is 4 per contiguous pair, which lets a contiguous run of
+        // 3 chars (+8) beat three separate segment-start matches (+12) only
+        // when span/start penalties also apply. This balances "tab" vs "tbr"
+        // in "tab_bar.rs" correctly.
+        let score = bonus + Double(pairs) * 4 - span * 0.1 - Double(indices.first!) * 0.05
+        return Result(indices: indices, score: score)
+    }
+
+    // MARK: - Private helpers
+
+    private static func isSubsequence(_ q: [Character], of t: [Character]) -> Bool {
+        var qi = 0
+        for ch in t {
+            if qi < q.count, ch == q[qi] { qi += 1 }
+        }
+        return qi == q.count
+    }
+
+    /// For each query character, chooses the best matching position:
+    ///   1. Contiguous with the previous match (highest priority).
+    ///   2. First segment-start or uppercase match from searchFrom that
+    ///      doesn't strand the remainder of the query.
+    ///   3. First plain match from searchFrom (fallback).
+    ///
+    /// The lookahead in (1) and (2) is important: greedily taking a
+    /// later "preferred" position can skip past the only viable plain
+    /// match, leaving the rest of the query unmatchable. We verify with
+    /// `canMatchRemainder` before committing to a non-plain position.
+    private static func bestIndices(q: [Character], t: [Character], tLower: [Character]) -> [Int] {
+        var result: [Int] = []
+        result.reserveCapacity(q.count)
+        var searchFrom = 0
+        var lastChosen = -2
+
+        for qi in 0..<q.count {
+            let qChar = q[qi]
+
+            // 1. Contiguous check: if the immediate next position matches AND
+            // the remainder is still placeable, take it.
+            let contiguousPos = lastChosen + 1
+            if contiguousPos < t.count,
+               contiguousPos >= searchFrom,
+               tLower[contiguousPos] == qChar,
+               canMatchRemainder(q: q, qFrom: qi + 1, t: tLower, tFrom: contiguousPos + 1) {
+                result.append(contiguousPos)
+                lastChosen = contiguousPos
+                searchFrom = contiguousPos + 1
+                continue
+            }
+
+            // 2. Look for a segment-start or uppercase match from searchFrom
+            // that doesn't strand the remainder.
+            var preferred: Int? = nil
+            var plain: Int? = nil
+
+            for ti in searchFrom..<t.count {
+                guard tLower[ti] == qChar else { continue }
+                if plain == nil { plain = ti }
+                let isSegStart = (ti == 0 || isSegmentDelimiter(tLower[ti - 1]))
+                let isCap = t[ti].isLetter && t[ti].isUppercase
+                if isSegStart || isCap,
+                   canMatchRemainder(q: q, qFrom: qi + 1, t: tLower, tFrom: ti + 1) {
+                    preferred = ti
+                    break
+                }
+            }
+
+            // `plain` is guaranteed non-nil whenever `isSubsequence` succeeded
+            // and we have only ever advanced past positions whose remainder
+            // was reachable — but defend against an invariant break instead
+            // of force-unwrapping.
+            guard let chosen = preferred ?? plain else { return [] }
+            result.append(chosen)
+            lastChosen = chosen
+            searchFrom = chosen + 1
+        }
+
+        return result
+    }
+
+    /// True iff `q[qFrom...]` is a subsequence of `t[tFrom...]`.
+    private static func canMatchRemainder(
+        q: [Character], qFrom: Int,
+        t: [Character], tFrom: Int
+    ) -> Bool {
+        var qi = qFrom
+        var ti = tFrom
+        while qi < q.count, ti < t.count {
+            if t[ti] == q[qi] { qi += 1 }
+            ti += 1
+        }
+        return qi == q.count
+    }
+
+    private static func isSegmentDelimiter(_ c: Character) -> Bool {
+        c == "/" || c == "_" || c == "." || c == "-"
+    }
+}

--- a/Alas/Sources/Search/GitStatusCache.swift
+++ b/Alas/Sources/Search/GitStatusCache.swift
@@ -1,0 +1,79 @@
+import Foundation
+import os
+
+/// Per-worktree cache of `git status --porcelain` output, parsed down to
+/// the M/A/D/R badge set used by the search dialog. Cache TTL is 2s — the
+/// dialog only ever asks for these on first open and on result re-renders,
+/// and 2s is fresh enough to feel right after a save.
+///
+/// Status precedence (when both index and worktree show changes for the
+/// same file): we use the index status if non-blank, otherwise the
+/// worktree status. This matches the user-perceived "what changed?".
+actor GitStatusCache {
+    private let logger = Logger(subsystem: "io.nlopez.alas", category: "search.status")
+    private var cache: [String: (timestamp: Date, statuses: [String: GitStatusBadge])] = [:]
+    private let ttl: TimeInterval = 2
+
+    func statuses(forWorktreePath worktree: URL) async throws -> [String: GitStatusBadge] {
+        let key = worktree.path
+        if let hit = cache[key], Date().timeIntervalSince(hit.timestamp) < ttl {
+            return hit.statuses
+        }
+
+        let result = try await Process.git(
+            ["-c", "core.quotePath=false", "status", "--porcelain=v1", "--no-renames", "-z"],
+            cwd: worktree
+        )
+        guard result.exitCode == 0 else {
+            logger.error("git status exit \(result.exitCode): \(result.stderr)")
+            throw NSError(
+                domain: "GitStatusCache",
+                code: Int(result.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: result.stderr]
+            )
+        }
+
+        var map: [String: GitStatusBadge] = [:]
+        for entry in result.stdout.split(separator: "\0", omittingEmptySubsequences: true) {
+            // With -z, format is "XY path" NUL-delimited (X = index status, Y = worktree status).
+            let raw = String(entry)
+            guard raw.count >= 4 else { continue }
+            let chars = Array(raw)
+            let indexCh = chars[0]
+            let worktreeCh = chars[1]
+            // Path begins at index 3 (chars 0..1 = XY, char 2 = space).
+            let path = String(chars[3...])
+            let badge = badge(forIndex: indexCh, worktree: worktreeCh)
+            if let badge { map[path] = badge }
+        }
+
+        cache[key] = (Date(), map)
+        return map
+    }
+
+    func invalidate(forWorktreePath worktree: URL) {
+        cache.removeValue(forKey: worktree.path)
+    }
+
+    func invalidateAll() {
+        cache.removeAll()
+    }
+
+    /// Map porcelain XY codes to a single badge. Untracked (`??`) → nil
+    /// (the design's empty-state sort uses badges only; untracked files
+    /// don't get one).
+    private func badge(forIndex i: Character, worktree w: Character) -> GitStatusBadge? {
+        // Renames passed `--no-renames` will appear as D+A pairs instead;
+        // we still keep R in the enum for completeness in case we change
+        // the flag later.
+        switch (i, w) {
+        case ("?", "?"): return nil
+        case ("!", "!"): return nil
+        case ("M", _),  (_, "M"): return .modified
+        case ("A", _),  (_, "A"): return .added
+        case ("D", _),  (_, "D"): return .deleted
+        case ("R", _),  (_, "R"): return .renamed
+        default: return nil
+        }
+    }
+}

--- a/Alas/Sources/Search/SearchKind.swift
+++ b/Alas/Sources/Search/SearchKind.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum SearchKind: String, CaseIterable, Sendable {
+    case files
+    case content
+}

--- a/Alas/Sources/Search/SearchModel.swift
+++ b/Alas/Sources/Search/SearchModel.swift
@@ -1,0 +1,266 @@
+import Foundation
+import Observation
+
+/// A worktree the search dialog can target. Decoupled from `Worktree` so
+/// the model is testable without the full `AppState`.
+struct SearchWorktree: Equatable, Sendable, Identifiable {
+    let id: String
+    let projectId: String
+    let displayName: String
+    let absolutePath: URL
+}
+
+/// All inputs SearchModel needs from the rest of the app, isolated for
+/// testing. Closures capture `AppState` in production wiring.
+struct SearchEnvironment: Sendable {
+    var currentWorktreeId: @Sendable () -> String?
+    var allWorktrees: @Sendable () -> [SearchWorktree]
+    var entries: @Sendable (SearchWorktree) async throws -> [FileIndex.Entry]
+    var statuses: @Sendable (SearchWorktree) async throws -> [String: GitStatusBadge]
+}
+
+/// Bundle of what the dialog renders — keeps the model's published surface
+/// to one type so views observe a single property.
+struct SearchResults: Equatable, Sendable {
+    var fileResults: [FileSearchResult] = []
+    var contentGroups: [ContentSearchGroup] = []
+    /// Set when at least one worktree's enumeration failed in `.allRepos`.
+    /// Rendered as an inline banner above results.
+    var partialFailureMessage: String? = nil
+}
+
+@Observable
+@MainActor
+final class SearchModel {
+    var isOpen: Bool = false
+    // didSets gate on `isOpen` so that the resets in `close()` (which set
+    // these properties back to defaults) don't kick off a debounced search
+    // for a hidden dialog. `open()` calls `reschedule()` explicitly after
+    // seeding all the defaults.
+    var query: String = "" {
+        didSet { if isOpen { onQueryChanged() } }
+    }
+    var kind: SearchKind = .files {
+        didSet { if isOpen { reschedule() } }
+    }
+    var scope: SearchScope = .thisWorktree {
+        didSet { if isOpen { reschedule() } }
+    }
+    var selectedIndex: Int = 0
+    private(set) var results: SearchResults = SearchResults()
+    private(set) var isLoading: Bool = false
+
+    /// Total selectable rows across both modes, used by the view's keyboard
+    /// handler to clamp Up/Down. In files mode it's `fileResults.count`; in
+    /// content mode it's the total hit count across groups.
+    var totalResultRows: Int {
+        switch kind {
+        case .files:   return results.fileResults.count
+        case .content: return results.contentGroups.reduce(0) { $0 + $1.hits.count }
+        }
+    }
+
+    /// Trimmed query — strips the `> ` prefix used to invoke content mode
+    /// and caps length to avoid pathological matching on huge inputs.
+    var trimmedQuery: String {
+        let stripped = query.hasPrefix("> ") ? String(query.dropFirst(2)) : query
+        return stripped.count > 200 ? String(stripped.prefix(200)) : stripped
+    }
+
+    private let env: SearchEnvironment
+    private var searchTask: Task<Void, Never>?
+    private var taskGeneration: Int = 0
+    private let fileDebounce: UInt64 = 30_000_000     // 30ms in ns
+    private let contentDebounce: UInt64 = 120_000_000 // 120ms in ns
+    private var idleContinuations: [CheckedContinuation<Void, Never>] = []
+
+    init(environment: SearchEnvironment) {
+        self.env = environment
+    }
+
+    func open() {
+        isOpen = true
+        query = ""
+        kind = .files
+        selectedIndex = 0
+        scope = (env.currentWorktreeId() != nil) ? .thisWorktree : .allRepos
+        results = SearchResults()
+        reschedule()
+    }
+
+    func close() {
+        isOpen = false
+        searchTask?.cancel()
+        searchTask = nil
+        results = SearchResults()
+        query = ""
+    }
+
+    func toggleKind() {
+        kind = (kind == .files) ? .content : .files
+    }
+
+    /// Awaits the next scheduled search to settle. Test helper.
+    func waitForIdle() async {
+        if searchTask == nil && !isLoading { return }
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            idleContinuations.append(cont)
+        }
+    }
+
+    // MARK: - Internals
+
+    private func onQueryChanged() {
+        // VSCode-style content-mode prefix.
+        if query.hasPrefix("> ") && kind == .files {
+            kind = .content
+            return // setting kind triggers reschedule
+        }
+        reschedule()
+    }
+
+    private func reschedule() {
+        searchTask?.cancel()
+        let snapshotKind = kind
+        let snapshotScope = scope
+        let snapshotQuery = trimmedQuery
+        taskGeneration &+= 1
+        let myGeneration = taskGeneration
+
+        searchTask = Task { [weak self] in
+            guard let self else { return }
+            let debounce = (snapshotKind == .files) ? self.fileDebounce : self.contentDebounce
+            try? await Task.sleep(nanoseconds: debounce)
+            if Task.isCancelled { return }
+            await self.runSearch(kind: snapshotKind, scope: snapshotScope, query: snapshotQuery)
+            if Task.isCancelled { return }
+            self.signalIdle()
+            // Only clear if no newer reschedule has supplanted this one.
+            if self.taskGeneration == myGeneration {
+                self.searchTask = nil
+            }
+        }
+    }
+
+    private func runSearch(kind: SearchKind, scope: SearchScope, query: String) async {
+        isLoading = true
+        defer { isLoading = false }
+
+        let targets: [SearchWorktree]
+        switch scope {
+        case .thisWorktree:
+            if let id = env.currentWorktreeId(),
+               let wt = env.allWorktrees().first(where: { $0.id == id }) {
+                targets = [wt]
+            } else {
+                targets = []
+            }
+        case .allRepos:
+            targets = env.allWorktrees()
+        }
+
+        switch kind {
+        case .files:
+            await runFileSearch(query: query, targets: targets)
+        case .content:
+            // Phase 2 wires the Content tab visually but produces no hits;
+            // Phase 3 plugs in the ripgrep backend. For Phase 1 the Content
+            // tab isn't reachable from the UI, so this branch should be
+            // unreachable in practice — but keep results empty rather than
+            // crashing.
+            results.fileResults = []
+            results.contentGroups = []
+        }
+
+        if selectedIndex >= totalResultRows {
+            selectedIndex = 0
+        }
+    }
+
+    private func runFileSearch(query: String, targets: [SearchWorktree]) async {
+        var rows: [FileSearchResult] = []
+        var failures: [String] = []
+        var sinceCancelCheck = 0
+        for wt in targets {
+            do {
+                async let entriesTask = env.entries(wt)
+                async let statusTask = env.statuses(wt)
+                let entries = try await entriesTask
+                let statuses = (try? await statusTask) ?? [:]
+                if Task.isCancelled { return }
+
+                for entry in entries {
+                    // Cooperative cancellation inside the scoring loop —
+                    // a large worktree (or `.allRepos`) can have tens of
+                    // thousands of entries; without periodic checks a
+                    // stale task keeps scoring and overwrites a newer
+                    // task's results when it eventually publishes.
+                    sinceCancelCheck &+= 1
+                    if sinceCancelCheck >= 256 {
+                        sinceCancelCheck = 0
+                        if Task.isCancelled { return }
+                    }
+                    let badge = statuses[entry.relativePath]
+                    if query.isEmpty {
+                        rows.append(FileSearchResult(
+                            worktreeId: wt.id,
+                            projectId: wt.projectId,
+                            relativePath: entry.relativePath,
+                            ext: entry.ext,
+                            statusBadge: badge,
+                            matchIndices: [],
+                            score: badge != nil ? 100 : 0
+                        ))
+                    } else if let m = FuzzyMatch.score(query: query, target: entry.relativePath) {
+                        let slash = entry.relativePath.lastIndex(of: "/")
+                        let prefixLen = slash.map { entry.relativePath.distance(from: entry.relativePath.startIndex, to: $0) + 1 } ?? 0
+                        let inName = m.indices.allSatisfy { $0 >= prefixLen }
+                        let score = m.score + (inName ? 8 : 0) + (badge != nil ? 2 : 0)
+                        rows.append(FileSearchResult(
+                            worktreeId: wt.id,
+                            projectId: wt.projectId,
+                            relativePath: entry.relativePath,
+                            ext: entry.ext,
+                            statusBadge: badge,
+                            matchIndices: m.indices,
+                            score: score
+                        ))
+                    }
+                }
+            } catch {
+                failures.append(wt.displayName)
+            }
+        }
+
+        if query.isEmpty {
+            // Status-tagged files first, then alphabetical.
+            rows.sort { lhs, rhs in
+                if (lhs.statusBadge != nil) != (rhs.statusBadge != nil) {
+                    return lhs.statusBadge != nil
+                }
+                return lhs.relativePath.localizedStandardCompare(rhs.relativePath) == .orderedAscending
+            }
+        } else {
+            rows.sort { $0.score > $1.score }
+        }
+
+        let capped = Array(rows.prefix(50))
+        // Final cancellation check before publishing — stops a stale task
+        // from clobbering a newer query's results during the time we spent
+        // sorting/capping.
+        if Task.isCancelled { return }
+        results = SearchResults(
+            fileResults: capped,
+            contentGroups: [],
+            partialFailureMessage: failures.isEmpty
+                ? nil
+                : "Couldn't read files for \(failures.joined(separator: ", "))"
+        )
+    }
+
+    private func signalIdle() {
+        let conts = idleContinuations
+        idleContinuations.removeAll()
+        for c in conts { c.resume() }
+    }
+}

--- a/Alas/Sources/Search/SearchResult.swift
+++ b/Alas/Sources/Search/SearchResult.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// A file-mode result row. `worktreeId` is needed so we can route
+/// open-actions back to the correct worktree, and so SwiftUI list ids
+/// stay unique across worktrees in `.allRepos` scope.
+struct FileSearchResult: Identifiable, Equatable, Sendable {
+    let worktreeId: String
+    let projectId: String
+    /// Repo-relative path (e.g., `crates/alas-gui/src/main.rs`).
+    let relativePath: String
+    /// Filename extension without leading dot, lowercased (e.g., `rs`, `toml`).
+    let ext: String
+    /// `git status --porcelain` short code: M / A / D / R, or nil.
+    let statusBadge: GitStatusBadge?
+    /// Indices into `relativePath` of fuzzy-matched characters. Empty when
+    /// query is empty.
+    let matchIndices: [Int]
+    let score: Double
+
+    var id: String { worktreeId + ":" + relativePath }
+}
+
+enum GitStatusBadge: String, Sendable {
+    case modified = "M"
+    case added    = "A"
+    case deleted  = "D"
+    case renamed  = "R"
+}
+
+/// A single content-search hit. `groupKey` is `worktreeId + relativePath`,
+/// used to bucket hits into `ContentSearchGroup`s.
+struct ContentSearchHit: Identifiable, Equatable, Sendable {
+    let worktreeId: String
+    let projectId: String
+    let relativePath: String
+    let line: Int
+    let column: Int
+    let snippet: String
+    let matchByteRange: Range<Int>?
+
+    var id: String { "\(worktreeId):\(relativePath):\(line):\(column)" }
+    var groupKey: String { "\(worktreeId):\(relativePath)" }
+}
+
+struct ContentSearchGroup: Identifiable, Equatable, Sendable {
+    let worktreeId: String
+    let projectId: String
+    let relativePath: String
+    var hits: [ContentSearchHit]
+
+    var id: String { "\(worktreeId):\(relativePath)" }
+}

--- a/Alas/Sources/Search/SearchScope.swift
+++ b/Alas/Sources/Search/SearchScope.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+enum SearchScope: String, CaseIterable, Sendable {
+    case thisWorktree
+    case allRepos
+
+    var displayName: String {
+        switch self {
+        case .thisWorktree: return "This worktree"
+        case .allRepos:     return "All repos"
+        }
+    }
+}

--- a/Alas/Sources/Search/Views/FileResultRow.swift
+++ b/Alas/Sources/Search/Views/FileResultRow.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+/// Maps a file extension to a small colored 2-3 letter label, mirroring
+/// the design's `.fs-ext` element. Unknown extensions get a neutral label.
+private func extLabel(_ ext: String, theme: Theme) -> (Color, String) {
+    switch ext {
+    case "rs":        return (theme.color("del"),  "RS")
+    case "toml":      return (theme.color("info").opacity(0.85), "TOML")
+    case "md":        return (theme.color("info"), "MD")
+    case "swift":     return (theme.color("warn"), "SWFT")
+    case "ts", "tsx": return (theme.color("info"), "TS")
+    case "js", "jsx": return (theme.color("mod"),  "JS")
+    case "rb":        return (theme.color("del"),  "RB")
+    case "":          return (theme.color("fg-faint"), "—")
+    default:          return (theme.color("fg-faint"), String(ext.prefix(3)).uppercased())
+    }
+}
+
+struct FileResultRow: View {
+    let result: FileSearchResult
+    let isSelected: Bool
+    let showsRepoBadge: Bool
+    let repoName: String?
+    let onTap: () -> Void
+    let onHover: () -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        let (color, label) = extLabel(result.ext, theme: theme)
+        let parts = splitPath(result.relativePath)
+
+        HStack(spacing: 10) {
+            ExtBadge(label: label, color: color)
+            Highlighted(
+                text: parts.name,
+                indices: indicesIn(range: parts.dirLength..<result.relativePath.count)
+                    .map { $0 - parts.dirLength }
+            )
+            .font(.system(size: 12.5, weight: .medium, design: .monospaced))
+            .foregroundColor(theme.color("fg"))
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
+            Highlighted(
+                text: parts.dir,
+                indices: indicesIn(range: 0..<parts.dirLength)
+            )
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundColor(theme.color("fg-faint"))
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            if showsRepoBadge, let repoName {
+                Text(repoName)
+                    .font(.system(size: 10, design: .monospaced))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(theme.color("bg-3"))
+                    .foregroundColor(theme.color("fg-faint"))
+                    .clipShape(Capsule())
+            }
+            if let badge = result.statusBadge {
+                StatusBadgeView(badge: badge)
+            }
+            if isSelected {
+                SearchKbd(label: "↵")
+            }
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 28)
+        .background(
+            isSelected
+                ? theme.color("accent-soft")
+                : Color.clear
+        )
+        .overlay(
+            Rectangle()
+                .fill(isSelected ? theme.color("accent") : Color.clear)
+                .frame(width: 2)
+                .frame(maxHeight: .infinity),
+            alignment: .leading
+        )
+        .contentShape(Rectangle())
+        .onHover { hovering in if hovering { onHover() } }
+        .onTapGesture { onTap() }
+    }
+
+    private func indicesIn(range: Range<Int>) -> [Int] {
+        result.matchIndices.filter { range.contains($0) }
+    }
+
+    private func splitPath(_ p: String) -> (dir: String, name: String, dirLength: Int) {
+        if let slash = p.lastIndex(of: "/") {
+            let dir = String(p[..<slash]) + "/"
+            let name = String(p[p.index(after: slash)...])
+            return (dir, name, dir.count)
+        }
+        return ("", p, 0)
+    }
+}
+
+private struct ExtBadge: View {
+    let label: String
+    let color: Color
+    var body: some View {
+        Text(label)
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .tracking(0.5)
+            .frame(width: 36, height: 16)
+            .foregroundColor(color)
+            .overlay(
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .strokeBorder(color.opacity(0.33), lineWidth: 0.5)
+            )
+    }
+}
+
+private struct StatusBadgeView: View {
+    let badge: GitStatusBadge
+    @Environment(\.theme) private var theme
+    var body: some View {
+        let color: Color = {
+            switch badge {
+            case .modified: return theme.color("mod")
+            case .added:    return theme.color("add")
+            case .deleted:  return theme.color("del")
+            case .renamed:  return theme.color("info")
+            }
+        }()
+        return Text(badge.rawValue)
+            .font(.system(size: 9.5, weight: .bold, design: .monospaced))
+            .padding(.horizontal, 4)
+            .frame(height: 14)
+            .background(color.opacity(0.20))
+            .foregroundColor(color)
+            .clipShape(RoundedRectangle(cornerRadius: 2.5, style: .continuous))
+    }
+}
+

--- a/Alas/Sources/Search/Views/FileSearchDialog.swift
+++ b/Alas/Sources/Search/Views/FileSearchDialog.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// Top-level overlay dialog. Renders as a full-screen translucent backdrop
+/// with a centered card that animates in. Pass `appState` for open-action
+/// routing.
+struct FileSearchDialog: View {
+    @Bindable var appState: AppState
+    @Environment(\.theme) private var theme
+    @FocusState private var inputFocused: Bool
+
+    var body: some View {
+        if appState.isSearchOpen {
+            ZStack {
+                Color.black.opacity(0.42)
+                    .ignoresSafeArea()
+                    .onTapGesture { close() }
+
+                VStack(spacing: 0) {
+                    SearchInputRow(model: appState.search, inputFocused: $inputFocused)
+                    ScopeRow(
+                        model: appState.search,
+                        isThisWorktreeAvailable: appState.selectedWorktreeId != nil
+                    )
+                    if let banner = appState.search.results.partialFailureMessage {
+                        BannerRow(text: banner)
+                    }
+                    resultList
+                    SearchFooter(model: appState.search, showsKindToggle: false)
+                }
+                .frame(width: 720)
+                .frame(maxHeight: 520)
+                .background(theme.color("bg-1").opacity(0.92))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                )
+                .shadow(color: .black.opacity(0.5), radius: 30, x: 0, y: 20)
+                .padding(.top, 70)
+                .frame(maxHeight: .infinity, alignment: .top)
+                .onTapGesture { /* swallow taps so backdrop doesn't close */ }
+                .onKeyPress { press in handleKey(press) }
+            }
+            .transition(.opacity.combined(with: .offset(y: -6)))
+            .onAppear { inputFocused = true }
+        }
+    }
+
+    @ViewBuilder
+    private var resultList: some View {
+        let model = appState.search
+        if model.totalResultRows == 0 {
+            SearchEmptyState(model: model)
+                .frame(minHeight: 240, maxHeight: 460)
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(model.results.fileResults.enumerated()), id: \.element.id) { idx, r in
+                            FileResultRow(
+                                result: r,
+                                isSelected: idx == model.selectedIndex,
+                                showsRepoBadge: model.scope == .allRepos,
+                                repoName: repoName(for: r),
+                                onTap: { open(r) },
+                                onHover: { model.selectedIndex = idx }
+                            )
+                            .id(idx)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .frame(minHeight: 240, maxHeight: 460)
+                .onChange(of: model.selectedIndex) { _, new in
+                    proxy.scrollTo(new, anchor: .center)
+                }
+            }
+        }
+    }
+
+    private func repoName(for r: FileSearchResult) -> String? {
+        appState.projects.first(where: { $0.id == r.projectId })?.name
+    }
+
+    private func handleKey(_ press: KeyPress) -> KeyPress.Result {
+        let model = appState.search
+        switch press.key {
+        case .escape:
+            close()
+            return .handled
+        case .upArrow:
+            model.selectedIndex = max(0, model.selectedIndex - 1)
+            return .handled
+        case .downArrow:
+            model.selectedIndex = min(max(0, model.totalResultRows - 1), model.selectedIndex + 1)
+            return .handled
+        case .return:
+            if let row = model.results.fileResults[safe: model.selectedIndex] {
+                open(row)
+            }
+            return .handled
+        default:
+            return .ignored
+        }
+    }
+
+    private func open(_ r: FileSearchResult) {
+        appState.openFile(relativePath: r.relativePath, worktreeId: r.worktreeId)
+        close()
+    }
+
+    private func close() {
+        appState.search.close()
+        appState.isSearchOpen = false
+    }
+}
+
+private struct BannerRow: View {
+    let text: String
+    @Environment(\.theme) private var theme
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11))
+            .foregroundColor(theme.color("warn"))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 6)
+            .background(theme.color("warn").opacity(0.10))
+            .overlay(
+                Rectangle()
+                    .fill(theme.color("line-soft"))
+                    .frame(height: 0.5),
+                alignment: .bottom
+            )
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Alas/Sources/Search/Views/Highlighted.swift
+++ b/Alas/Sources/Search/Views/Highlighted.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Renders `text` with characters at `indices` highlighted. The highlight
+/// color is `mod` (slightly muted vs. design's brighter variant — close
+/// enough for v1 without per-theme JSON edits).
+///
+/// Indices are grapheme-cluster positions, matching what `FuzzyMatch`
+/// produces via `Array(target).enumerated()`.
+struct Highlighted: View {
+    let text: String
+    let indices: [Int]
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        let set = Set(indices)
+        var attributed = AttributedString(text)
+        for (i, _) in text.enumerated() where set.contains(i) {
+            let start = attributed.index(attributed.startIndex, offsetByCharacters: i)
+            let end   = attributed.index(start, offsetByCharacters: 1)
+            attributed[start..<end].foregroundColor = theme.color("mod")
+            attributed[start..<end].font = .system(
+                size: NSFont.systemFontSize,
+                weight: .heavy,
+                design: .monospaced
+            )
+        }
+        return Text(attributed)
+    }
+}

--- a/Alas/Sources/Search/Views/ScopeRow.swift
+++ b/Alas/Sources/Search/Views/ScopeRow.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+struct ScopeRow: View {
+    @Bindable var model: SearchModel
+    let isThisWorktreeAvailable: Bool
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("SCOPE")
+                .font(.system(size: 9.5, weight: .medium))
+                .tracking(0.5)
+                .foregroundColor(theme.color("fg-faint"))
+            HStack(spacing: 3) {
+                pill(.thisWorktree, enabled: isThisWorktreeAvailable)
+                pill(.allRepos,     enabled: true)
+            }
+            Spacer(minLength: 0)
+            Text(countText)
+                .font(.system(size: 10.5).monospacedDigit())
+                .foregroundColor(theme.color("fg-faint"))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 7)
+        .background(theme.color("bg-2").opacity(0.4))
+        .overlay(
+            Rectangle()
+                .fill(theme.color("line-soft"))
+                .frame(height: 0.5),
+            alignment: .bottom
+        )
+    }
+
+    private func pill(_ scope: SearchScope, enabled: Bool) -> some View {
+        let isOn = model.scope == scope
+        return Button {
+            model.scope = scope
+        } label: {
+            Text(scope.displayName)
+                .font(.system(size: 11, weight: .medium))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .fill(isOn ? theme.color("accent-soft") : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .strokeBorder(
+                            isOn ? theme.color("accent").opacity(0.35) : Color.clear,
+                            lineWidth: 0.5
+                        )
+                )
+                .foregroundColor(
+                    enabled
+                        ? (isOn ? theme.color("accent") : theme.color("fg-dim"))
+                        : theme.color("fg-faint").opacity(0.5)
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+    }
+
+    private var countText: String {
+        let n = model.totalResultRows
+        switch model.kind {
+        case .files:   return "\(n) \(n == 1 ? "file"  : "files")"
+        case .content: return "\(n) \(n == 1 ? "match" : "matches")"
+        }
+    }
+}

--- a/Alas/Sources/Search/Views/SearchEmptyState.swift
+++ b/Alas/Sources/Search/Views/SearchEmptyState.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct SearchEmptyState: View {
+    @Bindable var model: SearchModel
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 22, weight: .light))
+                .foregroundColor(theme.color("fg-faint"))
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(theme.color("fg-dim"))
+                .padding(.top, 4)
+            Text(subtitle)
+                .font(.system(size: 11.5))
+                .foregroundColor(theme.color("fg-faint"))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 360)
+                .lineSpacing(2)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 60)
+        .padding(.horizontal, 30)
+    }
+
+    private var title: String {
+        if !model.trimmedQuery.isEmpty { return "No matches" }
+        switch model.kind {
+        case .files:   return "Recent files"
+        case .content: return "Type to search contents"
+        }
+    }
+
+    private var subtitle: String {
+        if !model.trimmedQuery.isEmpty {
+            let where_: String
+            switch model.scope {
+            case .thisWorktree: where_ = "this worktree"
+            case .allRepos:     where_ = "any repo"
+            }
+            return "Nothing in \(where_) matches \u{201C}\(model.trimmedQuery)\u{201D}."
+        }
+        switch model.kind {
+        case .files:   return "Start typing to fuzzy-match a path."
+        case .content: return "Search across all tracked files. Tab to switch back to filenames."
+        }
+    }
+}

--- a/Alas/Sources/Search/Views/SearchFooter.swift
+++ b/Alas/Sources/Search/Views/SearchFooter.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Bottom hint row showing keyboard affordances. Phase 1 ships only the
+/// three honored hints: open, mode-toggle (hidden when content tab is
+/// not yet rendered), close. The mode-toggle is added in Phase 2.
+struct SearchFooter: View {
+    @Bindable var model: SearchModel
+    let showsKindToggle: Bool
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 16) {
+            HStack(spacing: 5) {
+                SearchKbd(label: "↵")
+                Text("open").font(.system(size: 10.5))
+                    .foregroundColor(theme.color("fg-faint"))
+            }
+            if showsKindToggle {
+                HStack(spacing: 5) {
+                    SearchKbd(label: "⇥")
+                    Text(model.kind == .files ? "content" : "files")
+                        .font(.system(size: 10.5))
+                        .foregroundColor(theme.color("fg-faint"))
+                }
+            }
+            HStack(spacing: 5) {
+                SearchKbd(label: "esc")
+                Text("close").font(.system(size: 10.5))
+                    .foregroundColor(theme.color("fg-faint"))
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 7)
+        .background(theme.color("bg-2").opacity(0.5))
+        .overlay(
+            Rectangle()
+                .fill(theme.color("line-soft"))
+                .frame(height: 0.5),
+            alignment: .top
+        )
+    }
+}

--- a/Alas/Sources/Search/Views/SearchInputRow.swift
+++ b/Alas/Sources/Search/Views/SearchInputRow.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct SearchInputRow: View {
+    @Bindable var model: SearchModel
+    @FocusState.Binding var inputFocused: Bool
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12, weight: .regular))
+                .foregroundColor(theme.color("fg-dim"))
+            TextField(placeholderText, text: $model.query)
+                .textFieldStyle(.plain)
+                .focused($inputFocused)
+                .font(.system(size: 15))
+                .foregroundColor(theme.color("fg"))
+                .autocorrectionDisabled(true)
+            if !model.query.isEmpty {
+                Button {
+                    model.query = ""
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .frame(width: 18, height: 18)
+                        .foregroundColor(theme.color("fg-dim"))
+                        .background(Circle().fill(theme.color("bg-3")))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .overlay(
+            Rectangle()
+                .fill(theme.color("line-soft"))
+                .frame(height: 0.5),
+            alignment: .bottom
+        )
+    }
+
+    private var placeholderText: String {
+        switch model.kind {
+        case .files:   return "Search files by name…"
+        case .content: return "Search file contents…"
+        }
+    }
+}

--- a/Alas/Sources/Search/Views/SearchKbd.swift
+++ b/Alas/Sources/Search/Views/SearchKbd.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Small key-cap pill used in the dialog's footer. Mirrors the design's
+/// `.fs-kbd` style: minimum 16px wide, 16px tall, soft border, dim text.
+struct SearchKbd: View {
+    let label: String
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 10, weight: .medium))
+            .foregroundColor(theme.color("fg-faint"))
+            .padding(.horizontal, 3)
+            .frame(minWidth: 16, minHeight: 16)
+            .background(
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .fill(theme.color("bg-3"))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .strokeBorder(theme.color("line-soft"), lineWidth: 0.5)
+            )
+    }
+}

--- a/AlasTests/FileIndexTests.swift
+++ b/AlasTests/FileIndexTests.swift
@@ -1,0 +1,82 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct FileIndexTests {
+    private func makeRepo() async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-fi-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        // Identity needed for commits in CI.
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "Test"], cwd: dir)
+        return dir
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    @Test func enumeratesTrackedFiles() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try write("hi", to: repo.appendingPathComponent("a.txt"))
+        try write("hi", to: repo.appendingPathComponent("nested/b.txt"))
+        _ = try await Process.git(["add", "."], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+
+        let entries = try await FileIndex().entries(forWorktreePath: repo)
+        let paths = entries.map(\.relativePath).sorted()
+        #expect(paths == ["a.txt", "nested/b.txt"])
+    }
+
+    @Test func includesUntrackedRespectsGitignore() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try write("ignored\n", to: repo.appendingPathComponent(".gitignore"))
+        _ = try await Process.git(["add", ".gitignore"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try write("hi", to: repo.appendingPathComponent("tracked.txt"))
+        try write("hi", to: repo.appendingPathComponent("ignored"))
+        try write("hi", to: repo.appendingPathComponent("untracked.txt"))
+
+        let entries = try await FileIndex().entries(forWorktreePath: repo)
+        let paths = Set(entries.map(\.relativePath))
+        #expect(paths.contains(".gitignore"))
+        #expect(paths.contains("tracked.txt"))
+        #expect(paths.contains("untracked.txt"))
+        #expect(!paths.contains("ignored"))
+    }
+
+    @Test func extIsLowercaseAndNoDot() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try write("hi", to: repo.appendingPathComponent("Foo.RS"))
+        try write("hi", to: repo.appendingPathComponent("Bar.toml"))
+        try write("hi", to: repo.appendingPathComponent("Makefile"))
+
+        let entries = try await FileIndex().entries(forWorktreePath: repo)
+        let byPath = Dictionary(uniqueKeysWithValues: entries.map { ($0.relativePath, $0.ext) })
+        #expect(byPath["Foo.RS"] == "rs")
+        #expect(byPath["Bar.toml"] == "toml")
+        #expect(byPath["Makefile"] == "")
+    }
+
+    @Test func enumeratesNonAsciiPaths() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let nonAscii = "résumé.txt"
+        try write("hi", to: repo.appendingPathComponent(nonAscii))
+        _ = try await Process.git(["add", "."], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+
+        let entries = try await FileIndex().entries(forWorktreePath: repo)
+        #expect(entries.contains(where: { $0.relativePath == nonAscii }))
+    }
+}

--- a/AlasTests/FuzzyMatchTests.swift
+++ b/AlasTests/FuzzyMatchTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct FuzzyMatchTests {
+    @Test func emptyQueryReturnsZeroScoreNoIndices() {
+        let m = FuzzyMatch.score(query: "", target: "anything")
+        #expect(m != nil)
+        #expect(m?.score == 0)
+        #expect(m?.indices.isEmpty == true)
+    }
+
+    @Test func nonSubsequenceReturnsNil() {
+        #expect(FuzzyMatch.score(query: "xyz", target: "tab_bar.rs") == nil)
+    }
+
+    @Test func emptyTargetWithNonEmptyQueryReturnsNil() {
+        #expect(FuzzyMatch.score(query: "x", target: "") == nil)
+    }
+
+    @Test func startOfSegmentBonusFiresAfterDelimiters() {
+        // "tb" matches t at index 0 (start) and b at index 4 (after _).
+        // Both should earn the +4 segment bonus.
+        let m = FuzzyMatch.score(query: "tb", target: "tab_bar.rs")
+        #expect(m != nil)
+        #expect(m?.indices == [0, 4])
+        // Two segment bonuses (+8) + small adjustments for span/start.
+        #expect((m?.score ?? 0) >= 7.5)
+    }
+
+    @Test func contiguousRunBeatsScattered() {
+        // "tab" as a contiguous run vs. "tbr" scattered across tab_bar.rs.
+        let contiguous = FuzzyMatch.score(query: "tab", target: "tab_bar.rs")
+        let scattered  = FuzzyMatch.score(query: "tbr", target: "tab_bar.rs")
+        #expect(contiguous != nil)
+        #expect(scattered != nil)
+        #expect((contiguous?.score ?? 0) > (scattered?.score ?? 0))
+    }
+
+    @Test func capitalMatchBonus() {
+        let m = FuzzyMatch.score(query: "DS", target: "DragState")
+        #expect(m != nil)
+        #expect(m?.indices == [0, 4])
+    }
+
+    @Test func earlierMatchWinsOverLater() {
+        let early = FuzzyMatch.score(query: "ab", target: "ab_xxx_xxx")!
+        let late  = FuzzyMatch.score(query: "ab", target: "xxx_xxx_ab")!
+        #expect(early.score > late.score)
+    }
+
+    @Test func tighterMatchWinsOverSpread() {
+        let tight  = FuzzyMatch.score(query: "tb", target: "tab")!
+        let spread = FuzzyMatch.score(query: "tb", target: "txxxxxb")!
+        #expect(tight.score > spread.score)
+    }
+
+    @Test func indicesAreInOrderAndUnique() {
+        let m = FuzzyMatch.score(query: "ape", target: "alphabet_pen")!
+        #expect(m.indices.count == 3)
+        // Strictly increasing.
+        for i in 1..<m.indices.count {
+            #expect(m.indices[i] > m.indices[i - 1])
+        }
+    }
+
+    @Test func caseInsensitiveMatching() {
+        let m = FuzzyMatch.score(query: "abc", target: "ABC.txt")
+        #expect(m?.indices == [0, 1, 2])
+    }
+
+    @Test func preferredPositionDoesNotStrandRemainder() {
+        // Regression: query "abz" against "axbz_b" passes isSubsequence
+        // (a@0, b@2, z@3). The greedy preferred-position pick used to
+        // jump to b@5 (segment start after `_`), leaving no room for
+        // 'z' afterward and trapping on a force-unwrap. The fix gates
+        // preferred selection on canMatchRemainder.
+        let m = FuzzyMatch.score(query: "abz", target: "axbz_b")
+        #expect(m != nil)
+        #expect(m?.indices == [0, 2, 3])
+    }
+
+    @Test func multiBlockMatchScoresAllContiguousPairs() {
+        // Regression: "abcd" against "ab_cd" has two contiguous blocks
+        // (ab and cd). Earlier versions reset the run counter on the gap
+        // between them and only credited the final block, scoring a
+        // multi-block match identically to a single-block one. The
+        // accumulator now sums pair counts across all blocks.
+        let multiBlock  = FuzzyMatch.score(query: "abcd", target: "ab_cd")!
+        let singleBlock = FuzzyMatch.score(query: "ad", target: "a___d")!
+        // multiBlock has 2 pairs (ab + cd) → +8 run bonus.
+        // singleBlock has 0 pairs → 0 run bonus. Plus segment-start bonuses
+        // and penalties — but the contiguity premium should make multiBlock
+        // strictly higher than what it would score with the old single-block
+        // accumulator (which was equivalent to 1 pair, i.e. +4).
+        #expect(multiBlock.score > singleBlock.score)
+        // Sanity: 2-pair credit, not 1-pair. With the bug, the score would
+        // be `bonus + 4 - 2*0.1 - 0`. With the fix, it's `bonus + 8 - ...`.
+        // bonus = +4 (segStart at 0) + 4 (segStart at 3 after `_`) = 8.
+        // span = 4 - 0 = 4 → -0.4. start = 0 → 0. score = 8 + 8 - 0.4 = 15.6.
+        #expect(abs(multiBlock.score - 15.6) < 0.001)
+    }
+}

--- a/AlasTests/GitStatusCacheTests.swift
+++ b/AlasTests/GitStatusCacheTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct GitStatusCacheTests {
+    private func makeRepoWithCommit() async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-gs-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "Test"], cwd: dir)
+        try "hello\n".write(to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: dir)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: dir)
+        return dir
+    }
+
+    @Test func modifiedFileSurfacesAsM() async throws {
+        let repo = try await makeRepoWithCommit()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "changed\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let cache = GitStatusCache()
+        let map = try await cache.statuses(forWorktreePath: repo)
+        #expect(map["a.txt"] == .modified)
+    }
+
+    @Test func untrackedNotSurfacedAsBadge() async throws {
+        let repo = try await makeRepoWithCommit()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "x".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        let cache = GitStatusCache()
+        let map = try await cache.statuses(forWorktreePath: repo)
+        // Untracked files are not in the M/A/D/R badge set; they have no entry.
+        #expect(map["new.txt"] == nil)
+    }
+
+    @Test func stagedAddSurfacesAsA() async throws {
+        let repo = try await makeRepoWithCommit()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "x".write(to: repo.appendingPathComponent("new.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "new.txt"], cwd: repo)
+        let cache = GitStatusCache()
+        let map = try await cache.statuses(forWorktreePath: repo)
+        #expect(map["new.txt"] == .added)
+    }
+
+    @Test func deletedSurfacesAsD() async throws {
+        let repo = try await makeRepoWithCommit()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try FileManager.default.removeItem(at: repo.appendingPathComponent("a.txt"))
+        let cache = GitStatusCache()
+        let map = try await cache.statuses(forWorktreePath: repo)
+        #expect(map["a.txt"] == .deleted)
+    }
+
+    @Test func nonAsciiPathSurfacesCorrectly() async throws {
+        let repo = try await makeRepoWithCommit()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let nonAscii = "src/résumé.txt"
+        try FileManager.default.createDirectory(
+            at: repo.appendingPathComponent("src"),
+            withIntermediateDirectories: true
+        )
+        try "x".write(to: repo.appendingPathComponent(nonAscii), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", nonAscii], cwd: repo)
+        let cache = GitStatusCache()
+        let map = try await cache.statuses(forWorktreePath: repo)
+        #expect(map[nonAscii] == .added)
+    }
+}

--- a/AlasTests/SearchModelTests.swift
+++ b/AlasTests/SearchModelTests.swift
@@ -1,0 +1,172 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct SearchModelTests {
+    private func makeEnv(
+        worktrees: [SearchWorktree] = [],
+        files: [String: [FileIndex.Entry]] = [:],
+        statuses: [String: [String: GitStatusBadge]] = [:]
+    ) -> SearchEnvironment {
+        SearchEnvironment(
+            currentWorktreeId: { worktrees.first?.id },
+            allWorktrees: { worktrees },
+            entries: { wt in files[wt.id] ?? [] },
+            statuses: { wt in statuses[wt.id] ?? [:] }
+        )
+    }
+
+    private func wt(_ id: String, projectId: String = "p1") -> SearchWorktree {
+        SearchWorktree(
+            id: id,
+            projectId: projectId,
+            displayName: "wt-\(id)",
+            absolutePath: URL(fileURLWithPath: "/tmp/\(id)")
+        )
+    }
+
+    @Test func openSeedsScopeFromCurrentWorktree() async {
+        var env = makeEnv(worktrees: [wt("a")])
+        let model = SearchModel(environment: env)
+        model.open()
+        #expect(model.scope == .thisWorktree)
+        #expect(model.kind == .files)
+        #expect(model.query == "")
+
+        env = SearchEnvironment(
+            currentWorktreeId: { nil },
+            allWorktrees: { [] },
+            entries: { _ in [] },
+            statuses: { _ in [:] }
+        )
+        let model2 = SearchModel(environment: env)
+        model2.open()
+        #expect(model2.scope == .allRepos)
+    }
+
+    @Test func emptyQueryInFilesModeShowsAllInThisWorktree() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [
+                .init(relativePath: "src/main.rs", ext: "rs"),
+                .init(relativePath: "README.md",  ext: "md"),
+            ]]
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        await model.waitForIdle()
+        #expect(model.results.fileResults.map(\.relativePath).sorted() == ["README.md", "src/main.rs"])
+    }
+
+    @Test func fuzzyQueryFiltersAndSortsByScore() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [
+                .init(relativePath: "tab_bar.rs",  ext: "rs"),
+                .init(relativePath: "tab_drag.rs", ext: "rs"),
+                .init(relativePath: "main.rs",     ext: "rs"),
+            ]]
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "tab"
+        await model.waitForIdle()
+        let paths = model.results.fileResults.map(\.relativePath)
+        #expect(paths.contains("tab_bar.rs"))
+        #expect(paths.contains("tab_drag.rs"))
+        #expect(!paths.contains("main.rs"))
+    }
+
+    @Test func selectionClampsOnResultShrink() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": (0..<10).map {
+                FileIndex.Entry(relativePath: "f\($0).rs", ext: "rs")
+            }]
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        await model.waitForIdle()
+        model.selectedIndex = 7
+        model.query = "f1"  // matches f1, f10..f19 — but only f1 exists; ~1 result.
+        await model.waitForIdle()
+        #expect(model.selectedIndex < model.totalResultRows)
+    }
+
+    @Test func contentPrefixFlipsKindToContent() async {
+        let env = makeEnv(worktrees: [wt("a")])
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "> foo"
+        #expect(model.kind == .content)
+        #expect(model.trimmedQuery == "foo")
+    }
+
+    @Test func toggleKindSwapsModeWithoutTouchingQuery() async {
+        let env = makeEnv(worktrees: [wt("a")])
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "abc"
+        model.toggleKind()
+        #expect(model.kind == .content)
+        #expect(model.query == "abc")
+        model.toggleKind()
+        #expect(model.kind == .files)
+    }
+
+    @Test func allReposScopeUnionsAcrossWorktrees() async {
+        let env = makeEnv(
+            worktrees: [wt("a"), wt("b", projectId: "p2")],
+            files: [
+                "a": [.init(relativePath: "x.rs", ext: "rs")],
+                "b": [.init(relativePath: "y.rs", ext: "rs")],
+            ]
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.scope = .allRepos
+        await model.waitForIdle()
+        let paths = Set(model.results.fileResults.map(\.relativePath))
+        #expect(paths == ["x.rs", "y.rs"])
+    }
+
+    @Test func resetClearsStateOnOpen() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [.init(relativePath: "x.rs", ext: "rs")]]
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "x"
+        model.kind = .content
+        model.selectedIndex = 0
+        model.open()
+        #expect(model.query == "")
+        #expect(model.kind == .files)
+        #expect(model.selectedIndex == 0)
+    }
+
+    @Test func waitForIdleReturnsImmediatelyWhenNothingScheduled() async {
+        let env = makeEnv(worktrees: [wt("a")])
+        let model = SearchModel(environment: env)
+        // No open() / no query change → no task scheduled.
+        // Should return ~immediately, not deadlock.
+        let started = Date()
+        await model.waitForIdle()
+        #expect(Date().timeIntervalSince(started) < 0.1)
+    }
+
+    @Test func waitForIdleAfterCompletedSearchDoesNotDeadlock() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            files: ["a": [.init(relativePath: "x.rs", ext: "rs")]]
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        await model.waitForIdle()      // first wait — completes
+        let started = Date()
+        await model.waitForIdle()      // second wait — must not park
+        #expect(Date().timeIntervalSince(started) < 0.1)
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
Adds a Cmd+P file search dialog with two scope pills (This worktree /
All repos), git-status badges, fuzzy-match highlighting, and keyboard
navigation. Files enumerated via `git ls-files -co --exclude-standard`.
Content search not yet present.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
<!-- gg:managed:end -->