### PR TITLE
feat(search): content search visual shell

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
 		A7BDA44A8E4364C4C335C4DA /* HookEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8820E4289EEB1ADCA9E490F /* HookEventTests.swift */; };
+		A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
 		AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */; };
@@ -326,6 +327,7 @@
 		C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Surface.swift; sourceTree = "<group>"; };
 		C995611A6313FABE30508248 /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
 		CA554728676F9D3B5E2C05FA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroup.swift; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
@@ -678,6 +680,7 @@
 		A1CA0BEB25542A9B175DBDFE /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */,
 				3375A79ACFD3567389DA855C /* FileResultRow.swift */,
 				F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */,
 				66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */,
@@ -1012,6 +1015,7 @@
 				0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */,
 				28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */,
 				0F560F9B2458B94C807E96A1 /* CodeTextView.swift in Sources */,
+				A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */,
 				49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */,
 				5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */,
 				90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */,

--- a/Alas/Sources/Search/SearchModel.swift
+++ b/Alas/Sources/Search/SearchModel.swift
@@ -19,6 +19,12 @@ struct SearchEnvironment: Sendable {
     var statuses: @Sendable (SearchWorktree) async throws -> [String: GitStatusBadge]
 }
 
+struct SearchContentOptions: Equatable, Sendable {
+    var caseSensitive: Bool = false
+    var wholeWord: Bool = false
+    var regex: Bool = false
+}
+
 /// Bundle of what the dialog renders — keeps the model's published surface
 /// to one type so views observe a single property.
 struct SearchResults: Equatable, Sendable {
@@ -39,6 +45,9 @@ final class SearchModel {
     // seeding all the defaults.
     var query: String = "" {
         didSet { if isOpen { onQueryChanged() } }
+    }
+    var contentOptions: SearchContentOptions = SearchContentOptions() {
+        didSet { if kind == .content { reschedule() } }
     }
     var kind: SearchKind = .files {
         didSet { if isOpen { reschedule() } }
@@ -163,13 +172,12 @@ final class SearchModel {
         case .files:
             await runFileSearch(query: query, targets: targets)
         case .content:
-            // Phase 2 wires the Content tab visually but produces no hits;
-            // Phase 3 plugs in the ripgrep backend. For Phase 1 the Content
-            // tab isn't reachable from the UI, so this branch should be
-            // unreachable in practice — but keep results empty rather than
-            // crashing.
-            results.fileResults = []
-            results.contentGroups = []
+            // Phase 2 makes the Content tab reachable visually (via tabs,
+            // Tab key, or `> ` prefix) but produces no hits — Phase 3
+            // plugs in the ripgrep backend. Reset everything (including a
+            // stale partialFailureMessage carried over from a prior file
+            // search in `.allRepos`) so the Content tab starts clean.
+            results = SearchResults()
         }
 
         if selectedIndex >= totalResultRows {

--- a/Alas/Sources/Search/SearchResult.swift
+++ b/Alas/Sources/Search/SearchResult.swift
@@ -36,7 +36,11 @@ struct ContentSearchHit: Identifiable, Equatable, Sendable {
     let line: Int
     let column: Int
     let snippet: String
-    let matchByteRange: Range<Int>?
+    /// Character (grapheme) offsets into `snippet` of the matched run, or
+    /// nil if the offsets don't align with character boundaries. Producers
+    /// (ContentSearcher) convert from raw byte offsets up-front so views
+    /// can slice with String.Index arithmetic safely on non-ASCII content.
+    let matchCharRange: Range<Int>?
 
     var id: String { "\(worktreeId):\(relativePath):\(line):\(column)" }
     var groupKey: String { "\(worktreeId):\(relativePath)" }

--- a/Alas/Sources/Search/Views/ContentResultGroup.swift
+++ b/Alas/Sources/Search/Views/ContentResultGroup.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+/// One file's worth of content-search hits, rendered as a header + list of
+/// snippet rows. Phase 2 ships the layout; Phase 3 makes hits real.
+struct ContentResultGroupView: View {
+    let group: ContentSearchGroup
+    let baseIndex: Int
+    let selectedIndex: Int
+    let onTap: (ContentSearchHit) -> Void
+    let onHover: (Int) -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            ForEach(Array(group.hits.enumerated()), id: \.element.id) { offset, hit in
+                let absIndex = baseIndex + offset
+                hitRow(hit: hit, absIndex: absIndex, isSelected: absIndex == selectedIndex)
+                    // Match the scroll-target id used by file rows so the
+                    // dialog's `ScrollViewReader.scrollTo(selectedIndex)`
+                    // can reach content hits as keyboard nav moves them.
+                    .id(absIndex)
+            }
+        }
+        .padding(.vertical, 6)
+        .overlay(
+            Rectangle()
+                .fill(theme.color("line-soft"))
+                .frame(height: 0.5),
+            alignment: .top
+        )
+    }
+
+    private var header: some View {
+        let parts = splitPath(group.relativePath)
+        return HStack(spacing: 10) {
+            Text(parts.name)
+                .font(.system(size: 12.5, weight: .medium, design: .monospaced))
+                .foregroundColor(theme.color("fg"))
+            Text(parts.dir)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(theme.color("fg-faint"))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: 0)
+            Text("\(group.hits.count)")
+                .font(.system(size: 9.5, weight: .semibold))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 1)
+                .background(theme.color("bg-3"))
+                .foregroundColor(theme.color("fg-dim"))
+                .clipShape(Capsule())
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 4)
+    }
+
+    private func hitRow(hit: ContentSearchHit, absIndex: Int, isSelected: Bool) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text("\(hit.line)")
+                .font(.system(size: 10.5, design: .monospaced).monospacedDigit())
+                .foregroundColor(theme.color("fg-faint"))
+                .frame(width: 32, alignment: .trailing)
+            snippet(for: hit)
+                .font(.system(size: 11.5, design: .monospaced))
+                .foregroundColor(theme.color("fg-dim"))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.leading, 56)
+        .padding(.trailing, 14)
+        .padding(.vertical, 4)
+        .background(
+            isSelected ? theme.color("accent-soft") : Color.clear
+        )
+        .overlay(
+            Rectangle()
+                .fill(isSelected ? theme.color("accent") : Color.clear)
+                .frame(width: 2),
+            alignment: .leading
+        )
+        .contentShape(Rectangle())
+        .onHover { if $0 { onHover(absIndex) } }
+        .onTapGesture { onTap(hit) }
+    }
+
+    @ViewBuilder
+    private func snippet(for hit: ContentSearchHit) -> some View {
+        if let range = hit.matchCharRange,
+           range.lowerBound >= 0,
+           range.upperBound <= hit.snippet.count {
+            let s = hit.snippet
+            let start = s.index(s.startIndex, offsetBy: range.lowerBound)
+            let end   = s.index(s.startIndex, offsetBy: range.upperBound)
+            Text(String(s[..<start])) +
+                Text(String(s[start..<end])).foregroundColor(theme.color("mod")).bold() +
+                Text(String(s[end...]))
+        } else {
+            Text(hit.snippet)
+        }
+    }
+
+    private func splitPath(_ p: String) -> (dir: String, name: String) {
+        if let slash = p.lastIndex(of: "/") {
+            return (String(p[..<slash]) + "/", String(p[p.index(after: slash)...]))
+        }
+        return ("", p)
+    }
+}

--- a/Alas/Sources/Search/Views/FileSearchDialog.swift
+++ b/Alas/Sources/Search/Views/FileSearchDialog.swift
@@ -25,7 +25,7 @@ struct FileSearchDialog: View {
                         BannerRow(text: banner)
                     }
                     resultList
-                    SearchFooter(model: appState.search, showsKindToggle: false)
+                    SearchFooter(model: appState.search, showsKindToggle: true)
                 }
                 .frame(width: 720)
                 .frame(maxHeight: 520)
@@ -56,16 +56,21 @@ struct FileSearchDialog: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(Array(model.results.fileResults.enumerated()), id: \.element.id) { idx, r in
-                            FileResultRow(
-                                result: r,
-                                isSelected: idx == model.selectedIndex,
-                                showsRepoBadge: model.scope == .allRepos,
-                                repoName: repoName(for: r),
-                                onTap: { open(r) },
-                                onHover: { model.selectedIndex = idx }
-                            )
-                            .id(idx)
+                        switch model.kind {
+                        case .files:
+                            ForEach(Array(model.results.fileResults.enumerated()), id: \.element.id) { idx, r in
+                                FileResultRow(
+                                    result: r,
+                                    isSelected: idx == model.selectedIndex,
+                                    showsRepoBadge: model.scope == .allRepos,
+                                    repoName: repoName(for: r),
+                                    onTap: { open(r) },
+                                    onHover: { model.selectedIndex = idx }
+                                )
+                                .id(idx)
+                            }
+                        case .content:
+                            contentGroupViews(model: model)
                         }
                     }
                     .padding(.vertical, 4)
@@ -76,6 +81,45 @@ struct FileSearchDialog: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func contentGroupViews(model: SearchModel) -> some View {
+        let pairs: [(ContentSearchGroup, Int)] = {
+            var out: [(ContentSearchGroup, Int)] = []
+            var base = 0
+            for g in model.results.contentGroups {
+                out.append((g, base))
+                base += g.hits.count
+            }
+            return out
+        }()
+        ForEach(pairs, id: \.0.id) { group, baseIdx in
+            ContentResultGroupView(
+                group: group,
+                baseIndex: baseIdx,
+                selectedIndex: model.selectedIndex,
+                onTap: { hit in openContent(hit) },
+                onHover: { idx in model.selectedIndex = idx }
+            )
+        }
+    }
+
+    private func openContent(_ hit: ContentSearchHit) {
+        appState.openFile(relativePath: hit.relativePath, worktreeId: hit.worktreeId)
+        close()
+    }
+
+    /// Resolve a flat selection index to a hit by walking groups in order.
+    private func hit(at index: Int, in groups: [ContentSearchGroup]) -> ContentSearchHit? {
+        var remaining = index
+        for group in groups {
+            if remaining < group.hits.count {
+                return group.hits[remaining]
+            }
+            remaining -= group.hits.count
+        }
+        return nil
     }
 
     private func repoName(for r: FileSearchResult) -> String? {
@@ -95,9 +139,22 @@ struct FileSearchDialog: View {
             model.selectedIndex = min(max(0, model.totalResultRows - 1), model.selectedIndex + 1)
             return .handled
         case .return:
-            if let row = model.results.fileResults[safe: model.selectedIndex] {
-                open(row)
+            // Branch on kind so a Tab → Return on a stale file row from a
+            // previous mode doesn't open the wrong thing while content
+            // results haven't arrived yet.
+            switch model.kind {
+            case .files:
+                if let row = model.results.fileResults[safe: model.selectedIndex] {
+                    open(row)
+                }
+            case .content:
+                if let hit = hit(at: model.selectedIndex, in: model.results.contentGroups) {
+                    openContent(hit)
+                }
             }
+            return .handled
+        case .tab:
+            model.toggleKind()
             return .handled
         default:
             return .ignored

--- a/Alas/Sources/Search/Views/ScopeRow.swift
+++ b/Alas/Sources/Search/Views/ScopeRow.swift
@@ -16,6 +16,25 @@ struct ScopeRow: View {
                 pill(.allRepos,     enabled: true)
             }
             Spacer(minLength: 0)
+            if model.kind == .content {
+                HStack(spacing: 2) {
+                    optionToggle(
+                        glyph: "Aa",
+                        isOn: model.contentOptions.caseSensitive,
+                        onTap: { model.contentOptions.caseSensitive.toggle() }
+                    )
+                    optionToggle(
+                        glyph: "W",
+                        isOn: model.contentOptions.wholeWord,
+                        onTap: { model.contentOptions.wholeWord.toggle() }
+                    )
+                    optionToggle(
+                        glyph: ".*",
+                        isOn: model.contentOptions.regex,
+                        onTap: { model.contentOptions.regex.toggle() }
+                    )
+                }
+            }
             Text(countText)
                 .font(.system(size: 10.5).monospacedDigit())
                 .foregroundColor(theme.color("fg-faint"))
@@ -59,6 +78,28 @@ struct ScopeRow: View {
         }
         .buttonStyle(.plain)
         .disabled(!enabled)
+    }
+
+    @ViewBuilder
+    private func optionToggle(glyph: String, isOn: Bool, onTap: @escaping () -> Void) -> some View {
+        Button(action: onTap) {
+            Text(glyph)
+                .font(.system(size: 10, design: .monospaced))
+                .frame(width: 22, height: 20)
+                .foregroundColor(isOn ? theme.color("accent") : theme.color("fg-faint"))
+                .background(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .fill(isOn ? theme.color("accent-soft") : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .strokeBorder(
+                            isOn ? theme.color("accent").opacity(0.35) : theme.color("line"),
+                            lineWidth: 0.5
+                        )
+                )
+        }
+        .buttonStyle(.plain)
     }
 
     private var countText: String {

--- a/Alas/Sources/Search/Views/SearchEmptyState.swift
+++ b/Alas/Sources/Search/Views/SearchEmptyState.swift
@@ -35,6 +35,8 @@ struct SearchEmptyState: View {
 
     private var subtitle: String {
         if !model.trimmedQuery.isEmpty {
+            // Phase 2 special case: content search isn't backed yet.
+            if model.kind == .content { return "Content search coming soon." }
             let where_: String
             switch model.scope {
             case .thisWorktree: where_ = "this worktree"

--- a/Alas/Sources/Search/Views/SearchInputRow.swift
+++ b/Alas/Sources/Search/Views/SearchInputRow.swift
@@ -28,6 +28,13 @@ struct SearchInputRow: View {
                 }
                 .buttonStyle(.plain)
             }
+            HStack(spacing: 0) {
+                tab("Files",   .files)
+                tab("Content", .content)
+            }
+            .padding(2)
+            .background(theme.color("bg-2"))
+            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
@@ -44,5 +51,24 @@ struct SearchInputRow: View {
         case .files:   return "Search files by name…"
         case .content: return "Search file contents…"
         }
+    }
+
+    @ViewBuilder
+    private func tab(_ label: String, _ k: SearchKind) -> some View {
+        let isOn = model.kind == k
+        Button {
+            model.kind = k
+        } label: {
+            Text(label)
+                .font(.system(size: 10.5, weight: .medium))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .foregroundColor(isOn ? theme.color("fg") : theme.color("fg-faint"))
+                .background(
+                    RoundedRectangle(cornerRadius: 3.5, style: .continuous)
+                        .fill(isOn ? theme.color("bg-3") : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/AlasTests/SearchModelTests.swift
+++ b/AlasTests/SearchModelTests.swift
@@ -170,3 +170,28 @@ struct SearchModelTests {
         #expect(Date().timeIntervalSince(started) < 0.1)
     }
 }
+
+extension SearchModelTests {
+    @Test func contentOptionsPersistAcrossKindToggles() async {
+        let env = makeEnv(worktrees: [wt("a")])
+        let model = SearchModel(environment: env)
+        model.open()
+        model.contentOptions.caseSensitive = true
+        model.contentOptions.regex = true
+        model.toggleKind() // -> content
+        model.toggleKind() // -> files
+        #expect(model.contentOptions.caseSensitive == true)
+        #expect(model.contentOptions.regex == true)
+        #expect(model.contentOptions.wholeWord == false)
+    }
+
+    @Test func contentPrefixWorksEvenWithStubbedBackend() async {
+        let env = makeEnv(worktrees: [wt("a")])
+        let model = SearchModel(environment: env)
+        model.open()
+        model.query = "> needle"
+        await model.waitForIdle()
+        #expect(model.kind == .content)
+        #expect(model.results.contentGroups.isEmpty)
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
Renders the Files/Content tab toggle, Aa/W/.* mode toggles, and content
result group skeleton. Content mode shows a "coming soon" empty state
when there's a query. The `> ` query prefix and Tab key both flip kind.
No backend yet.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
<!-- gg:managed:end -->