### PR TITLE
feat(search): ripgrep-backed content search

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768D12909DD5233659AC4E03 /* RepoGroupView.swift */; };
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
+		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
 		3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6CCD7F7273667B5D67F821 /* SearchScope.swift */; };
 		32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */; };
 		3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36992F601C8EB6C3D45B584F /* SearchKbd.swift */; };
@@ -118,6 +119,7 @@
 		A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
+		A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */; };
 		A7BDA44A8E4364C4C335C4DA /* HookEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8820E4289EEB1ADCA9E490F /* HookEventTests.swift */; };
 		A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
@@ -317,11 +319,13 @@
 		B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCacheTests.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfig.swift; sourceTree = "<group>"; };
+		BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcher.swift; sourceTree = "<group>"; };
 		BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManager.swift; sourceTree = "<group>"; };
 		BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
 		C1BE92AB2BD3552CC87670C4 /* neutral.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = neutral.json; sourceTree = "<group>"; };
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
+		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
 		C6CA79B71B4AA72697392702 /* NumstatParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParser.swift; sourceTree = "<group>"; };
 		C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTheme.swift; sourceTree = "<group>"; };
 		C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Surface.swift; sourceTree = "<group>"; };
@@ -395,6 +399,7 @@
 			children = (
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
+				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */,
@@ -643,6 +648,7 @@
 		986CC94FDFD6411BCED67A48 /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */,
 				E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */,
 				96E7159EED1183F784104B4F /* FuzzyMatch.swift */,
 				4261E417947C1A21E77C1587 /* GitStatusCache.swift */,
@@ -1016,6 +1022,7 @@
 				28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */,
 				0F560F9B2458B94C807E96A1 /* CodeTextView.swift in Sources */,
 				A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */,
+				A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */,
 				49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */,
 				5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */,
 				90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */,
@@ -1124,6 +1131,7 @@
 			files = (
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
+				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,
 				BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -242,6 +242,9 @@ final class AppState {
             },
             statuses: { [statusCache] wt in
                 try await statusCache.statuses(forWorktreePath: wt.absolutePath)
+            },
+            contentSearch: { [contentSearcher = ContentSearcher()] query, options, targets in
+                contentSearcher.search(query: query, options: options, worktrees: targets)
             }
         )
     }

--- a/Alas/Sources/Search/ContentSearcher.swift
+++ b/Alas/Sources/Search/ContentSearcher.swift
@@ -1,0 +1,342 @@
+import Foundation
+import os
+
+/// Streams content-search hits from `rg --json`. One `search(...)` call
+/// runs rg once per worktree, sequentially, and yields hits as they
+/// arrive. Cancellation terminates the running rg child.
+///
+/// Discovery: `which rg` is consulted on every `search(...)` call (cheap;
+/// not memoized).
+final class ContentSearcher: Sendable {
+    private let logger = Logger(subsystem: "io.nlopez.alas", category: "search.content")
+
+    /// Find an `rg` binary. Tries `which rg` first, then checks common
+    /// installation paths (Homebrew, /usr/local/bin) as a fallback for
+    /// environments where PATH is restricted (e.g. xcodebuild test runners).
+    static func discoverRg() -> String? {
+        if let found = try? syncWhich("rg") { return found }
+        let candidates = ["/opt/homebrew/bin/rg", "/usr/local/bin/rg"]
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    enum SearchError: Error, Equatable {
+        case rgNotFound
+        /// rg's regex engine rejected the pattern. NSRegularExpression's
+        /// up-front preflight catches most syntax errors, but rg's Rust
+        /// regex (without --pcre2) rejects features NSRegular accepts —
+        /// notably look-around `(?=…)` and backreferences. Detected via
+        /// known stderr markers.
+        case regexInvalid
+        /// rg exited with a non-success, non-no-match status that wasn't
+        /// detected as a regex error — most commonly a soft I/O failure
+        /// (unreadable file, permission denied).
+        case rgFailed(exitCode: Int32)
+    }
+
+    /// Stream all matches across the given worktrees. Each emitted hit
+    /// already has its `worktreeId`/`projectId`/`relativePath` set.
+    func search(
+        query: String,
+        options: SearchContentOptions,
+        worktrees: [SearchWorktree]
+    ) -> AsyncThrowingStream<ContentSearchHit, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                guard let rg = Self.discoverRg() else {
+                    continuation.finish(throwing: SearchError.rgNotFound)
+                    return
+                }
+                var deferredFailure: Error? = nil
+                for wt in worktrees {
+                    if Task.isCancelled { break }
+                    do {
+                        try await self.streamRg(
+                            rg: rg,
+                            query: query,
+                            options: options,
+                            worktree: wt,
+                            into: continuation
+                        )
+                    } catch is CancellationError {
+                        // Cancellation must propagate — it's not a per-
+                        // worktree failure, the whole search is being
+                        // superseded.
+                        continuation.finish()
+                        return
+                    } catch {
+                        // Catch ANY error per-worktree, not just SearchError.
+                        // `process.run()` can throw NSCocoaErrorDomain (cwd
+                        // missing for a stale linked worktree) before rg ever
+                        // produces a SearchError. Continuing past these keeps
+                        // `.allRepos` searching the remaining worktrees.
+                        self.logger.notice(
+                            "rg failure in \(wt.absolutePath.path, privacy: .public): \(String(describing: error))"
+                        )
+                        deferredFailure = error
+                    }
+                }
+                if let deferredFailure {
+                    continuation.finish(throwing: deferredFailure)
+                } else {
+                    continuation.finish()
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private func streamRg(
+        rg: String,
+        query: String,
+        options: SearchContentOptions,
+        worktree: SearchWorktree,
+        into continuation: AsyncThrowingStream<ContentSearchHit, Error>.Continuation
+    ) async throws {
+        // `--hidden` so dotfiles (e.g. .github/, .swiftlint.yml, .env.example)
+        // are searched. `git ls-files` already returns them, so file mode
+        // can find them by name; without this flag content mode silently
+        // misses any matches inside them. `.gitignore` is still respected.
+        // Exclude `.git/` itself so ripgrep doesn't descend into repo
+        // metadata (refs, logs, packed objects) — that bloats the 50-file
+        // / 200-hit caps with non-source results.
+        var args: [String] = [
+            "--json",
+            "--hidden",
+            "--glob", "!.git",
+            "--max-count=200",
+            "--max-columns=400",
+        ]
+        if options.caseSensitive { args.append("--case-sensitive") } else { args.append("--smart-case") }
+        if options.wholeWord     { args.append("--word-regexp") }
+        if !options.regex        { args.append("--fixed-strings") }
+        args.append("--")
+        args.append(query)
+        args.append(".")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: rg)
+        process.arguments = args
+        process.currentDirectoryURL = worktree.absolutePath
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        // Capture stderr to a small bounded buffer. We drain concurrently
+        // so a chatty rg (warnings, debug noise) can't fill the pipe and
+        // block the child, but cap accumulated bytes so a pathological
+        // case (thousands of warnings) doesn't balloon memory either.
+        process.standardError = errPipe
+
+        let handle = outPipe.fileHandleForReading
+        let errHandle = errPipe.fileHandleForReading
+        let stderrBuf = StderrBuffer(capBytes: 8192)
+        let drainTask = Task.detached {
+            while true {
+                let data = errHandle.availableData
+                if data.isEmpty { break }
+                await stderrBuf.append(data)
+            }
+        }
+
+        try process.run()
+
+        // `availableData` blocks until bytes arrive or EOF; it doesn't
+        // observe `Task.isCancelled`. Wire cancellation to terminate the
+        // child, which closes the pipe → reads return EOF immediately.
+        await withTaskCancellationHandler {
+            await readAllLines(handle: handle) { lineData in
+                if let hit = parseRgLine(lineData, worktree: worktree) {
+                    continuation.yield(hit)
+                }
+            }
+        } onCancel: {
+            // Called from any thread, possibly during a blocking read.
+            process.terminate()
+        }
+
+        if process.isRunning { process.terminate() }
+        process.waitUntilExit()
+        // Wait for stderr drain so any error text is visible below.
+        _ = await drainTask.value
+
+        // ripgrep exits 0 on matches, 1 on no matches, 2+ on its own errors.
+        // Skip the check if we cancelled the child ourselves.
+        if !Task.isCancelled,
+           process.terminationReason == .exit,
+           process.terminationStatus > 1 {
+            let stderr = await stderrBuf.text
+            // rg's regex parse errors begin with "regex parse error" or
+            // mention unsupported look-around / backreference features.
+            // Distinguish those from soft I/O errors so the model can
+            // surface "Invalid regex pattern." instead of a generic banner.
+            let lower = stderr.lowercased()
+            if lower.contains("regex parse error")
+                || lower.contains("look-around")
+                || lower.contains("backreference") {
+                throw SearchError.regexInvalid
+            }
+            throw SearchError.rgFailed(exitCode: process.terminationStatus)
+        }
+    }
+
+    /// Read newline-delimited output from `handle`, calling `onLine` for
+    /// each complete line. Returns when the pipe reports EOF.
+    private func readAllLines(
+        handle: FileHandle,
+        onLine: (Data) -> Void
+    ) async {
+        var leftover = Data()
+        while true {
+            let chunk = handle.availableData
+            if chunk.isEmpty { break }  // EOF
+            leftover.append(chunk)
+            while let nl = leftover.firstIndex(of: 0x0A) {
+                let line = leftover[..<nl]
+                leftover.removeSubrange(...nl)
+                onLine(Data(line))
+            }
+        }
+        if !leftover.isEmpty { onLine(leftover) }
+    }
+
+    /// Parse one rg JSON line. Only `match` events produce hits.
+    /// Format reference: https://docs.rs/grep-printer/latest/grep_printer/struct.JSON.html
+    private func parseRgLine(_ data: Data, worktree: SearchWorktree) -> ContentSearchHit? {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              (obj["type"] as? String) == "match",
+              let payload = obj["data"] as? [String: Any],
+              let lineNumber = payload["line_number"] as? Int,
+              let rawPath = (payload["path"] as? [String: Any])?["text"] as? String,
+              let lineBlob = (payload["lines"] as? [String: Any])?["text"] as? String
+        else { return nil }
+        // rg launched with `.` as the search path emits leading "./" on
+        // every relative path. Strip it so paths align with the cleaner
+        // form produced by `git ls-files` (and used as group keys).
+        let pathBlob = rawPath.hasPrefix("./") ? String(rawPath.dropFirst(2)) : rawPath
+        let submatches = (payload["submatches"] as? [[String: Any]]) ?? []
+        let first = submatches.first
+        let colByte = (first?["start"] as? Int) ?? 0
+        let endColByte = (first?["end"] as? Int) ?? colByte
+        let rawSnippet = lineBlob.trimmingCharacters(in: .newlines)
+
+        // `--max-columns=400` doesn't apply in `--json` mode (per rg --help).
+        // For a single very long line — minified JS, generated JSON, lockfiles —
+        // `lineBlob` can be megabytes; window the stored snippet around the
+        // match so the user actually sees what matched, not just the line's
+        // first 400 chars (which often don't include the match).
+        let (trimmedSnippet, charRange) = windowSnippet(
+            raw: rawSnippet,
+            matchStartByte: colByte,
+            matchEndByte: endColByte
+        )
+
+        return ContentSearchHit(
+            worktreeId: worktree.id,
+            projectId: worktree.projectId,
+            relativePath: pathBlob,
+            line: lineNumber,
+            column: colByte + 1,
+            snippet: trimmedSnippet,
+            matchCharRange: charRange
+        )
+    }
+
+    /// Convert a UTF-8 byte offset into a Character (grapheme) offset within
+    /// the given string. Returns nil if `bytes` is out of bounds or does not
+    /// fall on a character boundary.
+    private func charOffset(forByteOffset bytes: Int, in s: String) -> Int? {
+        guard bytes >= 0, bytes <= s.utf8.count else { return nil }
+        let utf8Index = s.utf8.index(s.utf8.startIndex, offsetBy: bytes)
+        guard let charIndex = utf8Index.samePosition(in: s) else { return nil }
+        return s.distance(from: s.startIndex, to: charIndex)
+    }
+
+    /// Bound a snippet to ~400 characters, centered on the matched range.
+    /// Returns the trimmed snippet plus a Character range pointing into it
+    /// for highlighting (or nil if the offsets don't align with grapheme
+    /// boundaries). For lines at or below the cap, returns the line as-is.
+    private func windowSnippet(
+        raw: String,
+        matchStartByte: Int,
+        matchEndByte: Int
+    ) -> (snippet: String, charRange: Range<Int>?) {
+        let cap = 400
+        // Convert byte offsets in the original line first — they're stable
+        // there even if we end up windowing.
+        guard let matchStartChar = charOffset(forByteOffset: matchStartByte, in: raw),
+              let matchEndChar   = charOffset(forByteOffset: matchEndByte,   in: raw) else {
+            // Couldn't align; truncate plainly and skip highlighting.
+            let truncated = raw.count > cap ? String(raw.prefix(cap)) + "…" : raw
+            return (truncated, nil)
+        }
+        let total = raw.count
+        if total <= cap {
+            let charRange = matchStartChar < matchEndChar
+                ? matchStartChar..<matchEndChar
+                : nil
+            return (raw, charRange)
+        }
+        // Window: try to keep ~`pad` chars on each side of the match. The
+        // window itself is hard-capped to `cap` chars regardless of how
+        // wide the match is — a regex like `.*` can match a full minified
+        // line, and we don't want to ship that much text.
+        let matchLen = matchEndChar - matchStartChar
+        let pad = max(0, (cap - min(matchLen, cap)) / 2)
+        let desiredStart = matchStartChar - pad
+        let windowStart = max(0, min(desiredStart, total - cap))
+        let windowEnd = min(total, windowStart + cap)
+        let leadEllipsis  = windowStart > 0
+        let trailEllipsis = windowEnd < total
+        let startIdx = raw.index(raw.startIndex, offsetBy: windowStart)
+        let endIdx   = raw.index(raw.startIndex, offsetBy: windowEnd)
+        let middle = String(raw[startIdx..<endIdx])
+        let snippet = (leadEllipsis ? "…" : "") + middle + (trailEllipsis ? "…" : "")
+        let prefixLen = leadEllipsis ? 1 : 0
+        let adjStart = matchStartChar - windowStart + prefixLen
+        // Clamp the highlight end to the snippet — when the match itself
+        // is wider than `cap`, the trailing portion gets truncated and we
+        // highlight all the way to the snippet boundary.
+        let snippetCount = snippet.count
+        let adjEnd = min(matchEndChar - windowStart + prefixLen, snippetCount)
+        let charRange: Range<Int>?
+        if adjStart >= 0, adjStart < adjEnd, adjEnd <= snippetCount {
+            charRange = adjStart..<adjEnd
+        } else {
+            charRange = nil
+        }
+        return (snippet, charRange)
+    }
+}
+
+/// Bounded accumulator for an rg child's stderr. The pipe drain task
+/// appends chunks until the cap is reached, then silently drops the rest
+/// — enough to detect known regex-error markers without ballooning
+/// memory if rg emits thousands of warnings.
+private actor StderrBuffer {
+    private var data = Data()
+    private let cap: Int
+    init(capBytes: Int) { self.cap = capBytes }
+    func append(_ chunk: Data) {
+        guard data.count < cap else { return }
+        let room = cap - data.count
+        data.append(chunk.prefix(room))
+    }
+    var text: String { String(data: data, encoding: .utf8) ?? "" }
+}
+
+/// Tiny synchronous `which` — used at startup to locate rg without
+/// blocking the actor model.
+private func syncWhich(_ name: String) throws -> String? {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    proc.arguments = ["which", name]
+    let pipe = Pipe()
+    proc.standardOutput = pipe
+    proc.standardError = Pipe()
+    try proc.run()
+    proc.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let s = String(data: data, encoding: .utf8)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    return (s?.isEmpty == false) ? s : nil
+}

--- a/Alas/Sources/Search/SearchModel.swift
+++ b/Alas/Sources/Search/SearchModel.swift
@@ -17,6 +17,9 @@ struct SearchEnvironment: Sendable {
     var allWorktrees: @Sendable () -> [SearchWorktree]
     var entries: @Sendable (SearchWorktree) async throws -> [FileIndex.Entry]
     var statuses: @Sendable (SearchWorktree) async throws -> [String: GitStatusBadge]
+    var contentSearch: @Sendable (
+        String, SearchContentOptions, [SearchWorktree]
+    ) -> AsyncThrowingStream<ContentSearchHit, Error>
 }
 
 struct SearchContentOptions: Equatable, Sendable {
@@ -172,12 +175,7 @@ final class SearchModel {
         case .files:
             await runFileSearch(query: query, targets: targets)
         case .content:
-            // Phase 2 makes the Content tab reachable visually (via tabs,
-            // Tab key, or `> ` prefix) but produces no hits — Phase 3
-            // plugs in the ripgrep backend. Reset everything (including a
-            // stale partialFailureMessage carried over from a prior file
-            // search in `.allRepos`) so the Content tab starts clean.
-            results = SearchResults()
+            await runContentSearch(query: query, targets: targets)
         }
 
         if selectedIndex >= totalResultRows {
@@ -264,6 +262,134 @@ final class SearchModel {
                 ? nil
                 : "Couldn't read files for \(failures.joined(separator: ", "))"
         )
+    }
+
+    private func runContentSearch(query: String, targets: [SearchWorktree]) async {
+        // Empty content queries match everything; rg would scan the whole
+        // worktree for nothing useful. Short-circuit to a clean state so the
+        // empty-state copy renders instead.
+        guard !query.isEmpty else {
+            results = SearchResults()
+            return
+        }
+
+        // Validate regex up-front when the toggle is on. rg's exit-2 covers
+        // both regex syntax errors and soft I/O errors, so the `rgFailed`
+        // catch can't tell them apart — surfacing the regex error here lets
+        // that catch stay generic for genuine I/O issues. NSRegularExpression
+        // is ICU-regex; rg uses Rust's regex crate. Most simple patterns
+        // (`[`, `(`, `\?`) are flagged identically; for exotic features
+        // they may diverge, in which case this just falls through to rg.
+        if contentOptions.regex {
+            do {
+                _ = try NSRegularExpression(pattern: query, options: [])
+            } catch {
+                results = SearchResults(
+                    fileResults: [],
+                    contentGroups: [],
+                    partialFailureMessage: "Invalid regex pattern."
+                )
+                return
+            }
+        }
+
+        // Caps
+        let maxHits  = 200
+        let maxFiles = 50
+        let partialEvery = 25
+
+        // Map from group key to index in `groups` (preserves encounter order).
+        var groupIndex: [String: Int] = [:]
+        // Accumulated groups, in encounter order.
+        var groups: [ContentSearchGroup] = []
+        var totalHits = 0
+
+        do {
+            let stream = env.contentSearch(query, contentOptions, targets)
+            for try await hit in stream {
+                if Task.isCancelled { return }
+
+                let key = hit.groupKey
+                if let idx = groupIndex[key] {
+                    groups[idx].hits.append(hit)
+                } else if groups.count < maxFiles {
+                    let newGroup = ContentSearchGroup(
+                        worktreeId: hit.worktreeId,
+                        projectId: hit.projectId,
+                        relativePath: hit.relativePath,
+                        hits: [hit]
+                    )
+                    groupIndex[key] = groups.count
+                    groups.append(newGroup)
+                }
+                // Always count toward totalHits — including hits dropped
+                // because they belong to a new file past the file cap. Without
+                // this, `maxHits` never fires for broad searches and we drain
+                // the entire rg stream after the UI is already capped.
+                totalHits += 1
+
+                // Push partial results every 25 hits so the UI animates.
+                if totalHits % partialEvery == 0 {
+                    results = SearchResults(
+                        fileResults: [],
+                        contentGroups: groups,
+                        partialFailureMessage: nil
+                    )
+                }
+
+                if totalHits >= maxHits { break }
+            }
+            // Final flush — but only if we haven't been superseded by a
+            // newer query. Otherwise the about-to-be-overwritten newer
+            // task's results would be clobbered with our stale snapshot.
+            if Task.isCancelled { return }
+            results = SearchResults(
+                fileResults: [],
+                contentGroups: groups,
+                partialFailureMessage: nil
+            )
+        } catch ContentSearcher.SearchError.rgNotFound {
+            results = SearchResults(
+                fileResults: [],
+                contentGroups: [],
+                partialFailureMessage: "Install ripgrep (`brew install ripgrep`) to enable content search."
+            )
+        } catch ContentSearcher.SearchError.regexInvalid {
+            // rg's stderr-detected regex parse error — covers patterns
+            // that the up-front NSRegularExpression preflight accepted
+            // but rg's Rust regex rejects (look-around, backrefs).
+            results = SearchResults(
+                fileResults: [],
+                contentGroups: [],
+                partialFailureMessage: "Invalid regex pattern."
+            )
+        } catch ContentSearcher.SearchError.rgFailed {
+            // ripgrep exit 2 covers both regex-syntax errors and soft I/O
+            // errors (unreadable file, permission denied, etc.) — see
+            // `rg --generate man`. Regex errors are caught up-front by the
+            // NSRegularExpression validation above, so by the time we reach
+            // here it's effectively always a soft I/O failure. Preserve any
+            // hits accumulated from earlier files.
+            let message = groups.isEmpty
+                ? "Content search failed."
+                : "Some files couldn't be searched."
+            results = SearchResults(
+                fileResults: [],
+                contentGroups: groups,
+                partialFailureMessage: message
+            )
+        } catch is CancellationError {
+            // A newer keystroke superseded this query — let the new task
+            // own `results`. Don't surface a banner.
+            return
+        } catch {
+            // Flush whatever was accumulated so far.
+            results = SearchResults(
+                fileResults: [],
+                contentGroups: groups,
+                partialFailureMessage: "Content search interrupted."
+            )
+        }
     }
 
     private func signalIdle() {

--- a/Alas/Sources/Search/Views/SearchEmptyState.swift
+++ b/Alas/Sources/Search/Views/SearchEmptyState.swift
@@ -35,8 +35,6 @@ struct SearchEmptyState: View {
 
     private var subtitle: String {
         if !model.trimmedQuery.isEmpty {
-            // Phase 2 special case: content search isn't backed yet.
-            if model.kind == .content { return "Content search coming soon." }
             let where_: String
             switch model.scope {
             case .thisWorktree: where_ = "this worktree"

--- a/AlasTests/ContentSearcherTests.swift
+++ b/AlasTests/ContentSearcherTests.swift
@@ -1,0 +1,107 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct ContentSearcherTests {
+    private func rgAvailable() -> Bool {
+        ContentSearcher.discoverRg() != nil
+    }
+
+    private func makeRepo(files: [(String, String)]) async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cs-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        for (path, contents) in files {
+            let url = dir.appendingPathComponent(path)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try contents.write(to: url, atomically: true, encoding: .utf8)
+        }
+        // Initialize git so rg respects gitignore semantics if added later.
+        _ = try? await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        return dir
+    }
+
+    @Test func findsMatchesAcrossFiles() async throws {
+        try #require(rgAvailable())
+        let repo = try await makeRepo(files: [
+            ("a.txt", "hello world\nfoo bar\nneedle here\n"),
+            ("nested/b.txt", "nothing\nneedle middle\nneedle end\n"),
+        ])
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let cs = ContentSearcher()
+        var hits: [ContentSearchHit] = []
+        for try await hit in cs.search(
+            query: "needle",
+            options: SearchContentOptions(),
+            worktrees: [SearchWorktree(
+                id: "w1", projectId: "p1", displayName: "w",
+                absolutePath: repo
+            )]
+        ) {
+            hits.append(hit)
+        }
+        #expect(hits.count == 3)
+        // Three hits across two distinct line numbers — line 3 in a.txt,
+        // lines 2 and 3 in nested/b.txt.
+        let pairs = Set(hits.map { "\($0.relativePath):\($0.line)" })
+        #expect(pairs == ["a.txt:3", "nested/b.txt:2", "nested/b.txt:3"])
+    }
+
+    @Test func cancellationStopsStream() async throws {
+        try #require(rgAvailable())
+        // Build a directory big enough that rg takes >50ms.
+        var pairs: [(String, String)] = []
+        for i in 0..<500 {
+            pairs.append(("f\(i).txt", "needle\n" * 100))
+        }
+        let repo = try await makeRepo(files: pairs)
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let cs = ContentSearcher()
+        let task = Task {
+            var n = 0
+            for try await _ in cs.search(
+                query: "needle",
+                options: SearchContentOptions(),
+                worktrees: [SearchWorktree(
+                    id: "w1", projectId: "p1", displayName: "w",
+                    absolutePath: repo
+                )]
+            ) {
+                n += 1
+                if n > 5 { break }
+            }
+            return n
+        }
+        let count = try await task.value
+        #expect(count <= 6)
+    }
+
+    @Test func caseSensitiveFlag() async throws {
+        try #require(rgAvailable())
+        let repo = try await makeRepo(files: [
+            ("a.txt", "Needle\nneedle\n"),
+        ])
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let cs = ContentSearcher()
+        var hitsCS: [ContentSearchHit] = []
+        for try await h in cs.search(
+            query: "Needle",
+            options: SearchContentOptions(caseSensitive: true, wholeWord: false, regex: false),
+            worktrees: [SearchWorktree(
+                id: "w1", projectId: "p1", displayName: "w",
+                absolutePath: repo
+            )]
+        ) { hitsCS.append(h) }
+        #expect(hitsCS.count == 1)
+    }
+}
+
+// `String * Int` operator for the cancellation test fixture.
+private func *(lhs: String, rhs: Int) -> String {
+    String(repeating: lhs, count: rhs)
+}

--- a/AlasTests/SearchModelTests.swift
+++ b/AlasTests/SearchModelTests.swift
@@ -4,16 +4,23 @@ import Foundation
 
 @MainActor
 struct SearchModelTests {
+    /// Returns a finished AsyncThrowingStream with no elements.
+    private func emptyContentStream() -> AsyncThrowingStream<ContentSearchHit, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+
     private func makeEnv(
         worktrees: [SearchWorktree] = [],
         files: [String: [FileIndex.Entry]] = [:],
-        statuses: [String: [String: GitStatusBadge]] = [:]
+        statuses: [String: [String: GitStatusBadge]] = [:],
+        contentSearch: (@Sendable (String, SearchContentOptions, [SearchWorktree]) -> AsyncThrowingStream<ContentSearchHit, Error>)? = nil
     ) -> SearchEnvironment {
         SearchEnvironment(
             currentWorktreeId: { worktrees.first?.id },
             allWorktrees: { worktrees },
             entries: { wt in files[wt.id] ?? [] },
-            statuses: { wt in statuses[wt.id] ?? [:] }
+            statuses: { wt in statuses[wt.id] ?? [:] },
+            contentSearch: contentSearch ?? { _, _, _ in AsyncThrowingStream { $0.finish() } }
         )
     }
 
@@ -38,7 +45,8 @@ struct SearchModelTests {
             currentWorktreeId: { nil },
             allWorktrees: { [] },
             entries: { _ in [] },
-            statuses: { _ in [:] }
+            statuses: { _ in [:] },
+            contentSearch: { _, _, _ in AsyncThrowingStream { $0.finish() } }
         )
         let model2 = SearchModel(environment: env)
         model2.open()
@@ -194,4 +202,241 @@ extension SearchModelTests {
         #expect(model.kind == .content)
         #expect(model.results.contentGroups.isEmpty)
     }
+
+    @Test func contentResultsAreGroupedByFile() async {
+        // Two files across the same worktree — accumulation logic under test,
+        // not the rg backend.
+        let worktree = wt("a")
+        func makeHit(path: String, line: Int) -> ContentSearchHit {
+            ContentSearchHit(
+                worktreeId: "a",
+                projectId: "p1",
+                relativePath: path,
+                line: line,
+                column: 1,
+                snippet: "some snippet",
+                matchCharRange: nil
+            )
+        }
+        let hits: [ContentSearchHit] = [
+            makeHit(path: "src/foo.rs", line: 10),
+            makeHit(path: "src/bar.rs", line: 5),
+            makeHit(path: "src/foo.rs", line: 20),
+            makeHit(path: "src/bar.rs", line: 15),
+        ]
+
+        let env = makeEnv(
+            worktrees: [worktree],
+            contentSearch: { _, _, _ in
+                AsyncThrowingStream { cont in
+                    Task {
+                        for h in hits { cont.yield(h) }
+                        cont.finish()
+                    }
+                }
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.kind = .content
+        model.query = "snippet"
+        await model.waitForIdle()
+
+        let groups = model.results.contentGroups
+        // Two distinct files → two groups, in encounter order.
+        #expect(groups.count == 2)
+        #expect(groups[0].relativePath == "src/foo.rs")
+        #expect(groups[1].relativePath == "src/bar.rs")
+        // Hits within each group in arrival order.
+        #expect(groups[0].hits.map(\.line) == [10, 20])
+        #expect(groups[1].hits.map(\.line) == [5, 15])
+    }
+
+    @Test func contentSearchCapsAtFiftyFiles() async {
+        let worktree = wt("a")
+        // Yield 60 distinct files (one hit each); cap is 50.
+        let hits: [ContentSearchHit] = (0..<60).map { i in
+            ContentSearchHit(
+                worktreeId: "a", projectId: "p1",
+                relativePath: "f\(i).rs",
+                line: 1, column: 1, snippet: "x", matchCharRange: nil
+            )
+        }
+        let env = makeEnv(
+            worktrees: [worktree],
+            contentSearch: { _, _, _ in
+                AsyncThrowingStream { cont in
+                    Task {
+                        for h in hits { cont.yield(h) }
+                        cont.finish()
+                    }
+                }
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.kind = .content
+        model.query = "x"
+        await model.waitForIdle()
+        #expect(model.results.contentGroups.count == 50)
+        // First 50 distinct files survived; the rest were dropped.
+        let surviving = Set(model.results.contentGroups.map(\.relativePath))
+        #expect(surviving.contains("f0.rs"))
+        #expect(surviving.contains("f49.rs"))
+        #expect(!surviving.contains("f50.rs"))
+        #expect(!surviving.contains("f59.rs"))
+    }
+
+    @Test func contentSearchCapsAtTwoHundredHits() async {
+        let worktree = wt("a")
+        // Yield 220 hits across two files (way above the 200-hit cap).
+        var hits: [ContentSearchHit] = []
+        for i in 0..<220 {
+            hits.append(ContentSearchHit(
+                worktreeId: "a", projectId: "p1",
+                relativePath: i.isMultiple(of: 2) ? "a.rs" : "b.rs",
+                line: i + 1, column: 1, snippet: "x", matchCharRange: nil
+            ))
+        }
+        let env = makeEnv(
+            worktrees: [worktree],
+            contentSearch: { _, _, _ in
+                AsyncThrowingStream { cont in
+                    Task {
+                        for h in hits { cont.yield(h) }
+                        cont.finish()
+                    }
+                }
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.kind = .content
+        model.query = "x"
+        await model.waitForIdle()
+        let totalHits = model.results.contentGroups.reduce(0) { $0 + $1.hits.count }
+        #expect(totalHits == 200)
+    }
+
+    @Test func invalidRegexIsCaughtBeforeBackendRuns() async {
+        // Validation is now up-front via NSRegularExpression — the backend
+        // closure should never be invoked for an unparseable pattern.
+        let backendInvoked = InvocationFlag()
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            contentSearch: { _, _, _ in
+                Task { await backendInvoked.set() }
+                return AsyncThrowingStream { $0.finish() }
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.kind = .content
+        model.contentOptions.regex = true
+        model.query = "["  // unparseable
+        await model.waitForIdle()
+        #expect(model.results.contentGroups.isEmpty)
+        #expect(model.results.partialFailureMessage == "Invalid regex pattern.")
+        #expect(await backendInvoked.value == false)
+    }
+
+    @Test func backendRegexInvalidSurfacesInvalidPatternBanner() async {
+        // For patterns NSRegularExpression accepts but rg rejects (look-around,
+        // backrefs), rg's stderr-detected regex error throws regexInvalid —
+        // model should label it as a regex error, not as a generic failure.
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            contentSearch: { _, _, _ in
+                AsyncThrowingStream { cont in
+                    cont.finish(throwing: ContentSearcher.SearchError.regexInvalid)
+                }
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.kind = .content
+        model.contentOptions.regex = true
+        // Look-around — NSRegular accepts, rg's default rejects.
+        model.query = "(?=needle)"
+        await model.waitForIdle()
+        #expect(model.results.contentGroups.isEmpty)
+        #expect(model.results.partialFailureMessage == "Invalid regex pattern.")
+    }
+
+    @Test func validRegexProceedsToBackendAndReportsSoftFailureGenerically() async {
+        // A valid regex that nevertheless trips rg's exit 2 (e.g. unreadable
+        // file) must not be mislabeled as an invalid pattern — that was the
+        // PR 37 round-7 finding.
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            contentSearch: { _, _, _ in
+                AsyncThrowingStream { cont in
+                    cont.finish(throwing: ContentSearcher.SearchError.rgFailed(exitCode: 2))
+                }
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.kind = .content
+        model.contentOptions.regex = true
+        model.query = "^needle$"  // valid regex
+        await model.waitForIdle()
+        #expect(model.results.contentGroups.isEmpty)
+        #expect(model.results.partialFailureMessage == "Content search failed.")
+    }
+
+    @Test func rgFailedInLiteralModeWithNoHitsSaysGenericFailure() async {
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            contentSearch: { _, _, _ in
+                AsyncThrowingStream { cont in
+                    cont.finish(throwing: ContentSearcher.SearchError.rgFailed(exitCode: 2))
+                }
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.kind = .content
+        // regex toggle off — exit 2 here is a soft I/O error, not a regex syntax error.
+        model.query = "needle"
+        await model.waitForIdle()
+        #expect(model.results.contentGroups.isEmpty)
+        #expect(model.results.partialFailureMessage == "Content search failed.")
+    }
+
+    @Test func rgFailedAfterPartialResultsPreservesGroupsWithSoftBanner() async {
+        let hit = ContentSearchHit(
+            worktreeId: "a", projectId: "p1",
+            relativePath: "x.rs", line: 1, column: 1,
+            snippet: "match", matchCharRange: nil
+        )
+        let env = makeEnv(
+            worktrees: [wt("a")],
+            contentSearch: { _, _, _ in
+                AsyncThrowingStream { cont in
+                    Task {
+                        cont.yield(hit)
+                        cont.finish(throwing: ContentSearcher.SearchError.rgFailed(exitCode: 2))
+                    }
+                }
+            }
+        )
+        let model = SearchModel(environment: env)
+        model.open()
+        model.kind = .content
+        model.query = "match"
+        await model.waitForIdle()
+        // The earlier hit must survive — Codex's regression scenario was
+        // that a soft I/O error wiped accumulated groups from earlier files.
+        #expect(model.results.contentGroups.count == 1)
+        #expect(model.results.partialFailureMessage == "Some files couldn't be searched.")
+    }
+}
+
+/// Test helper used by `invalidRegexIsCaughtBeforeBackendRuns` to flag
+/// whether the contentSearch closure was invoked.
+private actor InvocationFlag {
+    private var invoked = false
+    func set() { invoked = true }
+    var value: Bool { invoked }
 }


### PR DESCRIPTION
<!-- gg:managed:start -->
Plugs in `rg --json` for content search, parses streaming match events
into per-file groups (preserving encounter order), wires Aa/W/.* toggles
to rg flags, and applies caps (200 hits / 50 files) with partial flushes
every 25 hits for streaming UX. If `rg` isn't on PATH the dialog shows
an install hint without breaking file search. Cancellation kills the rg
child process via withTaskCancellationHandler.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
<!-- gg:managed:end -->