### PR TITLE
feat(editor): editable buffers, save, hot exit, conflict banner

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		0294EF678CFA762C8B5D381B /* HookInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */; };
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
 		043B6662FCBEC5969946D61A /* HookWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7116359F27BF0A139E0F643B /* HookWatcher.swift */; };
+		0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
@@ -42,6 +43,7 @@
 		3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2498E56CBAF84CB67166C /* HarnessKind.swift */; };
 		3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B450918CC98255AD9170586 /* AppearancePane.swift */; };
 		3B34A2725C1F6B6E29C312F1 /* SearchInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */; };
+		3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */; };
 		3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */; };
 		3BA0F34C4D9EE5081736F458 /* claude-code.sh in Resources */ = {isa = PBXBuildFile; fileRef = 4501413979E60464DCE5602C /* claude-code.sh */; };
 		3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C1705E68E97111E85D83F3 /* RightPaneState.swift */; };
@@ -67,14 +69,6 @@
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */; };
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
-		4C02B761E19F45A799D6B6D2 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278C393477D54F4E95FFF863 /* LineEnding.swift */; };
-		94F5A64AA9F740CFA5CB4611 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */; };
-		11512BD57B844766B1C087A6 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */; };
-		AA0203CF936A4A6C978501A0 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */; };
-		1AF3214EE437431286FB3B52 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45119A3BDC964BE88EA7228A /* EditorBuffer.swift */; };
-		39F37C8B85E04FA69AD2FBFE /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AF47C0031F4DE5829C367B /* EditorConflictBanner.swift */; };
-		9C63D1DA9FBC4F32BD5A1528 /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */; };
-		D966900E7D3C44ADB37B25F3 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58F12D5B21403FB682A58A /* TabsManagerBufferTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
@@ -85,6 +79,7 @@
 		671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A17A797374500E1FDD2382C /* PersistenceStore.swift */; };
 		676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4261E417947C1A21E77C1587 /* GitStatusCache.swift */; };
 		67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */; };
+		6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4A215AF2876091E31F6F8A /* LineEnding.swift */; };
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
@@ -122,6 +117,7 @@
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
+		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
 		A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */; };
@@ -138,6 +134,7 @@
 		AD3469F4745DF96ED3D0E06E /* codex-cli.sh in Resources */ = {isa = PBXBuildFile; fileRef = F1524DAA94E33D2938853810 /* codex-cli.sh */; };
 		B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7159EED1183F784104B4F /* FuzzyMatch.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
+		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
 		B6C31E7AC3CE21AFEA371389 /* cool-slate.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DEB85132B767DB3B253620C /* cool-slate.json */; };
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
@@ -153,6 +150,7 @@
 		C51D65D3D40F801BC94ABBDD /* TabsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A218B5125FC963339E40605E /* TabsManager.swift */; };
 		C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDEA496740F5B0B5EE808B /* Process+Git.swift */; };
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
+		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
 		CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */; };
 		CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */; };
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
@@ -168,6 +166,8 @@
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
+		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
+		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
 		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
@@ -215,14 +215,6 @@
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
 		1688AB1B49758FAB5BF0AF2F /* light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = light.json; sourceTree = "<group>"; };
-		278C393477D54F4E95FFF863 /* LineEnding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEnding.swift; sourceTree = "<group>"; };
-		4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
-		6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
-		1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
-		45119A3BDC964BE88EA7228A /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
-		77AF47C0031F4DE5829C367B /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
-		BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
-		FE58F12D5B21403FB682A58A /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -248,6 +240,7 @@
 		3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindow.swift; sourceTree = "<group>"; };
 		345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistryTests.swift; sourceTree = "<group>"; };
 		3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputRow.swift; sourceTree = "<group>"; };
+		35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
 		36992F601C8EB6C3D45B584F /* SearchKbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKbd.swift; sourceTree = "<group>"; };
 		36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKind.swift; sourceTree = "<group>"; };
@@ -279,6 +272,7 @@
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
 		642163EB929E060A878211E2 /* HookInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstaller.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
+		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
@@ -286,6 +280,7 @@
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
+		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		7116359F27BF0A139E0F643B /* HookWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookWatcher.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
 		71E3734FE56F51B4615EF1A5 /* HookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookEvent.swift; sourceTree = "<group>"; };
@@ -336,10 +331,12 @@
 		BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcher.swift; sourceTree = "<group>"; };
 		BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManager.swift; sourceTree = "<group>"; };
 		BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
 		C6CA79B71B4AA72697392702 /* NumstatParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParser.swift; sourceTree = "<group>"; };
+		C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
 		C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTheme.swift; sourceTree = "<group>"; };
 		C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Surface.swift; sourceTree = "<group>"; };
 		C995611A6313FABE30508248 /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
@@ -353,6 +350,7 @@
 		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D6A9977C979705A40595FD5E /* TabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerTests.swift; sourceTree = "<group>"; };
+		D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
 		D97EF761C70A3AF83C00879A /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		D9E6D61B213F3378243B4A26 /* AlasField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasField.swift; sourceTree = "<group>"; };
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
@@ -363,6 +361,7 @@
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClientTests.swift; sourceTree = "<group>"; };
+		EB52B59655B85764D85CFB7F /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
 		EBBBF87CC508451B2C0F3A66 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
 		EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParserTests.swift; sourceTree = "<group>"; };
@@ -378,6 +377,7 @@
 		F9F85B92952C963DCF136315 /* HarnessDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetector.swift; sourceTree = "<group>"; };
 		FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
+		FC4A215AF2876091E31F6F8A /* LineEnding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEnding.swift; sourceTree = "<group>"; };
 		FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorView.swift; sourceTree = "<group>"; };
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
 		FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPane.swift; sourceTree = "<group>"; };
@@ -417,6 +417,8 @@
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
 				1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */,
+				35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */,
+				C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */,
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
 				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
 				3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */,
@@ -428,6 +430,7 @@
 				F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */,
 				A8820E4289EEB1ADCA9E490F /* HookEventTests.swift */,
 				954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */,
+				EB52B59655B85764D85CFB7F /* LineEndingTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
@@ -437,15 +440,12 @@
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
+				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
 				1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */,
 				88379ACE40F42BE4A3257659 /* ThemeTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
-				4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */,
-				1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */,
-				BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */,
-				FE58F12D5B21403FB682A58A /* TabsManagerBufferTests.swift */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 			);
 			path = AlasTests;
@@ -750,11 +750,11 @@
 				30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */,
 				FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */,
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
-				45119A3BDC964BE88EA7228A /* EditorBuffer.swift */,
-				6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */,
-				77AF47C0031F4DE5829C367B /* EditorConflictBanner.swift */,
+				64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */,
+				D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */,
+				BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
-				278C393477D54F4E95FFF863 /* LineEnding.swift */,
+				FC4A215AF2876091E31F6F8A /* LineEnding.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -1049,12 +1049,11 @@
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,
 				AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */,
 				1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */,
+				A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */,
+				B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */,
+				DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
-				11512BD57B844766B1C087A6 /* EditorBufferStore.swift in Sources */,
-				1AF3214EE437431286FB3B52 /* EditorBuffer.swift in Sources */,
-				39F37C8B85E04FA69AD2FBFE /* EditorConflictBanner.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,
-				4C02B761E19F45A799D6B6D2 /* LineEnding.swift in Sources */,
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,
 				950C937884477417569DC20B /* EmptyTabView.swift in Sources */,
 				7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */,
@@ -1087,6 +1086,7 @@
 				91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */,
 				3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */,
 				C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */,
+				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */,
 				F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */,
@@ -1160,6 +1160,8 @@
 				BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */,
+				3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */,
+				C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */,
 				C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */,
 				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
@@ -1175,6 +1177,7 @@
 				79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */,
 				C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */,
 				9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */,
+				DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,
@@ -1184,16 +1187,13 @@
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,
+				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
 				59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */,
 				BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */,
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
-				94F5A64AA9F740CFA5CB4611 /* LineEndingTests.swift in Sources */,
-				AA0203CF936A4A6C978501A0 /* EditorBufferStoreTests.swift in Sources */,
-				9C63D1DA9FBC4F32BD5A1528 /* EditorBufferTests.swift in Sources */,
-				D966900E7D3C44ADB37B25F3 /* TabsManagerBufferTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
 		4C02B761E19F45A799D6B6D2 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278C393477D54F4E95FFF863 /* LineEnding.swift */; };
 		94F5A64AA9F740CFA5CB4611 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */; };
+		11512BD57B844766B1C087A6 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */; };
+		AA0203CF936A4A6C978501A0 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
@@ -211,6 +213,8 @@
 		1688AB1B49758FAB5BF0AF2F /* light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = light.json; sourceTree = "<group>"; };
 		278C393477D54F4E95FFF863 /* LineEnding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEnding.swift; sourceTree = "<group>"; };
 		4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
+		6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
+		1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -431,6 +435,7 @@
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */,
+				1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 			);
 			path = AlasTests;
@@ -735,6 +740,7 @@
 				30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */,
 				FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */,
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
+				6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
 				278C393477D54F4E95FFF863 /* LineEnding.swift */,
 			);
@@ -1032,6 +1038,7 @@
 				AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */,
 				1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
+				11512BD57B844766B1C087A6 /* EditorBufferStore.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,
 				4C02B761E19F45A799D6B6D2 /* LineEnding.swift in Sources */,
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,
@@ -1170,6 +1177,7 @@
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
 				94F5A64AA9F740CFA5CB4611 /* LineEndingTests.swift in Sources */,
+				AA0203CF936A4A6C978501A0 /* EditorBufferStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		11512BD57B844766B1C087A6 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */; };
 		AA0203CF936A4A6C978501A0 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */; };
 		1AF3214EE437431286FB3B52 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45119A3BDC964BE88EA7228A /* EditorBuffer.swift */; };
+		39F37C8B85E04FA69AD2FBFE /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AF47C0031F4DE5829C367B /* EditorConflictBanner.swift */; };
 		9C63D1DA9FBC4F32BD5A1528 /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */; };
 		D966900E7D3C44ADB37B25F3 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58F12D5B21403FB682A58A /* TabsManagerBufferTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
@@ -219,6 +220,7 @@
 		6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
 		1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
 		45119A3BDC964BE88EA7228A /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
+		77AF47C0031F4DE5829C367B /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
 		BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
 		FE58F12D5B21403FB682A58A /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
@@ -750,6 +752,7 @@
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
 				45119A3BDC964BE88EA7228A /* EditorBuffer.swift */,
 				6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */,
+				77AF47C0031F4DE5829C367B /* EditorConflictBanner.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
 				278C393477D54F4E95FFF863 /* LineEnding.swift */,
 			);
@@ -1049,6 +1052,7 @@
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
 				11512BD57B844766B1C087A6 /* EditorBufferStore.swift in Sources */,
 				1AF3214EE437431286FB3B52 /* EditorBuffer.swift in Sources */,
+				39F37C8B85E04FA69AD2FBFE /* EditorConflictBanner.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,
 				4C02B761E19F45A799D6B6D2 /* LineEnding.swift in Sources */,
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */; };
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
+		4C02B761E19F45A799D6B6D2 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 278C393477D54F4E95FFF863 /* LineEnding.swift */; };
+		94F5A64AA9F740CFA5CB4611 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
@@ -207,6 +209,8 @@
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
 		1688AB1B49758FAB5BF0AF2F /* light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = light.json; sourceTree = "<group>"; };
+		278C393477D54F4E95FFF863 /* LineEnding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEnding.swift; sourceTree = "<group>"; };
+		4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -426,6 +430,7 @@
 				88379ACE40F42BE4A3257659 /* ThemeTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
+				4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 			);
 			path = AlasTests;
@@ -731,6 +736,7 @@
 				FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */,
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
+				278C393477D54F4E95FFF863 /* LineEnding.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -1027,6 +1033,7 @@
 				1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,
+				4C02B761E19F45A799D6B6D2 /* LineEnding.swift in Sources */,
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,
 				950C937884477417569DC20B /* EmptyTabView.swift in Sources */,
 				7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */,
@@ -1162,6 +1169,7 @@
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
+				94F5A64AA9F740CFA5CB4611 /* LineEndingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		94F5A64AA9F740CFA5CB4611 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */; };
 		11512BD57B844766B1C087A6 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */; };
 		AA0203CF936A4A6C978501A0 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */; };
+		1AF3214EE437431286FB3B52 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45119A3BDC964BE88EA7228A /* EditorBuffer.swift */; };
+		9C63D1DA9FBC4F32BD5A1528 /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
@@ -215,6 +217,8 @@
 		4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
 		6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
 		1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
+		45119A3BDC964BE88EA7228A /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
+		BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -436,6 +440,7 @@
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */,
 				1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */,
+				BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 			);
 			path = AlasTests;
@@ -740,6 +745,7 @@
 				30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */,
 				FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */,
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
+				45119A3BDC964BE88EA7228A /* EditorBuffer.swift */,
 				6E1274202FB3468A8D4B9231 /* EditorBufferStore.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
 				278C393477D54F4E95FFF863 /* LineEnding.swift */,
@@ -1039,6 +1045,7 @@
 				1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
 				11512BD57B844766B1C087A6 /* EditorBufferStore.swift in Sources */,
+				1AF3214EE437431286FB3B52 /* EditorBuffer.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,
 				4C02B761E19F45A799D6B6D2 /* LineEnding.swift in Sources */,
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,
@@ -1178,6 +1185,7 @@
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
 				94F5A64AA9F740CFA5CB4611 /* LineEndingTests.swift in Sources */,
 				AA0203CF936A4A6C978501A0 /* EditorBufferStoreTests.swift in Sources */,
+				9C63D1DA9FBC4F32BD5A1528 /* EditorBufferTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		AA0203CF936A4A6C978501A0 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */; };
 		1AF3214EE437431286FB3B52 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45119A3BDC964BE88EA7228A /* EditorBuffer.swift */; };
 		9C63D1DA9FBC4F32BD5A1528 /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */; };
+		D966900E7D3C44ADB37B25F3 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE58F12D5B21403FB682A58A /* TabsManagerBufferTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
@@ -219,6 +220,7 @@
 		1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
 		45119A3BDC964BE88EA7228A /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
 		BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
+		FE58F12D5B21403FB682A58A /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 				4B3B75D2A7254D37A5635B57 /* LineEndingTests.swift */,
 				1219FC591AAD497D989AB5D5 /* EditorBufferStoreTests.swift */,
 				BDBB1FBDC60A44F28B8C538B /* EditorBufferTests.swift */,
+				FE58F12D5B21403FB682A58A /* TabsManagerBufferTests.swift */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 			);
 			path = AlasTests;
@@ -1186,6 +1189,7 @@
 				94F5A64AA9F740CFA5CB4611 /* LineEndingTests.swift in Sources */,
 				AA0203CF936A4A6C978501A0 /* EditorBufferStoreTests.swift in Sources */,
 				9C63D1DA9FBC4F32BD5A1528 /* EditorBufferTests.swift in Sources */,
+				D966900E7D3C44ADB37B25F3 /* TabsManagerBufferTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -35,6 +35,10 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasNewTerminalTab, object: nil)
                 }
                 .keyboardShortcut("t", modifiers: .command)
+                Button("Save") {
+                    NotificationCenter.default.post(name: .alasSaveActiveTab, object: nil)
+                }
+                .keyboardShortcut("s", modifiers: .command)
                 Button("Close Tab") {
                     NotificationCenter.default.post(name: .alasCloseTab, object: nil)
                 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -137,12 +137,21 @@ final class AppState {
         return try replaceMissingTerminalSession(worktreeId: worktreeId, tab: state)
     }
 
+    func saveActiveTab(worktreeId: String) {
+        _ = tabs.saveActive(worktreeId: worktreeId)
+    }
+
     func closeTab(worktreeId: String, tabId: TabID) {
-        if let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
-           case .terminal(let s) = tab {
-            harness.detector.unregister(sessionId: s.sessionId)
-            harness.forgetSession(s.sessionId)
-            terminal.closeSession(id: s.sessionId)
+        let allTabs = tabs.tabs(forWorktree: worktreeId)
+        if let tab = allTabs.first(where: { $0.id == tabId }) {
+            if case .terminal(let s) = tab {
+                harness.detector.unregister(sessionId: s.sessionId)
+                harness.forgetSession(s.sessionId)
+                terminal.closeSession(id: s.sessionId)
+            }
+            if case .editor = tab {
+                tabs.discardBuffer(worktreeId: worktreeId, tabId: tabId)
+            }
         }
         tabs.close(worktreeId: worktreeId, tabId: tabId)
     }
@@ -158,28 +167,40 @@ final class AppState {
         }
     }
 
+    private func cleanupClosedEditorBuffers(worktreeId: String, allTabs: [Tab], closedIds: [TabID]) {
+        for id in closedIds {
+            if let tab = allTabs.first(where: { $0.id == id }), case .editor = tab {
+                tabs.discardBuffer(worktreeId: worktreeId, tabId: id)
+            }
+        }
+    }
+
     func closeOtherTabs(worktreeId: String, keeping tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeOthers(worktreeId: worktreeId, keeping: tabId)
         cleanupTerminals(allTabs: allTabs, tabIds: closed)
+        cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
     }
 
     func closeAllTabs(worktreeId: String) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeAll(worktreeId: worktreeId)
         cleanupTerminals(allTabs: allTabs, tabIds: closed)
+        cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
     }
 
     func closeTabsToLeft(worktreeId: String, of tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeToLeft(worktreeId: worktreeId, of: tabId)
         cleanupTerminals(allTabs: allTabs, tabIds: closed)
+        cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
     }
 
     func closeTabsToRight(worktreeId: String, of tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeToRight(worktreeId: worktreeId, of: tabId)
         cleanupTerminals(allTabs: allTabs, tabIds: closed)
+        cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
     }
 
     @discardableResult

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -9,7 +9,14 @@ final class AppState {
     var themeStore: ThemeStore
     var projectsManager: ProjectsManager
     var selectedWorktreeId: String?
-    let tabs = TabsManager()
+    @ObservationIgnored
+    private var _tabs: TabsManager?
+    var tabs: TabsManager {
+        if let _tabs { return _tabs }
+        let manager = TabsManager(lsp: lsp)
+        _tabs = manager
+        return manager
+    }
     let terminal = TerminalService()
     let rightPaneStore = RightPaneStore()
     let harness = HarnessService()

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -86,6 +86,11 @@ struct RootView: View {
                 state.closeTab(worktreeId: wt.id, tabId: active)
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .alasSaveActiveTab)) { _ in
+            if let wt = selectedWorktree() {
+                state.saveActiveTab(worktreeId: wt.id)
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .alasOpenSettings)) { _ in
             openSettingsWindow()
         }
@@ -155,4 +160,5 @@ extension Notification.Name {
     static let alasCloseTab        = Notification.Name("AlasCloseTab")
     static let alasOpenSettings    = Notification.Name("AlasOpenSettings")
     static let alasOpenSearch      = Notification.Name("AlasOpenSearch")
+    static let alasSaveActiveTab   = Notification.Name("AlasSaveActiveTab")
 }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct RootView: View {
@@ -97,6 +98,9 @@ struct RootView: View {
         .onReceive(NotificationCenter.default.publisher(for: .alasOpenSearch)) { _ in
             state.search.open()
             state.isSearchOpen = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+            state.tabs.snapshotDirtyBuffersForQuit()
         }
         .sheet(isPresented: $showNewProject) {
             NewProjectDialog(state: state, presented: $showNewProject)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -21,6 +21,11 @@ struct CenterPaneView: View {
                     }
                     return nil
                 },
+                dirtyLookup: { id in
+                    let buffer = state.tabs.peekBuffer(tabId: id)
+                    _ = buffer?.editGeneration
+                    return buffer?.dirty ?? false
+                },
                 onActivate: { id in state.tabs.activate(worktreeId: worktree.id, tabId: id) },
                 onClose:    { id in state.closeTab(worktreeId: worktree.id, tabId: id) },
                 onCloseOthers: { id in state.closeOtherTabs(worktreeId: worktree.id, keeping: id) },

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -23,6 +23,10 @@ struct CenterPaneView: View {
                 },
                 dirtyLookup: { id in
                     let buffer = state.tabs.peekBuffer(tabId: id)
+                    // Touch editGeneration so SwiftUI's Observation tracker
+                    // re-evaluates this closure on every keystroke; without
+                    // this, `dirty` (which depends on non-observable
+                    // NSTextStorage) would only refresh on theme/tab changes.
                     _ = buffer?.editGeneration
                     return buffer?.dirty ?? false
                 },

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -11,8 +11,15 @@ struct EditorTabView: View {
     @Environment(\.theme) var theme
 
     var body: some View {
-        VStack(spacing: 0) {
+        let buffer = appState.tabs.buffer(
+            worktreeId: worktreeId,
+            tabId: tabId,
+            worktreeRoot: worktreePath,
+            relativePath: relativePath
+        )
+        return VStack(spacing: 0) {
             breadcrumb
+            EditorConflictBanner(buffer: buffer)
             CodeEditorView(
                 worktreeId: worktreeId,
                 worktreeRoot: worktreePath,

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -4,6 +4,7 @@ struct TabBarView: View {
     let tabs: [Tab]
     let activeId: TabID?
     let harnessLookup: (TabID) -> (kind: HarnessKind, state: String)?
+    let dirtyLookup: (TabID) -> Bool
     let onActivate: (TabID) -> Void
     let onClose: (TabID) -> Void
     let onCloseOthers: (TabID) -> Void
@@ -23,6 +24,7 @@ struct TabBarView: View {
                     active: tab.id == activeId,
                     showClose: tabs.count > 1,
                     harnessInfo: harnessLookup(tab.id),
+                    dirty: dirtyLookup(tab.id),
                     onActivate: { onActivate(tab.id) },
                     onClose: { onClose(tab.id) }
                 )
@@ -62,6 +64,7 @@ private struct TabButton: View {
     let active: Bool
     let showClose: Bool
     let harnessInfo: (kind: HarnessKind, state: String)?
+    let dirty: Bool
     let onActivate: () -> Void
     let onClose: () -> Void
     @Environment(\.theme) var theme
@@ -81,14 +84,23 @@ private struct TabButton: View {
             }
             if showClose {
                 Button(action: onClose) {
-                    Icon(name: "x", size: 9,
-                         color: hoveringClose ? theme.color("fg") : theme.color("fg-faint"))
-                        .frame(width: 14, height: 14)
-                        .background(hoveringClose ? theme.color("bg-4") : .clear)
-                        .clipShape(RoundedRectangle(cornerRadius: 3))
+                    ZStack {
+                        if dirty && !hoveringClose {
+                            Circle()
+                                .fill(theme.color("fg"))
+                                .frame(width: 7, height: 7)
+                        } else {
+                            Icon(name: "x", size: 9,
+                                 color: hoveringClose ? theme.color("fg") : theme.color("fg-faint"))
+                                .background(hoveringClose ? theme.color("bg-4") : .clear)
+                                .clipShape(RoundedRectangle(cornerRadius: 3))
+                        }
+                    }
+                    .frame(width: 14, height: 14)
                 }
                 .buttonStyle(.plain)
                 .onHover { hoveringClose = $0 }
+                .help(dirty ? "Unsaved changes — click to close" : "Close")
             }
         }
         .padding(.horizontal, 10)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -240,8 +240,13 @@ final class TabsManager {
     }
 
     /// Tear down the buffer for `tabId`: snapshot if dirty, close watcher,
-    /// drop from cache.
+    /// drop from cache. `worktreeId` is asserted in debug builds against the
+    /// recorded owner so a tab discarded from the wrong worktree context
+    /// surfaces immediately rather than silently mis-routing the snapshot.
     func discardBuffer(worktreeId: String, tabId: TabID) {
+        if let owner = bufferOwners[tabId] {
+            assert(owner == worktreeId, "discardBuffer called with worktreeId=\(worktreeId) but buffer is owned by \(owner)")
+        }
         guard let buffer = buffers.removeValue(forKey: tabId) else { return }
         bufferOwners.removeValue(forKey: tabId)
         buffer.close()

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -17,9 +17,11 @@ final class TabsManager {
     // Map tabId → worktreeId so `discardBuffer` and `snapshotDirtyBuffersForQuit`
     // know which subtree to write to without forcing callers to pass it.
     private var bufferOwners: [TabID: String] = [:]
+    private let lsp: WorkspaceLSPManager?
 
-    init(bufferStore: EditorBufferStore = EditorBufferStore()) {
+    init(bufferStore: EditorBufferStore = EditorBufferStore(), lsp: WorkspaceLSPManager? = nil) {
         self.bufferStore = bufferStore
+        self.lsp = lsp
     }
 
     func tabs(forWorktree id: String) -> [Tab] {
@@ -219,13 +221,25 @@ final class TabsManager {
     /// hot-restore from snapshot) on first access.
     func buffer(worktreeId: String, tabId: TabID, worktreeRoot: URL, relativePath: String) -> EditorBuffer {
         if let existing = buffers[tabId] { return existing }
-        let buffer = EditorBuffer(
-            worktreeRoot: worktreeRoot,
-            relativePath: relativePath,
-            store: bufferStore,
-            worktreeId: worktreeId,
-            tabId: tabId
-        )
+        let buffer: EditorBuffer
+        if let lsp {
+            buffer = EditorBuffer(
+                worktreeRoot: worktreeRoot,
+                relativePath: relativePath,
+                store: bufferStore,
+                worktreeId: worktreeId,
+                tabId: tabId,
+                lsp: lsp
+            )
+        } else {
+            buffer = EditorBuffer(
+                worktreeRoot: worktreeRoot,
+                relativePath: relativePath,
+                store: bufferStore,
+                worktreeId: worktreeId,
+                tabId: tabId
+            )
+        }
         buffer.startWatching()
         buffer.checkForConflictOnRestore()
         buffers[tabId] = buffer

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -289,10 +289,9 @@ final class TabsManager {
         guard let activeId = activeTabId(forWorktree: worktreeId),
               let buffer = buffers[activeId] else { return false }
         do {
-            try buffer.save()
+            try buffer.saveRecordingError()
             return true
         } catch {
-            buffer.lastSaveError = (error as NSError).localizedDescription
             return false
         }
     }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -253,17 +253,19 @@ final class TabsManager {
         buffers[tabId]
     }
 
-    /// Tear down the buffer for `tabId`: snapshot if dirty, close watcher,
-    /// drop from cache. `worktreeId` is asserted in debug builds against the
-    /// recorded owner so a tab discarded from the wrong worktree context
-    /// surfaces immediately rather than silently mis-routing the snapshot.
+    /// Tear down the buffer for `tabId`, close its watcher, and drop it from
+    /// cache. Explicit tab removal discards hot-exit snapshots; app quit paths
+    /// snapshot dirty buffers before teardown. `worktreeId` is asserted in
+    /// debug builds against the recorded owner so a tab discarded from the
+    /// wrong worktree context surfaces immediately rather than silently
+    /// mis-routing the snapshot.
     func discardBuffer(worktreeId: String, tabId: TabID) {
         if let owner = bufferOwners[tabId] {
             assert(owner == worktreeId, "discardBuffer called with worktreeId=\(worktreeId) but buffer is owned by \(owner)")
         }
         guard let buffer = buffers.removeValue(forKey: tabId) else { return }
         bufferOwners.removeValue(forKey: tabId)
-        buffer.close()
+        buffer.close(persistDirtySnapshot: false)
     }
 
     /// Tab IDs whose buffers are currently dirty. Order is unspecified.

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -8,9 +8,19 @@ struct TabsFile: Codable {
 }
 
 @Observable
+@MainActor
 final class TabsManager {
     private var byWorktree: [String: TabsFile] = [:]
     private let store = PersistenceStore()
+    private let bufferStore: EditorBufferStore
+    private var buffers: [TabID: EditorBuffer] = [:]
+    // Map tabId → worktreeId so `discardBuffer` and `snapshotDirtyBuffersForQuit`
+    // know which subtree to write to without forcing callers to pass it.
+    private var bufferOwners: [TabID: String] = [:]
+
+    init(bufferStore: EditorBufferStore = EditorBufferStore()) {
+        self.bufferStore = bufferStore
+    }
 
     func tabs(forWorktree id: String) -> [Tab] {
         byWorktree[id]?.tabs ?? []
@@ -201,5 +211,68 @@ final class TabsManager {
     private func persist(_ worktreeId: String) {
         guard let file = byWorktree[worktreeId] else { return }
         try? store.write(file, to: Paths.tabsFile(forWorktreeId: worktreeId))
+    }
+
+    // MARK: - Buffer lifecycle
+
+    /// Returns the buffer for `tabId`, creating it (cold-load from disk or
+    /// hot-restore from snapshot) on first access.
+    func buffer(worktreeId: String, tabId: TabID, worktreeRoot: URL, relativePath: String) -> EditorBuffer {
+        if let existing = buffers[tabId] { return existing }
+        let buffer = EditorBuffer(
+            worktreeRoot: worktreeRoot,
+            relativePath: relativePath,
+            store: bufferStore,
+            worktreeId: worktreeId,
+            tabId: tabId
+        )
+        buffer.startWatching()
+        buffer.checkForConflictOnRestore()
+        buffers[tabId] = buffer
+        bufferOwners[tabId] = worktreeId
+        return buffer
+    }
+
+    /// Inspect (do not create) the buffer for `tabId`. Used by tests and by
+    /// dirty-tab queries.
+    func peekBuffer(tabId: TabID) -> EditorBuffer? {
+        buffers[tabId]
+    }
+
+    /// Tear down the buffer for `tabId`: snapshot if dirty, close watcher,
+    /// drop from cache.
+    func discardBuffer(worktreeId: String, tabId: TabID) {
+        guard let buffer = buffers.removeValue(forKey: tabId) else { return }
+        bufferOwners.removeValue(forKey: tabId)
+        buffer.close()
+    }
+
+    /// Tab IDs whose buffers are currently dirty. Order is unspecified.
+    func dirtyTabIds() -> [TabID] {
+        buffers.compactMap { $0.value.dirty ? $0.key : nil }
+    }
+
+    /// Walk all dirty buffers and write a final snapshot. Called by the
+    /// quit handler. Errors are swallowed — failing to snapshot one buffer
+    /// must not block snapshotting the rest, and quit must not be blocked.
+    func snapshotDirtyBuffersForQuit() {
+        for buffer in buffers.values where buffer.dirty {
+            buffer.snapshotNow()
+        }
+    }
+
+    /// Save the active editor tab's buffer for `worktreeId`. No-op if the
+    /// active tab is not an editor or has no buffer.
+    @discardableResult
+    func saveActive(worktreeId: String) -> Bool {
+        guard let activeId = activeTabId(forWorktree: worktreeId),
+              let buffer = buffers[activeId] else { return false }
+        do {
+            try buffer.save()
+            return true
+        } catch {
+            buffer.lastSaveError = (error as NSError).localizedDescription
+            return false
+        }
     }
 }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -12,6 +12,7 @@ final class CodeEditorCoordinator {
     let appState: AppState
     private weak var textView: CodeTextView?
     private weak var buffer: EditorBuffer?
+    private var layoutManager: NSLayoutManager?
 
     private var currentTabId: TabID?
     private var currentWorktreeId: String?
@@ -29,14 +30,16 @@ final class CodeEditorCoordinator {
 
     private var editObserverToken: EditorBuffer.EditObserverToken?
     private var didChangeTask: Task<Void, Never>?
+    private var hasPendingDidChange = false
 
     init(appState: AppState) {
         self.appState = appState
     }
 
-    func attach(textView: CodeTextView, buffer: EditorBuffer, worktreeId: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme) {
+    func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme) {
         self.textView = textView
         self.buffer = buffer
+        self.layoutManager = layoutManager
         self.currentWorktreeId = worktreeId
         self.currentTabId = tabId
         self.currentRoot = buffer.worktreeRoot
@@ -114,10 +117,18 @@ final class CodeEditorCoordinator {
             buffer.removeOnEdit(token)
         }
         editObserverToken = nil
+        if hasPendingDidChange {
+            notifyLSPDidChange()
+            hasPendingDidChange = false
+        }
         diagnosticsTask?.cancel()
         diagnosticsTask = nil
         didChangeTask?.cancel()
         didChangeTask = nil
+        if let buffer, let layoutManager {
+            buffer.storage.removeLayoutManager(layoutManager)
+        }
+        layoutManager = nil
         hover = nil
         definition = nil
         textView = nil
@@ -130,11 +141,13 @@ final class CodeEditorCoordinator {
 
     private func scheduleEditPropagation() {
         didChangeTask?.cancel()
+        hasPendingDidChange = true
         didChangeTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 150_000_000)
             guard let self, !Task.isCancelled, let theme = self.currentTheme else { return }
             await MainActor.run {
                 self.runHighlight(theme: theme)
+                self.hasPendingDidChange = false
                 self.notifyLSPDidChange()
             }
         }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -1,44 +1,58 @@
 import AppKit
 import Foundation
 
-/// Owns the lifecycle of a `CodeTextView` for a single file: reads the
-/// source from disk, applies tree-sitter highlights, opens the document
-/// with the workspace LSP, and routes diagnostics back as squiggle
-/// attributes on the text storage.
-///
-/// Hover and Cmd-click are wired up by Tasks 13/16 — this task only
-/// covers load + highlight + diagnostics.
+/// Lifecycle adapter between a `CodeTextView` (per-mount, recreated by
+/// SwiftUI) and an `EditorBuffer` (per-tab, owned by `TabsManager`). The
+/// coordinator handles syntax highlighting, LSP `didChange` debouncing,
+/// hover/definition feature wiring, theme repaints, and go-to-definition
+/// reveal scrolling. Disk I/O, save, file-watch, and dirty tracking live
+/// in `EditorBuffer`.
 @MainActor
 final class CodeEditorCoordinator {
     let appState: AppState
     private weak var textView: CodeTextView?
+    private weak var buffer: EditorBuffer?
 
+    private var currentTabId: TabID?
     private var currentWorktreeId: String?
     private var currentRoot: URL?
     private var currentRelativePath: String?
     private var currentLanguage: String?
     private var currentTheme: Theme?
-    private var currentMtime: Date?
     private var lastAppliedReveal: (tabId: TabID, line: Int, character: Int)?
+
     private var diagnosticsTask: Task<Void, Never>?
     private let diagnosticsFeature = DiagnosticsFeature()
     let symbolsFeature = SymbolsFeature()
     private var hover: HoverFeature?
     private var definition: DefinitionFeature?
-    private var fileWatcher: DispatchSourceFileSystemObject?
-    private var fileWatcherFD: Int32 = -1
-    private static let fileWatchQueue = DispatchQueue(label: "alas.editor.filewatch", qos: .utility)
+
+    private var editObserverToken: EditorBuffer.EditObserverToken?
+    private var didChangeTask: Task<Void, Never>?
 
     init(appState: AppState) {
         self.appState = appState
     }
 
-    func attach(textView: CodeTextView, worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme) {
+    func attach(textView: CodeTextView, buffer: EditorBuffer, worktreeId: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme) {
         self.textView = textView
+        self.buffer = buffer
         self.currentWorktreeId = worktreeId
+        self.currentTabId = tabId
+        self.currentRoot = buffer.worktreeRoot
+        self.currentRelativePath = buffer.relativePath
         self.currentTheme = theme
-        load(worktreeRoot: worktreeRoot, relativePath: relativePath, theme: theme)
-        applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
+
+        applyBaseStyle(theme: theme)
+        let ext = (buffer.relativePath as NSString).pathExtension
+        currentLanguage = appState.lsp.language(forFileExtension: ext)
+        runHighlight(theme: theme)
+        openLSPIfNeeded(text: buffer.storage.string, theme: theme)
+
+        editObserverToken = buffer.onEdit { [weak self] in
+            self?.scheduleEditPropagation()
+        }
+
         hover = HoverFeature(
             textView: textView,
             getClient: { [weak self] in
@@ -80,145 +94,133 @@ final class CodeEditorCoordinator {
                 )
             }
         )
+        applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
     }
 
     func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme) {
-        let fileChanged = !(currentRoot == worktreeRoot && currentRelativePath == relativePath && currentWorktreeId == worktreeId)
-        if fileChanged {
-            // Capture the previous document before `load` overwrites
-            // `currentRoot`, `currentRelativePath`, and `currentLanguage` —
-            // otherwise the fire-and-forget close races and ends up sending
-            // `didClose` for the *new* file or shutting down its
-            // freshly-spawned client.
-            let previous = takeCurrentDocument()
-            currentWorktreeId = worktreeId
-            load(worktreeRoot: worktreeRoot, relativePath: relativePath, theme: theme)
-            if let previous { Task { await self.close(document: previous) } }
-        } else if let root = currentRoot, let rel = currentRelativePath,
-                  let onDisk = mtime(of: root.appendingPathComponent(rel)),
-                  onDisk != currentMtime {
-            // The file changed on disk while the tab was unfocused (terminal
-            // edit, external tool, …). Re-read the content, refresh the view,
-            // and notify the language server via `didChange` so its hover /
-            // diagnostics / definitions move off the stale snapshot.
-            reloadFromDisk(theme: theme)
-        } else if currentTheme != theme {
-            // Theme change without file change — SwiftUI's previous
-            // per-line `Text` editor recomputed colors from the environment
-            // every render, but the AppKit text view holds onto the old
-            // background, foreground, syntax colors, and diagnostic colors
-            // until something forces a repaint. Re-run highlight + base
-            // styling so a live theme switch takes effect immediately.
-            repaint(theme: theme)
+        // The view representable hands us the same parameters every render.
+        // The only thing we react to here is theme change (re-paint) and
+        // reveal hints (scroll).
+        if currentTheme != theme {
+            applyBaseStyle(theme: theme)
+            runHighlight(theme: theme)
+            currentTheme = theme
         }
-        currentTheme = theme
         applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
     }
 
     func detach() {
-        let previous = takeCurrentDocument()
-        if let previous { Task { await self.close(document: previous) } }
-        diagnosticsTask?.cancel()
-        stopWatching()
-        hover = nil
-        definition = nil
-    }
-
-    // MARK: - Load + highlight
-
-    private func load(worktreeRoot: URL, relativePath: String, theme: Theme) {
-        guard let textView else { return }
-        // Cancel any in-flight diagnostics subscription from the previous
-        // file before we (potentially) early-return for a non-LSP extension —
-        // otherwise the old server can keep delivering diagnostics that get
-        // applied as squiggles on the reused text view. Also drop the
-        // cached `current` list so a subsequent `repaint` (theme change)
-        // or `reloadFromDisk` (external edit) doesn't reapply the previous
-        // file's ranges on top of the new content.
+        if let buffer, let token = editObserverToken {
+            buffer.removeOnEdit(token)
+        }
+        editObserverToken = nil
         diagnosticsTask?.cancel()
         diagnosticsTask = nil
-        diagnosticsFeature.reset()
-        let url = worktreeRoot.appendingPathComponent(relativePath)
+        didChangeTask?.cancel()
+        didChangeTask = nil
+        hover = nil
+        definition = nil
+        textView = nil
+        buffer = nil
+        // We deliberately do NOT close the LSP document or stop the file
+        // watcher — the buffer owns those for as long as the tab is alive.
+    }
+
+    // MARK: - Edit propagation (highlight + didChange debouncer)
+
+    private func scheduleEditPropagation() {
+        didChangeTask?.cancel()
+        didChangeTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            guard let self, !Task.isCancelled, let theme = self.currentTheme else { return }
+            await MainActor.run {
+                self.runHighlight(theme: theme)
+                self.notifyLSPDidChange()
+            }
+        }
+    }
+
+    private func notifyLSPDidChange() {
+        guard let buffer, let language = currentLanguage else { return }
+        let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
+        let text = buffer.storage.string
+        Task {
+            await appState.lsp.didChange(
+                worktreeRoot: buffer.worktreeRoot,
+                fileURL: url,
+                languageId: language,
+                text: text
+            )
+        }
+    }
+
+    // MARK: - Highlight + base styling
+
+    private func applyBaseStyle(theme: Theme) {
+        guard let buffer, let textView else { return }
+        textView.backgroundColor = NSColor(theme.color("bg-1"))
         let editorTheme = EditorTheme(theme: theme)
         let baseAttrs: [NSAttributedString.Key: Any] = [
             .font: textView.font ?? NSFont.monospacedSystemFont(ofSize: 12.5, weight: .regular),
             .foregroundColor: editorTheme.defaultFG
         ]
+        let storage = buffer.storage
+        storage.beginEditing()
+        storage.setAttributes(baseAttrs, range: NSRange(location: 0, length: storage.length))
+        storage.endEditing()
+    }
 
-        // Stage 1 — immediate. Read the file synchronously and paint plain
-        // text so the user sees content right away. Tree-sitter parsing and
-        // LSP startup follow asynchronously below.
-        let text = (try? String(contentsOf: url, encoding: .utf8)) ?? "(unable to read file)"
-        textView.textStorage?.setAttributedString(NSAttributedString(string: text, attributes: baseAttrs))
-
-        currentRoot = worktreeRoot
-        currentRelativePath = relativePath
-        currentMtime = mtime(of: url)
-        startWatching(url)
-
-        let ext = (relativePath as NSString).pathExtension
-
-        // Stage 2 — async tree-sitter highlight. Parsing a non-trivial file
-        // can take 10s of ms; doing it on the main actor freezes the
-        // first paint. Run it on a detached priority-userInitiated task and
-        // apply the spans back on the main actor. Bail if the user
-        // navigated to a different file before the parse finished.
-        let stableRoot = worktreeRoot
-        let stableRel = relativePath
+    private func runHighlight(theme: Theme) {
+        guard let buffer else { return }
+        let storage = buffer.storage
+        let text = storage.string
+        let ext = (buffer.relativePath as NSString).pathExtension
+        let editorTheme = EditorTheme(theme: theme)
+        let stableTabId = currentTabId
+        let cachedDiagnostics = diagnosticsFeature.current
         Task.detached(priority: .userInitiated) { [weak self] in
             let spans = TreeSitterHighlighter.highlight(source: text, fileExtension: ext)
             await MainActor.run {
-                guard let self = self,
-                      let storage = self.textView?.textStorage,
-                      self.currentRoot == stableRoot,
-                      self.currentRelativePath == stableRel else { return }
+                guard let self,
+                      let b = self.buffer,
+                      b.storage === storage,
+                      self.currentTabId == stableTabId else { return }
                 storage.beginEditing()
                 for span in spans {
                     storage.addAttributes(editorTheme.attributes(for: span.capture), range: span.range)
                 }
                 storage.endEditing()
+                if !cachedDiagnostics.isEmpty {
+                    self.diagnosticsFeature.apply(cachedDiagnostics, to: storage, theme: theme)
+                }
             }
         }
+    }
 
-        // Stage 3 — async LSP setup. Resolve the language via the registry
-        // so user-defined servers (Settings → Code) are honored alongside
-        // the built-in Swift entry.
+    // MARK: - LSP open + diagnostics subscription
+
+    private func openLSPIfNeeded(text: String, theme: Theme) {
+        guard let buffer, let language = currentLanguage else { return }
+        let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
         let manager = appState.lsp
-        let language = manager.language(forFileExtension: ext)
-        currentLanguage = language
-        guard let language else { return }
-
-        // Snapshot the file we're loading so the async block can detect a
-        // mid-flight file switch — the manager's `openDocument` awaits
-        // `initialize()` which may take seconds; without this guard we'd
-        // subscribe diagnostics and refresh symbols for the *previous* URI,
-        // and `subscribeDiagnostics` would cancel the new file's
-        // diagnostics task on its way through.
-        Task { [stableRoot, stableRel] in
+        diagnosticsTask?.cancel()
+        diagnosticsFeature.reset()
+        let stableTabId = currentTabId
+        Task { [weak self, language] in
             let client = await manager.openDocument(
-                worktreeRoot: worktreeRoot,
+                worktreeRoot: buffer.worktreeRoot,
                 fileURL: url,
                 languageId: language,
                 text: text
             )
-            let stillCurrent = self.currentRoot == stableRoot && self.currentRelativePath == stableRel
-            guard stillCurrent else {
-                // The user closed the tab or switched files while
-                // `openDocument` was in flight. If the manager opened a
-                // server for us we owe it a matching `closeDocument` —
-                // otherwise the refcount stays elevated and the server
-                // process hangs around until app shutdown.
+            guard let self, self.currentTabId == stableTabId else {
                 if client != nil {
-                    await manager.closeDocument(
-                        worktreeRoot: stableRoot,
-                        fileURL: url,
-                        languageId: language
-                    )
+                    await manager.closeDocument(worktreeRoot: buffer.worktreeRoot, fileURL: url, languageId: language)
                 }
                 return
             }
             await self.subscribeDiagnostics(for: client, uri: url.lspURI, theme: theme)
-            await symbolsFeature.refresh(client: client, uri: url.lspURI)
+            await self.symbolsFeature.refresh(client: client, uri: url.lspURI)
         }
     }
 
@@ -229,179 +231,11 @@ final class CodeEditorCoordinator {
             for await batch in await client.subscribeDiagnostics() {
                 if batch.uri != uri { continue }
                 await MainActor.run {
-                    self?.applyDiagnostics(batch.diagnostics, theme: theme)
+                    guard let self, let buffer = self.buffer else { return }
+                    self.diagnosticsFeature.apply(batch.diagnostics, to: buffer.storage, theme: theme)
                 }
             }
         }
-    }
-
-    private func applyDiagnostics(_ diagnostics: [LSPDiagnostic], theme: Theme) {
-        guard let storage = textView?.textStorage else { return }
-        diagnosticsFeature.apply(diagnostics, to: storage, theme: theme)
-    }
-
-    /// Re-reads the current file from disk, repaints the view, and notifies
-    /// the language server via `didChange` so its hover/diagnostics catch up
-    /// to external edits.
-    private func reloadFromDisk(theme: Theme) {
-        guard let textView, let root = currentRoot, let rel = currentRelativePath else { return }
-        let url = root.appendingPathComponent(rel)
-        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return }
-        let editorTheme = EditorTheme(theme: theme)
-        let baseAttrs: [NSAttributedString.Key: Any] = [
-            .font: textView.font ?? NSFont.monospacedSystemFont(ofSize: 12.5, weight: .regular),
-            .foregroundColor: editorTheme.defaultFG
-        ]
-        textView.textStorage?.setAttributedString(NSAttributedString(string: text, attributes: baseAttrs))
-        currentMtime = mtime(of: url)
-        // Atomic-save (write tempfile + rename onto target) replaces the
-        // file's inode, so our prior `O_EVTONLY` fd no longer reflects
-        // the live file. Re-arm the watcher on the current path.
-        startWatching(url)
-
-        let ext = (rel as NSString).pathExtension
-        let stableRoot = root
-        let stableRel = rel
-        let cachedDiagnostics = diagnosticsFeature.current
-        Task.detached(priority: .userInitiated) { [weak self] in
-            let spans = TreeSitterHighlighter.highlight(source: text, fileExtension: ext)
-            await MainActor.run {
-                guard let self = self,
-                      let s = self.textView?.textStorage,
-                      self.currentRoot == stableRoot,
-                      self.currentRelativePath == stableRel else { return }
-                s.beginEditing()
-                for span in spans {
-                    s.addAttributes(editorTheme.attributes(for: span.capture), range: span.range)
-                }
-                s.endEditing()
-                if !cachedDiagnostics.isEmpty {
-                    self.diagnosticsFeature.apply(cachedDiagnostics, to: s, theme: theme)
-                }
-            }
-        }
-
-        if let language = currentLanguage {
-            let manager = appState.lsp
-            Task {
-                await manager.didChange(
-                    worktreeRoot: stableRoot,
-                    fileURL: url,
-                    languageId: language,
-                    text: text
-                )
-            }
-        }
-    }
-
-    private func mtime(of url: URL) -> Date? {
-        (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date
-    }
-
-    /// Watches `url` so external edits (terminal, another editor, formatters)
-    /// land in the view immediately rather than waiting for SwiftUI to
-    /// re-render. Replaces any prior watcher.
-    private func startWatching(_ url: URL) {
-        stopWatching()
-        let fd = open(url.path, O_EVTONLY)
-        guard fd >= 0 else { return }
-        let src = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: fd,
-            eventMask: [.write, .extend, .rename, .delete, .attrib],
-            queue: Self.fileWatchQueue
-        )
-        src.setEventHandler { [weak self] in
-            Task { @MainActor in self?.handleWatchedFileChange() }
-        }
-        src.setCancelHandler { Darwin.close(fd) }
-        src.resume()
-        fileWatcher = src
-        fileWatcherFD = fd
-    }
-
-    private func stopWatching() {
-        fileWatcher?.cancel()
-        fileWatcher = nil
-        fileWatcherFD = -1
-    }
-
-    private func handleWatchedFileChange() {
-        guard let root = currentRoot, let rel = currentRelativePath, let theme = currentTheme else { return }
-        let url = root.appendingPathComponent(rel)
-        // Compare mtime in case the kqueue event was a touch or attribute
-        // change with no real content delta. If the file went away (delete
-        // without atomic replace), bail — the next user action will surface
-        // an "unable to read" state.
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
-        guard let onDisk = mtime(of: url), onDisk != currentMtime else { return }
-        reloadFromDisk(theme: theme)
-    }
-
-    /// Re-applies background, base text attributes, and tree-sitter
-    /// highlights to the existing storage without re-reading the file or
-    /// touching LSP state. Called when the theme changes mid-session.
-    private func repaint(theme: Theme) {
-        guard let textView, let storage = textView.textStorage,
-              let root = currentRoot, let rel = currentRelativePath else { return }
-        let editorTheme = EditorTheme(theme: theme)
-        textView.backgroundColor = NSColor(theme.color("bg-1"))
-        let baseAttrs: [NSAttributedString.Key: Any] = [
-            .font: textView.font ?? NSFont.monospacedSystemFont(ofSize: 12.5, weight: .regular),
-            .foregroundColor: editorTheme.defaultFG
-        ]
-        let text = storage.string
-        let fullRange = NSRange(location: 0, length: storage.length)
-        storage.setAttributes(baseAttrs, range: fullRange)
-
-        let ext = (rel as NSString).pathExtension
-        let stableRoot = root
-        let stableRel = rel
-        let cachedDiagnostics = diagnosticsFeature.current
-        Task.detached(priority: .userInitiated) { [weak self] in
-            let spans = TreeSitterHighlighter.highlight(source: text, fileExtension: ext)
-            await MainActor.run {
-                guard let self = self,
-                      let s = self.textView?.textStorage,
-                      self.currentRoot == stableRoot,
-                      self.currentRelativePath == stableRel else { return }
-                s.beginEditing()
-                for span in spans {
-                    s.addAttributes(editorTheme.attributes(for: span.capture), range: span.range)
-                }
-                s.endEditing()
-                // Reapply existing diagnostics — `setAttributes` above wiped
-                // the underline style/color for every diagnostic range, and
-                // we won't get another `publishDiagnostics` until something
-                // changes server-side. Without this, squiggles vanish on
-                // theme switch until the next batch happens to arrive.
-                if !cachedDiagnostics.isEmpty {
-                    self.diagnosticsFeature.apply(cachedDiagnostics, to: s, theme: theme)
-                }
-            }
-        }
-    }
-
-    private struct OpenDocument {
-        let root: URL
-        let relativePath: String
-        let language: String
-    }
-
-    /// Snapshots the currently-open document and clears the coordinator's
-    /// `current*` fields so the caller can safely overwrite them with the
-    /// next file's state. The returned snapshot is later passed to
-    /// `close(document:)` which sends `didClose` against the captured URI.
-    private func takeCurrentDocument() -> OpenDocument? {
-        guard let root = currentRoot, let rel = currentRelativePath, let lang = currentLanguage else { return nil }
-        currentRoot = nil
-        currentRelativePath = nil
-        currentLanguage = nil
-        return OpenDocument(root: root, relativePath: rel, language: lang)
-    }
-
-    private func close(document: OpenDocument) async {
-        let url = document.root.appendingPathComponent(document.relativePath)
-        await appState.lsp.closeDocument(worktreeRoot: document.root, fileURL: url, languageId: document.language)
     }
 
     // MARK: - Reveal (go-to-definition scroll target)
@@ -420,8 +254,8 @@ final class CodeEditorCoordinator {
            last.tabId == tabId, last.line == line, last.character == character {
             return
         }
-        guard let textView, let storage = textView.textStorage else { return }
-        let nsString = storage.string as NSString
+        guard let textView, let buffer else { return }
+        let nsString = buffer.storage.string as NSString
         // Walk to the requested line, then add the UTF-16 character offset.
         var charIndex = 0
         var currentLine = 0

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -187,6 +187,8 @@ final class CodeEditorCoordinator {
         guard let buffer else { return }
         let storage = buffer.storage
         let text = storage.string
+        let textLength = storage.length
+        let editGeneration = buffer.editGeneration
         let ext = (buffer.relativePath as NSString).pathExtension
         let editorTheme = EditorTheme(theme: theme)
         let stableTabId = currentTabId
@@ -197,9 +199,12 @@ final class CodeEditorCoordinator {
                 guard let self,
                       let b = self.buffer,
                       b.storage === storage,
-                      self.currentTabId == stableTabId else { return }
+                      self.currentTabId == stableTabId,
+                      b.editGeneration == editGeneration,
+                      storage.length == textLength else { return }
                 storage.beginEditing()
                 for span in spans {
+                    guard NSMaxRange(span.range) <= storage.length else { continue }
                     storage.addAttributes(editorTheme.attributes(for: span.capture), range: span.range)
                 }
                 storage.endEditing()

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -47,7 +47,7 @@ final class CodeEditorCoordinator {
         let ext = (buffer.relativePath as NSString).pathExtension
         currentLanguage = appState.lsp.language(forFileExtension: ext)
         runHighlight(theme: theme)
-        openLSPIfNeeded(text: buffer.storage.string, theme: theme)
+        subscribeIfPossible(theme: theme)
 
         editObserverToken = buffer.onEdit { [weak self] in
             self?.scheduleEditPropagation()
@@ -197,28 +197,21 @@ final class CodeEditorCoordinator {
         }
     }
 
-    // MARK: - LSP open + diagnostics subscription
+    // MARK: - Diagnostics subscription
 
-    private func openLSPIfNeeded(text: String, theme: Theme) {
+    /// Waits for the buffer's LSP open to complete (via `clientWhenReady`),
+    /// then subscribes to diagnostics. The buffer owns open/close; the
+    /// coordinator only wires the diagnostic stream.
+    private func subscribeIfPossible(theme: Theme) {
         guard let buffer, let language = currentLanguage else { return }
         let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
         let manager = appState.lsp
         diagnosticsTask?.cancel()
         diagnosticsFeature.reset()
         let stableTabId = currentTabId
-        Task { [weak self, language] in
-            let client = await manager.openDocument(
-                worktreeRoot: buffer.worktreeRoot,
-                fileURL: url,
-                languageId: language,
-                text: text
-            )
-            guard let self, self.currentTabId == stableTabId else {
-                if client != nil {
-                    await manager.closeDocument(worktreeRoot: buffer.worktreeRoot, fileURL: url, languageId: language)
-                }
-                return
-            }
+        Task { [weak self] in
+            let client = await manager.clientWhenReady(forFile: url, worktreeRoot: buffer.worktreeRoot, language: language)
+            guard let self, self.currentTabId == stableTabId, let client else { return }
             await self.subscribeDiagnostics(for: client, uri: url.lspURI, theme: theme)
             await self.symbolsFeature.refresh(client: client, uri: url.lspURI)
         }

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -30,17 +30,19 @@ struct CodeEditorView: NSViewRepresentable {
         scroll.drawsBackground = true
         scroll.backgroundColor = NSColor(theme.color("bg-1"))
 
-        // Build an explicit TextKit 1 chain. On macOS 14+ NSTextView defaults
-        // to TextKit 2 (NSTextLayoutManager + NSTextContentStorage) when it
-        // creates its own container — and in that mode the legacy
-        // `textView.textStorage` returns nil, so any code that mutates it
-        // silently no-ops. We rely on `textStorage.setAttributedString(...)`
-        // and `addAttributes(_:range:)` for highlights and diagnostics, so
-        // we need TextKit 1. Wiring the chain manually (storage → layout
-        // manager → container → text view) guarantees that.
-        let textStorage = NSTextStorage()
+        let buffer = appState.tabs.buffer(
+            worktreeId: worktreeId,
+            tabId: tabId,
+            worktreeRoot: worktreeRoot,
+            relativePath: relativePath
+        )
+
+        // Build the TextKit 1 chain around the buffer's existing storage.
+        // We deliberately do NOT call `setAttributedString` here — that's
+        // the buffer's job (load / revert / restore). All this view does is
+        // present the storage.
         let layoutManager = NSLayoutManager()
-        textStorage.addLayoutManager(layoutManager)
+        buffer.storage.addLayoutManager(layoutManager)
         let containerSize = NSSize(
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude
@@ -50,9 +52,6 @@ struct CodeEditorView: NSViewRepresentable {
         textContainer.heightTracksTextView = false
         layoutManager.addTextContainer(textContainer)
 
-        // Two-direction-scroll code editor: the textView grows to fit its
-        // content (longest line = width, total lines = height); it does
-        // NOT track the scroll view's size. Hence autoresizingMask = [].
         let initialFrame = NSRect(x: 0, y: 0, width: 800, height: 600)
         let textView = CodeTextView(frame: initialFrame, textContainer: textContainer)
         textView.font = NSFont.monospacedSystemFont(ofSize: 12.5, weight: .regular)
@@ -68,9 +67,8 @@ struct CodeEditorView: NSViewRepresentable {
 
         context.coordinator.attach(
             textView: textView,
+            buffer: buffer,
             worktreeId: worktreeId,
-            worktreeRoot: worktreeRoot,
-            relativePath: relativePath,
             tabId: tabId,
             revealLine: revealLine,
             revealCharacter: revealCharacter,
@@ -92,6 +90,8 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: CodeEditorCoordinator) {
+        // Detach the coordinator from the text view, but DO NOT close the
+        // buffer's LSP document or watcher — the buffer outlives this view.
         coordinator.detach()
     }
 }

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -68,6 +68,7 @@ struct CodeEditorView: NSViewRepresentable {
         context.coordinator.attach(
             textView: textView,
             buffer: buffer,
+            layoutManager: layoutManager,
             worktreeId: worktreeId,
             tabId: tabId,
             revealLine: revealLine,

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -1,22 +1,28 @@
 import AppKit
 
-/// Read-only `NSTextView` subclass that exposes mouse hover and Cmd-click
-/// callbacks. The coordinator wires the callbacks; this class itself stays
-/// dumb so it can be unit-tested in isolation if needed.
+/// Editable `NSTextView` subclass. The coordinator wires hover and
+/// Cmd-click callbacks; the storage is owned and managed by an
+/// `EditorBuffer` outside this view. Editing is enabled but undo/redo,
+/// dirty tracking, save, file-watch, and LSP `didChange` are all
+/// orchestrated by the buffer + coordinator pair.
 final class CodeTextView: NSTextView {
     var hoverHandler: ((NSPoint) -> Void)?
     var commandClickHandler: ((NSPoint) -> Void)?
 
     override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
         super.init(frame: frameRect, textContainer: container)
-        self.isEditable = false
+        self.isEditable = true
         self.isSelectable = true
+        self.allowsUndo = true
         self.isRichText = false
-        self.allowsUndo = false
         self.usesFindBar = true
         self.isAutomaticQuoteSubstitutionEnabled = false
         self.isAutomaticDashSubstitutionEnabled = false
         self.isAutomaticTextReplacementEnabled = false
+        self.isAutomaticSpellingCorrectionEnabled = false
+        self.isContinuousSpellCheckingEnabled = false
+        self.isGrammarCheckingEnabled = false
+        self.smartInsertDeleteEnabled = false
         self.textContainerInset = NSSize(width: 12, height: 8)
     }
 

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -47,6 +47,14 @@ final class EditorBuffer {
     private var watcherFD: Int32 = -1
     @ObservationIgnored
     private static let watchQueue = DispatchQueue(label: "alas.editor.buffer.watch", qos: .utility)
+    @ObservationIgnored
+    private let store: EditorBufferStore?
+    @ObservationIgnored
+    private let worktreeId: String?
+    @ObservationIgnored
+    private let tabId: String?
+    @ObservationIgnored
+    private var snapshotTask: Task<Void, Never>?
 
     struct EditObserverToken { fileprivate let id: UUID }
 
@@ -58,14 +66,36 @@ final class EditorBuffer {
         return storage.string != originalText
     }
 
-    init(worktreeRoot: URL, relativePath: String) {
+    /// Convenience initializer for callers that do not need hot-exit support
+    /// (tests from Tasks 3-6, and any non-persisted buffer).
+    convenience init(worktreeRoot: URL, relativePath: String) {
+        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: nil, worktreeId: nil, tabId: nil, restoreEnabled: false)
+    }
+
+    /// Production initializer that opts into hot-exit. The `store` is consulted
+    /// at init time for any persisted snapshot; if found, it overlays disk
+    /// content with `dirty = true`.
+    convenience init(worktreeRoot: URL, relativePath: String, store: EditorBufferStore, worktreeId: String, tabId: String) {
+        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: store, worktreeId: worktreeId, tabId: tabId, restoreEnabled: true)
+    }
+
+    private init(worktreeRoot: URL, relativePath: String, store: EditorBufferStore?, worktreeId: String?, tabId: String?, restoreEnabled: Bool) {
         self.worktreeRoot = worktreeRoot
         self.relativePath = relativePath
         self.storage = NSTextStorage()
+        self.store = store
+        self.worktreeId = worktreeId
+        self.tabId = tabId
         let delegate = BufferStorageDelegate { [weak self] in self?.handleEdit() }
         self.storageDelegate = delegate
         self.storage.delegate = delegate
         loadFromDisk()
+        if restoreEnabled,
+           let store, let worktreeId, let tabId,
+           let snap = (try? store.read(worktreeId: worktreeId, tabId: tabId)) {
+            applySnapshot(snap)
+        }
+        onEdit { [weak self] in self?.scheduleSnapshot() }
     }
 
     @discardableResult
@@ -220,6 +250,70 @@ final class EditorBuffer {
             originalMtime = mtime
         }
         startWatching()
+        discardSnapshot()
+    }
+
+    // MARK: - Snapshot / restore (hot-exit)
+
+    private func applySnapshot(_ snap: EditorBufferStore.Snapshot) {
+        loading = true
+        defer { loading = false }
+        storage.setAttributedString(NSAttributedString(string: snap.content))
+        originalText = snap.originalText
+        originalMtime = snap.originalMtime
+        lineEnding = snap.lineEnding
+        readOnly = false
+    }
+
+    private func scheduleSnapshot() {
+        guard store != nil, worktreeId != nil, tabId != nil else { return }
+        snapshotTask?.cancel()
+        snapshotTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 750_000_000)
+            guard let self, !Task.isCancelled else { return }
+            await MainActor.run { self.snapshotNow() }
+        }
+    }
+
+    func snapshotNow() {
+        guard let store, let worktreeId, let tabId, dirty else { return }
+        let snap = EditorBufferStore.Snapshot(
+            relativePath: relativePath,
+            content: storage.string,
+            originalText: originalText,
+            originalMtime: originalMtime,
+            lineEnding: lineEnding
+        )
+        try? store.write(snap, worktreeId: worktreeId, tabId: tabId)
+    }
+
+    private func discardSnapshot() {
+        guard let store, let worktreeId, let tabId else { return }
+        store.discard(worktreeId: worktreeId, tabId: tabId)
+    }
+
+    /// Tear-down for a tab close. If dirty, writes a final snapshot
+    /// synchronously so the user sees their work on relaunch.
+    func close() {
+        snapshotTask?.cancel()
+        if dirty { snapshotNow() }
+        stopWatching()
+    }
+
+    /// Compares the snapshot's recorded original mtime to the current file's
+    /// mtime. If they differ, the file changed while we were quit and the
+    /// user's snapshot is "their version" against a moved baseline — show
+    /// the conflict banner. Called on first display after restore.
+    func checkForConflictOnRestore() {
+        let url = worktreeRoot.appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            if dirty { conflict = .deletedOnDisk }
+            return
+        }
+        guard let onDiskMtime = (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date else { return }
+        if dirty && onDiskMtime != originalMtime {
+            conflict = .changedOnDisk
+        }
     }
 
     private func loadFromDisk() {

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -172,9 +172,9 @@ final class EditorBuffer {
                 conflict = .deletedOnDisk
             }
             // If the buffer is clean and the file vanished, leave the buffer
-            // contents in place but clear original-text bookkeeping so the
-            // next save recreates the file. Don't raise a conflict — we have
-            // nothing to lose.
+            // contents in place. The next ⌘S will hit `save()`'s
+            // moveItem-when-target-missing branch and recreate the file.
+            // No conflict raised — we have nothing to lose.
             return
         }
         guard let onDiskMtime = (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date,

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -31,7 +31,7 @@ final class EditorBuffer {
     @ObservationIgnored
     private var editObservers: [UUID: () -> Void] = [:]
     @ObservationIgnored
-    private var storageDelegate: BufferStorageDelegate!
+    private var storageDelegate: BufferStorageDelegate = .init({})
     @ObservationIgnored
     private var loading = false
 
@@ -49,8 +49,9 @@ final class EditorBuffer {
         self.worktreeRoot = worktreeRoot
         self.relativePath = relativePath
         self.storage = NSTextStorage()
-        self.storageDelegate = BufferStorageDelegate { [weak self] in self?.handleEdit() }
-        self.storage.delegate = self.storageDelegate
+        let delegate = BufferStorageDelegate { [weak self] in self?.handleEdit() }
+        self.storageDelegate = delegate
+        self.storage.delegate = delegate
         loadFromDisk()
     }
 
@@ -67,7 +68,8 @@ final class EditorBuffer {
 
     private func handleEdit() {
         guard !loading else { return }
-        for block in editObservers.values { block() }
+        let snapshot = Array(editObservers.values)
+        for block in snapshot { block() }
     }
 
     func revert() {

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -281,6 +281,15 @@ final class EditorBuffer {
         }
     }
 
+    func saveRecordingError() throws {
+        do {
+            try save()
+        } catch {
+            lastSaveError = (error as NSError).localizedDescription
+            throw error
+        }
+    }
+
     // MARK: - Snapshot / restore (hot-exit)
 
     private func applySnapshot(_ snap: EditorBufferStore.Snapshot) {

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -60,7 +60,13 @@ final class EditorBuffer {
         // Write + fsync. We open with O_WRONLY|O_CREAT|O_TRUNC so a leftover
         // tmp from a crashed prior save is overwritten, not appended to.
         let fd = open(tmp.path, O_WRONLY | O_CREAT | O_TRUNC, 0o644)
-        if fd < 0 { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        if fd < 0 {
+            // Defensive: POSIX open(2) shouldn't create the file when returning
+            // -1, but some filesystem edge cases can leave a zero-byte tmp file.
+            // Clean it up so a later save attempt doesn't trip over it.
+            try? FileManager.default.removeItem(at: tmp)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
         defer { Darwin.close(fd) }
         try data.withUnsafeBytes { buf in
             guard let base = buf.baseAddress else { return }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Foundation
+import Observation
+
+/// Per-tab editor buffer. Owns the live `NSTextStorage` displayed by
+/// `CodeTextView`, plus the original-on-disk snapshot used for dirty
+/// detection, save normalization, and conflict resolution.
+///
+/// Buffers are stored in `TabsManager.buffers` keyed by `TabID` so they
+/// outlive the SwiftUI view (which can be torn down and rebuilt). All
+/// state mutations happen on the main actor; storage delegate callbacks,
+/// LSP responses, and file-watch events are routed through `MainActor`
+/// before touching `self`.
+@Observable
+@MainActor
+final class EditorBuffer {
+    let worktreeRoot: URL
+    let relativePath: String
+
+    /// The live AppKit text storage displayed by the text view. The
+    /// reference is stable for the lifetime of the buffer; tearing down
+    /// the view detaches it without releasing it.
+    let storage: NSTextStorage
+
+    private(set) var originalText: String = ""
+    private(set) var originalMtime: Date = .distantPast
+    private(set) var permissions: mode_t = 0o644
+    private(set) var lineEnding: LineEnding = .lf
+    private(set) var readOnly: Bool = false
+
+    /// `true` while the in-memory text differs from the bytes last read
+    /// from / written to disk. Computed from `storage.string` against
+    /// `originalText` (cheap for files under ~1 MB).
+    var dirty: Bool {
+        guard !readOnly else { return false }
+        return storage.string != originalText
+    }
+
+    init(worktreeRoot: URL, relativePath: String) {
+        self.worktreeRoot = worktreeRoot
+        self.relativePath = relativePath
+        self.storage = NSTextStorage()
+        loadFromDisk()
+    }
+
+    private func loadFromDisk() {
+        let url = worktreeRoot.appendingPathComponent(relativePath)
+        guard let raw = try? String(contentsOf: url, encoding: .utf8) else {
+            storage.setAttributedString(NSAttributedString(string: "(unable to read file)"))
+            readOnly = true
+            return
+        }
+        let detected = LineEnding.detect(in: raw)
+        let canonical = LineEnding.lf.normalize(raw)
+        storage.setAttributedString(NSAttributedString(string: canonical))
+        originalText = canonical
+        lineEnding = detected
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) {
+            originalMtime = (attrs[.modificationDate] as? Date) ?? .distantPast
+            if let nsPerms = attrs[.posixPermissions] as? NSNumber {
+                permissions = mode_t(nsPerms.uint16Value)
+            }
+        }
+        readOnly = false
+    }
+}

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -28,12 +28,25 @@ final class EditorBuffer {
     private(set) var lineEnding: LineEnding = .lf
     private(set) var readOnly: Bool = false
 
+    enum Conflict: Equatable {
+        case changedOnDisk
+        case deletedOnDisk
+    }
+
+    private(set) var conflict: Conflict?
+
     @ObservationIgnored
     private var editObservers: [UUID: () -> Void] = [:]
     @ObservationIgnored
     private var storageDelegate: BufferStorageDelegate = .init({})
     @ObservationIgnored
     private var loading = false
+    @ObservationIgnored
+    private var watcherSource: DispatchSourceFileSystemObject?
+    @ObservationIgnored
+    private var watcherFD: Int32 = -1
+    @ObservationIgnored
+    private static let watchQueue = DispatchQueue(label: "alas.editor.buffer.watch", qos: .utility)
 
     struct EditObserverToken { fileprivate let id: UUID }
 
@@ -74,6 +87,69 @@ final class EditorBuffer {
 
     func revert() {
         loadFromDisk()
+    }
+
+    func startWatching() {
+        stopWatching()
+        let path = worktreeRoot.appendingPathComponent(relativePath).path
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else { return }
+        let src = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd,
+            eventMask: [.write, .extend, .rename, .delete, .attrib],
+            queue: Self.watchQueue
+        )
+        src.setEventHandler { [weak self] in
+            Task { @MainActor in self?.handleWatcherEvent() }
+        }
+        src.setCancelHandler { Darwin.close(fd) }
+        src.resume()
+        watcherSource = src
+        watcherFD = fd
+    }
+
+    func stopWatching() {
+        watcherSource?.cancel()
+        watcherSource = nil
+        watcherFD = -1
+    }
+
+    private func handleWatcherEvent() {
+        let url = worktreeRoot.appendingPathComponent(relativePath)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            if dirty {
+                conflict = .deletedOnDisk
+            }
+            // If the buffer is clean and the file vanished, leave the buffer
+            // contents in place but clear original-text bookkeeping so the
+            // next save recreates the file. Don't raise a conflict — we have
+            // nothing to lose.
+            return
+        }
+        guard let onDiskMtime = (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date,
+              onDiskMtime != originalMtime else { return }
+        if dirty {
+            conflict = .changedOnDisk
+            return
+        }
+        revert()
+        // Re-arm watcher in case rename swapped the inode (atomic save by an
+        // external tool).
+        startWatching()
+    }
+
+    func resolveConflictKeepingMine() {
+        let url = worktreeRoot.appendingPathComponent(relativePath)
+        if let mtime = (try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date {
+            originalMtime = mtime
+        }
+        conflict = nil
+    }
+
+    func resolveConflictReloadingFromDisk() {
+        revert()
+        conflict = nil
+        startWatching()
     }
 
     /// Persist the buffer to disk atomically. Writes to a temp file in the
@@ -143,6 +219,7 @@ final class EditorBuffer {
            let mtime = attrs[.modificationDate] as? Date {
             originalMtime = mtime
         }
+        startWatching()
     }
 
     private func loadFromDisk() {

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -35,6 +35,8 @@ final class EditorBuffer {
 
     private(set) var conflict: Conflict?
 
+    var lastSaveError: String?
+
     @ObservationIgnored
     private var editObservers: [UUID: () -> Void] = [:]
     @ObservationIgnored
@@ -188,6 +190,7 @@ final class EditorBuffer {
     /// `originalMtime`, and clears `dirty`. Throws on any IO failure; the
     /// buffer is left dirty so the user can retry.
     func save() throws {
+        lastSaveError = nil
         guard !readOnly else { return }
         let url = worktreeRoot.appendingPathComponent(relativePath)
         let canonical = storage.string

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -37,6 +37,8 @@ final class EditorBuffer {
 
     var lastSaveError: String?
 
+    private(set) var editGeneration: Int = 0
+
     @ObservationIgnored
     private var editObservers: [UUID: () -> Void] = [:]
     @ObservationIgnored
@@ -129,6 +131,7 @@ final class EditorBuffer {
 
     private func handleEdit() {
         guard !loading else { return }
+        editGeneration &+= 1
         let snapshot = Array(editObservers.values)
         for block in snapshot { block() }
     }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -57,6 +57,10 @@ final class EditorBuffer {
     private let tabId: String?
     @ObservationIgnored
     private var snapshotTask: Task<Void, Never>?
+    @ObservationIgnored
+    private let lsp: WorkspaceLSPManager?
+    @ObservationIgnored
+    private(set) var language: String?
 
     struct EditObserverToken { fileprivate let id: UUID }
 
@@ -71,23 +75,30 @@ final class EditorBuffer {
     /// Convenience initializer for callers that do not need hot-exit support
     /// (tests from Tasks 3-6, and any non-persisted buffer).
     convenience init(worktreeRoot: URL, relativePath: String) {
-        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: nil, worktreeId: nil, tabId: nil, restoreEnabled: false)
+        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: nil, worktreeId: nil, tabId: nil, restoreEnabled: false, lsp: nil)
     }
 
-    /// Production initializer that opts into hot-exit. The `store` is consulted
-    /// at init time for any persisted snapshot; if found, it overlays disk
-    /// content with `dirty = true`.
+    /// Production initializer that opts into hot-exit (no LSP). The `store`
+    /// is consulted at init time for any persisted snapshot.
     convenience init(worktreeRoot: URL, relativePath: String, store: EditorBufferStore, worktreeId: String, tabId: String) {
-        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: store, worktreeId: worktreeId, tabId: tabId, restoreEnabled: true)
+        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: store, worktreeId: worktreeId, tabId: tabId, restoreEnabled: true, lsp: nil)
     }
 
-    private init(worktreeRoot: URL, relativePath: String, store: EditorBufferStore?, worktreeId: String?, tabId: String?, restoreEnabled: Bool) {
+    /// Production initializer that opts into hot-exit and opens an LSP
+    /// document. The buffer owns the LSP open/close lifecycle for this file.
+    convenience init(worktreeRoot: URL, relativePath: String, store: EditorBufferStore, worktreeId: String, tabId: String, lsp: WorkspaceLSPManager) {
+        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: store, worktreeId: worktreeId, tabId: tabId, restoreEnabled: true, lsp: lsp)
+    }
+
+    private init(worktreeRoot: URL, relativePath: String, store: EditorBufferStore?, worktreeId: String?, tabId: String?, restoreEnabled: Bool, lsp: WorkspaceLSPManager?) {
         self.worktreeRoot = worktreeRoot
         self.relativePath = relativePath
         self.storage = NSTextStorage()
         self.store = store
         self.worktreeId = worktreeId
         self.tabId = tabId
+        self.lsp = lsp
+        self.language = lsp?.language(forFileExtension: (relativePath as NSString).pathExtension)
         let delegate = BufferStorageDelegate { [weak self] in self?.handleEdit() }
         self.storageDelegate = delegate
         self.storage.delegate = delegate
@@ -98,6 +109,11 @@ final class EditorBuffer {
             applySnapshot(snap)
         }
         onEdit { [weak self] in self?.scheduleSnapshot() }
+        if let lsp, let language {
+            let url = worktreeRoot.appendingPathComponent(relativePath)
+            let text = storage.string
+            Task { await lsp.openDocument(worktreeRoot: worktreeRoot, fileURL: url, languageId: language, text: text) }
+        }
     }
 
     @discardableResult
@@ -254,6 +270,10 @@ final class EditorBuffer {
         }
         startWatching()
         discardSnapshot()
+        if let lsp, let language {
+            let url = worktreeRoot.appendingPathComponent(relativePath)
+            Task { await lsp.didSave(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: language) }
+        }
     }
 
     // MARK: - Snapshot / restore (hot-exit)
@@ -305,6 +325,10 @@ final class EditorBuffer {
         snapshotTask?.cancel()
         if dirty { snapshotNow() }
         stopWatching()
+        if let lsp, let language {
+            let url = worktreeRoot.appendingPathComponent(relativePath)
+            Task { await lsp.closeDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: language) }
+        }
     }
 
     /// Compares the snapshot's recorded original mtime to the current file's

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -314,10 +314,14 @@ final class EditorBuffer {
 
     /// Writes an immediate snapshot if the buffer is dirty and hot-exit is
     /// enabled (store/worktreeId/tabId all set on the production init).
-    /// Safe to call from any state — a no-op when there is nothing to
-    /// persist or when the store is absent (test convenience init).
+    /// Safe to call from any state — clean buffers discard stale snapshots,
+    /// while buffers without a store remain a no-op.
     func snapshotNow() {
-        guard let store, let worktreeId, let tabId, dirty else { return }
+        guard let store, let worktreeId, let tabId else { return }
+        guard dirty else {
+            discardSnapshot()
+            return
+        }
         let snap = EditorBufferStore.Snapshot(
             relativePath: relativePath,
             content: storage.string,

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -138,6 +138,8 @@ final class EditorBuffer {
 
     func revert() {
         loadFromDisk()
+        discardSnapshot()
+        handleEdit()
     }
 
     func startWatching() {
@@ -322,11 +324,15 @@ final class EditorBuffer {
         store.discard(worktreeId: worktreeId, tabId: tabId)
     }
 
-    /// Tear-down for a tab close. If dirty, writes a final snapshot
-    /// synchronously so the user sees their work on relaunch.
-    func close() {
+    /// Tear-down for a buffer. App quit paths can keep a final dirty snapshot
+    /// for hot-exit restore; explicit tab removal discards it.
+    func close(persistDirtySnapshot: Bool = true) {
         snapshotTask?.cancel()
-        if dirty { snapshotNow() }
+        if persistDirtySnapshot {
+            if dirty { snapshotNow() }
+        } else {
+            discardSnapshot()
+        }
         stopWatching()
         if let lsp, let language {
             let url = worktreeRoot.appendingPathComponent(relativePath)

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -28,6 +28,15 @@ final class EditorBuffer {
     private(set) var lineEnding: LineEnding = .lf
     private(set) var readOnly: Bool = false
 
+    @ObservationIgnored
+    private var editObservers: [UUID: () -> Void] = [:]
+    @ObservationIgnored
+    private var storageDelegate: BufferStorageDelegate!
+    @ObservationIgnored
+    private var loading = false
+
+    struct EditObserverToken { fileprivate let id: UUID }
+
     /// `true` while the in-memory text differs from the bytes last read
     /// from / written to disk. Computed from `storage.string` against
     /// `originalText` (cheap for files under ~1 MB).
@@ -40,6 +49,28 @@ final class EditorBuffer {
         self.worktreeRoot = worktreeRoot
         self.relativePath = relativePath
         self.storage = NSTextStorage()
+        self.storageDelegate = BufferStorageDelegate { [weak self] in self?.handleEdit() }
+        self.storage.delegate = self.storageDelegate
+        loadFromDisk()
+    }
+
+    @discardableResult
+    func onEdit(_ block: @escaping () -> Void) -> EditObserverToken {
+        let id = UUID()
+        editObservers[id] = block
+        return EditObserverToken(id: id)
+    }
+
+    func removeOnEdit(_ token: EditObserverToken) {
+        editObservers.removeValue(forKey: token.id)
+    }
+
+    private func handleEdit() {
+        guard !loading else { return }
+        for block in editObservers.values { block() }
+    }
+
+    func revert() {
         loadFromDisk()
     }
 
@@ -113,6 +144,8 @@ final class EditorBuffer {
     }
 
     private func loadFromDisk() {
+        loading = true
+        defer { loading = false }
         let url = worktreeRoot.appendingPathComponent(relativePath)
         guard let raw = try? String(contentsOf: url, encoding: .utf8) else {
             storage.setAttributedString(NSAttributedString(string: "(unable to read file)"))
@@ -131,5 +164,24 @@ final class EditorBuffer {
             }
         }
         readOnly = false
+    }
+}
+
+private final class BufferStorageDelegate: NSObject, NSTextStorageDelegate {
+    private let onDidProcess: () -> Void
+    init(_ onDidProcess: @escaping () -> Void) {
+        self.onDidProcess = onDidProcess
+    }
+    func textStorage(
+        _ textStorage: NSTextStorage,
+        didProcessEditing editedMask: NSTextStorageEditActions,
+        range editedRange: NSRange,
+        changeInLength delta: Int
+    ) {
+        // We only care about character changes (typing, paste, delete).
+        // Attribute-only edits (highlighter applying colors) are ignored —
+        // otherwise re-highlighting would loop through the observer.
+        guard editedMask.contains(.editedCharacters) else { return }
+        onDidProcess()
     }
 }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -275,6 +275,10 @@ final class EditorBuffer {
         }
     }
 
+    /// Writes an immediate snapshot if the buffer is dirty and hot-exit is
+    /// enabled (store/worktreeId/tabId all set on the production init).
+    /// Safe to call from any state — a no-op when there is nothing to
+    /// persist or when the store is absent (test convenience init).
     func snapshotNow() {
         guard let store, let worktreeId, let tabId, dirty else { return }
         let snap = EditorBufferStore.Snapshot(

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -43,6 +43,69 @@ final class EditorBuffer {
         loadFromDisk()
     }
 
+    /// Persist the buffer to disk atomically. Writes to a temp file in the
+    /// same directory, fsyncs, renames onto the target, and restores the
+    /// captured POSIX permissions on the new inode. Updates `originalText`,
+    /// `originalMtime`, and clears `dirty`. Throws on any IO failure; the
+    /// buffer is left dirty so the user can retry.
+    func save() throws {
+        guard !readOnly else { return }
+        let url = worktreeRoot.appendingPathComponent(relativePath)
+        let canonical = storage.string
+        let onDisk = lineEnding.normalize(canonical)
+        let dir = url.deletingLastPathComponent()
+        let tmp = dir.appendingPathComponent(".\(url.lastPathComponent).alas-\(UUID().uuidString).tmp")
+        let data = Data(onDisk.utf8)
+
+        // Write + fsync. We open with O_WRONLY|O_CREAT|O_TRUNC so a leftover
+        // tmp from a crashed prior save is overwritten, not appended to.
+        let fd = open(tmp.path, O_WRONLY | O_CREAT | O_TRUNC, 0o644)
+        if fd < 0 { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        defer { Darwin.close(fd) }
+        try data.withUnsafeBytes { buf in
+            guard let base = buf.baseAddress else { return }
+            var remaining = buf.count
+            var ptr = base
+            while remaining > 0 {
+                let n = Darwin.write(fd, ptr, remaining)
+                if n < 0 {
+                    try? FileManager.default.removeItem(at: tmp)
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+                ptr = ptr.advanced(by: n)
+                remaining -= n
+            }
+        }
+        if Darwin.fsync(fd) != 0 {
+            try? FileManager.default.removeItem(at: tmp)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        // Atomic rename. `replaceItemAt` preserves the original inode's xattrs
+        // when available; if the target doesn't exist (deleted on disk), fall
+        // back to moveItem.
+        do {
+            if FileManager.default.fileExists(atPath: url.path) {
+                _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
+            } else {
+                try FileManager.default.moveItem(at: tmp, to: url)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: tmp)
+            throw error
+        }
+
+        // Restore captured perms; failure is non-fatal (file is saved, just
+        // not with our preferred mode).
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: UInt16(permissions))], ofItemAtPath: url.path)
+
+        originalText = canonical
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+           let mtime = attrs[.modificationDate] as? Date {
+            originalMtime = mtime
+        }
+    }
+
     private func loadFromDisk() {
         let url = worktreeRoot.appendingPathComponent(relativePath)
         guard let raw = try? String(contentsOf: url, encoding: .utf8) else {

--- a/Alas/Sources/Code/Editor/EditorBufferStore.swift
+++ b/Alas/Sources/Code/Editor/EditorBufferStore.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// On-disk hot-exit snapshot store for dirty editor buffers. Snapshots live
+/// at `<AppSupport>/Alas/buffers/<worktreeId>/<tabId>.json` and are written
+/// on a debounce during typing, on tab close, and at app quit. They are
+/// consumed at next launch when the matching tab is re-displayed.
+@MainActor
+final class EditorBufferStore {
+    struct Snapshot: Codable, Equatable {
+        var relativePath: String
+        var content: String
+        var originalText: String
+        var originalMtime: Date
+        var lineEnding: LineEnding
+    }
+
+    private let root: URL
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    /// `rootOverride` is for tests only; production callers omit it and
+    /// the store reads/writes under `Paths.buffersRoot`.
+    init(rootOverride: URL? = nil) {
+        self.root = rootOverride ?? Paths.buffersRoot
+        let enc = JSONEncoder()
+        enc.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        enc.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(date.timeIntervalSinceReferenceDate)
+        }
+        self.encoder = enc
+        let dec = JSONDecoder()
+        dec.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let ti = try container.decode(Double.self)
+            return Date(timeIntervalSinceReferenceDate: ti)
+        }
+        self.decoder = dec
+    }
+
+    func write(_ snapshot: Snapshot, worktreeId: String, tabId: String) throws {
+        let dir = root.appendingPathComponent(worktreeId, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("\(tabId).json")
+        let data = try encoder.encode(snapshot)
+        let tmp = file.appendingPathExtension("tmp")
+        try data.write(to: tmp, options: .atomic)
+        if FileManager.default.fileExists(atPath: file.path) {
+            _ = try FileManager.default.replaceItemAt(file, withItemAt: tmp)
+        } else {
+            try FileManager.default.moveItem(at: tmp, to: file)
+        }
+    }
+
+    func read(worktreeId: String, tabId: String) throws -> Snapshot? {
+        let file = root
+            .appendingPathComponent(worktreeId, isDirectory: true)
+            .appendingPathComponent("\(tabId).json")
+        guard FileManager.default.fileExists(atPath: file.path) else { return nil }
+        let data: Data
+        do {
+            data = try Data(contentsOf: file)
+        } catch {
+            return nil
+        }
+        do {
+            return try decoder.decode(Snapshot.self, from: data)
+        } catch {
+            // Corruption: delete and treat as no-snapshot. We can't recover,
+            // and leaving the broken file in place would mean every subsequent
+            // launch tries (and fails) to restore it.
+            try? FileManager.default.removeItem(at: file)
+            return nil
+        }
+    }
+
+    func discard(worktreeId: String, tabId: String) {
+        let file = root
+            .appendingPathComponent(worktreeId, isDirectory: true)
+            .appendingPathComponent("\(tabId).json")
+        try? FileManager.default.removeItem(at: file)
+    }
+}

--- a/Alas/Sources/Code/Editor/EditorBufferStore.swift
+++ b/Alas/Sources/Code/Editor/EditorBufferStore.swift
@@ -38,10 +38,15 @@ final class EditorBufferStore {
         self.decoder = dec
     }
 
+    private func fileURL(worktreeId: String, tabId: String) -> URL {
+        root.appendingPathComponent(worktreeId, isDirectory: true)
+            .appendingPathComponent("\(tabId).json")
+    }
+
     func write(_ snapshot: Snapshot, worktreeId: String, tabId: String) throws {
         let dir = root.appendingPathComponent(worktreeId, isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let file = dir.appendingPathComponent("\(tabId).json")
+        let file = fileURL(worktreeId: worktreeId, tabId: tabId)
         let data = try encoder.encode(snapshot)
         let tmp = file.appendingPathExtension("tmp")
         try data.write(to: tmp, options: .atomic)
@@ -53,9 +58,7 @@ final class EditorBufferStore {
     }
 
     func read(worktreeId: String, tabId: String) throws -> Snapshot? {
-        let file = root
-            .appendingPathComponent(worktreeId, isDirectory: true)
-            .appendingPathComponent("\(tabId).json")
+        let file = fileURL(worktreeId: worktreeId, tabId: tabId)
         guard FileManager.default.fileExists(atPath: file.path) else { return nil }
         let data: Data
         do {
@@ -75,9 +78,7 @@ final class EditorBufferStore {
     }
 
     func discard(worktreeId: String, tabId: String) {
-        let file = root
-            .appendingPathComponent(worktreeId, isDirectory: true)
-            .appendingPathComponent("\(tabId).json")
+        let file = fileURL(worktreeId: worktreeId, tabId: tabId)
         try? FileManager.default.removeItem(at: file)
     }
 }

--- a/Alas/Sources/Code/Editor/EditorConflictBanner.swift
+++ b/Alas/Sources/Code/Editor/EditorConflictBanner.swift
@@ -22,7 +22,15 @@ struct EditorConflictBanner: View {
             case .deletedOnDisk:
                 row(
                     message: "File was deleted on disk.",
-                    primary: ("Save anyway", { try? buffer.save(); buffer.resolveConflictKeepingMine() }),
+                    primary: ("Save anyway", {
+                        do {
+                            try buffer.save()
+                            buffer.resolveConflictKeepingMine()
+                        } catch {
+                            // save() already set lastSaveError; leave the
+                            // conflict in place so the user can retry.
+                        }
+                    }),
                     secondary: ("Keep mine", { buffer.resolveConflictKeepingMine() })
                 )
             }

--- a/Alas/Sources/Code/Editor/EditorConflictBanner.swift
+++ b/Alas/Sources/Code/Editor/EditorConflictBanner.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/// Overlay shown above the editor when the on-disk file diverges from
+/// the dirty buffer (`changedOnDisk` / `deletedOnDisk`) or when the
+/// last save failed (`lastSaveError`). The banner is a single horizontal
+/// strip so it doesn't shift the editor's scroll geometry.
+struct EditorConflictBanner: View {
+    let buffer: EditorBuffer
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        if let error = buffer.lastSaveError {
+            row(message: "Couldn't save: \(error)", action: nil)
+        } else if let conflict = buffer.conflict {
+            switch conflict {
+            case .changedOnDisk:
+                row(
+                    message: "File changed on disk while you have unsaved edits.",
+                    primary: ("Reload from disk", { buffer.resolveConflictReloadingFromDisk() }),
+                    secondary: ("Keep mine", { buffer.resolveConflictKeepingMine() })
+                )
+            case .deletedOnDisk:
+                row(
+                    message: "File was deleted on disk.",
+                    primary: ("Save anyway", { try? buffer.save(); buffer.resolveConflictKeepingMine() }),
+                    secondary: ("Keep mine", { buffer.resolveConflictKeepingMine() })
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func row(message: String, action: (label: String, run: () -> Void)?) -> some View {
+        HStack(spacing: 10) {
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg"))
+            Spacer()
+            if let action {
+                Button(action.label, action: action.run)
+                    .buttonStyle(.borderless)
+                    .font(.system(size: 12))
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 28)
+        .background(theme.color("bg-3"))
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    @ViewBuilder
+    private func row(message: String, primary: (label: String, run: () -> Void), secondary: (label: String, run: () -> Void)) -> some View {
+        HStack(spacing: 10) {
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg"))
+            Spacer()
+            Button(secondary.label, action: secondary.run).buttonStyle(.borderless).font(.system(size: 12))
+            Button(primary.label, action: primary.run).buttonStyle(.borderless).font(.system(size: 12)).foregroundColor(theme.color("accent"))
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 28)
+        .background(theme.color("bg-3"))
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+}

--- a/Alas/Sources/Code/Editor/EditorConflictBanner.swift
+++ b/Alas/Sources/Code/Editor/EditorConflictBanner.swift
@@ -24,10 +24,10 @@ struct EditorConflictBanner: View {
                     message: "File was deleted on disk.",
                     primary: ("Save anyway", {
                         do {
-                            try buffer.save()
+                            try buffer.saveRecordingError()
                             buffer.resolveConflictKeepingMine()
                         } catch {
-                            // save() already set lastSaveError; leave the
+                            // saveRecordingError() already set lastSaveError; leave the
                             // conflict in place so the user can retry.
                         }
                     }),

--- a/Alas/Sources/Code/Editor/LineEnding.swift
+++ b/Alas/Sources/Code/Editor/LineEnding.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Line-ending style of a file as read from disk. The buffer captures this
+/// at load time and the save path normalizes back to it before writing, so
+/// editing a CRLF file in the editor doesn't silently rewrite it as LF.
+enum LineEnding: String, Codable {
+    case lf
+    case crlf
+
+    /// Detects the dominant line ending in `text`. If any CRLF appears, the
+    /// file is treated as CRLF (we err on the side of preserving the foreign
+    /// style — it's much better to leave a stray LF in a CRLF file than to
+    /// rewrite the whole file with the wrong endings).
+    static func detect(in text: String) -> LineEnding {
+        text.contains("\r\n") ? .crlf : .lf
+    }
+
+    /// Returns `text` with its line endings rewritten to this style. The
+    /// editor stores text in the AppKit-canonical LF form internally, so
+    /// `normalize` is only meaningful when writing to disk.
+    func normalize(_ text: String) -> String {
+        // Always go through LF as the canonical form so that double-CRLF
+        // ("\r\r\n") doesn't get produced when normalizing an already-CRLF
+        // string with `crlf`.
+        let lfForm = text.replacingOccurrences(of: "\r\n", with: "\n")
+        switch self {
+        case .lf:   return lfForm
+        case .crlf: return lfForm.replacingOccurrences(of: "\n", with: "\r\n")
+        }
+    }
+}

--- a/Alas/Sources/Code/LSP/LSPClient.swift
+++ b/Alas/Sources/Code/LSP/LSPClient.swift
@@ -84,6 +84,12 @@ actor LSPClient {
         ])
     }
 
+    func didSave(uri: String) throws {
+        try sendNotification(method: "textDocument/didSave", params: [
+            "textDocument": ["uri": uri]
+        ])
+    }
+
     /// Full-document content sync. We don't keep a local edit history, so
     /// every change is sent as a single replacement of the whole document.
     /// Caller is responsible for monotonic version numbers per URI.

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -231,6 +231,20 @@ final class WorkspaceLSPManager {
         }
     }
 
+    /// Fire-and-forget `textDocument/didSave`. Skipped if the document was
+    /// never opened on the server (init still in flight, or a different
+    /// holder is in play). Mirrors `didChange`'s readiness semantics.
+    func didSave(worktreeRoot: URL, fileURL: URL, languageId: String) async {
+        let markers = registry.entry(forLanguage: languageId)?.rootMarkers ?? []
+        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: markers)
+        let key = Key(root: lspRoot.path, language: languageId)
+        let uri = fileURL.lspURI
+        guard let holder = holders[key], holder.openedURIs.contains(uri) else { return }
+        let initOk = await holder.ready.value
+        guard initOk, let cur = holders[key], cur.openedURIs.contains(uri) else { return }
+        try? await cur.client.didSave(uri: uri)
+    }
+
     /// Returns the live client serving `fileURL` for `language`, if any.
     /// Resolves the LSP root via the configured `rootMarkers` so a nested
     /// package's client is found correctly even when the caller only knows

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -245,6 +245,20 @@ final class WorkspaceLSPManager {
         try? await cur.client.didSave(uri: uri)
     }
 
+    /// Polls until the live client for `(fileURL, language)` is available
+    /// (i.e. the buffer's `openDocument` task has completed and a holder
+    /// exists), then returns it. Returns `nil` if no client appears within
+    /// `timeout` seconds or the task is cancelled.
+    func clientWhenReady(forFile fileURL: URL, worktreeRoot: URL, language: String, timeout: TimeInterval = 30) async -> LSPClient? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let c = client(forFile: fileURL, worktreeRoot: worktreeRoot, language: language) { return c }
+            try? await Task.sleep(nanoseconds: 50_000_000) // 50 ms
+            if Task.isCancelled { return nil }
+        }
+        return nil
+    }
+
     /// Returns the live client serving `fileURL` for `language`, if any.
     /// Resolves the LSP root via the configured `rootMarkers` so a nested
     /// package's client is found correctly even when the caller only knows

--- a/Alas/Sources/Persistence/Paths.swift
+++ b/Alas/Sources/Persistence/Paths.swift
@@ -33,8 +33,4 @@ extension Paths {
     static func buffersDir(forWorktreeId id: String) -> URL {
         buffersRoot.appendingPathComponent(id, isDirectory: true)
     }
-
-    static func bufferFile(worktreeId: String, tabId: String) -> URL {
-        buffersDir(forWorktreeId: worktreeId).appendingPathComponent("\(tabId).json")
-    }
 }

--- a/Alas/Sources/Persistence/Paths.swift
+++ b/Alas/Sources/Persistence/Paths.swift
@@ -26,3 +26,15 @@ extension Paths {
         tabsDir.appendingPathComponent("\(id).json")
     }
 }
+
+extension Paths {
+    static var buffersRoot: URL { appSupportRoot.appendingPathComponent("buffers", isDirectory: true) }
+
+    static func buffersDir(forWorktreeId id: String) -> URL {
+        buffersRoot.appendingPathComponent(id, isDirectory: true)
+    }
+
+    static func bufferFile(worktreeId: String, tabId: String) -> URL {
+        buffersDir(forWorktreeId: worktreeId).appendingPathComponent("\(tabId).json")
+    }
+}

--- a/AlasTests/EditorBufferStoreTests.swift
+++ b/AlasTests/EditorBufferStoreTests.swift
@@ -1,0 +1,67 @@
+// AlasTests/EditorBufferStoreTests.swift
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct EditorBufferStoreTests {
+    private func makeStore() -> (EditorBufferStore, URL) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-buffer-store-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        return (EditorBufferStore(rootOverride: tmp), tmp)
+    }
+
+    @Test func snapshotRoundTripPreservesContent() throws {
+        let (store, _) = makeStore()
+        let snap = EditorBufferStore.Snapshot(
+            relativePath: "src/foo.swift",
+            content: "edited\n",
+            originalText: "original\n",
+            originalMtime: Date(timeIntervalSince1970: 1_700_000_000),
+            lineEnding: .lf
+        )
+        try store.write(snap, worktreeId: "wt-1", tabId: "tab-1")
+        let loaded = try store.read(worktreeId: "wt-1", tabId: "tab-1")
+        #expect(loaded == snap)
+    }
+
+    @Test func readMissingReturnsNil() throws {
+        let (store, _) = makeStore()
+        #expect(try store.read(worktreeId: "wt-1", tabId: "absent") == nil)
+    }
+
+    @Test func discardRemovesFile() throws {
+        let (store, _) = makeStore()
+        let snap = EditorBufferStore.Snapshot(
+            relativePath: "x.txt", content: "hi", originalText: "",
+            originalMtime: Date(), lineEnding: .lf
+        )
+        try store.write(snap, worktreeId: "wt", tabId: "t")
+        store.discard(worktreeId: "wt", tabId: "t")
+        #expect(try store.read(worktreeId: "wt", tabId: "t") == nil)
+    }
+
+    @Test func corruptJSONReturnsNilAndDeletes() throws {
+        let (store, root) = makeStore()
+        let dir = root.appendingPathComponent("wt")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("t.json")
+        try "{this is not json".write(to: file, atomically: true, encoding: .utf8)
+        #expect(try store.read(worktreeId: "wt", tabId: "t") == nil)
+        #expect(!FileManager.default.fileExists(atPath: file.path))
+    }
+
+    @Test func crlfRoundTrips() throws {
+        let (store, _) = makeStore()
+        let snap = EditorBufferStore.Snapshot(
+            relativePath: "win.txt",
+            content: "edited\r\nlines\r\n",
+            originalText: "lines\r\n",
+            originalMtime: Date(),
+            lineEnding: .crlf
+        )
+        try store.write(snap, worktreeId: "wt", tabId: "t")
+        #expect(try store.read(worktreeId: "wt", tabId: "t") == snap)
+    }
+}

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -114,4 +114,27 @@ struct EditorBufferTests {
         try buffer.save()
         #expect(buffer.originalMtime > oldMtime)
     }
+
+    @Test func editingFlipsDirtyAndFiresObserver() async {
+        let root = tempWorktree()
+        _ = try? writeFile(root, "a.txt", "hello\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        var fired = 0
+        let token = buffer.onEdit { fired += 1 }
+        defer { buffer.removeOnEdit(token) }
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 5), with: "HELLO")
+        #expect(buffer.dirty == true)
+        #expect(fired == 1)
+    }
+
+    @Test func revertReloadsFromDiskAndClearsDirty() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "original\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "junk")
+        #expect(buffer.dirty == true)
+        buffer.revert()
+        #expect(buffer.storage.string == "original\n")
+        #expect(buffer.dirty == false)
+    }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -276,4 +276,33 @@ struct EditorBufferTests {
         restored.checkForConflictOnRestore()
         #expect(restored.conflict == .changedOnDisk)
     }
+
+    @Test func coordinatorDetachRemovesMountedLayoutManager() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "v1\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        let layoutManager = NSLayoutManager()
+        buffer.storage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: AppState())
+        let theme = try ThemeStore().current
+
+        coordinator.attach(
+            textView: textView,
+            buffer: buffer,
+            layoutManager: layoutManager,
+            worktreeId: "wt",
+            tabId: "t",
+            revealLine: nil,
+            revealCharacter: nil,
+            theme: theme
+        )
+        #expect(buffer.storage.layoutManagers.contains { $0 === layoutManager })
+
+        coordinator.detach()
+
+        #expect(!buffer.storage.layoutManagers.contains { $0 === layoutManager })
+    }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -137,4 +137,80 @@ struct EditorBufferTests {
         #expect(buffer.storage.string == "original\n")
         #expect(buffer.dirty == false)
     }
+
+    @Test func externalChangeWhileCleanReloadsSilently() async throws {
+        let root = tempWorktree()
+        let url = try writeFile(root, "a.txt", "v1\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.startWatching()
+        defer { buffer.stopWatching() }
+        try await Task.sleep(nanoseconds: 1_100_000_000)
+        try "v2\n".write(to: url, atomically: true, encoding: .utf8)
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(buffer.storage.string == "v2\n")
+        #expect(buffer.dirty == false)
+        #expect(buffer.conflict == nil)
+    }
+
+    @Test func externalChangeWhileDirtyRaisesConflict() async throws {
+        let root = tempWorktree()
+        let url = try writeFile(root, "a.txt", "v1\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.startWatching()
+        defer { buffer.stopWatching() }
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        #expect(buffer.dirty == true)
+        try await Task.sleep(nanoseconds: 1_100_000_000)
+        try "external\n".write(to: url, atomically: true, encoding: .utf8)
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(buffer.conflict == .changedOnDisk)
+        #expect(buffer.storage.string == "edited v1\n")
+        #expect(buffer.dirty == true)
+    }
+
+    @Test func resolveConflictByKeepingMineClearsConflictAdvancesMtime() async throws {
+        let root = tempWorktree()
+        let url = try writeFile(root, "a.txt", "v1\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.startWatching()
+        defer { buffer.stopWatching() }
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        try await Task.sleep(nanoseconds: 1_100_000_000)
+        try "external\n".write(to: url, atomically: true, encoding: .utf8)
+        try await Task.sleep(nanoseconds: 500_000_000)
+        let onDiskMtime = (try FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate]) as? Date
+        buffer.resolveConflictKeepingMine()
+        #expect(buffer.conflict == nil)
+        #expect(buffer.originalMtime == onDiskMtime)
+        #expect(buffer.dirty == true)
+    }
+
+    @Test func resolveConflictByReloadingFromDiskReplacesContent() async throws {
+        let root = tempWorktree()
+        let url = try writeFile(root, "a.txt", "v1\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.startWatching()
+        defer { buffer.stopWatching() }
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        try await Task.sleep(nanoseconds: 1_100_000_000)
+        try "external\n".write(to: url, atomically: true, encoding: .utf8)
+        try await Task.sleep(nanoseconds: 500_000_000)
+        buffer.resolveConflictReloadingFromDisk()
+        #expect(buffer.conflict == nil)
+        #expect(buffer.dirty == false)
+        #expect(buffer.storage.string == "external\n")
+    }
+
+    @Test func deletionOnDiskRaisesDeletedConflict() async throws {
+        let root = tempWorktree()
+        let url = try writeFile(root, "a.txt", "v1\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.startWatching()
+        defer { buffer.stopWatching() }
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        try FileManager.default.removeItem(at: url)
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(buffer.conflict == .deletedOnDisk)
+        #expect(buffer.dirty == true)
+    }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -103,6 +103,17 @@ struct EditorBufferTests {
         #expect(buffer.originalText == "x")
     }
 
+    @Test func saveRecordingErrorStoresThrownSaveFailure() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "x")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "more\n")
+        try FileManager.default.removeItem(at: root)
+        #expect(throws: (any Error).self) { try buffer.saveRecordingError() }
+        #expect(buffer.lastSaveError?.isEmpty == false)
+        #expect(buffer.dirty == true)
+    }
+
     @Test func saveUpdatesMtime() async throws {
         let root = tempWorktree()
         _ = try writeFile(root, "a.txt", "x")

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -52,4 +52,66 @@ struct EditorBufferTests {
         #expect(buffer.readOnly == true)
         #expect(buffer.dirty == false)
     }
+
+    @Test func saveWritesContentAndClearsDirty() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "hello\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 5), with: "HELLO")
+        #expect(buffer.dirty == true)
+        try buffer.save()
+        #expect(buffer.dirty == false)
+        let onDisk = try String(contentsOf: root.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(onDisk == "HELLO\n")
+        #expect(buffer.originalText == "HELLO\n")
+    }
+
+    @Test func saveCRLFFilePreservesCRLFOnDisk() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "win.txt", "a\r\nb\r\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "win.txt")
+        // In-memory storage is canonical LF; user appends a line.
+        buffer.storage.replaceCharacters(in: NSRange(location: buffer.storage.length, length: 0), with: "c\n")
+        try buffer.save()
+        let onDisk = try Data(contentsOf: root.appendingPathComponent("win.txt"))
+        #expect(onDisk == Data("a\r\nb\r\nc\r\n".utf8))
+        #expect(buffer.dirty == false)
+    }
+
+    @Test func savePreservesPosixPermissions() throws {
+        let root = tempWorktree()
+        let url = try writeFile(root, "exe.sh", "#!/bin/sh\necho hi\n", perms: 0o755)
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "exe.sh")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "# touched\n")
+        try buffer.save()
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? 0
+        #expect(perms == 0o755)
+    }
+
+    @Test func saveOnReadOnlyDirThrowsAndKeepsBufferDirty() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "x")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "more\n")
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: root.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: root.path)
+        }
+        #expect(throws: (any Error).self) { try buffer.save() }
+        #expect(buffer.dirty == true)
+        #expect(buffer.originalText == "x")
+    }
+
+    @Test func saveUpdatesMtime() async throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "x")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        let oldMtime = buffer.originalMtime
+        // Sleep a tiny bit so HFS/APFS-second-resolution mtimes actually advance.
+        try await Task.sleep(nanoseconds: 1_100_000_000)
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "y")
+        try buffer.save()
+        #expect(buffer.originalMtime > oldMtime)
+    }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -142,6 +142,9 @@ struct EditorBufferTests {
         let root = tempWorktree()
         let url = try writeFile(root, "a.txt", "v1\n")
         let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        var fired = 0
+        let token = buffer.onEdit { fired += 1 }
+        defer { buffer.removeOnEdit(token) }
         buffer.startWatching()
         defer { buffer.stopWatching() }
         try await Task.sleep(nanoseconds: 1_100_000_000)
@@ -150,6 +153,7 @@ struct EditorBufferTests {
         #expect(buffer.storage.string == "v2\n")
         #expect(buffer.dirty == false)
         #expect(buffer.conflict == nil)
+        #expect(fired == 1)
     }
 
     @Test func externalChangeWhileDirtyRaisesConflict() async throws {
@@ -188,10 +192,13 @@ struct EditorBufferTests {
     @Test func resolveConflictByReloadingFromDiskReplacesContent() async throws {
         let root = tempWorktree()
         let url = try writeFile(root, "a.txt", "v1\n")
-        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        let store = EditorBufferStore(rootOverride: tempWorktree())
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
         buffer.startWatching()
         defer { buffer.stopWatching() }
         buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        buffer.snapshotNow()
+        #expect(try store.read(worktreeId: "wt", tabId: "t") != nil)
         try await Task.sleep(nanoseconds: 1_100_000_000)
         try "external\n".write(to: url, atomically: true, encoding: .utf8)
         try await Task.sleep(nanoseconds: 500_000_000)
@@ -199,6 +206,7 @@ struct EditorBufferTests {
         #expect(buffer.conflict == nil)
         #expect(buffer.dirty == false)
         #expect(buffer.storage.string == "external\n")
+        #expect(try store.read(worktreeId: "wt", tabId: "t") == nil)
     }
 
     @Test func deletionOnDiskRaisesDeletedConflict() async throws {

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -213,4 +213,48 @@ struct EditorBufferTests {
         #expect(buffer.conflict == .deletedOnDisk)
         #expect(buffer.dirty == true)
     }
+
+    @Test func snapshotRestoreRoundTrip() async throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "v1\n")
+        let store = EditorBufferStore(rootOverride: tempWorktree())
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        buffer.snapshotNow()
+        let restored = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        #expect(restored.storage.string == "edited v1\n")
+        #expect(restored.dirty == true)
+        #expect(restored.originalText == "v1\n")
+    }
+
+    @Test func closeSnapshotsThenDiscardsOnSave() async throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "v1\n")
+        let storeRoot = tempWorktree()
+        let store = EditorBufferStore(rootOverride: storeRoot)
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "x")
+        buffer.close()
+        #expect(try store.read(worktreeId: "wt", tabId: "t") != nil)
+        let again = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        try again.save()
+        #expect(try store.read(worktreeId: "wt", tabId: "t") == nil)
+    }
+
+    @Test func restoreOnDifferentMtimeRaisesConflict() async throws {
+        let root = tempWorktree()
+        let url = try writeFile(root, "a.txt", "v1\n")
+        let storeRoot = tempWorktree()
+        let store = EditorBufferStore(rootOverride: storeRoot)
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        buffer.snapshotNow()
+        try await Task.sleep(nanoseconds: 1_100_000_000)
+        try "v2\n".write(to: url, atomically: true, encoding: .utf8)
+        let restored = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        restored.startWatching()
+        defer { restored.stopWatching() }
+        restored.checkForConflictOnRestore()
+        #expect(restored.conflict == .changedOnDisk)
+    }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -260,6 +260,22 @@ struct EditorBufferTests {
         #expect(try store.read(worktreeId: "wt", tabId: "t") == nil)
     }
 
+    @Test func snapshotNowDiscardsStaleSnapshotWhenBufferIsClean() async throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "v1\n")
+        let store = EditorBufferStore(rootOverride: tempWorktree())
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        buffer.snapshotNow()
+        #expect(try store.read(worktreeId: "wt", tabId: "t") != nil)
+
+        buffer.storage.setAttributedString(NSAttributedString(string: "v1\n"))
+        buffer.snapshotNow()
+
+        #expect(buffer.dirty == false)
+        #expect(try store.read(worktreeId: "wt", tabId: "t") == nil)
+    }
+
     @Test func restoreOnDifferentMtimeRaisesConflict() async throws {
         let root = tempWorktree()
         let url = try writeFile(root, "a.txt", "v1\n")

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -1,0 +1,55 @@
+// AlasTests/EditorBufferTests.swift
+import Testing
+import Foundation
+import AppKit
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct EditorBufferTests {
+    private func tempWorktree() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-buffer-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func writeFile(_ root: URL, _ rel: String, _ contents: String, perms: Int = 0o644) throws -> URL {
+        let url = root.appendingPathComponent(rel)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: perms], ofItemAtPath: url.path)
+        return url
+    }
+
+    @Test func coldLoadCapturesContentMtimeAndPerms() throws {
+        let root = tempWorktree()
+        let url = try writeFile(root, "a.txt", "hello\nworld\n", perms: 0o644)
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        #expect(buffer.storage.string == "hello\nworld\n")
+        #expect(buffer.originalText == "hello\nworld\n")
+        #expect(buffer.lineEnding == .lf)
+        #expect(buffer.dirty == false)
+        #expect(buffer.permissions == 0o644)
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let onDisk = attrs[.modificationDate] as? Date
+        #expect(buffer.originalMtime == onDisk)
+    }
+
+    @Test func coldLoadDetectsCRLF() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "win.txt", "a\r\nb\r\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "win.txt")
+        #expect(buffer.lineEnding == .crlf)
+        // We canonicalize to LF in memory; save normalizes back.
+        #expect(buffer.storage.string == "a\nb\n")
+        #expect(buffer.originalText == "a\nb\n")
+    }
+
+    @Test func coldLoadOnMissingFileReadsAsErrorAndIsReadOnly() {
+        let root = tempWorktree()
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "missing.txt")
+        #expect(buffer.storage.string == "(unable to read file)")
+        #expect(buffer.readOnly == true)
+        #expect(buffer.dirty == false)
+    }
+}

--- a/AlasTests/LineEndingTests.swift
+++ b/AlasTests/LineEndingTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct LineEndingTests {
+    @Test func detectsLFOnly() {
+        #expect(LineEnding.detect(in: "alpha\nbeta\n") == .lf)
+    }
+
+    @Test func detectsCRLFOnly() {
+        #expect(LineEnding.detect(in: "alpha\r\nbeta\r\n") == .crlf)
+    }
+
+    @Test func mixedFavorsCRLF() {
+        // Files commonly have a trailing LF but CRLF lines elsewhere; treat
+        // the dominant style as CRLF so saves don't silently rewrite the file.
+        #expect(LineEnding.detect(in: "alpha\r\nbeta\n") == .crlf)
+    }
+
+    @Test func emptyDefaultsToLF() {
+        #expect(LineEnding.detect(in: "") == .lf)
+    }
+
+    @Test func noLineBreaksDefaultsToLF() {
+        #expect(LineEnding.detect(in: "alpha") == .lf)
+    }
+
+    @Test func normalizeToLFCollapsesCRLF() {
+        #expect(LineEnding.lf.normalize("alpha\r\nbeta") == "alpha\nbeta")
+    }
+
+    @Test func normalizeToCRLFExpandsLF() {
+        #expect(LineEnding.crlf.normalize("alpha\nbeta") == "alpha\r\nbeta")
+    }
+
+    @Test func normalizeToCRLFIsIdempotent() {
+        #expect(LineEnding.crlf.normalize("alpha\r\nbeta") == "alpha\r\nbeta")
+    }
+}

--- a/AlasTests/TabsManagerBufferTests.swift
+++ b/AlasTests/TabsManagerBufferTests.swift
@@ -28,15 +28,16 @@ struct TabsManagerBufferTests {
         #expect(b1 === b2)
     }
 
-    @Test func closingDirtyBufferWritesSnapshotThenDiscardsBuffer() throws {
+    @Test func closingDirtyBufferDiscardsSnapshotAndBuffer() throws {
         let root = tempWorktree()
         try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
         let (manager, store, _) = makeManager()
         let buffer = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
         buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        buffer.snapshotNow()
         manager.discardBuffer(worktreeId: "wt", tabId: "t1")
         #expect(manager.peekBuffer(tabId: "t1") == nil)
-        #expect(try store.read(worktreeId: "wt", tabId: "t1") != nil)
+        #expect(try store.read(worktreeId: "wt", tabId: "t1") == nil)
     }
 
     @Test func dirtyTabsReportsAcrossWorktrees() throws {

--- a/AlasTests/TabsManagerBufferTests.swift
+++ b/AlasTests/TabsManagerBufferTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct TabsManagerBufferTests {
+    private func tempWorktree() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-tabs-buffer-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func makeManager() -> (TabsManager, EditorBufferStore, URL) {
+        let storeRoot = tempWorktree()
+        let store = EditorBufferStore(rootOverride: storeRoot)
+        let manager = TabsManager(bufferStore: store)
+        return (manager, store, storeRoot)
+    }
+
+    @Test func bufferReturnsSameInstanceAcrossCalls() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, _, _) = makeManager()
+        let b1 = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
+        let b2 = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
+        #expect(b1 === b2)
+    }
+
+    @Test func closingDirtyBufferWritesSnapshotThenDiscardsBuffer() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let buffer = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "edited ")
+        manager.discardBuffer(worktreeId: "wt", tabId: "t1")
+        #expect(manager.peekBuffer(tabId: "t1") == nil)
+        #expect(try store.read(worktreeId: "wt", tabId: "t1") != nil)
+    }
+
+    @Test func dirtyTabsReportsAcrossWorktrees() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "y".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, _, _) = makeManager()
+        let a = manager.buffer(worktreeId: "wt", tabId: "ta", worktreeRoot: root, relativePath: "a.txt")
+        _ = manager.buffer(worktreeId: "wt", tabId: "tb", worktreeRoot: root, relativePath: "b.txt")
+        a.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+        let dirty = manager.dirtyTabIds()
+        #expect(dirty == ["ta"])
+    }
+
+    @Test func snapshotDirtyBuffersForQuitWritesOnlyDirty() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "y".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let a = manager.buffer(worktreeId: "wt", tabId: "ta", worktreeRoot: root, relativePath: "a.txt")
+        _ = manager.buffer(worktreeId: "wt", tabId: "tb", worktreeRoot: root, relativePath: "b.txt")
+        a.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+        manager.snapshotDirtyBuffersForQuit()
+        #expect(try store.read(worktreeId: "wt", tabId: "ta") != nil)
+        #expect(try store.read(worktreeId: "wt", tabId: "tb") == nil)
+    }
+}

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import Alas
 
+@MainActor
 struct TabsManagerTests {
     @Test func newTerminalAppendsAndActivates() {
         let worktreeId = "tabs-manager-new-terminal"

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -182,3 +182,18 @@ Pre-req: a Swift project, `sourcekit-lsp` available via `xcrun --find sourcekit-
 3. Add a custom language entry (e.g. Rust → `rust-analyzer`). Save. Restart. Confirm the entry persists.
 4. Disable Swift. Reopen a `.swift` file. Confirm tree-sitter coloring still works but hover / diagnostics / go-to-def are gone.
 5. Re-enable Swift. Reopen the file. Confirm hover and diagnostics return after the server initializes.
+
+## Editor — editable files (v1)
+
+Run from a real worktree with at least one Swift file and one CRLF text file.
+
+- **Save round-trip.** Open a Swift file, type a comment, ⌘S. `git status` shows the file modified.
+- **Tab persistence.** Open a file, type, switch tabs, switch back. Content preserved.
+- **Hot exit.** Open a file, type, ⌘Q without saving. Relaunch. Tab restored, dirty dot present, content matches what you typed.
+- **External change while clean.** Open a file (do not edit). In a terminal, append a line to the file. The editor reflects the new line within ~1 s.
+- **External change while dirty.** Open a file, type a character, then in a terminal `echo z >> path`. The conflict banner appears. **Reload from disk** discards edits and shows external content. **Keep mine** keeps your buffer; subsequent ⌘S overwrites the external change.
+- **Deletion conflict.** Open a file, type, then `rm` it externally. Banner shows "File was deleted on disk." **Save anyway** recreates it; **Keep mine** leaves the buffer in place (without writing).
+- **CRLF preservation.** Drop a CRLF-encoded text file in the worktree (`printf 'a\r\nb\r\n' > win.txt`). Open it, append a line, ⌘S. `xxd win.txt` shows the new line as CRLF as well.
+- **Permissions preservation.** `chmod 755` a script file, open it, edit, ⌘S. `ls -l` still shows `-rwxr-xr-x`.
+- **Big file responsiveness.** Open a 5 k-line file, type rapidly. No visible flicker. Diagnostics catch up within ~1 s of pause.
+- **Save failure.** `chmod 555` the parent directory, edit, ⌘S. The conflict-banner area shows "Couldn't save: …". Restore perms, ⌘S succeeds.


### PR DESCRIPTION
## Summary

- Makes the Alas code editor writeable: typing, undo, ⌘S save, dirty indicator, hot-exit snapshots that survive quit/relaunch, and a conflict banner for external-edit + save-failure cases.
- Lifts the live `NSTextStorage` out of the SwiftUI view into a per-tab `EditorBuffer` owned by `TabsManager`, so unsaved edits survive view rebuilds. The coordinator becomes a thin lifecycle adapter; the buffer owns disk I/O, kqueue file-watching, LSP `didOpen`/`didChange`/`didSave`/`didClose`, and snapshot persistence.
- Atomic save (write `.tmp` + fsync + rename) preserves POSIX permissions and CRLF/LF line endings detected on load. Conflict detection compares mtime against `originalMtime`; clean buffers silently auto-reload, dirty buffers raise the banner with **Reload from disk** / **Keep mine** (or **Save anyway** for deletions). Hot-exit writes a 750ms-debounced snapshot to `<AppSupport>/Alas/buffers/<wt>/<tab>.json`, restored on next launch with a conflict banner if disk diverged while quit.

## Test Plan

- [x] `xcodebuild test` — full suite green (LineEnding 8, EditorBufferStore 5, EditorBuffer 18, TabsManagerBuffer 4, plus all pre-existing tests).
- [ ] Manual smoke per `docs/manual-test.md` "Editor — editable files (v1)" section: save round-trip, tab persistence, hot exit on ⌘Q, external-edit-while-clean silent reload, external-edit-while-dirty banner, deletion conflict, CRLF preservation, perms preservation, big-file responsiveness, save-failure banner.
- [ ] Verify ⌘Q from the app menu fires `NSApplication.willTerminateNotification` reliably on the SwiftUI scene config — final code reviewer flagged this as worth eyeballing pre-merge.

## Deferred

12 follow-ups grouped into 4 GitHub issues (#39 lifecycle commands, #40 editing polish, #41 perf, #42 edge cases). Spec at `docs/superpowers/specs/2026-05-07-editable-files-design.md` (gitignored).