### PR TITLE
Add editor file lifecycle commands

### DIFF
--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -12,6 +12,34 @@ struct AlasApp: App {
         .windowResizability(.contentSize)
         .defaultSize(width: 1320, height: 820)
         .commands {
+            CommandGroup(replacing: .newItem) {
+                Button("New File…") {
+                    NotificationCenter.default.post(name: .alasNewFile, object: nil)
+                }
+                .keyboardShortcut("n", modifiers: .command)
+            }
+            CommandGroup(replacing: .saveItem) {
+                Button("Save") {
+                    NotificationCenter.default.post(name: .alasSaveActiveTab, object: nil)
+                }
+                .keyboardShortcut("s", modifiers: .command)
+                Button("Save As…") {
+                    NotificationCenter.default.post(name: .alasSaveActiveTabAs, object: nil)
+                }
+                .keyboardShortcut("s", modifiers: [.command, .shift])
+                Button("Save All") {
+                    NotificationCenter.default.post(name: .alasSaveAllTabs, object: nil)
+                }
+                .keyboardShortcut("s", modifiers: [.command, .option])
+                Divider()
+                Button("Revert") {
+                    NotificationCenter.default.post(name: .alasRevertActiveTab, object: nil)
+                }
+                Divider()
+                Button("Rename File…") {
+                    NotificationCenter.default.post(name: .alasRenameActiveFile, object: nil)
+                }
+            }
             CommandGroup(replacing: .appSettings) {
                 Button("Settings…") {
                     NotificationCenter.default.post(name: .alasOpenSettings, object: nil)
@@ -35,10 +63,6 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasNewTerminalTab, object: nil)
                 }
                 .keyboardShortcut("t", modifiers: .command)
-                Button("Save") {
-                    NotificationCenter.default.post(name: .alasSaveActiveTab, object: nil)
-                }
-                .keyboardShortcut("s", modifiers: .command)
                 Button("Close Tab") {
                     NotificationCenter.default.post(name: .alasCloseTab, object: nil)
                 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -141,6 +141,95 @@ final class AppState {
         _ = tabs.saveActive(worktreeId: worktreeId)
     }
 
+    func saveAllTabs() {
+        var roots: [String: URL] = [:]
+        for project in projects {
+            for worktree in projectsManager.worktrees(projectId: project.id) {
+                roots[worktree.id] = roots[worktree.id] ?? worktree.path
+            }
+        }
+        let errors = tabs.saveAll(worktreeRoots: roots)
+        guard !errors.isEmpty else { return }
+        showFileActionError(
+            title: "Save All Failed",
+            message: "\(errors.count) file\(errors.count == 1 ? "" : "s") could not be saved."
+        )
+    }
+
+    func revertActiveTab(worktreeId: String) {
+        _ = tabs.revertActive(worktreeId: worktreeId)
+    }
+
+    func newFile(in worktreeId: String) {
+        guard let worktree = worktree(withId: worktreeId) else { return }
+        let panel = NSSavePanel()
+        panel.title = "New File"
+        panel.message = "Choose where to create the new file."
+        panel.directoryURL = worktree.path
+        panel.nameFieldStringValue = "untitled.txt"
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let relativePath = try relativePath(for: url, in: worktree.path)
+            if FileManager.default.fileExists(atPath: url.path) {
+                throw CocoaError(.fileWriteFileExists)
+            }
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data().write(to: url, options: .withoutOverwriting)
+            openFile(relativePath: relativePath, worktreeId: worktreeId)
+        } catch {
+            showFileActionError(title: "New File Failed", message: error.localizedDescription)
+        }
+    }
+
+    func saveActiveTabAs(worktreeId: String) {
+        guard let worktree = worktree(withId: worktreeId),
+              let context = tabs.activeEditorContext(worktreeId: worktreeId) else { return }
+        let currentURL = worktree.path.appendingPathComponent(context.tab.relativePath)
+        let panel = NSSavePanel()
+        panel.title = "Save As"
+        panel.message = "Choose the new path for this editor buffer."
+        panel.directoryURL = currentURL.deletingLastPathComponent()
+        panel.nameFieldStringValue = currentURL.lastPathComponent
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let relativePath = try relativePath(for: url, in: worktree.path)
+            guard !tabs.hasEditor(worktreeId: worktreeId, relativePath: relativePath, excluding: context.tab.id) else {
+                showFileActionError(title: "Save As Failed", message: "That file is already open in another editor tab.")
+                return
+            }
+            try context.buffer.saveAs(relativePath: relativePath)
+            _ = tabs.updateEditorPath(worktreeId: worktreeId, tabId: context.tab.id, relativePath: relativePath)
+        } catch {
+            showFileActionError(title: "Save As Failed", message: error.localizedDescription)
+        }
+    }
+
+    func renameActiveFile(worktreeId: String) {
+        guard let worktree = worktree(withId: worktreeId),
+              let context = tabs.activeEditorContext(worktreeId: worktreeId) else { return }
+        let currentURL = worktree.path.appendingPathComponent(context.tab.relativePath)
+        let panel = NSSavePanel()
+        panel.title = "Rename File"
+        panel.message = "Choose the new path for this file."
+        panel.directoryURL = currentURL.deletingLastPathComponent()
+        panel.nameFieldStringValue = currentURL.lastPathComponent
+        panel.canCreateDirectories = true
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let relativePath = try relativePath(for: url, in: worktree.path)
+            guard relativePath != context.tab.relativePath else { return }
+            try context.buffer.moveTo(relativePath: relativePath)
+            _ = tabs.updateEditorPath(worktreeId: worktreeId, tabId: context.tab.id, relativePath: relativePath)
+        } catch {
+            showFileActionError(title: "Rename File Failed", message: error.localizedDescription)
+        }
+    }
+
     func closeTab(worktreeId: String, tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         if let tab = allTabs.first(where: { $0.id == tabId }) {
@@ -298,5 +387,36 @@ final class AppState {
             )
             tabs.activate(worktreeId: worktree.id, tabId: tab.id)
         }
+    }
+
+    private func relativePath(for url: URL, in worktreeRoot: URL) throws -> String {
+        let root = worktreeRoot.standardizedFileURL.path
+        let target = url.standardizedFileURL.path
+        let rootWithSlash = root.hasSuffix("/") ? root : root + "/"
+        guard target.hasPrefix(rootWithSlash) else {
+            throw NSError(
+                domain: "AppState",
+                code: 4,
+                userInfo: [NSLocalizedDescriptionKey: "File must be inside the selected worktree."]
+            )
+        }
+        let rel = String(target.dropFirst(rootWithSlash.count))
+        guard !rel.isEmpty, !rel.split(separator: "/").contains("..") else {
+            throw NSError(
+                domain: "AppState",
+                code: 5,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid file path."]
+            )
+        }
+        return rel
+    }
+
+    private func showFileActionError(title: String, message: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -72,36 +72,12 @@ struct RootView: View {
         .background(WindowConfigurator())
         .frame(minWidth: 900, minHeight: 600)
         .ignoresSafeArea()
-        .onReceive(NotificationCenter.default.publisher(for: .alasToggleRightPane)) { _ in
-            state.config.rightPaneVisible.toggle()
-            state.saveConfig()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .alasNewWorktree)) { _ in
-            showNewWorktree = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .alasNewTerminalTab)) { _ in
-            if let wt = selectedWorktree() { try? state.openTerminalTab(for: wt) }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .alasCloseTab)) { _ in
-            if let wt = selectedWorktree(), let active = state.tabs.activeTabId(forWorktree: wt.id) {
-                state.closeTab(worktreeId: wt.id, tabId: active)
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .alasSaveActiveTab)) { _ in
-            if let wt = selectedWorktree() {
-                state.saveActiveTab(worktreeId: wt.id)
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .alasOpenSettings)) { _ in
-            openSettingsWindow()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .alasOpenSearch)) { _ in
-            state.search.open()
-            state.isSearchOpen = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
-            state.tabs.snapshotDirtyBuffersForQuit()
-        }
+        .modifier(RootCommandHandlers(
+            state: state,
+            showNewWorktree: $showNewWorktree,
+            selectedWorktree: selectedWorktree,
+            openSettings: openSettingsWindow
+        ))
         .sheet(isPresented: $showNewProject) {
             NewProjectDialog(state: state, presented: $showNewProject)
         }
@@ -115,9 +91,7 @@ struct RootView: View {
             // can't do this because refreshAll runs async after init.
             state.reloadTabs()
             if state.selectedWorktreeId == nil {
-                state.selectedWorktreeId = state.projects
-                    .flatMap { state.projectsManager.worktrees(projectId: $0.id) }
-                    .first?.id
+                state.selectedWorktreeId = firstWorktreeId()
             }
         }
     }
@@ -131,6 +105,15 @@ struct RootView: View {
         for project in state.projects {
             if let wt = state.projectsManager.worktrees(projectId: project.id).first(where: { $0.id == id }) {
                 return wt
+            }
+        }
+        return nil
+    }
+
+    private func firstWorktreeId() -> String? {
+        for project in state.projects {
+            if let worktree = state.projectsManager.worktrees(projectId: project.id).first {
+                return worktree.id
             }
         }
         return nil
@@ -157,6 +140,70 @@ struct RootView: View {
     }
 }
 
+private struct RootCommandHandlers: ViewModifier {
+    @Bindable var state: AppState
+    @Binding var showNewWorktree: Bool
+    let selectedWorktree: () -> Worktree?
+    let openSettings: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .alasToggleRightPane)) { _ in
+                state.config.rightPaneVisible.toggle()
+                state.saveConfig()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasNewWorktree)) { _ in
+                showNewWorktree = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasNewTerminalTab)) { _ in
+                if let wt = selectedWorktree() { try? state.openTerminalTab(for: wt) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasCloseTab)) { _ in
+                if let wt = selectedWorktree(), let active = state.tabs.activeTabId(forWorktree: wt.id) {
+                    state.closeTab(worktreeId: wt.id, tabId: active)
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasSaveActiveTab)) { _ in
+                if let wt = selectedWorktree() {
+                    state.saveActiveTab(worktreeId: wt.id)
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasSaveActiveTabAs)) { _ in
+                if let wt = selectedWorktree() {
+                    state.saveActiveTabAs(worktreeId: wt.id)
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasSaveAllTabs)) { _ in
+                state.saveAllTabs()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasRevertActiveTab)) { _ in
+                if let wt = selectedWorktree() {
+                    state.revertActiveTab(worktreeId: wt.id)
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasNewFile)) { _ in
+                if let wt = selectedWorktree() {
+                    state.newFile(in: wt.id)
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasRenameActiveFile)) { _ in
+                if let wt = selectedWorktree() {
+                    state.renameActiveFile(worktreeId: wt.id)
+                }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasOpenSettings)) { _ in
+                openSettings()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasOpenSearch)) { _ in
+                state.search.open()
+                state.isSearchOpen = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+                state.tabs.snapshotDirtyBuffersForQuit()
+            }
+    }
+}
+
 extension Notification.Name {
     static let alasToggleRightPane = Notification.Name("AlasToggleRightPane")
     static let alasNewWorktree     = Notification.Name("AlasNewWorktree")
@@ -165,4 +212,9 @@ extension Notification.Name {
     static let alasOpenSettings    = Notification.Name("AlasOpenSettings")
     static let alasOpenSearch      = Notification.Name("AlasOpenSearch")
     static let alasSaveActiveTab   = Notification.Name("AlasSaveActiveTab")
+    static let alasSaveActiveTabAs = Notification.Name("AlasSaveActiveTabAs")
+    static let alasSaveAllTabs     = Notification.Name("AlasSaveAllTabs")
+    static let alasRevertActiveTab = Notification.Name("AlasRevertActiveTab")
+    static let alasNewFile         = Notification.Name("AlasNewFile")
+    static let alasRenameActiveFile = Notification.Name("AlasRenameActiveFile")
 }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -253,6 +253,14 @@ final class TabsManager {
         buffers[tabId]
     }
 
+    func activeEditorContext(worktreeId: String) -> (tab: EditorTabState, buffer: EditorBuffer)? {
+        guard let activeId = activeTabId(forWorktree: worktreeId),
+              let tab = tabs(forWorktree: worktreeId).first(where: { $0.id == activeId }),
+              case .editor(let state) = tab,
+              let buffer = buffers[activeId] else { return nil }
+        return (state, buffer)
+    }
+
     /// Tear down the buffer for `tabId`, close its watcher, and drop it from
     /// cache. Explicit tab removal discards hot-exit snapshots; app quit paths
     /// snapshot dirty buffers before teardown. `worktreeId` is asserted in
@@ -273,6 +281,28 @@ final class TabsManager {
         buffers.compactMap { $0.value.dirty ? $0.key : nil }
     }
 
+    @discardableResult
+    func updateEditorPath(worktreeId: String, tabId: TabID, relativePath: String) -> Bool {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .editor(var state) = file.tabs[idx] else { return false }
+        state.relativePath = relativePath
+        state.title = (relativePath as NSString).lastPathComponent
+        state.revealLine = nil
+        state.revealCharacter = nil
+        file.tabs[idx] = .editor(state)
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return true
+    }
+
+    func hasEditor(worktreeId: String, relativePath: String, excluding tabId: TabID? = nil) -> Bool {
+        tabs(forWorktree: worktreeId).contains { tab in
+            guard case .editor(let state) = tab else { return false }
+            return state.id != tabId && state.relativePath == relativePath
+        }
+    }
+
     /// Walk all dirty buffers and write a final snapshot. Called by the
     /// quit handler. Errors are swallowed — failing to snapshot one buffer
     /// must not block snapshotting the rest, and quit must not be blocked.
@@ -280,6 +310,53 @@ final class TabsManager {
         for buffer in buffers.values where buffer.dirty {
             buffer.snapshotNow()
         }
+    }
+
+    @discardableResult
+    func saveAll(worktreeRoots: [String: URL] = [:]) -> [(tabId: TabID, error: Error)] {
+        var errors: [(TabID, Error)] = []
+        for (tabId, buffer) in buffers where buffer.dirty {
+            do {
+                try buffer.saveRecordingError()
+            } catch {
+                errors.append((tabId, error))
+            }
+        }
+        for (worktreeId, file) in byWorktree {
+            guard let root = worktreeRoots[worktreeId] else { continue }
+            for tab in file.tabs {
+                guard case .editor(let state) = tab,
+                      buffers[state.id] == nil,
+                      (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) != nil else { continue }
+                let buffer: EditorBuffer
+                if let lsp {
+                    buffer = EditorBuffer(
+                        worktreeRoot: root,
+                        relativePath: state.relativePath,
+                        store: bufferStore,
+                        worktreeId: worktreeId,
+                        tabId: state.id,
+                        lsp: lsp
+                    )
+                } else {
+                    buffer = EditorBuffer(
+                        worktreeRoot: root,
+                        relativePath: state.relativePath,
+                        store: bufferStore,
+                        worktreeId: worktreeId,
+                        tabId: state.id
+                    )
+                }
+                do {
+                    try buffer.saveRecordingError()
+                    buffer.close(persistDirtySnapshot: false)
+                } catch {
+                    errors.append((state.id, error))
+                    buffer.close(persistDirtySnapshot: true)
+                }
+            }
+        }
+        return errors
     }
 
     /// Save the active editor tab's buffer for `worktreeId`. No-op if the
@@ -294,5 +371,13 @@ final class TabsManager {
         } catch {
             return false
         }
+    }
+
+    @discardableResult
+    func revertActive(worktreeId: String) -> Bool {
+        guard let activeId = activeTabId(forWorktree: worktreeId),
+              let buffer = buffers[activeId] else { return false }
+        buffer.revert()
+        return true
     }
 }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -23,6 +23,7 @@ final class CodeEditorCoordinator {
     private var lastAppliedReveal: (tabId: TabID, line: Int, character: Int)?
 
     private var diagnosticsTask: Task<Void, Never>?
+    private var diagnosticsSetupTask: Task<Void, Never>?
     private let diagnosticsFeature = DiagnosticsFeature()
     let symbolsFeature = SymbolsFeature()
     private var hover: HoverFeature?
@@ -101,9 +102,25 @@ final class CodeEditorCoordinator {
     }
 
     func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme) {
-        // The view representable hands us the same parameters every render.
-        // The only thing we react to here is theme change (re-paint) and
-        // reveal hints (scroll).
+        let nextLanguage = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+        let pathChanged = currentWorktreeId != worktreeId
+            || currentTabId != tabId
+            || currentRoot != worktreeRoot
+            || currentRelativePath != relativePath
+            || currentLanguage != nextLanguage
+
+        if pathChanged {
+            didChangeTask?.cancel()
+            hasPendingDidChange = false
+            currentWorktreeId = worktreeId
+            currentTabId = tabId
+            currentRoot = worktreeRoot
+            currentRelativePath = relativePath
+            currentLanguage = nextLanguage
+            runHighlight(theme: theme)
+            subscribeIfPossible(theme: theme)
+        }
+
         if currentTheme != theme {
             applyBaseStyle(theme: theme)
             runHighlight(theme: theme)
@@ -123,6 +140,8 @@ final class CodeEditorCoordinator {
         }
         diagnosticsTask?.cancel()
         diagnosticsTask = nil
+        diagnosticsSetupTask?.cancel()
+        diagnosticsSetupTask = nil
         didChangeTask?.cancel()
         didChangeTask = nil
         if let buffer, let layoutManager {
@@ -221,15 +240,25 @@ final class CodeEditorCoordinator {
     /// then subscribes to diagnostics. The buffer owns open/close; the
     /// coordinator only wires the diagnostic stream.
     private func subscribeIfPossible(theme: Theme) {
-        guard let buffer, let language = currentLanguage else { return }
-        let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
-        let manager = appState.lsp
+        guard let buffer else { return }
+        diagnosticsSetupTask?.cancel()
         diagnosticsTask?.cancel()
-        diagnosticsFeature.reset()
+        diagnosticsFeature.apply([], to: buffer.storage, theme: theme)
+        guard let language = currentLanguage else { return }
+        let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
+        let root = buffer.worktreeRoot
+        let relativePath = buffer.relativePath
+        let manager = appState.lsp
         let stableTabId = currentTabId
-        Task { [weak self] in
-            let client = await manager.clientWhenReady(forFile: url, worktreeRoot: buffer.worktreeRoot, language: language)
-            guard let self, self.currentTabId == stableTabId, let client else { return }
+        diagnosticsSetupTask = Task { [weak self] in
+            let client = await manager.clientWhenReady(forFile: url, worktreeRoot: root, language: language)
+            guard let self,
+                  !Task.isCancelled,
+                  self.currentTabId == stableTabId,
+                  self.currentRoot == root,
+                  self.currentRelativePath == relativePath,
+                  self.currentLanguage == language,
+                  let client else { return }
             await self.subscribeDiagnostics(for: client, uri: url.lspURI, theme: theme)
             await self.symbolsFeature.refresh(client: client, uri: url.lspURI)
         }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -15,7 +15,7 @@ import Observation
 @MainActor
 final class EditorBuffer {
     let worktreeRoot: URL
-    let relativePath: String
+    private(set) var relativePath: String
 
     /// The live AppKit text storage displayed by the text view. The
     /// reference is stable for the lifetime of the buffer; tearing down
@@ -215,8 +215,97 @@ final class EditorBuffer {
         guard !readOnly else { return }
         let url = worktreeRoot.appendingPathComponent(relativePath)
         let canonical = storage.string
+        try write(canonical: canonical, to: url, createDirectories: false)
+        originalText = canonical
+        updateOriginalMtime(from: url)
+        startWatching()
+        discardSnapshot()
+        notifyDidSave(url: url)
+    }
+
+    func saveAs(relativePath newRelativePath: String) throws {
+        lastSaveError = nil
+        guard !readOnly else { return }
+        let oldURL = worktreeRoot.appendingPathComponent(relativePath)
+        let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
+        let oldLanguage = language
+        let canonical = storage.string
+        stopWatching()
+        do {
+            try write(canonical: canonical, to: newURL, createDirectories: true)
+            relativePath = newRelativePath
+            language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+            originalText = canonical
+            updateOriginalMtime(from: newURL)
+            discardSnapshot()
+            notifyDidClose(url: oldURL, language: oldLanguage)
+            notifyDidOpen(url: newURL, text: canonical)
+            notifyDidSave(url: newURL)
+            startWatching()
+        } catch {
+            startWatching()
+            throw error
+        }
+    }
+
+    func moveTo(relativePath newRelativePath: String) throws {
+        lastSaveError = nil
+        guard !readOnly else { return }
+        let oldURL = worktreeRoot.appendingPathComponent(relativePath)
+        let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
+        let oldLanguage = language
+        stopWatching()
+        do {
+            try FileManager.default.createDirectory(at: newURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            if FileManager.default.fileExists(atPath: newURL.path) {
+                guard sameExistingFile(oldURL, newURL) else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+                try renameItem(at: oldURL, to: newURL)
+            } else {
+                try FileManager.default.moveItem(at: oldURL, to: newURL)
+            }
+            relativePath = newRelativePath
+            language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+            updateOriginalMtime(from: newURL)
+            if dirty {
+                snapshotNow()
+            } else {
+                discardSnapshot()
+            }
+            notifyDidClose(url: oldURL, language: oldLanguage)
+            notifyDidOpen(url: newURL, text: storage.string)
+            startWatching()
+        } catch {
+            startWatching()
+            throw error
+        }
+    }
+
+    private func sameExistingFile(_ lhs: URL, _ rhs: URL) -> Bool {
+        guard let leftValues = try? lhs.resourceValues(forKeys: [.fileResourceIdentifierKey, .volumeIdentifierKey]),
+              let rightValues = try? rhs.resourceValues(forKeys: [.fileResourceIdentifierKey, .volumeIdentifierKey]),
+              let leftFile = leftValues.fileResourceIdentifier,
+              let rightFile = rightValues.fileResourceIdentifier,
+              let leftVolume = leftValues.volumeIdentifier,
+              let rightVolume = rightValues.volumeIdentifier else { return false }
+        return (leftFile as AnyObject).isEqual(rightFile)
+            && (leftVolume as AnyObject).isEqual(rightVolume)
+    }
+
+    private func renameItem(at oldURL: URL, to newURL: URL) throws {
+        guard oldURL.path != newURL.path else { return }
+        if Darwin.rename(oldURL.path, newURL.path) != 0 {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    private func write(canonical: String, to url: URL, createDirectories: Bool) throws {
         let onDisk = lineEnding.normalize(canonical)
         let dir = url.deletingLastPathComponent()
+        if createDirectories {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
         let tmp = dir.appendingPathComponent(".\(url.lastPathComponent).alas-\(UUID().uuidString).tmp")
         let data = Data(onDisk.utf8)
 
@@ -268,16 +357,30 @@ final class EditorBuffer {
         // not with our preferred mode).
         try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: UInt16(permissions))], ofItemAtPath: url.path)
 
-        originalText = canonical
+    }
+
+    private func updateOriginalMtime(from url: URL) {
         if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
            let mtime = attrs[.modificationDate] as? Date {
             originalMtime = mtime
         }
-        startWatching()
-        discardSnapshot()
+    }
+
+    private func notifyDidSave(url: URL) {
         if let lsp, let language {
-            let url = worktreeRoot.appendingPathComponent(relativePath)
             Task { await lsp.didSave(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: language) }
+        }
+    }
+
+    private func notifyDidClose(url: URL, language: String?) {
+        if let lsp, let language {
+            Task { await lsp.closeDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: language) }
+        }
+    }
+
+    private func notifyDidOpen(url: URL, text: String) {
+        if let lsp, let language {
+            Task { await lsp.openDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: language, text: text) }
         }
     }
 

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -66,6 +66,76 @@ struct EditorBufferTests {
         #expect(buffer.originalText == "HELLO\n")
     }
 
+    @Test func saveAsWritesNewPathAndLeavesOriginalFile() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "hello\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 5), with: "HELLO")
+
+        try buffer.saveAs(relativePath: "nested/b.txt")
+
+        #expect(buffer.relativePath == "nested/b.txt")
+        #expect(buffer.dirty == false)
+        #expect(try String(contentsOf: root.appendingPathComponent("a.txt"), encoding: .utf8) == "hello\n")
+        #expect(try String(contentsOf: root.appendingPathComponent("nested/b.txt"), encoding: .utf8) == "HELLO\n")
+    }
+
+    @Test func moveToRenamesFileAndKeepsDirtyEdits() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "hello\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 5), with: "HELLO")
+
+        try buffer.moveTo(relativePath: "b.txt")
+
+        #expect(buffer.relativePath == "b.txt")
+        #expect(buffer.dirty == true)
+        #expect(!FileManager.default.fileExists(atPath: root.appendingPathComponent("a.txt").path))
+        #expect(try String(contentsOf: root.appendingPathComponent("b.txt"), encoding: .utf8) == "hello\n")
+    }
+
+    @Test func moveToRewritesSnapshotWhenBufferStaysDirty() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "hello\n")
+        let store = EditorBufferStore(rootOverride: tempWorktree())
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 5), with: "HELLO")
+        buffer.snapshotNow()
+
+        try buffer.moveTo(relativePath: "b.txt")
+
+        let snapshot = try store.read(worktreeId: "wt", tabId: "t")
+        #expect(snapshot?.relativePath == "b.txt")
+        #expect(snapshot?.content == "HELLO\n")
+        #expect(buffer.dirty == true)
+    }
+
+    @Test func moveToAllowsCaseOnlyRename() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "case.txt", "hello\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "case.txt")
+
+        try buffer.moveTo(relativePath: "Case.txt")
+
+        #expect(buffer.relativePath == "Case.txt")
+        #expect(try String(contentsOf: root.appendingPathComponent("Case.txt"), encoding: .utf8) == "hello\n")
+    }
+
+    @Test func moveToRejectsExistingDifferentFile() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "a\n")
+        _ = try writeFile(root, "b.txt", "b\n")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+
+        #expect(throws: (any Error).self) {
+            try buffer.moveTo(relativePath: "b.txt")
+        }
+
+        #expect(buffer.relativePath == "a.txt")
+        #expect(try String(contentsOf: root.appendingPathComponent("a.txt"), encoding: .utf8) == "a\n")
+        #expect(try String(contentsOf: root.appendingPathComponent("b.txt"), encoding: .utf8) == "b\n")
+    }
+
     @Test func saveCRLFFilePreservesCRLFOnDisk() throws {
         let root = tempWorktree()
         _ = try writeFile(root, "win.txt", "a\r\nb\r\n")

--- a/AlasTests/TabsManagerBufferTests.swift
+++ b/AlasTests/TabsManagerBufferTests.swift
@@ -64,4 +64,86 @@ struct TabsManagerBufferTests {
         #expect(try store.read(worktreeId: "wt", tabId: "ta") != nil)
         #expect(try store.read(worktreeId: "wt", tabId: "tb") == nil)
     }
+
+    @Test func updateEditorPathPersistsTabMetadata() throws {
+        let (manager, _, _) = makeManager()
+        let tab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+
+        #expect(manager.updateEditorPath(worktreeId: "wt", tabId: tab.id, relativePath: "src/b.txt"))
+
+        let updated = manager.tabs(forWorktree: "wt").first { $0.id == tab.id }
+        #expect(updated?.title == "b.txt")
+        #expect(updated?.relativeFilePath == "src/b.txt")
+    }
+
+    @Test func hasEditorCanExcludeCurrentTab() throws {
+        let (manager, _, _) = makeManager()
+        let first = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        _ = manager.appendEditor(worktreeId: "wt", title: "b.txt", relativePath: "b.txt")
+
+        #expect(manager.hasEditor(worktreeId: "wt", relativePath: "a.txt"))
+        #expect(!manager.hasEditor(worktreeId: "wt", relativePath: "a.txt", excluding: first.id))
+        #expect(manager.hasEditor(worktreeId: "wt", relativePath: "b.txt", excluding: first.id))
+    }
+
+    @Test func saveAllOnlySavesDirtyBuffersAndReturnsErrors() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "y".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, _, _) = makeManager()
+        let a = manager.buffer(worktreeId: "wt", tabId: "ta", worktreeRoot: root, relativePath: "a.txt")
+        _ = manager.buffer(worktreeId: "wt", tabId: "tb", worktreeRoot: root, relativePath: "b.txt")
+        a.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+
+        let errors = manager.saveAll()
+
+        #expect(errors.isEmpty)
+        #expect(a.dirty == false)
+        #expect(try String(contentsOf: root.appendingPathComponent("a.txt"), encoding: .utf8) == "zx")
+        #expect(try String(contentsOf: root.appendingPathComponent("b.txt"), encoding: .utf8) == "y")
+    }
+
+    @Test func saveAllSavesUnloadedDirtySnapshots() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let tab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "a.txt",
+            content: "edited\n",
+            originalText: "x",
+            originalMtime: Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: tab.id)
+
+        let errors = manager.saveAll(worktreeRoots: ["wt": root])
+
+        #expect(errors.isEmpty)
+        #expect(manager.peekBuffer(tabId: tab.id) == nil)
+        #expect(try store.read(worktreeId: "wt", tabId: tab.id) == nil)
+        #expect(try String(contentsOf: root.appendingPathComponent("a.txt"), encoding: .utf8) == "edited\n")
+    }
+
+    @Test func saveAllPreservesUnloadedSnapshotWhenSaveFails() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let tab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "a.txt",
+            content: "edited\n",
+            originalText: "x",
+            originalMtime: Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: tab.id)
+        try FileManager.default.removeItem(at: root)
+
+        let errors = manager.saveAll(worktreeRoots: ["wt": root])
+
+        #expect(errors.map(\.tabId) == [tab.id])
+        #expect(manager.peekBuffer(tabId: tab.id) == nil)
+        #expect(try store.read(worktreeId: "wt", tabId: tab.id) != nil)
+    }
 }


### PR DESCRIPTION
## Summary
- add File menu commands for New File, Save As, Save All, Revert, and Rename File
- wire editor buffer path changes through tab persistence, snapshots, watchers, and LSP lifecycle
- add focused editor buffer and tab manager coverage

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test

Closes #39