### PR TITLE
Optimize editor change propagation

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
+		F20871AEC0E533818C8E1B95 /* TextEditCoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF73FD04363A737BB67F6E4 /* TextEditCoordinatesTests.swift */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
 /* End PBXBuildFile section */
@@ -281,6 +282,7 @@
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
+		6FF73FD04363A737BB67F6E4 /* TextEditCoordinatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinatesTests.swift; sourceTree = "<group>"; };
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		7116359F27BF0A139E0F643B /* HookWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookWatcher.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
@@ -493,6 +495,7 @@
 		2ED9D6E2F4F80DC4EC282918 /* Code */ = {
 			isa = PBXGroup;
 			children = (
+				6FF73FD04363A737BB67F6E4 /* TextEditCoordinatesTests.swift */,
 				99296E46F8BEA6DE0DFBBBD2 /* Highlight */,
 				C9BE5D9821AF38B59009DD0B /* LSP */,
 			);
@@ -1193,6 +1196,7 @@
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
+				F20871AEC0E533818C8E1B95 /* TextEditCoordinatesTests.swift in Sources */,
 				59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */,
 				BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */,
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
 		41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */; };
 		41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */; };
+		4239885256AB11FE8207D31E /* TextEditCoordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8062405A67C934905EE61D98 /* TextEditCoordinates.swift */; };
 		42C0AE388E5CF8B2AAEADE3C /* SearchEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */; };
 		43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
@@ -295,6 +296,7 @@
 		7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApp.swift; sourceTree = "<group>"; };
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
 		7FFC9539E615699AC90A7412 /* ProjectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManager.swift; sourceTree = "<group>"; };
+		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
@@ -568,6 +570,7 @@
 			isa = PBXGroup;
 			children = (
 				3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */,
+				8062405A67C934905EE61D98 /* TextEditCoordinates.swift */,
 				B99EAA756E84360237C3E3D2 /* Editor */,
 				08AFF75AE216ACC5E010B709 /* Highlight */,
 				98B31DB084754D0D15591339 /* LSP */,
@@ -1131,6 +1134,7 @@
 				A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */,
 				3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */,
 				DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */,
+				4239885256AB11FE8207D31E /* TextEditCoordinates.swift in Sources */,
 				A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */,
 				32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */,
 				D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */,

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -32,6 +32,8 @@ final class CodeEditorCoordinator {
     private var editObserverToken: EditorBuffer.EditObserverToken?
     private var didChangeTask: Task<Void, Never>?
     private var hasPendingDidChange = false
+    private var pendingTextEdits: [EditorTextEdit] = []
+    private let highlightSession = TreeSitterHighlighter.Session()
 
     init(appState: AppState) {
         self.appState = appState
@@ -53,8 +55,8 @@ final class CodeEditorCoordinator {
         runHighlight(theme: theme)
         subscribeIfPossible(theme: theme)
 
-        editObserverToken = buffer.onEdit { [weak self] in
-            self?.scheduleEditPropagation()
+        editObserverToken = buffer.onTextEdit { [weak self] edit in
+            self?.scheduleEditPropagation(edit: edit)
         }
 
         hover = HoverFeature(
@@ -112,6 +114,9 @@ final class CodeEditorCoordinator {
         if pathChanged {
             didChangeTask?.cancel()
             hasPendingDidChange = false
+            pendingTextEdits.removeAll()
+            let session = highlightSession
+            Task { await session.reset() }
             currentWorktreeId = worktreeId
             currentTabId = tabId
             currentRoot = worktreeRoot
@@ -135,9 +140,10 @@ final class CodeEditorCoordinator {
         }
         editObserverToken = nil
         if hasPendingDidChange {
-            notifyLSPDidChange()
+            notifyLSPDidChange(edits: pendingTextEdits)
             hasPendingDidChange = false
         }
+        pendingTextEdits.removeAll()
         diagnosticsTask?.cancel()
         diagnosticsTask = nil
         diagnosticsSetupTask?.cancel()
@@ -158,21 +164,28 @@ final class CodeEditorCoordinator {
 
     // MARK: - Edit propagation (highlight + didChange debouncer)
 
-    private func scheduleEditPropagation() {
+    private func scheduleEditPropagation(edit: EditorTextEdit?) {
         didChangeTask?.cancel()
         hasPendingDidChange = true
+        if let edit {
+            pendingTextEdits.append(edit)
+        } else {
+            pendingTextEdits.removeAll()
+        }
         didChangeTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 150_000_000)
             guard let self, !Task.isCancelled, let theme = self.currentTheme else { return }
             await MainActor.run {
                 self.runHighlight(theme: theme)
                 self.hasPendingDidChange = false
-                self.notifyLSPDidChange()
+                let edits = self.pendingTextEdits
+                self.pendingTextEdits.removeAll()
+                self.notifyLSPDidChange(edits: edits)
             }
         }
     }
 
-    private func notifyLSPDidChange() {
+    private func notifyLSPDidChange(edits: [EditorTextEdit]? = nil) {
         guard let buffer, let language = currentLanguage else { return }
         let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
         let text = buffer.storage.string
@@ -181,7 +194,8 @@ final class CodeEditorCoordinator {
                 worktreeRoot: buffer.worktreeRoot,
                 fileURL: url,
                 languageId: language,
-                text: text
+                text: text,
+                edits: edits
             )
         }
     }
@@ -212,24 +226,24 @@ final class CodeEditorCoordinator {
         let editorTheme = EditorTheme(theme: theme)
         let stableTabId = currentTabId
         let cachedDiagnostics = diagnosticsFeature.current
-        Task.detached(priority: .userInitiated) { [weak self] in
-            let spans = TreeSitterHighlighter.highlight(source: text, fileExtension: ext)
-            await MainActor.run {
-                guard let self,
-                      let b = self.buffer,
-                      b.storage === storage,
-                      self.currentTabId == stableTabId,
-                      b.editGeneration == editGeneration,
-                      storage.length == textLength else { return }
-                storage.beginEditing()
-                for span in spans {
-                    guard NSMaxRange(span.range) <= storage.length else { continue }
-                    storage.addAttributes(editorTheme.attributes(for: span.capture), range: span.range)
-                }
-                storage.endEditing()
-                if !cachedDiagnostics.isEmpty {
-                    self.diagnosticsFeature.apply(cachedDiagnostics, to: storage, theme: theme)
-                }
+        let session = highlightSession
+        let edits = pendingTextEdits
+        Task(priority: .userInitiated) { [weak self] in
+            let spans = await session.highlight(source: text, fileExtension: ext, edits: edits)
+            guard let self,
+                  let b = self.buffer,
+                  b.storage === storage,
+                  self.currentTabId == stableTabId,
+                  b.editGeneration == editGeneration,
+                  storage.length == textLength else { return }
+            storage.beginEditing()
+            for span in spans {
+                guard NSMaxRange(span.range) <= storage.length else { continue }
+                storage.addAttributes(editorTheme.attributes(for: span.capture), range: span.range)
+            }
+            storage.endEditing()
+            if !cachedDiagnostics.isEmpty {
+                self.diagnosticsFeature.apply(cachedDiagnostics, to: storage, theme: theme)
             }
         }
     }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -40,9 +40,9 @@ final class EditorBuffer {
     private(set) var editGeneration: Int = 0
 
     @ObservationIgnored
-    private var editObservers: [UUID: () -> Void] = [:]
+    private var editObservers: [UUID: (EditorTextEdit?) -> Void] = [:]
     @ObservationIgnored
-    private var storageDelegate: BufferStorageDelegate = .init({})
+    private var storageDelegate: BufferStorageDelegate = .init { _ in }
     @ObservationIgnored
     private var loading = false
     @ObservationIgnored
@@ -101,7 +101,7 @@ final class EditorBuffer {
         self.tabId = tabId
         self.lsp = lsp
         self.language = lsp?.language(forFileExtension: (relativePath as NSString).pathExtension)
-        let delegate = BufferStorageDelegate { [weak self] in self?.handleEdit() }
+        let delegate = BufferStorageDelegate { [weak self] edit in self?.handleEdit(edit: edit) }
         self.storageDelegate = delegate
         self.storage.delegate = delegate
         loadFromDisk()
@@ -120,6 +120,11 @@ final class EditorBuffer {
 
     @discardableResult
     func onEdit(_ block: @escaping () -> Void) -> EditObserverToken {
+        onTextEdit { _ in block() }
+    }
+
+    @discardableResult
+    func onTextEdit(_ block: @escaping (EditorTextEdit?) -> Void) -> EditObserverToken {
         let id = UUID()
         editObservers[id] = block
         return EditObserverToken(id: id)
@@ -129,17 +134,17 @@ final class EditorBuffer {
         editObservers.removeValue(forKey: token.id)
     }
 
-    private func handleEdit() {
+    private func handleEdit(edit: EditorTextEdit?) {
         guard !loading else { return }
         editGeneration &+= 1
         let snapshot = Array(editObservers.values)
-        for block in snapshot { block() }
+        for block in snapshot { block(edit) }
     }
 
     func revert() {
         loadFromDisk()
         discardSnapshot()
-        handleEdit()
+        handleEdit(edit: nil)
     }
 
     func startWatching() {
@@ -497,10 +502,12 @@ final class EditorBuffer {
 }
 
 private final class BufferStorageDelegate: NSObject, NSTextStorageDelegate {
-    private let onDidProcess: () -> Void
-    init(_ onDidProcess: @escaping () -> Void) {
+    private let onDidProcess: (EditorTextEdit) -> Void
+
+    init(_ onDidProcess: @escaping (EditorTextEdit) -> Void) {
         self.onDidProcess = onDidProcess
     }
+
     func textStorage(
         _ textStorage: NSTextStorage,
         didProcessEditing editedMask: NSTextStorageEditActions,
@@ -511,6 +518,13 @@ private final class BufferStorageDelegate: NSObject, NSTextStorageDelegate {
         // Attribute-only edits (highlighter applying colors) are ignored —
         // otherwise re-highlighting would loop through the observer.
         guard editedMask.contains(.editedCharacters) else { return }
-        onDidProcess()
+        let replacementText = (textStorage.string as NSString).substring(with: editedRange)
+        let oldLength = max(0, editedRange.length - delta)
+        let edit = EditorTextEdit(
+            location: editedRange.location,
+            oldLength: oldLength,
+            replacementText: replacementText
+        )
+        onDidProcess(edit)
     }
 }

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -70,7 +70,7 @@ struct TreeSitterHighlighter {
         }
 
         private func apply(edits: [EditorTextEdit], oldText: String, newText: String, to tree: MutableTree) -> MutableTree? {
-            guard !edits.isEmpty else { return tree }
+            guard !edits.isEmpty else { return oldText == newText ? tree : nil }
             var rollingText = oldText
             for edit in edits {
                 guard let editedText = TextEditCoordinates.apply(edit, to: rollingText),

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -10,6 +10,80 @@ import SwiftTreeSitter
 /// UTF-8 byte conversion is needed. (See `SwiftTreeSitter.Parser.parse`
 /// and `Range<UInt32>.range` in `Encoding+Helpers.swift`.)
 struct TreeSitterHighlighter {
+    actor Session {
+        private var parser: Parser?
+        private var tree: MutableTree?
+        private var fileExtension: String?
+        private var previousText: String?
+
+        func reset() {
+            parser = nil
+            tree = nil
+            fileExtension = nil
+            previousText = nil
+        }
+
+        func highlight(source: String, fileExtension ext: String, edits: [EditorTextEdit]) -> [HighlightSpan] {
+            guard
+                let language = LanguageRegistry.language(forFileExtension: ext),
+                let query = LanguageRegistry.highlightQuery(forExtension: ext)
+            else {
+                reset()
+                return RegexFallbackHighlighter.highlight(source: source, fileExtension: ext)
+            }
+
+            let parser = parser(for: language, fileExtension: ext)
+            let nextTree: MutableTree?
+            if let oldText = previousText,
+               fileExtension == ext,
+               let editedTree = tree,
+               let incrementallyEditedTree = apply(edits: edits, oldText: oldText, newText: source, to: editedTree) {
+                nextTree = parser.parse(tree: incrementallyEditedTree, string: source)
+            } else {
+                nextTree = parser.parse(source)
+            }
+            guard let nextTree, let root = nextTree.rootNode else {
+                previousText = source
+                tree = nil
+                return []
+            }
+
+            tree = nextTree
+            previousText = source
+            fileExtension = ext
+            return TreeSitterHighlighter.spans(query: query, root: root, tree: nextTree)
+        }
+
+        private func parser(for language: Language, fileExtension ext: String) -> Parser {
+            if let parser, fileExtension == ext { return parser }
+            let parser = Parser()
+            do {
+                try parser.setLanguage(language)
+                self.parser = parser
+                self.tree = nil
+                self.previousText = nil
+                self.fileExtension = ext
+            } catch {
+                self.parser = nil
+            }
+            return parser
+        }
+
+        private func apply(edits: [EditorTextEdit], oldText: String, newText: String, to tree: MutableTree) -> MutableTree? {
+            guard !edits.isEmpty else { return tree }
+            var rollingText = oldText
+            for edit in edits {
+                guard let editedText = TextEditCoordinates.apply(edit, to: rollingText),
+                      let inputEdit = TextEditCoordinates.inputEdit(for: edit, oldText: rollingText, newText: editedText) else {
+                    return nil
+                }
+                tree.edit(inputEdit)
+                rollingText = editedText
+            }
+            return rollingText == newText ? tree : nil
+        }
+    }
+
     /// Tokenize a full file. Returns highlight spans against `source`.
     static func highlight(source: String, fileExtension ext: String) -> [HighlightSpan] {
         guard
@@ -26,7 +100,16 @@ struct TreeSitterHighlighter {
         }
         guard let tree = parser.parse(source) else { return [] }
         guard let root = tree.rootNode else { return [] }
+        return spans(query: query, root: root, tree: tree)
+    }
 
+    /// Per-line API used by the diff pane. Tokenizes a single line in
+    /// isolation. Returns spans with offsets local to `line`.
+    static func tokenize(line: String, fileExtension ext: String) -> [HighlightSpan] {
+        highlight(source: line, fileExtension: ext)
+    }
+
+    private static func spans(query: Query, root: Node, tree: MutableTree) -> [HighlightSpan] {
         var spans: [HighlightSpan] = []
         let cursor = query.execute(node: root, in: tree)
         while let match = cursor.next() {
@@ -39,12 +122,6 @@ struct TreeSitterHighlighter {
             }
         }
         return spans
-    }
-
-    /// Per-line API used by the diff pane. Tokenizes a single line in
-    /// isolation. Returns spans with offsets local to `line`.
-    static func tokenize(line: String, fileExtension ext: String) -> [HighlightSpan] {
-        highlight(source: line, fileExtension: ext)
     }
 }
 

--- a/Alas/Sources/Code/LSP/LSPClient.swift
+++ b/Alas/Sources/Code/LSP/LSPClient.swift
@@ -90,14 +90,15 @@ actor LSPClient {
         ])
     }
 
-    /// Full-document content sync. We don't keep a local edit history, so
-    /// every change is sent as a single replacement of the whole document.
+    /// Sends content sync using server capabilities. Incremental servers get
+    /// the concrete AppKit edit ranges when available; otherwise we fall
+    /// back to a single ranged full-document replacement.
     /// Caller is responsible for monotonic version numbers per URI.
-    func didChange(uri: String, version: Int, text: String, previousText: String?) throws {
+    func didChange(uri: String, version: Int, text: String, previousText: String?, edits: [EditorTextEdit]? = nil) throws {
         guard textDocumentSyncKind != .none else { return }
         let changes: [[String: Any]]
         if textDocumentSyncKind == .incremental, let previousText {
-            changes = [[
+            changes = Self.incrementalChanges(edits: edits, previousText: previousText, nextText: text) ?? [[
                 "range": Self.fullRange(for: previousText).json,
                 "rangeLength": (previousText as NSString).length,
                 "text": text
@@ -213,20 +214,30 @@ actor LSPClient {
 
     private static func fullRange(for text: String) -> LSPRange {
         let nsText = text as NSString
-        var line = 0
-        var lineStart = 0
-        var index = 0
-        while index < nsText.length {
-            if nsText.character(at: index) == 10 {
-                line += 1
-                lineStart = index + 1
-            }
-            index += 1
-        }
+        let end = TextEditCoordinates.lspPosition(utf16Offset: nsText.length, in: text) ?? LSPPosition(line: 0, character: 0)
         return LSPRange(
             start: LSPPosition(line: 0, character: 0),
-            end: LSPPosition(line: line, character: nsText.length - lineStart)
+            end: end
         )
+    }
+
+    private static func incrementalChanges(edits: [EditorTextEdit]?, previousText: String, nextText: String) -> [[String: Any]]? {
+        guard let edits, !edits.isEmpty else { return nil }
+        var rollingText = previousText
+        var changes: [[String: Any]] = []
+        for edit in edits {
+            guard let range = TextEditCoordinates.lspRange(for: edit.oldRange, in: rollingText),
+                  let editedText = TextEditCoordinates.apply(edit, to: rollingText) else {
+                return nil
+            }
+            changes.append([
+                "range": range.json,
+                "rangeLength": edit.oldLength,
+                "text": edit.replacementText
+            ])
+            rollingText = editedText
+        }
+        return rollingText == nextText ? changes : nil
     }
 
     private nonisolated func sendNotification(method: String, params: Any?) throws {

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -163,7 +163,7 @@ final class WorkspaceLSPManager {
     /// (so no `didOpen` has gone out yet), updates `pendingOpenText` so the
     /// delayed `didOpen` carries the latest content — otherwise we'd lose
     /// the reload and the server would analyze the stale tab-open snapshot.
-    func didChange(worktreeRoot: URL, fileURL: URL, languageId: String, text: String) async {
+    func didChange(worktreeRoot: URL, fileURL: URL, languageId: String, text: String, edits: [EditorTextEdit]? = nil) async {
         let markers = registry.entry(forLanguage: languageId)?.rootMarkers ?? []
         let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: markers)
         let key = Key(root: lspRoot.path, language: languageId)
@@ -185,7 +185,7 @@ final class WorkspaceLSPManager {
         cur.versions[uri] = nextVersion
         cur.texts[uri] = text
         holders[key] = cur
-        try? await cur.client.didChange(uri: uri, version: nextVersion, text: text, previousText: previousText)
+        try? await cur.client.didChange(uri: uri, version: nextVersion, text: text, previousText: previousText, edits: edits)
     }
 
     func closeDocument(worktreeRoot: URL, fileURL: URL, languageId: String) async {

--- a/Alas/Sources/Code/TextEditCoordinates.swift
+++ b/Alas/Sources/Code/TextEditCoordinates.swift
@@ -40,9 +40,9 @@ enum TextEditCoordinates {
             startByte: edit.location * 2,
             oldEndByte: (edit.location + edit.oldLength) * 2,
             newEndByte: (edit.location + edit.newLength) * 2,
-            startPoint: Point(row: start.line, column: start.character),
-            oldEndPoint: Point(row: oldEnd.line, column: oldEnd.character),
-            newEndPoint: Point(row: newEnd.line, column: newEnd.character)
+            startPoint: Point(row: start.line, column: start.byteColumn),
+            oldEndPoint: Point(row: oldEnd.line, column: oldEnd.byteColumn),
+            newEndPoint: Point(row: newEnd.line, column: newEnd.byteColumn)
         )
     }
 
@@ -51,7 +51,7 @@ enum TextEditCoordinates {
         return LSPPosition(line: point.line, character: point.character)
     }
 
-    private static func point(utf16Offset target: Int, in text: String) -> (line: Int, character: Int)? {
+    private static func point(utf16Offset target: Int, in text: String) -> (line: Int, character: Int, byteColumn: Int)? {
         let ns = text as NSString
         guard target >= 0, target <= ns.length else { return nil }
         var line = 0
@@ -64,6 +64,7 @@ enum TextEditCoordinates {
             }
             index += 1
         }
-        return (line, target - lineStart)
+        let character = target - lineStart
+        return (line, character, character * 2)
     }
 }

--- a/Alas/Sources/Code/TextEditCoordinates.swift
+++ b/Alas/Sources/Code/TextEditCoordinates.swift
@@ -1,0 +1,69 @@
+import Foundation
+import SwiftTreeSitter
+
+struct EditorTextEdit: Sendable, Equatable {
+    let location: Int
+    let oldLength: Int
+    let replacementText: String
+
+    var newLength: Int { (replacementText as NSString).length }
+    var oldRange: NSRange { NSRange(location: location, length: oldLength) }
+    var newRange: NSRange { NSRange(location: location, length: newLength) }
+}
+
+enum TextEditCoordinates {
+    static func apply(_ edit: EditorTextEdit, to text: String) -> String? {
+        let ns = text as NSString
+        guard edit.location >= 0,
+              edit.oldLength >= 0,
+              NSMaxRange(edit.oldRange) <= ns.length else {
+            return nil
+        }
+        return ns.replacingCharacters(in: edit.oldRange, with: edit.replacementText)
+    }
+
+    static func lspRange(for range: NSRange, in text: String) -> LSPRange? {
+        guard let start = lspPosition(utf16Offset: range.location, in: text),
+              let end = lspPosition(utf16Offset: NSMaxRange(range), in: text) else {
+            return nil
+        }
+        return LSPRange(start: start, end: end)
+    }
+
+    static func inputEdit(for edit: EditorTextEdit, oldText: String, newText: String) -> InputEdit? {
+        guard let start = point(utf16Offset: edit.location, in: oldText),
+              let oldEnd = point(utf16Offset: edit.location + edit.oldLength, in: oldText),
+              let newEnd = point(utf16Offset: edit.location + edit.newLength, in: newText) else {
+            return nil
+        }
+        return InputEdit(
+            startByte: edit.location * 2,
+            oldEndByte: (edit.location + edit.oldLength) * 2,
+            newEndByte: (edit.location + edit.newLength) * 2,
+            startPoint: Point(row: start.line, column: start.character),
+            oldEndPoint: Point(row: oldEnd.line, column: oldEnd.character),
+            newEndPoint: Point(row: newEnd.line, column: newEnd.character)
+        )
+    }
+
+    static func lspPosition(utf16Offset target: Int, in text: String) -> LSPPosition? {
+        guard let point = point(utf16Offset: target, in: text) else { return nil }
+        return LSPPosition(line: point.line, character: point.character)
+    }
+
+    private static func point(utf16Offset target: Int, in text: String) -> (line: Int, character: Int)? {
+        let ns = text as NSString
+        guard target >= 0, target <= ns.length else { return nil }
+        var line = 0
+        var lineStart = 0
+        var index = 0
+        while index < target {
+            if ns.character(at: index) == 10 {
+                line += 1
+                lineStart = index + 1
+            }
+            index += 1
+        }
+        return (line, target - lineStart)
+    }
+}

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -36,4 +36,18 @@ struct TreeSitterHighlighterTests {
         let captures = Set(spans.map { $0.capture })
         #expect(captures.contains(.string))
     }
+
+    @Test("session accepts incremental edits")
+    func sessionIncrementalEdit() async throws {
+        let session = TreeSitterHighlighter.Session()
+        _ = await session.highlight(source: "func foo() {}", fileExtension: "swift", edits: [])
+        let spans = await session.highlight(
+            source: "func foobar() {}",
+            fileExtension: "swift",
+            edits: [EditorTextEdit(location: 8, oldLength: 0, replacementText: "bar")]
+        )
+        let captures = Set(spans.map { $0.capture })
+        #expect(captures.contains(.keyword))
+        #expect(captures.contains(.function))
+    }
 }

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -50,4 +50,13 @@ struct TreeSitterHighlighterTests {
         #expect(captures.contains(.keyword))
         #expect(captures.contains(.function))
     }
+
+    @Test("session reparses changed source when edit ranges are unavailable")
+    func sessionReparsesChangedSourceWithoutEdits() async throws {
+        let session = TreeSitterHighlighter.Session()
+        _ = await session.highlight(source: "func foo() {}", fileExtension: "swift", edits: [])
+        let spans = await session.highlight(source: #"let value = "hello""#, fileExtension: "swift", edits: [])
+        let captures = Set(spans.map { $0.capture })
+        #expect(captures.contains(.string))
+    }
 }

--- a/AlasTests/Code/LSP/LSPClientTests.swift
+++ b/AlasTests/Code/LSP/LSPClientTests.swift
@@ -89,6 +89,34 @@ struct LSPClientLifecycleTests {
         transport.finish()
     }
 
+    @Test("incremental text sync sends concrete edit ranges")
+    func incrementalTextSyncUsesConcreteEditRanges() async throws {
+        let transport = FakeTransport()
+        let client = LSPClient(transport: transport, language: "swift", rootURI: "file:///tmp")
+        transport.onSend = { sent in
+            if sent.contains("\"method\":\"initialize\"") {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"textDocumentSync":2}}}"#)
+            }
+        }
+        try await client.initialize()
+        try await client.didChange(
+            uri: "file:///tmp/x.swift",
+            version: 2,
+            text: "let xy = 1\n",
+            previousText: "let x = 1\n",
+            edits: [EditorTextEdit(location: 5, oldLength: 0, replacementText: "y")]
+        )
+        let change = transport.sent.last ?? ""
+        #expect(change.contains(#""start":{"#))
+        #expect(change.contains(#""end":{"#))
+        #expect(change.contains(#""line":0"#))
+        #expect(change.contains(#""character":5"#))
+        #expect(change.contains(#""rangeLength":0"#))
+        #expect(change.contains(#""text":"y""#))
+        #expect(!change.contains(#""text":"let xy = 1\n""#))
+        transport.finish()
+    }
+
     @Test("full text sync keeps full-document changes")
     func fullTextSyncUsesFullDocumentPayload() async throws {
         let transport = FakeTransport()

--- a/AlasTests/Code/TextEditCoordinatesTests.swift
+++ b/AlasTests/Code/TextEditCoordinatesTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("TextEditCoordinates")
+struct TextEditCoordinatesTests {
+    @Test("tree-sitter input edit points use UTF-16 byte columns")
+    func inputEditUsesUTF16ByteColumns() throws {
+        let oldText = "let a\nlet b\n"
+        let edit = EditorTextEdit(location: 8, oldLength: 0, replacementText: "xy")
+        let newText = try #require(TextEditCoordinates.apply(edit, to: oldText))
+        let inputEdit = try #require(TextEditCoordinates.inputEdit(for: edit, oldText: oldText, newText: newText))
+
+        #expect(inputEdit.startByte == 16)
+        #expect(inputEdit.oldEndByte == 16)
+        #expect(inputEdit.newEndByte == 20)
+        #expect(inputEdit.startPoint.row == 1)
+        #expect(inputEdit.startPoint.column == 4)
+        #expect(inputEdit.oldEndPoint.row == 1)
+        #expect(inputEdit.oldEndPoint.column == 4)
+        #expect(inputEdit.newEndPoint.row == 1)
+        #expect(inputEdit.newEndPoint.column == 8)
+    }
+}


### PR DESCRIPTION
## Summary
- capture AppKit edit ranges from editor buffers
- reuse edits for incremental Tree-sitter parsing and range-based LSP didChange payloads
- add UTF-16 coordinate helpers and focused coverage

Fixes #41

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test