### PR TITLE
fix(editor): fix editor edge cases

### DIFF
--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -10,13 +10,16 @@ struct TabsFile: Codable {
 @Observable
 @MainActor
 final class TabsManager {
+    private struct BufferKey: Hashable {
+        var worktreeId: String
+        var relativePath: String
+    }
+
     private var byWorktree: [String: TabsFile] = [:]
     private let store = PersistenceStore()
     private let bufferStore: EditorBufferStore
-    private var buffers: [TabID: EditorBuffer] = [:]
-    // Map tabId → worktreeId so `discardBuffer` and `snapshotDirtyBuffersForQuit`
-    // know which subtree to write to without forcing callers to pass it.
-    private var bufferOwners: [TabID: String] = [:]
+    private var buffers: [BufferKey: EditorBuffer] = [:]
+    private var bufferKeys: [TabID: BufferKey] = [:]
     private let lsp: WorkspaceLSPManager?
 
     init(bufferStore: EditorBufferStore = EditorBufferStore(), lsp: WorkspaceLSPManager? = nil) {
@@ -220,7 +223,12 @@ final class TabsManager {
     /// Returns the buffer for `tabId`, creating it (cold-load from disk or
     /// hot-restore from snapshot) on first access.
     func buffer(worktreeId: String, tabId: TabID, worktreeRoot: URL, relativePath: String) -> EditorBuffer {
-        if let existing = buffers[tabId] { return existing }
+        if let key = bufferKeys[tabId], let existing = buffers[key] { return existing }
+        let key = BufferKey(worktreeId: worktreeId, relativePath: relativePath)
+        if let existing = buffers[key] {
+            bufferKeys[tabId] = key
+            return existing
+        }
         let buffer: EditorBuffer
         if let lsp {
             buffer = EditorBuffer(
@@ -242,22 +250,37 @@ final class TabsManager {
         }
         buffer.startWatching()
         buffer.checkForConflictOnRestore()
-        buffers[tabId] = buffer
-        bufferOwners[tabId] = worktreeId
+        buffer.shouldFollowPathChange = { [weak self] oldPath, newPath in
+            self?.canFollowBufferPathChange(worktreeId: worktreeId, oldPath: oldPath, newPath: newPath) ?? false
+        }
+        buffer.onPathChanged = { [weak self] oldPath, newPath in
+            self?.handleBufferPathChanged(worktreeId: worktreeId, oldPath: oldPath, newPath: newPath)
+        }
+        buffer.onSnapshotRequested = { [weak self, weak buffer] in
+            guard let buffer else { return }
+            self?.snapshotBufferForAllTabs(buffer)
+        }
+        buffer.onDiscardSnapshotsRequested = { [weak self, weak buffer] in
+            guard let buffer else { return }
+            self?.discardSnapshotsForAllTabs(buffer)
+        }
+        buffers[key] = buffer
+        bufferKeys[tabId] = key
         return buffer
     }
 
     /// Inspect (do not create) the buffer for `tabId`. Used by tests and by
     /// dirty-tab queries.
     func peekBuffer(tabId: TabID) -> EditorBuffer? {
-        buffers[tabId]
+        guard let key = bufferKeys[tabId] else { return nil }
+        return buffers[key]
     }
 
     func activeEditorContext(worktreeId: String) -> (tab: EditorTabState, buffer: EditorBuffer)? {
         guard let activeId = activeTabId(forWorktree: worktreeId),
               let tab = tabs(forWorktree: worktreeId).first(where: { $0.id == activeId }),
               case .editor(let state) = tab,
-              let buffer = buffers[activeId] else { return nil }
+              let buffer = peekBuffer(tabId: activeId) else { return nil }
         return (state, buffer)
     }
 
@@ -268,17 +291,25 @@ final class TabsManager {
     /// wrong worktree context surfaces immediately rather than silently
     /// mis-routing the snapshot.
     func discardBuffer(worktreeId: String, tabId: TabID) {
-        if let owner = bufferOwners[tabId] {
-            assert(owner == worktreeId, "discardBuffer called with worktreeId=\(worktreeId) but buffer is owned by \(owner)")
+        guard let key = bufferKeys.removeValue(forKey: tabId) else { return }
+        assert(key.worktreeId == worktreeId, "discardBuffer called with worktreeId=\(worktreeId) but buffer is owned by \(key.worktreeId)")
+        bufferStore.discard(worktreeId: worktreeId, tabId: tabId)
+        guard let buffer = buffers[key] else { return }
+        if let nextTabId = bufferKeys.first(where: { $0.value == key })?.key {
+            if buffer.persistenceTabId == tabId {
+                buffer.adoptPersistenceTabId(nextTabId)
+            }
+            return
         }
-        guard let buffer = buffers.removeValue(forKey: tabId) else { return }
-        bufferOwners.removeValue(forKey: tabId)
+        buffers.removeValue(forKey: key)
         buffer.close(persistDirtySnapshot: false)
     }
 
     /// Tab IDs whose buffers are currently dirty. Order is unspecified.
     func dirtyTabIds() -> [TabID] {
-        buffers.compactMap { $0.value.dirty ? $0.key : nil }
+        bufferKeys.compactMap { tabId, key in
+            buffers[key]?.dirty == true ? tabId : nil
+        }
     }
 
     @discardableResult
@@ -293,6 +324,13 @@ final class TabsManager {
         file.tabs[idx] = .editor(state)
         byWorktree[worktreeId] = file
         persist(worktreeId)
+        if let oldKey = bufferKeys[tabId] {
+            let newKey = BufferKey(worktreeId: worktreeId, relativePath: relativePath)
+            bufferKeys[tabId] = newKey
+            if oldKey != newKey, let buffer = buffers.removeValue(forKey: oldKey) {
+                buffers[newKey] = buffer
+            }
+        }
         return true
     }
 
@@ -307,15 +345,21 @@ final class TabsManager {
     /// quit handler. Errors are swallowed — failing to snapshot one buffer
     /// must not block snapshotting the rest, and quit must not be blocked.
     func snapshotDirtyBuffersForQuit() {
-        for buffer in buffers.values where buffer.dirty {
-            buffer.snapshotNow()
+        for (tabId, key) in bufferKeys {
+            guard let buffer = buffers[key], buffer.dirty else { continue }
+            buffer.snapshotNow(tabId: tabId)
         }
     }
 
     @discardableResult
     func saveAll(worktreeRoots: [String: URL] = [:]) -> [(tabId: TabID, error: Error)] {
         var errors: [(TabID, Error)] = []
-        for (tabId, buffer) in buffers where buffer.dirty {
+        var saved = Set<ObjectIdentifier>()
+        for (tabId, key) in bufferKeys {
+            guard let buffer = buffers[key], buffer.dirty else { continue }
+            let id = ObjectIdentifier(buffer)
+            guard !saved.contains(id) else { continue }
+            saved.insert(id)
             do {
                 try buffer.saveRecordingError()
             } catch {
@@ -326,7 +370,7 @@ final class TabsManager {
             guard let root = worktreeRoots[worktreeId] else { continue }
             for tab in file.tabs {
                 guard case .editor(let state) = tab,
-                      buffers[state.id] == nil,
+                      peekBuffer(tabId: state.id) == nil,
                       (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) != nil else { continue }
                 let buffer: EditorBuffer
                 if let lsp {
@@ -364,7 +408,7 @@ final class TabsManager {
     @discardableResult
     func saveActive(worktreeId: String) -> Bool {
         guard let activeId = activeTabId(forWorktree: worktreeId),
-              let buffer = buffers[activeId] else { return false }
+              let buffer = peekBuffer(tabId: activeId) else { return false }
         do {
             try buffer.saveRecordingError()
             return true
@@ -376,8 +420,74 @@ final class TabsManager {
     @discardableResult
     func revertActive(worktreeId: String) -> Bool {
         guard let activeId = activeTabId(forWorktree: worktreeId),
-              let buffer = buffers[activeId] else { return false }
+              let buffer = peekBuffer(tabId: activeId) else { return false }
         buffer.revert()
         return true
+    }
+
+    private func handleBufferPathChanged(worktreeId: String, oldPath: String, newPath: String) {
+        let oldKey = BufferKey(worktreeId: worktreeId, relativePath: oldPath)
+        let newKey = BufferKey(worktreeId: worktreeId, relativePath: newPath)
+        let affectedTabIds = bufferKeys.compactMap { tabId, key in key == oldKey ? tabId : nil }
+        guard !affectedTabIds.isEmpty else { return }
+
+        if let buffer = buffers.removeValue(forKey: oldKey) {
+            buffers[newKey] = buffer
+        }
+        for tabId in affectedTabIds {
+            bufferKeys[tabId] = newKey
+            _ = updateEditorPath(worktreeId: worktreeId, tabId: tabId, relativePath: newPath)
+        }
+    }
+
+    private func canFollowBufferPathChange(worktreeId: String, oldPath: String, newPath: String) -> Bool {
+        let oldKey = BufferKey(worktreeId: worktreeId, relativePath: oldPath)
+        let newKey = BufferKey(worktreeId: worktreeId, relativePath: newPath)
+        guard oldKey != newKey else { return true }
+        guard buffers[newKey] == nil else { return false }
+        guard let file = byWorktree[worktreeId] else { return true }
+        return !file.tabs.contains { tab in
+            guard case .editor(let state) = tab,
+                  state.relativePath == newPath,
+                  bufferKeys[state.id] == nil,
+                  (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) != nil else { return false }
+            return true
+        }
+    }
+
+    private func snapshotBufferForAllTabs(_ buffer: EditorBuffer) {
+        for (tabId, _) in tabIdsSharing(buffer: buffer) {
+            buffer.snapshotNow(tabId: tabId)
+        }
+    }
+
+    private func discardSnapshotsForAllTabs(_ buffer: EditorBuffer) {
+        for (tabId, key) in tabIdsSharing(buffer: buffer) {
+            bufferStore.discard(worktreeId: key.worktreeId, tabId: tabId)
+        }
+    }
+
+    private func tabIdsSharing(buffer: EditorBuffer) -> [(TabID, BufferKey)] {
+        var result: [(TabID, BufferKey)] = []
+        var seen = Set<TabID>()
+        let liveKeys = Set(bufferKeys.compactMap { _, key in buffers[key] === buffer ? key : nil })
+
+        for (tabId, key) in bufferKeys where liveKeys.contains(key) {
+            result.append((tabId, key))
+            seen.insert(tabId)
+        }
+
+        for key in liveKeys {
+            guard let file = byWorktree[key.worktreeId] else { continue }
+            for tab in file.tabs {
+                guard case .editor(let state) = tab,
+                      state.relativePath == key.relativePath,
+                      !seen.contains(state.id) else { continue }
+                result.append((state.id, key))
+                seen.insert(state.id)
+            }
+        }
+
+        return result
     }
 }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -2,11 +2,11 @@ import AppKit
 import Foundation
 import Observation
 
-/// Per-tab editor buffer. Owns the live `NSTextStorage` displayed by
+/// Editor buffer for one open worktree file. Owns the live `NSTextStorage` displayed by
 /// `CodeTextView`, plus the original-on-disk snapshot used for dirty
 /// detection, save normalization, and conflict resolution.
 ///
-/// Buffers are stored in `TabsManager.buffers` keyed by `TabID` so they
+/// Buffers are stored in `TabsManager` by worktree-relative path so they
 /// outlive the SwiftUI view (which can be torn down and rebuilt). All
 /// state mutations happen on the main actor; storage delegate callbacks,
 /// LSP responses, and file-watch events are routed through `MainActor`
@@ -52,17 +52,30 @@ final class EditorBuffer {
     @ObservationIgnored
     private static let watchQueue = DispatchQueue(label: "alas.editor.buffer.watch", qos: .utility)
     @ObservationIgnored
+    private var originalFileIdentifier: AnyObject?
+    @ObservationIgnored
+    private var originalVolumeIdentifier: AnyObject?
+    @ObservationIgnored
     private let store: EditorBufferStore?
     @ObservationIgnored
     private let worktreeId: String?
     @ObservationIgnored
-    private let tabId: String?
+    private var tabId: String?
     @ObservationIgnored
     private var snapshotTask: Task<Void, Never>?
     @ObservationIgnored
     private let lsp: WorkspaceLSPManager?
     @ObservationIgnored
     private(set) var language: String?
+    @ObservationIgnored
+    var shouldFollowPathChange: ((String, String) -> Bool)?
+    @ObservationIgnored
+    var onPathChanged: ((String, String) -> Void)?
+    @ObservationIgnored
+    var onSnapshotRequested: (() -> Void)?
+    @ObservationIgnored
+    var onDiscardSnapshotsRequested: (() -> Void)?
+    var persistenceTabId: String? { tabId }
 
     struct EditObserverToken { fileprivate let id: UUID }
 
@@ -134,6 +147,12 @@ final class EditorBuffer {
         editObservers.removeValue(forKey: token.id)
     }
 
+    func adoptPersistenceTabId(_ tabId: String) {
+        guard self.tabId != tabId else { return }
+        self.tabId = tabId
+        if dirty { snapshotNow() }
+    }
+
     private func handleEdit(edit: EditorTextEdit?) {
         guard !loading else { return }
         editGeneration &+= 1
@@ -175,6 +194,10 @@ final class EditorBuffer {
     private func handleWatcherEvent() {
         let url = worktreeRoot.appendingPathComponent(relativePath)
         if !FileManager.default.fileExists(atPath: url.path) {
+            if let movedPath = findMovedRelativePath() {
+                followMovedFile(to: movedPath)
+                return
+            }
             if dirty {
                 conflict = .deletedOnDisk
             }
@@ -194,6 +217,44 @@ final class EditorBuffer {
         // Re-arm watcher in case rename swapped the inode (atomic save by an
         // external tool).
         startWatching()
+    }
+
+    private func followMovedFile(to newRelativePath: String) {
+        let oldURL = worktreeRoot.appendingPathComponent(relativePath)
+        let oldRelativePath = relativePath
+        let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
+        let oldLanguage = language
+        let wasDirty = dirty
+        guard shouldFollowPathChange?(oldRelativePath, newRelativePath) ?? true else {
+            if wasDirty {
+                conflict = .deletedOnDisk
+            }
+            return
+        }
+        stopWatching()
+        relativePath = newRelativePath
+        language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
+        if wasDirty {
+            updateOriginalFileIdentity(from: newURL)
+            conflict = movedFileDiffersFromOriginal(at: newURL) ? .changedOnDisk : nil
+            snapshotNow()
+        } else {
+            loadFromDisk()
+            discardSnapshot()
+            handleEdit(edit: nil)
+        }
+        notifyDidClose(url: oldURL, language: oldLanguage)
+        notifyDidOpen(url: newURL, text: storage.string)
+        onPathChanged?(oldRelativePath, newRelativePath)
+        startWatching()
+    }
+
+    private func movedFileDiffersFromOriginal(at url: URL) -> Bool {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let mtime = attrs[.modificationDate] as? Date else { return true }
+        if mtime != originalMtime { return true }
+        guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return true }
+        return LineEnding.lf.normalize(raw) != originalText
     }
 
     func resolveConflictKeepingMine() {
@@ -231,6 +292,9 @@ final class EditorBuffer {
     func saveAs(relativePath newRelativePath: String) throws {
         lastSaveError = nil
         guard !readOnly else { return }
+        guard shouldFollowPathChange?(relativePath, newRelativePath) ?? true else {
+            throw CocoaError(.fileWriteFileExists)
+        }
         let oldURL = worktreeRoot.appendingPathComponent(relativePath)
         let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
         let oldLanguage = language
@@ -242,10 +306,12 @@ final class EditorBuffer {
             language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
             originalText = canonical
             updateOriginalMtime(from: newURL)
+            updateOriginalFileIdentity(from: newURL)
             discardSnapshot()
             notifyDidClose(url: oldURL, language: oldLanguage)
             notifyDidOpen(url: newURL, text: canonical)
             notifyDidSave(url: newURL)
+            onPathChanged?(oldURLRelativePath(from: oldURL), newRelativePath)
             startWatching()
         } catch {
             startWatching()
@@ -256,6 +322,9 @@ final class EditorBuffer {
     func moveTo(relativePath newRelativePath: String) throws {
         lastSaveError = nil
         guard !readOnly else { return }
+        guard shouldFollowPathChange?(relativePath, newRelativePath) ?? true else {
+            throw CocoaError(.fileWriteFileExists)
+        }
         let oldURL = worktreeRoot.appendingPathComponent(relativePath)
         let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
         let oldLanguage = language
@@ -273,6 +342,7 @@ final class EditorBuffer {
             relativePath = newRelativePath
             language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
             updateOriginalMtime(from: newURL)
+            updateOriginalFileIdentity(from: newURL)
             if dirty {
                 snapshotNow()
             } else {
@@ -280,6 +350,7 @@ final class EditorBuffer {
             }
             notifyDidClose(url: oldURL, language: oldLanguage)
             notifyDidOpen(url: newURL, text: storage.string)
+            onPathChanged?(oldURLRelativePath(from: oldURL), newRelativePath)
             startWatching()
         } catch {
             startWatching()
@@ -369,6 +440,56 @@ final class EditorBuffer {
            let mtime = attrs[.modificationDate] as? Date {
             originalMtime = mtime
         }
+        updateOriginalFileIdentity(from: url)
+    }
+
+    private func updateOriginalFileIdentity(from url: URL) {
+        guard let values = try? url.resourceValues(forKeys: [.fileResourceIdentifierKey, .volumeIdentifierKey]),
+              let file = values.fileResourceIdentifier,
+              let volume = values.volumeIdentifier else {
+            originalFileIdentifier = nil
+            originalVolumeIdentifier = nil
+            return
+        }
+        originalFileIdentifier = file as AnyObject
+        originalVolumeIdentifier = volume as AnyObject
+    }
+
+    private func findMovedRelativePath() -> String? {
+        guard let originalFileIdentifier, let originalVolumeIdentifier else { return nil }
+        let keys: Set<URLResourceKey> = [.isRegularFileKey, .isDirectoryKey, .fileResourceIdentifierKey, .volumeIdentifierKey]
+        guard let enumerator = FileManager.default.enumerator(
+            at: worktreeRoot,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsPackageDescendants]
+        ) else { return nil }
+
+        for case let candidate as URL in enumerator {
+            if candidate.lastPathComponent == ".git" {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard let values = try? candidate.resourceValues(forKeys: keys),
+                  values.isRegularFile == true,
+                  let file = values.fileResourceIdentifier,
+                  let volume = values.volumeIdentifier,
+                  (file as AnyObject).isEqual(originalFileIdentifier),
+                  (volume as AnyObject).isEqual(originalVolumeIdentifier) else { continue }
+            return relativePath(for: candidate)
+        }
+        return nil
+    }
+
+    private func relativePath(for url: URL) -> String? {
+        let root = worktreeRoot.standardizedFileURL.path
+        let target = url.standardizedFileURL.path
+        let prefix = root.hasSuffix("/") ? root : root + "/"
+        guard target.hasPrefix(prefix) else { return nil }
+        return String(target.dropFirst(prefix.count))
+    }
+
+    private func oldURLRelativePath(from url: URL) -> String {
+        relativePath(for: url) ?? relativePath
     }
 
     private func notifyDidSave(url: URL) {
@@ -416,7 +537,13 @@ final class EditorBuffer {
         snapshotTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 750_000_000)
             guard let self, !Task.isCancelled else { return }
-            await MainActor.run { self.snapshotNow() }
+            await MainActor.run {
+                if let onSnapshotRequested = self.onSnapshotRequested {
+                    onSnapshotRequested()
+                } else {
+                    self.snapshotNow()
+                }
+            }
         }
     }
 
@@ -424,10 +551,11 @@ final class EditorBuffer {
     /// enabled (store/worktreeId/tabId all set on the production init).
     /// Safe to call from any state — clean buffers discard stale snapshots,
     /// while buffers without a store remain a no-op.
-    func snapshotNow() {
+    func snapshotNow(tabId overrideTabId: String? = nil) {
         guard let store, let worktreeId, let tabId else { return }
+        let snapshotTabId = overrideTabId ?? tabId
         guard dirty else {
-            discardSnapshot()
+            store.discard(worktreeId: worktreeId, tabId: snapshotTabId)
             return
         }
         let snap = EditorBufferStore.Snapshot(
@@ -437,10 +565,14 @@ final class EditorBuffer {
             originalMtime: originalMtime,
             lineEnding: lineEnding
         )
-        try? store.write(snap, worktreeId: worktreeId, tabId: tabId)
+        try? store.write(snap, worktreeId: worktreeId, tabId: snapshotTabId)
     }
 
     private func discardSnapshot() {
+        if let onDiscardSnapshotsRequested {
+            onDiscardSnapshotsRequested()
+            return
+        }
         guard let store, let worktreeId, let tabId else { return }
         store.discard(worktreeId: worktreeId, tabId: tabId)
     }
@@ -481,8 +613,13 @@ final class EditorBuffer {
         loading = true
         defer { loading = false }
         let url = worktreeRoot.appendingPathComponent(relativePath)
-        guard let raw = try? String(contentsOf: url, encoding: .utf8) else {
+        guard FileManager.default.fileExists(atPath: url.path) else {
             storage.setAttributedString(NSAttributedString(string: "(unable to read file)"))
+            readOnly = true
+            return
+        }
+        guard let raw = try? String(contentsOf: url, encoding: .utf8) else {
+            storage.setAttributedString(NSAttributedString(string: "(read-only: file is not valid UTF-8)"))
             readOnly = true
             return
         }
@@ -497,6 +634,7 @@ final class EditorBuffer {
                 permissions = mode_t(nsPerms.uint16Value)
             }
         }
+        updateOriginalFileIdentity(from: url)
         readOnly = false
     }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -53,6 +53,18 @@ struct EditorBufferTests {
         #expect(buffer.dirty == false)
     }
 
+    @Test func coldLoadOnNonUTF8FileIsReadOnlyWithClearMessage() throws {
+        let root = tempWorktree()
+        let url = root.appendingPathComponent("latin1.txt")
+        try Data([0x63, 0x61, 0x66, 0xE9]).write(to: url)
+
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "latin1.txt")
+
+        #expect(buffer.storage.string == "(read-only: file is not valid UTF-8)")
+        #expect(buffer.readOnly == true)
+        #expect(buffer.dirty == false)
+    }
+
     @Test func saveWritesContentAndClearsDirty() throws {
         let root = tempWorktree()
         _ = try writeFile(root, "a.txt", "hello\n")
@@ -235,6 +247,81 @@ struct EditorBufferTests {
         #expect(buffer.dirty == false)
         #expect(buffer.conflict == nil)
         #expect(fired == 1)
+    }
+
+    @Test func externalRenameReloadsCleanBufferFromMovedFile() async throws {
+        let root = tempWorktree()
+        let oldURL = try writeFile(root, "a.txt", "v1\n")
+        let newURL = root.appendingPathComponent("nested/b.txt")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        var pathChanges: [(String, String)] = []
+        buffer.onPathChanged = { oldPath, newPath in pathChanges.append((oldPath, newPath)) }
+        buffer.startWatching()
+        defer { buffer.stopWatching() }
+
+        try FileManager.default.createDirectory(at: newURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.moveItem(at: oldURL, to: newURL)
+        let handle = try FileHandle(forWritingTo: newURL)
+        try handle.truncate(atOffset: 0)
+        try handle.write(contentsOf: Data("v2\n".utf8))
+        try handle.close()
+        for _ in 0..<20 where buffer.relativePath != "nested/b.txt" {
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        #expect(buffer.relativePath == "nested/b.txt")
+        #expect(buffer.storage.string == "v2\n")
+        #expect(buffer.originalText == "v2\n")
+        #expect(buffer.dirty == false)
+        #expect(buffer.conflict == nil)
+        #expect(pathChanges.count == 1)
+        #expect(pathChanges.first?.0 == "a.txt")
+        #expect(pathChanges.first?.1 == "nested/b.txt")
+    }
+
+    @Test func externalRenameOfDirtyBufferRaisesConflictWhenMovedFileChanged() async throws {
+        let root = tempWorktree()
+        let oldURL = try writeFile(root, "a.txt", "v1\n")
+        let newURL = root.appendingPathComponent("nested/b.txt")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 2), with: "mine")
+        #expect(buffer.dirty == true)
+        buffer.startWatching()
+        defer { buffer.stopWatching() }
+
+        try FileManager.default.createDirectory(at: newURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.moveItem(at: oldURL, to: newURL)
+        let handle = try FileHandle(forWritingTo: newURL)
+        try handle.truncate(atOffset: 0)
+        try handle.write(contentsOf: Data("external\n".utf8))
+        try handle.close()
+        for _ in 0..<20 where buffer.relativePath != "nested/b.txt" {
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        #expect(buffer.relativePath == "nested/b.txt")
+        #expect(buffer.storage.string == "mine\n")
+        #expect(buffer.originalText == "v1\n")
+        #expect(buffer.dirty == true)
+        #expect(buffer.conflict == .changedOnDisk)
+    }
+
+    @Test func externalRenameFollowsHiddenFiles() async throws {
+        let root = tempWorktree()
+        let oldURL = try writeFile(root, ".env", "TOKEN=a\n")
+        let newURL = root.appendingPathComponent(".env.local")
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: ".env")
+        buffer.startWatching()
+        defer { buffer.stopWatching() }
+
+        try FileManager.default.moveItem(at: oldURL, to: newURL)
+        for _ in 0..<20 where buffer.relativePath != ".env.local" {
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        #expect(buffer.relativePath == ".env.local")
+        #expect(buffer.storage.string == "TOKEN=a\n")
+        #expect(buffer.conflict == nil)
     }
 
     @Test func externalChangeWhileDirtyRaisesConflict() async throws {

--- a/AlasTests/TabsManagerBufferTests.swift
+++ b/AlasTests/TabsManagerBufferTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Darwin
 @testable import Alas
 
 @MainActor
@@ -26,6 +27,108 @@ struct TabsManagerBufferTests {
         let b1 = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
         let b2 = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
         #expect(b1 === b2)
+    }
+
+    @Test func buffersForSamePathShareOneInstanceAcrossTabs() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, _, _) = makeManager()
+
+        let first = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
+        let second = manager.buffer(worktreeId: "wt", tabId: "t2", worktreeRoot: root, relativePath: "a.txt")
+        first.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+
+        #expect(first === second)
+        #expect(second.storage.string == "zx")
+        #expect(manager.dirtyTabIds().sorted() == ["t1", "t2"])
+    }
+
+    @Test func closingOneTabForSharedPathKeepsBufferForOtherTab() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, _, _) = makeManager()
+        let first = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
+        _ = manager.buffer(worktreeId: "wt", tabId: "t2", worktreeRoot: root, relativePath: "a.txt")
+        first.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+
+        manager.discardBuffer(worktreeId: "wt", tabId: "t1")
+
+        #expect(manager.peekBuffer(tabId: "t1") == nil)
+        #expect(manager.peekBuffer(tabId: "t2") === first)
+        #expect(manager.peekBuffer(tabId: "t2")?.storage.string == "zx")
+    }
+
+    @Test func externalRenameIntoOpenPathDoesNotReplaceDestinationBuffer() async throws {
+        let root = tempWorktree()
+        let oldURL = root.appendingPathComponent("a.txt")
+        let destinationURL = root.appendingPathComponent("b.txt")
+        try "a\n".write(to: oldURL, atomically: true, encoding: .utf8)
+        try "b\n".write(to: destinationURL, atomically: true, encoding: .utf8)
+        let (manager, _, _) = makeManager()
+        let source = manager.buffer(worktreeId: "wt", tabId: "ta", worktreeRoot: root, relativePath: "a.txt")
+        let destination = manager.buffer(worktreeId: "wt", tabId: "tb", worktreeRoot: root, relativePath: "b.txt")
+        source.storage.replaceCharacters(in: NSRange(location: 0, length: 1), with: "mine")
+        destination.storage.replaceCharacters(in: NSRange(location: 0, length: 1), with: "dirty")
+
+        #expect(Darwin.rename(oldURL.path, destinationURL.path) == 0)
+        for _ in 0..<20 where source.conflict == nil {
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        #expect(manager.peekBuffer(tabId: "tb") === destination)
+        #expect(destination.storage.string == "dirty\n")
+        #expect(destination.dirty == true)
+        #expect(source.relativePath == "a.txt")
+        #expect(source.conflict == .deletedOnDisk)
+    }
+
+    @Test func inAppRenameIntoOpenPathDoesNotReplaceDestinationBuffer() throws {
+        let root = tempWorktree()
+        let sourceURL = root.appendingPathComponent("a.txt")
+        let destinationURL = root.appendingPathComponent("b.txt")
+        try "a\n".write(to: sourceURL, atomically: true, encoding: .utf8)
+        try "b\n".write(to: destinationURL, atomically: true, encoding: .utf8)
+        let (manager, _, _) = makeManager()
+        let source = manager.buffer(worktreeId: "wt", tabId: "ta", worktreeRoot: root, relativePath: "a.txt")
+        let destination = manager.buffer(worktreeId: "wt", tabId: "tb", worktreeRoot: root, relativePath: "b.txt")
+        destination.storage.replaceCharacters(in: NSRange(location: 0, length: 1), with: "dirty")
+        try FileManager.default.removeItem(at: destinationURL)
+
+        #expect(throws: (any Error).self) {
+            try source.moveTo(relativePath: "b.txt")
+        }
+
+        #expect(manager.peekBuffer(tabId: "tb") === destination)
+        #expect(destination.storage.string == "dirty\n")
+        #expect(destination.dirty == true)
+        #expect(source.relativePath == "a.txt")
+    }
+
+    @Test func inAppRenameIntoUnloadedSnapshotPathIsRejected() throws {
+        let root = tempWorktree()
+        try "a\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "b\n".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let sourceTab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let destinationTab = manager.appendEditor(worktreeId: "wt", title: "b.txt", relativePath: "b.txt")
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "b.txt",
+            content: "dirty b\n",
+            originalText: "b\n",
+            originalMtime: Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: destinationTab.id)
+        let source = manager.buffer(worktreeId: "wt", tabId: sourceTab.id, worktreeRoot: root, relativePath: "a.txt")
+        try FileManager.default.removeItem(at: root.appendingPathComponent("b.txt"))
+
+        #expect(throws: (any Error).self) {
+            try source.moveTo(relativePath: "b.txt")
+        }
+
+        #expect(source.relativePath == "a.txt")
+        #expect(try store.read(worktreeId: "wt", tabId: destinationTab.id)?.content == "dirty b\n")
+        #expect(manager.peekBuffer(tabId: destinationTab.id) == nil)
     }
 
     @Test func closingDirtyBufferDiscardsSnapshotAndBuffer() throws {
@@ -63,6 +166,91 @@ struct TabsManagerBufferTests {
         manager.snapshotDirtyBuffersForQuit()
         #expect(try store.read(worktreeId: "wt", tabId: "ta") != nil)
         #expect(try store.read(worktreeId: "wt", tabId: "tb") == nil)
+    }
+
+    @Test func snapshotDirtyBuffersForQuitWritesEveryTabSharingDirtyBuffer() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let first = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
+        _ = manager.buffer(worktreeId: "wt", tabId: "t2", worktreeRoot: root, relativePath: "a.txt")
+        first.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+
+        manager.snapshotDirtyBuffersForQuit()
+
+        #expect(try store.read(worktreeId: "wt", tabId: "t1")?.content == "zx")
+        #expect(try store.read(worktreeId: "wt", tabId: "t2")?.content == "zx")
+    }
+
+    @Test func editTimeSnapshotWritesEveryTabSharingDirtyBuffer() async throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let buffer = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
+        _ = manager.buffer(worktreeId: "wt", tabId: "t2", worktreeRoot: root, relativePath: "a.txt")
+
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+        try await Task.sleep(nanoseconds: 900_000_000)
+
+        #expect(try store.read(worktreeId: "wt", tabId: "t1")?.content == "zx")
+        #expect(try store.read(worktreeId: "wt", tabId: "t2")?.content == "zx")
+    }
+
+    @Test func editTimeSnapshotWritesUnloadedTabsSharingDirtyBuffer() async throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let first = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let second = manager.appendEditor(worktreeId: "wt", title: "a copy", relativePath: "a.txt")
+        let buffer = manager.buffer(worktreeId: "wt", tabId: first.id, worktreeRoot: root, relativePath: "a.txt")
+
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+        try await Task.sleep(nanoseconds: 900_000_000)
+
+        #expect(try store.read(worktreeId: "wt", tabId: first.id)?.content == "zx")
+        #expect(try store.read(worktreeId: "wt", tabId: second.id)?.content == "zx")
+        #expect(manager.peekBuffer(tabId: second.id) == nil)
+    }
+
+    @Test func savingSharedBufferDiscardsEveryTabSnapshot() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let buffer = manager.buffer(worktreeId: "wt", tabId: "t1", worktreeRoot: root, relativePath: "a.txt")
+        _ = manager.buffer(worktreeId: "wt", tabId: "t2", worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+        manager.snapshotDirtyBuffersForQuit()
+        #expect(try store.read(worktreeId: "wt", tabId: "t1") != nil)
+        #expect(try store.read(worktreeId: "wt", tabId: "t2") != nil)
+
+        try buffer.save()
+
+        #expect(try store.read(worktreeId: "wt", tabId: "t1") == nil)
+        #expect(try store.read(worktreeId: "wt", tabId: "t2") == nil)
+    }
+
+    @Test func savingSharedBufferDiscardsUnloadedSiblingSnapshot() throws {
+        let root = tempWorktree()
+        try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let first = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let second = manager.appendEditor(worktreeId: "wt", title: "a copy", relativePath: "a.txt")
+        let stale = EditorBufferStore.Snapshot(
+            relativePath: "a.txt",
+            content: "stale\n",
+            originalText: "x",
+            originalMtime: Date(),
+            lineEnding: .lf
+        )
+        try store.write(stale, worktreeId: "wt", tabId: second.id)
+        let buffer = manager.buffer(worktreeId: "wt", tabId: first.id, worktreeRoot: root, relativePath: "a.txt")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "z")
+
+        try buffer.save()
+
+        #expect(try store.read(worktreeId: "wt", tabId: first.id) == nil)
+        #expect(try store.read(worktreeId: "wt", tabId: second.id) == nil)
+        #expect(manager.peekBuffer(tabId: second.id) == nil)
     }
 
     @Test func updateEditorPathPersistsTabMetadata() throws {


### PR DESCRIPTION
## Summary

Fixes the editor edge cases tracked in #42:

- Coalesces live editor buffers by worktree-relative path so duplicate tabs for the same file share one `NSTextStorage` and save state.
- Follows external renames/moves by remembering the loaded file identity and resolving the moved path when the watched path disappears.
- Opens existing non-UTF-8 files as read-only with an explicit message instead of the generic unreadable-file placeholder.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`