### PR TITLE
Font selector for terminal and editor

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B450918CC98255AD9170586 /* AppearancePane.swift */; };
 		92969E6FE10C4FE9B6D6DA05 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */; };
 		A1A1A1A1A1A1A1A1A1A1A1A1 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B2B2B2B2B2B2B2B2B2B2B2 /* MonospaceFontCatalog.swift */; };
+		C3C3C3C3C3C3C3C3C3C3C3C3 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D4D4D4D4D4D4D4D4D4D4D4 /* SettingsBinding.swift */; };
 		3B34A2725C1F6B6E29C312F1 /* SearchInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */; };
 		3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */; };
 		3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */; };
@@ -264,6 +265,7 @@
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
 		FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
 		B2B2B2B2B2B2B2B2B2B2B2B2 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
+		D4D4D4D4D4D4D4D4D4D4D4D4 /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
@@ -606,6 +608,7 @@
 				B2B2B2B2B2B2B2B2B2B2B2B2 /* MonospaceFontCatalog.swift */,
 				F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */,
 				515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */,
+				D4D4D4D4D4D4D4D4D4D4D4D4 /* SettingsBinding.swift */,
 				EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */,
 				FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */,
 				FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */,
@@ -1076,6 +1079,7 @@
 				D59E731EE52408DDF87BABDA /* FilesSectionView.swift in Sources */,
 				92969E6FE10C4FE9B6D6DA05 /* FontFamilyPicker.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A1A1A1 /* MonospaceFontCatalog.swift in Sources */,
+				C3C3C3C3C3C3C3C3C3C3C3C3 /* SettingsBinding.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
 		A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */; };
 		A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */; };
+		E5E5E5E5E5E5E5E5E5E5E5E5 /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F6F6F6F6F6F6F6F6F6F6F6 /* FontSizeCommands.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
 		A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */; };
@@ -302,6 +303,7 @@
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
 		7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApp.swift; sourceTree = "<group>"; };
+		F6F6F6F6F6F6F6F6F6F6F6F6 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
 		7FFC9539E615699AC90A7412 /* ProjectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManager.swift; sourceTree = "<group>"; };
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
@@ -883,6 +885,7 @@
 			isa = PBXGroup;
 			children = (
 				7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */,
+				F6F6F6F6F6F6F6F6F6F6F6F6 /* FontSizeCommands.swift */,
 				17C2AC0F8B3A1B75239995AC /* AppState.swift */,
 				7FFC9539E615699AC90A7412 /* ProjectsManager.swift */,
 				69024633944E9FFF6DA76FAE /* RootView.swift */,
@@ -1036,6 +1039,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */,
+				E5E5E5E5E5E5E5E5E5E5E5E5 /* FontSizeCommands.swift in Sources */,
 				5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */,
 				24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */,
 				9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2498E56CBAF84CB67166C /* HarnessKind.swift */; };
 		3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B450918CC98255AD9170586 /* AppearancePane.swift */; };
 		92969E6FE10C4FE9B6D6DA05 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */; };
+		A1A1A1A1A1A1A1A1A1A1A1A1 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B2B2B2B2B2B2B2B2B2B2B2 /* MonospaceFontCatalog.swift */; };
 		3B34A2725C1F6B6E29C312F1 /* SearchInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */; };
 		3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */; };
 		3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */; };
@@ -262,6 +263,7 @@
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
 		FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
+		B2B2B2B2B2B2B2B2B2B2B2B2 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
@@ -601,6 +603,7 @@
 				93CDC9895F48619E97461875 /* CodePane.swift */,
 				FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */,
 				0240C5961343C3042D865570 /* GeneralPane.swift */,
+				B2B2B2B2B2B2B2B2B2B2B2B2 /* MonospaceFontCatalog.swift */,
 				F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */,
 				515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */,
 				EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */,
@@ -1072,6 +1075,7 @@
 				4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */,
 				D59E731EE52408DDF87BABDA /* FilesSectionView.swift in Sources */,
 				92969E6FE10C4FE9B6D6DA05 /* FontFamilyPicker.swift in Sources */,
+				A1A1A1A1A1A1A1A1A1A1A1A1 /* MonospaceFontCatalog.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */; };
 		3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2498E56CBAF84CB67166C /* HarnessKind.swift */; };
 		3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B450918CC98255AD9170586 /* AppearancePane.swift */; };
+		92969E6FE10C4FE9B6D6DA05 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */; };
 		3B34A2725C1F6B6E29C312F1 /* SearchInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */; };
 		3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */; };
 		3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */; };
@@ -260,6 +261,7 @@
 		4501413979E60464DCE5602C /* claude-code.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "claude-code.sh"; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
+		FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
@@ -597,6 +599,7 @@
 				4B450918CC98255AD9170586 /* AppearancePane.swift */,
 				A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */,
 				93CDC9895F48619E97461875 /* CodePane.swift */,
+				FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */,
 				0240C5961343C3042D865570 /* GeneralPane.swift */,
 				F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */,
 				515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */,
@@ -1068,6 +1071,7 @@
 				DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */,
 				4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */,
 				D59E731EE52408DDF87BABDA /* FilesSectionView.swift in Sources */,
+				92969E6FE10C4FE9B6D6DA05 /* FontFamilyPicker.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -68,6 +68,21 @@ struct AlasApp: App {
                 }
                 .keyboardShortcut("w", modifiers: .command)
             }
+            CommandGroup(after: .toolbar) {
+                Divider()
+                Button("Increase Font Size") {
+                    NSApp.sendAction(#selector(FontSizeResponder.increaseFontSize(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("=", modifiers: .command)
+                Button("Decrease Font Size") {
+                    NSApp.sendAction(#selector(FontSizeResponder.decreaseFontSize(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("-", modifiers: .command)
+                Button("Reset Font Size") {
+                    NSApp.sendAction(#selector(FontSizeResponder.resetFontSize(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("0", modifiers: .command)
+            }
         }
 
         Window("Settings", id: "settings") {

--- a/Alas/Sources/App/FontSizeCommands.swift
+++ b/Alas/Sources/App/FontSizeCommands.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import AppKit
+
+/// Selectors that font-size responders implement. `CodeTextView` conforms in
+/// a later task. Menu commands route to whichever firstResponder responds to
+/// the selector. The terminal does NOT participate — Ghostty handles
+/// Cmd-+/-/0 natively inside the surface.
+@objc protocol FontSizeResponder: AnyObject {
+    func increaseFontSize(_ sender: Any?)
+    func decreaseFontSize(_ sender: Any?)
+    func resetFontSize(_ sender: Any?)
+}

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -27,7 +27,9 @@ struct EditorTabView: View {
                 tabId: tabId,
                 revealLine: revealLine,
                 revealCharacter: revealCharacter,
-                appState: appState
+                appState: appState,
+                fontFamily: appState.config.code.fontFamily,
+                fontSize: appState.config.code.fontSize
             )
         }
         .background(theme.color("bg-1"))

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -63,6 +63,9 @@ final class CodeEditorCoordinator {
         self.currentFontFamily = family
         self.currentFontSize = size
         textView.font = Self.resolveFont(family: family, size: size)
+        textView.increaseFontSizeHandler = { [weak self] in self?.adjustFontSize(by: 1) }
+        textView.decreaseFontSizeHandler = { [weak self] in self?.adjustFontSize(by: -1) }
+        textView.resetFontSizeHandler = { [weak self] in self?.resetFontSize() }
 
         applyBaseStyle(theme: theme)
         let ext = (buffer.relativePath as NSString).pathExtension
@@ -185,6 +188,9 @@ final class CodeEditorCoordinator {
         layoutManager = nil
         hover = nil
         definition = nil
+        textView?.increaseFontSizeHandler = nil
+        textView?.decreaseFontSizeHandler = nil
+        textView?.resetFontSizeHandler = nil
         textView = nil
         buffer = nil
         // We deliberately do NOT close the LSP document or stop the file
@@ -318,6 +324,25 @@ final class CodeEditorCoordinator {
                     self.diagnosticsFeature.apply(batch.diagnostics, to: buffer.storage, theme: theme)
                 }
             }
+        }
+    }
+
+    // MARK: - Font size adjustments
+
+    private func adjustFontSize(by delta: Int) {
+        let current = appState.config.code.fontSize
+        let next = max(8, min(64, current + delta))
+        if next != current {
+            appState.config.code.fontSize = next
+            appState.saveConfig()
+        }
+    }
+
+    private func resetFontSize() {
+        let target = AppConfig.defaults.code.fontSize
+        if appState.config.code.fontSize != target {
+            appState.config.code.fontSize = target
+            appState.saveConfig()
         }
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -20,6 +20,8 @@ final class CodeEditorCoordinator {
     private var currentRelativePath: String?
     private var currentLanguage: String?
     private var currentTheme: Theme?
+    private var currentFontFamily: String?
+    private var currentFontSize: CGFloat?
     private var lastAppliedReveal: (tabId: TabID, line: Int, character: Int)?
 
     private var diagnosticsTask: Task<Void, Never>?
@@ -35,6 +37,13 @@ final class CodeEditorCoordinator {
     private var pendingTextEdits: [EditorTextEdit] = []
     private let highlightSession = TreeSitterHighlighter.Session()
 
+    static func resolveFont(family: String, size: CGFloat) -> NSFont {
+        if !family.isEmpty, let font = NSFont(name: family, size: size) {
+            return font
+        }
+        return .monospacedSystemFont(ofSize: size, weight: .regular)
+    }
+
     init(appState: AppState) {
         self.appState = appState
     }
@@ -48,6 +57,12 @@ final class CodeEditorCoordinator {
         self.currentRoot = buffer.worktreeRoot
         self.currentRelativePath = buffer.relativePath
         self.currentTheme = theme
+
+        let family = appState.config.code.fontFamily
+        let size = CGFloat(appState.config.code.fontSize)
+        self.currentFontFamily = family
+        self.currentFontSize = size
+        textView.font = Self.resolveFont(family: family, size: size)
 
         applyBaseStyle(theme: theme)
         let ext = (buffer.relativePath as NSString).pathExtension
@@ -131,6 +146,20 @@ final class CodeEditorCoordinator {
             runHighlight(theme: theme)
             currentTheme = theme
         }
+
+        let family = appState.config.code.fontFamily
+        let size = CGFloat(appState.config.code.fontSize)
+        let fontChanged = currentFontFamily != family || currentFontSize != size
+        if fontChanged {
+            currentFontFamily = family
+            currentFontSize = size
+            if let textView {
+                textView.font = Self.resolveFont(family: family, size: size)
+            }
+            applyBaseStyle(theme: theme)
+            runHighlight(theme: theme)
+        }
+
         applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -38,9 +38,32 @@ final class CodeEditorCoordinator {
     private let highlightSession = TreeSitterHighlighter.Session()
 
     static func resolveFont(family: String, size: CGFloat) -> NSFont {
-        if !family.isEmpty, let font = NSFont(name: family, size: size) {
-            return font
+        guard !family.isEmpty else {
+            return .monospacedSystemFont(ofSize: size, weight: .regular)
         }
+        // The picker stores family names (e.g. "JetBrains Mono"), but
+        // NSFont(name:size:) requires the PostScript name of a specific
+        // face ("JetBrainsMono-Regular"). Walk the family's members and
+        // pick the face closest to regular weight (NSFontManager weight 5)
+        // so multi-face families resolve to a real face instead of nil.
+        let members = NSFontManager.shared.availableMembers(ofFontFamily: family) ?? []
+        if !members.isEmpty {
+            let sorted = members.sorted { lhs, rhs in
+                let lw = (lhs.count > 2 ? lhs[2] as? Int : nil) ?? 5
+                let rw = (rhs.count > 2 ? rhs[2] as? Int : nil) ?? 5
+                return abs(lw - 5) < abs(rw - 5)
+            }
+            if let psName = sorted.first?.first as? String,
+               let font = NSFont(name: psName, size: size) {
+                return font
+            }
+        }
+        // Last-resort fallbacks: try the user's string verbatim (covers the
+        // case where they typed a PostScript name themselves), then a font
+        // descriptor by family, then the system default.
+        if let font = NSFont(name: family, size: size) { return font }
+        let descriptor = NSFontDescriptor(fontAttributes: [.family: family])
+        if let font = NSFont(descriptor: descriptor, size: size) { return font }
         return .monospacedSystemFont(ofSize: size, weight: .regular)
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -15,6 +15,13 @@ struct CodeEditorView: NSViewRepresentable {
     let revealLine: Int?
     let revealCharacter: Int?
     let appState: AppState
+    /// Pulled from `appState.config.code.fontFamily` by the parent view's
+    /// body so SwiftUI registers the dependency. NSViewRepresentable hooks
+    /// (makeNSView/updateNSView) are not part of body evaluation, so reads
+    /// inside them are not tracked — passing the values as inputs is what
+    /// causes `updateNSView` to fire when the user changes the font.
+    let fontFamily: String
+    let fontSize: Int
     @Environment(\.theme) var theme
 
     func makeCoordinator() -> CodeEditorCoordinator {
@@ -55,8 +62,8 @@ struct CodeEditorView: NSViewRepresentable {
         let initialFrame = NSRect(x: 0, y: 0, width: 800, height: 600)
         let textView = CodeTextView(frame: initialFrame, textContainer: textContainer)
         textView.font = CodeEditorCoordinator.resolveFont(
-            family: appState.config.code.fontFamily,
-            size: CGFloat(appState.config.code.fontSize)
+            family: fontFamily,
+            size: CGFloat(fontSize)
         )
         textView.backgroundColor = NSColor(theme.color("bg-1"))
         textView.drawsBackground = true
@@ -82,9 +89,6 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
-        // Touch fontFamily/fontSize so SwiftUI tracks reads and re-fires updateNSView when they change.
-        _ = appState.config.code.fontFamily
-        _ = appState.config.code.fontSize
         context.coordinator.updateIfNeeded(
             worktreeId: worktreeId,
             worktreeRoot: worktreeRoot,

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -54,7 +54,10 @@ struct CodeEditorView: NSViewRepresentable {
 
         let initialFrame = NSRect(x: 0, y: 0, width: 800, height: 600)
         let textView = CodeTextView(frame: initialFrame, textContainer: textContainer)
-        textView.font = NSFont.monospacedSystemFont(ofSize: 12.5, weight: .regular)
+        textView.font = CodeEditorCoordinator.resolveFont(
+            family: appState.config.code.fontFamily,
+            size: CGFloat(appState.config.code.fontSize)
+        )
         textView.backgroundColor = NSColor(theme.color("bg-1"))
         textView.drawsBackground = true
         textView.minSize = NSSize(width: 0, height: 0)
@@ -79,6 +82,9 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
+        // Touch fontFamily/fontSize so SwiftUI tracks reads and re-fires updateNSView when they change.
+        _ = appState.config.code.fontFamily
+        _ = appState.config.code.fontSize
         context.coordinator.updateIfNeeded(
             worktreeId: worktreeId,
             worktreeRoot: worktreeRoot,

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -5,9 +5,19 @@ import AppKit
 /// `EditorBuffer` outside this view. Editing is enabled but undo/redo,
 /// dirty tracking, save, file-watch, and LSP `didChange` are all
 /// orchestrated by the buffer + coordinator pair.
-final class CodeTextView: NSTextView {
+final class CodeTextView: NSTextView, FontSizeResponder {
     var hoverHandler: ((NSPoint) -> Void)?
     var commandClickHandler: ((NSPoint) -> Void)?
+
+    /// Set by `CodeEditorCoordinator.attach`. Each closure mutates the shared
+    /// `code.fontSize` config in response to the matching menu command.
+    var increaseFontSizeHandler: (() -> Void)?
+    var decreaseFontSizeHandler: (() -> Void)?
+    var resetFontSizeHandler: (() -> Void)?
+
+    @objc func increaseFontSize(_ sender: Any?) { increaseFontSizeHandler?() }
+    @objc func decreaseFontSize(_ sender: Any?) { decreaseFontSizeHandler?() }
+    @objc func resetFontSize(_ sender: Any?)    { resetFontSizeHandler?() }
 
     override init(frame frameRect: NSRect, textContainer container: NSTextContainer?) {
         super.init(frame: frameRect, textContainer: container)

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -55,7 +55,13 @@ struct AppConfig: Codable, Equatable {
     }
 
     struct Code: Codable, Equatable {
+        var fontFamily: String      // "" = system monospaced fallback
+        var fontSize: Int           // clamped [8, 64] on decode/write
         var languageServers: [LanguageServerConfig]
+
+        enum CodingKeys: String, CodingKey {
+            case fontFamily, fontSize, languageServers
+        }
     }
 
     static let defaults = AppConfig(
@@ -96,7 +102,11 @@ struct AppConfig: Codable, Equatable {
             bell: "visual"
         ),
         harness: Harness(notifyOnFinish: true),
-        code: Code(languageServers: [])
+        code: Code(
+            fontFamily: "SF Mono",
+            fontSize: 13,
+            languageServers: []
+        )
     )
 }
 
@@ -126,6 +136,14 @@ extension AppConfig {
         worktrees = try c.decode(Worktrees.self, forKey: .worktrees)
         terminal = try c.decode(Terminal.self, forKey: .terminal)
         harness = try c.decode(Harness.self, forKey: .harness)
-        code = (try c.decodeIfPresent(Code.self, forKey: .code)) ?? Code(languageServers: [])
+        if let codeContainer = try? c.nestedContainer(keyedBy: AppConfig.Code.CodingKeys.self, forKey: .code) {
+            let fontFamily = (try? codeContainer.decode(String.self, forKey: .fontFamily)) ?? "SF Mono"
+            let rawSize = (try? codeContainer.decode(Int.self, forKey: .fontSize)) ?? 13
+            let fontSize = max(8, min(64, rawSize))
+            let servers = (try? codeContainer.decode([LanguageServerConfig].self, forKey: .languageServers)) ?? []
+            code = Code(fontFamily: fontFamily, fontSize: fontSize, languageServers: servers)
+        } else {
+            code = Code(fontFamily: "SF Mono", fontSize: 13, languageServers: [])
+        }
     }
 }

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -15,6 +15,25 @@ struct CodePane: View {
                     .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
                     .padding(.bottom, 12)
 
+                SettingsGroup(title: "Appearance") {
+                    SettingsRow(name: "Font family") {
+                        FontFamilyPicker(
+                            family: state.bind(\.code.fontFamily),
+                            catalog: MonospaceFontCatalog.families()
+                        )
+                    }
+                    SettingsRow(name: "Font size") {
+                        AlasField(text: Binding(
+                            get: { String(state.config.code.fontSize) },
+                            set: {
+                                let raw = Int($0) ?? 13
+                                state.config.code.fontSize = max(8, min(64, raw))
+                                state.saveConfig()
+                            }
+                        ), monospaced: true).frame(width: 80)
+                    }
+                }
+
                 SettingsGroup(title: "Languages") {
                     ForEach(allEntries(), id: \.id) { entry in
                         SettingsRow(name: entry.language,

--- a/Alas/Sources/Settings/FontFamilyPicker.swift
+++ b/Alas/Sources/Settings/FontFamilyPicker.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import AppKit
+
+/// Popover-based picker that shows a monospace font list with per-row preview.
+/// The trigger renders the currently-selected family in that family.
+struct FontFamilyPicker: View {
+    @Binding var family: String
+    let catalog: [String]
+
+    @Environment(\.theme) var theme
+    @State private var open = false
+    @State private var search = ""
+
+    var body: some View {
+        Button(action: { open.toggle() }) {
+            HStack(spacing: 6) {
+                Text(triggerLabel)
+                    .font(triggerFont)
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 24)
+            .background(theme.color("bg-0"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $open, arrowEdge: .bottom) {
+            popoverBody
+        }
+    }
+
+    private var isInstalled: Bool { catalog.contains(family) }
+
+    private var triggerLabel: String {
+        isInstalled || family.isEmpty ? family : "\(family) (not installed)"
+    }
+
+    private var triggerFont: Font {
+        if isInstalled, !family.isEmpty {
+            return Font.custom(family, size: 12)
+        }
+        return .system(size: 12)
+    }
+
+    private var filteredCatalog: [String] {
+        if search.isEmpty { return catalog }
+        return catalog.filter { $0.localizedCaseInsensitiveContains(search) }
+    }
+
+    @ViewBuilder
+    private var popoverBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            AlasField(text: $search, placeholder: "Search fonts…")
+                .padding(8)
+
+            Divider().background(theme.color("line"))
+
+            if catalog.isEmpty {
+                Text("No monospace fonts found")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding(12)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        if !isInstalled, !family.isEmpty {
+                            row(name: family, missing: true)
+                            Divider().background(theme.color("line"))
+                        }
+                        ForEach(filteredCatalog, id: \.self) { name in
+                            row(name: name, missing: false)
+                        }
+                    }
+                }
+                .frame(maxHeight: 320)
+            }
+        }
+        .frame(width: 280)
+    }
+
+    @ViewBuilder
+    private func row(name: String, missing: Bool) -> some View {
+        Button(action: {
+            family = name
+            open = false
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                    .opacity(name == family ? 1 : 0)
+                Text(missing ? "\(name) (not installed)" : name)
+                    .font(missing ? .system(size: 13) : .custom(name, size: 14))
+                    .foregroundColor(missing ? theme.color("fg-dim") : theme.color("fg"))
+                    .lineLimit(1)
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(missing)
+    }
+}

--- a/Alas/Sources/Settings/MonospaceFontCatalog.swift
+++ b/Alas/Sources/Settings/MonospaceFontCatalog.swift
@@ -1,0 +1,28 @@
+import AppKit
+
+/// Returns installed monospace font family names. Cached after first call —
+/// the system font set doesn't change at runtime.
+enum MonospaceFontCatalog {
+    private static let cache: [String] = {
+        let fm = NSFontManager.shared
+        let fixedPSNames = Set(fm.availableFontNames(with: .fixedPitchFontMask) ?? [])
+        // availableFontFamilies returns family names; availableFontNames(with:)
+        // returns PostScript names. A family is considered monospace if any of
+        // its members is fixed-pitch.
+        let allFamilies = fm.availableFontFamilies
+        var monospace: [String] = []
+        for family in allFamilies {
+            let members = fm.availableMembers(ofFontFamily: family) ?? []
+            let hasFixed = members.contains { row in
+                guard let psName = row.first as? String else { return false }
+                return fixedPSNames.contains(psName)
+            }
+            if hasFixed {
+                monospace.append(family)
+            }
+        }
+        return monospace.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }()
+
+    static func families() -> [String] { cache }
+}

--- a/Alas/Sources/Settings/SettingsBinding.swift
+++ b/Alas/Sources/Settings/SettingsBinding.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+extension AppState {
+    /// Two-way binding into `AppConfig` that auto-saves on each write.
+    func bind<T>(_ kp: WritableKeyPath<AppConfig, T>) -> Binding<T> {
+        Binding(
+            get: { self.config[keyPath: kp] },
+            set: { self.config[keyPath: kp] = $0; self.saveConfig() }
+        )
+    }
+}

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -16,14 +16,14 @@ struct TerminalPane: View {
 
                 SettingsGroup(title: "Shell") {
                     SettingsRow(name: "Default shell", desc: "Path to the shell executable.") {
-                        AlasField(text: bind(\.terminal.shell), monospaced: true)
+                        AlasField(text: state.bind(\.terminal.shell), monospaced: true)
                     }
                     // "Last used" intentionally omitted: TerminalService
                     // doesn't track per-session cwd yet (resolveWorkingDirectory
                     // would silently fall through to the worktree root). It'll
                     // come back here once that tracking lands.
                     SettingsRow(name: "Working directory") {
-                        Seg(value: bind(\.terminal.workingDirectory), options: [
+                        Seg(value: state.bind(\.terminal.workingDirectory), options: [
                             ("worktreeRoot", "Worktree root"),
                             ("repoRoot", "Repo root"),
                         ])
@@ -33,7 +33,7 @@ struct TerminalPane: View {
                 SettingsGroup(title: "Startup scripts") {
                     SettingsRow(name: "Run on session open",
                                 desc: "Executed in every new terminal pane after the shell starts.") {
-                        TextEditor(text: bind(\.terminal.startupScript))
+                        TextEditor(text: state.bind(\.terminal.startupScript))
                             .font(.system(size: 12, design: .monospaced))
                             .foregroundColor(theme.color("fg"))
                             .scrollContentBackground(.hidden)
@@ -44,7 +44,7 @@ struct TerminalPane: View {
                     }
                     SettingsRow(name: "Run on worktree create",
                                 desc: "Executed once after a worktree is created.") {
-                        TextEditor(text: bind(\.terminal.worktreeCreateScript))
+                        TextEditor(text: state.bind(\.terminal.worktreeCreateScript))
                             .font(.system(size: 12, design: .monospaced))
                             .foregroundColor(theme.color("fg"))
                             .scrollContentBackground(.hidden)
@@ -55,13 +55,13 @@ struct TerminalPane: View {
                     }
                     SettingsRow(name: "Inherit parent env",
                                 desc: "Pass environment from launching shell into terminals.") {
-                        AlasToggle(on: bind(\.terminal.inheritParentEnv))
+                        AlasToggle(on: state.bind(\.terminal.inheritParentEnv))
                     }
                 }
 
                 SettingsGroup(title: "Appearance") {
                     SettingsRow(name: "Font family") {
-                        AlasField(text: bind(\.terminal.fontFamily), monospaced: true)
+                        AlasField(text: state.bind(\.terminal.fontFamily), monospaced: true)
                     }
                     SettingsRow(name: "Font size") {
                         AlasField(text: Binding(
@@ -70,12 +70,12 @@ struct TerminalPane: View {
                         ), monospaced: true).frame(width: 80)
                     }
                     SettingsRow(name: "Cursor style") {
-                        Seg(value: bind(\.terminal.cursorStyle), options: [
+                        Seg(value: state.bind(\.terminal.cursorStyle), options: [
                             ("block","block"), ("beam","beam"), ("underline","underline")
                         ])
                     }
                     SettingsRow(name: "Cursor blink") {
-                        AlasToggle(on: bind(\.terminal.cursorBlink))
+                        AlasToggle(on: state.bind(\.terminal.cursorBlink))
                     }
                     SettingsRow(name: "Scrollback lines") {
                         AlasField(text: Binding(
@@ -84,7 +84,7 @@ struct TerminalPane: View {
                         ), monospaced: true).frame(width: 100)
                     }
                     SettingsRow(name: "Bell") {
-                        Seg(value: bind(\.terminal.bell), options: [
+                        Seg(value: state.bind(\.terminal.bell), options: [
                             ("off","off"), ("visual","visual"), ("sound","sound")
                         ])
                     }
@@ -131,10 +131,4 @@ struct TerminalPane: View {
         }
     }
 
-    private func bind<T>(_ kp: WritableKeyPath<AppConfig, T>) -> Binding<T> {
-        Binding(
-            get: { state.config[keyPath: kp] },
-            set: { state.config[keyPath: kp] = $0; state.saveConfig() }
-        )
-    }
 }

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -61,12 +61,19 @@ struct TerminalPane: View {
 
                 SettingsGroup(title: "Appearance") {
                     SettingsRow(name: "Font family") {
-                        AlasField(text: state.bind(\.terminal.fontFamily), monospaced: true)
+                        FontFamilyPicker(
+                            family: state.bind(\.terminal.fontFamily),
+                            catalog: MonospaceFontCatalog.families()
+                        )
                     }
                     SettingsRow(name: "Font size") {
                         AlasField(text: Binding(
                             get: { String(state.config.terminal.fontSize) },
-                            set: { state.config.terminal.fontSize = Int($0) ?? 13; state.saveConfig() }
+                            set: {
+                                let raw = Int($0) ?? 13
+                                state.config.terminal.fontSize = max(8, min(64, raw))
+                                state.saveConfig()
+                            }
                         ), monospaced: true).frame(width: 80)
                     }
                     SettingsRow(name: "Cursor style") {

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -23,7 +23,7 @@ extension AlasGhostty {
 
     /// Terminal display view. Each session owns exactly one of these.
     @MainActor
-    final class SurfaceView: NSView {
+    final class SurfaceView: NSView, FontSizeResponder {
 
         // MARK: - Public callbacks
 
@@ -240,6 +240,26 @@ extension AlasGhostty {
             case GHOSTTY_MOUSE_SHAPE_N_RESIZE: NSCursor.resizeUp.set()
             case GHOSTTY_MOUSE_SHAPE_S_RESIZE: NSCursor.resizeDown.set()
             default: NSCursor.arrow.set()
+            }
+        }
+
+        // MARK: - Font size (FontSizeResponder)
+
+        // The app's menu shortcuts ⌘= / ⌘- / ⌘0 walk the responder chain via
+        // `NSApp.sendAction(...)`. Without these, the menu would intercept the
+        // keystroke before Ghostty's `performKeyEquivalent` could see it and
+        // terminal users would lose font zoom entirely. We forward each menu
+        // action straight to Ghostty's named binding action so behavior matches
+        // pressing the shortcut directly inside the surface.
+
+        @objc func increaseFontSize(_ sender: Any?) { runBindingAction("increase_font_size:1") }
+        @objc func decreaseFontSize(_ sender: Any?) { runBindingAction("decrease_font_size:1") }
+        @objc func resetFontSize(_ sender: Any?)    { runBindingAction("reset_font_size") }
+
+        private func runBindingAction(_ action: String) {
+            guard let surface = cSurface else { return }
+            action.withCString { ptr in
+                _ = ghostty_surface_binding_action(surface, ptr, UInt(action.utf8.count))
             }
         }
 


### PR DESCRIPTION
## Summary

- Adds a reusable monospace-only font picker (popover with search + per-row preview) used in both Settings → Terminal and a new Settings → Code → Appearance group.
- Adds \`code.fontFamily\` / \`code.fontSize\` config keys (defaults SF Mono / 13, clamped [8, 64], backward-compatible decode for older configs).
- Editor reads font from config and propagates live across all open editor tabs (mirrors the existing theme-change branch in \`CodeEditorCoordinator\`).
- Wires Cmd-= / Cmd-- / Cmd-0 to the editor's font size via a \`FontSizeResponder\` \`@objc\` protocol on \`CodeTextView\`, routed through the responder chain.
- Terminal Cmd-+/-/0 are handled natively by Ghostty (per-session, ephemeral) — see Known limitations.

## Known limitations (v1)

- Live terminal font updates are not propagated. Ghostty's C API has no per-surface \`set_font_size\` / \`set_font_family\`, and re-creating the \`AlasGhostty.App\` would orphan existing surfaces. Settings changes only affect new terminal sessions.
- Terminal Cmd-+/-/0 don't persist — Ghostty handles them in the surface and our config doesn't see the change. Persistence still works via the Settings field.

## Test plan

- [ ] Settings → Terminal → Appearance: picker shows monospace fonts only; selecting one persists; new terminal sessions pick up the change.
- [ ] Settings → Code → Appearance: new group is above Languages; picker + size field both work.
- [ ] Open a code file; change \`code.fontFamily\` or \`code.fontSize\` in Settings — open editor repaints live.
- [ ] Cmd-= / Cmd-- in a focused editor adjust font size (clamped 8–64); Cmd-0 resets to default 13. Quit + relaunch persists.
- [ ] Cmd-= / Cmd-- in a focused terminal change Ghostty's font (ephemeral, per-session). Settings field is unchanged.
- [ ] Edit \`config.json\` to point \`code.fontFamily\` at a missing font: editor falls back to system monospaced, picker shows the name with "(not installed)".
- [ ] Old config (no \`code.fontFamily\` / \`fontSize\`) loads cleanly with defaults.