### PR TITLE
Fix language server availability detection

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
 		3DC6518A9050D1029D4D99A4 /* aider.sh in Resources */ = {isa = PBXBuildFile; fileRef = 2AC91D744E42A7C071268B74 /* aider.sh */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
+		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
 		41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */; };
@@ -177,6 +178,7 @@
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
 		E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */; };
+		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EC1B515505AEC98FB199B02A /* HookInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 642163EB929E060A878211E2 /* HookInstaller.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
@@ -308,6 +310,7 @@
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
 		932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFeature.swift; sourceTree = "<group>"; };
 		93CDC9895F48619E97461875 /* CodePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePane.swift; sourceTree = "<group>"; };
+		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
 		954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallerTests.swift; sourceTree = "<group>"; };
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
@@ -317,6 +320,7 @@
 		A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimer.swift; sourceTree = "<group>"; };
 		A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailView.swift; sourceTree = "<group>"; };
 		A8820E4289EEB1ADCA9E490F /* HookEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookEventTests.swift; sourceTree = "<group>"; };
+		A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailabilityTests.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
@@ -686,6 +690,7 @@
 		98B31DB084754D0D15591339 /* LSP */ = {
 			isa = PBXGroup;
 			children = (
+				949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */,
 				09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */,
 				A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */,
 				F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */,
@@ -788,6 +793,7 @@
 		C9BE5D9821AF38B59009DD0B /* LSP */ = {
 			isa = PBXGroup;
 			children = (
+				A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */,
 				345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */,
 				E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */,
 				DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */,
@@ -1091,6 +1097,7 @@
 				70FCC2B12AE446728EE7CF8D /* LSPTransport.swift in Sources */,
 				91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */,
 				3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */,
+				EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */,
 				C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
@@ -1183,6 +1190,7 @@
 				524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */,
 				79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */,
 				C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */,
+				4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */,
 				9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */,
 				DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,

--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -9,12 +9,12 @@ struct LanguageServerAvailability {
 
     private let environment: [String: String]
     private let fileManager: FileManager
-    private let xcrunFind: (String) -> Bool
+    private let xcrunFind: (String) -> String?
 
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default,
-        xcrunFind: @escaping (String) -> Bool = LanguageServerAvailability.xcrunFind
+        xcrunFind: @escaping (String) -> String? = LanguageServerAvailability.xcrunFind
     ) {
         self.environment = environment
         self.fileManager = fileManager
@@ -23,26 +23,45 @@ struct LanguageServerAvailability {
 
     func status(for entry: LanguageServerConfig) -> Status {
         guard entry.enabled else { return .disabled }
-        guard !entry.command.isEmpty else { return .notInstalled }
-
-        if entry.command.contains("/") {
-            return fileManager.isExecutableFile(atPath: entry.command) ? .available : .notInstalled
-        }
-
-        if executableNamed(entry.command) != nil {
-            return .available
-        }
-
-        if entry.language == "swift", entry.command == "sourcekit-lsp", xcrunFind("sourcekit-lsp") {
-            return .available
-        }
-
-        return .notInstalled
+        return resolvedCommand(for: entry) != nil ? .available : .notInstalled
     }
 
-    private func executableNamed(_ name: String) -> String? {
-        let path = environment["PATH"] ?? "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-        for dir in path.split(separator: ":", omittingEmptySubsequences: true) {
+    func resolvedCommand(for entry: LanguageServerConfig) -> String? {
+        guard entry.enabled, !entry.command.isEmpty else { return nil }
+
+        if entry.command.contains("/") {
+            return fileManager.isExecutableFile(atPath: entry.command) ? entry.command : nil
+        }
+
+        if let pathHit = executableNamed(entry.command, env: entry.env) {
+            return pathHit
+        }
+
+        if entry.language == "swift", entry.command == "sourcekit-lsp",
+           let xcrunPath = xcrunFind("sourcekit-lsp") {
+            return xcrunPath
+        }
+
+        return nil
+    }
+
+    func spawnArguments(for entry: LanguageServerConfig) -> (executable: String, arguments: [String])? {
+        guard let resolved = resolvedCommand(for: entry) else { return nil }
+        if resolved.contains("/") {
+            return (executable: resolved, arguments: entry.args)
+        }
+        return (executable: "/usr/bin/env", arguments: [resolved] + entry.args)
+    }
+
+    private func executableNamed(_ name: String, env: [String: String] = [:]) -> String? {
+        let mergedPath: String
+        if let envPath = env["PATH"], !envPath.isEmpty {
+            let basePath = environment["PATH"] ?? "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+            mergedPath = envPath + ":" + basePath
+        } else {
+            mergedPath = environment["PATH"] ?? "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        }
+        for dir in mergedPath.split(separator: ":", omittingEmptySubsequences: true) {
             let candidate = URL(fileURLWithPath: String(dir)).appendingPathComponent(name).path
             if fileManager.isExecutableFile(atPath: candidate) {
                 return candidate
@@ -51,19 +70,23 @@ struct LanguageServerAvailability {
         return nil
     }
 
-    private static func xcrunFind(_ tool: String) -> Bool {
+    private static func xcrunFind(_ tool: String) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
         process.arguments = ["--find", tool]
-        process.standardOutput = Pipe()
+        let pipe = Pipe()
+        process.standardOutput = pipe
         process.standardError = Pipe()
 
         do {
             try process.run()
             process.waitUntilExit()
-            return process.terminationStatus == 0
+            guard process.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+            return output.isEmpty ? nil : output
         } catch {
-            return false
+            return nil
         }
     }
 }

--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+struct LanguageServerAvailability {
+    enum Status: Equatable {
+        case disabled
+        case available
+        case notInstalled
+    }
+
+    private let environment: [String: String]
+    private let fileManager: FileManager
+    private let xcrunFind: (String) -> Bool
+
+    init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        xcrunFind: @escaping (String) -> Bool = LanguageServerAvailability.xcrunFind
+    ) {
+        self.environment = environment
+        self.fileManager = fileManager
+        self.xcrunFind = xcrunFind
+    }
+
+    func status(for entry: LanguageServerConfig) -> Status {
+        guard entry.enabled else { return .disabled }
+        guard !entry.command.isEmpty else { return .notInstalled }
+
+        if entry.command.contains("/") {
+            return fileManager.isExecutableFile(atPath: entry.command) ? .available : .notInstalled
+        }
+
+        if executableNamed(entry.command) != nil {
+            return .available
+        }
+
+        if entry.language == "swift", entry.command == "sourcekit-lsp", xcrunFind("sourcekit-lsp") {
+            return .available
+        }
+
+        return .notInstalled
+    }
+
+    private func executableNamed(_ name: String) -> String? {
+        let path = environment["PATH"] ?? "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        for dir in path.split(separator: ":", omittingEmptySubsequences: true) {
+            let candidate = URL(fileURLWithPath: String(dir)).appendingPathComponent(name).path
+            if fileManager.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private static func xcrunFind(_ tool: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = ["--find", tool]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+}

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -90,7 +90,7 @@ final class WorkspaceLSPManager {
             ready = existing.ready
             isFirstOpener = false
         } else {
-            let spawn = Self.resolveSpawn(command: entry.command, args: entry.args)
+            let spawn = Self.resolveSpawn(command: entry.command, args: entry.args, env: entry.env, language: entry.language)
             let transport = LSPTransport(executable: spawn.executable, arguments: spawn.arguments, environment: entry.env.isEmpty ? nil : entry.env)
             let newClient = LSPClient(transport: transport, language: languageId, rootURI: lspRoot.lspURI)
             let task = Task<Bool, Never> {
@@ -283,14 +283,23 @@ final class WorkspaceLSPManager {
         let arguments: [String]
     }
 
-    /// `Process.executableURL` does not search `PATH`. If `command` contains
-    /// no `/` (e.g. `rust-analyzer`, `sourcekit-lsp`), we wrap the call with
-    /// `/usr/bin/env` so the system path is searched at exec time —
-    /// otherwise users entering bare command names in Settings → Code would
-    /// silently fail unless their cwd happened to contain the binary.
-    private static func resolveSpawn(command: String, args: [String]) -> Spawn {
+    /// Resolves the spawn command for `entry`. Bare commands (no `/`) are
+    /// resolved against PATH and the Swift xcrun fallback so the badge and
+    /// launch paths stay consistent. When `xcrun --find sourcekit-lsp`
+    /// returns an absolute path, we use it directly instead of wrapping
+    /// with `/usr/bin/env` — that ensures `sourcekit-lsp` launches even
+    /// when it lives inside Xcode.app and isn't on PATH.
+    private static func resolveSpawn(command: String, args: [String], env: [String: String], language: String) -> Spawn {
         if command.contains("/") {
             return Spawn(executable: URL(fileURLWithPath: command), arguments: args)
+        }
+        let probe = LanguageServerConfig(
+            language: language, extensions: [], command: command, args: args,
+            env: env, rootMarkers: [], enabled: true
+        )
+        let availability = LanguageServerAvailability()
+        if let spawnArgs = availability.spawnArguments(for: probe) {
+            return Spawn(executable: URL(fileURLWithPath: spawnArgs.executable), arguments: spawnArgs.arguments)
         }
         return Spawn(executable: URL(fileURLWithPath: "/usr/bin/env"), arguments: [command] + args)
     }

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -52,10 +52,12 @@ struct CodePane: View {
         return registry.allEntries()
     }
 
+    private let availability = LanguageServerAvailability()
+
     private func statusBadge(for entry: LanguageServerConfig) -> some View {
         let label: String
         let color: Color
-        switch LanguageServerAvailability().status(for: entry) {
+        switch availability.status(for: entry) {
         case .disabled:
             label = "Disabled"; color = theme.color("fg-faint")
         case .available:

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -52,18 +52,15 @@ struct CodePane: View {
         return registry.allEntries()
     }
 
-    // NOTE: `isExecutableFile` returns false for bare names like "sourcekit-lsp"
-    // that rely on PATH lookup, so PATH-resolved entries currently render as
-    // "Not installed" even when they work. v1: acceptable; revisit by spawning
-    // `which` or searching PATH ourselves.
     private func statusBadge(for entry: LanguageServerConfig) -> some View {
         let label: String
         let color: Color
-        if !entry.enabled {
+        switch LanguageServerAvailability().status(for: entry) {
+        case .disabled:
             label = "Disabled"; color = theme.color("fg-faint")
-        } else if FileManager.default.isExecutableFile(atPath: entry.command) {
+        case .available:
             label = "Available"; color = theme.color("add")
-        } else {
+        case .notInstalled:
             label = "Not installed"; color = theme.color("warn")
         }
         return Text(label).font(.system(size: 10.5)).foregroundColor(color)

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -7,7 +7,7 @@ struct LanguageServerAvailabilityTests {
     @Test("disabled entries report disabled")
     func disabled() {
         let entry = config(language: "swift", command: "sourcekit-lsp", enabled: false)
-        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in true })
+        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil })
         #expect(availability.status(for: entry) == .disabled)
     }
 
@@ -21,7 +21,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: executable.path)
-        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in false })
+        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil })
         #expect(availability.status(for: entry) == .available)
     }
 
@@ -35,7 +35,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: "test-lsp")
-        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in false })
+        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil })
         #expect(availability.status(for: entry) == .available)
     }
 
@@ -45,7 +45,7 @@ struct LanguageServerAvailabilityTests {
         let entry = config(language: "swift", command: "sourcekit-lsp")
         let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { tool in
             requestedTool = tool
-            return true
+            return "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
         })
 
         #expect(availability.status(for: entry) == .available)
@@ -58,20 +58,73 @@ struct LanguageServerAvailabilityTests {
         let entry = config(language: "rust", command: "rust-analyzer")
         let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in
             didCallXcrun = true
-            return true
+            return "/usr/local/bin/rust-analyzer"
         })
 
         #expect(availability.status(for: entry) == .notInstalled)
         #expect(didCallXcrun == false)
     }
 
-    private func config(language: String = "test", command: String, enabled: Bool = true) -> LanguageServerConfig {
+    @Test("resolvedCommand returns xcrun path for Swift")
+    func resolvedCommandXcrun() {
+        let entry = config(language: "swift", command: "sourcekit-lsp")
+        let xcrunPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath })
+
+        #expect(availability.resolvedCommand(for: entry) == xcrunPath)
+    }
+
+    @Test("spawnArguments uses absolute path from xcrun")
+    func spawnArgumentsXcrun() {
+        let entry = config(language: "swift", command: "sourcekit-lsp", args: ["--flag"])
+        let xcrunPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath })
+        let spawn = availability.spawnArguments(for: entry)
+
+        #expect(spawn != nil)
+        #expect(spawn!.executable == xcrunPath)
+        #expect(spawn!.arguments == ["--flag"])
+    }
+
+    @Test("spawnArguments wraps bare PATH command with env")
+    func spawnArgumentsPathCommand() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("test-lsp")
+        let created = FileManager.default.createFile(atPath: executable.path, contents: Data())
+        #expect(created)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let entry = config(command: "test-lsp", args: ["--verbose"])
+        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil })
+        let spawn = availability.spawnArguments(for: entry)
+
+        #expect(spawn != nil)
+        #expect(spawn!.executable == "/usr/bin/env")
+        #expect(spawn!.arguments == ["test-lsp", "--verbose"])
+    }
+
+    @Test("entry.env PATH is merged for resolution")
+    func envPathResolution() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("custom-lsp")
+        let created = FileManager.default.createFile(atPath: executable.path, contents: Data())
+        #expect(created)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let entry = config(command: "custom-lsp", env: ["PATH": dir.path])
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil })
+        #expect(availability.status(for: entry) == .available)
+    }
+
+    private func config(language: String = "test", command: String, args: [String] = [], env: [String: String] = [:], enabled: Bool = true) -> LanguageServerConfig {
         LanguageServerConfig(
             language: language,
             extensions: [language],
             command: command,
-            args: [],
-            env: [:],
+            args: args,
+            env: env,
             rootMarkers: [],
             enabled: enabled
         )

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -86,7 +86,7 @@ struct LanguageServerAvailabilityTests {
         #expect(spawn!.arguments == ["--flag"])
     }
 
-    @Test("spawnArguments wraps bare PATH command with env")
+    @Test("spawnArguments uses resolved absolute path from PATH")
     func spawnArgumentsPathCommand() throws {
         let dir = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -100,8 +100,17 @@ struct LanguageServerAvailabilityTests {
         let spawn = availability.spawnArguments(for: entry)
 
         #expect(spawn != nil)
-        #expect(spawn!.executable == "/usr/bin/env")
-        #expect(spawn!.arguments == ["test-lsp", "--verbose"])
+        #expect(spawn!.executable == executable.path)
+        #expect(spawn!.arguments == ["--verbose"])
+    }
+
+    @Test("spawnArguments wraps unresolvable bare command with env")
+    func spawnArgumentsEnvFallback() {
+        let entry = config(command: "missing-lsp", args: ["--flag"])
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil })
+        let spawn = availability.spawnArguments(for: entry)
+
+        #expect(spawn == nil)
     }
 
     @Test("entry.env PATH is merged for resolution")

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("LanguageServerAvailability")
+struct LanguageServerAvailabilityTests {
+    @Test("disabled entries report disabled")
+    func disabled() {
+        let entry = config(language: "swift", command: "sourcekit-lsp", enabled: false)
+        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in true })
+        #expect(availability.status(for: entry) == .disabled)
+    }
+
+    @Test("absolute executable path reports available")
+    func absoluteExecutable() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("server")
+        let created = FileManager.default.createFile(atPath: executable.path, contents: Data())
+        #expect(created)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let entry = config(command: executable.path)
+        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in false })
+        #expect(availability.status(for: entry) == .available)
+    }
+
+    @Test("bare command resolves against PATH")
+    func pathExecutable() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("test-lsp")
+        let created = FileManager.default.createFile(atPath: executable.path, contents: Data())
+        #expect(created)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let entry = config(command: "test-lsp")
+        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in false })
+        #expect(availability.status(for: entry) == .available)
+    }
+
+    @Test("Swift sourcekit-lsp falls back to xcrun")
+    func swiftXcrunFallback() {
+        var requestedTool: String?
+        let entry = config(language: "swift", command: "sourcekit-lsp")
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { tool in
+            requestedTool = tool
+            return true
+        })
+
+        #expect(availability.status(for: entry) == .available)
+        #expect(requestedTool == "sourcekit-lsp")
+    }
+
+    @Test("xcrun fallback is Swift sourcekit-lsp only")
+    func xcrunFallbackIsSwiftOnly() {
+        var didCallXcrun = false
+        let entry = config(language: "rust", command: "rust-analyzer")
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in
+            didCallXcrun = true
+            return true
+        })
+
+        #expect(availability.status(for: entry) == .notInstalled)
+        #expect(didCallXcrun == false)
+    }
+
+    private func config(language: String = "test", command: String, enabled: Bool = true) -> LanguageServerConfig {
+        LanguageServerConfig(
+            language: language,
+            extensions: [language],
+            command: command,
+            args: [],
+            env: [:],
+            rootMarkers: [],
+            enabled: enabled
+        )
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AlasTests")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes Swift language server showing as "Not installed" in Settings when `sourcekit-lsp` is available via `xcrun` but not on the bare PATH
- Adds `LanguageServerAvailability` resolver with DI for testability, handling: disabled entries, absolute executable paths, bare commands via PATH traversal, and Swift `sourcekit-lsp` via `xcrun --find` fallback
- Replaces inline `isExecutableFile` check in `CodePane.swift` with a `switch` on the resolver's `Status` enum
- Adds 5 Swift Testing cases covering all resolution paths

## Test plan

- [ ] Verify Swift shows "Available" in Settings when sourcekit-lsp is installed via Xcode toolchain
- [ ] Verify other languages still show correct availability status
- [ ] Verify disabled entries show as disabled