### PR TITLE
Move new-worktree action inline per repo

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
+		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
 		2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768D12909DD5233659AC4E03 /* RepoGroupView.swift */; };
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
@@ -42,9 +43,6 @@
 		3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */; };
 		3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2498E56CBAF84CB67166C /* HarnessKind.swift */; };
 		3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B450918CC98255AD9170586 /* AppearancePane.swift */; };
-		92969E6FE10C4FE9B6D6DA05 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */; };
-		A1A1A1A1A1A1A1A1A1A1A1A1 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B2B2B2B2B2B2B2B2B2B2B2 /* MonospaceFontCatalog.swift */; };
-		C3C3C3C3C3C3C3C3C3C3C3C3 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D4D4D4D4D4D4D4D4D4D4D4 /* SettingsBinding.swift */; };
 		3B34A2725C1F6B6E29C312F1 /* SearchInputRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */; };
 		3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */; };
 		3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */; };
@@ -106,6 +104,7 @@
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
+		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		8622E85C972946E5411CAC48 /* ChangesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E947E110B003FB519DAD1B3 /* ChangesSectionView.swift */; };
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
@@ -115,6 +114,7 @@
 		90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */; };
 		90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */; };
 		91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C69060B922A729DD807920 /* LSPURI.swift */; };
+		93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D759586280250330A9A04 /* FontSizeCommands.swift */; };
 		9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */; };
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
@@ -127,7 +127,6 @@
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
 		A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */; };
 		A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */; };
-		E5E5E5E5E5E5E5E5E5E5E5E5 /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F6F6F6F6F6F6F6F6F6F6F6 /* FontSizeCommands.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
 		A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */; };
@@ -135,6 +134,7 @@
 		A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
+		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
 		AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */; };
 		AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF8152B18C9D6290724122F /* HoverFeature.swift */; };
 		AD3469F4745DF96ED3D0E06E /* codex-cli.sh in Resources */ = {isa = PBXBuildFile; fileRef = F1524DAA94E33D2938853810 /* codex-cli.sh */; };
@@ -214,10 +214,12 @@
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
 		0AF8152B18C9D6290724122F /* HoverFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeature.swift; sourceTree = "<group>"; };
+		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
 		0F68A9692F85197ED9E16262 /* WorktreesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreesPane.swift; sourceTree = "<group>"; };
 		1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
+		12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
 		1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandleTests.swift; sourceTree = "<group>"; };
 		14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabView.swift; sourceTree = "<group>"; };
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
@@ -266,9 +268,6 @@
 		4501413979E60464DCE5602C /* claude-code.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "claude-code.sh"; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
-		FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
-		B2B2B2B2B2B2B2B2B2B2B2B2 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
-		D4D4D4D4D4D4D4D4D4D4D4D4 /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
@@ -287,6 +286,7 @@
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
+		6A190D4B29B35C457AA9829F /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
 		6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModelTests.swift; sourceTree = "<group>"; };
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -305,7 +305,6 @@
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
 		7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApp.swift; sourceTree = "<group>"; };
-		F6F6F6F6F6F6F6F6F6F6F6F6 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
 		7FFC9539E615699AC90A7412 /* ProjectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManager.swift; sourceTree = "<group>"; };
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
@@ -335,6 +334,7 @@
 		B1AA2B3E548B50097C9AF9D3 /* FilesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesSectionView.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
+		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
 		B4C486F9097A2B145D101E2C /* AlasButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasButton.swift; sourceTree = "<group>"; };
 		B65018D176CD2E52A3999CF0 /* AlasTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlasTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTests.swift; sourceTree = "<group>"; };
@@ -609,12 +609,12 @@
 				4B450918CC98255AD9170586 /* AppearancePane.swift */,
 				A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */,
 				93CDC9895F48619E97461875 /* CodePane.swift */,
-				FF0AE6F654DD418497089E35 /* FontFamilyPicker.swift */,
+				12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */,
 				0240C5961343C3042D865570 /* GeneralPane.swift */,
-				B2B2B2B2B2B2B2B2B2B2B2B2 /* MonospaceFontCatalog.swift */,
+				0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */,
+				6A190D4B29B35C457AA9829F /* SettingsBinding.swift */,
 				F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */,
 				515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */,
-				D4D4D4D4D4D4D4D4D4D4D4D4 /* SettingsBinding.swift */,
 				EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */,
 				FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */,
 				FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */,
@@ -891,8 +891,8 @@
 			isa = PBXGroup;
 			children = (
 				7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */,
-				F6F6F6F6F6F6F6F6F6F6F6F6 /* FontSizeCommands.swift */,
 				17C2AC0F8B3A1B75239995AC /* AppState.swift */,
+				B44D759586280250330A9A04 /* FontSizeCommands.swift */,
 				7FFC9539E615699AC90A7412 /* ProjectsManager.swift */,
 				69024633944E9FFF6DA76FAE /* RootView.swift */,
 				F211897D927000B71316F28A /* WindowChrome */,
@@ -1045,7 +1045,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */,
-				E5E5E5E5E5E5E5E5E5E5E5E5 /* FontSizeCommands.swift in Sources */,
 				5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */,
 				24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */,
 				9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */,
@@ -1087,9 +1086,8 @@
 				DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */,
 				4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */,
 				D59E731EE52408DDF87BABDA /* FilesSectionView.swift in Sources */,
-				92969E6FE10C4FE9B6D6DA05 /* FontFamilyPicker.swift in Sources */,
-				A1A1A1A1A1A1A1A1A1A1A1A1 /* MonospaceFontCatalog.swift in Sources */,
-				C3C3C3C3C3C3C3C3C3C3C3C3 /* SettingsBinding.swift in Sources */,
+				AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */,
+				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,
@@ -1116,6 +1114,7 @@
 				EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */,
 				C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
+				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */,
 				F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */,
@@ -1144,6 +1143,7 @@
 				3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */,
 				D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */,
 				9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */,
+				2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */,
 				3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */,
 				730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */,
 				8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -5,6 +5,7 @@ struct RootView: View {
     @Bindable var state: AppState
     @State private var showNewProject = false
     @State private var showNewWorktree = false
+    @State private var newWorktreePresetProjectId: String?
     @State private var collapsedProjects: Set<String> = []
     @Environment(\.openWindow) private var openWindow
 
@@ -34,7 +35,11 @@ struct RootView: View {
                                 state: state,
                                 collapsedProjects: $collapsedProjects,
                                 onSettings: { openSettingsWindow() },
-                                onNewWorktree: { showNewWorktree = true }
+                                onAddProject: { showNewProject = true },
+                                onNewWorktree: { projectId in
+                                    newWorktreePresetProjectId = projectId
+                                    showNewWorktree = true
+                                }
                             )
                         },
                         center: {
@@ -81,8 +86,12 @@ struct RootView: View {
         .sheet(isPresented: $showNewProject) {
             NewProjectDialog(state: state, presented: $showNewProject)
         }
-        .sheet(isPresented: $showNewWorktree) {
-            NewWorktreeDialog(state: state, presented: $showNewWorktree)
+        .sheet(isPresented: $showNewWorktree, onDismiss: { newWorktreePresetProjectId = nil }) {
+            NewWorktreeDialog(
+                state: state,
+                presented: $showNewWorktree,
+                presetProjectId: newWorktreePresetProjectId
+            )
         }
         .task {
             state.startHarness()

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct NewWorktreeDialog: View {
     @Bindable var state: AppState
     @Binding var presented: Bool
+    var presetProjectId: String? = nil
 
     @State private var projectId: String = ""
     // Defaults are seeded from the persisted Worktrees settings in .onAppear
@@ -69,7 +70,11 @@ struct NewWorktreeDialog: View {
         )
         .onAppear {
             if projectId.isEmpty {
-                projectId = state.projects.first?.id ?? ""
+                if let preset = presetProjectId, state.projects.contains(where: { $0.id == preset }) {
+                    projectId = preset
+                } else {
+                    projectId = state.projects.first?.id ?? ""
+                }
             }
             if base.isEmpty {
                 base = state.config.worktrees.baseBranch

--- a/Alas/Sources/Icons/Icon.swift
+++ b/Alas/Sources/Icons/Icon.swift
@@ -25,6 +25,7 @@ struct Icon: View {
         case "chev-down":  return "chevron.down"
         case "chev-right": return "chevron.right"
         case "folder":     return "folder"
+        case "folder-plus": return "folder.badge.plus"
         case "file":       return "doc"
         case "menu":       return "ellipsis"
         case "split":      return "rectangle.split.2x1"

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -6,7 +6,10 @@ struct RepoGroupView: View {
     @Binding var collapsed: Bool
     let selectedWorktreeId: String?
     let onSelect: (Worktree) -> Void
+    let onNewWorktree: () -> Void
     @Environment(\.theme) var theme
+    @State private var hovering = false
+    @State private var plusHovering = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -18,15 +21,33 @@ struct RepoGroupView: View {
                         .font(.system(size: 11.5, weight: .semibold))
                         .foregroundColor(theme.color("fg-muted"))
                     Spacer()
-                    Text("\(worktrees.count)")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(theme.color("fg-faint"))
+                    ZStack {
+                        Text("\(worktrees.count)")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(theme.color("fg-faint"))
+                            .monospacedDigit()
+                            .opacity(hovering ? 0 : 1)
+                        Button(action: { onNewWorktree() }) {
+                            Icon(name: "plus", size: 11,
+                                 color: plusHovering ? theme.color("fg") : theme.color("fg-faint"))
+                                .frame(width: 18, height: 18)
+                                .background(plusHovering ? theme.color("bg-4") : .clear)
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                        .buttonStyle(.plain)
+                        .onHover { plusHovering = $0 }
+                        .help("New worktree in \(project.name)")
+                        .opacity(hovering ? 1 : 0)
+                        .allowsHitTesting(hovering)
+                    }
+                    .frame(width: 18, height: 18)
                 }
                 .padding(.horizontal, 12).padding(.vertical, 5)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .onHover { hovering = $0 }
             if !collapsed {
                 VStack(spacing: 1) {
                     ForEach(worktrees) { wt in

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -13,40 +13,46 @@ struct RepoGroupView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Button { collapsed.toggle() } label: {
-                HStack(spacing: 7) {
-                    Icon(name: collapsed ? "chev-right" : "chev-down", size: 10, color: theme.color("fg-faint"))
-                    RepoDot(color: project.color, letter: letter)
-                    Text(project.name)
-                        .font(.system(size: 11.5, weight: .semibold))
-                        .foregroundColor(theme.color("fg-muted"))
-                    Spacer()
-                    ZStack {
-                        Text("\(worktrees.count)")
-                            .font(.system(size: 10, weight: .medium))
-                            .foregroundColor(theme.color("fg-faint"))
-                            .monospacedDigit()
-                            .opacity(hovering ? 0 : 1)
-                        Button(action: { onNewWorktree() }) {
-                            Icon(name: "plus", size: 11,
-                                 color: plusHovering ? theme.color("fg") : theme.color("fg-faint"))
-                                .frame(width: 18, height: 18)
-                                .background(plusHovering ? theme.color("bg-4") : .clear)
-                                .clipShape(RoundedRectangle(cornerRadius: 4))
-                        }
-                        .buttonStyle(.plain)
-                        .onHover { plusHovering = $0 }
-                        .help("New worktree in \(project.name)")
-                        .opacity(hovering ? 1 : 0)
-                        .allowsHitTesting(hovering)
-                    }
-                    .frame(width: 18, height: 18)
-                }
-                .padding(.horizontal, 12).padding(.vertical, 5)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+            // Collapse toggle and the inline + are independent controls in the
+            // same row. Don't wrap the row in a parent Button — that nests the
+            // + inside another button's hit region and clicking the + can also
+            // fire the collapse action.
+            HStack(spacing: 7) {
+                Icon(name: collapsed ? "chev-right" : "chev-down", size: 10, color: theme.color("fg-faint"))
+                RepoDot(color: project.color, letter: letter)
+                Text(project.name)
+                    .font(.system(size: 11.5, weight: .semibold))
+                    .foregroundColor(theme.color("fg-muted"))
+                Spacer(minLength: 0)
             }
-            .buttonStyle(.plain)
+            .padding(.leading, 12)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
+            .onTapGesture { collapsed.toggle() }
+            .overlay(alignment: .trailing) {
+                ZStack {
+                    Text("\(worktrees.count)")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(theme.color("fg-faint"))
+                        .monospacedDigit()
+                        .opacity(hovering ? 0 : 1)
+                        .allowsHitTesting(false)
+                    Button(action: onNewWorktree) {
+                        Icon(name: "plus", size: 11,
+                             color: plusHovering ? theme.color("fg") : theme.color("fg-faint"))
+                            .frame(width: 18, height: 18)
+                            .background(plusHovering ? theme.color("bg-4") : .clear)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { plusHovering = $0 }
+                    .help("New worktree in \(project.name)")
+                    .opacity(hovering ? 1 : 0)
+                    .allowsHitTesting(hovering)
+                }
+                .frame(width: 18, height: 18)
+                .padding(.trailing, 12)
+            }
             .onHover { hovering = $0 }
             if !collapsed {
                 VStack(spacing: 1) {

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct SidebarHeaderView: View {
     let onSettings: () -> Void
-    let onNewWorktree: () -> Void
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -22,7 +21,6 @@ struct SidebarHeaderView: View {
             // codex flagged correctly as misleading.
             HStack(spacing: 2) {
                 ToolbarBtn(icon: "gear", action: onSettings)
-                ToolbarBtn(icon: "plus", action: onNewWorktree)
             }
         }
         .padding(.horizontal, 12)

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -4,17 +4,15 @@ struct SidebarView: View {
     @Bindable var state: AppState
     @Binding var collapsedProjects: Set<String>
     let onSettings: () -> Void
-    let onNewWorktree: () -> Void
+    let onAddProject: () -> Void
+    let onNewWorktree: (_ projectId: String?) -> Void
     @Environment(\.theme) var theme
 
     var body: some View {
         ZStack {
             VisualEffectView(material: .fullScreenUI, blendingMode: .behindWindow)
             VStack(spacing: 0) {
-                SidebarHeaderView(
-                    onSettings: onSettings,
-                    onNewWorktree: onNewWorktree
-                )
+                SidebarHeaderView(onSettings: onSettings)
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {
                         ForEach(state.projects) { project in
@@ -29,7 +27,8 @@ struct SidebarView: View {
                                     }
                                 ),
                                 selectedWorktreeId: state.selectedWorktreeId,
-                                onSelect: { wt in state.selectedWorktreeId = wt.id }
+                                onSelect: { wt in state.selectedWorktreeId = wt.id },
+                                onNewWorktree: { onNewWorktree(project.id) }
                             )
                         }
                     }
@@ -37,7 +36,7 @@ struct SidebarView: View {
                 }
                 Divider().opacity(0.5)
                 HStack(spacing: 6) {
-                    AlasButton(title: "New worktree", icon: "plus", style: .normal, action: onNewWorktree)
+                    AlasButton(title: "Add repository", icon: "folder-plus", style: .normal, action: onAddProject)
                         .frame(maxWidth: .infinity)
                     Button(action: onSettings) {
                         Icon(name: "gear", size: 13)


### PR DESCRIPTION
## Summary
- Footer button changes from "New worktree" → "Add repository", which opens the existing add-project dialog.
- Each repo row gets an inline `+` button, only visible on hover, that opens the new-worktree dialog with that repo preselected.
- Hover swaps the worktree count and the `+` button in place (same 18×18 slot) so the row doesn't shift.
- Sidebar header `+` removed since the per-repo button now owns that action.

## Test plan
- [ ] Open the app: footer shows "Add repository"; clicking opens add-project dialog.
- [ ] Hover a repo row: count fades out, `+` fades in, no layout jump. Click `+` opens New Worktree with the row's project preselected.
- [ ] Header has only the gear button (no `+`).
- [ ] Existing keyboard shortcut / menu for new worktree still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)