### PR TITLE
Rebind editor layout manager on tab switch

### DIFF
--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -73,12 +73,9 @@ final class CodeEditorCoordinator {
 
     func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme) {
         self.textView = textView
-        self.buffer = buffer
         self.layoutManager = layoutManager
         self.currentWorktreeId = worktreeId
         self.currentTabId = tabId
-        self.currentRoot = buffer.worktreeRoot
-        self.currentRelativePath = buffer.relativePath
         self.currentTheme = theme
 
         let family = appState.config.code.fontFamily
@@ -90,15 +87,7 @@ final class CodeEditorCoordinator {
         textView.decreaseFontSizeHandler = { [weak self] in self?.adjustFontSize(by: -1) }
         textView.resetFontSizeHandler = { [weak self] in self?.resetFontSize() }
 
-        applyBaseStyle(theme: theme)
-        let ext = (buffer.relativePath as NSString).pathExtension
-        currentLanguage = appState.lsp.language(forFileExtension: ext)
-        runHighlight(theme: theme)
-        subscribeIfPossible(theme: theme)
-
-        editObserverToken = buffer.onTextEdit { [weak self] edit in
-            self?.scheduleEditPropagation(edit: edit)
-        }
+        bindBuffer(buffer, theme: theme)
 
         hover = HoverFeature(
             textView: textView,
@@ -160,11 +149,18 @@ final class CodeEditorCoordinator {
             Task { await session.reset() }
             currentWorktreeId = worktreeId
             currentTabId = tabId
-            currentRoot = worktreeRoot
-            currentRelativePath = relativePath
-            currentLanguage = nextLanguage
-            runHighlight(theme: theme)
-            subscribeIfPossible(theme: theme)
+            // Fetch (and if needed, create) the buffer for the new tab and
+            // re-bind the layout manager onto its storage. Without this swap
+            // the text view keeps rendering the *previous* buffer's storage,
+            // so every editor tab appears to show the file that was opened
+            // first.
+            let nextBuffer = appState.tabs.buffer(
+                worktreeId: worktreeId,
+                tabId: tabId,
+                worktreeRoot: worktreeRoot,
+                relativePath: relativePath
+            )
+            bindBuffer(nextBuffer, theme: theme)
         }
 
         if currentTheme != theme {
@@ -187,6 +183,35 @@ final class CodeEditorCoordinator {
         }
 
         applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
+    }
+
+    /// Wire the coordinator and the text view to `buffer`. If a previous
+    /// buffer is already bound, its layout manager and edit observer are torn
+    /// down first so the text view stops rendering the old storage.
+    private func bindBuffer(_ buffer: EditorBuffer, theme: Theme) {
+        if let previous = self.buffer {
+            if let token = editObserverToken {
+                previous.removeOnEdit(token)
+            }
+            editObserverToken = nil
+            if let layoutManager {
+                previous.storage.removeLayoutManager(layoutManager)
+            }
+        }
+        self.buffer = buffer
+        self.currentRoot = buffer.worktreeRoot
+        self.currentRelativePath = buffer.relativePath
+        let ext = (buffer.relativePath as NSString).pathExtension
+        currentLanguage = appState.lsp.language(forFileExtension: ext)
+        if let layoutManager {
+            buffer.storage.addLayoutManager(layoutManager)
+        }
+        applyBaseStyle(theme: theme)
+        runHighlight(theme: theme)
+        subscribeIfPossible(theme: theme)
+        editObserverToken = buffer.onTextEdit { [weak self] edit in
+            self?.scheduleEditPropagation(edit: edit)
+        }
     }
 
     func detach() {

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -27,6 +27,12 @@ final class CodeEditorCoordinator {
     private var diagnosticsTask: Task<Void, Never>?
     private var diagnosticsSetupTask: Task<Void, Never>?
     let diagnosticsFeature = DiagnosticsFeature()
+    /// Most recent diagnostics batch the LSP server has published, keyed by
+    /// LSP URI. The server doesn't replay past batches to new subscribers,
+    /// so when a tab is rebound we restore from this cache; otherwise the
+    /// switched-to file would lose its squiggles until the server happens to
+    /// publish again. Internal so tests can seed it.
+    var lastDiagnosticsByURI: [String: [LSPDiagnostic]] = [:]
     let symbolsFeature = SymbolsFeature()
     private var hover: HoverFeature?
     private var definition: DefinitionFeature?
@@ -360,7 +366,14 @@ final class CodeEditorCoordinator {
         guard let buffer else { return }
         diagnosticsSetupTask?.cancel()
         diagnosticsTask?.cancel()
-        diagnosticsFeature.apply([], to: buffer.storage, theme: theme)
+        // Restore from cache instead of clearing. The LSP server doesn't
+        // replay past batches to new subscribers, so without this a tab
+        // switch would lose its squiggles until the server happened to
+        // republish (typically only after an edit/save). When there's no
+        // cached batch this still acts as the clear it used to be.
+        let bufferURI = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath).lspURI
+        let cached = lastDiagnosticsByURI[bufferURI] ?? []
+        diagnosticsFeature.apply(cached, to: buffer.storage, theme: theme)
         guard let language = currentLanguage else { return }
         let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
         let root = buffer.worktreeRoot
@@ -386,9 +399,13 @@ final class CodeEditorCoordinator {
         diagnosticsTask?.cancel()
         diagnosticsTask = Task { [weak self] in
             for await batch in await client.subscribeDiagnostics() {
-                if batch.uri != uri { continue }
                 await MainActor.run {
-                    guard let self, let buffer = self.buffer else { return }
+                    guard let self else { return }
+                    // Cache every batch we see, not just the active URI's —
+                    // when a tab is rebound back to a previously-open file
+                    // we read this cache to restore its squiggles.
+                    self.lastDiagnosticsByURI[batch.uri] = batch.diagnostics
+                    guard batch.uri == uri, let buffer = self.buffer else { return }
                     self.diagnosticsFeature.apply(batch.diagnostics, to: buffer.storage, theme: theme)
                 }
             }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -289,8 +289,18 @@ final class CodeEditorCoordinator {
         guard let buffer, let textView else { return }
         textView.backgroundColor = NSColor(theme.color("bg-1"))
         let editorTheme = EditorTheme(theme: theme)
+        // Resolve the font from the coordinator's tracked family/size, not
+        // from `textView.font`. The latter's getter reads `.font` from char 0
+        // of the current storage — and immediately after binding a freshly
+        // loaded buffer that attribute is unset, so it falls back to the
+        // system default (a proportional font). Reading our own state keeps
+        // the editor monospaced regardless of what the storage looks like.
+        let family = currentFontFamily ?? appState.config.code.fontFamily
+        let size = currentFontSize ?? CGFloat(appState.config.code.fontSize)
+        let font = Self.resolveFont(family: family, size: size)
+        textView.font = font
         let baseAttrs: [NSAttributedString.Key: Any] = [
-            .font: textView.font ?? NSFont.monospacedSystemFont(ofSize: 12.5, weight: .regular),
+            .font: font,
             .foregroundColor: editorTheme.defaultFG
         ]
         let storage = buffer.storage

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -26,7 +26,7 @@ final class CodeEditorCoordinator {
 
     private var diagnosticsTask: Task<Void, Never>?
     private var diagnosticsSetupTask: Task<Void, Never>?
-    private let diagnosticsFeature = DiagnosticsFeature()
+    let diagnosticsFeature = DiagnosticsFeature()
     let symbolsFeature = SymbolsFeature()
     private var hover: HoverFeature?
     private var definition: DefinitionFeature?
@@ -189,6 +189,7 @@ final class CodeEditorCoordinator {
     /// buffer is already bound, its layout manager and edit observer are torn
     /// down first so the text view stops rendering the old storage.
     private func bindBuffer(_ buffer: EditorBuffer, theme: Theme) {
+        let isRebind = self.buffer != nil
         if let previous = self.buffer {
             if let token = editObserverToken {
                 previous.removeOnEdit(token)
@@ -205,6 +206,15 @@ final class CodeEditorCoordinator {
         currentLanguage = appState.lsp.language(forFileExtension: ext)
         if let layoutManager {
             buffer.storage.addLayoutManager(layoutManager)
+        }
+        if isRebind {
+            // Drop any state captured against the previous buffer before we
+            // start the highlight: stale diagnostics would otherwise be
+            // re-applied to the new storage by the async highlight task, and
+            // stale undo records would let Undo/Redo mutate the wrong tab
+            // because the NSUndoManager belongs to the (reused) NSTextView.
+            diagnosticsFeature.reset()
+            textView?.undoManager?.removeAllActions()
         }
         applyBaseStyle(theme: theme)
         runHighlight(theme: theme)

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -389,27 +389,36 @@ final class CodeEditorCoordinator {
                   self.currentRelativePath == relativePath,
                   self.currentLanguage == language,
                   let client else { return }
-            await self.subscribeDiagnostics(for: client, uri: url.lspURI, theme: theme)
+            await self.subscribeDiagnostics(for: client, theme: theme)
             await self.symbolsFeature.refresh(client: client, uri: url.lspURI)
         }
     }
 
-    private func subscribeDiagnostics(for client: LSPClient?, uri: String, theme: Theme) async {
+    private func subscribeDiagnostics(for client: LSPClient?, theme: Theme) async {
         guard let client else { return }
         diagnosticsTask?.cancel()
         diagnosticsTask = Task { [weak self] in
             for await batch in await client.subscribeDiagnostics() {
                 await MainActor.run {
-                    guard let self else { return }
-                    // Cache every batch we see, not just the active URI's —
-                    // when a tab is rebound back to a previously-open file
-                    // we read this cache to restore its squiggles.
-                    self.lastDiagnosticsByURI[batch.uri] = batch.diagnostics
-                    guard batch.uri == uri, let buffer = self.buffer else { return }
-                    self.diagnosticsFeature.apply(batch.diagnostics, to: buffer.storage, theme: theme)
+                    self?.processDiagnosticsBatch(batch, theme: theme)
                 }
             }
         }
+    }
+
+    /// Cache every batch we see (so a rebind back to a previously-open file
+    /// can restore its squiggles), but only paint when the batch's URI
+    /// matches the *currently bound* buffer's URI. Cancelling the old
+    /// `diagnosticsTask` doesn't synchronously drain in-flight batches, so
+    /// without this active-URI check a batch from the previous subscription
+    /// could land on the new buffer's storage between cancellation and the
+    /// new subscription starting.
+    func processDiagnosticsBatch(_ batch: LSPPublishDiagnosticsParams, theme: Theme) {
+        lastDiagnosticsByURI[batch.uri] = batch.diagnostics
+        guard let buffer else { return }
+        let activeURI = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath).lspURI
+        guard batch.uri == activeURI else { return }
+        diagnosticsFeature.apply(batch.diagnostics, to: buffer.storage, theme: theme)
     }
 
     // MARK: - Font size adjustments

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -44,12 +44,11 @@ struct CodeEditorView: NSViewRepresentable {
             relativePath: relativePath
         )
 
-        // Build the TextKit 1 chain around the buffer's existing storage.
-        // We deliberately do NOT call `setAttributedString` here — that's
-        // the buffer's job (load / revert / restore). All this view does is
-        // present the storage.
+        // Build the TextKit 1 chain. The coordinator owns the
+        // storage<->layoutManager binding (see `bindBuffer`) so that swapping
+        // buffers across tab switches can rebind onto the new storage; we
+        // pass an unattached layout manager here.
         let layoutManager = NSLayoutManager()
-        buffer.storage.addLayoutManager(layoutManager)
         let containerSize = NSSize(
             width: CGFloat.greatestFiniteMagnitude,
             height: CGFloat.greatestFiniteMagnitude

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -617,6 +617,61 @@ struct EditorBufferTests {
         #expect(coordinator.diagnosticsFeature.current.isEmpty)
     }
 
+    @Test func coordinatorRebindRestoresCachedDiagnosticsForKnownURI() throws {
+        // Regression: the LSP server doesn't replay past publishDiagnostics
+        // batches to new subscribers. Without an in-coordinator cache, a
+        // tab switch to a previously-open file would lose its squiggles
+        // until the server happened to publish again. We cache every batch
+        // we see and restore from it on rebind.
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.swift", "let a = 1\n")
+        _ = try writeFile(root, "b.swift", "let b = 2\n")
+        let appState = AppState()
+        let bufferA = appState.tabs.buffer(
+            worktreeId: "wt", tabId: "tab-a",
+            worktreeRoot: root, relativePath: "a.swift"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+        coordinator.attach(
+            textView: textView, buffer: bufferA, layoutManager: layoutManager,
+            worktreeId: "wt", tabId: "tab-a",
+            revealLine: nil, revealCharacter: nil, theme: theme
+        )
+
+        // Seed the per-URI cache as if the LSP had published diagnostics
+        // for A while we were attached.
+        let uriA = root.appendingPathComponent("a.swift").lspURI
+        let json = #"{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":5}},"severity":1,"message":"boom"}"#
+        let fakeDiag = try JSONDecoder().decode(LSPDiagnostic.self, from: Data(json.utf8))
+        coordinator.lastDiagnosticsByURI[uriA] = [fakeDiag]
+        coordinator.diagnosticsFeature.apply([fakeDiag], to: bufferA.storage, theme: theme)
+        #expect(bufferA.storage.attribute(.underlineStyle, at: 0, effectiveRange: nil) != nil)
+
+        // Switch to B (no cached diagnostics for B), then back to A.
+        coordinator.updateIfNeeded(
+            worktreeId: "wt", worktreeRoot: root,
+            relativePath: "b.swift", tabId: "tab-b",
+            revealLine: nil, revealCharacter: nil, theme: theme
+        )
+        coordinator.updateIfNeeded(
+            worktreeId: "wt", worktreeRoot: root,
+            relativePath: "a.swift", tabId: "tab-a",
+            revealLine: nil, revealCharacter: nil, theme: theme
+        )
+
+        // Cached diagnostics for A should be re-applied to its storage —
+        // the underline attribute the diagnosticsFeature paints should be
+        // present again, even though no LSP server is running in this
+        // headless test.
+        let underline = bufferA.storage.attribute(.underlineStyle, at: 0, effectiveRange: nil)
+        #expect(underline != nil)
+    }
+
     @Test func coordinatorPathChangeClearsTextViewUndoStack() throws {
         // Regression: NSTextView's undoManager survives across tab swaps
         // because CenterPaneView reuses the same text view. Without an

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -455,7 +455,6 @@ struct EditorBufferTests {
         _ = try writeFile(root, "a.txt", "v1\n")
         let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt")
         let layoutManager = NSLayoutManager()
-        buffer.storage.addLayoutManager(layoutManager)
         let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
         layoutManager.addTextContainer(textContainer)
         let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
@@ -477,5 +476,59 @@ struct EditorBufferTests {
         coordinator.detach()
 
         #expect(!buffer.storage.layoutManagers.contains { $0 === layoutManager })
+    }
+
+    @Test func coordinatorPathChangeRebindsLayoutManagerToNewBufferStorage() throws {
+        // Regression: when the active editor tab switched, the coordinator
+        // updated its bookkeeping but never moved the layout manager off the
+        // first buffer's NSTextStorage, so the text view kept rendering the
+        // first file's contents for every subsequent tab.
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.md", "alpha\n")
+        _ = try writeFile(root, "b.swift", "let beta = 1\n")
+        let appState = AppState()
+        let bufferA = appState.tabs.buffer(
+            worktreeId: "wt",
+            tabId: "tab-a",
+            worktreeRoot: root,
+            relativePath: "a.md"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+
+        coordinator.attach(
+            textView: textView,
+            buffer: bufferA,
+            layoutManager: layoutManager,
+            worktreeId: "wt",
+            tabId: "tab-a",
+            revealLine: nil,
+            revealCharacter: nil,
+            theme: theme
+        )
+        #expect(bufferA.storage.layoutManagers.contains { $0 === layoutManager })
+
+        coordinator.updateIfNeeded(
+            worktreeId: "wt",
+            worktreeRoot: root,
+            relativePath: "b.swift",
+            tabId: "tab-b",
+            revealLine: nil,
+            revealCharacter: nil,
+            theme: theme
+        )
+
+        let bufferB = appState.tabs.buffer(
+            worktreeId: "wt",
+            tabId: "tab-b",
+            worktreeRoot: root,
+            relativePath: "b.swift"
+        )
+        #expect(!bufferA.storage.layoutManagers.contains { $0 === layoutManager })
+        #expect(bufferB.storage.layoutManagers.contains { $0 === layoutManager })
     }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -478,6 +478,45 @@ struct EditorBufferTests {
         #expect(!buffer.storage.layoutManagers.contains { $0 === layoutManager })
     }
 
+    @Test func coordinatorAppliesMonospacedFontToLoadedContent() throws {
+        // Regression: after rebinding, applyBaseStyle was reading
+        // `textView.font` whose getter falls back to the system default font
+        // (proportional) when the freshly bound storage has no `.font`
+        // attribute on char 0. The styled storage ended up with a
+        // proportional font for existing content while typing remained
+        // monospaced.
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.swift", "let answer = 42\n")
+        let appState = AppState()
+        let buffer = appState.tabs.buffer(
+            worktreeId: "wt",
+            tabId: "tab",
+            worktreeRoot: root,
+            relativePath: "a.swift"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+
+        coordinator.attach(
+            textView: textView,
+            buffer: buffer,
+            layoutManager: layoutManager,
+            worktreeId: "wt",
+            tabId: "tab",
+            revealLine: nil,
+            revealCharacter: nil,
+            theme: theme
+        )
+
+        let appliedFont = buffer.storage.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(appliedFont != nil)
+        #expect(appliedFont?.isFixedPitch == true)
+    }
+
     @Test func coordinatorPathChangeRebindsLayoutManagerToNewBufferStorage() throws {
         // Regression: when the active editor tab switched, the coordinator
         // updated its bookkeeping but never moved the layout manager off the
@@ -530,5 +569,11 @@ struct EditorBufferTests {
         )
         #expect(!bufferA.storage.layoutManagers.contains { $0 === layoutManager })
         #expect(bufferB.storage.layoutManagers.contains { $0 === layoutManager })
+        // The newly bound storage must come back styled monospaced. The
+        // original bug here was that applyBaseStyle resolved the font from
+        // textView.font, which after rebinding read char 0 of the new
+        // (unstyled) storage and fell back to the proportional system font.
+        let fontB = bufferB.storage.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(fontB?.isFixedPitch == true)
     }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -672,6 +672,47 @@ struct EditorBufferTests {
         #expect(underline != nil)
     }
 
+    @Test func coordinatorIgnoresDiagnosticsBatchForNonActiveURI() throws {
+        // Regression: cancelling the old diagnostics subscription on tab
+        // switch doesn't synchronously drain in-flight batches. A batch
+        // delivered after the rebind would otherwise pass the captured-URI
+        // guard and paint onto the *new* buffer's storage. The fix checks
+        // the batch URI against the currently bound buffer's URI.
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.swift", "let a = 1\n")
+        _ = try writeFile(root, "b.swift", "let b = 2\n")
+        let appState = AppState()
+        let bufferA = appState.tabs.buffer(
+            worktreeId: "wt", tabId: "tab-a",
+            worktreeRoot: root, relativePath: "a.swift"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+        coordinator.attach(
+            textView: textView, buffer: bufferA, layoutManager: layoutManager,
+            worktreeId: "wt", tabId: "tab-a",
+            revealLine: nil, revealCharacter: nil, theme: theme
+        )
+
+        // Build a batch addressed to file B but feed it to the coordinator
+        // while A is still the active buffer — simulating an in-flight
+        // batch that beat the rebind.
+        let uriB = root.appendingPathComponent("b.swift").lspURI
+        let json = #"{"uri":"\#(uriB)","diagnostics":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":5}},"severity":1,"message":"boom"}]}"#
+        let batch = try JSONDecoder().decode(LSPPublishDiagnosticsParams.self, from: Data(json.utf8))
+
+        coordinator.processDiagnosticsBatch(batch, theme: theme)
+
+        // Cache must be updated regardless of the active buffer …
+        #expect(coordinator.lastDiagnosticsByURI[uriB]?.count == 1)
+        // … but the batch must not paint onto A's storage.
+        #expect(bufferA.storage.attribute(.underlineStyle, at: 0, effectiveRange: nil) == nil)
+    }
+
     @Test func coordinatorPathChangeClearsTextViewUndoStack() throws {
         // Regression: NSTextView's undoManager survives across tab swaps
         // because CenterPaneView reuses the same text view. Without an

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -576,4 +576,93 @@ struct EditorBufferTests {
         let fontB = bufferB.storage.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
         #expect(fontB?.isFixedPitch == true)
     }
+
+    @Test func coordinatorPathChangeDropsStaleDiagnostics() throws {
+        // Regression: runHighlight captures diagnosticsFeature.current at the
+        // start of its async task; if we don't reset before the rebind, the
+        // task can re-apply the previous file's diagnostics onto the newly
+        // bound storage.
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.swift", "let a = 1\n")
+        _ = try writeFile(root, "b.swift", "let b = 2\n")
+        let appState = AppState()
+        let bufferA = appState.tabs.buffer(
+            worktreeId: "wt", tabId: "tab-a",
+            worktreeRoot: root, relativePath: "a.swift"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+        coordinator.attach(
+            textView: textView, buffer: bufferA, layoutManager: layoutManager,
+            worktreeId: "wt", tabId: "tab-a",
+            revealLine: nil, revealCharacter: nil, theme: theme
+        )
+
+        // LSPDiagnostic only has a Codable init, so build via JSON.
+        let json = #"{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":5}},"severity":1,"message":"boom"}"#
+        let fakeDiag = try JSONDecoder().decode(LSPDiagnostic.self, from: Data(json.utf8))
+        coordinator.diagnosticsFeature.apply([fakeDiag], to: bufferA.storage, theme: theme)
+        #expect(coordinator.diagnosticsFeature.current.count == 1)
+
+        coordinator.updateIfNeeded(
+            worktreeId: "wt", worktreeRoot: root,
+            relativePath: "b.swift", tabId: "tab-b",
+            revealLine: nil, revealCharacter: nil, theme: theme
+        )
+
+        #expect(coordinator.diagnosticsFeature.current.isEmpty)
+    }
+
+    @Test func coordinatorPathChangeClearsTextViewUndoStack() throws {
+        // Regression: NSTextView's undoManager survives across tab swaps
+        // because CenterPaneView reuses the same text view. Without an
+        // explicit removeAllActions on rebind, Undo would mutate the wrong
+        // buffer's storage.
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.swift", "let a = 1\n")
+        _ = try writeFile(root, "b.swift", "let b = 2\n")
+        let appState = AppState()
+        let bufferA = appState.tabs.buffer(
+            worktreeId: "wt", tabId: "tab-a",
+            worktreeRoot: root, relativePath: "a.swift"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: textContainer)
+        // NSTextView's undoManager comes from the responder chain; in this
+        // headless test we don't have a window, so feed one in via a
+        // delegate so the rebind path has something concrete to clear.
+        let undoOwner = TestUndoOwner()
+        textView.delegate = undoOwner
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+        coordinator.attach(
+            textView: textView, buffer: bufferA, layoutManager: layoutManager,
+            worktreeId: "wt", tabId: "tab-a",
+            revealLine: nil, revealCharacter: nil, theme: theme
+        )
+
+        // Stage an undoable action so canUndo flips on; payload is irrelevant.
+        textView.undoManager?.registerUndo(withTarget: bufferA) { _ in }
+        #expect(textView.undoManager?.canUndo == true)
+
+        coordinator.updateIfNeeded(
+            worktreeId: "wt", worktreeRoot: root,
+            relativePath: "b.swift", tabId: "tab-b",
+            revealLine: nil, revealCharacter: nil, theme: theme
+        )
+
+        #expect(textView.undoManager?.canUndo == false)
+    }
+}
+
+@MainActor
+private final class TestUndoOwner: NSObject, NSTextViewDelegate {
+    let undoManager = UndoManager()
+    func undoManager(for view: NSTextView) -> UndoManager? { undoManager }
 }


### PR DESCRIPTION
## Summary
Fixes a bug where every editor tab kept showing the file that was opened first (e.g. open AGENTS.md, then open Theme.swift via search → Theme.swift's tab still rendered AGENTS.md's content).

**Root cause:** `CodeEditorView.makeNSView` wired the `NSLayoutManager` to the *first* buffer's `NSTextStorage`. SwiftUI reuses the same `NSScrollView` across editor tab switches (calls `updateNSView`, not `makeNSView`), and the coordinator's `updateIfNeeded` only refreshed highlight/LSP/bookkeeping — it never moved the layout manager onto the new buffer's storage. The text view kept rendering the original buffer forever.

**Fix:** moved the storage<->layoutManager binding (and the edit observer) into a `bindBuffer` helper inside `CodeEditorCoordinator`. `attach()` calls it for the initial mount; `updateIfNeeded` now fetches the new buffer via `TabsManager.buffer(...)` and re-binds when worktreeId/tabId/relativePath/language change.

`CodeEditorView.makeNSView` no longer adds the layout manager itself — the coordinator is the sole binding site, which keeps the lifecycle in one place.

## Tests
- `coordinatorDetachRemovesMountedLayoutManager` — updated to match the new contract (attach now owns the bind).
- `coordinatorPathChangeRebindsLayoutManagerToNewBufferStorage` — new regression test. Asserts that after `updateIfNeeded` with a new path, the layout manager is removed from buffer A's storage and present on buffer B's. This is the coverage gap that let the bug ship.

## Test plan
- [ ] Open AGENTS.md in an editor tab.
- [ ] Open another file (e.g. Theme.swift) via the file search — verify it actually shows Theme.swift's content.
- [ ] Switch back to AGENTS.md tab — content is correct.
- [ ] Open a third file, switch around — each tab shows its own content.
- [ ] Edit, save, scroll, syntax highlight, LSP diagnostics still work after a tab switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)