### PR TITLE
Move sidebar add-repo / settings into the header

### DIFF
--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SidebarHeaderView: View {
     let onSettings: () -> Void
+    let onAddProject: () -> Void
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -20,6 +21,7 @@ struct SidebarHeaderView: View {
             // Previously rendered as a no-op ToolbarBtn(action: {}) which
             // codex flagged correctly as misleading.
             HStack(spacing: 2) {
+                ToolbarBtn(icon: "folder-plus", action: onAddProject)
                 ToolbarBtn(icon: "gear", action: onSettings)
             }
         }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -12,7 +12,7 @@ struct SidebarView: View {
         ZStack {
             VisualEffectView(material: .fullScreenUI, blendingMode: .behindWindow)
             VStack(spacing: 0) {
-                SidebarHeaderView(onSettings: onSettings)
+                SidebarHeaderView(onSettings: onSettings, onAddProject: onAddProject)
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {
                         ForEach(state.projects) { project in
@@ -34,19 +34,6 @@ struct SidebarView: View {
                     }
                     .padding(.top, 8)
                 }
-                Divider().opacity(0.5)
-                HStack(spacing: 6) {
-                    AlasButton(title: "Add repository", icon: "folder-plus", style: .normal, action: onAddProject)
-                        .frame(maxWidth: .infinity)
-                    Button(action: onSettings) {
-                        Icon(name: "gear", size: 13)
-                            .frame(width: 32, height: 26)
-                            .background(theme.color("bg-3"))
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
-                    }
-                    .buttonStyle(.plain)
-                }
-                .padding(8)
             }
         }
     }


### PR DESCRIPTION
## Summary
Sidebar footer is gone. Add-repository and settings buttons now sit in the sidebar header next to the brand, matching the latest design. The repo list reclaims the bottom space.

## Test plan
- [ ] Sidebar shows the folder-plus and gear buttons in the header (right of "Alas").
- [ ] Footer area no longer renders.
- [ ] Clicking folder-plus opens the new-project dialog.
- [ ] Clicking gear opens settings.
- [ ] Per-repo hover-only `+` button still opens new-worktree for that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)