### PR TITLE
Add built-in LSP configs for rust, kotlin, markdown, typescript, json

### DIFF
--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -60,9 +60,42 @@ struct LanguageServerRegistry {
             rootMarkers: [".marksman.toml", ".git"],
             enabled: true
         ),
+        // typescript-language-server distinguishes typescript /
+        // typescriptreact / javascript / javascriptreact in
+        // `mode2ScriptKind` and never re-derives the mode from the file
+        // extension, so TSX/JSX files opened with `languageId: "typescript"`
+        // get parsed as plain TS. Each LSP language ID needs its own
+        // registry entry; they all spawn the same binary.
         LanguageServerConfig(
             language: "typescript",
-            extensions: ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
+            extensions: ["ts"],
+            command: "typescript-language-server",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["tsconfig.json", "jsconfig.json", "package.json", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "typescriptreact",
+            extensions: ["tsx"],
+            command: "typescript-language-server",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["tsconfig.json", "jsconfig.json", "package.json", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "javascript",
+            extensions: ["js", "mjs", "cjs"],
+            command: "typescript-language-server",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["tsconfig.json", "jsconfig.json", "package.json", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "javascriptreact",
+            extensions: ["jsx"],
             command: "typescript-language-server",
             args: ["--stdio"],
             env: [:],
@@ -71,7 +104,19 @@ struct LanguageServerRegistry {
         ),
         LanguageServerConfig(
             language: "json",
-            extensions: ["json", "jsonc"],
+            extensions: ["json"],
+            command: "vscode-json-languageserver",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["package.json", ".git"],
+            enabled: true
+        ),
+        // vscode-json-languageserver only allows comments when the document
+        // languageId is "jsonc"; opening a .jsonc as "json" gets the strict
+        // parser and bogus diagnostics on every comment.
+        LanguageServerConfig(
+            language: "jsonc",
+            extensions: ["jsonc"],
             command: "vscode-json-languageserver",
             args: ["--stdio"],
             env: [:],

--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -68,7 +68,7 @@ struct LanguageServerRegistry {
         // registry entry; they all spawn the same binary.
         LanguageServerConfig(
             language: "typescript",
-            extensions: ["ts"],
+            extensions: ["ts", "mts", "cts"],
             command: "typescript-language-server",
             args: ["--stdio"],
             env: [:],

--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -28,6 +28,55 @@ struct LanguageServerRegistry {
             env: [:],
             rootMarkers: ["Package.swift", "*.xcodeproj", ".git"],
             enabled: true
+        ),
+        LanguageServerConfig(
+            language: "rust",
+            extensions: ["rs"],
+            command: "rust-analyzer",
+            args: [],
+            env: [:],
+            rootMarkers: ["Cargo.toml", "rust-project.json", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "kotlin",
+            extensions: ["kt", "kts"],
+            command: "kotlin-lsp",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: [
+                "build.gradle.kts", "build.gradle",
+                "settings.gradle.kts", "settings.gradle",
+                "pom.xml", ".git"
+            ],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "markdown",
+            extensions: ["md", "markdown"],
+            command: "marksman",
+            args: ["server"],
+            env: [:],
+            rootMarkers: [".marksman.toml", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "typescript",
+            extensions: ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
+            command: "typescript-language-server",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["tsconfig.json", "jsconfig.json", "package.json", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "json",
+            extensions: ["json", "jsonc"],
+            command: "vscode-json-languageserver",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["package.json", ".git"],
+            enabled: true
         )
     ]
 

--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -38,6 +38,11 @@ struct LanguageServerRegistry {
             rootMarkers: ["Cargo.toml", "rust-project.json", ".git"],
             enabled: true
         ),
+        // JetBrains kotlin-lsp uses pull-based diagnostics
+        // (`textDocument/diagnostic`) and the LSPClient currently only
+        // handles push-based `publishDiagnostics`. Ship the preset
+        // disabled so it's discoverable in Settings but doesn't silently
+        // open .kt/.kts files with diagnostics that never arrive.
         LanguageServerConfig(
             language: "kotlin",
             extensions: ["kt", "kts"],
@@ -49,7 +54,7 @@ struct LanguageServerRegistry {
                 "settings.gradle.kts", "settings.gradle",
                 "pom.xml", ".git"
             ],
-            enabled: true
+            enabled: false
         ),
         LanguageServerConfig(
             language: "markdown",

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -4,7 +4,15 @@ import Observation
 @Observable
 @MainActor
 final class WorkspaceLSPManager {
-    private struct Key: Hashable { let root: String; let language: String }
+    /// Identifies a holder by the resolved server (root + spawn command +
+    /// args) rather than the LSP languageId. typescript-language-server
+    /// requires per-extension language IDs (`typescript`, `typescriptreact`,
+    /// `javascript`, `javascriptreact`), but they all point at the same
+    /// binary and a single instance handles cross-file references and
+    /// unsaved buffers across the whole project. Keying on the languageId
+    /// would split them into 4 isolated servers and stale-out cross-file
+    /// hover/diagnostics/definitions for unsaved edits.
+    private struct Key: Hashable { let root: String; let command: String; let args: [String] }
 
     /// One holder per `(worktreeRoot, language)`. Inserted **before**
     /// awaiting `initialize()` so a concurrent `closeDocument` can find it
@@ -57,7 +65,7 @@ final class WorkspaceLSPManager {
     func openDocument(worktreeRoot: URL, fileURL: URL, languageId: String, text: String) async -> LSPClient? {
         guard let entry = registry.entry(forLanguage: languageId) else { return nil }
         let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, language: languageId)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args)
         let uri = fileURL.lspURI
         // If a previous holder's server died (process exited, transport
         // closed) we'd otherwise reuse the dead client and silently fail to
@@ -164,9 +172,9 @@ final class WorkspaceLSPManager {
     /// delayed `didOpen` carries the latest content — otherwise we'd lose
     /// the reload and the server would analyze the stale tab-open snapshot.
     func didChange(worktreeRoot: URL, fileURL: URL, languageId: String, text: String, edits: [EditorTextEdit]? = nil) async {
-        let markers = registry.entry(forLanguage: languageId)?.rootMarkers ?? []
-        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: markers)
-        let key = Key(root: lspRoot.path, language: languageId)
+        guard let entry = registry.entry(forLanguage: languageId) else { return }
+        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args)
         let uri = fileURL.lspURI
         guard var holder = holders[key] else { return }
         if !holder.openedURIs.contains(uri) {
@@ -189,9 +197,9 @@ final class WorkspaceLSPManager {
     }
 
     func closeDocument(worktreeRoot: URL, fileURL: URL, languageId: String) async {
-        let markers = registry.entry(forLanguage: languageId)?.rootMarkers ?? []
-        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: markers)
-        let key = Key(root: lspRoot.path, language: languageId)
+        guard let entry = registry.entry(forLanguage: languageId) else { return }
+        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args)
         let uri = fileURL.lspURI
         guard var holder = holders[key], (holder.refsByURI[uri] ?? 0) > 0 else { return }
         var refs = holder.refsByURI
@@ -235,9 +243,9 @@ final class WorkspaceLSPManager {
     /// never opened on the server (init still in flight, or a different
     /// holder is in play). Mirrors `didChange`'s readiness semantics.
     func didSave(worktreeRoot: URL, fileURL: URL, languageId: String) async {
-        let markers = registry.entry(forLanguage: languageId)?.rootMarkers ?? []
-        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: markers)
-        let key = Key(root: lspRoot.path, language: languageId)
+        guard let entry = registry.entry(forLanguage: languageId) else { return }
+        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args)
         let uri = fileURL.lspURI
         guard let holder = holders[key], holder.openedURIs.contains(uri) else { return }
         let initOk = await holder.ready.value
@@ -264,9 +272,9 @@ final class WorkspaceLSPManager {
     /// package's client is found correctly even when the caller only knows
     /// the worktree root.
     func client(forFile fileURL: URL, worktreeRoot: URL, language: String) -> LSPClient? {
-        let markers = registry.entry(forLanguage: language)?.rootMarkers ?? []
-        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: markers)
-        return holders[Key(root: lspRoot.path, language: language)]?.client
+        guard let entry = registry.entry(forLanguage: language) else { return nil }
+        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
+        return holders[Key(root: lspRoot.path, command: entry.command, args: entry.args)]?.client
     }
 
     /// Maps a file extension to its configured language id, or nil if no

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -4,15 +4,24 @@ import Observation
 @Observable
 @MainActor
 final class WorkspaceLSPManager {
-    /// Identifies a holder by the resolved server (root + spawn command +
-    /// args) rather than the LSP languageId. typescript-language-server
+    /// Identifies a holder by the resolved spawn (root + command + args +
+    /// env) rather than the LSP languageId. typescript-language-server
     /// requires per-extension language IDs (`typescript`, `typescriptreact`,
     /// `javascript`, `javascriptreact`), but they all point at the same
     /// binary and a single instance handles cross-file references and
     /// unsaved buffers across the whole project. Keying on the languageId
     /// would split them into 4 isolated servers and stale-out cross-file
-    /// hover/diagnostics/definitions for unsaved edits.
-    private struct Key: Hashable { let root: String; let command: String; let args: [String] }
+    /// hover/diagnostics/definitions for unsaved edits. `env` is part of
+    /// the identity because two configs that share root+command+args but
+    /// pin different `PATH` / variables must still launch separate
+    /// processes — a user override won't be silently merged onto the
+    /// first match's environment.
+    private struct Key: Hashable {
+        let root: String
+        let command: String
+        let args: [String]
+        let env: [String: String]
+    }
 
     /// One holder per `(worktreeRoot, language)`. Inserted **before**
     /// awaiting `initialize()` so a concurrent `closeDocument` can find it
@@ -65,7 +74,7 @@ final class WorkspaceLSPManager {
     func openDocument(worktreeRoot: URL, fileURL: URL, languageId: String, text: String) async -> LSPClient? {
         guard let entry = registry.entry(forLanguage: languageId) else { return nil }
         let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         let uri = fileURL.lspURI
         // If a previous holder's server died (process exited, transport
         // closed) we'd otherwise reuse the dead client and silently fail to
@@ -174,7 +183,7 @@ final class WorkspaceLSPManager {
     func didChange(worktreeRoot: URL, fileURL: URL, languageId: String, text: String, edits: [EditorTextEdit]? = nil) async {
         guard let entry = registry.entry(forLanguage: languageId) else { return }
         let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         let uri = fileURL.lspURI
         guard var holder = holders[key] else { return }
         if !holder.openedURIs.contains(uri) {
@@ -199,7 +208,7 @@ final class WorkspaceLSPManager {
     func closeDocument(worktreeRoot: URL, fileURL: URL, languageId: String) async {
         guard let entry = registry.entry(forLanguage: languageId) else { return }
         let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         let uri = fileURL.lspURI
         guard var holder = holders[key], (holder.refsByURI[uri] ?? 0) > 0 else { return }
         var refs = holder.refsByURI
@@ -245,7 +254,7 @@ final class WorkspaceLSPManager {
     func didSave(worktreeRoot: URL, fileURL: URL, languageId: String) async {
         guard let entry = registry.entry(forLanguage: languageId) else { return }
         let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         let uri = fileURL.lspURI
         guard let holder = holders[key], holder.openedURIs.contains(uri) else { return }
         let initOk = await holder.ready.value
@@ -274,7 +283,7 @@ final class WorkspaceLSPManager {
     func client(forFile fileURL: URL, worktreeRoot: URL, language: String) -> LSPClient? {
         guard let entry = registry.entry(forLanguage: language) else { return nil }
         let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        return holders[Key(root: lspRoot.path, command: entry.command, args: entry.args)]?.client
+        return holders[Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)]?.client
     }
 
     /// Maps a file extension to its configured language id, or nil if no

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -181,11 +181,12 @@ final class WorkspaceLSPManager {
     /// delayed `didOpen` carries the latest content — otherwise we'd lose
     /// the reload and the server would analyze the stale tab-open snapshot.
     func didChange(worktreeRoot: URL, fileURL: URL, languageId: String, text: String, edits: [EditorTextEdit]? = nil) async {
-        guard let entry = registry.entry(forLanguage: languageId) else { return }
-        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         let uri = fileURL.lspURI
-        guard var holder = holders[key] else { return }
+        // Look up by URI instead of recomputing the key from the current
+        // entry: if the user edited the registry (command/args/env) after
+        // the file was opened, the original holder lives under the old key
+        // and a recomputed lookup would miss it, leaking the server.
+        guard let key = holderKey(forURI: uri), var holder = holders[key] else { return }
         if !holder.openedURIs.contains(uri) {
             // Server still in `initialize()`. Update the pending text so the
             // suspended `openDocument` reads the new value when it resumes.
@@ -206,11 +207,10 @@ final class WorkspaceLSPManager {
     }
 
     func closeDocument(worktreeRoot: URL, fileURL: URL, languageId: String) async {
-        guard let entry = registry.entry(forLanguage: languageId) else { return }
-        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         let uri = fileURL.lspURI
-        guard var holder = holders[key], (holder.refsByURI[uri] ?? 0) > 0 else { return }
+        // See `didChange` — find the holder by URI so registry edits made
+        // after the open don't strand the original server.
+        guard let key = holderKey(forURI: uri), var holder = holders[key], (holder.refsByURI[uri] ?? 0) > 0 else { return }
         var refs = holder.refsByURI
         let newRef = (refs[uri] ?? 0) - 1
         if newRef <= 0 {
@@ -252,11 +252,10 @@ final class WorkspaceLSPManager {
     /// never opened on the server (init still in flight, or a different
     /// holder is in play). Mirrors `didChange`'s readiness semantics.
     func didSave(worktreeRoot: URL, fileURL: URL, languageId: String) async {
-        guard let entry = registry.entry(forLanguage: languageId) else { return }
-        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         let uri = fileURL.lspURI
-        guard let holder = holders[key], holder.openedURIs.contains(uri) else { return }
+        // See `didChange` — find the holder by URI so registry edits made
+        // after the open still hit the original server.
+        guard let key = holderKey(forURI: uri), let holder = holders[key], holder.openedURIs.contains(uri) else { return }
         let initOk = await holder.ready.value
         guard initOk, let cur = holders[key], cur.openedURIs.contains(uri) else { return }
         try? await cur.client.didSave(uri: uri)
@@ -281,9 +280,24 @@ final class WorkspaceLSPManager {
     /// package's client is found correctly even when the caller only knows
     /// the worktree root.
     func client(forFile fileURL: URL, worktreeRoot: URL, language: String) -> LSPClient? {
-        guard let entry = registry.entry(forLanguage: language) else { return nil }
-        let lspRoot = Self.resolveLSPRoot(fileURL: fileURL, worktreeRoot: worktreeRoot, markers: entry.rootMarkers)
-        return holders[Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)]?.client
+        // Look up by URI so a server opened under a now-edited entry is
+        // still findable by hover/diagnostic callers. `worktreeRoot` and
+        // `language` are kept on the signature for source compatibility
+        // and aren't needed once a holder exists for the file.
+        let uri = fileURL.lspURI
+        guard let key = holderKey(forURI: uri) else { return nil }
+        return holders[key]?.client
+    }
+
+    /// Locates the holder currently tracking `uri` (regardless of which
+    /// registry entry version was used to spawn it). Used by close,
+    /// didChange, didSave, and `client(forFile:)` so a registry edit
+    /// after an open doesn't leak the original server.
+    private func holderKey(forURI uri: String) -> Key? {
+        for (key, holder) in holders where holder.refsByURI[uri] != nil {
+            return key
+        }
+        return nil
     }
 
     /// Maps a file extension to its configured language id, or nil if no

--- a/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
@@ -41,7 +41,7 @@ struct LanguageServerRegistryTests {
         let r = LanguageServerRegistry(userDefined: [])
         #expect(r.language(forFileExtension: "swift") == "swift")
         #expect(r.language(forFileExtension: "rs") == "rust")
-        #expect(r.language(forFileExtension: "kt") == "kotlin")
+        #expect(r.language(forFileExtension: "kt") == nil)
         #expect(r.language(forFileExtension: "md") == "markdown")
         #expect(r.language(forFileExtension: "ts") == "typescript")
         #expect(r.language(forFileExtension: "mts") == "typescript")

--- a/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
@@ -40,6 +40,12 @@ struct LanguageServerRegistryTests {
     func byExtension() {
         let r = LanguageServerRegistry(userDefined: [])
         #expect(r.language(forFileExtension: "swift") == "swift")
-        #expect(r.language(forFileExtension: "rs") == nil)
+        #expect(r.language(forFileExtension: "rs") == "rust")
+        #expect(r.language(forFileExtension: "kt") == "kotlin")
+        #expect(r.language(forFileExtension: "md") == "markdown")
+        #expect(r.language(forFileExtension: "ts") == "typescript")
+        #expect(r.language(forFileExtension: "tsx") == "typescript")
+        #expect(r.language(forFileExtension: "json") == "json")
+        #expect(r.language(forFileExtension: "xyz") == nil)
     }
 }

--- a/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
@@ -44,8 +44,11 @@ struct LanguageServerRegistryTests {
         #expect(r.language(forFileExtension: "kt") == "kotlin")
         #expect(r.language(forFileExtension: "md") == "markdown")
         #expect(r.language(forFileExtension: "ts") == "typescript")
-        #expect(r.language(forFileExtension: "tsx") == "typescript")
+        #expect(r.language(forFileExtension: "tsx") == "typescriptreact")
+        #expect(r.language(forFileExtension: "js") == "javascript")
+        #expect(r.language(forFileExtension: "jsx") == "javascriptreact")
         #expect(r.language(forFileExtension: "json") == "json")
+        #expect(r.language(forFileExtension: "jsonc") == "jsonc")
         #expect(r.language(forFileExtension: "xyz") == nil)
     }
 }

--- a/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
@@ -44,6 +44,8 @@ struct LanguageServerRegistryTests {
         #expect(r.language(forFileExtension: "kt") == "kotlin")
         #expect(r.language(forFileExtension: "md") == "markdown")
         #expect(r.language(forFileExtension: "ts") == "typescript")
+        #expect(r.language(forFileExtension: "mts") == "typescript")
+        #expect(r.language(forFileExtension: "cts") == "typescript")
         #expect(r.language(forFileExtension: "tsx") == "typescriptreact")
         #expect(r.language(forFileExtension: "js") == "javascript")
         #expect(r.language(forFileExtension: "jsx") == "javascriptreact")


### PR DESCRIPTION
## Summary
- Add five pre-configured language servers (rust-analyzer, kotlin-lsp, marksman, typescript-language-server, vscode-json-languageserver) to the built-in registry.
- Each uses a bare command name so PATH resolution activates them automatically when installed; otherwise the Code settings pane shows "Not installed".
- Update `LanguageServerRegistryTests.byExtension` to cover the new extension → language mappings.

## Test plan
- [x] xcodebuild build succeeds for the Alas scheme on macOS.
- [x] LanguageServerRegistry + LanguageServerAvailability tests pass (14/14).
- [ ] With one of the LSPs installed on PATH, opening a matching file spawns the server and the Code pane shows "Available".

🤖 Generated with [Claude Code](https://claude.com/claude-code)