### PR TITLE
Cmd-click polish: out-of-worktree, picker, hover affordance

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		8622E85C972946E5411CAC48 /* ChangesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E947E110B003FB519DAD1B3 /* ChangesSectionView.swift */; };
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
+		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2AC0F8B3A1B75239995AC /* AppState.swift */; };
@@ -303,6 +304,7 @@
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
 		768D12909DD5233659AC4E03 /* RepoGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupView.swift; sourceTree = "<group>"; };
 		76F2498E56CBAF84CB67166C /* HarnessKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessKind.swift; sourceTree = "<group>"; };
+		781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionPicker.swift; sourceTree = "<group>"; };
 		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = .build/ghostty/GhosttyKit.xcframework; sourceTree = "<group>"; };
 		795056B6AD803D2B555FC866 /* RightPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStore.swift; sourceTree = "<group>"; };
 		79DDEA496740F5B0B5EE808B /* Process+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Process+Git.swift"; sourceTree = "<group>"; };
@@ -790,6 +792,7 @@
 			isa = PBXGroup;
 			children = (
 				F12340A649892955245BECB7 /* DefinitionFeature.swift */,
+				781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */,
 				932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */,
 				0AF8152B18C9D6290724122F /* HoverFeature.swift */,
 				019A03B92542169A6595D432 /* HoverHighlightFeature.swift */,
@@ -1074,6 +1077,7 @@
 				A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */,
 				49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */,
 				5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */,
+				884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */,
 				90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */,
 				9FD539228216762192A02C69 /* DialogChrome.swift in Sources */,
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		7B85B033B476943E77867BA3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69024633944E9FFF6DA76FAE /* RootView.swift */; };
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
+		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		8622E85C972946E5411CAC48 /* ChangesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E947E110B003FB519DAD1B3 /* ChangesSectionView.swift */; };
@@ -118,6 +119,7 @@
 		93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D759586280250330A9A04 /* FontSizeCommands.swift */; };
 		9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */; };
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
+		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
@@ -213,6 +215,7 @@
 		019A03B92542169A6595D432 /* HoverHighlightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeature.swift; sourceTree = "<group>"; };
 		0240C5961343C3042D865570 /* GeneralPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPane.swift; sourceTree = "<group>"; };
 		02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.SurfaceView.swift; sourceTree = "<group>"; };
+		0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCache.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
@@ -310,6 +313,7 @@
 		79DDEA496740F5B0B5EE808B /* Process+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Process+Git.swift"; sourceTree = "<group>"; };
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
+		7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCacheTests.swift; sourceTree = "<group>"; };
 		7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApp.swift; sourceTree = "<group>"; };
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
 		7FFC9539E615699AC90A7412 /* ProjectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManager.swift; sourceTree = "<group>"; };
@@ -523,6 +527,7 @@
 		31CE84DE21D266EF233D2D1E /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */,
 				412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */,
 				100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */,
 			);
@@ -793,6 +798,7 @@
 			children = (
 				F12340A649892955245BECB7 /* DefinitionFeature.swift */,
 				781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */,
+				0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */,
 				932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */,
 				0AF8152B18C9D6290724122F /* HoverFeature.swift */,
 				019A03B92542169A6595D432 /* HoverHighlightFeature.swift */,
@@ -1078,6 +1084,7 @@
 				49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */,
 				5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */,
 				884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */,
+				97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */,
 				90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */,
 				9FD539228216762192A02C69 /* DialogChrome.swift in Sources */,
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,
@@ -1198,6 +1205,7 @@
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,
+				7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */,
 				BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
 				A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
+		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
 		D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */; };
 		D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */; };
@@ -181,6 +182,7 @@
 		E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66950F2226F1182DCDD39A /* RightPaneView.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
+		E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A03B92542169A6595D432 /* HoverHighlightFeature.swift */; };
 		E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */; };
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EC1B515505AEC98FB199B02A /* HookInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 642163EB929E060A878211E2 /* HookInstaller.swift */; };
@@ -207,6 +209,7 @@
 /* Begin PBXFileReference section */
 		008E982C8526670670425AB8 /* EmptyTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabView.swift; sourceTree = "<group>"; };
 		010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowConfigurator.swift; sourceTree = "<group>"; };
+		019A03B92542169A6595D432 /* HoverHighlightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeature.swift; sourceTree = "<group>"; };
 		0240C5961343C3042D865570 /* GeneralPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPane.swift; sourceTree = "<group>"; };
 		02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.SurfaceView.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
@@ -218,6 +221,7 @@
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
 		0F68A9692F85197ED9E16262 /* WorktreesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreesPane.swift; sourceTree = "<group>"; };
+		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
 		1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
 		12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
 		1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandleTests.swift; sourceTree = "<group>"; };
@@ -518,6 +522,7 @@
 			isa = PBXGroup;
 			children = (
 				412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */,
+				100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -787,6 +792,7 @@
 				F12340A649892955245BECB7 /* DefinitionFeature.swift */,
 				932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */,
 				0AF8152B18C9D6290724122F /* HoverFeature.swift */,
+				019A03B92542169A6595D432 /* HoverHighlightFeature.swift */,
 				0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */,
 			);
 			path = Features;
@@ -1104,6 +1110,7 @@
 				EC1B515505AEC98FB199B02A /* HookInstaller.swift in Sources */,
 				043B6662FCBEC5969946D61A /* HookWatcher.swift in Sources */,
 				AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */,
+				E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */,
 				CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */,
 				E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */,
 				C1EBF68A32C7C1D61ECC89AC /* LSPClient.swift in Sources */,
@@ -1203,6 +1210,7 @@
 				D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */,
 				A7BDA44A8E4364C4C335C4DA /* HookEventTests.swift in Sources */,
 				0294EF678CFA762C8B5D381B /* HookInstallerTests.swift in Sources */,
+				D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */,
 				524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */,
 				79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */,
 				C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -69,7 +69,8 @@ struct CenterPaneView: View {
                                       tabId: s.id,
                                       revealLine: s.revealLine,
                                       revealCharacter: s.revealCharacter,
-                                      appState: state)
+                                      appState: state,
+                                      externalAbsolutePath: s.externalAbsolutePath)
                     case .diff(let s):
                         DiffTabView(worktreePath: worktree.path,
                                     relativePath: s.relativePath)

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -70,7 +70,8 @@ struct CenterPaneView: View {
                                       revealLine: s.revealLine,
                                       revealCharacter: s.revealCharacter,
                                       appState: state,
-                                      externalAbsolutePath: s.externalAbsolutePath)
+                                      externalAbsolutePath: s.externalAbsolutePath,
+                                      originatingRelativePath: s.originatingRelativePath)
                     case .diff(let s):
                         DiffTabView(worktreePath: worktree.path,
                                     relativePath: s.relativePath)

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -8,6 +8,7 @@ struct EditorTabView: View {
     let revealLine: Int?
     let revealCharacter: Int?
     let appState: AppState
+    let externalAbsolutePath: String?
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -28,6 +29,7 @@ struct EditorTabView: View {
                 revealLine: revealLine,
                 revealCharacter: revealCharacter,
                 appState: appState,
+                externalAbsolutePath: externalAbsolutePath,
                 fontFamily: appState.config.code.fontFamily,
                 fontSize: appState.config.code.fontSize
             )

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -9,18 +9,24 @@ struct EditorTabView: View {
     let revealCharacter: Int?
     let appState: AppState
     let externalAbsolutePath: String?
+    let originatingRelativePath: String?
     @Environment(\.theme) var theme
 
     var body: some View {
-        let buffer = appState.tabs.buffer(
-            worktreeId: worktreeId,
-            tabId: tabId,
-            worktreeRoot: worktreePath,
-            relativePath: relativePath
-        )
         return VStack(spacing: 0) {
             breadcrumb
-            EditorConflictBanner(buffer: buffer)
+            if externalAbsolutePath == nil {
+                // In-worktree tabs: create a normal buffer and show the
+                // conflict banner (external tabs are read-only and have no
+                // conflict semantics).
+                let buffer = appState.tabs.buffer(
+                    worktreeId: worktreeId,
+                    tabId: tabId,
+                    worktreeRoot: worktreePath,
+                    relativePath: relativePath
+                )
+                EditorConflictBanner(buffer: buffer)
+            }
             CodeEditorView(
                 worktreeId: worktreeId,
                 worktreeRoot: worktreePath,
@@ -30,6 +36,7 @@ struct EditorTabView: View {
                 revealCharacter: revealCharacter,
                 appState: appState,
                 externalAbsolutePath: externalAbsolutePath,
+                originatingRelativePath: originatingRelativePath,
                 fontFamily: appState.config.code.fontFamily,
                 fontSize: appState.config.code.fontSize
             )

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -33,7 +33,7 @@ enum Tab: Codable, Equatable, Identifiable {
 
     var relativeFilePath: String? {
         switch self {
-        case .editor(let s): return s.relativePath
+        case .editor(let s): return s.isExternal ? nil : s.relativePath
         default:             return nil
         }
     }
@@ -48,9 +48,12 @@ struct TerminalTabState: Codable, Equatable, Identifiable {
 struct EditorTabState: Codable, Equatable, Identifiable {
     let id: TabID
     var title: String
-    var relativePath: String   // relative to worktree root
+    var relativePath: String   // relative to worktree root; empty when external
     var revealLine: Int? = nil       // 0-based, optional reveal hint set by go-to-definition
     var revealCharacter: Int? = nil  // 0-based UTF-16
+    var externalAbsolutePath: String? = nil  // set when navigating to a file outside the worktree
+
+    var isExternal: Bool { externalAbsolutePath != nil }
 }
 
 struct DiffTabState: Codable, Equatable, Identifiable {

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -52,6 +52,12 @@ struct EditorTabState: Codable, Equatable, Identifiable {
     var revealLine: Int? = nil       // 0-based, optional reveal hint set by go-to-definition
     var revealCharacter: Int? = nil  // 0-based UTF-16
     var externalAbsolutePath: String? = nil  // set when navigating to a file outside the worktree
+    /// The worktree-relative path of the in-worktree file the user was
+    /// viewing when they ⌘-clicked to open this external tab. Persisted so
+    /// that app-restart reopens can still route LSP traffic to the correct
+    /// holder in nested-package layouts. Nil for tabs persisted before this
+    /// field was added (backward-compatible via the default value).
+    var originatingRelativePath: String? = nil
 
     var isExternal: Bool { externalAbsolutePath != nil }
 }

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -78,6 +78,11 @@ private struct TabButton: View {
                 .font(.system(size: 11.5))
                 .foregroundColor(active ? theme.color("fg") : theme.color("fg-dim"))
                 .lineLimit(1)
+            if case .editor(let state) = tab, state.isExternal {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(theme.color("fg-faint"))
+            }
             if let info = harnessInfo {
                 Circle().fill(stateColor(info.state)).frame(width: 6, height: 6)
                     .opacity(info.state == "running" ? 0.85 : 1)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -23,6 +23,17 @@ final class TabsManager {
     /// Tracks the absolute URL for external (out-of-worktree) tabs so that
     /// `discardBuffer(worktreeId:tabId:)` can tear them down too.
     private var externalTabURLs: [TabID: (worktreeId: String, url: URL)] = [:]
+    /// LSP parameters recorded when `externalBuffer` fires `openExternalDocument`
+    /// so that `discardBuffer` can issue the matching `closeExternalDocument`.
+    private struct ExternalLSPInfo {
+        var worktreeRoot: URL
+        var originatingFileURL: URL?
+        var language: String
+    }
+    private var externalLSPInfo: [TabID: ExternalLSPInfo] = [:]
+    /// Tracks which tab IDs have already had `openExternalDocument` fired so
+    /// that cache-hit calls to `externalBuffer` don't double-count the ref.
+    private var openedExternalDocs: Set<TabID> = []
     private let lsp: WorkspaceLSPManager?
 
     init(bufferStore: EditorBufferStore = EditorBufferStore(), lsp: WorkspaceLSPManager? = nil) {
@@ -325,11 +336,67 @@ final class TabsManager {
     /// Registering `tabId` in `externalTabURLs` ensures that the normal
     /// `discardBuffer(worktreeId:tabId:)` close-tab path tears the buffer
     /// down and stops its file watcher.
-    func externalBuffer(worktreeId: String, tabId: TabID, absoluteURL: URL) -> EditorBuffer {
+    ///
+    /// On first access (cache miss) fires `openExternalDocument` via the LSP
+    /// manager so the holder's reference count is tied to the buffer's
+    /// lifetime, not the `CodeEditorView`'s. Subsequent calls for the same
+    /// `tabId` (cache hit after a tab switch) are idempotent.
+    func externalBuffer(
+        worktreeId: String,
+        tabId: TabID,
+        absoluteURL: URL,
+        worktreeRoot: URL? = nil,
+        originatingFileURL: URL? = nil,
+        language: String? = nil
+    ) -> EditorBuffer {
         externalTabURLs[tabId] = (worktreeId: worktreeId, url: absoluteURL)
         let buffer = bufferStore.externalBuffer(worktreeId: worktreeId, absoluteURL: absoluteURL)
         buffer.startWatching()
+
+        // Fire openExternalDocument the FIRST time this tab's buffer is
+        // accessed.  Cache hits (tab switch back) must not re-open.
+        if let lsp,
+           let root = worktreeRoot,
+           let lang = language,
+           !openedExternalDocs.contains(tabId) {
+            openedExternalDocs.insert(tabId)
+            let info = ExternalLSPInfo(
+                worktreeRoot: root,
+                originatingFileURL: originatingFileURL,
+                language: lang
+            )
+            externalLSPInfo[tabId] = info
+            let contents = buffer.storage.string
+            Task { [lsp] in
+                await lsp.openExternalDocument(
+                    absoluteURL: absoluteURL,
+                    originatingWorktreeRoot: root,
+                    originatingFileURL: originatingFileURL,
+                    language: lang,
+                    contents: contents
+                )
+            }
+        }
+
         return buffer
+    }
+
+    /// Updates the LSP info recorded for an external tab (called by the
+    /// coordinator when the originating path changes mid-session).  The
+    /// caller is responsible for firing the close-old / open-new pair;
+    /// this method only updates the record so that the eventual
+    /// `discardBuffer` close targets the right holder.
+    func updateExternalLSPInfo(
+        tabId: TabID,
+        worktreeRoot: URL,
+        originatingFileURL: URL?,
+        language: String
+    ) {
+        externalLSPInfo[tabId] = ExternalLSPInfo(
+            worktreeRoot: worktreeRoot,
+            originatingFileURL: originatingFileURL,
+            language: language
+        )
     }
 
     /// Inspect (do not create) the buffer for `tabId`. Used by tests and by
@@ -358,6 +425,20 @@ final class TabsManager {
         // externalBuffers cache rather than the in-worktree `buffers` dict.
         if let ext = externalTabURLs.removeValue(forKey: tabId) {
             assert(ext.worktreeId == worktreeId, "discardBuffer called with worktreeId=\(worktreeId) but external buffer is owned by \(ext.worktreeId)")
+            // Fire closeExternalDocument to release the LSP ref that was
+            // acquired in externalBuffer(...) on cache miss.
+            if let info = externalLSPInfo.removeValue(forKey: tabId), let lsp {
+                let url = ext.url
+                Task { [lsp, info] in
+                    await lsp.closeExternalDocument(
+                        absoluteURL: url,
+                        originatingWorktreeRoot: info.worktreeRoot,
+                        originatingFileURL: info.originatingFileURL,
+                        language: info.language
+                    )
+                }
+            }
+            openedExternalDocs.remove(tabId)
             bufferStore.discardExternalBuffer(worktreeId: ext.worktreeId, absoluteURL: ext.url)
             return
         }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -137,13 +137,19 @@ final class TabsManager {
     /// in-worktree file from which the user navigated here (e.g. via
     /// ⌘-click). Stored on the tab so that LSP traffic for this external
     /// file is routed to the correct holder in nested-package layouts.
+    ///
+    /// `originatingWorktreeRoot` and `language` are used to rebind the
+    /// external LSP holder when reusing an existing tab from a different
+    /// origin package, even while the tab is inactive.
     @discardableResult
     func openExternalEditor(
         worktreeId: String,
         absoluteURL: URL,
         revealLine: Int?,
         revealCharacter: Int?,
-        originatingRelativePath: String? = nil
+        originatingRelativePath: String? = nil,
+        originatingWorktreeRoot: URL? = nil,
+        language: String? = nil
     ) -> Tab {
         let absPath = absoluteURL.path
         if var file = byWorktree[worktreeId],
@@ -152,6 +158,7 @@ final class TabsManager {
                return false
            }) {
             if case .editor(var s) = file.tabs[idx] {
+                let originChanged = (s.originatingRelativePath != originatingRelativePath)
                 s.revealLine = revealLine
                 s.revealCharacter = revealCharacter
                 s.originatingRelativePath = originatingRelativePath   // refresh the origin
@@ -159,6 +166,17 @@ final class TabsManager {
                 file.activeTabId = s.id
                 byWorktree[worktreeId] = file
                 persist(worktreeId)
+                if originChanged, let originatingWorktreeRoot, let language {
+                    rebindExternalLSPHolder(
+                        tabId: s.id,
+                        absoluteURL: absoluteURL,
+                        worktreeRoot: originatingWorktreeRoot,
+                        originatingFileURL: originatingRelativePath.flatMap {
+                            originatingWorktreeRoot.appendingPathComponent($0)
+                        },
+                        language: language
+                    )
+                }
                 return .editor(s)
             }
         }
@@ -175,6 +193,50 @@ final class TabsManager {
         let tab = Tab.editor(state)
         append(tab, to: worktreeId)
         return tab
+    }
+
+    /// Rebind an external tab's LSP holder when the originating in-worktree
+    /// file changes (e.g. the user ⌘-clicked the same SDK file from a
+    /// different package while the external tab was inactive). Operates
+    /// regardless of whether the tab is currently active, so the fix applies
+    /// even when the coordinator's `updateIfNeeded` path is never reached.
+    private func rebindExternalLSPHolder(
+        tabId: TabID,
+        absoluteURL: URL,
+        worktreeRoot: URL,
+        originatingFileURL: URL?,
+        language: String
+    ) {
+        let oldInfo = externalLSPInfo[tabId]
+        let newInfo = ExternalLSPInfo(
+            worktreeRoot: worktreeRoot,
+            originatingFileURL: originatingFileURL,
+            language: language
+        )
+        externalLSPInfo[tabId] = newInfo
+
+        // Cancel any in-flight open targeting the old holder so its completion
+        // handler can no longer record openedExternalDocs for a stale holder.
+        pendingExternalOpenTasks[tabId]?.cancel()
+        pendingExternalOpenTasks[tabId] = nil
+
+        // If we already opened against the OLD holder, close that ref now.
+        if openedExternalDocs.contains(tabId), let old = oldInfo {
+            let lsp = self.lsp
+            Task { [lsp, old] in
+                await lsp?.closeExternalDocument(
+                    absoluteURL: absoluteURL,
+                    originatingWorktreeRoot: old.worktreeRoot,
+                    originatingFileURL: old.originatingFileURL,
+                    language: old.language
+                )
+            }
+        }
+
+        // Clear the opened flag so ensureExternalLSPOpen retries against the
+        // new holder even if the tab was already open against the old one.
+        openedExternalDocs.remove(tabId)
+        ensureExternalLSPOpen(tabId: tabId)
     }
 
     @discardableResult
@@ -413,24 +475,6 @@ final class TabsManager {
             }
         }
         pendingExternalOpenTasks[tabId] = task
-    }
-
-    /// Updates the LSP info recorded for an external tab (called by the
-    /// coordinator when the originating path changes mid-session).  The
-    /// caller is responsible for firing the close-old / open-new pair;
-    /// this method only updates the record so that the eventual
-    /// `discardBuffer` close targets the right holder.
-    func updateExternalLSPInfo(
-        tabId: TabID,
-        worktreeRoot: URL,
-        originatingFileURL: URL?,
-        language: String
-    ) {
-        externalLSPInfo[tabId] = ExternalLSPInfo(
-            worktreeRoot: worktreeRoot,
-            originatingFileURL: originatingFileURL,
-            language: language
-        )
     }
 
     /// Inspect (do not create) the buffer for `tabId`. Used by tests and by

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -25,7 +25,7 @@ final class TabsManager {
     private var externalTabURLs: [TabID: (worktreeId: String, url: URL)] = [:]
     /// LSP parameters recorded when `externalBuffer` fires `openExternalDocument`
     /// so that `discardBuffer` can issue the matching `closeExternalDocument`.
-    private struct ExternalLSPInfo {
+    private struct ExternalLSPInfo: Equatable {
         var worktreeRoot: URL
         var originatingFileURL: URL?
         var language: String
@@ -445,27 +445,48 @@ final class TabsManager {
               let entry = externalTabURLs[tabId] else { return }
         let absoluteURL = entry.url
         let contents = bufferStore.externalBuffer(worktreeId: entry.worktreeId, absoluteURL: absoluteURL).storage.string
+        // Capture the info snapshot this Task is opening against so the completion
+        // can detect a mid-flight rebind and undo the open on the old holder.
+        let snapshot = info
         let task = Task { [weak self] in
             let opened = await lsp.openExternalDocument(
                 absoluteURL: absoluteURL,
-                originatingWorktreeRoot: info.worktreeRoot,
-                originatingFileURL: info.originatingFileURL,
-                language: info.language,
+                originatingWorktreeRoot: snapshot.worktreeRoot,
+                originatingFileURL: snapshot.originatingFileURL,
+                language: snapshot.language,
                 contents: contents
             )
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 self.pendingExternalOpenTasks[tabId] = nil
                 // If the tab was discarded while the open was in flight, undo it
-                // so the URI doesn't leak on the holder until app exit.
+                // against the snapshot we actually opened against, so the URI
+                // doesn't leak on the holder until app exit.
                 if self.externalTabURLs[tabId] == nil {
                     if opened {
-                        Task { [lsp, info] in
+                        Task { [lsp, snapshot] in
                             await lsp.closeExternalDocument(
                                 absoluteURL: absoluteURL,
-                                originatingWorktreeRoot: info.worktreeRoot,
-                                originatingFileURL: info.originatingFileURL,
-                                language: info.language
+                                originatingWorktreeRoot: snapshot.worktreeRoot,
+                                originatingFileURL: snapshot.originatingFileURL,
+                                language: snapshot.language
+                            )
+                        }
+                    }
+                    return
+                }
+                // Info changed mid-flight (rebind). Undo the open against the
+                // snapshot so the old holder's ref is balanced. Don't touch
+                // openedExternalDocs — the rebind's ensureExternalLSPOpen call
+                // (issued after the rebind) will register the new holder.
+                if let current = self.externalLSPInfo[tabId], current != snapshot {
+                    if opened {
+                        Task { [lsp, snapshot] in
+                            await lsp.closeExternalDocument(
+                                absoluteURL: absoluteURL,
+                                originatingWorktreeRoot: snapshot.worktreeRoot,
+                                originatingFileURL: snapshot.originatingFileURL,
+                                language: snapshot.language
                             )
                         }
                     }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -312,7 +312,9 @@ final class TabsManager {
 
     /// Returns (or creates) a read-only external buffer keyed by absolute URL.
     func externalBuffer(worktreeId: String, absoluteURL: URL) -> EditorBuffer {
-        bufferStore.externalBuffer(worktreeId: worktreeId, absoluteURL: absoluteURL)
+        let buffer = bufferStore.externalBuffer(worktreeId: worktreeId, absoluteURL: absoluteURL)
+        buffer.startWatching()
+        return buffer
     }
 
     /// Inspect (do not create) the buffer for `tabId`. Used by tests and by

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -34,6 +34,11 @@ final class TabsManager {
     /// Tracks which tab IDs have already had `openExternalDocument` fired so
     /// that cache-hit calls to `externalBuffer` don't double-count the ref.
     private var openedExternalDocs: Set<TabID> = []
+    /// Tracks tab IDs for which an `openExternalDocument` Task is currently
+    /// in flight. Prevents two concurrent Tasks from double-bumping the LSP
+    /// refcount when both `externalBuffer` and the coordinator's `attach`
+    /// fire `ensureExternalLSPOpen` before the first Task completes.
+    private var pendingExternalOpens: Set<TabID> = []
     private let lsp: WorkspaceLSPManager?
 
     init(bufferStore: EditorBufferStore = EditorBufferStore(), lsp: WorkspaceLSPManager? = nil) {
@@ -337,10 +342,11 @@ final class TabsManager {
     /// `discardBuffer(worktreeId:tabId:)` close-tab path tears the buffer
     /// down and stops its file watcher.
     ///
-    /// On first access (cache miss) fires `openExternalDocument` via the LSP
-    /// manager so the holder's reference count is tied to the buffer's
-    /// lifetime, not the `CodeEditorView`'s. Subsequent calls for the same
-    /// `tabId` (cache hit after a tab switch) are idempotent.
+    /// Fires `openExternalDocument` via the LSP manager so the holder's
+    /// reference count is tied to the buffer's lifetime, not the
+    /// `CodeEditorView`'s. The open is retried on every call until a holder
+    /// is found — this handles the case where a persisted external tab is
+    /// restored before any in-worktree file has started the language server.
     func externalBuffer(
         worktreeId: String,
         tabId: TabID,
@@ -353,32 +359,45 @@ final class TabsManager {
         let buffer = bufferStore.externalBuffer(worktreeId: worktreeId, absoluteURL: absoluteURL)
         buffer.startWatching()
 
-        // Fire openExternalDocument the FIRST time this tab's buffer is
-        // accessed.  Cache hits (tab switch back) must not re-open.
-        if let lsp,
-           let root = worktreeRoot,
-           let lang = language,
-           !openedExternalDocs.contains(tabId) {
-            openedExternalDocs.insert(tabId)
-            let info = ExternalLSPInfo(
+        if let root = worktreeRoot, let lang = language {
+            externalLSPInfo[tabId] = ExternalLSPInfo(
                 worktreeRoot: root,
                 originatingFileURL: originatingFileURL,
                 language: lang
             )
-            externalLSPInfo[tabId] = info
-            let contents = buffer.storage.string
-            Task { [lsp] in
-                await lsp.openExternalDocument(
-                    absoluteURL: absoluteURL,
-                    originatingWorktreeRoot: root,
-                    originatingFileURL: originatingFileURL,
-                    language: lang,
-                    contents: contents
-                )
-            }
         }
 
+        ensureExternalLSPOpen(tabId: tabId)
+
         return buffer
+    }
+
+    /// Attempts to open the LSP document for `tabId` if it hasn't been opened
+    /// yet. Idempotent: no-ops if already opened or if an open is already in
+    /// flight. Retries silently until a holder is available — this covers the
+    /// case where a persisted external tab is restored before any in-worktree
+    /// file has started the language server.
+    func ensureExternalLSPOpen(tabId: TabID) {
+        guard !openedExternalDocs.contains(tabId), !pendingExternalOpens.contains(tabId) else { return }
+        guard let lsp,
+              let info = externalLSPInfo[tabId],
+              let entry = externalTabURLs[tabId] else { return }
+        let absoluteURL = entry.url
+        let contents = bufferStore.externalBuffer(worktreeId: entry.worktreeId, absoluteURL: absoluteURL).storage.string
+        pendingExternalOpens.insert(tabId)
+        Task { [weak self] in
+            let opened = await lsp.openExternalDocument(
+                absoluteURL: absoluteURL,
+                originatingWorktreeRoot: info.worktreeRoot,
+                originatingFileURL: info.originatingFileURL,
+                language: info.language,
+                contents: contents
+            )
+            await MainActor.run { [weak self] in
+                self?.pendingExternalOpens.remove(tabId)
+                if opened { self?.openedExternalDocs.insert(tabId) }
+            }
+        }
     }
 
     /// Updates the LSP info recorded for an external tab (called by the
@@ -439,6 +458,7 @@ final class TabsManager {
                 }
             }
             openedExternalDocs.remove(tabId)
+            pendingExternalOpens.remove(tabId)
             bufferStore.discardExternalBuffer(worktreeId: ext.worktreeId, absoluteURL: ext.url)
             return
         }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -310,6 +310,11 @@ final class TabsManager {
         return buffer
     }
 
+    /// Returns (or creates) a read-only external buffer keyed by absolute URL.
+    func externalBuffer(worktreeId: String, absoluteURL: URL) -> EditorBuffer {
+        bufferStore.externalBuffer(worktreeId: worktreeId, absoluteURL: absoluteURL)
+    }
+
     /// Inspect (do not create) the buffer for `tabId`. Used by tests and by
     /// dirty-tab queries.
     func peekBuffer(tabId: TabID) -> EditorBuffer? {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -38,6 +38,11 @@ final class TabsManager {
     /// Cancellation on `discardBuffer` prevents a completed-but-unregistered
     /// open from leaking the URI if the tab was closed before the Task landed.
     private var pendingExternalOpenTasks: [TabID: Task<Void, Never>] = [:]
+    /// Generation counter per tab for the pending open task. When a rebind
+    /// cancels and replaces the task, the generation increments. The task's
+    /// completion handler only clears pendingExternalOpenTasks if its
+    /// captured generation still matches the current one.
+    private var pendingExternalOpenGen: [TabID: Int] = [:]
     private let lsp: WorkspaceLSPManager?
 
     init(bufferStore: EditorBufferStore = EditorBufferStore(), lsp: WorkspaceLSPManager? = nil) {
@@ -219,6 +224,7 @@ final class TabsManager {
         // handler can no longer record openedExternalDocs for a stale holder.
         pendingExternalOpenTasks[tabId]?.cancel()
         pendingExternalOpenTasks[tabId] = nil
+        pendingExternalOpenGen[tabId] = nil
 
         // If we already opened against the OLD holder, close that ref now.
         if openedExternalDocs.contains(tabId), let old = oldInfo {
@@ -448,6 +454,8 @@ final class TabsManager {
         // Capture the info snapshot this Task is opening against so the completion
         // can detect a mid-flight rebind and undo the open on the old holder.
         let snapshot = info
+        let gen = (pendingExternalOpenGen[tabId] ?? 0) + 1
+        pendingExternalOpenGen[tabId] = gen
         let task = Task { [weak self] in
             let opened = await lsp.openExternalDocument(
                 absoluteURL: absoluteURL,
@@ -458,7 +466,10 @@ final class TabsManager {
             )
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                self.pendingExternalOpenTasks[tabId] = nil
+                // Only clear our own entry — a rebind may have installed a successor.
+                if self.pendingExternalOpenGen[tabId] == gen {
+                    self.pendingExternalOpenTasks[tabId] = nil
+                }
                 // If the tab was discarded while the open was in flight, undo it
                 // against the snapshot we actually opened against, so the URI
                 // doesn't leak on the holder until app exit.
@@ -530,6 +541,7 @@ final class TabsManager {
             // the LSP request had already been sent before cancellation.
             pendingExternalOpenTasks[tabId]?.cancel()
             pendingExternalOpenTasks[tabId] = nil
+            pendingExternalOpenGen[tabId] = nil
             // Fire closeExternalDocument to release the LSP ref that was
             // acquired in externalBuffer(...) on cache miss.
             if let info = externalLSPInfo.removeValue(forKey: tabId), let lsp {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -117,12 +117,18 @@ final class TabsManager {
     /// worktree (SDK headers, dependencies). Reuse-or-create keyed by
     /// absolute path. The tab is "owned" by `worktreeId` so closing the
     /// worktree cascades.
+    ///
+    /// `originatingRelativePath` is the worktree-relative path of the
+    /// in-worktree file from which the user navigated here (e.g. via
+    /// ⌘-click). Stored on the tab so that LSP traffic for this external
+    /// file is routed to the correct holder in nested-package layouts.
     @discardableResult
     func openExternalEditor(
         worktreeId: String,
         absoluteURL: URL,
         revealLine: Int?,
-        revealCharacter: Int?
+        revealCharacter: Int?,
+        originatingRelativePath: String? = nil
     ) -> Tab {
         let absPath = absoluteURL.path
         if var file = byWorktree[worktreeId],
@@ -147,7 +153,8 @@ final class TabsManager {
             relativePath: "",
             revealLine: revealLine,
             revealCharacter: revealCharacter,
-            externalAbsolutePath: absPath
+            externalAbsolutePath: absPath,
+            originatingRelativePath: originatingRelativePath
         )
         let tab = Tab.editor(state)
         append(tab, to: worktreeId)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -20,6 +20,9 @@ final class TabsManager {
     private let bufferStore: EditorBufferStore
     private var buffers: [BufferKey: EditorBuffer] = [:]
     private var bufferKeys: [TabID: BufferKey] = [:]
+    /// Tracks the absolute URL for external (out-of-worktree) tabs so that
+    /// `discardBuffer(worktreeId:tabId:)` can tear them down too.
+    private var externalTabURLs: [TabID: (worktreeId: String, url: URL)] = [:]
     private let lsp: WorkspaceLSPManager?
 
     init(bufferStore: EditorBufferStore = EditorBufferStore(), lsp: WorkspaceLSPManager? = nil) {
@@ -311,7 +314,11 @@ final class TabsManager {
     }
 
     /// Returns (or creates) a read-only external buffer keyed by absolute URL.
-    func externalBuffer(worktreeId: String, absoluteURL: URL) -> EditorBuffer {
+    /// Registering `tabId` in `externalTabURLs` ensures that the normal
+    /// `discardBuffer(worktreeId:tabId:)` close-tab path tears the buffer
+    /// down and stops its file watcher.
+    func externalBuffer(worktreeId: String, tabId: TabID, absoluteURL: URL) -> EditorBuffer {
+        externalTabURLs[tabId] = (worktreeId: worktreeId, url: absoluteURL)
         let buffer = bufferStore.externalBuffer(worktreeId: worktreeId, absoluteURL: absoluteURL)
         buffer.startWatching()
         return buffer
@@ -339,6 +346,13 @@ final class TabsManager {
     /// wrong worktree context surfaces immediately rather than silently
     /// mis-routing the snapshot.
     func discardBuffer(worktreeId: String, tabId: TabID) {
+        // Handle external (out-of-worktree) tabs whose buffers live in the
+        // externalBuffers cache rather than the in-worktree `buffers` dict.
+        if let ext = externalTabURLs.removeValue(forKey: tabId) {
+            assert(ext.worktreeId == worktreeId, "discardBuffer called with worktreeId=\(worktreeId) but external buffer is owned by \(ext.worktreeId)")
+            bufferStore.discardExternalBuffer(worktreeId: ext.worktreeId, absoluteURL: ext.url)
+            return
+        }
         guard let key = bufferKeys.removeValue(forKey: tabId) else { return }
         assert(key.worktreeId == worktreeId, "discardBuffer called with worktreeId=\(worktreeId) but buffer is owned by \(key.worktreeId)")
         bufferStore.discard(worktreeId: worktreeId, tabId: tabId)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -139,6 +139,7 @@ final class TabsManager {
             if case .editor(var s) = file.tabs[idx] {
                 s.revealLine = revealLine
                 s.revealCharacter = revealCharacter
+                s.originatingRelativePath = originatingRelativePath   // refresh the origin
                 file.tabs[idx] = .editor(s)
                 file.activeTabId = s.id
                 byWorktree[worktreeId] = file

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -110,6 +110,47 @@ final class TabsManager {
         return tab
     }
 
+    /// Open or focus an editor tab for an absolute URL outside the
+    /// worktree (SDK headers, dependencies). Reuse-or-create keyed by
+    /// absolute path. The tab is "owned" by `worktreeId` so closing the
+    /// worktree cascades.
+    @discardableResult
+    func openExternalEditor(
+        worktreeId: String,
+        absoluteURL: URL,
+        revealLine: Int?,
+        revealCharacter: Int?
+    ) -> Tab {
+        let absPath = absoluteURL.path
+        if var file = byWorktree[worktreeId],
+           let idx = file.tabs.firstIndex(where: {
+               if case .editor(let s) = $0 { return s.externalAbsolutePath == absPath }
+               return false
+           }) {
+            if case .editor(var s) = file.tabs[idx] {
+                s.revealLine = revealLine
+                s.revealCharacter = revealCharacter
+                file.tabs[idx] = .editor(s)
+                file.activeTabId = s.id
+                byWorktree[worktreeId] = file
+                persist(worktreeId)
+                return .editor(s)
+            }
+        }
+        let title = absoluteURL.lastPathComponent
+        let state = EditorTabState(
+            id: UUID().uuidString,
+            title: title,
+            relativePath: "",
+            revealLine: revealLine,
+            revealCharacter: revealCharacter,
+            externalAbsolutePath: absPath
+        )
+        let tab = Tab.editor(state)
+        append(tab, to: worktreeId)
+        return tab
+    }
+
     @discardableResult
     func appendDiff(worktreeId: String, title: String, relativePath: String) -> Tab {
         let state = DiffTabState(id: UUID().uuidString, title: title, relativePath: relativePath)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -34,11 +34,10 @@ final class TabsManager {
     /// Tracks which tab IDs have already had `openExternalDocument` fired so
     /// that cache-hit calls to `externalBuffer` don't double-count the ref.
     private var openedExternalDocs: Set<TabID> = []
-    /// Tracks tab IDs for which an `openExternalDocument` Task is currently
-    /// in flight. Prevents two concurrent Tasks from double-bumping the LSP
-    /// refcount when both `externalBuffer` and the coordinator's `attach`
-    /// fire `ensureExternalLSPOpen` before the first Task completes.
-    private var pendingExternalOpens: Set<TabID> = []
+    /// Tracks in-flight `openExternalDocument` Tasks keyed by tabId.
+    /// Cancellation on `discardBuffer` prevents a completed-but-unregistered
+    /// open from leaking the URI if the tab was closed before the Task landed.
+    private var pendingExternalOpenTasks: [TabID: Task<Void, Never>] = [:]
     private let lsp: WorkspaceLSPManager?
 
     init(bufferStore: EditorBufferStore = EditorBufferStore(), lsp: WorkspaceLSPManager? = nil) {
@@ -378,14 +377,13 @@ final class TabsManager {
     /// case where a persisted external tab is restored before any in-worktree
     /// file has started the language server.
     func ensureExternalLSPOpen(tabId: TabID) {
-        guard !openedExternalDocs.contains(tabId), !pendingExternalOpens.contains(tabId) else { return }
+        guard !openedExternalDocs.contains(tabId), pendingExternalOpenTasks[tabId] == nil else { return }
         guard let lsp,
               let info = externalLSPInfo[tabId],
               let entry = externalTabURLs[tabId] else { return }
         let absoluteURL = entry.url
         let contents = bufferStore.externalBuffer(worktreeId: entry.worktreeId, absoluteURL: absoluteURL).storage.string
-        pendingExternalOpens.insert(tabId)
-        Task { [weak self] in
+        let task = Task { [weak self] in
             let opened = await lsp.openExternalDocument(
                 absoluteURL: absoluteURL,
                 originatingWorktreeRoot: info.worktreeRoot,
@@ -394,10 +392,27 @@ final class TabsManager {
                 contents: contents
             )
             await MainActor.run { [weak self] in
-                self?.pendingExternalOpens.remove(tabId)
-                if opened { self?.openedExternalDocs.insert(tabId) }
+                guard let self else { return }
+                self.pendingExternalOpenTasks[tabId] = nil
+                // If the tab was discarded while the open was in flight, undo it
+                // so the URI doesn't leak on the holder until app exit.
+                if self.externalTabURLs[tabId] == nil {
+                    if opened {
+                        Task { [lsp, info] in
+                            await lsp.closeExternalDocument(
+                                absoluteURL: absoluteURL,
+                                originatingWorktreeRoot: info.worktreeRoot,
+                                originatingFileURL: info.originatingFileURL,
+                                language: info.language
+                            )
+                        }
+                    }
+                    return
+                }
+                if opened { self.openedExternalDocs.insert(tabId) }
             }
         }
+        pendingExternalOpenTasks[tabId] = task
     }
 
     /// Updates the LSP info recorded for an external tab (called by the
@@ -444,6 +459,12 @@ final class TabsManager {
         // externalBuffers cache rather than the in-worktree `buffers` dict.
         if let ext = externalTabURLs.removeValue(forKey: tabId) {
             assert(ext.worktreeId == worktreeId, "discardBuffer called with worktreeId=\(worktreeId) but external buffer is owned by \(ext.worktreeId)")
+            // Cancel any in-flight open Task so it bails out before recording
+            // the stale tabId in openedExternalDocs. The Task's completion
+            // handler will also re-check externalTabURLs and undo the open if
+            // the LSP request had already been sent before cancellation.
+            pendingExternalOpenTasks[tabId]?.cancel()
+            pendingExternalOpenTasks[tabId] = nil
             // Fire closeExternalDocument to release the LSP ref that was
             // acquired in externalBuffer(...) on cache miss.
             if let info = externalLSPInfo.removeValue(forKey: tabId), let lsp {
@@ -458,7 +479,6 @@ final class TabsManager {
                 }
             }
             openedExternalDocs.remove(tabId)
-            pendingExternalOpens.remove(tabId)
             bufferStore.discardExternalBuffer(worktreeId: ext.worktreeId, absoluteURL: ext.url)
             return
         }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -25,6 +25,7 @@ final class CodeEditorCoordinator {
     private var lastAppliedReveal: (tabId: TabID, line: Int, character: Int)?
     private var currentExternalAbsolutePath: String?
     private var currentOriginatingWorktreeRoot: URL?
+    private var currentOriginatingRelativePath: String?
 
     private var diagnosticsTask: Task<Void, Never>?
     private var diagnosticsSetupTask: Task<Void, Never>?
@@ -80,7 +81,7 @@ final class CodeEditorCoordinator {
         self.appState = appState
     }
 
-    func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, worktreeRoot: URL, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil) {
+    func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, worktreeRoot: URL, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil, originatingRelativePath: String? = nil) {
         self.textView = textView
         self.layoutManager = layoutManager
         self.currentWorktreeId = worktreeId
@@ -89,8 +90,10 @@ final class CodeEditorCoordinator {
         self.currentExternalAbsolutePath = externalAbsolutePath
         if externalAbsolutePath != nil {
             currentOriginatingWorktreeRoot = worktreeRoot
+            currentOriginatingRelativePath = originatingRelativePath
         } else {
             currentOriginatingWorktreeRoot = nil
+            currentOriginatingRelativePath = nil
         }
 
         let family = appState.config.code.fontFamily
@@ -168,11 +171,18 @@ final class CodeEditorCoordinator {
                         revealCharacter: character
                     )
                 } else {
+                    // Pass the current in-worktree file as the originating
+                    // path so LSP traffic for the external file is routed to
+                    // the correct holder in nested-package layouts.
+                    let originatingRel = self.currentExternalAbsolutePath == nil
+                        ? self.currentRelativePath
+                        : self.currentOriginatingRelativePath
                     self.appState.tabs.openExternalEditor(
                         worktreeId: wid,
                         absoluteURL: url,
                         revealLine: line,
-                        revealCharacter: character
+                        revealCharacter: character,
+                        originatingRelativePath: originatingRel
                     )
                 }
             }
@@ -206,10 +216,12 @@ final class CodeEditorCoordinator {
            let lang = currentLanguage {
             let url = URL(fileURLWithPath: abs)
             let contents = buffer.storage.string
+            let originatingFileURL: URL? = currentOriginatingRelativePath.map { originating.appendingPathComponent($0) }
             Task { [appState = appState] in
                 await appState.lsp.openExternalDocument(
                     absoluteURL: url,
                     originatingWorktreeRoot: originating,
+                    originatingFileURL: originatingFileURL,
                     language: lang,
                     contents: contents
                 )
@@ -219,7 +231,7 @@ final class CodeEditorCoordinator {
         applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
     }
 
-    func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil) {
+    func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil, originatingRelativePath: String? = nil) {
         let nextLanguage: String?
         if let abs = externalAbsolutePath {
             nextLanguage = appState.lsp.language(forFileExtension: (abs as NSString).pathExtension)
@@ -260,10 +272,12 @@ final class CodeEditorCoordinator {
                oldAbs != externalAbsolutePath {
                 let url = URL(fileURLWithPath: oldAbs)
                 let appState = self.appState
+                let oldOriginatingFileURL: URL? = currentOriginatingRelativePath.map { originating.appendingPathComponent($0) }
                 Task {
                     await appState.lsp.closeExternalDocument(
                         absoluteURL: url,
                         originatingWorktreeRoot: originating,
+                        originatingFileURL: oldOriginatingFileURL,
                         language: lang
                     )
                 }
@@ -274,8 +288,10 @@ final class CodeEditorCoordinator {
             currentExternalAbsolutePath = externalAbsolutePath
             if externalAbsolutePath != nil {
                 currentOriginatingWorktreeRoot = worktreeRoot
+                currentOriginatingRelativePath = originatingRelativePath
             } else {
                 currentOriginatingWorktreeRoot = nil
+                currentOriginatingRelativePath = nil
             }
 
             // Fetch (and if needed, create) the buffer for the new tab and
@@ -313,10 +329,12 @@ final class CodeEditorCoordinator {
                let lang = currentLanguage {
                 let url = URL(fileURLWithPath: abs)
                 let contents = nextBuffer.storage.string
+                let originatingFileURL: URL? = currentOriginatingRelativePath.map { originating.appendingPathComponent($0) }
                 Task { [appState = appState] in
                     await appState.lsp.openExternalDocument(
                         absoluteURL: url,
                         originatingWorktreeRoot: originating,
+                        originatingFileURL: originatingFileURL,
                         language: lang,
                         contents: contents
                     )
@@ -391,16 +409,19 @@ final class CodeEditorCoordinator {
            let lang = currentLanguage {
             let url = URL(fileURLWithPath: abs)
             let appState = self.appState
+            let originatingFileURL: URL? = currentOriginatingRelativePath.map { originating.appendingPathComponent($0) }
             Task {
                 await appState.lsp.closeExternalDocument(
                     absoluteURL: url,
                     originatingWorktreeRoot: originating,
+                    originatingFileURL: originatingFileURL,
                     language: lang
                 )
             }
         }
         currentExternalAbsolutePath = nil
         currentOriginatingWorktreeRoot = nil
+        currentOriginatingRelativePath = nil
         if let buffer, let token = editObserverToken {
             buffer.removeOnEdit(token)
         }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -210,23 +210,9 @@ final class CodeEditorCoordinator {
             }
         )
 
-        if buffer.isExternal,
-           let abs = currentExternalAbsolutePath,
-           let originating = currentOriginatingWorktreeRoot,
-           let lang = currentLanguage {
-            let url = URL(fileURLWithPath: abs)
-            let contents = buffer.storage.string
-            let originatingFileURL: URL? = currentOriginatingRelativePath.map { originating.appendingPathComponent($0) }
-            Task { [appState = appState] in
-                await appState.lsp.openExternalDocument(
-                    absoluteURL: url,
-                    originatingWorktreeRoot: originating,
-                    originatingFileURL: originatingFileURL,
-                    language: lang,
-                    contents: contents
-                )
-            }
-        }
+        // LSP open/close for external buffers is managed by TabsManager
+        // (tied to the buffer's cached lifetime), not by the coordinator
+        // (which is torn down on every tab switch by SwiftUI's dismantleNSView).
 
         applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
     }
@@ -331,7 +317,10 @@ final class CodeEditorCoordinator {
                 textView?.isEditable = true
             }
 
-            // If switching to a new external, open its LSP document.
+            // If the origin changed for an external buffer, open the LSP
+            // document under the NEW holder (the close-old Task fired above
+            // released the ref on the old holder). Also update the manager's
+            // externalLSPInfo so discardBuffer closes the right holder.
             if nextBuffer.isExternal,
                let abs = externalAbsolutePath,
                let originating = currentOriginatingWorktreeRoot,
@@ -339,6 +328,12 @@ final class CodeEditorCoordinator {
                 let url = URL(fileURLWithPath: abs)
                 let contents = nextBuffer.storage.string
                 let originatingFileURL: URL? = currentOriginatingRelativePath.map { originating.appendingPathComponent($0) }
+                appState.tabs.updateExternalLSPInfo(
+                    tabId: tabId,
+                    worktreeRoot: originating,
+                    originatingFileURL: originatingFileURL,
+                    language: lang
+                )
                 Task { [appState = appState] in
                     await appState.lsp.openExternalDocument(
                         absoluteURL: url,
@@ -413,21 +408,10 @@ final class CodeEditorCoordinator {
     }
 
     func detach() {
-        if let abs = currentExternalAbsolutePath,
-           let originating = currentOriginatingWorktreeRoot,
-           let lang = currentLanguage {
-            let url = URL(fileURLWithPath: abs)
-            let appState = self.appState
-            let originatingFileURL: URL? = currentOriginatingRelativePath.map { originating.appendingPathComponent($0) }
-            Task {
-                await appState.lsp.closeExternalDocument(
-                    absoluteURL: url,
-                    originatingWorktreeRoot: originating,
-                    originatingFileURL: originatingFileURL,
-                    language: lang
-                )
-            }
-        }
+        // LSP open/close for external buffers is managed by TabsManager
+        // (tied to the buffer's cached lifetime), not by the coordinator
+        // (which is torn down on every tab switch by SwiftUI's dismantleNSView).
+        // Do NOT call closeExternalDocument here.
         currentExternalAbsolutePath = nil
         currentOriginatingWorktreeRoot = nil
         currentOriginatingRelativePath = nil

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -287,6 +287,7 @@ final class CodeEditorCoordinator {
             if let abs = externalAbsolutePath {
                 nextBuffer = appState.tabs.externalBuffer(
                     worktreeId: worktreeId,
+                    tabId: tabId,
                     absoluteURL: URL(fileURLWithPath: abs)
                 )
             } else {

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -23,6 +23,7 @@ final class CodeEditorCoordinator {
     private var currentFontFamily: String?
     private var currentFontSize: CGFloat?
     private var lastAppliedReveal: (tabId: TabID, line: Int, character: Int)?
+    private var currentExternalAbsolutePath: String?
 
     private var diagnosticsTask: Task<Void, Never>?
     private var diagnosticsSetupTask: Task<Void, Never>?
@@ -78,12 +79,13 @@ final class CodeEditorCoordinator {
         self.appState = appState
     }
 
-    func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme) {
+    func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil) {
         self.textView = textView
         self.layoutManager = layoutManager
         self.currentWorktreeId = worktreeId
         self.currentTabId = tabId
         self.currentTheme = theme
+        self.currentExternalAbsolutePath = externalAbsolutePath
 
         let family = appState.config.code.fontFamily
         let size = CGFloat(appState.config.code.fontSize)
@@ -96,25 +98,45 @@ final class CodeEditorCoordinator {
 
         bindBuffer(buffer, theme: theme)
 
+        if buffer.isExternal {
+            textView.isEditable = false
+        }
+
         hover = HoverFeature(
             textView: textView,
             getClient: { [weak self] in
-                guard let self, let root = self.currentRoot, let rel = self.currentRelativePath, let lang = self.currentLanguage else { return nil }
+                guard let self, let root = self.currentRoot, let lang = self.currentLanguage else { return nil }
+                if self.currentExternalAbsolutePath != nil {
+                    return self.appState.lsp.client(forFile: root, worktreeRoot: root, language: lang)
+                }
+                guard let rel = self.currentRelativePath else { return nil }
                 return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
             },
             getURI: { [weak self] in
-                guard let self, let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
+                guard let self else { return nil }
+                if let abs = self.currentExternalAbsolutePath {
+                    return URL(fileURLWithPath: abs).lspURI
+                }
+                guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return root.appendingPathComponent(rel).lspURI
             }
         )
         definition = DefinitionFeature(
             textView: textView,
             getClient: { [weak self] in
-                guard let self, let root = self.currentRoot, let rel = self.currentRelativePath, let lang = self.currentLanguage else { return nil }
+                guard let self, let root = self.currentRoot, let lang = self.currentLanguage else { return nil }
+                if self.currentExternalAbsolutePath != nil {
+                    return self.appState.lsp.client(forFile: root, worktreeRoot: root, language: lang)
+                }
+                guard let rel = self.currentRelativePath else { return nil }
                 return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
             },
             getURI: { [weak self] in
-                guard let self, let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
+                guard let self else { return nil }
+                if let abs = self.currentExternalAbsolutePath {
+                    return URL(fileURLWithPath: abs).lspURI
+                }
+                guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return root.appendingPathComponent(rel).lspURI
             },
             openTarget: { [weak self] url, line, character in
@@ -142,27 +164,51 @@ final class CodeEditorCoordinator {
             getClient: { [weak self] in
                 guard let self,
                       let root = self.currentRoot,
-                      let rel = self.currentRelativePath,
                       let lang = self.currentLanguage else { return nil }
+                if self.currentExternalAbsolutePath != nil {
+                    return self.appState.lsp.client(forFile: root, worktreeRoot: root, language: lang)
+                }
+                guard let rel = self.currentRelativePath else { return nil }
                 return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
             },
             getURI: { [weak self] in
-                guard let self,
-                      let root = self.currentRoot,
+                guard let self else { return nil }
+                if let abs = self.currentExternalAbsolutePath {
+                    return URL(fileURLWithPath: abs).lspURI
+                }
+                guard let root = self.currentRoot,
                       let rel = self.currentRelativePath else { return nil }
                 return root.appendingPathComponent(rel).lspURI
             }
         )
+
+        if buffer.isExternal,
+           let abs = currentExternalAbsolutePath,
+           let root = currentRoot,
+           let lang = currentLanguage {
+            let url = URL(fileURLWithPath: abs)
+            let contents = buffer.storage.string
+            Task { [appState = appState] in
+                await appState.lsp.openExternalDocument(
+                    absoluteURL: url,
+                    originatingWorktreeRoot: root,
+                    language: lang,
+                    contents: contents
+                )
+            }
+        }
+
         applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
     }
 
-    func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme) {
+    func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil) {
         let nextLanguage = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
         let pathChanged = currentWorktreeId != worktreeId
             || currentTabId != tabId
             || currentRoot != worktreeRoot
             || currentRelativePath != relativePath
             || currentLanguage != nextLanguage
+            || currentExternalAbsolutePath != externalAbsolutePath
 
         if pathChanged {
             didChangeTask?.cancel()
@@ -170,20 +216,70 @@ final class CodeEditorCoordinator {
             pendingTextEdits.removeAll()
             let session = highlightSession
             Task { await session.reset() }
+
+            // If switching away from an external, close the old LSP document.
+            if let oldAbs = currentExternalAbsolutePath,
+               let root = currentRoot,
+               let lang = currentLanguage,
+               oldAbs != externalAbsolutePath {
+                let url = URL(fileURLWithPath: oldAbs)
+                let appState = self.appState
+                Task {
+                    await appState.lsp.closeExternalDocument(
+                        absoluteURL: url,
+                        originatingWorktreeRoot: root,
+                        language: lang
+                    )
+                }
+            }
+
             currentWorktreeId = worktreeId
             currentTabId = tabId
+            currentExternalAbsolutePath = externalAbsolutePath
+
             // Fetch (and if needed, create) the buffer for the new tab and
             // re-bind the layout manager onto its storage. Without this swap
             // the text view keeps rendering the *previous* buffer's storage,
             // so every editor tab appears to show the file that was opened
             // first.
-            let nextBuffer = appState.tabs.buffer(
-                worktreeId: worktreeId,
-                tabId: tabId,
-                worktreeRoot: worktreeRoot,
-                relativePath: relativePath
-            )
+            let nextBuffer: EditorBuffer
+            if let abs = externalAbsolutePath {
+                nextBuffer = appState.tabs.externalBuffer(
+                    worktreeId: worktreeId,
+                    absoluteURL: URL(fileURLWithPath: abs)
+                )
+            } else {
+                nextBuffer = appState.tabs.buffer(
+                    worktreeId: worktreeId,
+                    tabId: tabId,
+                    worktreeRoot: worktreeRoot,
+                    relativePath: relativePath
+                )
+            }
             bindBuffer(nextBuffer, theme: theme)
+
+            if nextBuffer.isExternal {
+                textView?.isEditable = false
+            } else {
+                textView?.isEditable = true
+            }
+
+            // If switching to a new external, open its LSP document.
+            if nextBuffer.isExternal,
+               let abs = externalAbsolutePath,
+               let root = currentRoot,
+               let lang = currentLanguage {
+                let url = URL(fileURLWithPath: abs)
+                let contents = nextBuffer.storage.string
+                Task { [appState = appState] in
+                    await appState.lsp.openExternalDocument(
+                        absoluteURL: url,
+                        originatingWorktreeRoot: root,
+                        language: lang,
+                        contents: contents
+                    )
+                }
+            }
         }
 
         if currentTheme != theme {
@@ -248,6 +344,20 @@ final class CodeEditorCoordinator {
     }
 
     func detach() {
+        if let abs = currentExternalAbsolutePath,
+           let root = currentRoot,
+           let lang = currentLanguage {
+            let url = URL(fileURLWithPath: abs)
+            let appState = self.appState
+            Task {
+                await appState.lsp.closeExternalDocument(
+                    absoluteURL: url,
+                    originatingWorktreeRoot: root,
+                    language: lang
+                )
+            }
+        }
+        currentExternalAbsolutePath = nil
         if let buffer, let token = editObserverToken {
             buffer.removeOnEdit(token)
         }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -260,10 +260,10 @@ final class CodeEditorCoordinator {
             let session = highlightSession
             Task { await session.reset() }
 
-            // If switching away from an external (or reusing the same external from a
-            // different originating path), close the old LSP document first.
             // Capture old values into locals BEFORE mutating the current* properties
-            // so the close goes to the right holder.
+            // so the close goes to the right holder, and so we can compute the
+            // isSameTabOriginChange gate from pre-mutation state.
+            let oldTabId = currentTabId
             let oldAbs = currentExternalAbsolutePath
             let oldOriginatingRoot = currentOriginatingWorktreeRoot
             let oldOriginatingRelPath = currentOriginatingRelativePath
@@ -280,10 +280,21 @@ final class CodeEditorCoordinator {
                 currentOriginatingRelativePath = nil
             }
 
-            if let oldAbs,
+            // Only fire the close-old/open-new pair when this is a genuine
+            // same-tab origin change (same tabId, same external abs path, but
+            // the originating in-worktree path changed). When the coordinator
+            // is reused for a DIFFERENT tab the manager's discardBuffer path
+            // owns the old tab's LSP ref — firing close here would prematurely
+            // release it while the old tab is still open.
+            let isSameTabOriginChange = (oldTabId == tabId)
+                && (oldAbs == externalAbsolutePath)
+                && (oldAbs != nil)
+
+            if isSameTabOriginChange,
+               let oldAbs,
                let originating = oldOriginatingRoot,
                let lang = oldLang,
-               (oldAbs != externalAbsolutePath || oldOriginatingRelPath != originatingRelativePath) {
+               oldOriginatingRelPath != originatingRelativePath {
                 let url = URL(fileURLWithPath: oldAbs)
                 let appState = self.appState
                 let oldOriginatingFileURL: URL? = oldOriginatingRelPath.map { originating.appendingPathComponent($0) }
@@ -325,11 +336,14 @@ final class CodeEditorCoordinator {
                 textView?.isEditable = true
             }
 
-            // If the origin changed for an external buffer, open the LSP
-            // document under the NEW holder (the close-old Task fired above
-            // released the ref on the old holder). Also update the manager's
-            // externalLSPInfo so discardBuffer closes the right holder.
-            if nextBuffer.isExternal,
+            // If the origin changed for an external buffer on the SAME tab,
+            // open the LSP document under the NEW holder (the close-old Task
+            // fired above released the ref on the old holder). Also update the
+            // manager's externalLSPInfo so discardBuffer closes the right holder.
+            // For tab swaps (different tabId), TabsManager's externalBuffer call
+            // above already drives ensureExternalLSPOpen for the new tab.
+            if isSameTabOriginChange,
+               nextBuffer.isExternal,
                let abs = externalAbsolutePath,
                let originating = currentOriginatingWorktreeRoot,
                let lang = currentLanguage {

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -174,15 +174,21 @@ final class CodeEditorCoordinator {
                     // Pass the current in-worktree file as the originating
                     // path so LSP traffic for the external file is routed to
                     // the correct holder in nested-package layouts.
+                    // Also pass the worktree root and language so TabsManager
+                    // can rebind the LSP holder even when the tab is inactive.
                     let originatingRel = self.currentExternalAbsolutePath == nil
                         ? self.currentRelativePath
                         : self.currentOriginatingRelativePath
+                    let originatingRoot = self.currentOriginatingWorktreeRoot ?? self.currentRoot
+                    let lang = self.currentLanguage
                     self.appState.tabs.openExternalEditor(
                         worktreeId: wid,
                         absoluteURL: url,
                         revealLine: line,
                         revealCharacter: character,
-                        originatingRelativePath: originatingRel
+                        originatingRelativePath: originatingRel,
+                        originatingWorktreeRoot: originatingRoot,
+                        language: lang
                     )
                 }
             }
@@ -260,15 +266,6 @@ final class CodeEditorCoordinator {
             let session = highlightSession
             Task { await session.reset() }
 
-            // Capture old values into locals BEFORE mutating the current* properties
-            // so the close goes to the right holder, and so we can compute the
-            // isSameTabOriginChange gate from pre-mutation state.
-            let oldTabId = currentTabId
-            let oldAbs = currentExternalAbsolutePath
-            let oldOriginatingRoot = currentOriginatingWorktreeRoot
-            let oldOriginatingRelPath = currentOriginatingRelativePath
-            let oldLang = currentLanguage
-
             currentWorktreeId = worktreeId
             currentTabId = tabId
             currentExternalAbsolutePath = externalAbsolutePath
@@ -278,34 +275,6 @@ final class CodeEditorCoordinator {
             } else {
                 currentOriginatingWorktreeRoot = nil
                 currentOriginatingRelativePath = nil
-            }
-
-            // Only fire the close-old/open-new pair when this is a genuine
-            // same-tab origin change (same tabId, same external abs path, but
-            // the originating in-worktree path changed). When the coordinator
-            // is reused for a DIFFERENT tab the manager's discardBuffer path
-            // owns the old tab's LSP ref — firing close here would prematurely
-            // release it while the old tab is still open.
-            let isSameTabOriginChange = (oldTabId == tabId)
-                && (oldAbs == externalAbsolutePath)
-                && (oldAbs != nil)
-
-            if isSameTabOriginChange,
-               let oldAbs,
-               let originating = oldOriginatingRoot,
-               let lang = oldLang,
-               oldOriginatingRelPath != originatingRelativePath {
-                let url = URL(fileURLWithPath: oldAbs)
-                let appState = self.appState
-                let oldOriginatingFileURL: URL? = oldOriginatingRelPath.map { originating.appendingPathComponent($0) }
-                Task {
-                    await appState.lsp.closeExternalDocument(
-                        absoluteURL: url,
-                        originatingWorktreeRoot: originating,
-                        originatingFileURL: oldOriginatingFileURL,
-                        language: lang
-                    )
-                }
             }
 
             // Fetch (and if needed, create) the buffer for the new tab and
@@ -345,37 +314,12 @@ final class CodeEditorCoordinator {
             } else {
                 textView?.isEditable = true
             }
-
-            // If the origin changed for an external buffer on the SAME tab,
-            // open the LSP document under the NEW holder (the close-old Task
-            // fired above released the ref on the old holder). Also update the
-            // manager's externalLSPInfo so discardBuffer closes the right holder.
-            // For tab swaps (different tabId), TabsManager's externalBuffer call
-            // above already drives ensureExternalLSPOpen for the new tab.
-            if isSameTabOriginChange,
-               nextBuffer.isExternal,
-               let abs = externalAbsolutePath,
-               let originating = currentOriginatingWorktreeRoot,
-               let lang = currentLanguage {
-                let url = URL(fileURLWithPath: abs)
-                let contents = nextBuffer.storage.string
-                let originatingFileURL: URL? = currentOriginatingRelativePath.map { originating.appendingPathComponent($0) }
-                appState.tabs.updateExternalLSPInfo(
-                    tabId: tabId,
-                    worktreeRoot: originating,
-                    originatingFileURL: originatingFileURL,
-                    language: lang
-                )
-                Task { [appState = appState] in
-                    await appState.lsp.openExternalDocument(
-                        absoluteURL: url,
-                        originatingWorktreeRoot: originating,
-                        originatingFileURL: originatingFileURL,
-                        language: lang,
-                        contents: contents
-                    )
-                }
-            }
+            // Note: origin-change rebinding (close-old-holder / open-new-holder)
+            // is now handled entirely by TabsManager.rebindExternalLSPHolder,
+            // which runs at openExternalEditor() time regardless of tab activation.
+            // The coordinator's externalBuffer() call above drives
+            // ensureExternalLSPOpen for the common case where the tab is active
+            // but the origin didn't change (normal tab switch).
         }
 
         if currentTheme != theme {

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -112,9 +112,10 @@ final class CodeEditorCoordinator {
             textView: textView,
             getClient: { [weak self] in
                 guard let self, let lang = self.currentLanguage else { return nil }
-                if self.currentExternalAbsolutePath != nil,
+                if let abs = self.currentExternalAbsolutePath,
                    let originating = self.currentOriginatingWorktreeRoot {
-                    return self.appState.lsp.client(forFile: originating, worktreeRoot: originating, language: lang)
+                    let absURL = URL(fileURLWithPath: abs)
+                    return self.appState.lsp.client(forFile: absURL, worktreeRoot: originating, language: lang)
                 }
                 guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
@@ -132,9 +133,10 @@ final class CodeEditorCoordinator {
             textView: textView,
             getClient: { [weak self] in
                 guard let self, let lang = self.currentLanguage else { return nil }
-                if self.currentExternalAbsolutePath != nil,
+                if let abs = self.currentExternalAbsolutePath,
                    let originating = self.currentOriginatingWorktreeRoot {
-                    return self.appState.lsp.client(forFile: originating, worktreeRoot: originating, language: lang)
+                    let absURL = URL(fileURLWithPath: abs)
+                    return self.appState.lsp.client(forFile: absURL, worktreeRoot: originating, language: lang)
                 }
                 guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
@@ -179,9 +181,10 @@ final class CodeEditorCoordinator {
             textView: textView,
             getClient: { [weak self] in
                 guard let self, let lang = self.currentLanguage else { return nil }
-                if self.currentExternalAbsolutePath != nil,
+                if let abs = self.currentExternalAbsolutePath,
                    let originating = self.currentOriginatingWorktreeRoot {
-                    return self.appState.lsp.client(forFile: originating, worktreeRoot: originating, language: lang)
+                    let absURL = URL(fileURLWithPath: abs)
+                    return self.appState.lsp.client(forFile: absURL, worktreeRoot: originating, language: lang)
                 }
                 guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
@@ -217,7 +220,12 @@ final class CodeEditorCoordinator {
     }
 
     func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil) {
-        let nextLanguage = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+        let nextLanguage: String?
+        if let abs = externalAbsolutePath {
+            nextLanguage = appState.lsp.language(forFileExtension: (abs as NSString).pathExtension)
+        } else {
+            nextLanguage = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+        }
         let pathChanged = currentWorktreeId != worktreeId
             || currentTabId != tabId
             || currentRoot != worktreeRoot

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -148,23 +148,31 @@ final class CodeEditorCoordinator {
                 return root.appendingPathComponent(rel).lspURI
             },
             openTarget: { [weak self] url, line, character in
-                guard let self, let root = self.currentRoot, let wid = self.currentWorktreeId else { return }
-                // Targets outside the current worktree (SDK headers,
-                // DerivedData, modulemap files) are dropped on the floor for
-                // now — `appendingPathComponent` would treat the absolute
-                // path as a sub-path of the worktree and the editor would
-                // open a bogus `<worktree>/<abs>` location. v1.5 will route
-                // these via absolute URLs so they can be opened in a new tab.
+                guard let self,
+                      let wid = self.currentWorktreeId else { return }
+                // For external buffers, the originating worktree root is the
+                // anchor for in-worktree-vs-external classification, not the
+                // sentinel that bindBuffer set on currentRoot.
+                let anchor = self.currentOriginatingWorktreeRoot ?? self.currentRoot
+                guard let root = anchor else { return }
                 let abs = url.path
                 let prefix = root.path + "/"
-                guard abs.hasPrefix(prefix) else { return }
-                let rel = String(abs.dropFirst(prefix.count))
-                self.appState.tabs.openEditor(
-                    worktreeId: wid,
-                    relativePath: rel,
-                    revealLine: line,
-                    revealCharacter: character
-                )
+                if abs.hasPrefix(prefix) {
+                    let rel = String(abs.dropFirst(prefix.count))
+                    self.appState.tabs.openEditor(
+                        worktreeId: wid,
+                        relativePath: rel,
+                        revealLine: line,
+                        revealCharacter: character
+                    )
+                } else {
+                    self.appState.tabs.openExternalEditor(
+                        worktreeId: wid,
+                        absoluteURL: url,
+                        revealLine: line,
+                        revealCharacter: character
+                    )
+                }
             }
         )
         hoverHighlight = HoverHighlightFeature(

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -416,6 +416,7 @@ final class CodeEditorCoordinator {
         textView?.hoverHandler = nil
         textView?.commandClickHandler = nil
         textView?.flagsChangedHandler = nil
+        textView?.mouseExitedHandler = nil
         textView?.increaseFontSizeHandler = nil
         textView?.decreaseFontSizeHandler = nil
         textView?.resetFontSizeHandler = nil

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -24,6 +24,7 @@ final class CodeEditorCoordinator {
     private var currentFontSize: CGFloat?
     private var lastAppliedReveal: (tabId: TabID, line: Int, character: Int)?
     private var currentExternalAbsolutePath: String?
+    private var currentOriginatingWorktreeRoot: URL?
 
     private var diagnosticsTask: Task<Void, Never>?
     private var diagnosticsSetupTask: Task<Void, Never>?
@@ -79,13 +80,18 @@ final class CodeEditorCoordinator {
         self.appState = appState
     }
 
-    func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil) {
+    func attach(textView: CodeTextView, buffer: EditorBuffer, layoutManager: NSLayoutManager, worktreeId: String, worktreeRoot: URL, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil) {
         self.textView = textView
         self.layoutManager = layoutManager
         self.currentWorktreeId = worktreeId
         self.currentTabId = tabId
         self.currentTheme = theme
         self.currentExternalAbsolutePath = externalAbsolutePath
+        if externalAbsolutePath != nil {
+            currentOriginatingWorktreeRoot = worktreeRoot
+        } else {
+            currentOriginatingWorktreeRoot = nil
+        }
 
         let family = appState.config.code.fontFamily
         let size = CGFloat(appState.config.code.fontSize)
@@ -105,11 +111,12 @@ final class CodeEditorCoordinator {
         hover = HoverFeature(
             textView: textView,
             getClient: { [weak self] in
-                guard let self, let root = self.currentRoot, let lang = self.currentLanguage else { return nil }
-                if self.currentExternalAbsolutePath != nil {
-                    return self.appState.lsp.client(forFile: root, worktreeRoot: root, language: lang)
+                guard let self, let lang = self.currentLanguage else { return nil }
+                if self.currentExternalAbsolutePath != nil,
+                   let originating = self.currentOriginatingWorktreeRoot {
+                    return self.appState.lsp.client(forFile: originating, worktreeRoot: originating, language: lang)
                 }
-                guard let rel = self.currentRelativePath else { return nil }
+                guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
             },
             getURI: { [weak self] in
@@ -124,11 +131,12 @@ final class CodeEditorCoordinator {
         definition = DefinitionFeature(
             textView: textView,
             getClient: { [weak self] in
-                guard let self, let root = self.currentRoot, let lang = self.currentLanguage else { return nil }
-                if self.currentExternalAbsolutePath != nil {
-                    return self.appState.lsp.client(forFile: root, worktreeRoot: root, language: lang)
+                guard let self, let lang = self.currentLanguage else { return nil }
+                if self.currentExternalAbsolutePath != nil,
+                   let originating = self.currentOriginatingWorktreeRoot {
+                    return self.appState.lsp.client(forFile: originating, worktreeRoot: originating, language: lang)
                 }
-                guard let rel = self.currentRelativePath else { return nil }
+                guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
             },
             getURI: { [weak self] in
@@ -162,13 +170,12 @@ final class CodeEditorCoordinator {
         hoverHighlight = HoverHighlightFeature(
             textView: textView,
             getClient: { [weak self] in
-                guard let self,
-                      let root = self.currentRoot,
-                      let lang = self.currentLanguage else { return nil }
-                if self.currentExternalAbsolutePath != nil {
-                    return self.appState.lsp.client(forFile: root, worktreeRoot: root, language: lang)
+                guard let self, let lang = self.currentLanguage else { return nil }
+                if self.currentExternalAbsolutePath != nil,
+                   let originating = self.currentOriginatingWorktreeRoot {
+                    return self.appState.lsp.client(forFile: originating, worktreeRoot: originating, language: lang)
                 }
-                guard let rel = self.currentRelativePath else { return nil }
+                guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
             },
             getURI: { [weak self] in
@@ -184,14 +191,14 @@ final class CodeEditorCoordinator {
 
         if buffer.isExternal,
            let abs = currentExternalAbsolutePath,
-           let root = currentRoot,
+           let originating = currentOriginatingWorktreeRoot,
            let lang = currentLanguage {
             let url = URL(fileURLWithPath: abs)
             let contents = buffer.storage.string
             Task { [appState = appState] in
                 await appState.lsp.openExternalDocument(
                     absoluteURL: url,
-                    originatingWorktreeRoot: root,
+                    originatingWorktreeRoot: originating,
                     language: lang,
                     contents: contents
                 )
@@ -219,7 +226,7 @@ final class CodeEditorCoordinator {
 
             // If switching away from an external, close the old LSP document.
             if let oldAbs = currentExternalAbsolutePath,
-               let root = currentRoot,
+               let originating = currentOriginatingWorktreeRoot,
                let lang = currentLanguage,
                oldAbs != externalAbsolutePath {
                 let url = URL(fileURLWithPath: oldAbs)
@@ -227,7 +234,7 @@ final class CodeEditorCoordinator {
                 Task {
                     await appState.lsp.closeExternalDocument(
                         absoluteURL: url,
-                        originatingWorktreeRoot: root,
+                        originatingWorktreeRoot: originating,
                         language: lang
                     )
                 }
@@ -236,6 +243,11 @@ final class CodeEditorCoordinator {
             currentWorktreeId = worktreeId
             currentTabId = tabId
             currentExternalAbsolutePath = externalAbsolutePath
+            if externalAbsolutePath != nil {
+                currentOriginatingWorktreeRoot = worktreeRoot
+            } else {
+                currentOriginatingWorktreeRoot = nil
+            }
 
             // Fetch (and if needed, create) the buffer for the new tab and
             // re-bind the layout manager onto its storage. Without this swap
@@ -267,14 +279,14 @@ final class CodeEditorCoordinator {
             // If switching to a new external, open its LSP document.
             if nextBuffer.isExternal,
                let abs = externalAbsolutePath,
-               let root = currentRoot,
+               let originating = currentOriginatingWorktreeRoot,
                let lang = currentLanguage {
                 let url = URL(fileURLWithPath: abs)
                 let contents = nextBuffer.storage.string
                 Task { [appState = appState] in
                     await appState.lsp.openExternalDocument(
                         absoluteURL: url,
-                        originatingWorktreeRoot: root,
+                        originatingWorktreeRoot: originating,
                         language: lang,
                         contents: contents
                     )
@@ -345,19 +357,20 @@ final class CodeEditorCoordinator {
 
     func detach() {
         if let abs = currentExternalAbsolutePath,
-           let root = currentRoot,
+           let originating = currentOriginatingWorktreeRoot,
            let lang = currentLanguage {
             let url = URL(fileURLWithPath: abs)
             let appState = self.appState
             Task {
                 await appState.lsp.closeExternalDocument(
                     absoluteURL: url,
-                    originatingWorktreeRoot: root,
+                    originatingWorktreeRoot: originating,
                     language: lang
                 )
             }
         }
         currentExternalAbsolutePath = nil
+        currentOriginatingWorktreeRoot = nil
         if let buffer, let token = editObserverToken {
             buffer.removeOnEdit(token)
         }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -213,6 +213,14 @@ final class CodeEditorCoordinator {
         // LSP open/close for external buffers is managed by TabsManager
         // (tied to the buffer's cached lifetime), not by the coordinator
         // (which is torn down on every tab switch by SwiftUI's dismantleNSView).
+        // However, the initial open may have found no holder if the language
+        // server hadn't started yet (e.g. persisted external tab restored
+        // before any in-worktree file launches the server). Retry here so
+        // that when the coordinator re-attaches after a server is up,
+        // hover and ⌘-click start working without the user closing the tab.
+        if externalAbsolutePath != nil {
+            appState.tabs.ensureExternalLSPOpen(tabId: tabId)
+        }
 
         applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
     }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -226,12 +226,25 @@ final class CodeEditorCoordinator {
         } else {
             nextLanguage = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
         }
-        let pathChanged = currentWorktreeId != worktreeId
-            || currentTabId != tabId
-            || currentRoot != worktreeRoot
-            || currentRelativePath != relativePath
-            || currentLanguage != nextLanguage
-            || currentExternalAbsolutePath != externalAbsolutePath
+
+        let pathChanged: Bool
+        if externalAbsolutePath != nil || currentExternalAbsolutePath != nil {
+            // External-tab identity: only the (worktree, tabId, abs path) tuple matters.
+            // Don't compare currentRoot/currentRelativePath against the in-worktree
+            // worktreeRoot/relativePath — bindBuffer set them to sentinel values for
+            // the external buffer, which will never equal the parameters here.
+            // The || currentExternalAbsolutePath != nil clause catches the
+            // in-worktree-to-external and external-to-in-worktree transitions.
+            pathChanged = currentWorktreeId != worktreeId
+                || currentTabId != tabId
+                || currentExternalAbsolutePath != externalAbsolutePath
+        } else {
+            pathChanged = currentWorktreeId != worktreeId
+                || currentTabId != tabId
+                || currentRoot != worktreeRoot
+                || currentRelativePath != relativePath
+                || currentLanguage != nextLanguage
+        }
 
         if pathChanged {
             didChangeTask?.cancel()

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -250,6 +250,7 @@ final class CodeEditorCoordinator {
             pathChanged = currentWorktreeId != worktreeId
                 || currentTabId != tabId
                 || currentExternalAbsolutePath != externalAbsolutePath
+                || currentOriginatingRelativePath != originatingRelativePath
         } else {
             pathChanged = currentWorktreeId != worktreeId
                 || currentTabId != tabId
@@ -265,23 +266,14 @@ final class CodeEditorCoordinator {
             let session = highlightSession
             Task { await session.reset() }
 
-            // If switching away from an external, close the old LSP document.
-            if let oldAbs = currentExternalAbsolutePath,
-               let originating = currentOriginatingWorktreeRoot,
-               let lang = currentLanguage,
-               oldAbs != externalAbsolutePath {
-                let url = URL(fileURLWithPath: oldAbs)
-                let appState = self.appState
-                let oldOriginatingFileURL: URL? = currentOriginatingRelativePath.map { originating.appendingPathComponent($0) }
-                Task {
-                    await appState.lsp.closeExternalDocument(
-                        absoluteURL: url,
-                        originatingWorktreeRoot: originating,
-                        originatingFileURL: oldOriginatingFileURL,
-                        language: lang
-                    )
-                }
-            }
+            // If switching away from an external (or reusing the same external from a
+            // different originating path), close the old LSP document first.
+            // Capture old values into locals BEFORE mutating the current* properties
+            // so the close goes to the right holder.
+            let oldAbs = currentExternalAbsolutePath
+            let oldOriginatingRoot = currentOriginatingWorktreeRoot
+            let oldOriginatingRelPath = currentOriginatingRelativePath
+            let oldLang = currentLanguage
 
             currentWorktreeId = worktreeId
             currentTabId = tabId
@@ -292,6 +284,23 @@ final class CodeEditorCoordinator {
             } else {
                 currentOriginatingWorktreeRoot = nil
                 currentOriginatingRelativePath = nil
+            }
+
+            if let oldAbs,
+               let originating = oldOriginatingRoot,
+               let lang = oldLang,
+               (oldAbs != externalAbsolutePath || oldOriginatingRelPath != originatingRelativePath) {
+                let url = URL(fileURLWithPath: oldAbs)
+                let appState = self.appState
+                let oldOriginatingFileURL: URL? = oldOriginatingRelPath.map { originating.appendingPathComponent($0) }
+                Task {
+                    await appState.lsp.closeExternalDocument(
+                        absoluteURL: url,
+                        originatingWorktreeRoot: originating,
+                        originatingFileURL: oldOriginatingFileURL,
+                        language: lang
+                    )
+                }
             }
 
             // Fetch (and if needed, create) the buffer for the new tab and

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -36,6 +36,7 @@ final class CodeEditorCoordinator {
     let symbolsFeature = SymbolsFeature()
     private var hover: HoverFeature?
     private var definition: DefinitionFeature?
+    private var hoverHighlight: HoverHighlightFeature?
 
     private var editObserverToken: EditorBuffer.EditObserverToken?
     private var didChangeTask: Task<Void, Never>?
@@ -134,6 +135,22 @@ final class CodeEditorCoordinator {
                     revealLine: line,
                     revealCharacter: character
                 )
+            }
+        )
+        hoverHighlight = HoverHighlightFeature(
+            textView: textView,
+            getClient: { [weak self] in
+                guard let self,
+                      let root = self.currentRoot,
+                      let rel = self.currentRelativePath,
+                      let lang = self.currentLanguage else { return nil }
+                return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
+            },
+            getURI: { [weak self] in
+                guard let self,
+                      let root = self.currentRoot,
+                      let rel = self.currentRelativePath else { return nil }
+                return root.appendingPathComponent(rel).lspURI
             }
         )
         applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
@@ -252,6 +269,10 @@ final class CodeEditorCoordinator {
         layoutManager = nil
         hover = nil
         definition = nil
+        hoverHighlight = nil
+        textView?.hoverHandler = nil
+        textView?.commandClickHandler = nil
+        textView?.flagsChangedHandler = nil
         textView?.increaseFontSizeHandler = nil
         textView?.decreaseFontSizeHandler = nil
         textView?.resetFontSizeHandler = nil

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -315,10 +315,20 @@ final class CodeEditorCoordinator {
             // first.
             let nextBuffer: EditorBuffer
             if let abs = externalAbsolutePath {
+                let absURL = URL(fileURLWithPath: abs)
+                let originatingFileURL: URL? = originatingRelativePath.flatMap {
+                    worktreeRoot.appendingPathComponent($0)
+                }
+                let language = appState.lsp.language(
+                    forFileExtension: (abs as NSString).pathExtension
+                )
                 nextBuffer = appState.tabs.externalBuffer(
                     worktreeId: worktreeId,
                     tabId: tabId,
-                    absoluteURL: URL(fileURLWithPath: abs)
+                    absoluteURL: absURL,
+                    worktreeRoot: worktreeRoot,
+                    originatingFileURL: originatingFileURL,
+                    language: language
                 )
             } else {
                 nextBuffer = appState.tabs.buffer(

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -260,6 +260,7 @@ final class CodeEditorCoordinator {
         }
 
         if pathChanged {
+            hoverHighlight?.cancelAndClear()
             didChangeTask?.cancel()
             hasPendingDidChange = false
             pendingTextEdits.removeAll()

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -15,6 +15,7 @@ struct CodeEditorView: NSViewRepresentable {
     let revealLine: Int?
     let revealCharacter: Int?
     let appState: AppState
+    let externalAbsolutePath: String?
     /// Pulled from `appState.config.code.fontFamily` by the parent view's
     /// body so SwiftUI registers the dependency. NSViewRepresentable hooks
     /// (makeNSView/updateNSView) are not part of body evaluation, so reads
@@ -37,12 +38,20 @@ struct CodeEditorView: NSViewRepresentable {
         scroll.drawsBackground = true
         scroll.backgroundColor = NSColor(theme.color("bg-1"))
 
-        let buffer = appState.tabs.buffer(
-            worktreeId: worktreeId,
-            tabId: tabId,
-            worktreeRoot: worktreeRoot,
-            relativePath: relativePath
-        )
+        let buffer: EditorBuffer
+        if let abs = externalAbsolutePath {
+            buffer = appState.tabs.externalBuffer(
+                worktreeId: worktreeId,
+                absoluteURL: URL(fileURLWithPath: abs)
+            )
+        } else {
+            buffer = appState.tabs.buffer(
+                worktreeId: worktreeId,
+                tabId: tabId,
+                worktreeRoot: worktreeRoot,
+                relativePath: relativePath
+            )
+        }
 
         // Build the TextKit 1 chain. The coordinator owns the
         // storage<->layoutManager binding (see `bindBuffer`) so that swapping
@@ -82,7 +91,8 @@ struct CodeEditorView: NSViewRepresentable {
             tabId: tabId,
             revealLine: revealLine,
             revealCharacter: revealCharacter,
-            theme: theme
+            theme: theme,
+            externalAbsolutePath: externalAbsolutePath
         )
         return scroll
     }
@@ -95,7 +105,8 @@ struct CodeEditorView: NSViewRepresentable {
             tabId: tabId,
             revealLine: revealLine,
             revealCharacter: revealCharacter,
-            theme: theme
+            theme: theme,
+            externalAbsolutePath: externalAbsolutePath
         )
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -44,10 +44,17 @@ struct CodeEditorView: NSViewRepresentable {
 
         let buffer: EditorBuffer
         if let abs = externalAbsolutePath {
+            let absoluteURL = URL(fileURLWithPath: abs)
+            let ext = (abs as NSString).pathExtension
+            let language = appState.lsp.language(forFileExtension: ext)
+            let originatingFileURL: URL? = originatingRelativePath.map { worktreeRoot.appendingPathComponent($0) }
             buffer = appState.tabs.externalBuffer(
                 worktreeId: worktreeId,
                 tabId: tabId,
-                absoluteURL: URL(fileURLWithPath: abs)
+                absoluteURL: absoluteURL,
+                worktreeRoot: worktreeRoot,
+                originatingFileURL: originatingFileURL,
+                language: language
             )
         } else {
             buffer = appState.tabs.buffer(

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -42,6 +42,7 @@ struct CodeEditorView: NSViewRepresentable {
         if let abs = externalAbsolutePath {
             buffer = appState.tabs.externalBuffer(
                 worktreeId: worktreeId,
+                tabId: tabId,
                 absoluteURL: URL(fileURLWithPath: abs)
             )
         } else {

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -88,6 +88,7 @@ struct CodeEditorView: NSViewRepresentable {
             buffer: buffer,
             layoutManager: layoutManager,
             worktreeId: worktreeId,
+            worktreeRoot: worktreeRoot,
             tabId: tabId,
             revealLine: revealLine,
             revealCharacter: revealCharacter,

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -16,6 +16,10 @@ struct CodeEditorView: NSViewRepresentable {
     let revealCharacter: Int?
     let appState: AppState
     let externalAbsolutePath: String?
+    /// The worktree-relative path of the in-worktree file from which the
+    /// user navigated to this external tab. Used to route LSP traffic for
+    /// the external file to the correct holder in nested-package layouts.
+    let originatingRelativePath: String?
     /// Pulled from `appState.config.code.fontFamily` by the parent view's
     /// body so SwiftUI registers the dependency. NSViewRepresentable hooks
     /// (makeNSView/updateNSView) are not part of body evaluation, so reads
@@ -94,7 +98,8 @@ struct CodeEditorView: NSViewRepresentable {
             revealLine: revealLine,
             revealCharacter: revealCharacter,
             theme: theme,
-            externalAbsolutePath: externalAbsolutePath
+            externalAbsolutePath: externalAbsolutePath,
+            originatingRelativePath: originatingRelativePath
         )
         return scroll
     }
@@ -108,7 +113,8 @@ struct CodeEditorView: NSViewRepresentable {
             revealLine: revealLine,
             revealCharacter: revealCharacter,
             theme: theme,
-            externalAbsolutePath: externalAbsolutePath
+            externalAbsolutePath: externalAbsolutePath,
+            originatingRelativePath: originatingRelativePath
         )
     }
 

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -9,6 +9,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     var hoverHandler: ((NSPoint) -> Void)?
     var commandClickHandler: ((NSPoint) -> Void)?
     var flagsChangedHandler: ((NSEvent) -> Void)?
+    var mouseExitedHandler: (() -> Void)?
 
     /// Set by `CodeEditorCoordinator.attach`. Each closure mutates the shared
     /// `code.fontSize` config in response to the matching menu command.
@@ -59,12 +60,17 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         flagsChangedHandler?(event)
     }
 
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        mouseExitedHandler?()
+    }
+
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
         for area in trackingAreas { removeTrackingArea(area) }
         let area = NSTrackingArea(
             rect: bounds,
-            options: [.mouseMoved, .activeInActiveApp, .inVisibleRect],
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
             owner: self, userInfo: nil
         )
         addTrackingArea(area)

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -8,6 +8,7 @@ import AppKit
 final class CodeTextView: NSTextView, FontSizeResponder {
     var hoverHandler: ((NSPoint) -> Void)?
     var commandClickHandler: ((NSPoint) -> Void)?
+    var flagsChangedHandler: ((NSEvent) -> Void)?
 
     /// Set by `CodeEditorCoordinator.attach`. Each closure mutates the shared
     /// `code.fontSize` config in response to the matching menu command.
@@ -51,6 +52,11 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             return
         }
         super.mouseDown(with: event)
+    }
+
+    override func flagsChanged(with event: NSEvent) {
+        super.flagsChanged(with: event)
+        flagsChangedHandler?(event)
     }
 
     override func updateTrackingAreas() {

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -17,6 +17,12 @@ final class EditorBuffer {
     let worktreeRoot: URL
     private(set) var relativePath: String
 
+    /// `true` when this buffer represents a file outside the worktree (e.g.
+    /// a dependency or system header opened via cmd-click). External buffers
+    /// are read-only, never emit `didChange` to LSP, and never write back to
+    /// disk — but they still reload when the file changes on disk.
+    let isExternal: Bool
+
     /// The live AppKit text storage displayed by the text view. The
     /// reference is stable for the lifetime of the buffer; tearing down
     /// the view detaches it without releasing it.
@@ -90,24 +96,46 @@ final class EditorBuffer {
     /// Convenience initializer for callers that do not need hot-exit support
     /// (tests from Tasks 3-6, and any non-persisted buffer).
     convenience init(worktreeRoot: URL, relativePath: String) {
-        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: nil, worktreeId: nil, tabId: nil, restoreEnabled: false, lsp: nil)
+        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, isExternal: false, store: nil, worktreeId: nil, tabId: nil, restoreEnabled: false, lsp: nil)
     }
 
     /// Production initializer that opts into hot-exit (no LSP). The `store`
     /// is consulted at init time for any persisted snapshot.
     convenience init(worktreeRoot: URL, relativePath: String, store: EditorBufferStore, worktreeId: String, tabId: String) {
-        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: store, worktreeId: worktreeId, tabId: tabId, restoreEnabled: true, lsp: nil)
+        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, isExternal: false, store: store, worktreeId: worktreeId, tabId: tabId, restoreEnabled: true, lsp: nil)
     }
 
     /// Production initializer that opts into hot-exit and opens an LSP
     /// document. The buffer owns the LSP open/close lifecycle for this file.
     convenience init(worktreeRoot: URL, relativePath: String, store: EditorBufferStore, worktreeId: String, tabId: String, lsp: WorkspaceLSPManager) {
-        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, store: store, worktreeId: worktreeId, tabId: tabId, restoreEnabled: true, lsp: lsp)
+        self.init(worktreeRoot: worktreeRoot, relativePath: relativePath, isExternal: false, store: store, worktreeId: worktreeId, tabId: tabId, restoreEnabled: true, lsp: lsp)
     }
 
-    private init(worktreeRoot: URL, relativePath: String, store: EditorBufferStore?, worktreeId: String?, tabId: String?, restoreEnabled: Bool, lsp: WorkspaceLSPManager?) {
+    /// External-mode init: loads `absoluteURL` synchronously, marks the buffer
+    /// read-only, and skips all save/didChange/file-watcher write paths. The
+    /// buffer still re-loads contents when the file changes on disk (passive
+    /// reload only — it never writes back). Uses sentinel worktreeRoot/
+    /// relativePath values (directory + filename) so the rest of the buffer
+    /// machinery works without optional-unwrap proliferation (option B).
+    convenience init(externalAbsoluteURL: URL) {
+        let worktreeRoot = externalAbsoluteURL.deletingLastPathComponent()
+        let relativePath = externalAbsoluteURL.lastPathComponent
+        self.init(
+            worktreeRoot: worktreeRoot,
+            relativePath: relativePath,
+            isExternal: true,
+            store: nil,
+            worktreeId: nil,
+            tabId: nil,
+            restoreEnabled: false,
+            lsp: nil
+        )
+    }
+
+    private init(worktreeRoot: URL, relativePath: String, isExternal: Bool, store: EditorBufferStore?, worktreeId: String?, tabId: String?, restoreEnabled: Bool, lsp: WorkspaceLSPManager?) {
         self.worktreeRoot = worktreeRoot
         self.relativePath = relativePath
+        self.isExternal = isExternal
         self.storage = NSTextStorage()
         self.store = store
         self.worktreeId = worktreeId
@@ -118,13 +146,14 @@ final class EditorBuffer {
         self.storageDelegate = delegate
         self.storage.delegate = delegate
         loadFromDisk()
-        if restoreEnabled,
+        if !isExternal,
+           restoreEnabled,
            let store, let worktreeId, let tabId,
            let snap = (try? store.read(worktreeId: worktreeId, tabId: tabId)) {
             applySnapshot(snap)
         }
         onEdit { [weak self] in self?.scheduleSnapshot() }
-        if let lsp, let language {
+        if !isExternal, let lsp, let language {
             let url = worktreeRoot.appendingPathComponent(relativePath)
             let text = storage.string
             Task { await lsp.openDocument(worktreeRoot: worktreeRoot, fileURL: url, languageId: language, text: text) }
@@ -155,6 +184,9 @@ final class EditorBuffer {
 
     private func handleEdit(edit: EditorTextEdit?) {
         guard !loading else { return }
+        // External buffers are read-only; suppress all observer notifications
+        // so didChange is never propagated to LSP or snapshot scheduler.
+        guard !isExternal else { return }
         editGeneration &+= 1
         let snapshot = Array(editObservers.values)
         for block in snapshot { block(edit) }
@@ -635,7 +667,9 @@ final class EditorBuffer {
             }
         }
         updateOriginalFileIdentity(from: url)
-        readOnly = false
+        // External buffers remain read-only even after a successful reload;
+        // the isExternal flag is the authoritative source of read-only-ness.
+        readOnly = isExternal ? true : false
     }
 }
 

--- a/Alas/Sources/Code/Editor/EditorBufferStore.swift
+++ b/Alas/Sources/Code/Editor/EditorBufferStore.swift
@@ -99,4 +99,12 @@ final class EditorBufferStore {
         externalBuffers[key] = buffer
         return buffer
     }
+
+    /// Remove an external buffer from the cache and stop its watcher.
+    /// A no-op if no buffer for this URL exists in `worktreeId`.
+    func discardExternalBuffer(worktreeId: String, absoluteURL: URL) {
+        let key = ExternalKey(worktreeId: worktreeId, path: absoluteURL.path)
+        guard let buffer = externalBuffers.removeValue(forKey: key) else { return }
+        buffer.close(persistDirtySnapshot: false)
+    }
 }

--- a/Alas/Sources/Code/Editor/EditorBufferStore.swift
+++ b/Alas/Sources/Code/Editor/EditorBufferStore.swift
@@ -18,6 +18,16 @@ final class EditorBufferStore {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
+    /// External (out-of-worktree) buffer cache keyed by
+    /// `(worktreeId, absolute path)`. Distinct from the in-worktree cache
+    /// so absolute paths never collide with relative ones.
+    private struct ExternalKey: Hashable {
+        let worktreeId: String
+        let path: String
+    }
+
+    private var externalBuffers: [ExternalKey: EditorBuffer] = [:]
+
     /// `rootOverride` is for tests only; production callers omit it and
     /// the store reads/writes under `Paths.buffersRoot`.
     init(rootOverride: URL? = nil) {
@@ -80,5 +90,13 @@ final class EditorBufferStore {
     func discard(worktreeId: String, tabId: String) {
         let file = fileURL(worktreeId: worktreeId, tabId: tabId)
         try? FileManager.default.removeItem(at: file)
+    }
+
+    func externalBuffer(worktreeId: String, absoluteURL: URL) -> EditorBuffer {
+        let key = ExternalKey(worktreeId: worktreeId, path: absoluteURL.path)
+        if let cached = externalBuffers[key] { return cached }
+        let buffer = EditorBuffer(externalAbsoluteURL: absoluteURL)
+        externalBuffers[key] = buffer
+        return buffer
     }
 }

--- a/Alas/Sources/Code/LSP/Features/DefinitionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/DefinitionFeature.swift
@@ -1,16 +1,19 @@
 import AppKit
+import SwiftUI
 import Foundation
 
 /// Cmd-click handler that resolves the symbol under the cursor via
-/// `textDocument/definition` and forwards the first matching location to
-/// `openTarget`. Multiple-result picker is left as a v1.5 follow-up; for
-/// now we always pick `locations.first`.
+/// `textDocument/definition` and forwards the result to `openTarget`.
+/// 0 results → no-op; 1 result → open immediately; 2+ → present an
+/// inline `DefinitionPicker` anchored at the click point.
 @MainActor
 final class DefinitionFeature {
     private weak var textView: CodeTextView?
     private let getClient: () -> LSPClient?
     private let getURI: () -> String?
     private let openTarget: (URL, Int, Int) -> Void
+    private var popover: NSPopover?
+    private let snippetCache = DefinitionSnippetCache()
 
     init(
         textView: CodeTextView,
@@ -26,17 +29,56 @@ final class DefinitionFeature {
     }
 
     private func onClick(at point: NSPoint) {
+        popover?.close()
         guard let textView, let client = getClient(), let uri = getURI() else { return }
         guard let position = textView.lspPosition(at: point) else { return }
         Task { [weak self] in
             guard let self else { return }
             let locations: [LSPLocation] = (try? await client.definition(uri: uri, position: position)) ?? []
-            // TODO: v1.5 — surface a picker popover when locations.count > 1.
-            guard let target = locations.first else { return }
-            let url = URL(string: target.uri) ?? URL(fileURLWithPath: target.uri.removingPercentEncoding ?? target.uri)
-            await MainActor.run {
-                self.openTarget(url, target.range.start.line, target.range.start.character)
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.handle(locations: locations, anchorPoint: point)
             }
         }
+    }
+
+    private func handle(locations: [LSPLocation], anchorPoint: NSPoint) {
+        switch locations.count {
+        case 0: return
+        case 1: openLocation(locations[0])
+        default: presentPicker(locations: locations, anchor: anchorPoint)
+        }
+    }
+
+    private func openLocation(_ target: LSPLocation) {
+        let url = URL(string: target.uri)
+            ?? URL(fileURLWithPath: target.uri.removingPercentEncoding ?? target.uri)
+        openTarget(url, target.range.start.line, target.range.start.character)
+    }
+
+    private func presentPicker(locations: [LSPLocation], anchor point: NSPoint) {
+        guard let textView else { return }
+        let entries = locations.map { loc -> DefinitionPickerEntry in
+            let url = URL(string: loc.uri)
+                ?? URL(fileURLWithPath: loc.uri.removingPercentEncoding ?? loc.uri)
+            let path = (url.lastPathComponent.isEmpty ? url.path : url.lastPathComponent)
+            let display = "\(path):\(loc.range.start.line + 1)"
+            let snippet = snippetCache.line(at: url, line: loc.range.start.line)
+            return DefinitionPickerEntry(displayPath: display, snippet: snippet)
+        }
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.contentSize = NSSize(width: 380, height: max(60, min(320, 24 + entries.count * 36)))
+        let host = NSHostingController(
+            rootView: DefinitionPicker(entries: entries) { [weak self, weak popover] choice in
+                popover?.close()
+                guard let self, let choice else { return }
+                self.openLocation(locations[choice])
+            }
+        )
+        popover.contentViewController = host
+        let anchorRect = NSRect(origin: point, size: NSSize(width: 1, height: 1))
+        popover.show(relativeTo: anchorRect, of: textView, preferredEdge: .maxY)
+        self.popover = popover
     }
 }

--- a/Alas/Sources/Code/LSP/Features/DefinitionPicker.swift
+++ b/Alas/Sources/Code/LSP/Features/DefinitionPicker.swift
@@ -23,11 +23,15 @@ struct DefinitionPicker: View {
                 .padding(.horizontal, 10)
                 .padding(.top, 8)
                 .padding(.bottom, 6)
-            ForEach(Array(entries.enumerated()), id: \.offset) { idx, entry in
-                row(idx: idx, entry: entry)
-                    .background(idx == selection ? Color.accentColor.opacity(0.18) : Color.clear)
-                    .contentShape(Rectangle())
-                    .onTapGesture { onChoose(idx) }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(entries.enumerated()), id: \.offset) { idx, entry in
+                        row(idx: idx, entry: entry)
+                            .background(idx == selection ? Color.accentColor.opacity(0.18) : Color.clear)
+                            .contentShape(Rectangle())
+                            .onTapGesture { onChoose(idx) }
+                    }
+                }
             }
         }
         .frame(width: 380)

--- a/Alas/Sources/Code/LSP/Features/DefinitionPicker.swift
+++ b/Alas/Sources/Code/LSP/Features/DefinitionPicker.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// Inline picker shown when LSP `textDocument/definition` returns more
+/// than one location. The view is hosted in an `NSPopover` by the caller
+/// and reports the chosen index (or nil for dismiss) through `onChoose`.
+struct DefinitionPickerEntry: Identifiable, Equatable {
+    let id = UUID()
+    let displayPath: String   // e.g. "Foo.swift:42"
+    let snippet: String       // single-line preview, may be empty
+}
+
+struct DefinitionPicker: View {
+    let entries: [DefinitionPickerEntry]
+    let onChoose: (Int?) -> Void
+
+    @State private var selection: Int = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("\(entries.count) DEFINITIONS")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 10)
+                .padding(.top, 8)
+                .padding(.bottom, 6)
+            ForEach(Array(entries.enumerated()), id: \.offset) { idx, entry in
+                row(idx: idx, entry: entry)
+                    .background(idx == selection ? Color.accentColor.opacity(0.18) : Color.clear)
+                    .contentShape(Rectangle())
+                    .onTapGesture { onChoose(idx) }
+            }
+        }
+        .frame(width: 380)
+        .padding(.bottom, 6)
+        .focusable()
+        .onKeyPress(.upArrow)   { selection = max(0, selection - 1); return .handled }
+        .onKeyPress(.downArrow) { selection = min(entries.count - 1, selection + 1); return .handled }
+        .onKeyPress(.return)    { onChoose(selection); return .handled }
+        .onKeyPress(.escape)    { onChoose(nil);       return .handled }
+    }
+
+    private func row(idx: Int, entry: DefinitionPickerEntry) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(entry.displayPath)
+                .font(.system(size: 11, design: .monospaced))
+            if !entry.snippet.isEmpty {
+                Text(entry.snippet)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Alas/Sources/Code/LSP/Features/DefinitionSnippetCache.swift
+++ b/Alas/Sources/Code/LSP/Features/DefinitionSnippetCache.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Per-coordinator snippet cache used by the multi-result picker. Reads a
+/// single line lazily on first access for `(absolutePath, line)` and
+/// returns the cached value on subsequent calls. Bounded to 64 entries.
+final class DefinitionSnippetCache {
+    private struct Key: Hashable { let path: String; let line: Int }
+    private var cache: [Key: String] = [:]
+    private var order: [Key] = []
+    private let limit = 64
+
+    func line(at url: URL, line: Int) -> String {
+        let key = Key(path: url.path, line: line)
+        if let cached = cache[key] { return cached }
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+            return store(key: key, value: "")
+        }
+        let lines = contents.split(separator: "\n", omittingEmptySubsequences: false)
+        guard line >= 0, line < lines.count else {
+            return store(key: key, value: "")
+        }
+        return store(key: key, value: String(lines[line]).trimmingCharacters(in: .whitespaces))
+    }
+
+    private func store(key: Key, value: String) -> String {
+        cache[key] = value
+        order.append(key)
+        if order.count > limit, let oldest = order.first {
+            order.removeFirst()
+            cache.removeValue(forKey: oldest)
+        }
+        return value
+    }
+}

--- a/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
@@ -122,6 +122,7 @@ final class HoverHighlightFeature {
     }
 
     private func clearUnderline() {
+        defer { restoreCursor() }
         guard let textView, let layoutManager = textView.layoutManager,
               let range = lastUnderlinedRange else {
             lastUnderlinedRange = nil

--- a/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
@@ -83,7 +83,9 @@ final class HoverHighlightFeature {
             try? await Task.sleep(nanoseconds: self?.debounceNanos ?? 0)
             guard !Task.isCancelled, let self else { return }
             let locations: [LSPLocation] = (try? await client.definition(uri: uri, position: position)) ?? []
-            await MainActor.run {
+            if Task.isCancelled { return }
+            await MainActor.run { [weak self] in
+                guard !Task.isCancelled, let self else { return }
                 if locations.isEmpty {
                     self.clearUnderline()
                     return

--- a/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
@@ -44,10 +44,8 @@ final class HoverHighlightFeature {
     private func onFlagsChanged(_ event: NSEvent) {
         let pressed = event.modifierFlags.contains(.command)
         if pressed && !commandHeld {
-            commandHeld = true
             simulateCommandPressed()
         } else if !pressed && commandHeld {
-            commandHeld = false
             simulateCommandReleased()
         }
     }
@@ -96,7 +94,8 @@ final class HoverHighlightFeature {
     }
 
     private func applyUnderline(at position: LSPPosition) {
-        guard let textView, let storage = textView.textStorage else { return }
+        guard let textView, let storage = textView.textStorage,
+              let layoutManager = textView.layoutManager else { return }
         let nsString = storage.string as NSString
         // Compute UTF-16 offset for `position`.
         var offset = 0
@@ -112,21 +111,21 @@ final class HoverHighlightFeature {
         let wordRange = nsString.rangeOfWord(at: offset)
         clearUnderline()
         if wordRange.length == 0 { return }
-        storage.addAttributes([
-            .underlineStyle: NSUnderlineStyle.single.rawValue,
-        ], range: wordRange)
+        layoutManager.addTemporaryAttributes(
+            [.underlineStyle: NSUnderlineStyle.single.rawValue],
+            forCharacterRange: wordRange
+        )
         lastUnderlinedRange = wordRange
         NSCursor.pointingHand.set()
     }
 
     private func clearUnderline() {
-        guard let textView, let storage = textView.textStorage,
-              let range = lastUnderlinedRange,
-              range.location + range.length <= storage.length else {
+        guard let textView, let layoutManager = textView.layoutManager,
+              let range = lastUnderlinedRange else {
             lastUnderlinedRange = nil
             return
         }
-        storage.removeAttribute(.underlineStyle, range: range)
+        layoutManager.removeTemporaryAttribute(.underlineStyle, forCharacterRange: range)
         lastUnderlinedRange = nil
     }
 

--- a/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
@@ -30,6 +30,9 @@ final class HoverHighlightFeature {
         textView.flagsChangedHandler = { [weak self] event in
             self?.onFlagsChanged(event)
         }
+        textView.mouseExitedHandler = { [weak self] in
+            self?.clearUnderline()
+        }
         // Reuse the existing hover handler — feature multiplexes hover and
         // command-hover through the same closure. The popover-based
         // `HoverFeature` already lives on `hoverHandler`, so install a

--- a/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
@@ -1,0 +1,163 @@
+import AppKit
+import Foundation
+
+/// ⌘-hover affordance. While the user holds ⌘, mouse-move events trigger
+/// debounced `textDocument/definition` queries; when LSP returns at least
+/// one location, the symbol under the cursor is underlined and the cursor
+/// is swapped to `.pointingHand`. Any of (⌘ released, mouse exits the
+/// view, cursor moves to a no-result position, request fails) clears the
+/// underline.
+@MainActor
+final class HoverHighlightFeature {
+    private weak var textView: CodeTextView?
+    private let getClient: () -> LSPClient?
+    private let getURI: () -> String?
+
+    private var commandHeld: Bool = false
+    private(set) var lastUnderlinedRange: NSRange?
+    private var inFlight: Task<Void, Never>?
+
+    private let debounceNanos: UInt64 = 80_000_000 // 80 ms
+
+    init(
+        textView: CodeTextView,
+        getClient: @escaping () -> LSPClient?,
+        getURI: @escaping () -> String?
+    ) {
+        self.textView = textView
+        self.getClient = getClient
+        self.getURI = getURI
+        textView.flagsChangedHandler = { [weak self] event in
+            self?.onFlagsChanged(event)
+        }
+        // Reuse the existing hover handler — feature multiplexes hover and
+        // command-hover through the same closure. The popover-based
+        // `HoverFeature` already lives on `hoverHandler`, so install a
+        // chained closure that calls both.
+        let prior = textView.hoverHandler
+        textView.hoverHandler = { [weak self] p in
+            prior?(p)
+            self?.onMove(at: p)
+        }
+    }
+
+    private func onFlagsChanged(_ event: NSEvent) {
+        let pressed = event.modifierFlags.contains(.command)
+        if pressed && !commandHeld {
+            commandHeld = true
+            simulateCommandPressed()
+        } else if !pressed && commandHeld {
+            commandHeld = false
+            simulateCommandReleased()
+        }
+    }
+
+    // MARK: - Internal seams (also used by tests)
+
+    func simulateCommandPressed() {
+        commandHeld = true
+    }
+
+    func simulateCommandReleased() {
+        commandHeld = false
+        cancelInFlight()
+        clearUnderline()
+        restoreCursor()
+    }
+
+    func simulateMouseMoved(at point: NSPoint) {
+        onMove(at: point)
+    }
+
+    private func onMove(at point: NSPoint) {
+        guard commandHeld else { return }
+        cancelInFlight()
+        guard let textView else { return }
+        guard let client = getClient(), let uri = getURI() else {
+            clearUnderline()
+            return
+        }
+        guard let position = textView.lspPosition(at: point) else {
+            clearUnderline()
+            return
+        }
+        inFlight = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: self?.debounceNanos ?? 0)
+            guard !Task.isCancelled, let self else { return }
+            let locations: [LSPLocation] = (try? await client.definition(uri: uri, position: position)) ?? []
+            await MainActor.run {
+                if locations.isEmpty {
+                    self.clearUnderline()
+                    return
+                }
+                self.applyUnderline(at: position)
+            }
+        }
+    }
+
+    private func applyUnderline(at position: LSPPosition) {
+        guard let textView, let storage = textView.textStorage else { return }
+        let nsString = storage.string as NSString
+        // Compute UTF-16 offset for `position`.
+        var offset = 0
+        var line = 0
+        while line < position.line {
+            let r = nsString.range(of: "\n", options: [], range: NSRange(location: offset, length: nsString.length - offset))
+            if r.location == NSNotFound { return }
+            offset = r.location + 1
+            line += 1
+        }
+        offset += position.character
+        guard offset < nsString.length else { return }
+        let wordRange = nsString.rangeOfWord(at: offset)
+        clearUnderline()
+        if wordRange.length == 0 { return }
+        storage.addAttributes([
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ], range: wordRange)
+        lastUnderlinedRange = wordRange
+        NSCursor.pointingHand.set()
+    }
+
+    private func clearUnderline() {
+        guard let textView, let storage = textView.textStorage,
+              let range = lastUnderlinedRange,
+              range.location + range.length <= storage.length else {
+            lastUnderlinedRange = nil
+            return
+        }
+        storage.removeAttribute(.underlineStyle, range: range)
+        lastUnderlinedRange = nil
+    }
+
+    private func restoreCursor() {
+        NSCursor.iBeam.set()
+    }
+
+    private func cancelInFlight() {
+        inFlight?.cancel()
+        inFlight = nil
+    }
+}
+
+private extension NSString {
+    /// Returns the contiguous identifier-like range covering `index`, or an
+    /// empty range if the character at `index` is not part of an identifier.
+    func rangeOfWord(at index: Int) -> NSRange {
+        guard index < length else { return NSRange(location: index, length: 0) }
+        let isWordChar: (unichar) -> Bool = { c in
+            (c >= 0x41 && c <= 0x5A) ||           // A-Z
+            (c >= 0x61 && c <= 0x7A) ||           // a-z
+            (c >= 0x30 && c <= 0x39) ||           // 0-9
+             c == 0x5F                             // _
+        }
+        guard isWordChar(character(at: index)) else {
+            return NSRange(location: index, length: 0)
+        }
+        var start = index
+        while start > 0 && isWordChar(character(at: start - 1)) { start -= 1 }
+        var end = index
+        while end < length && isWordChar(character(at: end)) { end += 1 }
+        return NSRange(location: start, length: end - start)
+    }
+}

--- a/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
@@ -72,6 +72,14 @@ final class HoverHighlightFeature {
         onMove(at: point)
     }
 
+    /// Cancel any in-flight LSP request and remove the underline + cursor
+    /// affordance. Does NOT change `commandHeld`, so a still-held ⌘ key
+    /// will resume normal hover behavior on the next mouse move.
+    func cancelAndClear() {
+        cancelInFlight()
+        clearUnderline()
+    }
+
     private func onMove(at point: NSPoint) {
         guard commandHeld else { return }
         cancelInFlight()

--- a/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
@@ -31,7 +31,9 @@ final class HoverHighlightFeature {
             self?.onFlagsChanged(event)
         }
         textView.mouseExitedHandler = { [weak self] in
-            self?.clearUnderline()
+            guard let self else { return }
+            self.cancelInFlight()
+            self.clearUnderline()
         }
         // Reuse the existing hover handler — feature multiplexes hover and
         // command-hover through the same closure. The popover-based

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -300,6 +300,21 @@ final class WorkspaceLSPManager {
         return nil
     }
 
+    /// Worktree-scoped variant: returns a holder for `uri` only if its
+    /// `Key.root` falls inside `worktreeRoot`. Used as the last fallback in
+    /// external open/close so a tab in worktree B never matches a holder in
+    /// worktree A that happens to serve the same SDK file.
+    private func holderKey(forURI uri: String, withinWorktreeRoot worktreeRoot: URL) -> Key? {
+        let rootPath = worktreeRoot.path
+        let rootPrefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        for (key, holder) in holders where holder.refsByURI[uri] != nil {
+            if key.root == rootPath || key.root.hasPrefix(rootPrefix) {
+                return key
+            }
+        }
+        return nil
+    }
+
     /// Find an existing holder serving any file inside `worktreeRoot` for
     /// `language`. Used by external-document open/close where we don't have
     /// an in-worktree file URI on hand but know the originating worktree.
@@ -366,7 +381,11 @@ final class WorkspaceLSPManager {
            let preciseKey = holderKey(forURI: originatingFileURL.lspURI) {
             key = preciseKey
         } else {
-            key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language)
+            // Fall back to prefix-scan; also try scanning by the external
+            // URI itself. Use worktree-scoped lookup as the last fallback
+            // to avoid matching a holder in a different worktree that
+            // happens to serve the same SDK file.
+            key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language) ?? holderKey(forURI: uri, withinWorktreeRoot: originatingWorktreeRoot)
         }
         guard let key, var holder = holders[key] else { return false }
 
@@ -431,7 +450,9 @@ final class WorkspaceLSPManager {
             // Fall back to prefix-scan; also try scanning by the external
             // URI itself (it may already be tracked in refsByURI if didOpen
             // was sent but the originating file was closed in the meantime).
-            key = holderKey(forURI: uri) ?? holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language)
+            // Use worktree-scoped lookup to avoid matching a holder in a
+            // different worktree that happens to serve the same SDK file.
+            key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language) ?? holderKey(forURI: uri, withinWorktreeRoot: originatingWorktreeRoot)
         }
         guard let key,
               var holder = holders[key],

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -447,12 +447,13 @@ final class WorkspaceLSPManager {
            let preciseKey = holderKey(forURI: originatingFileURL.lspURI) {
             key = preciseKey
         } else {
-            // Fall back to prefix-scan; also try scanning by the external
-            // URI itself (it may already be tracked in refsByURI if didOpen
-            // was sent but the originating file was closed in the meantime).
-            // Use worktree-scoped lookup to avoid matching a holder in a
-            // different worktree that happens to serve the same SDK file.
-            key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language) ?? holderKey(forURI: uri, withinWorktreeRoot: originatingWorktreeRoot)
+            // Scan the external URI itself first (scoped to the worktree) to
+            // ensure we decrement the correct holder. Only fall back to the
+            // language-by-worktree scan if the URI isn't found in any holder's
+            // refsByURI — with multiple nested LSP holders for the same language,
+            // the prefix-scan could pick an arbitrary holder that doesn't actually
+            // have this URI registered, leaving the ref count imbalanced.
+            key = holderKey(forURI: uri, withinWorktreeRoot: originatingWorktreeRoot) ?? holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language)
         }
         guard let key,
               var holder = holders[key],

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -348,15 +348,18 @@ final class WorkspaceLSPManager {
     /// approach when nil or when the originating file's URI isn't tracked yet
     /// (e.g. app restart with persisted external tabs).
     ///
-    /// Silently no-ops if no LSP client is running for the given worktree and
-    /// language (e.g. no in-worktree tab is open to have started the server).
+    /// Returns `true` when a holder was found and `didOpen` was sent (or the
+    /// URI was already open with a positive refcount). Returns `false` when no
+    /// holder was available — the call silently no-ops in that case and the
+    /// caller can retry later.
+    @discardableResult
     func openExternalDocument(
         absoluteURL: URL,
         originatingWorktreeRoot: URL,
         originatingFileURL: URL? = nil,
         language: String,
         contents: String
-    ) async {
+    ) async -> Bool {
         let uri = absoluteURL.lspURI
         let key: Key?
         if let originatingFileURL,
@@ -365,7 +368,7 @@ final class WorkspaceLSPManager {
         } else {
             key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language)
         }
-        guard let key, var holder = holders[key] else { return }
+        guard let key, var holder = holders[key] else { return false }
 
         // Bump refcount and record pending text in case the server is still
         // initializing — the same approach used by openDocument for in-worktree
@@ -380,7 +383,7 @@ final class WorkspaceLSPManager {
 
         let initOk = await holder.ready.value
         guard initOk, let cur = holders[key], cur.client === holder.client,
-              (cur.refsByURI[uri] ?? 0) > 0 else { return }
+              (cur.refsByURI[uri] ?? 0) > 0 else { return false }
 
         if !cur.openedURIs.contains(uri) {
             let openText = cur.pendingOpenText[uri] ?? contents
@@ -398,6 +401,7 @@ final class WorkspaceLSPManager {
                 text: openText
             )
         }
+        return true
     }
 
     /// Notify the running LSP client that a previously opened external

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -430,9 +430,15 @@ final class WorkspaceLSPManager {
                 holders[key] = c
             }
         }
-        // NOTE: intentionally do NOT shut down the holder here. External
-        // documents attach to a running server that serves in-worktree tabs;
-        // their closure must not trigger server teardown.
+        // Shut down the server only when no refs remain. External documents
+        // attach to a running server that may also serve in-worktree tabs;
+        // skip teardown when in-worktree refs are still present. If the
+        // external doc was the last reference, the holder must be cleaned up
+        // to avoid leaking the LSP process until app exit.
+        if let c = holders[key], c.refsByURI.isEmpty {
+            await c.client.shutdown()
+            holders.removeValue(forKey: key)
+        }
     }
 
     /// Maps a file extension to its configured language id, or nil if no

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -300,15 +300,39 @@ final class WorkspaceLSPManager {
         return nil
     }
 
-    /// Resolve the `Key` for an existing holder that was spawned for
-    /// `(originatingWorktreeRoot, language)`. Returns `nil` when no registry
-    /// entry is configured for `language` or when the holder has not been
-    /// started yet (i.e. no in-worktree file for that language is open).
-    private func holderKey(forWorktreeRoot root: URL, language: String) -> Key? {
+    /// Find an existing holder serving any file inside `worktreeRoot` for
+    /// `language`. Used by external-document open/close where we don't have
+    /// an in-worktree file URI on hand but know the originating worktree.
+    ///
+    /// Unlike the old `holderKey(forWorktreeRoot:language:)` helper, this
+    /// scans existing holders instead of recomputing the key from scratch.
+    /// That matters for workspaces with nested packages: the running holder
+    /// was keyed against the nested package directory, not the worktree root,
+    /// so a recomputed lookup would miss it.
+    private func holderKeyForExternal(worktreeRoot: URL, language: String) -> Key? {
         guard let entry = registry.entry(forLanguage: language) else { return nil }
-        let lspRoot = Self.resolveLSPRoot(fileURL: root, worktreeRoot: root, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
-        return holders[key] != nil ? key : nil
+        let worktreePath = worktreeRoot.path
+        let pathPrefix = worktreePath.hasSuffix("/") ? worktreePath : worktreePath + "/"
+        for (key, holder) in holders {
+            guard key.command == entry.command,
+                  key.args == entry.args,
+                  key.env == entry.env else { continue }
+            // The holder's lspRoot may be the worktree itself or a nested
+            // package directory inside it. Either way, its path must start
+            // with the worktree path.
+            if key.root == worktreePath || key.root.hasPrefix(pathPrefix) {
+                return key
+            }
+            // Fallback: if the holder has any open URI inside the worktree,
+            // it's serving this workspace.
+            for uri in holder.refsByURI.keys {
+                if let url = URL(string: uri),
+                   url.path.hasPrefix(pathPrefix) {
+                    return key
+                }
+            }
+        }
+        return nil
     }
 
     /// Notify the running LSP client for `originatingWorktreeRoot`/`language`
@@ -325,7 +349,7 @@ final class WorkspaceLSPManager {
         contents: String
     ) async {
         let uri = absoluteURL.lspURI
-        guard let key = holderKey(forWorktreeRoot: originatingWorktreeRoot, language: language),
+        guard let key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language),
               var holder = holders[key] else { return }
 
         // Bump refcount and record pending text in case the server is still
@@ -374,7 +398,7 @@ final class WorkspaceLSPManager {
         language: String
     ) async {
         let uri = absoluteURL.lspURI
-        guard let key = holderKey(forWorktreeRoot: originatingWorktreeRoot, language: language),
+        guard let key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language),
               var holder = holders[key],
               (holder.refsByURI[uri] ?? 0) > 0 else { return }
 

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -340,17 +340,32 @@ final class WorkspaceLSPManager {
     /// `textDocument/didOpen` the first time a given URI is registered and
     /// increments a reference count for subsequent calls with the same URI.
     ///
+    /// `originatingFileURL` is the in-worktree file the user was viewing when
+    /// they navigated to this external document (e.g. via ⌘-click). When
+    /// provided, the holder is looked up via the existing URI-keyed helper
+    /// (`holderKey(forURI:)`) so nested-package layouts with multiple LSP
+    /// servers resolve to the correct server. Falls back to the prefix-scan
+    /// approach when nil or when the originating file's URI isn't tracked yet
+    /// (e.g. app restart with persisted external tabs).
+    ///
     /// Silently no-ops if no LSP client is running for the given worktree and
     /// language (e.g. no in-worktree tab is open to have started the server).
     func openExternalDocument(
         absoluteURL: URL,
         originatingWorktreeRoot: URL,
+        originatingFileURL: URL? = nil,
         language: String,
         contents: String
     ) async {
         let uri = absoluteURL.lspURI
-        guard let key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language),
-              var holder = holders[key] else { return }
+        let key: Key?
+        if let originatingFileURL,
+           let preciseKey = holderKey(forURI: originatingFileURL.lspURI) {
+            key = preciseKey
+        } else {
+            key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language)
+        }
+        guard let key, var holder = holders[key] else { return }
 
         // Bump refcount and record pending text in case the server is still
         // initializing — the same approach used by openDocument for in-worktree
@@ -390,15 +405,31 @@ final class WorkspaceLSPManager {
     /// reference count incremented by `openExternalDocument`; when it reaches
     /// zero, issues `textDocument/didClose`.
     ///
+    /// `originatingFileURL` mirrors the parameter on `openExternalDocument`:
+    /// when provided, the holder is found via URI lookup for precision in
+    /// nested-package layouts. Falls back to the prefix-scan approach when
+    /// nil or not yet tracked.
+    ///
     /// Silently no-ops if no LSP client is running for the given worktree and
     /// language, or if the URI was never opened.
     func closeExternalDocument(
         absoluteURL: URL,
         originatingWorktreeRoot: URL,
+        originatingFileURL: URL? = nil,
         language: String
     ) async {
         let uri = absoluteURL.lspURI
-        guard let key = holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language),
+        let key: Key?
+        if let originatingFileURL,
+           let preciseKey = holderKey(forURI: originatingFileURL.lspURI) {
+            key = preciseKey
+        } else {
+            // Fall back to prefix-scan; also try scanning by the external
+            // URI itself (it may already be tracked in refsByURI if didOpen
+            // was sent but the originating file was closed in the meantime).
+            key = holderKey(forURI: uri) ?? holderKeyForExternal(worktreeRoot: originatingWorktreeRoot, language: language)
+        }
+        guard let key,
               var holder = holders[key],
               (holder.refsByURI[uri] ?? 0) > 0 else { return }
 

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -280,12 +280,8 @@ final class WorkspaceLSPManager {
     /// package's client is found correctly even when the caller only knows
     /// the worktree root.
     func client(forFile fileURL: URL, worktreeRoot: URL, language: String) -> LSPClient? {
-        // Look up by URI so a server opened under a now-edited entry is
-        // still findable by hover/diagnostic callers. `worktreeRoot` and
-        // `language` are kept on the signature for source compatibility
-        // and aren't needed once a holder exists for the file.
         let uri = fileURL.lspURI
-        guard let key = holderKey(forURI: uri) else { return nil }
+        guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot) else { return nil }
         return holders[key]?.client
     }
 

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -300,6 +300,117 @@ final class WorkspaceLSPManager {
         return nil
     }
 
+    /// Resolve the `Key` for an existing holder that was spawned for
+    /// `(originatingWorktreeRoot, language)`. Returns `nil` when no registry
+    /// entry is configured for `language` or when the holder has not been
+    /// started yet (i.e. no in-worktree file for that language is open).
+    private func holderKey(forWorktreeRoot root: URL, language: String) -> Key? {
+        guard let entry = registry.entry(forLanguage: language) else { return nil }
+        let lspRoot = Self.resolveLSPRoot(fileURL: root, worktreeRoot: root, markers: entry.rootMarkers)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
+        return holders[key] != nil ? key : nil
+    }
+
+    /// Notify the running LSP client for `originatingWorktreeRoot`/`language`
+    /// that a read-only out-of-worktree file is logically open. Issues
+    /// `textDocument/didOpen` the first time a given URI is registered and
+    /// increments a reference count for subsequent calls with the same URI.
+    ///
+    /// Silently no-ops if no LSP client is running for the given worktree and
+    /// language (e.g. no in-worktree tab is open to have started the server).
+    func openExternalDocument(
+        absoluteURL: URL,
+        originatingWorktreeRoot: URL,
+        language: String,
+        contents: String
+    ) async {
+        let uri = absoluteURL.lspURI
+        guard let key = holderKey(forWorktreeRoot: originatingWorktreeRoot, language: language),
+              var holder = holders[key] else { return }
+
+        // Bump refcount and record pending text in case the server is still
+        // initializing — the same approach used by openDocument for in-worktree
+        // files.
+        var refs = holder.refsByURI
+        refs[uri, default: 0] += 1
+        var pending = holder.pendingOpenText
+        if !holder.openedURIs.contains(uri) { pending[uri] = contents }
+        holder.refsByURI = refs
+        holder.pendingOpenText = pending
+        holders[key] = holder
+
+        let initOk = await holder.ready.value
+        guard initOk, let cur = holders[key], cur.client === holder.client,
+              (cur.refsByURI[uri] ?? 0) > 0 else { return }
+
+        if !cur.openedURIs.contains(uri) {
+            let openText = cur.pendingOpenText[uri] ?? contents
+            if var h = holders[key] {
+                h.openedURIs.insert(uri)
+                h.versions[uri] = 1
+                h.pendingOpenText.removeValue(forKey: uri)
+                h.texts[uri] = openText
+                holders[key] = h
+            }
+            try? await cur.client.didOpen(
+                uri: uri,
+                languageId: language,
+                version: 1,
+                text: openText
+            )
+        }
+    }
+
+    /// Notify the running LSP client that a previously opened external
+    /// (out-of-worktree) document is no longer needed. Decrements the
+    /// reference count incremented by `openExternalDocument`; when it reaches
+    /// zero, issues `textDocument/didClose`.
+    ///
+    /// Silently no-ops if no LSP client is running for the given worktree and
+    /// language, or if the URI was never opened.
+    func closeExternalDocument(
+        absoluteURL: URL,
+        originatingWorktreeRoot: URL,
+        language: String
+    ) async {
+        let uri = absoluteURL.lspURI
+        guard let key = holderKey(forWorktreeRoot: originatingWorktreeRoot, language: language),
+              var holder = holders[key],
+              (holder.refsByURI[uri] ?? 0) > 0 else { return }
+
+        // Decrement the refcount synchronously before awaiting.
+        var refs = holder.refsByURI
+        let newRef = (refs[uri] ?? 0) - 1
+        if newRef <= 0 {
+            refs.removeValue(forKey: uri)
+        } else {
+            refs[uri] = newRef
+        }
+        holder.refsByURI = refs
+        holders[key] = holder
+
+        let initOk = await holder.ready.value
+        guard initOk, let cur = holders[key] else { return }
+
+        // Another opener still has this URI open — nothing to send.
+        if (cur.refsByURI[uri] ?? 0) > 0 { return }
+
+        // Send didClose only if didOpen was actually delivered.
+        if cur.openedURIs.contains(uri) {
+            try? await cur.client.didClose(uri: uri)
+            if var c = holders[key] {
+                c.openedURIs.remove(uri)
+                c.versions.removeValue(forKey: uri)
+                c.pendingOpenText.removeValue(forKey: uri)
+                c.texts.removeValue(forKey: uri)
+                holders[key] = c
+            }
+        }
+        // NOTE: intentionally do NOT shut down the holder here. External
+        // documents attach to a running server that serves in-worktree tabs;
+        // their closure must not trigger server teardown.
+    }
+
     /// Maps a file extension to its configured language id, or nil if no
     /// enabled server claims that extension. Delegates to the registry so
     /// user-defined entries (Settings → Code) are honored.

--- a/AlasTests/Code/LSP/Features/DefinitionSnippetCacheTests.swift
+++ b/AlasTests/Code/LSP/Features/DefinitionSnippetCacheTests.swift
@@ -1,0 +1,38 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct DefinitionSnippetCacheTests {
+
+    private func tempFile(_ contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("snippet-\(UUID().uuidString).txt")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    @Test func returnsRequestedLine() throws {
+        let url = try tempFile("first\nsecond line\nthird\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let cache = DefinitionSnippetCache()
+        #expect(cache.line(at: url, line: 1) == "second line")
+    }
+
+    @Test func returnsEmptyForOutOfRange() throws {
+        let url = try tempFile("only\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let cache = DefinitionSnippetCache()
+        #expect(cache.line(at: url, line: 99) == "")
+    }
+
+    @Test func cachesRepeatedReads() throws {
+        let url = try tempFile("x\ny\nz\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let cache = DefinitionSnippetCache()
+        _ = cache.line(at: url, line: 1)
+        // Mutate the file; cache should still return the original.
+        try "DIFFERENT\nDATA\n".write(to: url, atomically: true, encoding: .utf8)
+        #expect(cache.line(at: url, line: 1) == "y")
+    }
+}

--- a/AlasTests/Code/LSP/Features/HoverHighlightFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/HoverHighlightFeatureTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import Foundation
+import AppKit
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct HoverHighlightFeatureTests {
+
+    /// Build a text view backed by a real layout chain so the feature can
+    /// resolve word ranges and write temp attributes.
+    private func makeTextView(_ text: String) -> CodeTextView {
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        let view = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        view.string = text
+        let storage = NSTextStorage(string: text)
+        storage.addLayoutManager(layoutManager)
+        return view
+    }
+
+    @Test func clearsUnderlineWhenCommandReleased() async {
+        let view = makeTextView("let resolve = 1\n")
+        let feature = HoverHighlightFeature(
+            textView: view,
+            getClient: { nil },
+            getURI: { "file:///cur.swift" }
+        )
+        // Simulate ⌘ pressed + mouse over "resolve". The nil-client path
+        // means no LSP query runs; the feature should still cleanly track
+        // command state and never set an underline.
+        feature.simulateCommandPressed()
+        feature.simulateMouseMoved(at: NSPoint(x: 30, y: 10))
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        feature.simulateCommandReleased()
+        #expect(feature.lastUnderlinedRange == nil)
+    }
+
+    @Test func clearsUnderlineWhenLSPReturnsEmpty() async {
+        let view = makeTextView("let x = 1\n")
+        let feature = HoverHighlightFeature(
+            textView: view,
+            getClient: { nil },
+            getURI: { "file:///cur.swift" }
+        )
+        feature.simulateCommandPressed()
+        feature.simulateMouseMoved(at: NSPoint(x: 30, y: 10))
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        #expect(feature.lastUnderlinedRange == nil)
+    }
+}

--- a/AlasTests/Code/LSP/Features/HoverHighlightFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/HoverHighlightFeatureTests.swift
@@ -14,9 +14,7 @@ struct HoverHighlightFeatureTests {
         let container = NSTextContainer(size: NSSize(width: 800, height: 600))
         layoutManager.addTextContainer(container)
         let view = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
-        view.string = text
-        let storage = NSTextStorage(string: text)
-        storage.addLayoutManager(layoutManager)
+        view.textStorage?.replaceCharacters(in: NSRange(location: 0, length: 0), with: text)
         return view
     }
 

--- a/AlasTests/EditorBufferStoreTests.swift
+++ b/AlasTests/EditorBufferStoreTests.swift
@@ -64,4 +64,20 @@ struct EditorBufferStoreTests {
         try store.write(snap, worktreeId: "wt", tabId: "t")
         #expect(try store.read(worktreeId: "wt", tabId: "t") == snap)
     }
+
+    @Test func externalBufferIsCachedSeparately() throws {
+        let (store, _) = makeStore()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ext-\(UUID().uuidString).h")
+        try "header content\n".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let a = store.externalBuffer(worktreeId: "w1", absoluteURL: url)
+        let b = store.externalBuffer(worktreeId: "w1", absoluteURL: url)
+        #expect(a === b)  // same instance reused
+
+        // Different worktreeId → distinct buffer.
+        let c = store.externalBuffer(worktreeId: "w2", absoluteURL: url)
+        #expect(c !== a)
+    }
 }

--- a/AlasTests/EditorBufferStoreTests.swift
+++ b/AlasTests/EditorBufferStoreTests.swift
@@ -80,4 +80,17 @@ struct EditorBufferStoreTests {
         let c = store.externalBuffer(worktreeId: "w2", absoluteURL: url)
         #expect(c !== a)
     }
+
+    @Test func externalBufferIsReleasedOnDiscard() throws {
+        let (store, _) = makeStore()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ext-discard-\(UUID().uuidString).h")
+        try "x\n".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let a = store.externalBuffer(worktreeId: "w", absoluteURL: url)
+        store.discardExternalBuffer(worktreeId: "w", absoluteURL: url)
+        let b = store.externalBuffer(worktreeId: "w", absoluteURL: url)
+        #expect(a !== b)  // a was discarded; b is a fresh instance
+    }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -713,6 +713,32 @@ struct EditorBufferTests {
         #expect(bufferA.storage.attribute(.underlineStyle, at: 0, effectiveRange: nil) == nil)
     }
 
+    @Test func externalBufferLoadsContentsAndIsReadOnly() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ext-\(UUID().uuidString).h")
+        try "external content\n".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let buffer = EditorBuffer(externalAbsoluteURL: url)
+        #expect(buffer.storage.string == "external content\n")
+        #expect(buffer.isExternal == true)
+        #expect(buffer.dirty == false)
+    }
+
+    @Test func externalBufferSaveIsNoOp() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ext-\(UUID().uuidString).h")
+        try "x\n".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let buffer = EditorBuffer(externalAbsoluteURL: url)
+        // Mutate storage as if user typed (test-only — production sets isEditable=false on the view)
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "INJECTED ")
+        // save() returns Void and is a no-op for external buffers (readOnly=true guard fires).
+        try buffer.save()
+        let onDisk = try String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "x\n")
+    }
+
     @Test func coordinatorPathChangeClearsTextViewUndoStack() throws {
         // Regression: NSTextView's undoManager survives across tab swaps
         // because CenterPaneView reuses the same text view. Without an

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -466,6 +466,7 @@ struct EditorBufferTests {
             buffer: buffer,
             layoutManager: layoutManager,
             worktreeId: "wt",
+            worktreeRoot: root,
             tabId: "t",
             revealLine: nil,
             revealCharacter: nil,
@@ -506,6 +507,7 @@ struct EditorBufferTests {
             buffer: buffer,
             layoutManager: layoutManager,
             worktreeId: "wt",
+            worktreeRoot: root,
             tabId: "tab",
             revealLine: nil,
             revealCharacter: nil,
@@ -544,6 +546,7 @@ struct EditorBufferTests {
             buffer: bufferA,
             layoutManager: layoutManager,
             worktreeId: "wt",
+            worktreeRoot: root,
             tabId: "tab-a",
             revealLine: nil,
             revealCharacter: nil,
@@ -598,7 +601,7 @@ struct EditorBufferTests {
         let theme = try ThemeStore().current
         coordinator.attach(
             textView: textView, buffer: bufferA, layoutManager: layoutManager,
-            worktreeId: "wt", tabId: "tab-a",
+            worktreeId: "wt", worktreeRoot: root, tabId: "tab-a",
             revealLine: nil, revealCharacter: nil, theme: theme
         )
 
@@ -639,7 +642,7 @@ struct EditorBufferTests {
         let theme = try ThemeStore().current
         coordinator.attach(
             textView: textView, buffer: bufferA, layoutManager: layoutManager,
-            worktreeId: "wt", tabId: "tab-a",
+            worktreeId: "wt", worktreeRoot: root, tabId: "tab-a",
             revealLine: nil, revealCharacter: nil, theme: theme
         )
 
@@ -694,7 +697,7 @@ struct EditorBufferTests {
         let theme = try ThemeStore().current
         coordinator.attach(
             textView: textView, buffer: bufferA, layoutManager: layoutManager,
-            worktreeId: "wt", tabId: "tab-a",
+            worktreeId: "wt", worktreeRoot: root, tabId: "tab-a",
             revealLine: nil, revealCharacter: nil, theme: theme
         )
 
@@ -765,7 +768,7 @@ struct EditorBufferTests {
         let theme = try ThemeStore().current
         coordinator.attach(
             textView: textView, buffer: bufferA, layoutManager: layoutManager,
-            worktreeId: "wt", tabId: "tab-a",
+            worktreeId: "wt", worktreeRoot: root, tabId: "tab-a",
             revealLine: nil, revealCharacter: nil, theme: theme
         )
 

--- a/AlasTests/TabsManagerBufferTests.swift
+++ b/AlasTests/TabsManagerBufferTests.swift
@@ -334,4 +334,20 @@ struct TabsManagerBufferTests {
         #expect(manager.peekBuffer(tabId: tab.id) == nil)
         #expect(try store.read(worktreeId: "wt", tabId: tab.id) != nil)
     }
+
+    @Test func externalBufferIsReleasedWhenTabIsClosed() throws {
+        let (manager, store, _) = makeManager()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ext-tab-discard-\(UUID().uuidString).h")
+        try "// header\n".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let tabId = "ext-tab"
+        let a = manager.externalBuffer(worktreeId: "wt", tabId: tabId, absoluteURL: url)
+        manager.discardBuffer(worktreeId: "wt", tabId: tabId)
+        // After discard the store must have evicted the entry; requesting the
+        // buffer again should return a new (distinct) instance.
+        let b = store.externalBuffer(worktreeId: "wt", absoluteURL: url)
+        #expect(a !== b)
+    }
 }

--- a/AlasTests/TabsManagerBufferTests.swift
+++ b/AlasTests/TabsManagerBufferTests.swift
@@ -350,4 +350,31 @@ struct TabsManagerBufferTests {
         let b = store.externalBuffer(worktreeId: "wt", absoluteURL: url)
         #expect(a !== b)
     }
+
+    /// Calling `externalBuffer` for the same `tabId` twice (simulating a tab
+    /// switch back) must return the SAME cached buffer instance — proving the
+    /// cache-hit path is exercised and that a second LSP open would be guarded
+    /// by the `openedExternalDocs` set.
+    @Test func externalBufferCacheHitReturnsSameInstance() throws {
+        let (manager, _, _) = makeManager()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ext-cache-hit-\(UUID().uuidString).h")
+        try "// header\n".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let root = FileManager.default.temporaryDirectory
+        let tabId = "ext-cache-tab"
+        let a = manager.externalBuffer(
+            worktreeId: "wt", tabId: tabId, absoluteURL: url,
+            worktreeRoot: root, originatingFileURL: nil, language: "c"
+        )
+        // Simulates the view being dismantled and remounted (tab switch away
+        // and back). The second call must return the same instance and must
+        // NOT attempt a second openExternalDocument.
+        let b = manager.externalBuffer(
+            worktreeId: "wt", tabId: tabId, absoluteURL: url,
+            worktreeRoot: root, originatingFileURL: nil, language: "c"
+        )
+        #expect(a === b)
+    }
 }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -95,6 +95,29 @@ struct TabsManagerTests {
         }
     }
 
+    @Test func editorTabStateRoundTripsOriginatingRelativePath() throws {
+        let s = EditorTabState(
+            id: "z", title: "NSString.h",
+            relativePath: "",
+            externalAbsolutePath: "/usr/include/NSString.h",
+            originatingRelativePath: "Foo/Bar.swift"
+        )
+        let data = try JSONEncoder().encode(s)
+        let back = try JSONDecoder().decode(EditorTabState.self, from: data)
+        #expect(back == s)
+        #expect(back.originatingRelativePath == "Foo/Bar.swift")
+    }
+
+    @Test func editorTabStateDecodesLegacyShapeWithoutOriginatingRelativePath() throws {
+        // Old shape: no originatingRelativePath key. Must decode cleanly.
+        let json = #"""
+        {"id":"z","title":"NSString.h","relativePath":"","externalAbsolutePath":"/usr/include/NSString.h"}
+        """#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(EditorTabState.self, from: json)
+        #expect(decoded.isExternal)
+        #expect(decoded.originatingRelativePath == nil)
+    }
+
     @Test func openExternalEditorReusesExistingTab() {
         let worktreeId = "tabs-manager-reuse-external"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -74,4 +74,39 @@ struct TabsManagerTests {
         #expect(back == s)
         #expect(back.isExternal)
     }
+
+    @Test func openExternalEditorAppendsAndActivates() {
+        let worktreeId = "tabs-manager-open-external"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let tab = mgr.openExternalEditor(
+            worktreeId: worktreeId,
+            absoluteURL: URL(fileURLWithPath: "/usr/include/foo.h"),
+            revealLine: 10, revealCharacter: 0
+        )
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == tab.id)
+        if case .editor(let s) = tab {
+            #expect(s.isExternal)
+            #expect(s.externalAbsolutePath == "/usr/include/foo.h")
+            #expect(s.title == "foo.h")
+            #expect(s.revealLine == 10)
+        } else {
+            Issue.record("expected editor tab")
+        }
+    }
+
+    @Test func openExternalEditorReusesExistingTab() {
+        let worktreeId = "tabs-manager-reuse-external"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let url = URL(fileURLWithPath: "/usr/include/foo.h")
+        let first = mgr.openExternalEditor(worktreeId: worktreeId, absoluteURL: url, revealLine: 1, revealCharacter: 0)
+        let second = mgr.openExternalEditor(worktreeId: worktreeId, absoluteURL: url, revealLine: 5, revealCharacter: 2)
+        #expect(first.id == second.id)
+        #expect(mgr.tabs(forWorktree: worktreeId).count == 1)
+        if case .editor(let s) = second {
+            #expect(s.revealLine == 5)
+            #expect(s.revealCharacter == 2)
+        }
+    }
 }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -132,4 +132,27 @@ struct TabsManagerTests {
             #expect(s.revealCharacter == 2)
         }
     }
+
+    @Test func openExternalEditorReuseRefreshesOriginatingRelativePath() {
+        let worktreeId = "tabs-manager-reuse-refresh-origin"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let url = URL(fileURLWithPath: "/usr/include/foo.h")
+        _ = mgr.openExternalEditor(
+            worktreeId: worktreeId, absoluteURL: url,
+            revealLine: 1, revealCharacter: 0,
+            originatingRelativePath: "PkgA/Sources/main.swift"
+        )
+        let second = mgr.openExternalEditor(
+            worktreeId: worktreeId, absoluteURL: url,
+            revealLine: 5, revealCharacter: 2,
+            originatingRelativePath: "PkgB/Sources/lib.swift"
+        )
+        if case .editor(let s) = second {
+            #expect(s.originatingRelativePath == "PkgB/Sources/lib.swift")
+            #expect(s.revealLine == 5)
+        } else {
+            Issue.record("expected editor tab")
+        }
+    }
 }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -51,4 +51,27 @@ struct TabsManagerTests {
         #expect(state.sessionId == "new")
         #expect(state.title == "x")
     }
+
+    @Test func editorTabStateDecodesLegacyShape() throws {
+        // Old shape: no externalAbsolutePath key.
+        let json = #"""
+        {"id":"x","title":"a.txt","relativePath":"a.txt"}
+        """#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(EditorTabState.self, from: json)
+        #expect(decoded.relativePath == "a.txt")
+        #expect(decoded.isExternal == false)
+        #expect(decoded.externalAbsolutePath == nil)
+    }
+
+    @Test func editorTabStateRoundTripsExternalPath() throws {
+        let s = EditorTabState(
+            id: "y", title: "NSString.h",
+            relativePath: "",
+            externalAbsolutePath: "/usr/include/NSString.h"
+        )
+        let data = try JSONEncoder().encode(s)
+        let back = try JSONDecoder().decode(EditorTabState.self, from: data)
+        #expect(back == s)
+        #expect(back.isExternal)
+    }
 }


### PR DESCRIPTION
## Summary

Three polish additions to the existing ⌘-click go-to-definition flow:

- **Out-of-worktree targets** open as read-only tabs attached to the originating worktree (lock glyph in the tab title), with full LSP read-side capability so recursive ⌘-click works inside SDK headers / SwiftPM dep checkouts.
- **Multi-result picker** appears anchored at the click point when LSP returns 2+ definitions (e.g. overloads), showing file:line + 1-line snippet preview. ↑/↓ + ⏎ to choose, esc / outside-click to dismiss.
- **⌘-hover affordance** underlines the symbol under the cursor (via temporary layout-manager attributes) and swaps to a pointer cursor whenever LSP confirms a definition exists. 80 ms debounce; clears on ⌘ release / no-result / mouse exit.

The existing in-worktree path is untouched.

## Notable design choices

- External buffers reuse the `EditorBuffer` type with sentinel `worktreeRoot` / `relativePath` (option B in the design doc) instead of making those properties optional. Avoids ripple across ~15 call sites; sentinels reconstruct the absolute URL exactly.
- The originating worktree root is tracked separately on the coordinator so LSP client lookup and `openExternalDocument` use the real worktree, not the sentinel parent dir.
- Hover underline uses `NSLayoutManager.addTemporaryAttributes` so it doesn't register on the undo stack and isn't wiped by re-highlights.
- `WorkspaceLSPManager.openExternalDocument` ref-counts external URIs against the originating client's holder and explicitly does NOT trigger server shutdown when the last external doc closes (the server still serves in-worktree tabs).

## Test plan

- [ ] In-worktree ⌘-click still works (regression check)
- [ ] ⌘-click into a SwiftPM dep / Foundation header opens read-only tab with 🔒 glyph; recursive ⌘-click works
- [ ] Picker shows for overloaded symbols; ↑/↓ + ⏎ navigates; esc / outside-click dismisses
- [ ] ⌘-hover shows underline + pointer; releasing ⌘ clears immediately
- [ ] External tab restores across app relaunch
- [ ] Missing external file on restore surfaces error state, no crash

## Tests

245/245 passing. New coverage:

- \`HoverHighlightFeatureTests\` (cmd release / empty result paths)
- \`DefinitionSnippetCacheTests\` (line read, out-of-range, repeated reads use cache)
- \`TabsManagerTests\` extensions (legacy decode, external round-trip, append-and-activate, reuse-existing)
- \`EditorBufferTests\` extensions (external load read-only, save no-op)
- \`EditorBufferStoreTests\` extension (external cache keyed by worktreeId+path)