### PR TITLE
fix(tabs): terminal tab switching

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1515,7 +1515,7 @@
 			repositoryURL = "https://github.com/tree-sitter/swift-tree-sitter";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.0;
+				minimumVersion = 0.25.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -12,6 +12,7 @@ struct TerminalTabView: View {
         Group {
             if let session = state.terminal.registry.session(for: sessionId) {
                 GhosttyHost(session: session)
+                    .id(sessionId)
             } else {
                 // Session was lost (likely after relaunch). Recreate.
                 TerminalRecoverPlaceholder(state: state, worktreeId: worktreeId, tabId: tabId)

--- a/Alas/Sources/Terminal/GhosttyHost.swift
+++ b/Alas/Sources/Terminal/GhosttyHost.swift
@@ -21,8 +21,16 @@ struct GhosttyHost: NSViewRepresentable {
     }
 
     @MainActor
+    static func dismantleNSView(_ nsView: NSView, coordinator: ()) {
+        nsView.subviews.forEach { $0.removeFromSuperview() }
+    }
+
+    @MainActor
     private func attach(_ container: NSView) {
-        // Detach surface from previous superview if any
+        for subview in container.subviews where subview !== session.surface {
+            subview.removeFromSuperview()
+        }
+
         if session.surface.superview !== container {
             session.surface.removeFromSuperview()
             session.surface.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## Summary

Fix terminal tab switching when multiple terminal sessions are open in the same workspace.

The native Ghostty host can be reused by SwiftUI while the active terminal session changes. The host now removes stale terminal surfaces from its container before attaching the active session, detaches hosted views during dismantle, and the terminal tab view keys the host by session id so SwiftUI/AppKit identity tracks the selected terminal session.

`xcodegen` also regenerated the project file, aligning the SwiftTreeSitter package minimum with `project.yml`.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test`

Note: the plain signed test invocation failed before running tests because Xcode reported the embedded `AlasTests.xctest` subcomponent was not signed. The same test suite passed with codesigning disabled.