### PR TITLE
Use existing Alas assets as the app icon

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88379ACE40F42BE4A3257659 /* ThemeTests.swift */; };
 		BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */; };
+		C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620C4A708CD1013DE2736A00 /* AppIconTests.swift */; };
 		C1EBF68A32C7C1D61ECC89AC /* LSPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */; };
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
 		C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */; };
@@ -288,6 +289,7 @@
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
+		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
 		642163EB929E060A878211E2 /* HookInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstaller.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
@@ -439,6 +441,7 @@
 			children = (
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
+				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
@@ -1203,6 +1206,7 @@
 			files = (
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
+				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,
 				7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */,

--- a/Alas/Resources/Info.plist
+++ b/Alas/Resources/Info.plist
@@ -6,6 +6,10 @@
 	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -18,13 +22,13 @@
 	<string>0.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2026 Nacho Lopez</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.developer-tools</string>
 </dict>
 </plist>

--- a/AlasTests/AppIconTests.swift
+++ b/AlasTests/AppIconTests.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Testing
+
+struct AppIconTests {
+    @Test func bundleMetadataUsesAlasAppIcon() {
+        let info = Bundle.main.infoDictionary
+
+        #expect(info?["CFBundleIconFile"] as? String == "AppIcon")
+        #expect(info?["CFBundleIconName"] as? String == "AppIcon")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -52,6 +52,8 @@ targets:
         NSHumanReadableCopyright: "Copyright © 2026 Nacho Lopez"
         NSPrincipalClass: NSApplication
         LSApplicationCategoryType: public.app-category.developer-tools
+        CFBundleIconFile: AppIcon
+        CFBundleIconName: AppIcon
     dependencies:
       - framework: .build/ghostty/GhosttyKit.xcframework
         embed: false
@@ -66,6 +68,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.nlopez.alas
         PRODUCT_NAME: Alas
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ENABLE_HARDENED_RUNTIME: YES
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_IDENTITY: "-"


### PR DESCRIPTION
## Summary

- Wire existing `AppIcon.appiconset` icon assets (added in #57) into the Alas app build so the launcher and window display the Alas icon instead of a generic default
- No new artwork was created — the existing brand mark assets are used

## Changes

- **`project.yml`** — source of truth: added `ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon` build setting and `CFBundleIconFile`/`CFBundleIconName` plist properties
- **`Alas/Resources/Info.plist`** — regenerated via `xcodegen` with the two icon keys
- **`Alas.xcodeproj/project.pbxproj`** — regenerated via `xcodegen`, includes new test file reference
- **`AlasTests/AppIconTests.swift`** — new Swift Testing regression test that verifies the built app bundle's icon metadata

## Validation

- `xcrun actool` confirmed `AppIcon.appiconset` compiles to `AppIcon.icns` with correct plist keys
- `xcodegen` regeneration produces clean output
- `git diff --check` passed
- Full `xcodebuild build` blocked by missing `.build/ghostty/GhosttyKit.xcframework` (pre-existing local setup issue, not caused by this change)

Closes #743