### PR TITLE
feat(tabs): harden tab names for terminals and allow renaming

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -125,7 +125,11 @@ final class AppState {
         harness.detector.register(sessionId: session.id) { [weak session] in
             session?.surface.foregroundPid
         }
-        return tabs.appendTerminal(worktreeId: worktree.id, title: worktree.branch, sessionId: session.id)
+        let title = tabs.nextTerminalTitle(
+            worktreeId: worktree.id,
+            baseTitle: defaultTerminalTitle(for: worktree)
+        )
+        return tabs.appendTerminal(worktreeId: worktree.id, title: title, sessionId: session.id)
     }
 
     @discardableResult
@@ -230,6 +234,26 @@ final class AppState {
         }
     }
 
+    func renameTerminalTab(worktreeId: String, tabId: TabID) {
+        guard let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
+              case .terminal(let state) = tab else { return }
+
+        let alert = NSAlert()
+        alert.messageText = "Rename Terminal"
+        alert.informativeText = "Choose a stable name for this terminal tab."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Rename")
+        alert.addButton(withTitle: "Cancel")
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        field.stringValue = state.title
+        field.lineBreakMode = .byTruncatingTail
+        alert.accessoryView = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        _ = tabs.renameTerminal(worktreeId: worktreeId, tabId: tabId, title: field.stringValue)
+    }
+
     func closeTab(worktreeId: String, tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         if let tab = allTabs.first(where: { $0.id == tabId }) {
@@ -318,6 +342,15 @@ final class AppState {
             throw NSError(domain: "AppState", code: 3)
         }
         return replacement
+    }
+
+    private func defaultTerminalTitle(for worktree: Worktree) -> String {
+        let folder = worktree.path.lastPathComponent.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !folder.isEmpty { return folder }
+        let name = worktree.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !name.isEmpty { return name }
+        let branch = worktree.branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        return branch.isEmpty ? "Terminal" : branch
     }
 
     private func worktree(withId id: String) -> Worktree? {

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -49,6 +49,9 @@ struct CenterPaneView: View {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(rel, forType: .string)
                 },
+                onRenameTerminal: { id in
+                    state.renameTerminalTab(worktreeId: worktree.id, tabId: id)
+                },
                 onNewTerminal: openTerminal
             )
             Group {

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -13,6 +13,7 @@ struct TabBarView: View {
     let onCloseToRight: (TabID) -> Void
     let onCopyPath: (TabID) -> Void
     let onCopyRelativePath: (TabID) -> Void
+    let onRenameTerminal: (TabID) -> Void
     let onNewTerminal: () -> Void
     @Environment(\.theme) var theme
 
@@ -29,6 +30,10 @@ struct TabBarView: View {
                     onClose: { onClose(tab.id) }
                 )
                 .contextMenu {
+                    if case .terminal = tab {
+                        Button("Rename…") { onRenameTerminal(tab.id) }
+                        Divider()
+                    }
                     Button("Close") { onClose(tab.id) }
                     Button("Close Other Tabs") { onCloseOthers(tab.id) }
                         .disabled(tabs.count <= 1)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -74,6 +74,37 @@ final class TabsManager {
         return tab
     }
 
+    func nextTerminalTitle(worktreeId: String, baseTitle: String) -> String {
+        let base = baseTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallback = base.isEmpty ? "Terminal" : base
+        let existing = Set(tabs(forWorktree: worktreeId).compactMap { tab -> String? in
+            guard case .terminal(let state) = tab else { return nil }
+            return state.title
+        })
+        guard existing.contains(fallback) else { return fallback }
+
+        var suffix = 2
+        while existing.contains("\(fallback) \(suffix)") {
+            suffix += 1
+        }
+        return "\(fallback) \(suffix)"
+    }
+
+    @discardableResult
+    func renameTerminal(worktreeId: String, tabId: TabID, title: String) -> Tab? {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .terminal(var state) = file.tabs[idx] else { return nil }
+        state.title = trimmed
+        let tab = Tab.terminal(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
     @discardableResult
     func replaceTerminalSession(worktreeId: String, tabId: TabID, sessionId: String) -> Tab? {
         guard var file = byWorktree[worktreeId],

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -52,6 +52,42 @@ struct TabsManagerTests {
         #expect(state.title == "x")
     }
 
+    @Test func nextTerminalTitleUsesStableNumericSuffix() {
+        let worktreeId = "tabs-manager-terminal-title-suffix"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+
+        #expect(mgr.nextTerminalTitle(worktreeId: worktreeId, baseTitle: "alas") == "alas")
+        _ = mgr.appendTerminal(worktreeId: worktreeId, title: "alas", sessionId: "s1")
+        #expect(mgr.nextTerminalTitle(worktreeId: worktreeId, baseTitle: "alas") == "alas 2")
+        _ = mgr.appendTerminal(worktreeId: worktreeId, title: "alas 2", sessionId: "s2")
+        #expect(mgr.nextTerminalTitle(worktreeId: worktreeId, baseTitle: "alas") == "alas 3")
+    }
+
+    @Test func renamingTerminalUpdatesTitleAndTrimsWhitespace() {
+        let worktreeId = "tabs-manager-rename-terminal"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: worktreeId, title: "alas", sessionId: "s")
+
+        let renamed = mgr.renameTerminal(worktreeId: worktreeId, tabId: tab.id, title: "  Server  ")
+
+        #expect(renamed?.title == "Server")
+        #expect(mgr.tabs(forWorktree: worktreeId).first?.title == "Server")
+    }
+
+    @Test func renamingTerminalRejectsEmptyTitle() {
+        let worktreeId = "tabs-manager-rename-terminal-empty"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: worktreeId, title: "alas", sessionId: "s")
+
+        let renamed = mgr.renameTerminal(worktreeId: worktreeId, tabId: tab.id, title: "   ")
+
+        #expect(renamed == nil)
+        #expect(mgr.tabs(forWorktree: worktreeId).first?.title == "alas")
+    }
+
     @Test func editorTabStateDecodesLegacyShape() throws {
         // Old shape: no externalAbsolutePath key.
         let json = #"""


### PR DESCRIPTION
## Summary
- Give new terminal tabs stable names based on the worktree folder instead of the current process or branch.
- Add numeric suffixes for duplicate terminal names in the same worktree.
- Add a terminal tab context-menu rename flow that persists trimmed, non-empty names.

## Testing
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build\n- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test\n\n<!-- gg:managed:start -->\nPart of stack `terminal-tab-name`\n\nCommit: 079a1bb\n<!-- gg:managed:end -->