### PR TITLE
Worktree context menu: archive and delete

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
+		89FAEDD5704F4564A07E203D /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FCF199AB641A0B84AC0F6 /* ProjectConfigTests.swift */; };
 		6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795056B6AD803D2B555FC866 /* RightPaneStore.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
@@ -282,6 +283,7 @@
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
+		8C2FCF199AB641A0B84AC0F6 /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		4FE58EF9CF8EC461667D9430 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavView.swift; sourceTree = "<group>"; };
 		519CFB3707E8DDBDECD6C5D1 /* Alas.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alas.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -478,6 +480,7 @@
 				7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */,
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
+				8C2FCF199AB641A0B84AC0F6 /* ProjectConfigTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
@@ -1253,6 +1256,7 @@
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
+				89FAEDD5704F4564A07E203D /* ProjectConfigTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -86,7 +86,6 @@
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
-		89FAEDD5704F4564A07E203D /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2FCF199AB641A0B84AC0F6 /* ProjectConfigTests.swift */; };
 		6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795056B6AD803D2B555FC866 /* RightPaneStore.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
@@ -169,6 +168,7 @@
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
 		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
+		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
@@ -283,13 +283,13 @@
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
-		8C2FCF199AB641A0B84AC0F6 /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		4FE58EF9CF8EC461667D9430 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavView.swift; sourceTree = "<group>"; };
 		519CFB3707E8DDBDECD6C5D1 /* Alas.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alas.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitTests.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
+		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
@@ -479,8 +479,8 @@
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
 				7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */,
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
+				5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
-				8C2FCF199AB641A0B84AC0F6 /* ProjectConfigTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
@@ -1255,8 +1255,8 @@
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
+				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
-				89FAEDD5704F4564A07E203D /* ProjectConfigTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -98,6 +98,23 @@ final class AppState {
     /// it, marks the path hidden in `ProjectConfig`, and re-points selection if
     /// the archived worktree was selected. Does NOT touch git or disk.
     func archiveWorktree(_ worktree: Worktree) {
+        let dirty = dirtyEditorTabIds(worktreeId: worktree.id)
+        if !dirty.isEmpty {
+            switch promptForDirtyBuffers(
+                action: "Archive",
+                branch: worktree.branch,
+                dirtyCount: dirty.count,
+                onDiskDestructive: false
+            ) {
+            case .save:
+                guard saveDirtyBuffers(in: worktree.id) else { return }
+            case .discard:
+                break
+            case .cancel:
+                return
+            }
+        }
+
         // Snapshot index in the visible list BEFORE we mutate anything, so we
         // can pick a sensible follow-up selection.
         let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
@@ -522,7 +539,26 @@ final class AppState {
     /// Delete a worktree from disk. Shows a confirm dialog; on dirty-tree
     /// failure offers a force retry. Cleans up in-app state on success.
     func deleteWorktree(_ worktree: Worktree) {
-        guard confirmDeleteWorktree(branch: worktree.branch) else { return }
+        let dirty = dirtyEditorTabIds(worktreeId: worktree.id)
+        let saveBuffersFirst: Bool
+        if dirty.isEmpty {
+            guard confirmDeleteWorktree(branch: worktree.branch) else { return }
+            saveBuffersFirst = false
+        } else {
+            switch promptForDirtyBuffers(
+                action: "Delete",
+                branch: worktree.branch,
+                dirtyCount: dirty.count,
+                onDiskDestructive: true
+            ) {
+            case .save: saveBuffersFirst = true
+            case .discard: saveBuffersFirst = false
+            case .cancel: return
+            }
+        }
+        if saveBuffersFirst {
+            guard saveDirtyBuffers(in: worktree.id) else { return }
+        }
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             showFileActionError(title: "Delete Failed", message: "Could not find the project for this worktree.")
             return
@@ -613,5 +649,81 @@ final class AppState {
         alert.addButton(withTitle: "Cancel")
         forceButton.hasDestructiveAction = true
         return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private enum DirtyBufferChoice {
+        case save
+        case discard
+        case cancel
+    }
+
+    /// Returns the editor tabs in this worktree whose buffers have unsaved
+    /// changes. Used by archive/delete to warn the user before tearing down
+    /// the buffer state.
+    private func dirtyEditorTabIds(worktreeId: String) -> [TabID] {
+        tabs.tabs(forWorktree: worktreeId).compactMap { tab in
+            guard case .editor(let state) = tab,
+                  let buffer = tabs.peekBuffer(tabId: state.id),
+                  buffer.dirty else { return nil }
+            return state.id
+        }
+    }
+
+    /// Three-way prompt for actions (archive, delete) that would otherwise
+    /// silently discard unsaved editor buffers. The default button (Enter)
+    /// is "Save & <action>"; the destructive button is "Discard & <action>".
+    /// `onDiskDestructive` true means `<action>` will also remove files from
+    /// disk; the message text adjusts accordingly.
+    private func promptForDirtyBuffers(
+        action: String,
+        branch: String,
+        dirtyCount: Int,
+        onDiskDestructive: Bool
+    ) -> DirtyBufferChoice {
+        let alert = NSAlert()
+        alert.messageText = "\(action) worktree '\(branch)'?"
+        let countSentence = dirtyCount == 1
+            ? "1 file has unsaved changes."
+            : "\(dirtyCount) files have unsaved changes."
+        let actionSentence = onDiskDestructive
+            ? "This removes its files from disk. The local branch will be deleted if merged."
+            : "The worktree itself stays on disk."
+        alert.informativeText = "\(countSentence) Saving will write them to disk; discarding will lose them. \(actionSentence)"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Save & \(action)")
+        let discardButton = alert.addButton(withTitle: "Discard & \(action)")
+        alert.addButton(withTitle: "Cancel")
+        discardButton.hasDestructiveAction = true
+        switch alert.runModal() {
+        case .alertFirstButtonReturn: return .save
+        case .alertSecondButtonReturn: return .discard
+        default: return .cancel
+        }
+    }
+
+    /// Save every dirty editor buffer in the given worktree. Returns true on
+    /// full success; on partial failure surfaces an aggregate error and
+    /// returns false so the caller can bail before the destructive cleanup.
+    private func saveDirtyBuffers(in worktreeId: String) -> Bool {
+        var failed: [(TabID, Error)] = []
+        for tab in tabs.tabs(forWorktree: worktreeId) {
+            guard case .editor(let state) = tab,
+                  let buffer = tabs.peekBuffer(tabId: state.id),
+                  buffer.dirty else { continue }
+            do {
+                try buffer.save()
+            } catch {
+                failed.append((state.id, error))
+            }
+        }
+        if !failed.isEmpty {
+            let count = failed.count
+            showFileActionError(
+                title: "Save Failed",
+                message: "\(count) file\(count == 1 ? "" : "s") could not be saved. The worktree was not archived or deleted."
+            )
+            return false
+        }
+        return true
     }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -549,6 +549,9 @@ final class AppState {
                             deleteBranchIfMerged: deleteBranch,
                             force: true
                         )
+                    } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
+                        showFileActionError(title: "Delete Failed", message: stderr)
+                        return
                     } catch {
                         showFileActionError(title: "Delete Failed", message: "\(error)")
                         return

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -107,7 +107,7 @@ final class AppState {
                 onDiskDestructive: false
             ) {
             case .save:
-                guard saveDirtyBuffers(in: worktree.id) else { return }
+                guard saveDirtyBuffers(in: worktree) else { return }
             case .discard:
                 break
             case .cancel:
@@ -557,7 +557,7 @@ final class AppState {
             }
         }
         if saveBuffersFirst {
-            guard saveDirtyBuffers(in: worktree.id) else { return }
+            guard saveDirtyBuffers(in: worktree) else { return }
         }
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             showFileActionError(title: "Delete Failed", message: "Could not find the project for this worktree.")
@@ -658,15 +658,10 @@ final class AppState {
     }
 
     /// Returns the editor tabs in this worktree whose buffers have unsaved
-    /// changes. Used by archive/delete to warn the user before tearing down
-    /// the buffer state.
+    /// changes — including tabs whose buffers are not yet instantiated but
+    /// have a persisted hot-exit snapshot on disk.
     private func dirtyEditorTabIds(worktreeId: String) -> [TabID] {
-        tabs.tabs(forWorktree: worktreeId).compactMap { tab in
-            guard case .editor(let state) = tab,
-                  let buffer = tabs.peekBuffer(tabId: state.id),
-                  buffer.dirty else { return nil }
-            return state.id
-        }
+        tabs.tabIdsWithUnsavedChanges(forWorktree: worktreeId)
     }
 
     /// Three-way prompt for actions (archive, delete) that would otherwise
@@ -701,23 +696,15 @@ final class AppState {
         }
     }
 
-    /// Save every dirty editor buffer in the given worktree. Returns true on
-    /// full success; on partial failure surfaces an aggregate error and
-    /// returns false so the caller can bail before the destructive cleanup.
-    private func saveDirtyBuffers(in worktreeId: String) -> Bool {
-        var failed: [(TabID, Error)] = []
-        for tab in tabs.tabs(forWorktree: worktreeId) {
-            guard case .editor(let state) = tab,
-                  let buffer = tabs.peekBuffer(tabId: state.id),
-                  buffer.dirty else { continue }
-            do {
-                try buffer.save()
-            } catch {
-                failed.append((state.id, error))
-            }
-        }
-        if !failed.isEmpty {
-            let count = failed.count
+    /// Save every dirty editor buffer in the given worktree — including tabs
+    /// whose buffers are not yet instantiated but have a persisted hot-exit
+    /// snapshot on disk. Returns true on full success; on partial failure
+    /// surfaces an aggregate error and returns false so the caller can bail
+    /// before the destructive cleanup.
+    private func saveDirtyBuffers(in worktree: Worktree) -> Bool {
+        let errors = tabs.saveAllUnsaved(forWorktree: worktree.id, root: worktree.path)
+        if !errors.isEmpty {
+            let count = errors.count
             showFileActionError(
                 title: "Save Failed",
                 message: "\(count) file\(count == 1 ? "" : "s") could not be saved. The worktree was not archived or deleted."

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -525,10 +525,12 @@ final class AppState {
         let repoPath = URL(fileURLWithPath: project.path)
         let deleteBranch = config.worktrees.deleteBranchOnRemove
 
-        // Snapshot for selection follow-up.
+        // Snapshot for selection follow-up. The index must be captured BEFORE
+        // the await because the worktree won't be in `visibleWorktrees` after
+        // `refreshWorktrees`. We re-check selection (live) post-await so a
+        // selection change during the dialog/await flow isn't clobbered.
         let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
         let removedIndex = siblingsBefore.firstIndex(where: { $0.id == worktree.id }) ?? 0
-        let wasSelected = selectedWorktreeId == worktree.id
 
         Task { @MainActor in
             let svc = WorktreeService()
@@ -567,7 +569,7 @@ final class AppState {
 
             cleanupWorktreeState(worktreeId: worktree.id)
             try? await projectsManager.refreshWorktrees(projectId: worktree.projectId)
-            if wasSelected {
+            if selectedWorktreeId == worktree.id {
                 selectedWorktreeId = selectionAfterRemoval(
                     removedFromProjectId: worktree.projectId,
                     removedAtIndex: removedIndex

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -513,4 +513,95 @@ final class AppState {
         alert.addButton(withTitle: "OK")
         alert.runModal()
     }
+
+    /// Delete a worktree from disk. Shows a confirm dialog; on dirty-tree
+    /// failure offers a force retry. Cleans up in-app state on success.
+    func deleteWorktree(_ worktree: Worktree) {
+        guard confirmDeleteWorktree(branch: worktree.branch) else { return }
+        guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
+            showFileActionError(title: "Delete Failed", message: "Could not find the project for this worktree.")
+            return
+        }
+        let repoPath = URL(fileURLWithPath: project.path)
+        let deleteBranch = config.worktrees.deleteBranchOnRemove
+
+        // Snapshot for selection follow-up.
+        let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
+        let removedIndex = siblingsBefore.firstIndex(where: { $0.id == worktree.id }) ?? 0
+        let wasSelected = selectedWorktreeId == worktree.id
+
+        Task { @MainActor in
+            let svc = WorktreeService()
+            do {
+                try await svc.remove(
+                    repoPath: repoPath,
+                    worktree: worktree,
+                    deleteBranchIfMerged: deleteBranch,
+                    force: false
+                )
+            } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
+                if Self.looksLikeDirtyWorktreeError(stderr) {
+                    guard confirmForceDeleteWorktree(branch: worktree.branch) else { return }
+                    do {
+                        try await svc.remove(
+                            repoPath: repoPath,
+                            worktree: worktree,
+                            deleteBranchIfMerged: deleteBranch,
+                            force: true
+                        )
+                    } catch {
+                        showFileActionError(title: "Delete Failed", message: "\(error)")
+                        return
+                    }
+                } else {
+                    showFileActionError(title: "Delete Failed", message: stderr)
+                    return
+                }
+            } catch {
+                showFileActionError(title: "Delete Failed", message: "\(error)")
+                return
+            }
+
+            cleanupWorktreeState(worktreeId: worktree.id)
+            try? await projectsManager.refreshWorktrees(projectId: worktree.projectId)
+            if wasSelected {
+                selectedWorktreeId = selectionAfterRemoval(
+                    removedFromProjectId: worktree.projectId,
+                    removedAtIndex: removedIndex
+                )
+            }
+        }
+    }
+
+    /// Permissive substring check: git's exact wording around dirty/locked
+    /// worktrees varies by version. If the match misses, the caller surfaces
+    /// the raw stderr instead, which is acceptable degradation.
+    private static func looksLikeDirtyWorktreeError(_ stderr: String) -> Bool {
+        let s = stderr.lowercased()
+        return s.contains("is dirty")
+            || s.contains("contains modified or untracked files")
+            || s.contains("modified or untracked")
+    }
+
+    private func confirmDeleteWorktree(branch: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Delete worktree '\(branch)'?"
+        alert.informativeText = "This removes its files from disk. The local branch will be deleted if merged."
+        alert.alertStyle = .warning
+        let deleteButton = alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        deleteButton.hasDestructiveAction = true
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private func confirmForceDeleteWorktree(branch: String) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "'\(branch)' has uncommitted changes."
+        alert.informativeText = "Force delete? Any uncommitted work in this worktree will be lost."
+        alert.alertStyle = .warning
+        let forceButton = alert.addButton(withTitle: "Force Delete")
+        alert.addButton(withTitle: "Cancel")
+        forceButton.hasDestructiveAction = true
+        return alert.runModal() == .alertFirstButtonReturn
+    }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -437,7 +437,7 @@ final class AppState {
                     guard let self else { return [] }
                     var out: [SearchWorktree] = []
                     for project in self.projects {
-                        for wt in self.projectsManager.worktrees(projectId: project.id) {
+                        for wt in self.projectsManager.visibleWorktrees(projectId: project.id) {
                             out.append(SearchWorktree(
                                 id: wt.id,
                                 projectId: project.id,
@@ -466,6 +466,11 @@ final class AppState {
     /// in a different worktree.
     func openFile(relativePath: String, worktreeId: String) {
         guard let worktree = worktree(withId: worktreeId) else { return }
+        // Reject archived worktrees: their ids may still appear in some legacy
+        // call sites (e.g. older persisted tabs). Selecting one would set
+        // `selectedWorktreeId` to a hidden id that `RootView.selectedWorktree()`
+        // (now visibility-aware) would reject anyway, leaving an empty pane.
+        guard !projectsManager.isWorktreeHidden(projectId: worktree.projectId, path: worktree.path) else { return }
         if selectedWorktreeId != worktree.id { selectedWorktreeId = worktree.id }
 
         let existing = tabs.tabs(forWorktree: worktree.id).first { tab in

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -86,7 +86,9 @@ final class AppState {
     func addProject(path: URL, displayName: String, color: String) async throws {
         _ = try await projectsManager.addProject(path: path, displayName: displayName, color: color)
         saveProjects()
-        await projectsManager.refreshAll()
+        if await projectsManager.refreshAll() {
+            saveProjects()
+        }
     }
 
     func removeProject(id: String) {
@@ -609,7 +611,9 @@ final class AppState {
             }
 
             cleanupWorktreeState(worktreeId: worktree.id)
-            try? await projectsManager.refreshWorktrees(projectId: worktree.projectId)
+            if (try? await projectsManager.refreshWorktrees(projectId: worktree.projectId)) == true {
+                saveProjects()
+            }
             if selectedWorktreeId == worktree.id {
                 selectedWorktreeId = selectionAfterRemoval(
                     removedFromProjectId: worktree.projectId,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -94,6 +94,39 @@ final class AppState {
         saveProjects()
     }
 
+    /// Archive (hide) a worktree. Closes all tabs/terminals/harness state for
+    /// it, marks the path hidden in `ProjectConfig`, and re-points selection if
+    /// the archived worktree was selected. Does NOT touch git or disk.
+    func archiveWorktree(_ worktree: Worktree) {
+        // Snapshot index in the visible list BEFORE we mutate anything, so we
+        // can pick a sensible follow-up selection.
+        let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
+        let removedIndex = siblingsBefore.firstIndex(where: { $0.id == worktree.id }) ?? 0
+        let wasSelected = selectedWorktreeId == worktree.id
+
+        cleanupWorktreeState(worktreeId: worktree.id)
+        projectsManager.setWorktreeHidden(
+            projectId: worktree.projectId,
+            path: worktree.path,
+            hidden: true
+        )
+        saveProjects()
+
+        if wasSelected {
+            selectedWorktreeId = selectionAfterRemoval(
+                removedFromProjectId: worktree.projectId,
+                removedAtIndex: removedIndex
+            )
+        }
+    }
+
+    /// Restore an archived worktree. Tabs/terminals are NOT recreated — they
+    /// were torn down at archive time and the user re-opens what they need.
+    func unarchiveWorktree(projectId: String, path: URL) {
+        projectsManager.setWorktreeHidden(projectId: projectId, path: path, hidden: false)
+        saveProjects()
+    }
+
     func startHarness() {
         // Sync the persisted preference into NotificationService BEFORE start —
         // otherwise the service defaults to enabled and users who turned
@@ -295,11 +328,18 @@ final class AppState {
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
     }
 
-    func closeAllTabs(worktreeId: String) {
+    /// Tear down every tab/terminal/harness reference for a worktree id without
+    /// touching git or persistence. Shared between Close-All, archive, and
+    /// delete so the bookkeeping stays in one place.
+    private func cleanupWorktreeState(worktreeId: String) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeAll(worktreeId: worktreeId)
         cleanupTerminals(allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
+    }
+
+    func closeAllTabs(worktreeId: String) {
+        cleanupWorktreeState(worktreeId: worktreeId)
     }
 
     func closeTabsToLeft(worktreeId: String, of tabId: TabID) {
@@ -357,6 +397,27 @@ final class AppState {
         for project in projects {
             if let worktree = projectsManager.worktrees(projectId: project.id).first(where: { $0.id == id }) {
                 return worktree
+            }
+        }
+        return nil
+    }
+
+    /// Pick a sensible new selection after a worktree was removed (archived or
+    /// deleted) from the given project at the given index in its visible list.
+    /// Prefers the entry now occupying that index in the same project (i.e.
+    /// what was the next sibling). Falls back to the new last entry if the
+    /// removed worktree was the last one. If the project has no remaining
+    /// visible worktrees, picks the first visible worktree across all projects
+    /// in declaration order. Returns `nil` if nothing is left.
+    private func selectionAfterRemoval(removedFromProjectId: String, removedAtIndex: Int) -> String? {
+        let siblings = projectsManager.visibleWorktrees(projectId: removedFromProjectId)
+        if !siblings.isEmpty {
+            let i = min(removedAtIndex, siblings.count - 1)
+            return siblings[i].id
+        }
+        for project in projects {
+            if let first = projectsManager.visibleWorktrees(projectId: project.id).first {
+                return first.id
             }
         }
         return nil

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -40,16 +40,58 @@ final class ProjectsManager {
         worktreesByProject[projectId] ?? []
     }
 
+    func visibleWorktrees(projectId: String) -> [Worktree] {
+        let hidden = hiddenSet(projectId: projectId)
+        return worktrees(projectId: projectId).filter { !hidden.contains(canonical($0.path)) }
+    }
+
+    func archivedWorktrees(projectId: String) -> [Worktree] {
+        let hidden = hiddenSet(projectId: projectId)
+        return worktrees(projectId: projectId).filter { hidden.contains(canonical($0.path)) }
+    }
+
+    func isWorktreeHidden(projectId: String, path: URL) -> Bool {
+        hiddenSet(projectId: projectId).contains(canonical(path))
+    }
+
+    func setWorktreeHidden(projectId: String, path: URL, hidden: Bool) {
+        guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return }
+        let key = canonical(path)
+        var paths = projects[idx].hiddenWorktreePaths
+        if hidden {
+            if !paths.contains(key) { paths.append(key) }
+        } else {
+            paths.removeAll { $0 == key }
+        }
+        projects[idx].hiddenWorktreePaths = paths
+    }
+
     func refreshWorktrees(projectId: String) async throws {
         guard let project = projects.first(where: { $0.id == projectId }) else { return }
         let url = URL(fileURLWithPath: project.path)
         let trees = try await worktreeSvc.list(repoPath: url, projectId: projectId)
         worktreesByProject[projectId] = trees
+        // GC orphan hidden entries: drop any hidden path that doesn't match a
+        // live worktree path. Prevents stale entries accumulating when worktrees
+        // get removed externally (e.g. `git worktree remove` from a terminal).
+        if let idx = projects.firstIndex(where: { $0.id == projectId }) {
+            let live = Set(trees.map { canonical($0.path) })
+            projects[idx].hiddenWorktreePaths.removeAll { !live.contains($0) }
+        }
     }
 
     func refreshAll() async {
         for project in projects {
             try? await refreshWorktrees(projectId: project.id)
         }
+    }
+
+    private func hiddenSet(projectId: String) -> Set<String> {
+        guard let project = projects.first(where: { $0.id == projectId }) else { return [] }
+        return Set(project.hiddenWorktreePaths)
+    }
+
+    private func canonical(_ url: URL) -> String {
+        url.standardizedFileURL.path
     }
 }

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -66,24 +66,36 @@ final class ProjectsManager {
         projects[idx].hiddenWorktreePaths = paths
     }
 
-    func refreshWorktrees(projectId: String) async throws {
-        guard let project = projects.first(where: { $0.id == projectId }) else { return }
+    /// Refresh the live worktree list for a project and GC orphan hidden
+    /// paths. Returns `true` when the GC dropped at least one entry, so the
+    /// caller can persist the change to disk; `false` otherwise.
+    @discardableResult
+    func refreshWorktrees(projectId: String) async throws -> Bool {
+        guard let project = projects.first(where: { $0.id == projectId }) else { return false }
         let url = URL(fileURLWithPath: project.path)
         let trees = try await worktreeSvc.list(repoPath: url, projectId: projectId)
         worktreesByProject[projectId] = trees
         // GC orphan hidden entries: drop any hidden path that doesn't match a
         // live worktree path. Prevents stale entries accumulating when worktrees
         // get removed externally (e.g. `git worktree remove` from a terminal).
-        if let idx = projects.firstIndex(where: { $0.id == projectId }) {
-            let live = Set(trees.map { canonical($0.path) })
-            projects[idx].hiddenWorktreePaths.removeAll { !live.contains($0) }
-        }
+        guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return false }
+        let live = Set(trees.map { canonical($0.path) })
+        let before = projects[idx].hiddenWorktreePaths.count
+        projects[idx].hiddenWorktreePaths.removeAll { !live.contains($0) }
+        return projects[idx].hiddenWorktreePaths.count != before
     }
 
-    func refreshAll() async {
+    /// Refresh every project. Returns `true` when at least one project's
+    /// hidden-path GC dropped an entry, so the caller can persist the change.
+    @discardableResult
+    func refreshAll() async -> Bool {
+        var changed = false
         for project in projects {
-            try? await refreshWorktrees(projectId: project.id)
+            if let didGC = try? await refreshWorktrees(projectId: project.id) {
+                changed = changed || didGC
+            }
         }
+        return changed
     }
 
     private func hiddenSet(projectId: String) -> Set<String> {

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -92,6 +92,6 @@ final class ProjectsManager {
     }
 
     private func canonical(_ url: URL) -> String {
-        url.standardizedFileURL.path
+        Worktree.makeId(path: url)
     }
 }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -95,7 +95,9 @@ struct RootView: View {
         }
         .task {
             state.startHarness()
-            await state.projectsManager.refreshAll()
+            if await state.projectsManager.refreshAll() {
+                state.saveProjects()
+            }
             // Worktrees now exist — load any persisted tab files for them. Init
             // can't do this because refreshAll runs async after init.
             state.reloadTabs()

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -112,7 +112,7 @@ struct RootView: View {
     private func selectedWorktree() -> Worktree? {
         guard let id = state.selectedWorktreeId else { return nil }
         for project in state.projects {
-            if let wt = state.projectsManager.worktrees(projectId: project.id).first(where: { $0.id == id }) {
+            if let wt = state.projectsManager.visibleWorktrees(projectId: project.id).first(where: { $0.id == id }) {
                 return wt
             }
         }
@@ -121,7 +121,7 @@ struct RootView: View {
 
     private func firstWorktreeId() -> String? {
         for project in state.projects {
-            if let worktree = state.projectsManager.worktrees(projectId: project.id).first {
+            if let worktree = state.projectsManager.visibleWorktrees(projectId: project.id).first {
                 return worktree.id
             }
         }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -590,9 +590,13 @@ final class TabsManager {
             bufferStore.discardExternalBuffer(worktreeId: ext.worktreeId, absoluteURL: ext.url)
             return
         }
+        // Always discard the persisted snapshot for in-worktree tabs, even
+        // when the buffer was never loaded (e.g. snapshot-only state after a
+        // relaunch). Otherwise the early-return below would leave snapshot
+        // JSON orphaned under App Support after tab teardown.
+        bufferStore.discard(worktreeId: worktreeId, tabId: tabId)
         guard let key = bufferKeys.removeValue(forKey: tabId) else { return }
         assert(key.worktreeId == worktreeId, "discardBuffer called with worktreeId=\(worktreeId) but buffer is owned by \(key.worktreeId)")
-        bufferStore.discard(worktreeId: worktreeId, tabId: tabId)
         guard let buffer = buffers[key] else { return }
         if let nextTabId = bufferKeys.first(where: { $0.value == key })?.key {
             if buffer.persistenceTabId == tabId {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -611,6 +611,25 @@ final class TabsManager {
         }
     }
 
+    /// Tab IDs in `worktreeId` that have unsaved changes — either a live dirty
+    /// buffer or a persisted hot-exit snapshot for a buffer that hasn't been
+    /// instantiated yet. Returns IDs in tab order (declaration order within the
+    /// worktree's tab list).
+    func tabIdsWithUnsavedChanges(forWorktree worktreeId: String) -> [TabID] {
+        guard let file = byWorktree[worktreeId] else { return [] }
+        var result: [TabID] = []
+        for tab in file.tabs {
+            guard case .editor(let state) = tab else { continue }
+            let tabId = state.id
+            if let buffer = peekBuffer(tabId: tabId) {
+                if buffer.dirty { result.append(tabId) }
+            } else if (try? bufferStore.read(worktreeId: worktreeId, tabId: tabId)) != nil {
+                result.append(tabId)
+            }
+        }
+        return result
+    }
+
     @discardableResult
     func updateEditorPath(worktreeId: String, tabId: TabID, relativePath: String) -> Bool {
         guard var file = byWorktree[worktreeId],
@@ -697,6 +716,63 @@ final class TabsManager {
                     errors.append((state.id, error))
                     buffer.close(persistDirtySnapshot: true)
                 }
+            }
+        }
+        return errors
+    }
+
+    /// Save all unsaved buffers for a single worktree. Mirrors the snapshot-
+    /// materialize pattern from `saveAll(worktreeRoots:)` but scoped to one
+    /// worktree so archive/delete can save before teardown.
+    /// Returns an array of (tabId, error) pairs; empty on full success.
+    @discardableResult
+    func saveAllUnsaved(forWorktree worktreeId: String, root: URL) -> [(tabId: TabID, error: Error)] {
+        var errors: [(TabID, Error)] = []
+        var saved = Set<ObjectIdentifier>()
+        // Pass 1: live dirty buffers belonging to this worktree.
+        for (tabId, key) in bufferKeys {
+            guard key.worktreeId == worktreeId,
+                  let buffer = buffers[key], buffer.dirty else { continue }
+            let id = ObjectIdentifier(buffer)
+            guard !saved.contains(id) else { continue }
+            saved.insert(id)
+            do {
+                try buffer.saveRecordingError()
+            } catch {
+                errors.append((tabId, error))
+            }
+        }
+        // Pass 2: editor tabs with no live buffer but a persisted snapshot.
+        guard let file = byWorktree[worktreeId] else { return errors }
+        for tab in file.tabs {
+            guard case .editor(let state) = tab,
+                  peekBuffer(tabId: state.id) == nil,
+                  (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) != nil else { continue }
+            let buffer: EditorBuffer
+            if let lsp {
+                buffer = EditorBuffer(
+                    worktreeRoot: root,
+                    relativePath: state.relativePath,
+                    store: bufferStore,
+                    worktreeId: worktreeId,
+                    tabId: state.id,
+                    lsp: lsp
+                )
+            } else {
+                buffer = EditorBuffer(
+                    worktreeRoot: root,
+                    relativePath: state.relativePath,
+                    store: bufferStore,
+                    worktreeId: worktreeId,
+                    tabId: state.id
+                )
+            }
+            do {
+                try buffer.saveRecordingError()
+                buffer.close(persistDirtySnapshot: false)
+            } catch {
+                errors.append((state.id, error))
+                buffer.close(persistDirtySnapshot: true)
             }
         }
         return errors

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -118,7 +118,9 @@ struct NewWorktreeDialog: View {
                     repoPath: URL(fileURLWithPath: project.path),
                     base: base, branch: branch, destination: dest, projectId: project.id
                 )
-                try await state.projectsManager.refreshWorktrees(projectId: project.id)
+                if try await state.projectsManager.refreshWorktrees(projectId: project.id) {
+                    state.saveProjects()
+                }
 
                 // Run worktree-create script if requested. Best-effort: errors
                 // in the user-supplied script don't roll back the worktree.

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -118,7 +118,21 @@ struct NewWorktreeDialog: View {
                     repoPath: URL(fileURLWithPath: project.path),
                     base: base, branch: branch, destination: dest, projectId: project.id
                 )
-                if try await state.projectsManager.refreshWorktrees(projectId: project.id) {
+                // Defensive: clear any stale hidden entry for this path. An
+                // archived worktree could have been externally removed and
+                // recreated at the same destination before any refresh/GC; the
+                // GC otherwise keeps the entry because the path is live again.
+                let wasHidden = state.projectsManager.isWorktreeHidden(
+                    projectId: project.id,
+                    path: newWorktree.path
+                )
+                state.projectsManager.setWorktreeHidden(
+                    projectId: project.id,
+                    path: newWorktree.path,
+                    hidden: false
+                )
+                let gcDropped = try await state.projectsManager.refreshWorktrees(projectId: project.id)
+                if wasHidden || gcDropped {
                     state.saveProjects()
                 }
 

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -73,11 +73,17 @@ struct WorktreeService {
     /// reliably resolve the branch name when `deleteBranchIfMerged` is true —
     /// path basenames diverge from branch names whenever the path template
     /// substitutes `/` (e.g. branch `feat/x` lives at dir basename `feat-x`).
-    func remove(repoPath: URL, worktree: Worktree, deleteBranchIfMerged: Bool) async throws {
-        let result = try await Process.git(
-            ["worktree", "remove", worktree.path.path],
-            cwd: repoPath
-        )
+    /// `force` adds `--force`, required when the worktree has uncommitted
+    /// changes or untracked files.
+    func remove(
+        repoPath: URL,
+        worktree: Worktree,
+        deleteBranchIfMerged: Bool,
+        force: Bool = false
+    ) async throws {
+        var args = ["worktree", "remove", worktree.path.path]
+        if force { args.append("--force") }
+        let result = try await Process.git(args, cwd: repoPath)
         guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
         if deleteBranchIfMerged && worktree.branch != "(detached)" {
             // Best-effort delete. -d only succeeds if merged; ignore failures.

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -11,4 +11,37 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var path: String         // absolute repo path
     var color: String        // hex string, e.g. "#5fb7c4"
     var addedAt: Date
+    var hiddenWorktreePaths: [String] = []
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, path, color, addedAt, hiddenWorktreePaths
+    }
+
+    init(
+        id: String,
+        name: String,
+        path: String,
+        color: String,
+        addedAt: Date,
+        hiddenWorktreePaths: [String] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.path = path
+        self.color = color
+        self.addedAt = addedAt
+        self.hiddenWorktreePaths = hiddenWorktreePaths
+    }
+
+    // Tolerant decode: older projects.json files predate hiddenWorktreePaths,
+    // so fall back to an empty array. Encode is still synthesized.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        path = try c.decode(String.self, forKey: .path)
+        color = try c.decode(String.self, forKey: .color)
+        addedAt = try c.decode(Date.self, forKey: .addedAt)
+        hiddenWorktreePaths = (try? c.decode([String].self, forKey: .hiddenWorktreePaths)) ?? []
+    }
 }

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -45,9 +45,26 @@ struct WorktreesPane: View {
                         AlasToggle(on: bind(\.worktrees.deleteBranchOnRemove))
                     }
                 }
+
+                if hasAnyArchived {
+                    SettingsGroup(title: "Archived worktrees") {
+                        ForEach(state.projects) { project in
+                            let archived = state.projectsManager.archivedWorktrees(projectId: project.id)
+                            if !archived.isEmpty {
+                                ArchivedProjectSection(project: project, archived: archived) { wt in
+                                    state.unarchiveWorktree(projectId: project.id, path: wt.path)
+                                }
+                            }
+                        }
+                    }
+                }
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
         }
+    }
+
+    private var hasAnyArchived: Bool {
+        state.projects.contains { !state.projectsManager.archivedWorktrees(projectId: $0.id).isEmpty }
     }
 
     private func bind<T>(_ kp: WritableKeyPath<AppConfig, T>) -> Binding<T> {
@@ -56,5 +73,38 @@ struct WorktreesPane: View {
             set: { state.config[keyPath: kp] = $0
             state.saveConfig() }
         )
+    }
+}
+
+private struct ArchivedProjectSection: View {
+    let project: ProjectConfig
+    let archived: [Worktree]
+    let onUnarchive: (Worktree) -> Void
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(project.name)
+                .font(.system(size: 11.5, weight: .semibold))
+                .foregroundColor(theme.color("fg-muted"))
+                .padding(.top, 4)
+            ForEach(archived) { wt in
+                HStack(alignment: .center, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(wt.branch)
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .foregroundColor(theme.color("fg"))
+                        Text(wt.path.path)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.color("fg-dim"))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer(minLength: 0)
+                    AlasButton(title: "Unarchive", style: .normal) { onUnarchive(wt) }
+                }
+                .padding(.vertical, 6)
+            }
+        }
     }
 }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -7,6 +7,12 @@ struct RepoGroupView: View {
     let selectedWorktreeId: String?
     let onSelect: (Worktree) -> Void
     let onNewWorktree: () -> Void
+    let onOpenTerminal: (Worktree) -> Void
+    let onCopyPath: (Worktree) -> Void
+    let onCopyBranch: (Worktree) -> Void
+    let onRevealInFinder: (Worktree) -> Void
+    let onArchive: (Worktree) -> Void
+    let onDelete: (Worktree) -> Void
     @Environment(\.theme) var theme
     @State private var hovering = false
     @State private var plusHovering = false
@@ -60,7 +66,13 @@ struct RepoGroupView: View {
                         WorktreeRowView(
                             worktree: wt,
                             isSelected: wt.id == selectedWorktreeId,
-                            onTap: { onSelect(wt) }
+                            onTap: { onSelect(wt) },
+                            onOpenTerminal: { onOpenTerminal(wt) },
+                            onCopyPath: { onCopyPath(wt) },
+                            onCopyBranch: { onCopyBranch(wt) },
+                            onRevealInFinder: { onRevealInFinder(wt) },
+                            onArchive: { onArchive(wt) },
+                            onDelete: { onDelete(wt) }
                         )
                     }
                 }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct SidebarView: View {
     @Bindable var state: AppState
@@ -18,7 +19,7 @@ struct SidebarView: View {
                         ForEach(state.projects) { project in
                             RepoGroupView(
                                 project: project,
-                                worktrees: state.projectsManager.worktrees(projectId: project.id),
+                                worktrees: state.projectsManager.visibleWorktrees(projectId: project.id),
                                 collapsed: Binding(
                                     get: { collapsedProjects.contains(project.id) },
                                     set: { collapsed in
@@ -28,7 +29,26 @@ struct SidebarView: View {
                                 ),
                                 selectedWorktreeId: state.selectedWorktreeId,
                                 onSelect: { wt in state.selectedWorktreeId = wt.id },
-                                onNewWorktree: { onNewWorktree(project.id) }
+                                onNewWorktree: { onNewWorktree(project.id) },
+                                onOpenTerminal: { wt in
+                                    state.selectedWorktreeId = wt.id
+                                    _ = try? state.openTerminalTab(for: wt)
+                                },
+                                onCopyPath: { wt in
+                                    let pb = NSPasteboard.general
+                                    pb.clearContents()
+                                    pb.setString(wt.path.path, forType: .string)
+                                },
+                                onCopyBranch: { wt in
+                                    let pb = NSPasteboard.general
+                                    pb.clearContents()
+                                    pb.setString(wt.branch, forType: .string)
+                                },
+                                onRevealInFinder: { wt in
+                                    NSWorkspace.shared.activateFileViewerSelecting([wt.path])
+                                },
+                                onArchive: { wt in state.archiveWorktree(wt) },
+                                onDelete: { wt in state.deleteWorktree(wt) }
                             )
                         }
                     }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -4,6 +4,12 @@ struct WorktreeRowView: View {
     let worktree: Worktree
     let isSelected: Bool
     let onTap: () -> Void
+    let onOpenTerminal: () -> Void
+    let onCopyPath: () -> Void
+    let onCopyBranch: () -> Void
+    let onRevealInFinder: () -> Void
+    let onArchive: () -> Void
+    let onDelete: () -> Void
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -52,6 +58,15 @@ struct WorktreeRowView: View {
         }
         .buttonStyle(.plain)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .contextMenu {
+            Button("Open in Terminal", action: onOpenTerminal)
+            Button("Copy Path", action: onCopyPath)
+            Button("Copy Branch Name", action: onCopyBranch)
+            Button("Reveal in Finder", action: onRevealInFinder)
+            Divider()
+            Button("Archive", action: onArchive)
+            Button("Delete Worktree…", role: .destructive, action: onDelete)
+        }
     }
 
     private func relative(_ date: Date) -> String {

--- a/AlasTests/ProjectConfigTests.swift
+++ b/AlasTests/ProjectConfigTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct ProjectConfigTests {
+    @Test func decodingOlderProjectsFileSuppliesEmptyHiddenPaths() throws {
+        // Older projects.json files predate hiddenWorktreePaths.
+        let json = """
+        {
+          "version": 1,
+          "projects": [{
+            "id": "abc",
+            "name": "alpha",
+            "path": "/tmp/alpha",
+            "color": "#5fb7c4",
+            "addedAt": 0
+          }]
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let file = try decoder.decode(ProjectsFile.self, from: json)
+        #expect(file.projects.count == 1)
+        #expect(file.projects[0].hiddenWorktreePaths == [])
+    }
+
+    @Test func roundTripPreservesHiddenPaths() throws {
+        let project = ProjectConfig(
+            id: "abc", name: "alpha", path: "/tmp/alpha",
+            color: "#5fb7c4", addedAt: Date(timeIntervalSince1970: 0),
+            hiddenWorktreePaths: ["/tmp/alpha/wt-a", "/tmp/alpha/wt-b"]
+        )
+        let file = ProjectsFile(projects: [project])
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(file)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(ProjectsFile.self, from: data)
+        #expect(decoded.projects[0].hiddenWorktreePaths == ["/tmp/alpha/wt-a", "/tmp/alpha/wt-b"])
+    }
+}

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -47,3 +47,42 @@ struct ProjectsManagerTests {
         #expect(mgr.worktrees(projectId: project.id).isEmpty)
     }
 }
+
+extension ProjectsManagerTests {
+    @Test func hidingAndUnhidingFlipsVisibilityAndArchive() async throws {
+        let repo = try await makeRepo(name: "delta")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "delta", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        let mainPath = trees[0].path
+
+        mgr.setWorktreeHidden(projectId: project.id, path: mainPath, hidden: true)
+        #expect(mgr.isWorktreeHidden(projectId: project.id, path: mainPath))
+        #expect(mgr.visibleWorktrees(projectId: project.id).isEmpty)
+        #expect(mgr.archivedWorktrees(projectId: project.id).count == 1)
+
+        mgr.setWorktreeHidden(projectId: project.id, path: mainPath, hidden: false)
+        #expect(!mgr.isWorktreeHidden(projectId: project.id, path: mainPath))
+        #expect(mgr.visibleWorktrees(projectId: project.id).count == 1)
+        #expect(mgr.archivedWorktrees(projectId: project.id).isEmpty)
+    }
+
+    @Test func refreshGarbageCollectsOrphanHiddenPaths() async throws {
+        let repo = try await makeRepo(name: "epsilon")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "epsilon", color: "#5fb7c4")
+        // Pre-seed a hidden path that doesn't correspond to any live worktree.
+        let bogus = URL(fileURLWithPath: "/nonexistent/orphan-worktree")
+        mgr.setWorktreeHidden(projectId: project.id, path: bogus, hidden: true)
+        #expect(mgr.isWorktreeHidden(projectId: project.id, path: bogus))
+
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        // Refresh should drop the orphan since git worktree list doesn't include it.
+        #expect(!mgr.isWorktreeHidden(projectId: project.id, path: bogus))
+    }
+}

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -80,9 +80,19 @@ extension ProjectsManagerTests {
         mgr.setWorktreeHidden(projectId: project.id, path: bogus, hidden: true)
         #expect(mgr.isWorktreeHidden(projectId: project.id, path: bogus))
 
-        try await mgr.refreshWorktrees(projectId: project.id)
+        let gcDropped = try await mgr.refreshWorktrees(projectId: project.id)
 
         // Refresh should drop the orphan since git worktree list doesn't include it.
+        #expect(gcDropped)
         #expect(!mgr.isWorktreeHidden(projectId: project.id, path: bogus))
+    }
+
+    @Test func refreshWithNoOrphansReturnsFalse() async throws {
+        let repo = try await makeRepo(name: "zeta")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "zeta", color: "#5fb7c4")
+        let gcDropped = try await mgr.refreshWorktrees(projectId: project.id)
+        #expect(!gcDropped)
     }
 }

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -82,3 +82,46 @@ struct WorktreeServiceTests {
         #expect(branches.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
     }
 }
+
+extension WorktreeServiceTests {
+    @Test func removeFailsOnDirtyWorktreeWithoutForce() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let dest = repo.deletingLastPathComponent().appendingPathComponent("\(repo.lastPathComponent)-dirty")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/dirty",
+            destination: dest, projectId: "p"
+        )
+        // Make the worktree dirty by writing an untracked file.
+        try "hello".write(
+            to: dest.appendingPathComponent("untracked.txt"),
+            atomically: true, encoding: .utf8
+        )
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+    }
+
+    @Test func removeWithForceSucceedsOnDirtyWorktree() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let dest = repo.deletingLastPathComponent().appendingPathComponent("\(repo.lastPathComponent)-force")
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/force",
+            destination: dest, projectId: "p"
+        )
+        try "hello".write(
+            to: dest.appendingPathComponent("untracked.txt"),
+            atomically: true, encoding: .utf8
+        )
+
+        try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false, force: true)
+
+        let listed = try await svc.list(repoPath: repo, projectId: "p")
+        #expect(listed.count == 1) // only main remains
+    }
+}


### PR DESCRIPTION
## Summary

- Right-click any worktree row in the sidebar for a six-item context menu: Open in Terminal, Copy Path, Copy Branch Name, Reveal in Finder, Archive, Delete Worktree…
- **Archive** hides a worktree from the sidebar and tears down its in-app state (tabs, terminals, harness sessions) without touching git or disk. Hidden state persists per-project in \`projects.json\`. Manage from Settings → Worktrees.
- **Delete** runs \`git worktree remove\` with a confirmation dialog; if the tree is dirty, a second dialog offers \`--force\`. Respects the existing \`deleteBranchOnRemove\` setting.

## Architecture

Hidden state lives on \`ProjectConfig.hiddenWorktreePaths\` with tolerant decode for older files. \`ProjectsManager\` exposes \`visibleWorktrees\`/\`archivedWorktrees\` filtered views and GCs orphan hidden entries on refresh. \`WorktreeService.remove\` gains a \`force\` parameter. \`AppState\` orchestrates archive/unarchive/delete via a shared \`cleanupWorktreeState\` helper that mirrors the existing \`closeAllTabs\` cleanup.

Selection follow-up: when an archived/deleted worktree was selected, selection moves to the next visible sibling in the same project (or first across projects, or nil).

## Test plan

- [ ] Right-click a worktree row → menu shows six items in the documented order with separator before Archive
- [ ] Open in Terminal selects the worktree and opens a new terminal tab
- [ ] Copy Path / Copy Branch Name put the right strings on the clipboard
- [ ] Reveal in Finder opens the path with the folder selected
- [ ] Archive a non-selected worktree → row disappears, archived count appears in Settings
- [ ] Archive the selected worktree → selection moves to next sibling
- [ ] Open tabs+terminal then archive → all torn down
- [ ] Unarchive in Settings → row reappears in sidebar (tabs not restored)
- [ ] Delete a clean worktree → confirm dialog → row gone, files removed, branch deleted if merged
- [ ] Delete a dirty worktree → confirm → second "Force delete?" alert; cancel works at either step
- [ ] Delete the primary worktree → git's stderr surfaces in error alert
- [ ] Restart app → archived state survives
- [ ] Externally \`git worktree remove\` an archived worktree, then refresh → orphan hidden entry GC'd
- [ ] Right-click a non-selected row → context menu acts on that row, not the selected one

🤖 Generated with [Claude Code](https://claude.com/claude-code)