### PR TITLE
feat: Cmd+number tab switching within worktree

### DIFF
--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -67,6 +67,43 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasCloseTab, object: nil)
                 }
                 .keyboardShortcut("w", modifiers: .command)
+                Divider()
+                Button("Select Tab 1") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 1)
+                }
+                .keyboardShortcut("1", modifiers: .command)
+                Button("Select Tab 2") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 2)
+                }
+                .keyboardShortcut("2", modifiers: .command)
+                Button("Select Tab 3") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 3)
+                }
+                .keyboardShortcut("3", modifiers: .command)
+                Button("Select Tab 4") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 4)
+                }
+                .keyboardShortcut("4", modifiers: .command)
+                Button("Select Tab 5") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 5)
+                }
+                .keyboardShortcut("5", modifiers: .command)
+                Button("Select Tab 6") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 6)
+                }
+                .keyboardShortcut("6", modifiers: .command)
+                Button("Select Tab 7") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 7)
+                }
+                .keyboardShortcut("7", modifiers: .command)
+                Button("Select Tab 8") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 8)
+                }
+                .keyboardShortcut("8", modifiers: .command)
+                Button("Select Tab 9") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 9)
+                }
+                .keyboardShortcut("9", modifiers: .command)
             }
             CommandGroup(after: .toolbar) {
                 Divider()

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -174,6 +174,11 @@ private struct RootCommandHandlers: ViewModifier {
                     state.closeTab(worktreeId: wt.id, tabId: active)
                 }
             }
+            .onReceive(NotificationCenter.default.publisher(for: .alasActivateTabByNumber)) { notification in
+                guard let number = notification.object as? Int,
+                      let wt = selectedWorktree() else { return }
+                state.tabs.activateTabNumber(number, worktreeId: wt.id)
+            }
             .onReceive(NotificationCenter.default.publisher(for: .alasSaveActiveTab)) { _ in
                 if let wt = selectedWorktree() {
                     state.saveActiveTab(worktreeId: wt.id)
@@ -220,6 +225,7 @@ extension Notification.Name {
     static let alasNewWorktree     = Notification.Name("AlasNewWorktree")
     static let alasNewTerminalTab  = Notification.Name("AlasNewTerminalTab")
     static let alasCloseTab        = Notification.Name("AlasCloseTab")
+    static let alasActivateTabByNumber = Notification.Name("AlasActivateTabByNumber")
     static let alasOpenSettings    = Notification.Name("AlasOpenSettings")
     static let alasOpenSearch      = Notification.Name("AlasOpenSearch")
     static let alasSaveActiveTab   = Notification.Name("AlasSaveActiveTab")

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -58,6 +58,17 @@ final class TabsManager {
         byWorktree[id]?.activeTabId
     }
 
+    @discardableResult
+    func activateTabNumber(_ number: Int, worktreeId: String) -> TabID? {
+        guard number > 0 else { return nil }
+        let index = number - 1
+        let tabs = tabs(forWorktree: worktreeId)
+        guard tabs.indices.contains(index) else { return nil }
+        let tabId = tabs[index].id
+        activate(worktreeId: worktreeId, tabId: tabId)
+        return tabId
+    }
+
     func loadAll(worktreeIds: [String]) {
         for id in worktreeIds {
             if let file = try? store.readIfExists(TabsFile.self, from: Paths.tabsFile(forWorktreeId: id)) {

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -34,6 +34,58 @@ struct TabsManagerTests {
         #expect(mgr.activeTabId(forWorktree: worktreeId) == nil)
     }
 
+    @Test func activatingTabNumberUsesOneBasedWorktreeLocalOrder() {
+        let worktreeId = "tabs-manager-activate-tab-number"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let first = mgr.appendTerminal(worktreeId: worktreeId, title: "one", sessionId: "s1")
+        let second = mgr.appendTerminal(worktreeId: worktreeId, title: "two", sessionId: "s2")
+
+        #expect(mgr.activateTabNumber(1, worktreeId: worktreeId) == first.id)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == first.id)
+        #expect(mgr.activateTabNumber(2, worktreeId: worktreeId) == second.id)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == second.id)
+    }
+
+    @Test func activatingTabNumberIsScopedToWorktree() {
+        let firstWorktreeId = "tabs-manager-activate-tab-number-a"
+        let secondWorktreeId = "tabs-manager-activate-tab-number-b"
+        defer {
+            try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: firstWorktreeId))
+            try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: secondWorktreeId))
+        }
+        let mgr = TabsManager()
+        let firstA = mgr.appendTerminal(worktreeId: firstWorktreeId, title: "a1", sessionId: "a1")
+        _ = mgr.appendTerminal(worktreeId: firstWorktreeId, title: "a2", sessionId: "a2")
+        _ = mgr.appendTerminal(worktreeId: secondWorktreeId, title: "b1", sessionId: "b1")
+        let secondB = mgr.appendTerminal(worktreeId: secondWorktreeId, title: "b2", sessionId: "b2")
+
+        #expect(mgr.activateTabNumber(1, worktreeId: firstWorktreeId) == firstA.id)
+        #expect(mgr.activeTabId(forWorktree: firstWorktreeId) == firstA.id)
+        #expect(mgr.activeTabId(forWorktree: secondWorktreeId) == secondB.id)
+    }
+
+    @Test func activatingOutOfBoundsTabNumberIsNoOp() {
+        let worktreeId = "tabs-manager-activate-tab-number-out-of-bounds"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        _ = mgr.appendTerminal(worktreeId: worktreeId, title: "one", sessionId: "s1")
+        let second = mgr.appendTerminal(worktreeId: worktreeId, title: "two", sessionId: "s2")
+
+        #expect(mgr.activateTabNumber(3, worktreeId: worktreeId) == nil)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == second.id)
+    }
+
+    @Test func activatingInvalidTabNumberIsNoOp() {
+        let worktreeId = "tabs-manager-activate-tab-number-invalid"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: worktreeId, title: "one", sessionId: "s1")
+
+        #expect(mgr.activateTabNumber(0, worktreeId: worktreeId) == nil)
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == tab.id)
+    }
+
     @Test func replacingTerminalSessionKeepsTabAndActiveSelection() {
         let worktreeId = "tabs-manager-replace-session"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }


### PR DESCRIPTION
## Summary

- Add `Cmd+1` through `Cmd+9` keyboard shortcuts to focus tabs by position within the currently selected worktree
- Tabs are scoped per-worktree — the shortcut never addresses tabs across projects or worktrees
- Invalid numbers (≤0, out-of-bounds) and missing worktree are silent no-ops
- `Cmd+0` (Reset Font Size) is untouched

## Key files

- **`Alas/Sources/Center/TabsManager.swift`** — added `activateTabNumber(_:worktreeId:)` with 1-based indexing and out-of-bounds no-op
- **`Alas/Sources/App/RootView.swift`** — added `.alasActivateTabByNumber` notification name and handler in `RootCommandHandlers`
- **`Alas/Sources/App/AlasApp.swift`** — added 9 `Button` entries with `.keyboardShortcut` in a new command group section
- **`AlasTests/TabsManagerTests.swift`** — added 5 Swift Testing cases: tab ordering, worktree isolation, out-of-bounds, zero no-op

Closes #761