### PR TITLE
Hide empty change summaries

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
 		3DC6518A9050D1029D4D99A4 /* aider.sh in Resources */ = {isa = PBXBuildFile; fileRef = 2AC91D744E42A7C071268B74 /* aider.sh */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
+		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
@@ -106,6 +107,7 @@
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
+		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
 		8622E85C972946E5411CAC48 /* ChangesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E947E110B003FB519DAD1B3 /* ChangesSectionView.swift */; };
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
@@ -287,6 +289,7 @@
 		515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavView.swift; sourceTree = "<group>"; };
 		519CFB3707E8DDBDECD6C5D1 /* Alas.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alas.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitTests.swift; sourceTree = "<group>"; };
+		524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibility.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
@@ -391,6 +394,7 @@
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
 		E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndex.swift; sourceTree = "<group>"; };
 		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
+		E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibilityTests.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClientTests.swift; sourceTree = "<group>"; };
@@ -456,6 +460,7 @@
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
+				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
 				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
@@ -559,6 +564,7 @@
 				B4C486F9097A2B145D101E2C /* AlasButton.swift */,
 				D9E6D61B213F3378243B4A26 /* AlasField.swift */,
 				1841997CCBDB9611576B930C /* AlasToggle.swift */,
+				524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
 				489C9B383554D7DAB170C2F8 /* Seg.swift */,
 				2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */,
@@ -1092,6 +1098,7 @@
 				8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */,
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
 				139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */,
+				40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */,
 				8622E85C972946E5411CAC48 /* ChangesSectionView.swift in Sources */,
 				EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */,
 				41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */,
@@ -1224,6 +1231,7 @@
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
+				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,
 				7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */,

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -59,11 +59,13 @@ struct DiffTabView: View {
                 .font(.system(size: 11.5))
                 .foregroundColor(theme.color("fg-dim"))
             Spacer()
-            HStack(spacing: 10) {
-                Text("+\(totalAdd)").foregroundColor(theme.color("add"))
-                Text("−\(totalDel)").foregroundColor(theme.color("del"))
+            if shouldShowChangeSummary(additions: totalAdd, deletions: totalDel) {
+                HStack(spacing: 10) {
+                    Text("+\(totalAdd)").foregroundColor(theme.color("add"))
+                    Text("−\(totalDel)").foregroundColor(theme.color("del"))
+                }
+                .font(.system(size: 11.5, design: .monospaced))
             }
-            .font(.system(size: 11.5, design: .monospaced))
             HStack(spacing: 4) {
                 if !staged {
                     AlasButton(title: "Stage hunk", style: .subtle, action: stageHunk)

--- a/Alas/Sources/Right/ChangesSectionView.swift
+++ b/Alas/Sources/Right/ChangesSectionView.swift
@@ -66,11 +66,13 @@ struct ChangesSectionView: View {
                 .clipShape(Capsule())
                 .foregroundColor(theme.color("fg-muted"))
             Spacer()
-            HStack(spacing: 6) {
-                Text("+\(totalAdd)").foregroundColor(theme.color("add"))
-                Text("−\(totalDel)").foregroundColor(theme.color("del"))
+            if shouldShowChangeSummary(additions: totalAdd, deletions: totalDel) {
+                HStack(spacing: 6) {
+                    Text("+\(totalAdd)").foregroundColor(theme.color("add"))
+                    Text("−\(totalDel)").foregroundColor(theme.color("del"))
+                }
+                .font(.system(size: 11, design: .monospaced))
             }
-            .font(.system(size: 11, design: .monospaced))
             Button(action: onRefresh) {
                 Icon(name: "search", size: 11)
             }

--- a/Alas/Sources/UI/ChangeSummaryVisibility.swift
+++ b/Alas/Sources/UI/ChangeSummaryVisibility.swift
@@ -1,0 +1,3 @@
+func shouldShowChangeSummary(additions: Int, deletions: Int) -> Bool {
+    additions > 0 || deletions > 0
+}

--- a/AlasTests/ChangeSummaryVisibilityTests.swift
+++ b/AlasTests/ChangeSummaryVisibilityTests.swift
@@ -1,0 +1,14 @@
+import Testing
+@testable import Alas
+
+struct ChangeSummaryVisibilityTests {
+    @Test func hidesEmptyChangeSummary() {
+        #expect(shouldShowChangeSummary(additions: 0, deletions: 0) == false)
+    }
+
+    @Test func showsChangeSummaryWhenEitherCountIsPresent() {
+        #expect(shouldShowChangeSummary(additions: 3, deletions: 0))
+        #expect(shouldShowChangeSummary(additions: 0, deletions: 5))
+        #expect(shouldShowChangeSummary(additions: 3, deletions: 5))
+    }
+}


### PR DESCRIPTION
## Summary
- hide zero-value change summaries instead of displaying `+0 -0`
- share the visibility check between center and right-side changes views
- add coverage for zero/non-zero summary visibility

## Validation
- `git diff --check origin/main...HEAD`

Mission Control task: #763