### PR TITLE
feat(markdown): rich-text preview for markdown files

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		12035048B950CE0197604F89 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CE7B4DAFDB65A79308FB63 /* GitService.swift */; };
 		139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
+		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
@@ -33,6 +34,7 @@
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
+		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
 		29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
 		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
@@ -239,6 +241,7 @@
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
 		0AF8152B18C9D6290724122F /* HoverFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeature.swift; sourceTree = "<group>"; };
 		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
+		0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewController.swift; sourceTree = "<group>"; };
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
 		0F68A9692F85197ED9E16262 /* WorktreesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreesPane.swift; sourceTree = "<group>"; };
@@ -400,6 +403,7 @@
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
+		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
 		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
@@ -732,6 +736,8 @@
 				5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */,
 				DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */,
 				CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */,
+				0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */,
+				CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */,
 				8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */,
 				CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */,
 			);
@@ -1203,6 +1209,8 @@
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
 				B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */,
 				29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */,
+				16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */,
+				2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */,
 				8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */; };
 		12035048B950CE0197604F89 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CE7B4DAFDB65A79308FB63 /* GitService.swift */; };
 		139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */; };
+		14D153B4A6C840E688FEF1B2 /* MarkdownPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0282E69C4E18745B24429620 /* MarkdownPane.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
@@ -234,6 +235,7 @@
 		010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowConfigurator.swift; sourceTree = "<group>"; };
 		019A03B92542169A6595D432 /* HoverHighlightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeature.swift; sourceTree = "<group>"; };
 		0240C5961343C3042D865570 /* GeneralPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPane.swift; sourceTree = "<group>"; };
+		0282E69C4E18745B24429620 /* MarkdownPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPane.swift; sourceTree = "<group>"; };
 		02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.SurfaceView.swift; sourceTree = "<group>"; };
 		0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCache.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
@@ -682,6 +684,7 @@
 				93CDC9895F48619E97461875 /* CodePane.swift */,
 				12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */,
 				0240C5961343C3042D865570 /* GeneralPane.swift */,
+				0282E69C4E18745B24429620 /* MarkdownPane.swift */,
 				0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */,
 				6A190D4B29B35C457AA9829F /* SettingsBinding.swift */,
 				F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */,
@@ -1211,6 +1214,7 @@
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
 				B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */,
+				14D153B4A6C840E688FEF1B2 /* MarkdownPane.swift in Sources */,
 				29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */,
 				16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */,
 				2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
+		6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */; };
 		6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795056B6AD803D2B555FC866 /* RightPaneStore.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
@@ -416,6 +417,7 @@
 		DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewModeTests.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
 		DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoader.swift; sourceTree = "<group>"; };
+		E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTabView.swift; sourceTree = "<group>"; };
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
 		E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndex.swift; sourceTree = "<group>"; };
 		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
@@ -739,6 +741,7 @@
 				0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */,
 				CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */,
 				8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */,
+				E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */,
 				CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */,
 			);
 			path = Markdown;
@@ -1212,6 +1215,7 @@
 				16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */,
 				2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */,
 				8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */,
+				6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
+		29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
 		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
 		2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768D12909DD5233659AC4E03 /* RepoGroupView.swift */; };
@@ -189,6 +190,7 @@
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
+		E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373D587E3153D902EB10208B /* MarkdownParserTests.swift */; };
 		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
 		E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA8FEE64D73BDEBAF74878 /* Kbd.swift */; };
@@ -274,6 +276,7 @@
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
 		36992F601C8EB6C3D45B584F /* SearchKbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKbd.swift; sourceTree = "<group>"; };
 		36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKind.swift; sourceTree = "<group>"; };
+		373D587E3153D902EB10208B /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
 		38499AFE31188908546EE222 /* LSPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransport.swift; sourceTree = "<group>"; };
 		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
 		39DFD138FE855D8CFC464847 /* SearchFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFooter.swift; sourceTree = "<group>"; };
@@ -388,6 +391,7 @@
 		CB020862232495EC1C5ECBEA /* WindowAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearance.swift; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
+		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
@@ -491,6 +495,7 @@
 				954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */,
 				EB52B59655B85764D85CFB7F /* LineEndingTests.swift */,
 				19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */,
+				373D587E3153D902EB10208B /* MarkdownParserTests.swift */,
 				DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
@@ -715,6 +720,7 @@
 			isa = PBXGroup;
 			children = (
 				5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */,
+				CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */,
 				CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */,
 			);
 			path = Markdown;
@@ -1183,6 +1189,7 @@
 				C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
+				29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
@@ -1285,6 +1292,7 @@
 				9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */,
 				DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */,
 				165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */,
+				E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */,
 				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -114,9 +114,11 @@
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
+		8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */; };
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
 		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
+		8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */; };
 		8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2AC0F8B3A1B75239995AC /* AppState.swift */; };
 		90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */; };
 		90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */; };
@@ -341,6 +343,7 @@
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
+		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
 		932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFeature.swift; sourceTree = "<group>"; };
@@ -361,6 +364,7 @@
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		B1AA2B3E548B50097C9AF9D3 /* FilesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesSectionView.swift; sourceTree = "<group>"; };
+		B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
@@ -496,6 +500,7 @@
 				EB52B59655B85764D85CFB7F /* LineEndingTests.swift */,
 				19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */,
 				373D587E3153D902EB10208B /* MarkdownParserTests.swift */,
+				B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */,
 				DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
@@ -721,6 +726,7 @@
 			children = (
 				5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */,
 				CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */,
+				8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */,
 				CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */,
 			);
 			path = Markdown;
@@ -1190,6 +1196,7 @@
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
 				29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */,
+				8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
@@ -1293,6 +1300,7 @@
 				DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */,
 				165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */,
 				E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */,
+				8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */,
 				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
+		1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */; };
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
@@ -403,6 +404,7 @@
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClientTests.swift; sourceTree = "<group>"; };
+		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
 		EB52B59655B85764D85CFB7F /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
 		EBBBF87CC508451B2C0F3A66 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
@@ -472,6 +474,7 @@
 				1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */,
 				35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */,
 				C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */,
+				E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */,
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
 				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
 				3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */,
@@ -1258,6 +1261,7 @@
 				A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */,
 				3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */,
 				C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */,
+				1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */,
 				C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */,
 				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */; };
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EC1B515505AEC98FB199B02A /* HookInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 642163EB929E060A878211E2 /* HookInstaller.swift */; };
+		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
@@ -344,6 +345,7 @@
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
 		954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallerTests.swift; sourceTree = "<group>"; };
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
+		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
 		A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClient.swift; sourceTree = "<group>"; };
@@ -466,6 +468,7 @@
 			isa = PBXGroup;
 			children = (
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
+				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
@@ -1251,6 +1254,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,
+				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
+		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2AC0F8B3A1B75239995AC /* AppState.swift */; };
 		90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */; };
@@ -138,6 +139,7 @@
 		A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */; };
 		A7BDA44A8E4364C4C335C4DA /* HookEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8820E4289EEB1ADCA9E490F /* HookEventTests.swift */; };
 		A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */; };
+		A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
@@ -382,6 +384,7 @@
 		CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroup.swift; sourceTree = "<group>"; };
 		CB020862232495EC1C5ECBEA /* WindowAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearance.swift; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
@@ -392,6 +395,7 @@
 		D97EF761C70A3AF83C00879A /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		D9E6D61B213F3378243B4A26 /* AlasField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasField.swift; sourceTree = "<group>"; };
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
+		DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewModeTests.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
 		E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndex.swift; sourceTree = "<group>"; };
@@ -481,6 +485,7 @@
 				954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */,
 				EB52B59655B85764D85CFB7F /* LineEndingTests.swift */,
 				19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */,
+				DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
@@ -704,6 +709,7 @@
 			isa = PBXGroup;
 			children = (
 				5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */,
+				CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */,
 			);
 			path = Markdown;
 			sourceTree = "<group>";
@@ -1171,6 +1177,7 @@
 				C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
+				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */,
@@ -1270,6 +1277,7 @@
 				9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */,
 				DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */,
 				165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */,
+				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */; };
 		90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */; };
 		91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C69060B922A729DD807920 /* LSPURI.swift */; };
+		92EEAFAEFB3E637FB72174A8 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
 		93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D759586280250330A9A04 /* FontSizeCommands.swift */; };
 		9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */; };
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
@@ -426,6 +427,7 @@
 				8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */,
 				1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */,
 				74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */,
+				92EEAFAEFB3E637FB72174A8 /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -974,6 +976,7 @@
 			packageProductDependencies = (
 				F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */,
 				77EF95AD63DDA8DB0504087B /* TreeSitterSwift */,
+				B69450B224F0C82A52D00662 /* Markdown */,
 			);
 			productName = Alas;
 			productReference = 519CFB3707E8DDBDECD6C5D1 /* Alas.app */;
@@ -1003,6 +1006,7 @@
 			mainGroup = 848F1B301BB31A69DEB82615;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				B9008B8C0F5A7E880C250FE4 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 				CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */,
 				7019D0C134F78A3B7F4CF4BB /* XCRemoteSwiftPackageReference "tree-sitter-swift" */,
 			);
@@ -1534,6 +1538,14 @@
 				revision = 7b7909f2f6b9414be0958275f4c8e5d69c3bca43;
 			};
 		};
+		B9008B8C0F5A7E880C250FE4 /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-markdown";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.4.0;
+			};
+		};
 		CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tree-sitter/swift-tree-sitter";
@@ -1549,6 +1561,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7019D0C134F78A3B7F4CF4BB /* XCRemoteSwiftPackageReference "tree-sitter-swift" */;
 			productName = TreeSitterSwift;
+		};
+		B69450B224F0C82A52D00662 /* Markdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B9008B8C0F5A7E880C250FE4 /* XCRemoteSwiftPackageReference "swift-markdown" */;
+			productName = Markdown;
 		};
 		F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */; };
 		12035048B950CE0197604F89 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CE7B4DAFDB65A79308FB63 /* GitService.swift */; };
 		139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */; };
+		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
@@ -32,6 +33,7 @@
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
+		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
 		2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768D12909DD5233659AC4E03 /* RepoGroupView.swift */; };
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
@@ -242,6 +244,7 @@
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		1841997CCBDB9611576B930C /* AlasToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasToggle.swift; sourceTree = "<group>"; };
+		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
 		1E947E110B003FB519DAD1B3 /* ChangesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesSectionView.swift; sourceTree = "<group>"; };
@@ -292,6 +295,7 @@
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
+		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
@@ -476,6 +480,7 @@
 				A8820E4289EEB1ADCA9E490F /* HookEventTests.swift */,
 				954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */,
 				EB52B59655B85764D85CFB7F /* LineEndingTests.swift */,
+				19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
@@ -622,6 +627,7 @@
 				B99EAA756E84360237C3E3D2 /* Editor */,
 				08AFF75AE216ACC5E010B709 /* Highlight */,
 				98B31DB084754D0D15591339 /* LSP */,
+				84098DAEB1A8FCEF82386437 /* Markdown */,
 			);
 			path = Code;
 			sourceTree = "<group>";
@@ -692,6 +698,14 @@
 				05EE713DD3CACF29F206553C /* ThemeStore.swift */,
 			);
 			path = Theme;
+			sourceTree = "<group>";
+		};
+		84098DAEB1A8FCEF82386437 /* Markdown */ = {
+			isa = PBXGroup;
+			children = (
+				5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */,
+			);
+			path = Markdown;
 			sourceTree = "<group>";
 		};
 		848F1B301BB31A69DEB82615 = {
@@ -1156,6 +1170,7 @@
 				EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */,
 				C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
+				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */,
@@ -1254,6 +1269,7 @@
 				4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */,
 				9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */,
 				DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */,
+				165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4261E417947C1A21E77C1587 /* GitStatusCache.swift */; };
 		67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */; };
 		6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4A215AF2876091E31F6F8A /* LineEnding.swift */; };
+		6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */; };
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
@@ -153,6 +154,7 @@
 		AD3469F4745DF96ED3D0E06E /* codex-cli.sh in Resources */ = {isa = PBXBuildFile; fileRef = F1524DAA94E33D2938853810 /* codex-cli.sh */; };
 		B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7159EED1183F784104B4F /* FuzzyMatch.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
+		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
 		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
 		B6C31E7AC3CE21AFEA371389 /* cool-slate.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DEB85132B767DB3B253620C /* cool-slate.json */; };
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
@@ -363,6 +365,7 @@
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
+		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
 		B1AA2B3E548B50097C9AF9D3 /* FilesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesSectionView.swift; sourceTree = "<group>"; };
 		B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
@@ -408,6 +411,7 @@
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
 		DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewModeTests.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
+		DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoader.swift; sourceTree = "<group>"; };
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
 		E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndex.swift; sourceTree = "<group>"; };
 		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
@@ -499,6 +503,7 @@
 				954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */,
 				EB52B59655B85764D85CFB7F /* LineEndingTests.swift */,
 				19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */,
+				B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */,
 				373D587E3153D902EB10208B /* MarkdownParserTests.swift */,
 				B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */,
 				DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */,
@@ -725,6 +730,7 @@
 			isa = PBXGroup;
 			children = (
 				5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */,
+				DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */,
 				CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */,
 				8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */,
 				CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */,
@@ -1195,6 +1201,7 @@
 				C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */,
 				6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */,
 				2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */,
+				B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */,
 				29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */,
 				8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
@@ -1299,6 +1306,7 @@
 				9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */,
 				DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */,
 				165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */,
+				6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */,
 				E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */,
 				8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */,
 				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "9209eb391e3fc9e4cd099d2cb3c6bd7eec22f35d07ffae645e59c6ec94ddd20b",
+  "originHash" : "470d4cfda5e64f6b510902e8e38178339db39391db2dd4b7a0a622f6fb223517",
   "pins" : [
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown",
+      "state" : {
+        "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
+        "version" : "0.8.0"
+      }
+    },
     {
       "identity" : "swift-tree-sitter",
       "kind" : "remoteSourceControl",
@@ -24,7 +42,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/alex-pinkus/tree-sitter-swift",
       "state" : {
-        "branch" : "with-generated-files",
         "revision" : "7b7909f2f6b9414be0958275f4c8e5d69c3bca43"
       }
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -507,6 +507,13 @@ final class AppState {
         }
     }
 
+    /// Open a markdown relative-link target as a new editor tab in the same worktree.
+    /// Delegates to `openFile` which handles find-or-create, activate, and
+    /// worktree-switch if necessary.
+    func openMarkdownLink(worktreeId: String, worktreeRoot: URL, relativePath: String) {
+        openFile(relativePath: relativePath, worktreeId: worktreeId)
+    }
+
     private func relativePath(for url: URL, in worktreeRoot: URL) throws -> String {
         let root = worktreeRoot.standardizedFileURL.path
         let target = url.standardizedFileURL.path

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -66,15 +66,29 @@ struct CenterPaneView: View {
                                         tabId: tab.id,
                                         sessionId: s.sessionId)
                     case .editor(let s):
-                        EditorTabView(worktreePath: worktree.path,
-                                      relativePath: s.relativePath,
-                                      worktreeId: worktree.id,
-                                      tabId: s.id,
-                                      revealLine: s.revealLine,
-                                      revealCharacter: s.revealCharacter,
-                                      appState: state,
-                                      externalAbsolutePath: s.externalAbsolutePath,
-                                      originatingRelativePath: s.originatingRelativePath)
+                        if MarkdownFileType.isMarkdown(relativePath: s.isExternal
+                                                        ? (s.externalAbsolutePath ?? "")
+                                                        : s.relativePath) {
+                            MarkdownTabView(worktreePath: worktree.path,
+                                            worktreeId: worktree.id,
+                                            tabId: s.id,
+                                            relativePath: s.relativePath,
+                                            externalAbsolutePath: s.externalAbsolutePath,
+                                            originatingRelativePath: s.originatingRelativePath,
+                                            revealLine: s.revealLine,
+                                            revealCharacter: s.revealCharacter,
+                                            appState: state)
+                        } else {
+                            EditorTabView(worktreePath: worktree.path,
+                                          relativePath: s.relativePath,
+                                          worktreeId: worktree.id,
+                                          tabId: s.id,
+                                          revealLine: s.revealLine,
+                                          revealCharacter: s.revealCharacter,
+                                          appState: state,
+                                          externalAbsolutePath: s.externalAbsolutePath,
+                                          originatingRelativePath: s.originatingRelativePath)
+                        }
                     case .diff(let s):
                         DiffTabView(worktreePath: worktree.path,
                                     relativePath: s.relativePath,

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -58,6 +58,12 @@ struct EditorTabState: Codable, Equatable, Identifiable {
     /// holder in nested-package layouts. Nil for tabs persisted before this
     /// field was added (backward-compatible via the default value).
     var originatingRelativePath: String? = nil
+    /// Last view mode the user selected for this markdown tab. `nil` means
+    /// "use `AppConfig.markdown.defaultViewMode`". Nil for non-markdown tabs.
+    var markdownViewMode: MarkdownViewMode? = nil
+    /// Editor-pane width as a fraction of the split container, persisted
+    /// per-tab. Nil → 0.5. Nil for non-markdown or non-split tabs.
+    var markdownSplitFraction: Double? = nil
 
     var isExternal: Bool { externalAbsolutePath != nil }
 }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -311,6 +311,39 @@ final class TabsManager {
         persist(worktreeId)
     }
 
+    // MARK: - Markdown tab helpers
+
+    /// Lookup the editor state for a given tab. Used by markdown tabs to read
+    /// persisted view-mode / split-fraction without re-walking the tab list.
+    func editorTabState(worktreeId: String, tabId: TabID) -> EditorTabState? {
+        guard let file = byWorktree[worktreeId] else { return nil }
+        if let tab = file.tabs.first(where: { $0.id == tabId }),
+           case .editor(let s) = tab { return s }
+        return nil
+    }
+
+    /// Update the per-tab markdown view mode and persist.
+    func setMarkdownViewMode(worktreeId: String, tabId: TabID, mode: MarkdownViewMode) {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .editor(var state) = file.tabs[idx] else { return }
+        state.markdownViewMode = mode
+        file.tabs[idx] = .editor(state)
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+    }
+
+    /// Update the per-tab markdown split fraction and persist.
+    func setMarkdownSplitFraction(worktreeId: String, tabId: TabID, fraction: Double) {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .editor(var state) = file.tabs[idx] else { return }
+        state.markdownSplitFraction = max(0.1, min(0.9, fraction))
+        file.tabs[idx] = .editor(state)
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+    }
+
     func activate(worktreeId: String, tabId: TabID) {
         var file = byWorktree[worktreeId] ?? TabsFile(tabs: [], activeTabId: nil)
         file.activeTabId = tabId

--- a/Alas/Sources/Code/Markdown/MarkdownFileType.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownFileType.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// File-type detection for markdown documents. Matches by extension
+/// (`.md`, `.markdown`, `.mdx`, case-insensitive) and a small set of
+/// extension-less conventional filenames found in source repos.
+enum MarkdownFileType {
+    private static let extensions: Set<String> = ["md", "markdown", "mdx"]
+    private static let extensionlessNames: Set<String> = [
+        "readme", "changelog", "contributing", "license", "notice", "authors"
+    ]
+
+    static func isMarkdown(relativePath: String) -> Bool {
+        guard !relativePath.isEmpty else { return false }
+        let filename = (relativePath as NSString).lastPathComponent
+        let ext = (filename as NSString).pathExtension.lowercased()
+        if !ext.isEmpty {
+            return extensions.contains(ext)
+        }
+        return extensionlessNames.contains(filename.lowercased())
+    }
+}

--- a/Alas/Sources/Code/Markdown/MarkdownImageLoader.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownImageLoader.swift
@@ -5,7 +5,11 @@ import Foundation
 /// synchronously on call; remote `https://` images are fetched
 /// asynchronously and cached. The caller is responsible for applying the
 /// fetched image to the placeholder attachment and invalidating layout.
-final class MarkdownImageLoader {
+///
+/// `@unchecked Sendable` is sound because the only mutable state is
+/// `NSCache`, which is documented thread-safe, and `URLSession`, which is
+/// itself `Sendable`. The class has no other writable storage.
+final class MarkdownImageLoader: @unchecked Sendable {
     enum Source: Equatable {
         case local(String)
         case remote(URL)

--- a/Alas/Sources/Code/Markdown/MarkdownImageLoader.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownImageLoader.swift
@@ -1,0 +1,60 @@
+import AppKit
+import Foundation
+
+/// Resolves and loads markdown image references. Local images are loaded
+/// synchronously on call; remote `https://` images are fetched
+/// asynchronously and cached. The caller is responsible for applying the
+/// fetched image to the placeholder attachment and invalidating layout.
+final class MarkdownImageLoader {
+    enum Source: Equatable {
+        case local(String)
+        case remote(URL)
+        case invalid
+    }
+
+    /// Categorize a markdown image `src` attribute. Empty → invalid.
+    /// `http(s)://` → remote. Anything else → local.
+    static func classify(_ src: String) -> Source {
+        guard !src.isEmpty else { return .invalid }
+        if let url = URL(string: src),
+           let scheme = url.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" {
+            return .remote(url)
+        }
+        return .local(src)
+    }
+
+    private let cache = NSCache<NSURL, NSImage>()
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+        cache.countLimit = 64
+    }
+
+    /// Load a local image relative to `baseDirectory`. Returns nil if the
+    /// file cannot be loaded.
+    func loadLocal(src: String, baseDirectory: URL) -> NSImage? {
+        let resolved = baseDirectory.appendingPathComponent(src).standardizedFileURL
+        return NSImage(contentsOf: resolved)
+    }
+
+    /// Returns a cached image immediately if available; otherwise schedules
+    /// an async fetch and calls `completion` on the main actor when the
+    /// image arrives. If the fetch fails, `completion` is called with nil.
+    @MainActor
+    func loadRemote(url: URL, completion: @escaping @MainActor (NSImage?) -> Void) -> NSImage? {
+        if let cached = cache.object(forKey: url as NSURL) {
+            return cached
+        }
+        let task = session.dataTask(with: url) { [weak self] data, _, _ in
+            let image = data.flatMap { NSImage(data: $0) }
+            if let image, let self {
+                self.cache.setObject(image, forKey: url as NSURL)
+            }
+            Task { @MainActor in completion(image) }
+        }
+        task.resume()
+        return nil
+    }
+}

--- a/Alas/Sources/Code/Markdown/MarkdownParser.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownParser.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Markdown
+
+/// Thin wrapper over `swift-markdown`'s `Document.init(parsing:options:)`.
+/// Provides a single, tested entry point so the renderer never has to
+/// remember the option set. GFM tables, task lists, strikethrough, and
+/// autolinks are enabled by default in current `swift-markdown` releases.
+enum MarkdownParser {
+    static func parse(_ source: String) -> Document {
+        Document(parsing: source)
+    }
+}

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
@@ -16,6 +16,7 @@ final class MarkdownPreviewController: NSObject {
     let scrollView: NSScrollView
 
     private let imageLoader = MarkdownImageLoader()
+    private nonisolated(unsafe) var anchorObserver: NSObjectProtocol?
 
     init(theme: Theme) {
         let scroll = NSScrollView()
@@ -63,6 +64,16 @@ final class MarkdownPreviewController: NSObject {
         self.scrollView = scroll
         super.init()
         textView.delegate = self
+
+        anchorObserver = NotificationCenter.default.addObserver(
+            forName: .markdownScrollToAnchor,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self,
+                  let slug = note.userInfo?["slug"] as? String else { return }
+            Task { @MainActor in self.scrollTo(slug: slug) }
+        }
     }
 
     /// Replace the rendered content. Must be called on the main thread.
@@ -97,6 +108,12 @@ final class MarkdownPreviewController: NSObject {
     func scrollTo(slug: String) {
         guard let range = anchorRanges[slug] else { return }
         textView.scrollRangeToVisible(range)
+    }
+
+    deinit {
+        if let anchorObserver {
+            NotificationCenter.default.removeObserver(anchorObserver)
+        }
     }
 }
 

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
@@ -1,0 +1,113 @@
+import AppKit
+
+/// Coordinator for `MarkdownPreviewView`. Owns the read-only `NSTextView`,
+/// intercepts link clicks, and asynchronously loads remote images by
+/// patching the text storage in place. Held by SwiftUI's `Coordinator` slot.
+@MainActor
+final class MarkdownPreviewController: NSObject {
+    /// Routes a link click. Set by `MarkdownTabView` when the preview is
+    /// installed (Task 16); called with the URL the user clicked.
+    var onLinkClick: ((URL) -> Void)?
+    /// Reports the anchor map so the controller can scroll to a heading
+    /// when the user clicks a `#slug` link. Filled in via `apply(result:)`.
+    var anchorRanges: [String: NSRange] = [:]
+
+    let textView: NSTextView
+    let scrollView: NSScrollView
+
+    private let imageLoader = MarkdownImageLoader()
+
+    init(theme: Theme) {
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = false
+        scroll.borderType = .noBorder
+        scroll.autohidesScrollers = false
+        scroll.drawsBackground = true
+        scroll.backgroundColor = NSColor(theme.color("bg-1"))
+
+        let containerSize = NSSize(width: scroll.contentSize.width,
+                                   height: CGFloat.greatestFiniteMagnitude)
+        let textContainer = NSTextContainer(size: containerSize)
+        textContainer.widthTracksTextView = true
+        textContainer.heightTracksTextView = false
+
+        let layoutManager = NSLayoutManager()
+        layoutManager.addTextContainer(textContainer)
+
+        let textStorage = NSTextStorage()
+        textStorage.addLayoutManager(layoutManager)
+
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600),
+                                  textContainer: textContainer)
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = true
+        textView.backgroundColor = NSColor(theme.color("bg-1"))
+        textView.textContainerInset = NSSize(width: 16, height: 16)
+        textView.linkTextAttributes = [
+            .foregroundColor: NSColor(theme.color("accent")),
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+        textView.isAutomaticLinkDetectionEnabled = false
+        textView.isAutomaticDataDetectionEnabled = false
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                  height: CGFloat.greatestFiniteMagnitude)
+        textView.isHorizontallyResizable = false
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        scroll.documentView = textView
+
+        self.textView = textView
+        self.scrollView = scroll
+        super.init()
+        textView.delegate = self
+    }
+
+    /// Replace the rendered content. Must be called on the main thread.
+    func apply(result: MarkdownRenderResult) {
+        anchorRanges = result.anchorRanges
+        textView.textStorage?.setAttributedString(result.attributedString)
+        for ref in result.remoteImages {
+            _ = imageLoader.loadRemote(url: ref.url) { [weak self] image in
+                guard let self, let image else { return }
+                ref.attachment.image = image
+                // Sizing: if attachment was placeholder (200x16), grow to image's
+                // natural size up to a max width of 600.
+                let maxWidth: CGFloat = 600
+                if image.size.width > maxWidth {
+                    let scale = maxWidth / image.size.width
+                    ref.attachment.bounds = NSRect(x: 0, y: 0, width: maxWidth, height: image.size.height * scale)
+                } else {
+                    ref.attachment.bounds = NSRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+                }
+                // Invalidate layout so the attachment glyph re-measures.
+                if let storage = self.textView.textStorage {
+                    let len = storage.length
+                    storage.edited([.editedAttributes, .editedCharacters],
+                                   range: NSRange(location: 0, length: len),
+                                   changeInLength: 0)
+                }
+            }
+        }
+    }
+
+    /// Scroll the preview so the anchor at `slug` is at the top.
+    func scrollTo(slug: String) {
+        guard let range = anchorRanges[slug] else { return }
+        textView.scrollRangeToVisible(range)
+    }
+}
+
+extension MarkdownPreviewController: NSTextViewDelegate {
+    nonisolated func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+        // Bounce to MainActor for the link routing closure.
+        if let url = link as? URL {
+            Task { @MainActor in self.onLinkClick?(url) }
+        } else if let s = link as? String, let url = URL(string: s) {
+            Task { @MainActor in self.onLinkClick?(url) }
+        }
+        return true
+    }
+}

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
@@ -81,25 +81,14 @@ final class MarkdownPreviewController: NSObject {
         anchorRanges = result.anchorRanges
         textView.textStorage?.setAttributedString(result.attributedString)
         for ref in result.remoteImages {
-            _ = imageLoader.loadRemote(url: ref.url) { [weak self] image in
+            // Cache hit returns synchronously and skips the completion handler.
+            // Apply it here so the fresh placeholder attachment created by the
+            // new attributed string actually shows the cached image.
+            if let cached = imageLoader.loadRemote(url: ref.url, completion: { [weak self] image in
                 guard let self, let image else { return }
-                ref.attachment.image = image
-                // Sizing: if attachment was placeholder (200x16), grow to image's
-                // natural size up to a max width of 600.
-                let maxWidth: CGFloat = 600
-                if image.size.width > maxWidth {
-                    let scale = maxWidth / image.size.width
-                    ref.attachment.bounds = NSRect(x: 0, y: 0, width: maxWidth, height: image.size.height * scale)
-                } else {
-                    ref.attachment.bounds = NSRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
-                }
-                // Invalidate layout so the attachment glyph re-measures.
-                if let storage = self.textView.textStorage {
-                    let len = storage.length
-                    storage.edited([.editedAttributes, .editedCharacters],
-                                   range: NSRange(location: 0, length: len),
-                                   changeInLength: 0)
-                }
+                self.applyRemoteImage(image, to: ref.attachment)
+            }) {
+                applyRemoteImage(cached, to: ref.attachment)
             }
         }
     }
@@ -108,6 +97,24 @@ final class MarkdownPreviewController: NSObject {
     func scrollTo(slug: String) {
         guard let range = anchorRanges[slug] else { return }
         textView.scrollRangeToVisible(range)
+    }
+
+    /// Install a loaded `NSImage` into the placeholder attachment, resize it
+    /// to fit within the preview, and invalidate layout so the glyph
+    /// re-measures.
+    private func applyRemoteImage(_ image: NSImage, to attachment: NSTextAttachment) {
+        attachment.image = image
+        let maxWidth: CGFloat = 600
+        if image.size.width > maxWidth {
+            let scale = maxWidth / image.size.width
+            attachment.bounds = NSRect(x: 0, y: 0, width: maxWidth, height: image.size.height * scale)
+        } else {
+            attachment.bounds = NSRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+        }
+        if let storage = textView.textStorage {
+            let len = storage.length
+            storage.edited([.editedAttributes], range: NSRange(location: 0, length: len), changeInLength: 0)
+        }
     }
 
     deinit {

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
@@ -99,6 +99,18 @@ final class MarkdownPreviewController: NSObject {
         textView.scrollRangeToVisible(range)
     }
 
+    /// Refresh the chrome colors that depend on the current theme. Safe to
+    /// call repeatedly; idempotent if the theme hasn't actually changed.
+    func reapplyTheme(_ theme: Theme) {
+        let bg = NSColor(theme.color("bg-1"))
+        scrollView.backgroundColor = bg
+        textView.backgroundColor = bg
+        textView.linkTextAttributes = [
+            .foregroundColor: NSColor(theme.color("accent")),
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+    }
+
     /// Install a loaded `NSImage` into the placeholder attachment, resize it
     /// to fit within the preview, and invalidate layout so the glyph
     /// re-measures.

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import AppKit
+
+struct MarkdownPreviewView: NSViewRepresentable {
+    let result: MarkdownRenderResult
+    let onLinkClick: (URL) -> Void
+    @Environment(\.theme) var theme
+
+    func makeCoordinator() -> MarkdownPreviewController {
+        MarkdownPreviewController(theme: theme)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        context.coordinator.onLinkClick = onLinkClick
+        context.coordinator.apply(result: result)
+        return context.coordinator.scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        context.coordinator.onLinkClick = onLinkClick
+        context.coordinator.apply(result: result)
+    }
+}

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewView.swift
@@ -12,12 +12,17 @@ struct MarkdownPreviewView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSScrollView {
         context.coordinator.onLinkClick = onLinkClick
+        context.coordinator.reapplyTheme(theme)
         context.coordinator.apply(result: result)
         return context.coordinator.scrollView
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         context.coordinator.onLinkClick = onLinkClick
+        // Theme/accent/system-appearance changes can produce a new `theme`
+        // value without recreating the coordinator, so we must push the new
+        // chrome colors into the existing NSScrollView/NSTextView here.
+        context.coordinator.reapplyTheme(theme)
         context.coordinator.apply(result: result)
     }
 }

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -34,6 +34,24 @@ final class MarkdownRenderer {
     private var inStrikethrough: Bool = false
     private var listDepth: Int = 0
 
+    private static let fenceLanguageToExtension: [String: String] = [
+        "swift": "swift",
+        "rust": "rs", "rs": "rs",
+        "json": "json",
+        "markdown": "md", "md": "md",
+        "python": "py", "py": "py",
+        "typescript": "ts", "ts": "ts",
+        "javascript": "js", "js": "js",
+        "tsx": "tsx", "jsx": "jsx",
+        "kotlin": "kt", "kt": "kt"
+    ]
+
+    private func extensionFor(fenceLanguage info: String?) -> String? {
+        guard let info, !info.isEmpty else { return nil }
+        let tag = info.split(separator: " ").first.map(String.init)?.lowercased() ?? ""
+        return MarkdownRenderer.fenceLanguageToExtension[tag]
+    }
+
     func render(
         document: Document,
         theme: Theme,
@@ -184,14 +202,31 @@ final class MarkdownRenderer {
     }
 
     private func visitCodeBlock(_ block: CodeBlock) {
-        // For this task: plain monospaced with a faint background. Syntax
-        // highlighting via tree-sitter is wired in Task 11.
-        let attrs: [NSAttributedString.Key: Any] = [
+        let baseAttrs: [NSAttributedString.Key: Any] = [
             .font: monospaceFont(size: monoSize),
             .foregroundColor: NSColor(theme.color("fg")),
             .backgroundColor: NSColor(theme.color("bg-2"))
         ]
-        output.append(NSAttributedString(string: block.code, attributes: attrs))
+        let start = output.length
+        output.append(NSAttributedString(string: block.code, attributes: baseAttrs))
+        let length = output.length - start
+
+        if let ext = extensionFor(fenceLanguage: block.language) {
+            let spans = TreeSitterHighlighter.highlight(source: block.code, fileExtension: ext)
+            let editorTheme = EditorTheme(theme: theme)
+            let blockRange = NSRange(location: start, length: length)
+            for span in spans {
+                let absolute = NSRange(location: start + span.range.location,
+                                       length: span.range.length)
+                // Guard against spans that escape the block (shouldn't happen,
+                // but defensive: TreeSitter is sometimes imprecise).
+                guard NSIntersectionRange(absolute, blockRange).length == absolute.length else { continue }
+                let attrs = editorTheme.attributes(for: span.capture)
+                for (key, value) in attrs {
+                    output.addAttribute(key, value: value, range: absolute)
+                }
+            }
+        }
         appendPlain("\n")
     }
 

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -29,6 +29,10 @@ final class MarkdownRenderer {
     private var monoFamily: String = "SF Mono"
     private var monoSize: CGFloat = 13
     private var baseDirectory: URL = URL(fileURLWithPath: "/")
+    /// Optional worktree root, used to resolve markdown-style root-relative
+    /// paths like `/assets/logo.png`. Nil for external tabs (where there is
+    /// no worktree-rooted view of the file).
+    private var worktreeRoot: URL?
     private let imageLoader = MarkdownImageLoader()
 
     private var currentTraits: NSFontDescriptor.SymbolicTraits = []
@@ -62,7 +66,8 @@ final class MarkdownRenderer {
         theme: Theme,
         monospacedFontFamily: String,
         monospacedFontSize: Int,
-        baseDirectory: URL
+        baseDirectory: URL,
+        worktreeRoot: URL? = nil
     ) -> MarkdownRenderResult {
         self.output = NSMutableAttributedString()
         self.anchorRanges = [:]
@@ -71,6 +76,7 @@ final class MarkdownRenderer {
         self.monoFamily = monospacedFontFamily
         self.monoSize = CGFloat(monospacedFontSize)
         self.baseDirectory = baseDirectory
+        self.worktreeRoot = worktreeRoot
         self.currentTraits = []
         self.inStrikethrough = false
         self.listDepth = 0
@@ -142,7 +148,20 @@ final class MarkdownRenderer {
                 output.append(NSAttributedString(string: alt, attributes: mutedAttributes()))
             }
         case .local(let path):
-            if let loaded = imageLoader.loadLocal(src: path, baseDirectory: baseDirectory) {
+            // Root-relative paths (`/assets/logo.png`) resolve from the
+            // worktree root when available, matching how the link handler
+            // treats `/README.md`. External tabs without a worktree root
+            // fall back to standard absolute-path resolution.
+            let resolveFrom: URL
+            let usePath: String
+            if path.hasPrefix("/"), let root = worktreeRoot {
+                resolveFrom = root
+                usePath = String(path.dropFirst())
+            } else {
+                resolveFrom = baseDirectory
+                usePath = path
+            }
+            if let loaded = imageLoader.loadLocal(src: usePath, baseDirectory: resolveFrom) {
                 output.append(attachmentString(for: loaded))
             } else if !alt.isEmpty {
                 output.append(NSAttributedString(string: alt, attributes: mutedAttributes()))

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -78,6 +78,9 @@ final class MarkdownRenderer {
         case let h as Heading:          visitHeading(h)
         case let l as UnorderedList:    visitUnorderedList(l)
         case let l as OrderedList:      visitOrderedList(l)
+        case let b as BlockQuote:       visitBlockQuote(b)
+        case _ as ThematicBreak:        appendThematicBreak()
+        case let c as CodeBlock:        visitCodeBlock(c)
         default:
             visitChildren(markup)
         }
@@ -150,6 +153,46 @@ final class MarkdownRenderer {
             n += 1
         }
         if listDepth == 0 { appendPlain("\n") }
+    }
+
+    private func visitBlockQuote(_ quote: BlockQuote) {
+        let startOfBlock = output.length
+        for child in quote.children { visit(child) }
+        // Insert a "│ " prefix on every line of the just-rendered block.
+        let nsOutput = output.string as NSString
+        let blockNS = NSRange(location: startOfBlock, length: nsOutput.length - startOfBlock)
+        guard blockNS.length > 0 else { return }
+        let blockText = nsOutput.substring(with: blockNS)
+        let lines = blockText.split(separator: "\n", omittingEmptySubsequences: false)
+        let rebuilt = lines.map { "│ \($0)" }.joined(separator: "\n")
+        output.replaceCharacters(in: blockNS, with: rebuilt)
+        // Color the entire rebuilt block in muted foreground.
+        let attrs: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor(theme.color("fg-muted")),
+            .font: bodyFont()
+        ]
+        output.addAttributes(attrs, range: NSRange(location: startOfBlock, length: (rebuilt as NSString).length))
+    }
+
+    private func appendThematicBreak() {
+        let line = String(repeating: "─", count: 32)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor(theme.color("fg-faint")),
+            .font: bodyFont()
+        ]
+        output.append(NSAttributedString(string: line + "\n\n", attributes: attrs))
+    }
+
+    private func visitCodeBlock(_ block: CodeBlock) {
+        // For this task: plain monospaced with a faint background. Syntax
+        // highlighting via tree-sitter is wired in Task 11.
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: monospaceFont(size: monoSize),
+            .foregroundColor: NSColor(theme.color("fg")),
+            .backgroundColor: NSColor(theme.color("bg-2"))
+        ]
+        output.append(NSAttributedString(string: block.code, attributes: attrs))
+        appendPlain("\n")
     }
 
     private func marker(for item: ListItem) -> String {

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -34,6 +34,10 @@ final class MarkdownRenderer {
     private var currentTraits: NSFontDescriptor.SymbolicTraits = []
     private var inStrikethrough: Bool = false
     private var listDepth: Int = 0
+    /// Counts how many times each base slug has been seen so duplicate
+    /// headings get GitHub-style `-1`, `-2`, … suffixes instead of clobbering
+    /// the earlier range in `anchorRanges`.
+    private var slugCounts: [String: Int] = [:]
 
     private static let fenceLanguageToExtension: [String: String] = [
         "swift": "swift",
@@ -70,6 +74,7 @@ final class MarkdownRenderer {
         self.currentTraits = []
         self.inStrikethrough = false
         self.listDepth = 0
+        self.slugCounts = [:]
 
         for child in document.children {
             visit(child)
@@ -177,9 +182,15 @@ final class MarkdownRenderer {
         ]
         output.append(NSAttributedString(string: plain, attributes: attrs))
         let length = output.length - start
-        let slug = MarkdownRenderer.slugify(plain)
-        if !slug.isEmpty, length > 0 {
-            anchorRanges[slug] = NSRange(location: start, length: length)
+        let baseSlug = MarkdownRenderer.slugify(plain)
+        if !baseSlug.isEmpty, length > 0 {
+            // GitHub-style disambiguation: first occurrence keeps the bare slug,
+            // subsequent occurrences get `-1`, `-2`, … so `[link](#install)`
+            // resolves to the first `## Install` heading instead of the last.
+            let count = slugCounts[baseSlug, default: 0]
+            let finalSlug = count == 0 ? baseSlug : "\(baseSlug)-\(count)"
+            anchorRanges[finalSlug] = NSRange(location: start, length: length)
+            slugCounts[baseSlug] = count + 1
         }
         appendPlain("\n\n")
     }

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -29,6 +29,7 @@ final class MarkdownRenderer {
     private var monoFamily: String = "SF Mono"
     private var monoSize: CGFloat = 13
     private var baseDirectory: URL = URL(fileURLWithPath: "/")
+    private let imageLoader = MarkdownImageLoader()
 
     private var currentTraits: NSFontDescriptor.SymbolicTraits = []
     private var inStrikethrough: Bool = false
@@ -93,6 +94,7 @@ final class MarkdownRenderer {
         case _ as SoftBreak:            appendPlain(" ")
         case _ as LineBreak:            appendPlain("\n")
         case let l as Markdown.Link:    visitLink(l)
+        case let img as Markdown.Image: visitImage(img)
         case let h as Heading:          visitHeading(h)
         case let l as UnorderedList:    visitUnorderedList(l)
         case let l as OrderedList:      visitOrderedList(l)
@@ -124,6 +126,45 @@ final class MarkdownRenderer {
         output.addAttribute(.link, value: url, range: range)
         output.addAttribute(.foregroundColor, value: NSColor(theme.color("accent")), range: range)
         output.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+    }
+
+    private func visitImage(_ image: Markdown.Image) {
+        let alt = image.plainText
+        let src = image.source ?? ""
+        switch MarkdownImageLoader.classify(src) {
+        case .invalid:
+            if !alt.isEmpty {
+                output.append(NSAttributedString(string: alt, attributes: mutedAttributes()))
+            }
+        case .local(let path):
+            if let loaded = imageLoader.loadLocal(src: path, baseDirectory: baseDirectory) {
+                output.append(attachmentString(for: loaded))
+            } else if !alt.isEmpty {
+                output.append(NSAttributedString(string: alt, attributes: mutedAttributes()))
+            }
+        case .remote(let url):
+            let attachment = NSTextAttachment()
+            attachment.bounds = NSRect(x: 0, y: 0, width: 200, height: 16)
+            remoteImages.append(RemoteImageReference(url: url, attachment: attachment))
+            output.append(NSAttributedString(attachment: attachment))
+        }
+    }
+
+    private func attachmentString(for image: NSImage) -> NSAttributedString {
+        let attachment = NSTextAttachment()
+        attachment.image = image
+        let maxWidth: CGFloat = 600
+        if image.size.width > maxWidth {
+            let scale = maxWidth / image.size.width
+            attachment.bounds = NSRect(x: 0, y: 0, width: maxWidth, height: image.size.height * scale)
+        } else {
+            attachment.bounds = NSRect(x: 0, y: 0, width: image.size.width, height: image.size.height)
+        }
+        return NSAttributedString(attachment: attachment)
+    }
+
+    private func mutedAttributes() -> [NSAttributedString.Key: Any] {
+        [.foregroundColor: NSColor(theme.color("fg-muted")), .font: bodyFont()]
     }
 
     private func visitHeading(_ heading: Heading) {

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -99,6 +99,7 @@ final class MarkdownRenderer {
         case let b as BlockQuote:       visitBlockQuote(b)
         case _ as ThematicBreak:        appendThematicBreak()
         case let c as CodeBlock:        visitCodeBlock(c)
+        case let t as Markdown.Table:   visitTable(t)
         default:
             visitChildren(markup)
         }
@@ -226,6 +227,44 @@ final class MarkdownRenderer {
                     output.addAttribute(key, value: value, range: absolute)
                 }
             }
+        }
+        appendPlain("\n")
+    }
+
+    private func visitTable(_ table: Markdown.Table) {
+        let header: [String] = table.head.cells.map { $0.plainText }
+        let bodyRows: [[String]] = table.body.rows.map { (row: Markdown.Table.Row) -> [String] in
+            row.cells.map { (cell: Markdown.Table.Cell) -> String in cell.plainText }
+        }
+        let allRows: [[String]] = [header] + bodyRows
+        let columnCount = allRows.map { (r: [String]) -> Int in r.count }.max() ?? 0
+        guard columnCount > 0 else { return }
+
+        var widths = Array(repeating: 0, count: columnCount)
+        for row in allRows {
+            for (i, cell) in row.enumerated() where i < columnCount {
+                widths[i] = max(widths[i], cell.count)
+            }
+        }
+
+        func formatRow(_ row: [String]) -> String {
+            let padded = (0..<columnCount).map { i -> String in
+                let cell = i < row.count ? row[i] : ""
+                return cell.padding(toLength: widths[i], withPad: " ", startingAt: 0)
+            }
+            return "| " + padded.joined(separator: " | ") + " |"
+        }
+
+        let separator = "|-" + widths.map { String(repeating: "-", count: $0) }.joined(separator: "-|-") + "-|"
+
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: monospaceFont(size: monoSize),
+            .foregroundColor: NSColor(theme.color("fg"))
+        ]
+        output.append(NSAttributedString(string: formatRow(header) + "\n", attributes: attrs))
+        output.append(NSAttributedString(string: separator + "\n", attributes: attrs))
+        for row in bodyRows {
+            output.append(NSAttributedString(string: formatRow(row) + "\n", attributes: attrs))
         }
         appendPlain("\n")
     }

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -229,20 +229,30 @@ final class MarkdownRenderer {
     private func visitBlockQuote(_ quote: BlockQuote) {
         let startOfBlock = output.length
         for child in quote.children { visit(child) }
-        // Insert a "│ " prefix on every line of the just-rendered block.
-        let nsOutput = output.string as NSString
-        let blockNS = NSRange(location: startOfBlock, length: nsOutput.length - startOfBlock)
+        let blockNS = NSRange(location: startOfBlock, length: output.length - startOfBlock)
         guard blockNS.length > 0 else { return }
-        let blockText = nsOutput.substring(with: blockNS)
-        let lines = blockText.split(separator: "\n", omittingEmptySubsequences: false)
-        let rebuilt = lines.map { "│ \($0)" }.joined(separator: "\n")
-        output.replaceCharacters(in: blockNS, with: rebuilt)
-        // Color the entire rebuilt block in muted foreground.
-        let attrs: [NSAttributedString.Key: Any] = [
+        // Insert a muted "│ " prefix at the start of every line in the just-
+        // rendered block. We work on the attributed substring so existing
+        // inline attributes (links, bold, italic, inline code) survive — a
+        // plain-`String` rebuild would drop them and turn `> see [docs](url)`
+        // into inert text.
+        let blockAttr = output.attributedSubstring(from: blockNS)
+        let prefixAttrs: [NSAttributedString.Key: Any] = [
             .foregroundColor: NSColor(theme.color("fg-muted")),
             .font: bodyFont()
         ]
-        output.addAttributes(attrs, range: NSRange(location: startOfBlock, length: (rebuilt as NSString).length))
+        let prefix = NSAttributedString(string: "│ ", attributes: prefixAttrs)
+        let rebuilt = NSMutableAttributedString(attributedString: blockAttr)
+        let raw = rebuilt.string as NSString
+        var insertions: [Int] = [0]
+        for i in 0..<raw.length where raw.character(at: i) == 0x0A && i + 1 < raw.length {
+            insertions.append(i + 1)
+        }
+        // Insert from end to start so earlier positions stay valid.
+        for pos in insertions.reversed() {
+            rebuilt.insert(prefix, at: pos)
+        }
+        output.replaceCharacters(in: blockNS, with: rebuilt)
     }
 
     private func appendThematicBreak() {

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -1,0 +1,159 @@
+import AppKit
+import Markdown
+import SwiftUI
+
+/// Result of rendering a markdown document. The attributed string is the
+/// only thing the preview text view consumes; the other maps support the
+/// link-click handler and the async remote-image loader (filled in by
+/// later tasks).
+struct MarkdownRenderResult {
+    let attributedString: NSAttributedString
+    let anchorRanges: [String: NSRange]
+    let remoteImages: [RemoteImageReference]
+}
+
+/// Captures one `https://`-image attachment in the result. The
+/// MarkdownPreviewController uses this to fire off async fetches and
+/// patch the text storage when each image arrives.
+struct RemoteImageReference {
+    let url: URL
+    let attachment: NSTextAttachment
+}
+
+@MainActor
+final class MarkdownRenderer {
+    private var output: NSMutableAttributedString = .init()
+    private var anchorRanges: [String: NSRange] = [:]
+    private var remoteImages: [RemoteImageReference] = []
+    private var theme: Theme!
+    private var monoFamily: String = "SF Mono"
+    private var monoSize: CGFloat = 13
+    private var baseDirectory: URL = URL(fileURLWithPath: "/")
+
+    private var currentTraits: NSFontDescriptor.SymbolicTraits = []
+    private var inStrikethrough: Bool = false
+
+    func render(
+        document: Document,
+        theme: Theme,
+        monospacedFontFamily: String,
+        monospacedFontSize: Int,
+        baseDirectory: URL
+    ) -> MarkdownRenderResult {
+        self.output = NSMutableAttributedString()
+        self.anchorRanges = [:]
+        self.remoteImages = []
+        self.theme = theme
+        self.monoFamily = monospacedFontFamily
+        self.monoSize = CGFloat(monospacedFontSize)
+        self.baseDirectory = baseDirectory
+        self.currentTraits = []
+        self.inStrikethrough = false
+
+        for child in document.children {
+            visit(child)
+        }
+        return MarkdownRenderResult(
+            attributedString: output.copy() as! NSAttributedString,
+            anchorRanges: anchorRanges,
+            remoteImages: remoteImages
+        )
+    }
+
+    // MARK: - Dispatch
+
+    private func visit(_ markup: Markup) {
+        switch markup {
+        case let p as Paragraph:        visitParagraph(p)
+        case let t as Markdown.Text:    appendText(t.string, attributes: bodyAttributes())
+        case let e as Emphasis:         withTrait(.italic) { visitChildren(e) }
+        case let s as Strong:           withTrait(.bold) { visitChildren(s) }
+        case let s as Strikethrough:    withStrikethrough { visitChildren(s) }
+        case let c as InlineCode:       appendText(c.code, attributes: inlineCodeAttributes())
+        case _ as SoftBreak:            appendPlain(" ")
+        case _ as LineBreak:            appendPlain("\n")
+        case let l as Markdown.Link:    visitLink(l)
+        default:
+            visitChildren(markup)
+        }
+    }
+
+    private func visitChildren(_ markup: Markup) {
+        for child in markup.children { visit(child) }
+    }
+
+    private func visitParagraph(_ p: Paragraph) {
+        for child in p.children { visit(child) }
+        appendPlain("\n\n")
+    }
+
+    private func visitLink(_ link: Markdown.Link) {
+        let start = output.length
+        visitChildren(link)
+        guard let dest = link.destination, !dest.isEmpty,
+              start < output.length else { return }
+        guard let url = URL(string: dest) else { return }
+        let range = NSRange(location: start, length: output.length - start)
+        output.addAttribute(.link, value: url, range: range)
+        output.addAttribute(.foregroundColor, value: NSColor(theme.color("accent")), range: range)
+        output.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+    }
+
+    // MARK: - Trait scoping
+
+    private func withTrait(_ t: NSFontDescriptor.SymbolicTraits, body: () -> Void) {
+        let previous = currentTraits
+        currentTraits.insert(t)
+        body()
+        currentTraits = previous
+    }
+
+    private func withStrikethrough(body: () -> Void) {
+        let previous = inStrikethrough
+        inStrikethrough = true
+        body()
+        inStrikethrough = previous
+    }
+
+    // MARK: - Attributes
+
+    private func bodyAttributes() -> [NSAttributedString.Key: Any] {
+        var attrs: [NSAttributedString.Key: Any] = [
+            .font: bodyFont(),
+            .foregroundColor: NSColor(theme.color("fg"))
+        ]
+        if inStrikethrough {
+            attrs[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+        }
+        return attrs
+    }
+
+    private func inlineCodeAttributes() -> [NSAttributedString.Key: Any] {
+        [
+            .font: monospaceFont(size: monoSize - 1),
+            .foregroundColor: NSColor(theme.color("fg")),
+            .backgroundColor: NSColor(theme.color("bg-2"))
+        ]
+    }
+
+    private func bodyFont() -> NSFont {
+        let base = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        if currentTraits.isEmpty { return base }
+        let desc = base.fontDescriptor.withSymbolicTraits(currentTraits)
+        return NSFont(descriptor: desc, size: base.pointSize) ?? base
+    }
+
+    private func monospaceFont(size: CGFloat) -> NSFont {
+        NSFont(name: monoFamily, size: size) ?? NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+    }
+
+    // MARK: - Append helpers
+
+    private func appendText(_ s: String, attributes: [NSAttributedString.Key: Any]) {
+        output.append(NSAttributedString(string: s, attributes: attributes))
+    }
+
+    private func appendPlain(_ s: String) {
+        output.append(NSAttributedString(string: s, attributes: bodyAttributes()))
+    }
+}

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -32,6 +32,7 @@ final class MarkdownRenderer {
 
     private var currentTraits: NSFontDescriptor.SymbolicTraits = []
     private var inStrikethrough: Bool = false
+    private var listDepth: Int = 0
 
     func render(
         document: Document,
@@ -49,6 +50,7 @@ final class MarkdownRenderer {
         self.baseDirectory = baseDirectory
         self.currentTraits = []
         self.inStrikethrough = false
+        self.listDepth = 0
 
         for child in document.children {
             visit(child)
@@ -74,6 +76,8 @@ final class MarkdownRenderer {
         case _ as LineBreak:            appendPlain("\n")
         case let l as Markdown.Link:    visitLink(l)
         case let h as Heading:          visitHeading(h)
+        case let l as UnorderedList:    visitUnorderedList(l)
+        case let l as OrderedList:      visitOrderedList(l)
         default:
             visitChildren(markup)
         }
@@ -125,6 +129,52 @@ final class MarkdownRenderer {
         case 4: return 16
         case 5: return 14
         default: return 13
+        }
+    }
+
+    private func visitUnorderedList(_ list: UnorderedList) {
+        listDepth += 1
+        defer { listDepth -= 1 }
+        for item in list.listItems {
+            appendListItem(item, marker: marker(for: item))
+        }
+        if listDepth == 0 { appendPlain("\n") }
+    }
+
+    private func visitOrderedList(_ list: OrderedList) {
+        listDepth += 1
+        defer { listDepth -= 1 }
+        var n = 1
+        for item in list.listItems {
+            appendListItem(item, marker: "\(n). ")
+            n += 1
+        }
+        if listDepth == 0 { appendPlain("\n") }
+    }
+
+    private func marker(for item: ListItem) -> String {
+        switch item.checkbox {
+        case .checked:   return "☑ "
+        case .unchecked: return "☐ "
+        case .none:      return "• "
+        }
+    }
+
+    private func appendListItem(_ item: ListItem, marker: String) {
+        let indent = String(repeating: "  ", count: max(0, listDepth - 1))
+        appendPlain(indent + marker)
+        // Render the first Paragraph child inline (no surrounding blank line),
+        // so the marker sits on the same line as the text. Subsequent block
+        // children (nested lists, code blocks) are visited normally.
+        var firstParagraphConsumed = false
+        for child in item.children {
+            if !firstParagraphConsumed, let p = child as? Paragraph {
+                for inline in p.children { visit(inline) }
+                appendPlain("\n")
+                firstParagraphConsumed = true
+            } else {
+                visit(child)
+            }
         }
     }
 

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -73,6 +73,7 @@ final class MarkdownRenderer {
         case _ as SoftBreak:            appendPlain(" ")
         case _ as LineBreak:            appendPlain("\n")
         case let l as Markdown.Link:    visitLink(l)
+        case let h as Heading:          visitHeading(h)
         default:
             visitChildren(markup)
         }
@@ -97,6 +98,55 @@ final class MarkdownRenderer {
         output.addAttribute(.link, value: url, range: range)
         output.addAttribute(.foregroundColor, value: NSColor(theme.color("accent")), range: range)
         output.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+    }
+
+    private func visitHeading(_ heading: Heading) {
+        let start = output.length
+        let plain = heading.plainText
+        let size = headingFontSize(level: heading.level)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: size, weight: .semibold),
+            .foregroundColor: NSColor(theme.color("fg"))
+        ]
+        output.append(NSAttributedString(string: plain, attributes: attrs))
+        let length = output.length - start
+        let slug = MarkdownRenderer.slugify(plain)
+        if !slug.isEmpty, length > 0 {
+            anchorRanges[slug] = NSRange(location: start, length: length)
+        }
+        appendPlain("\n\n")
+    }
+
+    private func headingFontSize(level: Int) -> CGFloat {
+        switch level {
+        case 1: return 28
+        case 2: return 22
+        case 3: return 18
+        case 4: return 16
+        case 5: return 14
+        default: return 13
+        }
+    }
+
+    static func slugify(_ text: String) -> String {
+        let lowered = text.lowercased()
+        var out = ""
+        var lastWasDash = false
+        for scalar in lowered.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(scalar) {
+                out.unicodeScalars.append(scalar)
+                lastWasDash = false
+            } else if scalar == " " || scalar == "-" || scalar == "_" {
+                if !lastWasDash {
+                    out.append("-")
+                    lastWasDash = true
+                }
+            }
+            // All other punctuation (apostrophes, commas, question marks, etc) is dropped.
+        }
+        while out.hasPrefix("-") { out.removeFirst() }
+        while out.hasSuffix("-") { out.removeLast() }
+        return out
     }
 
     // MARK: - Trait scoping

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -148,20 +148,21 @@ final class MarkdownRenderer {
                 output.append(NSAttributedString(string: alt, attributes: mutedAttributes()))
             }
         case .local(let path):
-            // Root-relative paths (`/assets/logo.png`) resolve from the
-            // worktree root when available, matching how the link handler
-            // treats `/README.md`. External tabs without a worktree root
-            // fall back to standard absolute-path resolution.
-            let resolveFrom: URL
-            let usePath: String
+            // Path resolution for local images:
+            //  * `/foo.png` in an in-worktree document → worktree root + foo.png
+            //    (mirrors how the link handler treats `/README.md`).
+            //  * `/foo.png` in an external preview → real filesystem-absolute
+            //    path; load directly without prepending baseDirectory.
+            //  * everything else → resolve against the document's directory.
+            let loaded: NSImage?
             if path.hasPrefix("/"), let root = worktreeRoot {
-                resolveFrom = root
-                usePath = String(path.dropFirst())
+                loaded = imageLoader.loadLocal(src: String(path.dropFirst()), baseDirectory: root)
+            } else if path.hasPrefix("/") {
+                loaded = NSImage(contentsOf: URL(fileURLWithPath: path))
             } else {
-                resolveFrom = baseDirectory
-                usePath = path
+                loaded = imageLoader.loadLocal(src: path, baseDirectory: baseDirectory)
             }
-            if let loaded = imageLoader.loadLocal(src: usePath, baseDirectory: resolveFrom) {
+            if let loaded {
                 output.append(attachmentString(for: loaded))
             } else if !alt.isEmpty {
                 output.append(NSAttributedString(string: alt, attributes: mutedAttributes()))

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -229,9 +229,15 @@ struct MarkdownTabView: View {
             )
             return
         }
-        // Relative file links (no scheme + non-empty path).
+        // Relative file links (no scheme + non-empty path). A path that
+        // begins with `/` (e.g. `[link](/README.md)`) is root-relative to
+        // the worktree, not absolute on the user's filesystem; resolve it
+        // from worktreePath rather than appending to baseDirectory.
         if url.scheme == nil {
-            let candidate = baseDirectory.appendingPathComponent(url.path).standardizedFileURL
+            let path = url.path
+            let candidate: URL = path.hasPrefix("/")
+                ? worktreePath.appendingPathComponent(String(path.dropFirst())).standardizedFileURL
+                : baseDirectory.appendingPathComponent(path).standardizedFileURL
             let worktreeRootPath = worktreePath.standardizedFileURL.path
             if candidate.path.hasPrefix(worktreeRootPath + "/") {
                 let relative = String(candidate.path.dropFirst(worktreeRootPath.count + 1))

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -245,14 +245,23 @@ struct MarkdownTabView: View {
             return
         }
         // Relative file links (no scheme + non-empty path). A path that
-        // begins with `/` (e.g. `[link](/README.md)`) is root-relative to
-        // the worktree, not absolute on the user's filesystem; resolve it
-        // from worktreePath rather than appending to baseDirectory.
+        // begins with `/` in an in-worktree document is root-relative to
+        // the worktree (e.g. `[link](/README.md)` should land at the repo
+        // root). External markdown previews have no worktree-rooted view,
+        // so a leading `/` there is genuinely system-absolute and we leave
+        // it alone — otherwise `[notes](/Users/me/notes.md)` would be
+        // rewritten to `<worktree>/Users/me/notes.md`.
         if url.scheme == nil {
             let path = url.path
-            let candidate: URL = path.hasPrefix("/")
-                ? worktreePath.appendingPathComponent(String(path.dropFirst())).standardizedFileURL
-                : baseDirectory.appendingPathComponent(path).standardizedFileURL
+            let isInWorktree = externalAbsolutePath == nil
+            let candidate: URL
+            if path.hasPrefix("/"), isInWorktree {
+                candidate = worktreePath.appendingPathComponent(String(path.dropFirst())).standardizedFileURL
+            } else if path.hasPrefix("/") {
+                candidate = URL(fileURLWithPath: path).standardizedFileURL
+            } else {
+                candidate = baseDirectory.appendingPathComponent(path).standardizedFileURL
+            }
             let worktreeRootPath = worktreePath.standardizedFileURL.path
             if candidate.path.hasPrefix(worktreeRootPath + "/") {
                 let relative = String(candidate.path.dropFirst(worktreeRootPath.count + 1))

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -263,7 +263,13 @@ struct MarkdownTabView: View {
                 )
                 return
             }
-            // Outside the worktree: fall through to NSWorkspace.
+            // Outside the worktree (or external-tab previews where there is
+            // no in-worktree containment): hand the RESOLVED candidate to
+            // NSWorkspace so neighboring files open via the system handler.
+            // Falling through with the raw `url` would try to open
+            // "other.md" as if it were system-absolute.
+            NSWorkspace.shared.open(candidate)
+            return
         }
         NSWorkspace.shared.open(url)
     }

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -75,6 +75,12 @@ struct MarkdownTabView: View {
         }
         .onAppear { scheduleRender(immediate: true) }
         .onChange(of: buffer.editGeneration) { _, _ in scheduleRender(immediate: false) }
+        // Re-render when the user switches themes or changes code font settings —
+        // the renderer captures those when invoked, so a stale `renderResult`
+        // would otherwise keep the previous colors/fonts until the next edit.
+        .onChange(of: appState.config.themeId) { _, _ in scheduleRender(immediate: true) }
+        .onChange(of: appState.config.code.fontFamily) { _, _ in scheduleRender(immediate: true) }
+        .onChange(of: appState.config.code.fontSize) { _, _ in scheduleRender(immediate: true) }
     }
 
     private func cycleMode() {

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -75,10 +75,13 @@ struct MarkdownTabView: View {
         }
         .onAppear { scheduleRender(immediate: true) }
         .onChange(of: buffer.editGeneration) { _, _ in scheduleRender(immediate: false) }
-        // Re-render when the user switches themes or changes code font settings —
-        // the renderer captures those when invoked, so a stale `renderResult`
+        // Re-render when the live theme or code font settings change — the
+        // renderer captures those when invoked, so a stale `renderResult`
         // would otherwise keep the previous colors/fonts until the next edit.
-        .onChange(of: appState.config.themeId) { _, _ in scheduleRender(immediate: true) }
+        // Watching `theme` directly catches every input that produces a new
+        // theme value (themeId, accent, matchSystemTheme, system appearance),
+        // not just config.themeId.
+        .onChange(of: theme) { _, _ in scheduleRender(immediate: true) }
         .onChange(of: appState.config.code.fontFamily) { _, _ in scheduleRender(immediate: true) }
         .onChange(of: appState.config.code.fontSize) { _, _ in scheduleRender(immediate: true) }
     }

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -53,16 +53,36 @@ struct MarkdownTabView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-            if externalAbsolutePath == nil {
-                EditorConflictBanner(buffer: buffer)
+        ZStack {
+            VStack(spacing: 0) {
+                header
+                if externalAbsolutePath == nil {
+                    EditorConflictBanner(buffer: buffer)
+                }
+                bodyView
             }
-            bodyView
+            .background(theme.color("bg-1"))
+
+            // Hidden zero-size shortcut button. The button only exists when
+            // this view is in the hierarchy, which only happens for markdown
+            // tabs that are the active tab — so the shortcut is implicitly
+            // scoped to markdown tabs without explicit isEnabled gating.
+            Button(action: cycleMode) { Color.clear }
+                .frame(width: 0, height: 0)
+                .keyboardShortcut("m", modifiers: [.command, .shift])
+                .opacity(0)
+                .accessibilityHidden(true)
         }
-        .background(theme.color("bg-1"))
         .onAppear { scheduleRender(immediate: true) }
         .onChange(of: buffer.editGeneration) { _, _ in scheduleRender(immediate: false) }
+    }
+
+    private func cycleMode() {
+        appState.tabs.setMarkdownViewMode(
+            worktreeId: worktreeId,
+            tabId: tabId,
+            mode: resolvedMode.next()
+        )
     }
 
     @ViewBuilder

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -1,0 +1,224 @@
+import SwiftUI
+import AppKit
+
+struct MarkdownTabView: View {
+    let worktreePath: URL
+    let worktreeId: String
+    let tabId: TabID
+    let relativePath: String
+    let externalAbsolutePath: String?
+    let originatingRelativePath: String?
+    let revealLine: Int?
+    let revealCharacter: Int?
+    @Bindable var appState: AppState
+    @Environment(\.theme) var theme
+
+    @State private var renderResult: MarkdownRenderResult?
+    @State private var debounceTask: Task<Void, Never>?
+
+    private var resolvedMode: MarkdownViewMode {
+        appState.tabs.editorTabState(worktreeId: worktreeId, tabId: tabId)?.markdownViewMode
+            ?? appState.config.markdown.defaultViewMode
+    }
+
+    private var splitFraction: Double {
+        appState.tabs.editorTabState(worktreeId: worktreeId, tabId: tabId)?.markdownSplitFraction ?? 0.5
+    }
+
+    private var buffer: EditorBuffer {
+        if let abs = externalAbsolutePath {
+            return appState.tabs.externalBuffer(
+                worktreeId: worktreeId,
+                tabId: tabId,
+                absoluteURL: URL(fileURLWithPath: abs),
+                worktreeRoot: worktreePath,
+                originatingFileURL: originatingRelativePath.map { worktreePath.appendingPathComponent($0) },
+                language: "markdown"
+            )
+        } else {
+            return appState.tabs.buffer(
+                worktreeId: worktreeId,
+                tabId: tabId,
+                worktreeRoot: worktreePath,
+                relativePath: relativePath
+            )
+        }
+    }
+
+    private var baseDirectory: URL {
+        if let abs = externalAbsolutePath {
+            return URL(fileURLWithPath: abs).deletingLastPathComponent()
+        }
+        return worktreePath.appendingPathComponent(relativePath).deletingLastPathComponent()
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            if externalAbsolutePath == nil {
+                EditorConflictBanner(buffer: buffer)
+            }
+            bodyView
+        }
+        .background(theme.color("bg-1"))
+        .onAppear { scheduleRender(immediate: true) }
+        .onChange(of: buffer.editGeneration) { _, _ in scheduleRender(immediate: false) }
+    }
+
+    @ViewBuilder
+    private var bodyView: some View {
+        switch resolvedMode {
+        case .editor:
+            codeEditor
+        case .preview:
+            preview
+        case .split:
+            GeometryReader { proxy in
+                let leftWidth = max(120, proxy.size.width * splitFraction)
+                HStack(spacing: 0) {
+                    codeEditor.frame(width: leftWidth)
+                    DragHandle(axis: .horizontal) { delta in
+                        let total = proxy.size.width
+                        guard total > 0 else { return }
+                        let newWidth = max(120, min(total - 120, leftWidth + delta))
+                        appState.tabs.setMarkdownSplitFraction(
+                            worktreeId: worktreeId, tabId: tabId,
+                            fraction: newWidth / total
+                        )
+                    }
+                    preview
+                }
+            }
+        }
+    }
+
+    private var codeEditor: some View {
+        CodeEditorView(
+            worktreeId: worktreeId,
+            worktreeRoot: worktreePath,
+            relativePath: relativePath,
+            tabId: tabId,
+            revealLine: revealLine,
+            revealCharacter: revealCharacter,
+            appState: appState,
+            externalAbsolutePath: externalAbsolutePath,
+            originatingRelativePath: originatingRelativePath,
+            fontFamily: appState.config.code.fontFamily,
+            fontSize: appState.config.code.fontSize
+        )
+    }
+
+    @ViewBuilder
+    private var preview: some View {
+        if let renderResult {
+            MarkdownPreviewView(result: renderResult, onLinkClick: handleLinkClick)
+        } else {
+            Color.clear.onAppear { scheduleRender(immediate: true) }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            breadcrumbText
+            Spacer()
+            Picker("", selection: Binding(
+                get: { resolvedMode },
+                set: { newMode in
+                    appState.tabs.setMarkdownViewMode(worktreeId: worktreeId, tabId: tabId, mode: newMode)
+                }
+            )) {
+                Image(systemName: "pencil").tag(MarkdownViewMode.editor)
+                Image(systemName: "rectangle.split.2x1").tag(MarkdownViewMode.split)
+                Image(systemName: "eye").tag(MarkdownViewMode.preview)
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 120)
+        }
+        .padding(.horizontal, 12).frame(height: 28)
+        .background(theme.color("bg-1"))
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    private var breadcrumbText: some View {
+        let components = relativePath.split(separator: "/")
+        let lastIndex = components.count - 1
+        return HStack(spacing: 6) {
+            ForEach(Array(components.enumerated()), id: \.offset) { (i, comp) in
+                Text(comp)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(i == lastIndex ? theme.color("fg") : theme.color("fg-muted"))
+                if i < lastIndex {
+                    Text("/").foregroundColor(theme.color("fg-faint"))
+                }
+            }
+        }
+    }
+
+    private func scheduleRender(immediate: Bool) {
+        debounceTask?.cancel()
+        let buffer = self.buffer
+        let theme = self.theme
+        let fontFamily = appState.config.code.fontFamily
+        let fontSize = appState.config.code.fontSize
+        let baseDir = baseDirectory
+        debounceTask = Task { @MainActor in
+            if !immediate {
+                try? await Task.sleep(nanoseconds: 200_000_000)
+                if Task.isCancelled { return }
+            }
+            let source = buffer.storage.string
+            let doc = MarkdownParser.parse(source)
+            let result = MarkdownRenderer().render(
+                document: doc,
+                theme: theme,
+                monospacedFontFamily: fontFamily,
+                monospacedFontSize: fontSize,
+                baseDirectory: baseDir
+            )
+            if Task.isCancelled { return }
+            renderResult = result
+        }
+    }
+
+    private func handleLinkClick(_ url: URL) {
+        // Anchor-only forms like "#some-heading": dispatch via NotificationCenter.
+        // Task 17 wires the observer on MarkdownPreviewController.
+        if url.absoluteString.hasPrefix("#") {
+            let slug = String(url.absoluteString.dropFirst())
+            NotificationCenter.default.post(
+                name: .markdownScrollToAnchor,
+                object: nil,
+                userInfo: ["slug": slug, "tabId": tabId]
+            )
+            return
+        }
+        if url.scheme == nil, let fragment = url.fragment, url.host == nil, url.path.isEmpty {
+            NotificationCenter.default.post(
+                name: .markdownScrollToAnchor,
+                object: nil,
+                userInfo: ["slug": fragment, "tabId": tabId]
+            )
+            return
+        }
+        // Relative file links (no scheme + non-empty path).
+        if url.scheme == nil {
+            let candidate = baseDirectory.appendingPathComponent(url.path).standardizedFileURL
+            let worktreeRootPath = worktreePath.standardizedFileURL.path
+            if candidate.path.hasPrefix(worktreeRootPath + "/") {
+                let relative = String(candidate.path.dropFirst(worktreeRootPath.count + 1))
+                appState.openMarkdownLink(
+                    worktreeId: worktreeId,
+                    worktreeRoot: worktreePath,
+                    relativePath: relative
+                )
+                return
+            }
+            // Outside the worktree: fall through to NSWorkspace.
+        }
+        NSWorkspace.shared.open(url)
+    }
+}
+
+extension Notification.Name {
+    static let markdownScrollToAnchor = Notification.Name("io.nlopez.alas.markdown.scrollToAnchor")
+}

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -84,6 +84,10 @@ struct MarkdownTabView: View {
         .onChange(of: theme) { _, _ in scheduleRender(immediate: true) }
         .onChange(of: appState.config.code.fontFamily) { _, _ in scheduleRender(immediate: true) }
         .onChange(of: appState.config.code.fontSize) { _, _ in scheduleRender(immediate: true) }
+        // Render kicks in when the user switches out of editor-only mode —
+        // editor mode skips rendering to avoid parsing+rendering the whole
+        // buffer on every keystroke when the preview isn't visible.
+        .onChange(of: resolvedMode) { _, _ in scheduleRender(immediate: true) }
     }
 
     private func cycleMode() {
@@ -184,12 +188,22 @@ struct MarkdownTabView: View {
     }
 
     private func scheduleRender(immediate: Bool) {
+        // No preview is visible in editor-only mode, so skip parsing and
+        // rendering entirely. Switching out of editor mode triggers
+        // scheduleRender via .onChange(of: resolvedMode).
+        guard resolvedMode != .editor else {
+            debounceTask?.cancel()
+            return
+        }
         debounceTask?.cancel()
         let buffer = self.buffer
         let theme = self.theme
         let fontFamily = appState.config.code.fontFamily
         let fontSize = appState.config.code.fontSize
         let baseDir = baseDirectory
+        // External tabs have no worktree root context, so root-relative
+        // paths (`/foo.md`) fall back to system-absolute resolution.
+        let worktreeRootOrNil: URL? = externalAbsolutePath == nil ? worktreePath : nil
         debounceTask = Task { @MainActor in
             if !immediate {
                 try? await Task.sleep(nanoseconds: 200_000_000)
@@ -202,7 +216,8 @@ struct MarkdownTabView: View {
                 theme: theme,
                 monospacedFontFamily: fontFamily,
                 monospacedFontSize: fontSize,
-                baseDirectory: baseDir
+                baseDirectory: baseDir,
+                worktreeRoot: worktreeRootOrNil
             )
             if Task.isCancelled { return }
             renderResult = result

--- a/Alas/Sources/Code/Markdown/MarkdownViewMode.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownViewMode.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// View mode for a markdown editor tab. Persisted in `EditorTabState`
+/// and in `AppConfig.markdown.defaultViewMode`. Raw values are part of
+/// the on-disk format — do not rename.
+enum MarkdownViewMode: String, Codable, Equatable, Sendable, CaseIterable {
+    case editor, split, preview
+
+    /// Cycle order used by the `⌘⇧M` shortcut: editor → split → preview → editor.
+    func next() -> MarkdownViewMode {
+        switch self {
+        case .editor:  return .split
+        case .split:   return .preview
+        case .preview: return .editor
+        }
+    }
+}

--- a/Alas/Sources/Code/Markdown/MarkdownViewMode.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownViewMode.swift
@@ -3,7 +3,7 @@ import Foundation
 /// View mode for a markdown editor tab. Persisted in `EditorTabState`
 /// and in `AppConfig.markdown.defaultViewMode`. Raw values are part of
 /// the on-disk format — do not rename.
-enum MarkdownViewMode: String, Codable, Equatable, Sendable, CaseIterable {
+enum MarkdownViewMode: String, Codable, Equatable, Hashable, Sendable, CaseIterable {
     case editor, split, preview
 
     /// Cycle order used by the `⌘⇧M` shortcut: editor → split → preview → editor.

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -13,6 +13,7 @@ struct AppConfig: Codable, Equatable {
     var terminal: Terminal
     var harness: Harness
     var code: Code
+    var markdown: Markdown
 
     struct General: Codable, Equatable {
         var launchAtLogin: Bool
@@ -64,6 +65,14 @@ struct AppConfig: Codable, Equatable {
         }
     }
 
+    struct Markdown: Codable, Equatable {
+        var defaultViewMode: MarkdownViewMode
+
+        enum CodingKeys: String, CodingKey {
+            case defaultViewMode
+        }
+    }
+
     static let defaults = AppConfig(
         themeId: "cool-slate",
         accent: "teal",
@@ -106,7 +115,8 @@ struct AppConfig: Codable, Equatable {
             fontFamily: "SF Mono",
             fontSize: 13,
             languageServers: []
-        )
+        ),
+        markdown: Markdown(defaultViewMode: .editor)
     )
 }
 
@@ -114,7 +124,7 @@ extension AppConfig {
     enum CodingKeys: String, CodingKey {
         case themeId, accent, density, matchSystemTheme,
              sidebarWidth, rightPaneWidth, rightPaneVisible,
-             general, worktrees, terminal, harness, code
+             general, worktrees, terminal, harness, code, markdown
     }
 
     // Custom decode tolerates older config files that predate `code`.
@@ -144,6 +154,13 @@ extension AppConfig {
             code = Code(fontFamily: fontFamily, fontSize: fontSize, languageServers: servers)
         } else {
             code = Code(fontFamily: "SF Mono", fontSize: 13, languageServers: [])
+        }
+        if let mdContainer = try? c.nestedContainer(keyedBy: AppConfig.Markdown.CodingKeys.self, forKey: .markdown) {
+            let raw = (try? mdContainer.decode(String.self, forKey: .defaultViewMode)) ?? "editor"
+            let mode = MarkdownViewMode(rawValue: raw) ?? .editor
+            markdown = Markdown(defaultViewMode: mode)
+        } else {
+            markdown = Markdown(defaultViewMode: .editor)
         }
     }
 }

--- a/Alas/Sources/Settings/MarkdownPane.swift
+++ b/Alas/Sources/Settings/MarkdownPane.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct MarkdownPane: View {
+    @Bindable var state: AppState
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Markdown").font(.system(size: 18, weight: .semibold))
+                Text("Rendering and default view mode for markdown files.")
+                    .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
+                    .padding(.bottom, 12)
+
+                SettingsGroup(title: "View") {
+                    SettingsRow(name: "Default view mode",
+                                desc: "Initial mode when a markdown file is opened.") {
+                        Picker("", selection: Binding(
+                            get: { state.config.markdown.defaultViewMode },
+                            set: {
+                                state.config.markdown.defaultViewMode = $0
+                                state.saveConfig()
+                            }
+                        )) {
+                            Text("Editor").tag(MarkdownViewMode.editor)
+                            Text("Split").tag(MarkdownViewMode.split)
+                            Text("Preview").tag(MarkdownViewMode.preview)
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 240)
+                    }
+                }
+            }
+            .padding(.horizontal, 32).padding(.vertical, 24)
+        }
+    }
+}

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum SettingsSection: String, CaseIterable, Identifiable {
-    case general, worktrees, terminal, code, appearance
+    case general, worktrees, terminal, code, markdown, appearance
     var id: String { rawValue }
     var label: String {
         switch self {
@@ -9,6 +9,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .worktrees:  return "Worktrees"
         case .terminal:   return "Terminal"
         case .code:       return "Code"
+        case .markdown:   return "Markdown"
         case .appearance: return "Appearance"
         }
     }
@@ -18,6 +19,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .worktrees:  return "branch"
         case .terminal:   return "terminal"
         case .code:       return "code"
+        case .markdown:   return "file"
         case .appearance: return "palette"
         }
     }

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -33,6 +33,7 @@ struct SettingsWindow: View {
                     case .worktrees:  WorktreesPane(state: state)
                     case .terminal:   TerminalPane(state: state)
                     case .code:       CodePane(state: state)
+                    case .markdown:   MarkdownPane(state: state)
                     case .appearance: AppearancePane(state: state)
                     }
                 }

--- a/AlasTests/AppConfigMarkdownTests.swift
+++ b/AlasTests/AppConfigMarkdownTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct AppConfigMarkdownTests {
+    @Test func defaultsHaveMarkdownEditorMode() {
+        #expect(AppConfig.defaults.markdown.defaultViewMode == .editor)
+    }
+
+    @Test func decodesLegacyConfigWithoutMarkdownKey() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "density": "comfortable",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/code/.worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.markdown.defaultViewMode == .editor)
+    }
+
+    @Test func roundTripsEachDefaultViewMode() throws {
+        for mode in MarkdownViewMode.allCases {
+            var cfg = AppConfig.defaults
+            cfg.markdown.defaultViewMode = mode
+            let data = try JSONEncoder().encode(cfg)
+            let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+            #expect(decoded.markdown.defaultViewMode == mode)
+        }
+    }
+}

--- a/AlasTests/EditorTabStateMarkdownCodableTests.swift
+++ b/AlasTests/EditorTabStateMarkdownCodableTests.swift
@@ -1,0 +1,48 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct EditorTabStateMarkdownCodableTests {
+    @Test func decodesLegacyStateWithoutMarkdownFields() throws {
+        // A persisted EditorTabState from before this feature shipped:
+        // no markdownViewMode, no markdownSplitFraction.
+        let json = """
+        {
+          "id": "t1",
+          "title": "README.md",
+          "relativePath": "README.md"
+        }
+        """
+        let state = try JSONDecoder().decode(EditorTabState.self, from: Data(json.utf8))
+        #expect(state.id == "t1")
+        #expect(state.markdownViewMode == nil)
+        #expect(state.markdownSplitFraction == nil)
+    }
+
+    @Test func roundTripsWithEachMode() throws {
+        for mode in MarkdownViewMode.allCases {
+            var state = EditorTabState(id: "t", title: "f.md", relativePath: "f.md")
+            state.markdownViewMode = mode
+            state.markdownSplitFraction = 0.42
+            let data = try JSONEncoder().encode(state)
+            let decoded = try JSONDecoder().decode(EditorTabState.self, from: data)
+            #expect(decoded.markdownViewMode == mode)
+            #expect(decoded.markdownSplitFraction == 0.42)
+        }
+    }
+
+    @Test func tabCodableRoundTripPreservesMarkdownFields() throws {
+        var state = EditorTabState(id: "t", title: "x.md", relativePath: "x.md")
+        state.markdownViewMode = .split
+        state.markdownSplitFraction = 0.6
+        let tab = Tab.editor(state)
+        let data = try JSONEncoder().encode(tab)
+        let decoded = try JSONDecoder().decode(Tab.self, from: data)
+        if case .editor(let s) = decoded {
+            #expect(s.markdownViewMode == .split)
+            #expect(s.markdownSplitFraction == 0.6)
+        } else {
+            Issue.record("expected .editor case")
+        }
+    }
+}

--- a/AlasTests/MarkdownFileTypeTests.swift
+++ b/AlasTests/MarkdownFileTypeTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import Alas
+
+struct MarkdownFileTypeTests {
+    @Test func detectsByExtension() {
+        #expect(MarkdownFileType.isMarkdown(relativePath: "README.md"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "docs/guide.markdown"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "Notes.MD"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "page.mdx"))
+    }
+
+    @Test func detectsExtensionlessConventionalNames() {
+        #expect(MarkdownFileType.isMarkdown(relativePath: "README"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "readme"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "CHANGELOG"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "CONTRIBUTING"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "LICENSE"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "NOTICE"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "AUTHORS"))
+    }
+
+    @Test func detectsNestedPaths() {
+        #expect(MarkdownFileType.isMarkdown(relativePath: "src/docs/README.md"))
+        #expect(MarkdownFileType.isMarkdown(relativePath: "a/b/c/CHANGELOG"))
+    }
+
+    @Test func rejectsNonMarkdown() {
+        #expect(!MarkdownFileType.isMarkdown(relativePath: "Cargo.toml"))
+        #expect(!MarkdownFileType.isMarkdown(relativePath: "foo.txt"))
+        #expect(!MarkdownFileType.isMarkdown(relativePath: "src/main.swift"))
+        #expect(!MarkdownFileType.isMarkdown(relativePath: "README.txt"))
+        #expect(!MarkdownFileType.isMarkdown(relativePath: ""))
+    }
+}

--- a/AlasTests/MarkdownImageLoaderTests.swift
+++ b/AlasTests/MarkdownImageLoaderTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import AppKit
+import Foundation
+@testable import Alas
+
+struct MarkdownImageLoaderTests {
+    @Test func loadsLocalRelativeImage() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-md-img-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let imageURL = tmp.appendingPathComponent("dot.png")
+        let img = NSImage(size: NSSize(width: 1, height: 1))
+        img.lockFocus()
+        NSColor.red.setFill()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+        img.unlockFocus()
+        if let tiff = img.tiffRepresentation,
+           let rep = NSBitmapImageRep(data: tiff),
+           let png = rep.representation(using: .png, properties: [:]) {
+            try png.write(to: imageURL)
+        }
+
+        let loader = MarkdownImageLoader()
+        let loaded = loader.loadLocal(src: "dot.png", baseDirectory: tmp)
+        #expect(loaded != nil)
+    }
+
+    @Test func missingLocalImageReturnsNil() {
+        let loader = MarkdownImageLoader()
+        let baseDir = URL(fileURLWithPath: "/tmp")
+        #expect(loader.loadLocal(src: "definitely-not-here-\(UUID().uuidString).png", baseDirectory: baseDir) == nil)
+    }
+
+    @Test func classifySrcRemote() {
+        switch MarkdownImageLoader.classify("https://example.com/a.png") {
+        case .remote(let url): #expect(url.absoluteString == "https://example.com/a.png")
+        default: Issue.record("expected .remote for https://")
+        }
+        switch MarkdownImageLoader.classify("http://example.com/a.png") {
+        case .remote(let url): #expect(url.absoluteString == "http://example.com/a.png")
+        default: Issue.record("expected .remote for http://")
+        }
+    }
+
+    @Test func classifySrcLocal() {
+        switch MarkdownImageLoader.classify("./a.png") {
+        case .local(let s): #expect(s == "./a.png")
+        default: Issue.record("expected .local for ./a.png")
+        }
+        switch MarkdownImageLoader.classify("subdir/image.png") {
+        case .local(let s): #expect(s == "subdir/image.png")
+        default: Issue.record("expected .local for subdir/image.png")
+        }
+    }
+
+    @Test func classifySrcEmptyIsInvalid() {
+        switch MarkdownImageLoader.classify("") {
+        case .invalid: break
+        default: Issue.record("expected .invalid for empty string")
+        }
+    }
+}

--- a/AlasTests/MarkdownParserTests.swift
+++ b/AlasTests/MarkdownParserTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Markdown
+@testable import Alas
+
+struct MarkdownParserTests {
+    @Test func parsesSimpleParagraph() {
+        let doc = MarkdownParser.parse("Hello, world.")
+        #expect(doc.childCount == 1)
+        #expect(doc.child(at: 0) is Paragraph)
+    }
+
+    @Test func parsesHeadings() {
+        let doc = MarkdownParser.parse("# Title")
+        let heading = doc.child(at: 0) as? Heading
+        #expect(heading?.level == 1)
+    }
+
+    @Test func parsesGFMTable() {
+        let source = """
+        | a | b |
+        | - | - |
+        | 1 | 2 |
+        """
+        let doc = MarkdownParser.parse(source)
+        #expect(doc.children.contains(where: { $0 is Table }))
+    }
+
+    @Test func parsesTaskList() {
+        let doc = MarkdownParser.parse("- [x] done\n- [ ] todo")
+        let list = doc.child(at: 0) as? UnorderedList
+        let items = list?.listItems.map { $0 } ?? []
+        #expect(items.count == 2)
+        #expect(items[0].checkbox == .checked)
+        #expect(items[1].checkbox == .unchecked)
+    }
+
+    @Test func parsesStrikethrough() {
+        let doc = MarkdownParser.parse("~~gone~~")
+        // Walk down to find a Strikethrough node.
+        let para = doc.child(at: 0) as? Paragraph
+        let hasStrike = para?.children.contains(where: { $0 is Strikethrough }) ?? false
+        #expect(hasStrike)
+    }
+}

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import AppKit
+@testable import Alas
+
+@MainActor
+struct MarkdownRendererTests {
+    static func render(_ source: String) throws -> MarkdownRenderResult {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        return MarkdownRenderer().render(
+            document: MarkdownParser.parse(source),
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+    }
+
+    @Test func rendersPlainParagraph() throws {
+        let r = try MarkdownRendererTests.render("Hello, world.")
+        #expect(r.attributedString.string.contains("Hello, world."))
+    }
+
+    @Test func appliesBoldFontTrait() throws {
+        let r = try MarkdownRendererTests.render("**bold**")
+        let s = r.attributedString
+        let boldRange = (s.string as NSString).range(of: "bold")
+        let font = s.attribute(.font, at: boldRange.location, effectiveRange: nil) as? NSFont
+        #expect(font?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+    }
+
+    @Test func appliesItalicFontTrait() throws {
+        let r = try MarkdownRendererTests.render("*it*")
+        let s = r.attributedString
+        let range = (s.string as NSString).range(of: "it")
+        let font = s.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
+        #expect(font?.fontDescriptor.symbolicTraits.contains(.italic) == true)
+    }
+
+    @Test func appliesStrikethroughAttribute() throws {
+        let r = try MarkdownRendererTests.render("~~gone~~")
+        let s = r.attributedString
+        let range = (s.string as NSString).range(of: "gone")
+        let style = s.attribute(.strikethroughStyle, at: range.location, effectiveRange: nil) as? Int
+        #expect((style ?? 0) != 0)
+    }
+
+    @Test func appliesMonospaceForInlineCode() throws {
+        let r = try MarkdownRendererTests.render("`code`")
+        let s = r.attributedString
+        let range = (s.string as NSString).range(of: "code")
+        let font = s.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
+        #expect(font?.isFixedPitch == true)
+    }
+
+    @Test func linkRunCarriesURLAttribute() throws {
+        let r = try MarkdownRendererTests.render("[example](https://example.com)")
+        let s = r.attributedString
+        let range = (s.string as NSString).range(of: "example")
+        let url = s.attribute(.link, at: range.location, effectiveRange: nil) as? URL
+        #expect(url?.absoluteString == "https://example.com")
+    }
+}

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -59,4 +59,30 @@ struct MarkdownRendererTests {
         let url = s.attribute(.link, at: range.location, effectiveRange: nil) as? URL
         #expect(url?.absoluteString == "https://example.com")
     }
+
+    @Test func rendersHeadingLargerThanBody() throws {
+        let r = try MarkdownRendererTests.render("# Title")
+        let s = r.attributedString
+        let range = (s.string as NSString).range(of: "Title")
+        let font = s.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
+        // h1 should be visibly larger than the system body font.
+        #expect((font?.pointSize ?? 0) > NSFont.systemFontSize)
+    }
+
+    @Test func recordsAnchorSlugForHeading() throws {
+        let r = try MarkdownRendererTests.render("## Hello World")
+        let range = r.anchorRanges["hello-world"]
+        #expect(range != nil)
+        let nsString = r.attributedString.string as NSString
+        if let range {
+            #expect(nsString.substring(with: range).contains("Hello World"))
+        }
+    }
+
+    @Test func slugifyHandlesPunctuationAndCase() throws {
+        let r = try MarkdownRendererTests.render("### What's Up, Doc?")
+        // Slug rule: lowercase, spaces and punctuation collapsed to "-",
+        // edges trimmed. Apostrophes drop, comma+space collapses to "-".
+        #expect(r.anchorRanges["whats-up-doc"] != nil)
+    }
 }

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -175,4 +175,51 @@ struct MarkdownRendererTests {
         // followed by trailing spaces before the next cell separator.
         #expect(s.contains("h1    "))
     }
+
+    @Test func rendersLocalImageAsAttachment() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-md-img-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let imageURL = tmp.appendingPathComponent("dot.png")
+        let img = NSImage(size: NSSize(width: 1, height: 1))
+        img.lockFocus(); NSColor.red.setFill()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill(); img.unlockFocus()
+        if let tiff = img.tiffRepresentation,
+           let rep = NSBitmapImageRep(data: tiff),
+           let png = rep.representation(using: .png, properties: [:]) {
+            try png.write(to: imageURL)
+        }
+
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let r = MarkdownRenderer().render(
+            document: MarkdownParser.parse("![alt](dot.png)"),
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: tmp
+        )
+        // Locate the attachment character (Unicode Object Replacement Character = 0xFFFC).
+        let attachChar = String(UnicodeScalar(0xFFFC)!)
+        #expect(r.attributedString.string.contains(attachChar))
+    }
+
+    @Test func rendersRemoteImagePlaceholderAndRecordsRef() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let r = MarkdownRenderer().render(
+            document: MarkdownParser.parse("![logo](https://example.com/logo.png)"),
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        #expect(r.remoteImages.count == 1)
+        #expect(r.remoteImages.first?.url.absoluteString == "https://example.com/logo.png")
+    }
+
+    @Test func brokenLocalImageRendersAltText() throws {
+        let r = try MarkdownRendererTests.render("![alt-text](nope-\(UUID().uuidString).png)")
+        let s = r.attributedString.string
+        #expect(s.contains("alt-text"))
+    }
 }

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -157,4 +157,22 @@ struct MarkdownRendererTests {
         let font = s.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
         #expect(font?.isFixedPitch == true)
     }
+
+    @Test func rendersTableAsAlignedMonospaceText() throws {
+        let source = """
+        | h1 | h2 |
+        | - | - |
+        | a | b |
+        | longer | x |
+        """
+        let r = try MarkdownRendererTests.render(source)
+        let s = r.attributedString.string
+        // All cells appear.
+        #expect(s.contains("h1"))
+        #expect(s.contains("h2"))
+        #expect(s.contains("longer"))
+        // Aligned: the column for h1/longer is at least 6 wide, so "h1" is
+        // followed by trailing spaces before the next cell separator.
+        #expect(s.contains("h1    "))
+    }
 }

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -86,6 +86,32 @@ struct MarkdownRendererTests {
         #expect(r.anchorRanges["whats-up-doc"] != nil)
     }
 
+    @Test func duplicateHeadingSlugsAreDisambiguated() throws {
+        let r = try MarkdownRendererTests.render("""
+        ## Install
+        first
+        ## Install
+        second
+        ## Install
+        third
+        """)
+        // First heading keeps the bare slug; later ones get -1, -2 suffixes
+        // (matching GitHub's behavior).
+        let nsString = r.attributedString.string as NSString
+        guard let first = r.anchorRanges["install"],
+              let second = r.anchorRanges["install-1"],
+              let third = r.anchorRanges["install-2"] else {
+            Issue.record("expected install / install-1 / install-2 anchors")
+            return
+        }
+        // They point at three distinct ranges, in source order.
+        #expect(first.location < second.location)
+        #expect(second.location < third.location)
+        #expect(nsString.substring(with: first).contains("Install"))
+        #expect(nsString.substring(with: second).contains("Install"))
+        #expect(nsString.substring(with: third).contains("Install"))
+    }
+
     @Test func rendersUnorderedListBullets() throws {
         let r = try MarkdownRendererTests.render("- one\n- two")
         let s = r.attributedString.string

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -115,4 +115,26 @@ struct MarkdownRendererTests {
         #expect(s.contains("• a"))
         #expect(s.contains("• b"))
     }
+
+    @Test func rendersBlockquoteWithIndent() throws {
+        let r = try MarkdownRendererTests.render("> quoted")
+        let s = r.attributedString.string
+        // Blockquote prefix is a vertical bar character.
+        #expect(s.contains("│ quoted"))
+    }
+
+    @Test func rendersThematicBreak() throws {
+        let r = try MarkdownRendererTests.render("---")
+        let s = r.attributedString.string
+        // A horizontal-rule run of box-drawing characters is emitted.
+        #expect(s.contains(String(repeating: "─", count: 8)))
+    }
+
+    @Test func rendersFencedCodeBlockMonospaced() throws {
+        let r = try MarkdownRendererTests.render("```\nlet x = 1\n```")
+        let s = r.attributedString
+        let range = (s.string as NSString).range(of: "let x = 1")
+        let font = s.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
+        #expect(font?.isFixedPitch == true)
+    }
 }

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -142,6 +142,15 @@ struct MarkdownRendererTests {
         #expect(s.contains("• b"))
     }
 
+    @Test func blockquotePreservesLinkAttributes() throws {
+        let r = try MarkdownRendererTests.render("> see [docs](https://example.com)")
+        let s = r.attributedString
+        let range = (s.string as NSString).range(of: "docs")
+        let url = s.attribute(.link, at: range.location, effectiveRange: nil) as? URL
+        // The "│ " rebuild must not strip the inline link attribute.
+        #expect(url?.absoluteString == "https://example.com")
+    }
+
     @Test func rendersBlockquoteWithIndent() throws {
         let r = try MarkdownRendererTests.render("> quoted")
         let s = r.attributedString.string

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -183,8 +183,10 @@ struct MarkdownRendererTests {
         defer { try? FileManager.default.removeItem(at: tmp) }
         let imageURL = tmp.appendingPathComponent("dot.png")
         let img = NSImage(size: NSSize(width: 1, height: 1))
-        img.lockFocus(); NSColor.red.setFill()
-        NSRect(x: 0, y: 0, width: 1, height: 1).fill(); img.unlockFocus()
+        img.lockFocus()
+        NSColor.red.setFill()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+        img.unlockFocus()
         if let tiff = img.tiffRepresentation,
            let rep = NSBitmapImageRep(data: tiff),
            let png = rep.representation(using: .png, properties: [:]) {

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -137,4 +137,24 @@ struct MarkdownRendererTests {
         let font = s.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
         #expect(font?.isFixedPitch == true)
     }
+
+    @Test func highlightsSwiftCodeBlockKeyword() throws {
+        let r = try MarkdownRendererTests.render("```swift\nfunc f() {}\n```")
+        let s = r.attributedString
+        let range = (s.string as NSString).range(of: "func")
+        let color = s.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+        // Keyword color is "syntax-keyword". Just confirm it is NOT the default
+        // fg ("fg") — any non-default color means the highlighter ran.
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let defaultFG = NSColor(theme.color("fg"))
+        #expect(color != defaultFG)
+    }
+
+    @Test func unknownLanguageRemainsPlainMonospaced() throws {
+        let r = try MarkdownRendererTests.render("```neverheardofit\nfoo\n```")
+        let s = r.attributedString
+        let range = (s.string as NSString).range(of: "foo")
+        let font = s.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
+        #expect(font?.isFixedPitch == true)
+    }
 }

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -85,4 +85,34 @@ struct MarkdownRendererTests {
         // edges trimmed. Apostrophes drop, comma+space collapses to "-".
         #expect(r.anchorRanges["whats-up-doc"] != nil)
     }
+
+    @Test func rendersUnorderedListBullets() throws {
+        let r = try MarkdownRendererTests.render("- one\n- two")
+        let s = r.attributedString.string
+        #expect(s.contains("• one"))
+        #expect(s.contains("• two"))
+    }
+
+    @Test func rendersOrderedListNumbers() throws {
+        let r = try MarkdownRendererTests.render("1. one\n2. two")
+        let s = r.attributedString.string
+        #expect(s.contains("1. one"))
+        #expect(s.contains("2. two"))
+    }
+
+    @Test func rendersTaskListCheckboxes() throws {
+        let r = try MarkdownRendererTests.render("- [x] done\n- [ ] todo")
+        let s = r.attributedString.string
+        #expect(s.contains("☑ done"))
+        #expect(s.contains("☐ todo"))
+    }
+
+    @Test func rendersNestedUnorderedList() throws {
+        let r = try MarkdownRendererTests.render("- a\n  - b")
+        let s = r.attributedString.string
+        // Both items should appear with bullets. Nesting indentation is added
+        // via "  " before deeper bullets; checking presence of both is enough.
+        #expect(s.contains("• a"))
+        #expect(s.contains("• b"))
+    }
 }

--- a/AlasTests/MarkdownViewModeTests.swift
+++ b/AlasTests/MarkdownViewModeTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import Alas
+
+struct MarkdownViewModeTests {
+    @Test func cyclesEditorSplitPreview() {
+        #expect(MarkdownViewMode.editor.next() == .split)
+        #expect(MarkdownViewMode.split.next() == .preview)
+        #expect(MarkdownViewMode.preview.next() == .editor)
+    }
+
+    @Test func rawValuesAreStable() {
+        // Persisted in JSON. If these change, in-flight tab state files will
+        // silently fall back to the default — keep them locked.
+        #expect(MarkdownViewMode.editor.rawValue == "editor")
+        #expect(MarkdownViewMode.split.rawValue == "split")
+        #expect(MarkdownViewMode.preview.rawValue == "preview")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -25,6 +25,9 @@ packages:
     # gitignores generated parser files, so SPM consumers must
     # pin to a `*-with-generated-files` revision.
     revision: 7b7909f2f6b9414be0958275f4c8e5d69c3bca43
+  Markdown:
+    url: https://github.com/apple/swift-markdown
+    from: 0.4.0
 
 targets:
   Alas:
@@ -66,6 +69,8 @@ targets:
         product: SwiftTreeSitter
       - package: TreeSitterSwift
         product: TreeSitterSwift
+      - package: Markdown
+        product: Markdown
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: io.nlopez.alas


### PR DESCRIPTION
## Summary

Adds rich-text rendering for markdown files in the editor with a VSCode/IntelliJ-style three-mode toggle (Editor / Split / Preview). Preview is read-only; editing still happens in the standard code editor.

- New `Alas/Sources/Code/Markdown/` module: parser wrapper over `apple/swift-markdown`, an `NSAttributedString` renderer that walks the AST, a read-only `NSTextView`-backed preview, and a `MarkdownTabView` that owns the mode and drives a debounced live preview (~200ms).
- File-type detection covers `.md`, `.markdown`, `.mdx`, and extension-less names (`README`, `CHANGELOG`, etc.).
- Fenced code blocks get syntax highlighting via the existing `TreeSitterHighlighter`.
- GFM: headings, lists, task lists, blockquotes, tables, strikethrough, autolinks, images (local + remote).
- Links: `https://` → default browser; relative `.md` → new editor tab; `#anchor` → preview scrolls.
- Per-tab mode + split-fraction persisted on `EditorTabState`; default mode configurable in Settings (new "Markdown" pane).
- `⌘⇧M` cycles Editor → Split → Preview.

## Test plan

- [ ] Open a `.md` from the sidebar → opens in the configured default mode (Editor by default).
- [ ] Toggle via segmented control → Split shows live preview as you type.
- [ ] `⌘⇧M` cycles Editor → Split → Preview → Editor.
- [ ] Close and reopen a markdown tab → restores last mode.
- [ ] Click a relative `.md` link in preview → opens a new tab.
- [ ] Click `#anchor` link → preview scrolls to that heading.
- [ ] Click external `https://...` link → opens in default browser.
- [ ] README with local + remote images → both render.
- [ ] Fenced ` ```swift ` block → syntax-highlighted.
- [ ] Change "Default view mode" in Settings → new markdown tabs use it; existing tabs keep their per-tab choice.
- [ ] Drag the split handle → widths change and persist across reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)