### PR TITLE
fix(config): update default worktree root to ~/.alas/worktrees

### DIFF
--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -87,7 +87,7 @@ struct AppConfig: Codable, Equatable {
             crashReports: false, usageAnalytics: false
         ),
         worktrees: Worktrees(
-            rootPath: "~/code/.worktrees",
+            rootPath: "~/.alas/worktrees",
             pathTemplate: "{worktreeRoot}/{repo}/{branch}",
             branchPrefix: "feature/",
             baseBranch: "main",

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -23,7 +23,18 @@ struct AppConfigTests {
         #expect(cfg.rightPaneVisible == true)
         #expect(cfg.terminal.shell == "/bin/zsh")
         #expect(cfg.harness.notifyOnFinish == true)
+        #expect(cfg.worktrees.rootPath == "~/.alas/worktrees")
         #expect(cfg.worktrees.branchPrefix == "feature/")
+    }
+
+    @Test func decodePreservesConfiguredWorktreeRoot() throws {
+        var cfg = AppConfig.defaults
+        cfg.worktrees.rootPath = "~/code/worktrees"
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.worktrees.rootPath == "~/code/worktrees")
     }
 
     @Test func warmAmberMigratesToCoolSlate() throws {


### PR DESCRIPTION
## Summary
- Change default worktree root from `~/code/.worktrees` to `~/.alas/worktrees` in `AppConfig.defaults`
- Existing user-configured values are preserved via normal Codable decode — no migration needed
- Added test coverage: new default assertion and round-trip preservation test for configured values

Closes #769