### PR TITLE
feat(projects): add rename context menu

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -96,6 +96,30 @@ final class AppState {
         saveProjects()
     }
 
+    func renameProject(id: String) {
+        guard let project = projects.first(where: { $0.id == id }) else { return }
+
+        let alert = NSAlert()
+        alert.messageText = "Rename Project"
+        alert.informativeText = "Choose a new name for this project."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Rename")
+        alert.addButton(withTitle: "Cancel")
+
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        field.stringValue = project.name
+        field.lineBreakMode = .byTruncatingTail
+        alert.accessoryView = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let name = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, name != project.name else { return }
+
+        projectsManager.renameProject(id: id, name: name)
+        saveProjects()
+    }
+
     /// Archive (hide) a worktree. Closes all tabs/terminals/harness state for
     /// it, marks the path hidden in `ProjectConfig`, and re-points selection if
     /// the archived worktree was selected. Does NOT touch git or disk.

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -36,6 +36,11 @@ final class ProjectsManager {
         worktreesByProject.removeValue(forKey: id)
     }
 
+    func renameProject(id: String, name: String) {
+        guard let idx = projects.firstIndex(where: { $0.id == id }) else { return }
+        projects[idx].name = name
+    }
+
     func worktrees(projectId: String) -> [Worktree] {
         worktreesByProject[projectId] ?? []
     }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -7,6 +7,7 @@ struct RepoGroupView: View {
     let selectedWorktreeId: String?
     let onSelect: (Worktree) -> Void
     let onNewWorktree: () -> Void
+    let onRenameProject: () -> Void
     let onOpenTerminal: (Worktree) -> Void
     let onCopyPath: (Worktree) -> Void
     let onCopyBranch: (Worktree) -> Void
@@ -35,6 +36,9 @@ struct RepoGroupView: View {
             .padding(.vertical, 5)
             .contentShape(Rectangle())
             .onTapGesture { collapsed.toggle() }
+            .contextMenu {
+                Button("Rename Project…", action: onRenameProject)
+            }
             .overlay(alignment: .trailing) {
                 ZStack {
                     Text("\(worktrees.count)")

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -30,6 +30,7 @@ struct SidebarView: View {
                                 selectedWorktreeId: state.selectedWorktreeId,
                                 onSelect: { wt in state.selectedWorktreeId = wt.id },
                                 onNewWorktree: { onNewWorktree(project.id) },
+                                onRenameProject: { state.renameProject(id: project.id) },
                                 onOpenTerminal: { wt in
                                     state.selectedWorktreeId = wt.id
                                     _ = try? state.openTerminalTab(for: wt)

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -46,6 +46,42 @@ struct ProjectsManagerTests {
         #expect(mgr.projects.isEmpty)
         #expect(mgr.worktrees(projectId: project.id).isEmpty)
     }
+
+    @Test func renameProjectUpdatesOnlyTheProjectName() {
+        let addedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let project = ProjectConfig(
+            id: "project-1",
+            name: "Before",
+            path: "/tmp/before",
+            color: "#5fb7c4",
+            addedAt: addedAt,
+            hiddenWorktreePaths: ["/tmp/before/.worktree"]
+        )
+        let other = ProjectConfig(
+            id: "project-2",
+            name: "Other",
+            path: "/tmp/other",
+            color: "#9789c7",
+            addedAt: addedAt.addingTimeInterval(1),
+            hiddenWorktreePaths: []
+        )
+        let mgr = ProjectsManager(persistedProjects: [project, other])
+
+        mgr.renameProject(id: project.id, name: "After")
+
+        #expect(mgr.projects[0].id == project.id)
+        #expect(mgr.projects[0].name == "After")
+        #expect(mgr.projects[0].path == project.path)
+        #expect(mgr.projects[0].color == project.color)
+        #expect(mgr.projects[0].addedAt == project.addedAt)
+        #expect(mgr.projects[0].hiddenWorktreePaths == project.hiddenWorktreePaths)
+        #expect(mgr.projects[1] == other)
+
+        mgr.renameProject(id: "missing", name: "Ignored")
+
+        #expect(mgr.projects[0].name == "After")
+        #expect(mgr.projects[1] == other)
+    }
 }
 
 extension ProjectsManagerTests {


### PR DESCRIPTION
## Summary

- Add **Rename Project…** contextual menu action to the project header row in the sidebar
- Prompt via `NSAlert` with pre-filled text field, validate trimmed/empty/unchanged names
- Persist the new name via `saveProjects()`, leaving all UI context intact (selected worktree, open tabs, collapsed state) since `ProjectConfig.id` is stable

## Changes

| File | Change |
|------|--------|
| `Alas/Sources/App/ProjectsManager.swift` | Added `renameProject(id:name:)` — finds project by id, mutates only `name` |
| `Alas/Sources/App/AppState.swift` | Added `renameProject(id:)` — NSAlert prompt, trim/empty/unchanged validation, calls manager + `saveProjects()` |
| `Alas/Sources/Sidebar/RepoGroupView.swift` | Added `onRenameProject` closure param; attached `.contextMenu` with `Button("Rename Project…")` to header HStack |
| `Alas/Sources/Sidebar/SidebarView.swift` | Wired `onRenameProject: { state.renameProject(id: project.id) }` |
| `AlasTests/ProjectsManagerTests.swift` | Added test covering name change, field preservation, other-project isolation, unknown-id no-op |