### PR TITLE
feat(worktrees): list available base branches

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
+		9E302329243407946D47DC91 /* BranchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */; };
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
 		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
@@ -278,6 +279,7 @@
 		2975A1465CA308E9766521F2 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		2AC91D744E42A7C071268B74 /* aider.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = aider.sh; sourceTree = "<group>"; };
 		2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRegistry.swift; sourceTree = "<group>"; };
+		2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchPicker.swift; sourceTree = "<group>"; };
 		2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficLights.swift; sourceTree = "<group>"; };
 		30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorCoordinator.swift; sourceTree = "<group>"; };
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
@@ -551,6 +553,7 @@
 			isa = PBXGroup;
 			children = (
 				413CE0B0BBC96D412D048B1D /* .gitkeep */,
+				2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */,
 				AAEDACEB27E6AF219054496E /* DialogChrome.swift */,
 				B24ABE96ED3C62146A3CED62 /* EmptyState.swift */,
 				EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */,
@@ -1163,6 +1166,7 @@
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
 				8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */,
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
+				9E302329243407946D47DC91 /* BranchPicker.swift in Sources */,
 				139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */,
 				40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */,
 				8622E85C972946E5411CAC48 /* ChangesSectionView.swift in Sources */,

--- a/Alas/Sources/Dialogs/BranchPicker.swift
+++ b/Alas/Sources/Dialogs/BranchPicker.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+struct BranchPicker: View {
+    @Binding var selection: String
+    let branches: [String]
+    let isLoading: Bool
+    let errorMessage: String?
+
+    @Environment(\.theme) var theme
+    @State private var open = false
+    @State private var search = ""
+
+    var body: some View {
+        Button(action: { open.toggle() }) {
+            HStack(spacing: 6) {
+                Text(selection.isEmpty ? "Choose a branch" : selection)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 8)
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.55)
+                        .frame(width: 12, height: 12)
+                }
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 28)
+            .background(theme.color("bg-1"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $open, arrowEdge: .bottom) {
+            popoverBody
+        }
+    }
+
+    private var filteredBranches: [String] {
+        if search.isEmpty { return branches }
+        return branches.filter { $0.localizedCaseInsensitiveContains(search) }
+    }
+
+    private var selectionIsListed: Bool {
+        selection.isEmpty || branches.contains(selection)
+    }
+
+    @ViewBuilder
+    private var popoverBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                AlasField(text: $selection, placeholder: "Branch or ref", monospaced: true)
+                AlasField(text: $search, placeholder: "Search branches...")
+            }
+            .padding(8)
+
+            Divider().background(theme.color("line"))
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundColor(.red)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                Divider().background(theme.color("line"))
+            }
+
+            if branches.isEmpty {
+                Text(isLoading ? "Loading branches..." : "No branches found")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding(12)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        if !selectionIsListed {
+                            row(name: selection, note: "manual")
+                            Divider().background(theme.color("line"))
+                        }
+                        ForEach(filteredBranches, id: \.self) { branch in
+                            row(name: branch)
+                        }
+                    }
+                }
+                .frame(maxHeight: 320)
+            }
+        }
+        .frame(width: 320)
+    }
+
+    @ViewBuilder
+    private func row(name: String, note: String? = nil) -> some View {
+        Button(action: {
+            selection = name
+            open = false
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                    .opacity(name == selection ? 1 : 0)
+                Text(name)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if let note {
+                    Text(note)
+                        .font(.system(size: 10))
+                        .foregroundColor(theme.color("fg-dim"))
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -14,6 +14,9 @@ struct NewWorktreeDialog: View {
     @State private var pathOverride: String = ""
     @State private var runStartup: Bool = true
     @State private var openTerminal: Bool = true
+    @State private var branches: [String] = []
+    @State private var isLoadingBranches = false
+    @State private var branchLoadError: String?
     @State private var isCreating = false
     @State private var errorMessage: String?
 
@@ -36,9 +39,12 @@ struct NewWorktreeDialog: View {
                     }
                 }
                 DialogField(label: "Base branch") {
-                    Seg(value: $base, options: [
-                        ("main", "main"), ("develop", "develop"), ("origin/HEAD", "origin/HEAD")
-                    ])
+                    BranchPicker(
+                        selection: $base,
+                        branches: branches,
+                        isLoading: isLoadingBranches,
+                        errorMessage: branchLoadError
+                    )
                 }
                 DialogField(label: "Branch name") {
                     AlasField(text: $branch, monospaced: true)
@@ -84,6 +90,10 @@ struct NewWorktreeDialog: View {
             if branch.isEmpty {
                 branch = state.config.worktrees.branchPrefix
             }
+            loadBranchesForSelectedProject()
+        }
+        .onChange(of: projectId) { _, _ in
+            loadBranchesForSelectedProject()
         }
     }
 
@@ -111,6 +121,39 @@ struct NewWorktreeDialog: View {
             .replacingOccurrences(of: "{user}", with: NSUserName())
             .replacingOccurrences(of: "{ts}", with: ISO8601DateFormatter().string(from: Date()))
         return (template as NSString).expandingTildeInPath
+    }
+
+    private func loadBranchesForSelectedProject() {
+        guard let project = state.projects.first(where: { $0.id == projectId }) else {
+            branches = []
+            branchLoadError = nil
+            isLoadingBranches = false
+            return
+        }
+
+        let selectedProjectId = project.id
+        isLoadingBranches = true
+        branchLoadError = nil
+        Task {
+            do {
+                let discovered = try await GitService().branches(at: URL(fileURLWithPath: project.path))
+                guard projectId == selectedProjectId else { return }
+                branches = discovered
+                base = Self.preferredBaseBranch(
+                    availableBranches: discovered,
+                    configuredDefault: state.config.worktrees.baseBranch
+                )
+            } catch {
+                guard projectId == selectedProjectId else { return }
+                branches = []
+                branchLoadError = error.localizedDescription
+                if base.isEmpty {
+                    base = state.config.worktrees.baseBranch
+                }
+            }
+            guard projectId == selectedProjectId else { return }
+            isLoadingBranches = false
+        }
     }
 
     private func create() {
@@ -186,5 +229,18 @@ struct NewWorktreeDialog: View {
         projects: [ProjectConfig]
     ) -> Bool {
         !projects.isEmpty && resolvedPresetProject(presetProjectId: presetProjectId, projects: projects) == nil
+    }
+
+    nonisolated static func preferredBaseBranch(
+        availableBranches: [String],
+        configuredDefault: String
+    ) -> String {
+        for preferred in ["main", "master", "trunk"] where availableBranches.contains(preferred) {
+            return preferred
+        }
+        if availableBranches.contains(configuredDefault) {
+            return configuredDefault
+        }
+        return availableBranches.first ?? configuredDefault
     }
 }

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -132,6 +132,7 @@ struct NewWorktreeDialog: View {
         }
 
         let selectedProjectId = project.id
+        let baseBeforeLoad = base
         isLoadingBranches = true
         branchLoadError = nil
         Task {
@@ -139,10 +140,13 @@ struct NewWorktreeDialog: View {
                 let discovered = try await GitService().branches(at: URL(fileURLWithPath: project.path))
                 guard projectId == selectedProjectId else { return }
                 branches = discovered
-                base = Self.preferredBaseBranch(
+                let preferred = Self.preferredBaseBranch(
                     availableBranches: discovered,
                     configuredDefault: state.config.worktrees.baseBranch
                 )
+                if base == baseBeforeLoad {
+                    base = preferred
+                }
             } catch {
                 guard projectId == selectedProjectId else { return }
                 branches = []

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -235,11 +235,11 @@ struct NewWorktreeDialog: View {
         availableBranches: [String],
         configuredDefault: String
     ) -> String {
+        if !configuredDefault.isEmpty && availableBranches.contains(configuredDefault) {
+            return configuredDefault
+        }
         for preferred in ["main", "master", "trunk"] where availableBranches.contains(preferred) {
             return preferred
-        }
-        if availableBranches.contains(configuredDefault) {
-            return configuredDefault
         }
         return availableBranches.first ?? configuredDefault
     }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -15,6 +15,41 @@ struct GitService {
         return Self.parseRemote(url) ?? path.lastPathComponent
     }
 
+    func branches(at repoPath: URL) async throws -> [String] {
+        let local = try await Process.git(
+            ["branch", "--list", "--format=%(refname:short)"],
+            cwd: repoPath
+        )
+        guard local.exitCode == 0 else {
+            throw BranchListError(stderr: local.stderr)
+        }
+
+        let remote = try await Process.git(
+            ["branch", "--remotes", "--format=%(refname:short)"],
+            cwd: repoPath
+        )
+        guard remote.exitCode == 0 else {
+            throw BranchListError(stderr: remote.stderr)
+        }
+
+        return Self.parseBranchList(local.stdout + "\n" + remote.stdout)
+    }
+
+    static func parseBranchList(_ output: String) -> [String] {
+        var seen = Set<String>()
+        var branches: [String] = []
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: false) {
+            var branch = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if branch.hasPrefix("* ") {
+                branch.removeFirst(2)
+                branch = branch.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            guard !branch.isEmpty, seen.insert(branch).inserted else { continue }
+            branches.append(branch)
+        }
+        return branches
+    }
+
     static func parseRemote(_ url: String) -> String? {
         // https://host/owner/repo(.git)?  or  git@host:owner/repo(.git)?
         var trimmed = url
@@ -35,6 +70,18 @@ struct GitService {
             return "\(segs[segs.count - 2])/\(segs[segs.count - 1])"
         }
         return nil
+    }
+}
+
+private struct BranchListError: LocalizedError {
+    let stderr: String
+
+    var errorDescription: String? {
+        let message = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        if message.isEmpty {
+            return "Could not load branches."
+        }
+        return message
     }
 }
 

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -28,10 +28,8 @@ struct WorktreesPane: View {
                         AlasField(text: bind(\.worktrees.branchPrefix), monospaced: true)
                     }
                     SettingsRow(name: "Base branch",
-                                desc: "Branch to fork new worktrees from.") {
-                        Seg(value: bind(\.worktrees.baseBranch), options: [
-                            ("main", "main"), ("develop", "develop"), ("origin/HEAD", "origin/HEAD")
-                        ])
+                                desc: "Default base branch for new worktrees; repo branches can be selected in the create dialog.") {
+                        AlasField(text: bind(\.worktrees.baseBranch), monospaced: true)
                     }
                 }
                 // trackUpstream / autoFetch / fetchIntervalMinutes / pruneStale

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -59,4 +59,42 @@ struct GitServiceTests {
         let name = try await svc.suggestProjectName(repo)
         #expect(name == repo.lastPathComponent)
     }
+
+    @Test func parseBranchListCleansAndDeduplicatesBranches() {
+        let branches = GitService.parseBranchList("""
+        main
+        release/1.2
+
+        main
+        origin/main
+        * feature/current
+        """)
+
+        #expect(branches == ["main", "release/1.2", "origin/main", "feature/current"])
+    }
+
+    @Test func branchesIncludesLocalAndRemoteRefs() async throws {
+        let repo = try await makeRepo()
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+
+        _ = try await Process.git(["checkout", "-q", "-b", "develop"], cwd: repo)
+        _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
+        _ = try await Process.git(["remote", "add", "origin", remote.path], cwd: repo)
+        _ = try await Process.git(["push", "-q", "origin", "main:main"], cwd: repo)
+        _ = try await Process.git(["push", "-q", "origin", "develop:release/remote-only"], cwd: repo)
+        _ = try await Process.git(["fetch", "-q", "origin"], cwd: repo)
+
+        let branches = try await GitService().branches(at: repo)
+
+        #expect(branches.contains("main"))
+        #expect(branches.contains("develop"))
+        #expect(branches.contains("origin/main"))
+        #expect(branches.contains("origin/release/remote-only"))
+        #expect(branches.firstIndex(of: "develop")! < branches.firstIndex(of: "origin/main")!)
+    }
 }

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -40,6 +40,51 @@ struct NewWorktreeDialogTests {
         )?.id == "repo-b")
     }
 
+    @Test func preferredBaseBranchChoosesMainFirst() {
+        let selected = NewWorktreeDialog.preferredBaseBranch(
+            availableBranches: ["trunk", "master", "main"],
+            configuredDefault: "develop"
+        )
+
+        #expect(selected == "main")
+    }
+
+    @Test func preferredBaseBranchChoosesMasterBeforeTrunk() {
+        let selected = NewWorktreeDialog.preferredBaseBranch(
+            availableBranches: ["trunk", "master"],
+            configuredDefault: "develop"
+        )
+
+        #expect(selected == "master")
+    }
+
+    @Test func preferredBaseBranchUsesConfiguredDefaultWhenAvailable() {
+        let selected = NewWorktreeDialog.preferredBaseBranch(
+            availableBranches: ["release/1.0", "develop"],
+            configuredDefault: "develop"
+        )
+
+        #expect(selected == "develop")
+    }
+
+    @Test func preferredBaseBranchUsesFirstAvailableBeforeUnavailableDefault() {
+        let selected = NewWorktreeDialog.preferredBaseBranch(
+            availableBranches: ["release/1.0", "develop"],
+            configuredDefault: "integration"
+        )
+
+        #expect(selected == "release/1.0")
+    }
+
+    @Test func preferredBaseBranchPreservesDefaultWhenNoBranchesAvailable() {
+        let selected = NewWorktreeDialog.preferredBaseBranch(
+            availableBranches: [],
+            configuredDefault: "integration"
+        )
+
+        #expect(selected == "integration")
+    }
+
     private static func project(id: String) -> ProjectConfig {
         ProjectConfig(
             id: id,

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -40,19 +40,28 @@ struct NewWorktreeDialogTests {
         )?.id == "repo-b")
     }
 
-    @Test func preferredBaseBranchChoosesMainFirst() {
+    @Test func preferredBaseBranchChoosesMainWhenNoConfiguredDefault() {
         let selected = NewWorktreeDialog.preferredBaseBranch(
             availableBranches: ["trunk", "master", "main"],
-            configuredDefault: "develop"
+            configuredDefault: ""
         )
 
         #expect(selected == "main")
     }
 
+    @Test func preferredBaseBranchUsesConfiguredDefaultOverMain() {
+        let selected = NewWorktreeDialog.preferredBaseBranch(
+            availableBranches: ["trunk", "master", "main", "develop"],
+            configuredDefault: "develop"
+        )
+
+        #expect(selected == "develop")
+    }
+
     @Test func preferredBaseBranchChoosesMasterBeforeTrunk() {
         let selected = NewWorktreeDialog.preferredBaseBranch(
             availableBranches: ["trunk", "master"],
-            configuredDefault: "develop"
+            configuredDefault: ""
         )
 
         #expect(selected == "master")


### PR DESCRIPTION
## Summary

- Add `GitService.branches(at:)` to discover local + remote branches from a repository
- Replace hardcoded `Seg` base branch selector in NewWorktreeDialog with a searchable `BranchPicker` that lists actual repo branches and allows manual entry
- Default selection prefers `main` > `master` > `trunk` > configured default > first available branch
- Change Worktrees settings base branch from fixed segmented control to free-form `AlasField`
- Add tests for branch parsing, integration listing, and preferred default selection

Closes #768