### PR TITLE
Fix language server availability after relaunch

### DIFF
--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -10,15 +10,18 @@ struct LanguageServerAvailability {
     private let environment: [String: String]
     private let fileManager: FileManager
     private let xcrunFind: (String) -> String?
+    private let additionalPathDirectories: [String]
 
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default,
-        xcrunFind: @escaping (String) -> String? = LanguageServerAvailability.xcrunFind
+        xcrunFind: @escaping (String) -> String? = LanguageServerAvailability.xcrunFind,
+        additionalPathDirectories: [String] = LanguageServerAvailability.defaultAdditionalPathDirectories()
     ) {
         self.environment = environment
         self.fileManager = fileManager
         self.xcrunFind = xcrunFind
+        self.additionalPathDirectories = additionalPathDirectories
     }
 
     func status(for entry: LanguageServerConfig) -> Status {
@@ -53,21 +56,73 @@ struct LanguageServerAvailability {
         return (executable: "/usr/bin/env", arguments: [resolved] + entry.args)
     }
 
-    private func executableNamed(_ name: String, env: [String: String] = [:]) -> String? {
-        let mergedPath: String
-        if let envPath = env["PATH"], !envPath.isEmpty {
-            let basePath = environment["PATH"] ?? "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-            mergedPath = envPath + ":" + basePath
-        } else {
-            mergedPath = environment["PATH"] ?? "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    func launchEnvironment(for entry: LanguageServerConfig) -> [String: String] {
+        var merged = environment
+        for (key, value) in entry.env {
+            merged[key] = value
         }
-        for dir in mergedPath.split(separator: ":", omittingEmptySubsequences: true) {
+        merged["PATH"] = effectivePath(env: entry.env)
+        return merged
+    }
+
+    private func executableNamed(_ name: String, env: [String: String] = [:]) -> String? {
+        for dir in effectivePath(env: env).split(separator: ":", omittingEmptySubsequences: true) {
             let candidate = URL(fileURLWithPath: String(dir)).appendingPathComponent(name).path
             if fileManager.isExecutableFile(atPath: candidate) {
                 return candidate
             }
         }
         return nil
+    }
+
+    private func effectivePath(env: [String: String]) -> String {
+        var seen = Set<String>()
+        var parts: [String] = []
+        for path in [env["PATH"], environment["PATH"]] {
+            for dir in pathEntries(path) where seen.insert(dir).inserted {
+                parts.append(dir)
+            }
+        }
+        for dir in additionalPathDirectories where !dir.isEmpty && seen.insert(dir).inserted {
+            parts.append(dir)
+        }
+        return parts.joined(separator: ":")
+    }
+
+    private func pathEntries(_ path: String?) -> [String] {
+        guard let path else { return [] }
+        return path.split(separator: ":", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    private static func defaultAdditionalPathDirectories() -> [String] {
+        var dirs: [String] = [
+            "/usr/local/bin",
+            "/opt/homebrew/bin",
+            "\(NSHomeDirectory())/.cargo/bin",
+            "\(NSHomeDirectory())/.local/bin",
+            "\(NSHomeDirectory())/.bun/bin",
+            "\(NSHomeDirectory())/.volta/bin"
+        ]
+
+        dirs.append(contentsOf: pathFileEntries(at: "/etc/paths"))
+
+        let pathsD = "/etc/paths.d"
+        if let entries = try? FileManager.default.contentsOfDirectory(atPath: pathsD) {
+            for entry in entries.sorted() {
+                dirs.append(contentsOf: pathFileEntries(at: "\(pathsD)/\(entry)"))
+            }
+        }
+
+        var seen = Set<String>()
+        return dirs.filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    private static func pathFileEntries(at path: String) -> [String] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return contents
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
     }
 
     private static func xcrunFind(_ tool: String) -> String? {

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -108,7 +108,7 @@ final class WorkspaceLSPManager {
             isFirstOpener = false
         } else {
             let spawn = Self.resolveSpawn(command: entry.command, args: entry.args, env: entry.env, language: entry.language)
-            let transport = LSPTransport(executable: spawn.executable, arguments: spawn.arguments, environment: entry.env.isEmpty ? nil : entry.env)
+            let transport = LSPTransport(executable: spawn.executable, arguments: spawn.arguments, environment: spawn.environment)
             let newClient = LSPClient(transport: transport, language: languageId, rootURI: lspRoot.lspURI)
             let task = Task<Bool, Never> {
                 do { try await newClient.initialize()
@@ -507,6 +507,7 @@ final class WorkspaceLSPManager {
     private struct Spawn {
         let executable: URL
         let arguments: [String]
+        let environment: [String: String]
     }
 
     /// Resolves the spawn command for `entry`. Bare commands (no `/`) are
@@ -516,18 +517,30 @@ final class WorkspaceLSPManager {
     /// with `/usr/bin/env` — that ensures `sourcekit-lsp` launches even
     /// when it lives inside Xcode.app and isn't on PATH.
     private static func resolveSpawn(command: String, args: [String], env: [String: String], language: String) -> Spawn {
-        if command.contains("/") {
-            return Spawn(executable: URL(fileURLWithPath: command), arguments: args)
-        }
         let probe = LanguageServerConfig(
             language: language, extensions: [], command: command, args: args,
             env: env, rootMarkers: [], enabled: true
         )
         let availability = LanguageServerAvailability()
-        if let spawnArgs = availability.spawnArguments(for: probe) {
-            return Spawn(executable: URL(fileURLWithPath: spawnArgs.executable), arguments: spawnArgs.arguments)
+        if command.contains("/") {
+            return Spawn(
+                executable: URL(fileURLWithPath: command),
+                arguments: args,
+                environment: availability.launchEnvironment(for: probe)
+            )
         }
-        return Spawn(executable: URL(fileURLWithPath: "/usr/bin/env"), arguments: [command] + args)
+        if let spawnArgs = availability.spawnArguments(for: probe) {
+            return Spawn(
+                executable: URL(fileURLWithPath: spawnArgs.executable),
+                arguments: spawnArgs.arguments,
+                environment: availability.launchEnvironment(for: probe)
+            )
+        }
+        return Spawn(
+            executable: URL(fileURLWithPath: "/usr/bin/env"),
+            arguments: [command] + args,
+            environment: availability.launchEnvironment(for: probe)
+        )
     }
 
     // MARK: - Root resolution

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -39,6 +39,26 @@ struct LanguageServerAvailabilityTests {
         #expect(availability.status(for: entry) == .available)
     }
 
+    @Test("minimal GUI PATH still checks additional tool directories")
+    func additionalToolDirectories() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("rust-analyzer")
+        let created = FileManager.default.createFile(atPath: executable.path, contents: Data())
+        #expect(created)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let entry = config(language: "rust", command: "rust-analyzer")
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [dir.path]
+        )
+
+        #expect(availability.status(for: entry) == .available)
+        #expect(availability.resolvedCommand(for: entry) == executable.path)
+    }
+
     @Test("Swift sourcekit-lsp falls back to xcrun")
     func swiftXcrunFallback() {
         var requestedTool: String?
@@ -125,6 +145,22 @@ struct LanguageServerAvailabilityTests {
         let entry = config(command: "custom-lsp", env: ["PATH": dir.path])
         let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil })
         #expect(availability.status(for: entry) == .available)
+    }
+
+    @Test("launch environment uses same augmented PATH as resolution")
+    func launchEnvironmentPath() {
+        let entry = config(command: "custom-lsp", env: ["PATH": "/custom/bin", "CUSTOM": "1"])
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": "/usr/bin:/bin", "HOME": "/Users/test"],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: ["/opt/homebrew/bin", "/custom/bin"]
+        )
+
+        let env = availability.launchEnvironment(for: entry)
+
+        #expect(env["CUSTOM"] == "1")
+        #expect(env["HOME"] == "/Users/test")
+        #expect(env["PATH"] == "/custom/bin:/usr/bin:/bin:/opt/homebrew/bin")
     }
 
     private func config(language: String = "test", command: String, args: [String] = [], env: [String: String] = [:], enabled: Bool = true) -> LanguageServerConfig {

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -7,7 +7,7 @@ struct LanguageServerAvailabilityTests {
     @Test("disabled entries report disabled")
     func disabled() {
         let entry = config(language: "swift", command: "sourcekit-lsp", enabled: false)
-        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil })
+        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil }, additionalPathDirectories: [])
         #expect(availability.status(for: entry) == .disabled)
     }
 
@@ -21,7 +21,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: executable.path)
-        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil })
+        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil }, additionalPathDirectories: [])
         #expect(availability.status(for: entry) == .available)
     }
 
@@ -35,7 +35,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: "test-lsp")
-        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil })
+        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil }, additionalPathDirectories: [])
         #expect(availability.status(for: entry) == .available)
     }
 
@@ -66,7 +66,7 @@ struct LanguageServerAvailabilityTests {
         let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { tool in
             requestedTool = tool
             return "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
-        })
+        }, additionalPathDirectories: [])
 
         #expect(availability.status(for: entry) == .available)
         #expect(requestedTool == "sourcekit-lsp")
@@ -79,7 +79,7 @@ struct LanguageServerAvailabilityTests {
         let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in
             didCallXcrun = true
             return "/usr/local/bin/rust-analyzer"
-        })
+        }, additionalPathDirectories: [])
 
         #expect(availability.status(for: entry) == .notInstalled)
         #expect(didCallXcrun == false)
@@ -89,7 +89,7 @@ struct LanguageServerAvailabilityTests {
     func resolvedCommandXcrun() {
         let entry = config(language: "swift", command: "sourcekit-lsp")
         let xcrunPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
-        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath })
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath }, additionalPathDirectories: [])
 
         #expect(availability.resolvedCommand(for: entry) == xcrunPath)
     }
@@ -98,7 +98,7 @@ struct LanguageServerAvailabilityTests {
     func spawnArgumentsXcrun() {
         let entry = config(language: "swift", command: "sourcekit-lsp", args: ["--flag"])
         let xcrunPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
-        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath })
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath }, additionalPathDirectories: [])
         let spawn = availability.spawnArguments(for: entry)
 
         #expect(spawn != nil)
@@ -116,7 +116,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: "test-lsp", args: ["--verbose"])
-        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil })
+        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil }, additionalPathDirectories: [])
         let spawn = availability.spawnArguments(for: entry)
 
         #expect(spawn != nil)
@@ -127,7 +127,7 @@ struct LanguageServerAvailabilityTests {
     @Test("spawnArguments wraps unresolvable bare command with env")
     func spawnArgumentsEnvFallback() {
         let entry = config(command: "missing-lsp", args: ["--flag"])
-        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil })
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil }, additionalPathDirectories: [])
         let spawn = availability.spawnArguments(for: entry)
 
         #expect(spawn == nil)
@@ -143,7 +143,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: "custom-lsp", env: ["PATH": dir.path])
-        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil })
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil }, additionalPathDirectories: [])
         #expect(availability.status(for: entry) == .available)
     }
 


### PR DESCRIPTION
## Summary
- expand language server command lookup beyond minimal GUI PATHs by including common developer tool directories and system path files
- launch language servers with the same augmented PATH used for availability checks
- add regression coverage for GUI-style PATHs and launch environment merging

## Validation
- `git show --check --stat --oneline HEAD`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/LanguageServerAvailabilityTests test` *(blocked: missing `.build/ghostty/GhosttyKit.xcframework` in this checkout)*

Mission Control task: #767