### PR TITLE
feat(icons): use nerd font file type icons

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		5EA1AA5C8D9DE003BACE8291 /* AlasGhostty.Surface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */; };
 		5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE58EF9CF8EC461667D9430 /* AppConfig.swift */; };
 		5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */; };
+		629B98E07ED9A159A695707D /* JetBrainsMonoNerdFont-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */; };
 		64ADA6AFE69C52F121A163E1 /* FileTypeIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F721FB733081A583D4053DDA /* FileTypeIconView.swift */; };
 		671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A17A797374500E1FDD2382C /* PersistenceStore.swift */; };
 		676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4261E417947C1A21E77C1587 /* GitStatusCache.swift */; };
@@ -120,6 +121,7 @@
 		7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CA79B71B4AA72697392702 /* NumstatParser.swift */; };
 		7B309C87C042B3A18AB31D0F /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49B5B544A3432F8D8105268 /* SearchModel.swift */; };
 		7B85B033B476943E77867BA3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69024633944E9FFF6DA76FAE /* RootView.swift */; };
+		7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */; };
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
@@ -334,6 +336,7 @@
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
+		57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledFontRegistrar.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
@@ -378,6 +381,7 @@
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
+		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
 		932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFeature.swift; sourceTree = "<group>"; };
@@ -806,6 +810,7 @@
 			children = (
 				1FFE2F486B5DB90050685166 /* Alas */,
 				1A6B0ED8FD355C82542D35C4 /* AlasTests */,
+				D693E9FFCCA3C968C18E4437 /* ThirdParty */,
 				40C7F06C7176E479491B0228 /* Frameworks */,
 				C86FE0D59F990939C552C7E2 /* Products */,
 			);
@@ -820,6 +825,14 @@
 				BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */,
 			);
 			path = Persistence;
+			sourceTree = "<group>";
+		};
+		92D8882514B9187F2418B51B /* src */ = {
+			isa = PBXGroup;
+			children = (
+				B302DA540625EA299CDC9833 /* font */,
+			);
+			path = src;
 			sourceTree = "<group>";
 		};
 		986CC94FDFD6411BCED67A48 /* Search */ = {
@@ -861,6 +874,14 @@
 			path = Highlight;
 			sourceTree = "<group>";
 		};
+		99DCC0EF4B5701083CB34167 /* ghostty */ = {
+			isa = PBXGroup;
+			children = (
+				92D8882514B9187F2418B51B /* src */,
+			);
+			path = ghostty;
+			sourceTree = "<group>";
+		};
 		A1CA0BEB25542A9B175DBDFE /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -888,6 +909,14 @@
 				5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */,
 			);
 			path = Ghostty;
+			sourceTree = "<group>";
+		};
+		B302DA540625EA299CDC9833 /* font */ = {
+			isa = PBXGroup;
+			children = (
+				F180B48403645336DCF3A60B /* res */,
+			);
+			path = font;
 			sourceTree = "<group>";
 		};
 		B4091CAB7D0E176C8D1E112C /* Harness */ = {
@@ -957,6 +986,14 @@
 			path = LSP;
 			sourceTree = "<group>";
 		};
+		D693E9FFCCA3C968C18E4437 /* ThirdParty */ = {
+			isa = PBXGroup;
+			children = (
+				99DCC0EF4B5701083CB34167 /* ghostty */,
+			);
+			path = ThirdParty;
+			sourceTree = "<group>";
+		};
 		E1F3B0D31B790569264710EB /* HookScripts */ = {
 			isa = PBXGroup;
 			children = (
@@ -975,6 +1012,14 @@
 				4A546C28E4A7690D621C99E0 /* Themes */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		F180B48403645336DCF3A60B /* res */ = {
+			isa = PBXGroup;
+			children = (
+				9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */,
+			);
+			path = res;
 			sourceTree = "<group>";
 		};
 		F211897D927000B71316F28A /* WindowChrome */ = {
@@ -1035,6 +1080,7 @@
 			children = (
 				7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */,
 				17C2AC0F8B3A1B75239995AC /* AppState.swift */,
+				57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */,
 				B44D759586280250330A9A04 /* FontSizeCommands.swift */,
 				7FFC9539E615699AC90A7412 /* ProjectsManager.swift */,
 				69024633944E9FFF6DA76FAE /* RootView.swift */,
@@ -1134,6 +1180,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */,
+				629B98E07ED9A159A695707D /* JetBrainsMonoNerdFont-Regular.ttf in Resources */,
 				3DC6518A9050D1029D4D99A4 /* aider.sh in Resources */,
 				3BA0F34C4D9EE5081736F458 /* claude-code.sh in Resources */,
 				AD3469F4745DF96ED3D0E06E /* codex-cli.sh in Resources */,
@@ -1203,6 +1250,7 @@
 				8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */,
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
 				9E302329243407946D47DC91 /* BranchPicker.swift in Sources */,
+				7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */,
 				139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */,
 				40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */,
 				8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -4,6 +4,10 @@ import SwiftUI
 struct AlasApp: App {
     @State private var state = AppState()
 
+    init() {
+        BundledFontRegistrar.registerFonts()
+    }
+
     var body: some Scene {
         Window("Alas", id: "main") {
             RootView(state: state)

--- a/Alas/Sources/App/BundledFontRegistrar.swift
+++ b/Alas/Sources/App/BundledFontRegistrar.swift
@@ -1,0 +1,17 @@
+import CoreText
+import Foundation
+
+enum BundledFontRegistrar {
+    static func registerFonts() {
+        registerFont(named: "JetBrainsMonoNerdFont-Regular", extension: "ttf")
+    }
+
+    private static func registerFont(named name: String, extension ext: String) {
+        guard let url = Bundle.main.url(forResource: name, withExtension: ext) else {
+            return
+        }
+
+        var error: Unmanaged<CFError>?
+        CTFontManagerRegisterFontsForURL(url as CFURL, .process, &error)
+    }
+}

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -9,7 +9,7 @@ struct ChangedRow: View {
         let basename = file.path.split(separator: "/").last.map(String.init) ?? file.path
         return Button(action: onSelect) {
             HStack(spacing: 6) {
-                FileTypeIconView(filename: basename, size: 13)
+                FileTypeIconView(filename: basename, size: 18)
                 Text(basename)
                     .font(.system(size: 11.5, design: .monospaced))
                     .lineLimit(1)

--- a/Alas/Sources/Right/FileTypeIconView.swift
+++ b/Alas/Sources/Right/FileTypeIconView.swift
@@ -1,111 +1,197 @@
+import AppKit
+import CoreText
 import SwiftUI
 
 /// File-type icon lookup: filename overrides win over extension matches.
 /// View wrapper is in the bottom of this file (added in Task 2).
 enum FileTypeIcon {
     struct Info: Equatable {
-        let label: String
+        let symbol: String
         let hex: String       // 6-char RGB hex, no leading "#"
         let kind: Kind
+        let style: Style
         enum Kind { case filename, ext, fallbackExt, generic }
+        enum Style { case nerdFont, text }
     }
+
+    static let nerdFontName = "JetBrainsMonoNF-Regular"
 
     static func info(for filename: String) -> Info {
         let lower = filename.lowercased()
 
         if let hit = filenameTable[lower] {
-            return Info(label: hit.label, hex: hit.hex, kind: .filename)
+            return Info(symbol: hit.symbol, hex: hit.hex, kind: .filename, style: .nerdFont)
         }
 
         guard let dot = lower.lastIndex(of: "."), dot != lower.startIndex else {
             // No extension at all (or leading-dot-only like ".unknownrc"
             // which has no second dot) → generic glyph.
-            return Info(label: "", hex: "7A8089", kind: .generic)
+            return Info(symbol: "\u{F15B}", hex: "7A8089", kind: .generic, style: .nerdFont)
         }
         let ext = String(lower[lower.index(after: dot)...])
 
         if let hit = extensionTable[ext] {
-            return Info(label: hit.label, hex: hit.hex, kind: .ext)
+            return Info(symbol: hit.symbol, hex: hit.hex, kind: .ext, style: .nerdFont)
         }
         // Fallback: gray tile with the extension text truncated to 3 chars.
-        let label = String(ext.prefix(3))
-        return Info(label: label, hex: "7A8089", kind: .fallbackExt)
+        let symbol = String(ext.prefix(3))
+        return Info(symbol: symbol, hex: "7A8089", kind: .fallbackExt, style: .text)
     }
 
     // Hex colors are RGB without "#". Reuse Color(hex:) from RepoDot.swift.
-    private static let extensionTable: [String: (label: String, hex: String)] = [
-        "swift": ("swift", "F05138"),
-        "rs":    ("rs",    "D97558"),
-        "toml":  ("TM",    "9C7B56"),
-        "lock":  ("\u{1F512}", "7A6A5A"),  // 🔒
-        "md":    ("M\u{2193}", "5A8FC4"),  // M↓
-        "mdx":   ("M\u{2193}", "5A8FC4"),
-        "ts":    ("TS",    "3178C6"),
-        "tsx":   ("TSX",   "3178C6"),
-        "js":    ("JS",    "E0C33B"),
-        "jsx":   ("JSX",   "61DAFB"),
-        "json":  ("{}",    "CBB04A"),
-        "html":  ("</>",   "E36B3A"),
-        "css":   ("#",     "5FA7D6"),
-        "scss":  ("#",     "CF649A"),
-        "py":    ("py",    "3B6E9C"),
-        "go":    ("go",    "4EC0D0"),
-        "c":     ("C",     "5A89BF"),
-        "h":     ("h",     "A87FC4"),
-        "cpp":   ("C+",    "5A89BF"),
-        "rb":    ("rb",    "CC342D"),
-        "java":  ("JV",    "E76F00"),
-        "kt":    ("kt",    "A97BF3"),
-        "sh":    (">_",    "7AA86A"),
-        "yaml":  ("YL",    "9C7B56"),
-        "yml":   ("YL",    "9C7B56"),
-        "svg":   ("svg",   "CBB04A"),
-        "png":   ("png",   "A87FC4"),
-        "jpg":   ("jpg",   "A87FC4"),
-        "jpeg":  ("jpg",   "A87FC4"),
-        "gif":   ("gif",   "A87FC4"),
-        "webp":  ("wp",    "A87FC4"),
-        "pdf":   ("PDF",   "CC342D"),
-        "zip":   ("zip",   "7A6A5A"),
-        "txt":   ("txt",   "7A7A7A"),
-        "sql":   ("sql",   "5FA7D6"),
-        "env":   ("env",   "7AA86A"),
+    private static let extensionTable: [String: (symbol: String, hex: String)] = [
+        "swift": ("\u{E699}", "F05138"),
+        "kt":    ("\u{E634}", "A97BF3"),
+        "kts":   ("\u{E634}", "A97BF3"),
+        "java":  ("\u{E256}", "E76F00"),
+        "rs":    ("\u{E68B}", "D97558"),
+        "py":    ("\u{E606}", "3B6E9C"),
+        "go":    ("\u{E627}", "4EC0D0"),
+        "ts":    ("\u{E628}", "3178C6"),
+        "mts":   ("\u{E628}", "3178C6"),
+        "cts":   ("\u{E628}", "3178C6"),
+        "tsx":   ("\u{E625}", "61DAFB"),
+        "js":    ("\u{E60C}", "E0C33B"),
+        "mjs":   ("\u{E60C}", "E0C33B"),
+        "cjs":   ("\u{E60C}", "E0C33B"),
+        "jsx":   ("\u{E625}", "61DAFB"),
+        "vue":   ("\u{E6A0}", "42B883"),
+        "svelte": ("\u{E697}", "FF3E00"),
+        "dart":  ("\u{E64C}", "00A4DC"),
+        "ex":    ("\u{E62D}", "7E57C2"),
+        "exs":   ("\u{E653}", "7E57C2"),
+        "hs":    ("\u{E61F}", "5D4F85"),
+        "lhs":   ("\u{E61F}", "5D4F85"),
+        "lua":   ("\u{E620}", "000080"),
+        "clj":   ("\u{E642}", "91DC47"),
+        "cljs":  ("\u{E642}", "91DC47"),
+        "cljc":  ("\u{E642}", "91DC47"),
+        "php":   ("\u{E608}", "777BB4"),
+        "rb":    ("\u{E605}", "CC342D"),
+        "jl":    ("\u{E624}", "9558B2"),
+        "zig":   ("\u{E6A9}", "F7A41D"),
+        "scala": ("\u{E68E}", "DC322F"),
+        "nim":   ("\u{E677}", "FFC200"),
+        "cr":    ("\u{E62F}", "000000"),
+        "ml":    ("\u{E67A}", "EC6813"),
+        "mli":   ("\u{E67A}", "EC6813"),
+        "c":     ("\u{E649}", "5A89BF"),
+        "h":     ("\u{E649}", "A87FC4"),
+        "cpp":   ("\u{E646}", "5A89BF"),
+        "cc":    ("\u{E646}", "5A89BF"),
+        "cxx":   ("\u{E646}", "5A89BF"),
+        "hpp":   ("\u{E646}", "A87FC4"),
+        "hh":    ("\u{E646}", "A87FC4"),
+        "hxx":   ("\u{E646}", "A87FC4"),
+        "fs":    ("\u{F031B}", "378BBA"),
+        "fsx":   ("\u{F031B}", "378BBA"),
+        "cs":    ("\u{F031B}", "68217A"),
+        "pl":    ("\u{E67E}", "39457E"),
+        "pm":    ("\u{E67E}", "39457E"),
+        "elm":   ("\u{E62C}", "60B5CC"),
+        "purs":  ("\u{E630}", "14161A"),
+        "r":     ("\u{F0C1F}", "276DC3"),
+
+        "html":  ("\u{E60E}", "E36B3A"),
+        "htm":   ("\u{E60E}", "E36B3A"),
+        "css":   ("\u{E614}", "5FA7D6"),
+        "scss":  ("\u{E603}", "CF649A"),
+        "sass":  ("\u{E603}", "CF649A"),
+        "less":  ("\u{F016E}", "1D365D"),
+        "styl":  ("\u{E600}", "7AA86A"),
+        "json":  ("\u{E60B}", "CBB04A"),
+        "jsonc": ("\u{E60B}", "CBB04A"),
+        "md":    ("\u{F48A}", "5A8FC4"),
+        "mdx":   ("\u{F48A}", "5A8FC4"),
+        "xml":   ("\u{F05C0}", "E36B3A"),
+        "svg":   ("\u{E698}", "CBB04A"),
+        "png":   ("\u{E60D}", "A87FC4"),
+        "jpg":   ("\u{E60D}", "A87FC4"),
+        "jpeg":  ("\u{E60D}", "A87FC4"),
+        "gif":   ("\u{E60D}", "A87FC4"),
+        "webp":  ("\u{E60D}", "A87FC4"),
+        "ico":   ("\u{E623}", "CBB04A"),
+        "sql":   ("\u{EACE}", "5FA7D6"),
+        "mysql": ("\u{E229}", "5FA7D6"),
+        "tf":    ("\u{F1062}", "7B42BC"),
+        "tfvars": ("\u{F1062}", "7B42BC"),
+        "graphql": ("\u{E662}", "E10098"),
+        "gql":   ("\u{E662}", "E10098"),
+        "prisma": ("\u{E684}", "2D3748"),
+        "proto": ("\u{F0A7D}", "5FA7D6"),
+
+        "dockerfile": ("\u{E650}", "2496ED"),
+        "gradle": ("\u{E660}", "02303A"),
+        "bazel": ("\u{E63A}", "43A047"),
+        "cmake": ("\u{E673}", "7A6A5A"),
+        "make":  ("\u{E673}", "7A6A5A"),
+        "lock":  ("\u{F023}", "7A6A5A"),
+        "toml":  ("\u{E60B}", "9C7B56"),
+        "yaml":  ("\u{E60B}", "9C7B56"),
+        "yml":   ("\u{E60B}", "9C7B56"),
+        "sh":    ("\u{EBCA}", "7AA86A"),
+        "bash":  ("\u{EBCA}", "7AA86A"),
+        "zsh":   ("\u{EBCA}", "7AA86A"),
+        "fish":  ("\u{EBCA}", "7AA86A"),
+        "ps1":   ("\u{EBC7}", "5391FE"),
+        "psm1":  ("\u{EBC7}", "5391FE"),
+        "env":   ("\u{EBCA}", "7AA86A"),
+
+        "pdf":   ("\u{F1C1}", "CC342D"),
+        "zip":   ("\u{F410}", "7A6A5A"),
+        "txt":   ("\u{F15C}", "7A7A7A"),
     ]
 
-    private static let filenameTable: [String: (label: String, hex: String)] = [
-        "cargo.toml":          ("rs",  "D97558"),
-        "cargo.lock":          ("rs",  "7A6A5A"),
-        "package.json":        ("pk",  "CB3837"),
-        "package-lock.json":   ("lk",  "CB3837"),
-        "tsconfig.json":       ("ts",  "3178C6"),
-        ".gitignore":          ("git", "F05033"),
-        ".gitattributes":      ("git", "F05033"),
-        "readme.md":           ("RM",  "5A8FC4"),
-        "license":             ("LIC", "9C8E6E"),
-        "dockerfile":          ("dk",  "2496ED"),
-        "rust-toolchain.toml": ("rs",  "D97558"),
+    private static let filenameTable: [String: (symbol: String, hex: String)] = [
+        "cargo.toml":          ("\u{E68B}", "D97558"),
+        "cargo.lock":          ("\u{E68B}", "7A6A5A"),
+        "rust-toolchain.toml": ("\u{E68B}", "D97558"),
+        "package.json":        ("\u{E616}", "CB3837"),
+        "package-lock.json":   ("\u{E616}", "CB3837"),
+        "npm-shrinkwrap.json": ("\u{E616}", "CB3837"),
+        "yarn.lock":           ("\u{EF75}", "2C8EBB"),
+        "pnpm-lock.yaml":      ("\u{E616}", "F69220"),
+        "tsconfig.json":       ("\u{E628}", "3178C6"),
+        "jsconfig.json":       ("\u{E60C}", "E0C33B"),
+        ".gitignore":          ("\u{E65D}", "F05033"),
+        ".gitattributes":      ("\u{E65D}", "F05033"),
+        ".gitmodules":         ("\u{E65D}", "F05033"),
+        ".github":             ("\u{EA84}", "7A8089"),
+        ".gitlab-ci.yml":      ("\u{F296}", "FC6D26"),
+        "readme.md":           ("\u{F48A}", "5A8FC4"),
+        "license":             ("\u{F02D}", "9C8E6E"),
+        "dockerfile":          ("\u{E650}", "2496ED"),
+        "docker-compose.yml":  ("\u{E650}", "2496ED"),
+        "docker-compose.yaml": ("\u{E650}", "2496ED"),
+        "go.mod":              ("\u{E627}", "4EC0D0"),
+        "go.sum":              ("\u{E627}", "4EC0D0"),
+        "gemfile":             ("\u{E605}", "CC342D"),
+        "rakefile":            ("\u{E604}", "CC342D"),
+        "mix.exs":             ("\u{E62D}", "7E57C2"),
+        "makefile":            ("\u{E673}", "7A6A5A"),
+        "cmakelists.txt":      ("\u{E673}", "7A6A5A"),
     ]
 }
 
-/// Square tile with the file-type glyph. For `.generic` kind, renders the
-/// existing SF Symbol `doc` so files with no extension still get an icon.
+/// Square tile with the file-type glyph.
 struct FileTypeIconView: View {
     let filename: String
-    var size: CGFloat = 13
+    var size: CGFloat = 18
     @Environment(\.theme) private var theme
 
     var body: some View {
         let info = FileTypeIcon.info(for: filename)
-        switch info.kind {
-        case .generic:
-            Icon(name: "file", size: size, color: theme.color("fg-faint"))
-        case .filename, .ext, .fallbackExt:
+        switch info.style {
+        case .nerdFont:
+            NerdFontGlyphView(symbol: info.symbol, hex: info.hex)
+                .frame(width: size, height: size)
+        case .text:
             let color = Color(hex: info.hex)
-            Text(info.label)
-                .font(.system(size: fontPx(for: info.label), weight: .bold, design: .monospaced))
+            Text(info.symbol)
+                .font(.custom(FileTypeIcon.nerdFontName, size: fontPx(for: info.symbol)))
                 .foregroundColor(color)
-                .kerning(-0.2)
                 .lineLimit(1)
+                .minimumScaleFactor(0.7)
                 .frame(width: size, height: size)
                 .background(color.opacity(0.14))
                 .overlay(
@@ -120,10 +206,121 @@ struct FileTypeIconView: View {
         let chars = max(1, label.count)
         let scale: CGFloat
         switch chars {
-        case 1:  scale = 0.60
-        case 2:  scale = 0.52
-        default: scale = 0.42  // 3+
+        case 1:  scale = 0.72
+        case 2:  scale = 0.60
+        default: scale = 0.48  // 3+
         }
-        return max(7, (size * scale).rounded())
+        return max(8, (size * scale).rounded())
+    }
+}
+
+private struct NerdFontGlyphView: NSViewRepresentable {
+    let symbol: String
+    let hex: String
+
+    func makeNSView(context: Context) -> GlyphDrawingView {
+        let view = GlyphDrawingView()
+        view.symbol = symbol
+        view.hex = hex
+        return view
+    }
+
+    func updateNSView(_ nsView: GlyphDrawingView, context: Context) {
+        nsView.symbol = symbol
+        nsView.hex = hex
+    }
+}
+
+private final class GlyphDrawingView: NSView {
+    var symbol: String = "" {
+        didSet { needsDisplay = true }
+    }
+
+    var hex: String = "7A8089" {
+        didSet { needsDisplay = true }
+    }
+
+    override var isFlipped: Bool { true }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        guard let context = NSGraphicsContext.current?.cgContext,
+              let path = NerdFontGlyphPath.path(for: symbol) else {
+            return
+        }
+
+        let bounds = path.boundingBoxOfPath
+        guard bounds.width > 0, bounds.height > 0 else { return }
+
+        let inset = max(1, min(self.bounds.width, self.bounds.height) * 0.06)
+        let target = self.bounds.insetBy(dx: inset, dy: inset)
+        let scale = min(target.width / bounds.width, target.height / bounds.height)
+        let scaledWidth = bounds.width * scale
+        let scaledHeight = bounds.height * scale
+
+        context.saveGState()
+        context.setFillColor(NSColor(hex: hex).cgColor)
+        context.translateBy(
+            x: target.midX - scaledWidth / 2 - bounds.minX * scale,
+            y: target.midY + scaledHeight / 2 + bounds.minY * scale
+        )
+        context.scaleBy(x: scale, y: -scale)
+        context.addPath(path)
+        context.fillPath()
+        context.restoreGState()
+    }
+}
+
+enum NerdFontGlyphPath {
+    static func path(for symbol: String) -> CGPath? {
+        guard !symbol.isEmpty else { return nil }
+
+        let font = CTFontCreateWithName(FileTypeIcon.nerdFontName as CFString, 1000, nil)
+        let attributed = NSAttributedString(
+            string: symbol,
+            attributes: [kCTFontAttributeName as NSAttributedString.Key: font]
+        )
+        let line = CTLineCreateWithAttributedString(attributed)
+        let runs = CTLineGetGlyphRuns(line) as! [CTRun]
+        let combined = CGMutablePath()
+
+        for run in runs {
+            let attributes = CTRunGetAttributes(run) as NSDictionary
+            let runFont = attributes[kCTFontAttributeName] as! CTFont
+            let count = CTRunGetGlyphCount(run)
+            guard count > 0 else { continue }
+
+            var glyphs = Array(repeating: CGGlyph(), count: count)
+            var positions = Array(repeating: CGPoint.zero, count: count)
+            CTRunGetGlyphs(run, CFRange(location: 0, length: count), &glyphs)
+            CTRunGetPositions(run, CFRange(location: 0, length: count), &positions)
+
+            for index in 0..<count {
+                guard let glyphPath = CTFontCreatePathForGlyph(runFont, glyphs[index], nil) else {
+                    continue
+                }
+                let transform = CGAffineTransform(
+                    translationX: positions[index].x,
+                    y: positions[index].y
+                )
+                combined.addPath(glyphPath, transform: transform)
+            }
+        }
+
+        return combined.isEmpty ? nil : combined
+    }
+}
+
+private extension NSColor {
+    convenience init(hex: String) {
+        var s = hex
+        if s.hasPrefix("#") { s.removeFirst() }
+        var int: UInt64 = 0
+        Scanner(string: s).scanHexInt64(&int)
+        let r = CGFloat((int >> 16) & 0xff) / 255.0
+        let g = CGFloat((int >> 8) & 0xff) / 255.0
+        let b = CGFloat(int & 0xff) / 255.0
+        self.init(srgbRed: r, green: g, blue: b, alpha: 1)
     }
 }

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -50,7 +50,7 @@ struct FilesTabView: View {
             return AnyView(
                 Button { onSelectFile(node) } label: {
                     HStack(spacing: 6) {
-                        FileTypeIconView(filename: node.name, size: 13)
+                        FileTypeIconView(filename: node.name, size: 18)
                         Text(node.name)
                             .font(.system(size: 11.5, design: .monospaced))
                             .foregroundColor(theme.color("fg"))

--- a/AlasTests/FileTypeIconTests.swift
+++ b/AlasTests/FileTypeIconTests.swift
@@ -4,45 +4,48 @@ import Testing
 struct FileTypeIconTests {
     @Test func extensionLookupReturnsRustEntry() {
         let info = FileTypeIcon.info(for: "tab_bar.rs")
-        #expect(info.label == "rs")
+        #expect(info.symbol == "\u{E68B}")
         #expect(info.hex == "D97558")
         #expect(info.kind == .ext)
+        #expect(info.style == .nerdFont)
     }
 
     @Test func extensionLookupIsCaseInsensitive() {
         let info = FileTypeIcon.info(for: "Main.SWIFT")
-        #expect(info.label == "swift")
+        #expect(info.symbol == "\u{E699}")
         #expect(info.hex == "F05138")
     }
 
     @Test func filenameOverrideBeatsExtension() {
         // cargo.toml should resolve to the Rust override, not the generic .toml entry.
         let info = FileTypeIcon.info(for: "Cargo.toml")
-        #expect(info.label == "rs")
+        #expect(info.symbol == "\u{E68B}")
         #expect(info.hex == "D97558")
         #expect(info.kind == .filename)
     }
 
     @Test func unknownExtensionFallsBackToGrayTileWithTruncatedExt() {
         let info = FileTypeIcon.info(for: "weird.zzz")
-        #expect(info.label == "zzz")
+        #expect(info.symbol == "zzz")
         #expect(info.kind == .fallbackExt)
+        #expect(info.style == .text)
     }
 
     @Test func unknownExtensionTruncatesToThreeChars() {
         let info = FileTypeIcon.info(for: "thing.abcdef")
-        #expect(info.label == "abc")
+        #expect(info.symbol == "abc")
         #expect(info.kind == .fallbackExt)
     }
 
     @Test func fileWithNoExtensionReturnsGenericMarker() {
         let info = FileTypeIcon.info(for: "Makefile")
-        #expect(info.kind == .generic)
+        #expect(info.kind == .filename)
+        #expect(info.symbol == "\u{E673}")
     }
 
     @Test func dotfileWithKnownNameMatchesFilename() {
         let info = FileTypeIcon.info(for: ".gitignore")
-        #expect(info.label == "git")
+        #expect(info.symbol == "\u{E65D}")
         #expect(info.kind == .filename)
     }
 
@@ -51,5 +54,34 @@ struct FileTypeIconTests {
         // no filename override, no extension to split on. Treat as generic.
         let info = FileTypeIcon.info(for: ".unknownrc")
         #expect(info.kind == .generic)
+        #expect(info.symbol == "\u{F15B}")
+        #expect(info.style == .nerdFont)
+    }
+
+    @Test func popularLanguagesUseNerdFontGlyphs() {
+        #expect(FileTypeIcon.info(for: "Main.kt").symbol == "\u{E634}")
+        #expect(FileTypeIcon.info(for: "App.java").symbol == "\u{E256}")
+        #expect(FileTypeIcon.info(for: "server.ts").symbol == "\u{E628}")
+        #expect(FileTypeIcon.info(for: "component.jsx").symbol == "\u{E625}")
+        #expect(FileTypeIcon.info(for: "Dockerfile").symbol == "\u{E650}")
+    }
+
+    @Test func markdownAndJSONUseIconGlyphsInsteadOfTextLabels() {
+        #expect(FileTypeIcon.info(for: "README.md").symbol == "\u{F48A}")
+        #expect(FileTypeIcon.info(for: "package.json").symbol == "\u{E616}")
+        #expect(FileTypeIcon.info(for: "data.json").symbol == "\u{E60B}")
+    }
+
+    @Test func supplementaryPlaneGlyphsResolveThroughCoreTextPathBuilder() {
+        let terraform = FileTypeIcon.info(for: "main.tf")
+        #expect(terraform.symbol == "\u{F1062}")
+        #expect(NerdFontGlyphPath.path(for: terraform.symbol) != nil)
+    }
+
+    @Test func cFamilyExtensionsKeepExplicitMappings() {
+        #expect(FileTypeIcon.info(for: "main.c").symbol == "\u{E649}")
+        #expect(FileTypeIcon.info(for: "foo.h").symbol == "\u{E649}")
+        #expect(FileTypeIcon.info(for: "widget.cpp").symbol == "\u{E646}")
+        #expect(FileTypeIcon.info(for: "view.hpp").symbol == "\u{E646}")
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -46,6 +46,9 @@ targets:
         buildPhase: resources
       - path: Alas/Resources/Assets.xcassets
         buildPhase: resources
+      - path: ThirdParty/ghostty/src/font/res/JetBrainsMonoNerdFont-Regular.ttf
+        buildPhase: resources
+        optional: true
     info:
       path: Alas/Resources/Info.plist
       properties:


### PR DESCRIPTION
## Summary
- Bundle and register the Nerd Font used for file type icons.
- Replace text badge file-type labels with Nerd Font glyph mappings for popular languages, frameworks, config, and tooling files.
- Render mapped glyphs through CoreText using real glyph bounds so icons are centered and visible in a larger file row slot.

## Validation
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/FileTypeIconTests test`

## Note
The full test suite was run during development and failed on `DebounceTimerTests.firesOnceAfterDelay`; the new `FileTypeIconTests` passed in that run.