### PR TITLE
Add awaiting harness ping notification

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */; };
+		8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */; };
 		8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2AC0F8B3A1B75239995AC /* AppState.swift */; };
 		90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */; };
 		90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */; };
@@ -484,6 +485,7 @@
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
 		F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchDialog.swift; sourceTree = "<group>"; };
+		F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessServiceTests.swift; sourceTree = "<group>"; };
 		F9F85B92952C963DCF136315 /* HarnessDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetector.swift; sourceTree = "<group>"; };
 		FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
@@ -555,6 +557,7 @@
 				B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */,
 				271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */,
 				F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */,
+				F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */,
 				A8820E4289EEB1ADCA9E490F /* HookEventTests.swift */,
 				954060BD47A1EFF3105F44EB /* HookInstallerTests.swift */,
 				A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */,
@@ -1437,6 +1440,7 @@
 				A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */,
 				9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */,
 				D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */,
+				8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */,
 				A7BDA44A8E4364C4C335C4DA /* HookEventTests.swift in Sources */,
 				0294EF678CFA762C8B5D381B /* HookInstallerTests.swift in Sources */,
 				D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -176,13 +176,18 @@ final class AppState {
         // notifications off in a previous session get them again until they
         // re-toggle.
         harness.notifications.setEnabled(config.harness.notifyOnFinish)
-        harness.start { [weak self] sessionId in
-            guard let self else { return nil }
-            for s in self.terminal.registry.all where s.id == sessionId {
-                return (projectId: s.projectId, worktreeId: s.worktreeId)
+        harness.start(
+            stateLookup: { [weak self] sessionId in
+                guard let self else { return nil }
+                for s in self.terminal.registry.all where s.id == sessionId {
+                    return (projectId: s.projectId, worktreeId: s.worktreeId)
+                }
+                return nil
+            },
+            shouldNotifyOnAwaiting: { [weak self] in
+                self?.config.harness.notifyOnAwaiting ?? true
             }
-            return nil
-        }
+        )
         harness.onClickThrough = { [weak self] _, worktreeId, _ in
             self?.selectedWorktreeId = worktreeId
             NSApp.activate(ignoringOtherApps: true)

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -24,7 +24,10 @@ final class HarnessService {
         watcher = HookWatcher(dir: Paths.hookDir)
     }
 
-    func start(stateLookup: @escaping (String) -> (projectId: String, worktreeId: String)?) {
+    func start(
+        stateLookup: @escaping (String) -> (projectId: String, worktreeId: String)?,
+        shouldNotifyOnAwaiting: @escaping () -> Bool = { true }
+    ) {
         detector.onUpdate = { [weak self] sid, kind in
             guard let self else { return }
             if let kind {
@@ -47,17 +50,37 @@ final class HarnessService {
         }
 
         watcher.onEvent = { [weak self] event in
-            guard let self else { return }
-            self.stateBySession[event.sessionId] = event.kind == "stop" ? "done" : "awaiting"
-            if event.kind == "stop", let kind = self.harnessBySession[event.sessionId],
-               let lookup = stateLookup(event.sessionId) {
-                self.notifications.notifyHarnessFinished(
-                    harness: kind, summary: event.summary,
-                    projectId: lookup.projectId, worktreeId: lookup.worktreeId, sessionId: event.sessionId
-                )
-            }
+            self?.handleHookEvent(
+                event,
+                stateLookup: stateLookup,
+                shouldNotifyOnAwaiting: shouldNotifyOnAwaiting
+            )
         }
         watcher.start()
+    }
+
+    func handleHookEvent(
+        _ event: HookEvent,
+        stateLookup: (String) -> (projectId: String, worktreeId: String)?,
+        shouldNotifyOnAwaiting: () -> Bool
+    ) {
+        let previousState = stateBySession[event.sessionId]
+        stateBySession[event.sessionId] = event.kind == "stop" ? "done" : "awaiting"
+
+        if event.kind == "awaiting" {
+            if previousState != "awaiting", shouldNotifyOnAwaiting() {
+                notifications.playAwaitingPing()
+            }
+            return
+        }
+
+        if event.kind == "stop", let kind = harnessBySession[event.sessionId],
+           let lookup = stateLookup(event.sessionId) {
+            notifications.notifyHarnessFinished(
+                harness: kind, summary: event.summary,
+                projectId: lookup.projectId, worktreeId: lookup.worktreeId, sessionId: event.sessionId
+            )
+        }
     }
 
     func stop() {

--- a/Alas/Sources/Harness/NotificationService.swift
+++ b/Alas/Sources/Harness/NotificationService.swift
@@ -6,6 +6,15 @@ final class NotificationService {
     let delegate = NotificationDelegate()
     private let center = UNUserNotificationCenter.current()
     private var enabled: Bool = true
+    var awaitingPingPlayer: () -> Void = {
+        DispatchQueue.main.async {
+            if let sound = NSSound(named: NSSound.Name("Tink")) {
+                sound.play()
+            } else {
+                NSSound.beep()
+            }
+        }
+    }
 
     func setup(onClick: @escaping (String, String, String) -> Void) {
         center.delegate = delegate
@@ -14,6 +23,10 @@ final class NotificationService {
     }
 
     func setEnabled(_ on: Bool) { enabled = on }
+
+    func playAwaitingPing() {
+        awaitingPingPlayer()
+    }
 
     func notifyHarnessFinished(harness: HarnessKind, summary: String?,
                                projectId: String, worktreeId: String, sessionId: String) {

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -53,6 +53,22 @@ struct AppConfig: Codable, Equatable {
 
     struct Harness: Codable, Equatable {
         var notifyOnFinish: Bool
+        var notifyOnAwaiting: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case notifyOnFinish, notifyOnAwaiting
+        }
+
+        init(notifyOnFinish: Bool, notifyOnAwaiting: Bool) {
+            self.notifyOnFinish = notifyOnFinish
+            self.notifyOnAwaiting = notifyOnAwaiting
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            notifyOnFinish = (try? c.decode(Bool.self, forKey: .notifyOnFinish)) ?? true
+            notifyOnAwaiting = (try? c.decode(Bool.self, forKey: .notifyOnAwaiting)) ?? true
+        }
     }
 
     struct Code: Codable, Equatable {
@@ -110,7 +126,7 @@ struct AppConfig: Codable, Equatable {
             scrollbackLines: 10000,
             bell: "visual"
         ),
-        harness: Harness(notifyOnFinish: true),
+        harness: Harness(notifyOnFinish: true, notifyOnAwaiting: true),
         code: Code(
             fontFamily: "SF Mono",
             fontSize: 13,

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -108,6 +108,10 @@ struct TerminalPane: View {
                             state.harness.notifications.setEnabled($0) }
                         ))
                     }
+                    SettingsRow(name: "Ping when AI harness needs input",
+                                desc: "Play a short sound when a detected harness is waiting for input.") {
+                        AlasToggle(on: state.bind(\.harness.notifyOnAwaiting))
+                    }
                     ForEach(HarnessKind.allCases) { kind in
                         SettingsRow(name: "Install hook for \(kind.displayName)") {
                             HStack {

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -23,8 +23,46 @@ struct AppConfigTests {
         #expect(cfg.rightPaneVisible == true)
         #expect(cfg.terminal.shell == "/bin/zsh")
         #expect(cfg.harness.notifyOnFinish == true)
+        #expect(cfg.harness.notifyOnAwaiting == true)
         #expect(cfg.worktrees.rootPath == "~/.alas/worktrees")
         #expect(cfg.worktrees.branchPrefix == "feature/")
+    }
+
+    @Test func decodeOldHarnessConfigDefaultsAwaitingPingOn() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "density": "comfortable",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/code/.worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": false}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.harness.notifyOnFinish == false)
+        #expect(cfg.harness.notifyOnAwaiting == true)
     }
 
     @Test func decodePreservesConfiguredWorktreeRoot() throws {

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -1,0 +1,36 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct HarnessServiceTests {
+    @Test func awaitingPingPlaysOnlyWhenEnteringAwaitingState() {
+        let service = HarnessService()
+        var pingCount = 0
+        service.notifications.awaitingPingPlayer = {
+            pingCount += 1
+        }
+
+        let awaiting = HookEvent(sessionId: "session-1", kind: "awaiting", timestamp: Date(), summary: nil)
+
+        service.handleHookEvent(awaiting, stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { true })
+        service.handleHookEvent(awaiting, stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { true })
+
+        #expect(service.stateBySession["session-1"] == "awaiting")
+        #expect(pingCount == 1)
+    }
+
+    @Test func awaitingPingRespectsPreference() {
+        let service = HarnessService()
+        var pingCount = 0
+        service.notifications.awaitingPingPlayer = {
+            pingCount += 1
+        }
+
+        let awaiting = HookEvent(sessionId: "session-1", kind: "awaiting", timestamp: Date(), summary: nil)
+
+        service.handleHookEvent(awaiting, stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false })
+
+        #expect(service.stateBySession["session-1"] == "awaiting")
+        #expect(pingCount == 0)
+    }
+}


### PR DESCRIPTION
## Summary

- Add a short, pleasant ping sound when a harness enters the `"awaiting"` state (agent needs user input)
- New persisted preference `harness.notifyOnAwaiting` (default `true`) with backward-compatible decoding
- Settings toggle in the Harness section to enable/disable the ping
- State-transition deduplication: ping only plays on transition *into* awaiting, not on duplicate events
- Uses macOS system sound `"Tink"` with `NSSound.beep()` fallback — no bundled assets needed

## Test plan

- [x] Config defaults include `notifyOnAwaiting == true`
- [x] Old config JSON without `notifyOnAwaiting` decodes successfully (migration test)
- [x] Duplicate awaiting events for the same session only trigger one ping (dedupe test)
- [x] Ping suppressed when `notifyOnAwaiting == false` (preference test)
- [ ] Manual: trigger an awaiting harness event and confirm one ping plays on transition
- [ ] Manual: trigger duplicate awaiting events and confirm no repeated ping
- [ ] Manual: disable setting and confirm ping is suppressed

Closes #771