### PR TITLE
Alas: move search button to left sidebar header

### DIFF
--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -3,15 +3,14 @@ import SwiftUI
 struct SidebarHeaderView: View {
     let onSettings: () -> Void
     let onAddProject: () -> Void
+    let onSearch: () -> Void
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(alignment: .center, spacing: 12) {
             TrafficLights()
             Spacer()
-            // Search will return here when there's an actual search handler.
-            // Previously rendered as a no-op ToolbarBtn(action: {}) which
-            // codex flagged correctly as misleading.
-            HStack(spacing: 2) {
+            HStack(alignment: .center, spacing: 2) {
+                ToolbarBtn(icon: "search", action: onSearch)
                 ToolbarBtn(icon: "folder-plus", action: onAddProject)
                 ToolbarBtn(icon: "gear", action: onSettings)
             }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -13,7 +13,13 @@ struct SidebarView: View {
         ZStack {
             VisualEffectView(material: .fullScreenUI, blendingMode: .behindWindow)
             VStack(spacing: 0) {
-                SidebarHeaderView(onSettings: onSettings, onAddProject: onAddProject)
+                SidebarHeaderView(
+                    onSettings: onSettings,
+                    onAddProject: onAddProject,
+                    onSearch: {
+                        NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
+                    }
+                )
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {
                         ForEach(state.projects) { project in


### PR DESCRIPTION
## Summary

- Add a clickable **search button** (`ToolbarBtn` with `"search"` icon) to the left sidebar header, placed alongside the existing add-project and settings buttons
- Wire the button to the existing `.alasOpenSearch` notification path (same mechanism used by the `Cmd+P` keyboard shortcut)
- Remove the stale comment saying search would return when a handler existed — the handler already works end-to-end
- Apply explicit `.center` alignment to both `HStack` rows so the three action icons (search, add project, settings) and the traffic lights align consistently

## Files changed

| File | Change |
|------|--------|
| `Alas/Sources/Sidebar/SidebarHeaderView.swift` | Added `onSearch` closure parameter, inserted search `ToolbarBtn`, removed stale comment, set `alignment: .center` on both `HStack`s |
| `Alas/Sources/Sidebar/SidebarView.swift` | Passed `onSearch` closure that posts `.alasOpenSearch` notification |

## Notes

- No new state, models, or dependencies introduced — reuses the app's existing notification-based search infrastructure
- `xcodegen` regenerated the project successfully
- Full `xcodebuild` validation was blocked by a prerequisite Ghostty dependency artifact (`GhosttyKit.xcframework`) that requires a first-time Zig build (`scripts/build-ghostty.sh`), not by this change