### PR TITLE
Add clickable awaiting harness notifications

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */; };
 		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
 		3DC6518A9050D1029D4D99A4 /* aider.sh in Resources */ = {isa = PBXBuildFile; fileRef = 2AC91D744E42A7C071268B74 /* aider.sh */; };
+		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
@@ -442,6 +443,7 @@
 		BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
+		C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
 		C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTabView.swift; sourceTree = "<group>"; };
@@ -586,6 +588,7 @@
 				B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */,
 				DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */,
 				E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */,
+				C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
@@ -1496,6 +1499,7 @@
 				8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */,
 				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
+				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,

--- a/Alas/Resources/HookScripts/aider.sh
+++ b/Alas/Resources/HookScripts/aider.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Alas hook for Aider completion. Hardcoded summary today; switch to python3
-# JSON serialization for consistency with the other hooks (and to ensure any
-# future caller-provided summary is escaped correctly).
+# Alas hook for Aider completion/awaiting events. By default this emits
+# completion; callers that have a reliable waiting signal can pass `--kind awaiting`.
 set -eu
 if [ -z "${ALAS_HOOK_DIR:-}" ] || [ -z "${ALAS_SESSION_ID:-}" ]; then exit 0; fi
 TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -9,14 +8,28 @@ mkdir -p "$ALAS_HOOK_DIR"
 # Microsecond precision: BSD `date +%s` collides on same-second events.
 TS_US=$(python3 -c 'import time; print(int(time.time()*1_000_000))')
 OUT="$ALAS_HOOK_DIR/$TS_US-$ALAS_SESSION_ID.json"
-SUMMARY="Aider finished" \
+KIND="${ALAS_HOOK_KIND:-stop}"
+if [ "${1:-}" = "--kind" ]; then
+    KIND="${2:-stop}"
+    shift 2
+elif [ "${1:-}" = "awaiting" ] || [ "${1:-}" = "stop" ]; then
+    KIND="$1"
+    shift
+fi
+if [ "$KIND" = "awaiting" ]; then
+    DEFAULT_SUMMARY="Aider is waiting for input"
+else
+    DEFAULT_SUMMARY="Aider finished"
+fi
+SUMMARY="${1:-$DEFAULT_SUMMARY}" \
 SESSION_ID="$ALAS_SESSION_ID" \
 TS="$TS" \
+KIND="$KIND" \
 python3 -c '
 import json, os
 print(json.dumps({
     "session_id": os.environ["SESSION_ID"],
-    "kind": "stop",
+    "kind": os.environ["KIND"],
     "timestamp": os.environ["TS"],
     "summary": os.environ["SUMMARY"],
 }))

--- a/Alas/Resources/HookScripts/claude-code.sh
+++ b/Alas/Resources/HookScripts/claude-code.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Alas hook for Claude Code Stop event.
+# Alas hook for Claude Code Stop and Notification events.
 # Receives event JSON on stdin from Claude's hook system, writes a HookEvent JSON
 # into $ALAS_HOOK_DIR for Alas to ingest.
 set -eu
@@ -8,6 +8,32 @@ if [ -z "${ALAS_SESSION_ID:-}" ]; then exit 0; fi
 
 INPUT=$(cat || true)
 TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+KIND=$(INPUT="$INPUT" python3 -c '
+import json, os
+try:
+    payload = json.loads(os.environ.get("INPUT", "") or "{}")
+except Exception:
+    payload = {}
+event = payload.get("hook_event_name")
+if event == "Notification":
+    print("awaiting")
+else:
+    print("stop")
+')
+
+SUMMARY=$(INPUT="$INPUT" python3 -c '
+import json, os
+try:
+    payload = json.loads(os.environ.get("INPUT", "") or "{}")
+except Exception:
+    payload = {}
+message = payload.get("message")
+if isinstance(message, str) and message:
+    print(message[:500])
+else:
+    print(os.environ.get("INPUT", "")[:500])
+')
 
 # Microsecond precision: BSD `date +%s` collides on same-second events,
 # which then race in FSEventStream and cause one hook to overwrite another.
@@ -20,14 +46,15 @@ mkdir -p "$ALAS_HOOK_DIR"
 # `sed 's/"/\\"/g' | tr -d '\n'` left backslashes, tabs, etc. unescaped, which
 # made HookEvent.decode silently drop those events. python3 is preinstalled on
 # every supported macOS.
-SUMMARY="${INPUT:0:500}" \
+SUMMARY="$SUMMARY" \
 SESSION_ID="$ALAS_SESSION_ID" \
 TS="$TS" \
+KIND="$KIND" \
 python3 -c '
 import json, os
 print(json.dumps({
     "session_id": os.environ["SESSION_ID"],
-    "kind": "stop",
+    "kind": os.environ["KIND"],
     "timestamp": os.environ["TS"],
     "summary": os.environ["SUMMARY"],
 }))

--- a/Alas/Resources/HookScripts/claude-code.sh
+++ b/Alas/Resources/HookScripts/claude-code.sh
@@ -17,10 +17,18 @@ except Exception:
     payload = {}
 event = payload.get("hook_event_name")
 if event == "Notification":
-    print("awaiting")
+    notification_type = payload.get("notification_type")
+    if notification_type in ("permission_prompt", "idle_prompt", "elicitation_dialog"):
+        print("awaiting")
+    else:
+        print("ignore")
 else:
     print("stop")
 ')
+
+if [ "$KIND" = "ignore" ]; then
+    exit 0
+fi
 
 SUMMARY=$(INPUT="$INPUT" python3 -c '
 import json, os

--- a/Alas/Resources/HookScripts/codex-cli.sh
+++ b/Alas/Resources/HookScripts/codex-cli.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Alas hook for Codex CLI completion. Caller invokes this with a summary as $1.
+# Alas hook for Codex CLI completion/awaiting events. By default this emits
+# completion; callers that have a reliable waiting signal can pass `--kind awaiting`.
 set -eu
 if [ -z "${ALAS_HOOK_DIR:-}" ] || [ -z "${ALAS_SESSION_ID:-}" ]; then exit 0; fi
 TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -7,17 +8,31 @@ mkdir -p "$ALAS_HOOK_DIR"
 # Microsecond precision: BSD `date +%s` collides on same-second events.
 TS_US=$(python3 -c 'import time; print(int(time.time()*1_000_000))')
 OUT="$ALAS_HOOK_DIR/$TS_US-$ALAS_SESSION_ID.json"
+KIND="${ALAS_HOOK_KIND:-stop}"
+if [ "${1:-}" = "--kind" ]; then
+    KIND="${2:-stop}"
+    shift 2
+elif [ "${1:-}" = "awaiting" ] || [ "${1:-}" = "stop" ]; then
+    KIND="$1"
+    shift
+fi
 # Serialize via python3 so summaries with embedded quotes / backslashes /
 # newlines produce valid JSON instead of silently invalid output that
 # HookEvent.decode would drop.
-SUMMARY="${1:-Codex finished}" \
+if [ "$KIND" = "awaiting" ]; then
+    DEFAULT_SUMMARY="Codex is waiting for input"
+else
+    DEFAULT_SUMMARY="Codex finished"
+fi
+SUMMARY="${1:-$DEFAULT_SUMMARY}" \
 SESSION_ID="$ALAS_SESSION_ID" \
 TS="$TS" \
+KIND="$KIND" \
 python3 -c '
 import json, os
 print(json.dumps({
     "session_id": os.environ["SESSION_ID"],
-    "kind": "stop",
+    "kind": os.environ["KIND"],
     "timestamp": os.environ["TS"],
     "summary": os.environ["SUMMARY"],
 }))

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -30,18 +30,7 @@ final class HarnessService {
     ) {
         detector.onUpdate = { [weak self] sid, kind in
             guard let self else { return }
-            if let kind {
-                if self.harnessBySession[sid] != kind {
-                    self.harnessBySession[sid] = kind
-                    self.stateBySession[sid] = "running"
-                }
-            } else {
-                // Process exited but the stop-hook event may still be in
-                // flight. Drop the running-state badge so the UI reflects
-                // "not actively running", but KEEP harnessBySession so the
-                // upcoming hook can attribute its kind.
-                self.stateBySession.removeValue(forKey: sid)
-            }
+            self.recordHarnessDetection(sessionId: sid, kind: kind)
         }
         detector.start()
 
@@ -59,6 +48,21 @@ final class HarnessService {
         watcher.start()
     }
 
+    func recordHarnessDetection(sessionId: String, kind: HarnessKind?) {
+        if let kind {
+            if harnessBySession[sessionId] != kind {
+                harnessBySession[sessionId] = kind
+                stateBySession[sessionId] = "running"
+            }
+        } else {
+            // Process exited but the stop-hook event may still be in
+            // flight. Drop the running-state badge so the UI reflects
+            // "not actively running", but KEEP harnessBySession so the
+            // upcoming hook can attribute its kind.
+            stateBySession.removeValue(forKey: sessionId)
+        }
+    }
+
     func handleHookEvent(
         _ event: HookEvent,
         stateLookup: (String) -> (projectId: String, worktreeId: String)?,
@@ -68,8 +72,15 @@ final class HarnessService {
         stateBySession[event.sessionId] = event.kind == "stop" ? "done" : "awaiting"
 
         if event.kind == "awaiting" {
-            if previousState != "awaiting", shouldNotifyOnAwaiting() {
-                notifications.playAwaitingPing()
+            if previousState != "awaiting", shouldNotifyOnAwaiting(),
+               let kind = harnessBySession[event.sessionId],
+               let lookup = stateLookup(event.sessionId) {
+                notifications.notifyHarnessAwaiting(
+                    harness: kind,
+                    projectId: lookup.projectId,
+                    worktreeId: lookup.worktreeId,
+                    sessionId: event.sessionId
+                )
             }
             return
         }

--- a/Alas/Sources/Harness/HookInstaller.swift
+++ b/Alas/Sources/Harness/HookInstaller.swift
@@ -29,11 +29,19 @@ enum HookInstaller {
         return dest
     }
 
-    /// Install the Claude Code Stop hook into ~/.claude/settings.json.
-    /// Idempotent — does nothing if a hook with the same path already exists.
-    static func installClaudeCodeStopHook(scriptPath: URL) throws -> Bool {
+    /// Install the Claude Code Stop and Notification hooks into ~/.claude/settings.json.
+    /// Idempotent — does nothing for events that already have a hook with the same path.
+    static func installClaudeCodeHooks(scriptPath: URL) throws -> Bool {
         let settingsPath = (NSString("~/.claude/settings.json") as NSString).expandingTildeInPath
-        let url = URL(fileURLWithPath: settingsPath)
+        return try installClaudeCodeHooks(scriptPath: scriptPath, settingsURL: URL(fileURLWithPath: settingsPath))
+    }
+
+    static func installClaudeCodeStopHook(scriptPath: URL) throws -> Bool {
+        try installClaudeCodeHooks(scriptPath: scriptPath)
+    }
+
+    static func installClaudeCodeHooks(scriptPath: URL, settingsURL url: URL) throws -> Bool {
+        let settingsPath = url.path
         try FileManager.default.createDirectory(atPath: (settingsPath as NSString).deletingLastPathComponent,
                                                 withIntermediateDirectories: true)
         var json: [String: Any]
@@ -55,23 +63,29 @@ enum HookInstaller {
             json = [:]
         }
         var hooks = (json["hooks"] as? [String: Any]) ?? [:]
-        var stop = (hooks["Stop"] as? [[String: Any]]) ?? []
         let entry: [String: Any] = [
-            "matcher": "*",
             "hooks": [["type": "command", "command": scriptPath.path]]
         ]
-        let alreadyInstalled = stop.contains { dict in
-            (dict["hooks"] as? [[String: Any]])?.contains { ($0["command"] as? String) == scriptPath.path } ?? false
+
+        var changed = false
+        for eventName in ["Stop", "Notification"] {
+            var eventHooks = (hooks[eventName] as? [[String: Any]]) ?? []
+            let alreadyInstalled = eventHooks.contains { dict in
+                (dict["hooks"] as? [[String: Any]])?.contains { ($0["command"] as? String) == scriptPath.path } ?? false
+            }
+            if !alreadyInstalled {
+                eventHooks.append(entry)
+                hooks[eventName] = eventHooks
+                changed = true
+            }
         }
-        if !alreadyInstalled {
-            stop.append(entry)
-            hooks["Stop"] = stop
+
+        if changed {
             json["hooks"] = hooks
             let data = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
             try data.write(to: url, options: .atomic)
-            return true
         }
-        return false
+        return changed
     }
 
     /// For Codex / Aider, the install is "PATH the script and call it from the user's

--- a/Alas/Sources/Harness/HookInstaller.swift
+++ b/Alas/Sources/Harness/HookInstaller.swift
@@ -63,21 +63,62 @@ enum HookInstaller {
             json = [:]
         }
         var hooks = (json["hooks"] as? [String: Any]) ?? [:]
-        let entry: [String: Any] = [
-            "hooks": [["type": "command", "command": scriptPath.path]]
+        let commandHooks: [[String: Any]] = [
+            ["type": "command", "command": scriptPath.path]
+        ]
+        let stopEntry: [String: Any] = [
+            "hooks": commandHooks
+        ]
+        let notificationEntry: [String: Any] = [
+            "matcher": "permission_prompt|idle_prompt|elicitation_dialog",
+            "hooks": commandHooks
+        ]
+        let entries = [
+            ("Stop", stopEntry),
+            ("Notification", notificationEntry)
         ]
 
+        func hasCommand(_ dict: [String: Any]) -> Bool {
+            (dict["hooks"] as? [[String: Any]])?.contains {
+                ($0["command"] as? String) == scriptPath.path
+            } ?? false
+        }
+
+        func matcherChanged(current: [String: Any], expected: [String: Any]) -> Bool {
+            (current["matcher"] as? String) != (expected["matcher"] as? String)
+        }
+
+        func hooksChanged(current: [String: Any], expected: [String: Any]) -> Bool {
+            guard let currentHooks = current["hooks"] as? [[String: Any]],
+                  let expectedHooks = expected["hooks"] as? [[String: Any]] else {
+                return true
+            }
+            guard currentHooks.count == expectedHooks.count else {
+                return true
+            }
+            return zip(currentHooks, expectedHooks).contains { current, expected in
+                (current["type"] as? String) != (expected["type"] as? String)
+                    || (current["command"] as? String) != (expected["command"] as? String)
+            }
+        }
+
         var changed = false
-        for eventName in ["Stop", "Notification"] {
+        for (eventName, entry) in entries {
             var eventHooks = (hooks[eventName] as? [[String: Any]]) ?? []
-            let alreadyInstalled = eventHooks.contains { dict in
-                (dict["hooks"] as? [[String: Any]])?.contains { ($0["command"] as? String) == scriptPath.path } ?? false
+            if let existingIndex = eventHooks.firstIndex(where: hasCommand) {
+                let existing = eventHooks[existingIndex]
+                if matcherChanged(current: existing, expected: entry)
+                    || hooksChanged(current: existing, expected: entry) {
+                    eventHooks[existingIndex] = entry
+                    hooks[eventName] = eventHooks
+                    changed = true
+                }
+                continue
             }
-            if !alreadyInstalled {
-                eventHooks.append(entry)
-                hooks[eventName] = eventHooks
-                changed = true
-            }
+
+            eventHooks.append(entry)
+            hooks[eventName] = eventHooks
+            changed = true
         }
 
         if changed {

--- a/Alas/Sources/Harness/HookInstaller.swift
+++ b/Alas/Sources/Harness/HookInstaller.swift
@@ -73,9 +73,9 @@ enum HookInstaller {
             "matcher": "permission_prompt|idle_prompt|elicitation_dialog",
             "hooks": commandHooks
         ]
-        let entries = [
-            ("Stop", stopEntry),
-            ("Notification", notificationEntry)
+        let entries: [(eventName: String, entry: [String: Any], matcher: String?)] = [
+            ("Stop", stopEntry, nil),
+            ("Notification", notificationEntry, "permission_prompt|idle_prompt|elicitation_dialog")
         ]
 
         func hasCommand(_ dict: [String: Any]) -> Bool {
@@ -88,28 +88,12 @@ enum HookInstaller {
             (current["matcher"] as? String) != (expected["matcher"] as? String)
         }
 
-        func hooksChanged(current: [String: Any], expected: [String: Any]) -> Bool {
-            guard let currentHooks = current["hooks"] as? [[String: Any]],
-                  let expectedHooks = expected["hooks"] as? [[String: Any]] else {
-                return true
-            }
-            guard currentHooks.count == expectedHooks.count else {
-                return true
-            }
-            return zip(currentHooks, expectedHooks).contains { current, expected in
-                (current["type"] as? String) != (expected["type"] as? String)
-                    || (current["command"] as? String) != (expected["command"] as? String)
-            }
-        }
-
         var changed = false
-        for (eventName, entry) in entries {
+        for (eventName, entry, matcher) in entries {
             var eventHooks = (hooks[eventName] as? [[String: Any]]) ?? []
             if let existingIndex = eventHooks.firstIndex(where: hasCommand) {
-                let existing = eventHooks[existingIndex]
-                if matcherChanged(current: existing, expected: entry)
-                    || hooksChanged(current: existing, expected: entry) {
-                    eventHooks[existingIndex] = entry
+                if let matcher, matcherChanged(current: eventHooks[existingIndex], expected: entry) {
+                    eventHooks[existingIndex]["matcher"] = matcher
                     hooks[eventName] = eventHooks
                     changed = true
                 }

--- a/Alas/Sources/Harness/NotificationService.swift
+++ b/Alas/Sources/Harness/NotificationService.swift
@@ -6,12 +6,23 @@ final class NotificationService {
     let delegate = NotificationDelegate()
     private let center = UNUserNotificationCenter.current()
     private var enabled: Bool = true
+    var notificationAdder: (UNNotificationRequest) -> Void
     var awaitingPingPlayer: () -> Void = {
         DispatchQueue.main.async {
             if let sound = NSSound(named: NSSound.Name("Tink")) {
                 sound.play()
             } else {
                 NSSound.beep()
+            }
+        }
+    }
+
+    init(notificationAdder: ((UNNotificationRequest) -> Void)? = nil) {
+        if let notificationAdder {
+            self.notificationAdder = notificationAdder
+        } else {
+            self.notificationAdder = { request in
+                UNUserNotificationCenter.current().add(request)
             }
         }
     }
@@ -28,6 +39,20 @@ final class NotificationService {
         awaitingPingPlayer()
     }
 
+    func notifyHarnessAwaiting(harness: HarnessKind,
+                               projectId: String, worktreeId: String, sessionId: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "\(harness.displayName) needs input"
+        content.body = "Session is waiting for you."
+        content.userInfo = [
+            "projectId": projectId,
+            "worktreeId": worktreeId,
+            "sessionId": sessionId
+        ]
+        let req = UNNotificationRequest(identifier: "\(sessionId)-awaiting", content: content, trigger: nil)
+        notificationAdder(req)
+    }
+
     func notifyHarnessFinished(harness: HarnessKind, summary: String?,
                                projectId: String, worktreeId: String, sessionId: String) {
         guard enabled else { return }
@@ -40,6 +65,6 @@ final class NotificationService {
             "sessionId": sessionId
         ]
         let req = UNNotificationRequest(identifier: sessionId, content: content, trigger: nil)
-        center.add(req)
+        notificationAdder(req)
     }
 }

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -108,8 +108,8 @@ struct TerminalPane: View {
                             state.harness.notifications.setEnabled($0) }
                         ))
                     }
-                    SettingsRow(name: "Ping when AI harness needs input",
-                                desc: "Play a short sound when a detected harness is waiting for input.") {
+                    SettingsRow(name: "Notify when AI harness needs input",
+                                desc: "Show a clickable notification when a detected harness is waiting for input.") {
                         AlasToggle(on: state.bind(\.harness.notifyOnAwaiting))
                     }
                     ForEach(HarnessKind.allCases) { kind in
@@ -134,7 +134,7 @@ struct TerminalPane: View {
             let scriptURL = try HookInstaller.installWrapper(for: kind)
             switch kind {
             case .claudeCode:
-                let added = try HookInstaller.installClaudeCodeStopHook(scriptPath: scriptURL)
+                let added = try HookInstaller.installClaudeCodeHooks(scriptPath: scriptURL)
                 hookStatus[kind] = added ? "Installed at \(scriptURL.path)"
                                           : "Already installed at \(scriptURL.path)"
             case .codex, .aider:

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -1,36 +1,77 @@
 import Testing
 import Foundation
+import UserNotifications
 @testable import Alas
 
 struct HarnessServiceTests {
-    @Test func awaitingPingPlaysOnlyWhenEnteringAwaitingState() {
+    @Test func awaitingNotificationPostsOnlyWhenEnteringAwaitingState() {
         let service = HarnessService()
-        var pingCount = 0
-        service.notifications.awaitingPingPlayer = {
-            pingCount += 1
+        var requests: [UNNotificationRequest] = []
+        service.notifications.notificationAdder = { request in
+            requests.append(request)
         }
+        service.recordHarnessDetection(sessionId: "session-1", kind: .claudeCode)
 
         let awaiting = HookEvent(sessionId: "session-1", kind: "awaiting", timestamp: Date(), summary: nil)
 
-        service.handleHookEvent(awaiting, stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { true })
-        service.handleHookEvent(awaiting, stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { true })
+        service.handleHookEvent(
+            awaiting,
+            stateLookup: { _ in (projectId: "project-1", worktreeId: "worktree-1") },
+            shouldNotifyOnAwaiting: { true }
+        )
+        service.handleHookEvent(
+            awaiting,
+            stateLookup: { _ in (projectId: "project-1", worktreeId: "worktree-1") },
+            shouldNotifyOnAwaiting: { true }
+        )
 
         #expect(service.stateBySession["session-1"] == "awaiting")
-        #expect(pingCount == 1)
+        #expect(requests.count == 1)
+        #expect(requests[0].identifier == "session-1-awaiting")
+        #expect(requests[0].content.title == "Claude Code needs input")
+        #expect(requests[0].content.userInfo["projectId"] as? String == "project-1")
     }
 
-    @Test func awaitingPingRespectsPreference() {
+    @Test func awaitingNotificationRespectsPreference() {
         let service = HarnessService()
-        var pingCount = 0
-        service.notifications.awaitingPingPlayer = {
-            pingCount += 1
+        var requests: [UNNotificationRequest] = []
+        service.notifications.notificationAdder = { request in
+            requests.append(request)
         }
+        service.recordHarnessDetection(sessionId: "session-1", kind: .codex)
 
         let awaiting = HookEvent(sessionId: "session-1", kind: "awaiting", timestamp: Date(), summary: nil)
 
-        service.handleHookEvent(awaiting, stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false })
+        service.handleHookEvent(
+            awaiting,
+            stateLookup: { _ in (projectId: "project-1", worktreeId: "worktree-1") },
+            shouldNotifyOnAwaiting: { false }
+        )
 
         #expect(service.stateBySession["session-1"] == "awaiting")
-        #expect(pingCount == 0)
+        #expect(requests.isEmpty)
+    }
+
+    @Test func stopNotificationStillPostsFinishedNotification() {
+        let service = HarnessService()
+        var requests: [UNNotificationRequest] = []
+        service.notifications.notificationAdder = { request in
+            requests.append(request)
+        }
+        service.recordHarnessDetection(sessionId: "session-1", kind: .aider)
+
+        let stop = HookEvent(sessionId: "session-1", kind: "stop", timestamp: Date(), summary: "Done\nDetails")
+
+        service.handleHookEvent(
+            stop,
+            stateLookup: { _ in (projectId: "project-1", worktreeId: "worktree-1") },
+            shouldNotifyOnAwaiting: { true }
+        )
+
+        #expect(service.stateBySession["session-1"] == "done")
+        #expect(requests.count == 1)
+        #expect(requests[0].identifier == "session-1")
+        #expect(requests[0].content.title == "Aider finished")
+        #expect(requests[0].content.body == "Done")
     }
 }

--- a/AlasTests/HookInstallerTests.swift
+++ b/AlasTests/HookInstallerTests.swift
@@ -17,4 +17,29 @@ struct HookInstallerTests {
             // succeed. Skip silently when the resource isn't present.
         }
     }
+
+    @Test func installClaudeCodeHooksWritesStopAndNotificationEntries() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let settingsURL = tempDir.appendingPathComponent("settings.json")
+        let scriptURL = URL(fileURLWithPath: "/tmp/alas-claude-code.sh")
+
+        let added = try HookInstaller.installClaudeCodeHooks(scriptPath: scriptURL, settingsURL: settingsURL)
+        let addedAgain = try HookInstaller.installClaudeCodeHooks(scriptPath: scriptURL, settingsURL: settingsURL)
+
+        #expect(added)
+        #expect(!addedAgain)
+
+        let data = try Data(contentsOf: settingsURL)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let hooks = try #require(json["hooks"] as? [String: Any])
+
+        for eventName in ["Stop", "Notification"] {
+            let entries = try #require(hooks[eventName] as? [[String: Any]])
+            #expect(entries.count == 1)
+            let commands = try #require(entries[0]["hooks"] as? [[String: Any]])
+            #expect(commands[0]["type"] as? String == "command")
+            #expect(commands[0]["command"] as? String == scriptURL.path)
+        }
+    }
 }

--- a/AlasTests/HookInstallerTests.swift
+++ b/AlasTests/HookInstallerTests.swift
@@ -41,5 +41,35 @@ struct HookInstallerTests {
             #expect(commands[0]["type"] as? String == "command")
             #expect(commands[0]["command"] as? String == scriptURL.path)
         }
+        let notificationEntries = try #require(hooks["Notification"] as? [[String: Any]])
+        #expect(notificationEntries[0]["matcher"] as? String == "permission_prompt|idle_prompt|elicitation_dialog")
+    }
+
+    @Test func installClaudeCodeHooksRestrictsExistingMatcherlessNotificationEntry() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let settingsURL = tempDir.appendingPathComponent("settings.json")
+        let scriptURL = URL(fileURLWithPath: "/tmp/alas-claude-code.sh")
+        let legacySettings: [String: Any] = [
+            "hooks": [
+                "Notification": [
+                    [
+                        "hooks": [["type": "command", "command": scriptURL.path]]
+                    ]
+                ]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: legacySettings, options: [.prettyPrinted])
+        try data.write(to: settingsURL)
+
+        let changed = try HookInstaller.installClaudeCodeHooks(scriptPath: scriptURL, settingsURL: settingsURL)
+
+        #expect(changed)
+        let updatedData = try Data(contentsOf: settingsURL)
+        let json = try #require(JSONSerialization.jsonObject(with: updatedData) as? [String: Any])
+        let hooks = try #require(json["hooks"] as? [String: Any])
+        let notificationEntries = try #require(hooks["Notification"] as? [[String: Any]])
+        #expect(notificationEntries[0]["matcher"] as? String == "permission_prompt|idle_prompt|elicitation_dialog")
     }
 }

--- a/AlasTests/HookInstallerTests.swift
+++ b/AlasTests/HookInstallerTests.swift
@@ -72,4 +72,41 @@ struct HookInstallerTests {
         let notificationEntries = try #require(hooks["Notification"] as? [[String: Any]])
         #expect(notificationEntries[0]["matcher"] as? String == "permission_prompt|idle_prompt|elicitation_dialog")
     }
+
+    @Test func installClaudeCodeHooksPreservesSiblingCommandsWhenRestrictingMatcher() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let settingsURL = tempDir.appendingPathComponent("settings.json")
+        let scriptURL = URL(fileURLWithPath: "/tmp/alas-claude-code.sh")
+        let siblingCommand = "/tmp/user-notifier.sh"
+        let groupedHooks = [
+            ["type": "command", "command": scriptURL.path],
+            ["type": "command", "command": siblingCommand]
+        ]
+        let legacySettings: [String: Any] = [
+            "hooks": [
+                "Stop": [["hooks": groupedHooks]],
+                "Notification": [["hooks": groupedHooks]]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: legacySettings, options: [.prettyPrinted])
+        try data.write(to: settingsURL)
+
+        let changed = try HookInstaller.installClaudeCodeHooks(scriptPath: scriptURL, settingsURL: settingsURL)
+
+        #expect(changed)
+        let updatedData = try Data(contentsOf: settingsURL)
+        let json = try #require(JSONSerialization.jsonObject(with: updatedData) as? [String: Any])
+        let hooks = try #require(json["hooks"] as? [String: Any])
+        let stopEntries = try #require(hooks["Stop"] as? [[String: Any]])
+        let stopCommands = try #require(stopEntries[0]["hooks"] as? [[String: Any]])
+        #expect(stopCommands.count == 2)
+        #expect(stopCommands[1]["command"] as? String == siblingCommand)
+        let notificationEntries = try #require(hooks["Notification"] as? [[String: Any]])
+        let notificationCommands = try #require(notificationEntries[0]["hooks"] as? [[String: Any]])
+        #expect(notificationCommands.count == 2)
+        #expect(notificationCommands[1]["command"] as? String == siblingCommand)
+        #expect(notificationEntries[0]["matcher"] as? String == "permission_prompt|idle_prompt|elicitation_dialog")
+    }
 }

--- a/AlasTests/NotificationServiceTests.swift
+++ b/AlasTests/NotificationServiceTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+import UserNotifications
+@testable import Alas
+
+struct NotificationServiceTests {
+    @Test func awaitingUsesClickableNotificationRequest() {
+        var requests: [UNNotificationRequest] = []
+        let service = NotificationService(notificationAdder: { request in
+            requests.append(request)
+        })
+
+        service.notifyHarnessAwaiting(
+            harness: .claudeCode,
+            projectId: "project-1",
+            worktreeId: "worktree-1",
+            sessionId: "session-1"
+        )
+
+        #expect(requests.count == 1)
+        #expect(requests[0].identifier == "session-1-awaiting")
+        #expect(requests[0].content.title == "Claude Code needs input")
+        #expect(requests[0].content.userInfo["projectId"] as? String == "project-1")
+        #expect(requests[0].content.userInfo["worktreeId"] as? String == "worktree-1")
+        #expect(requests[0].content.userInfo["sessionId"] as? String == "session-1")
+    }
+
+    @Test func finishedUsesCompletionNotificationRequest() {
+        var requests: [UNNotificationRequest] = []
+        let service = NotificationService(notificationAdder: { request in
+            requests.append(request)
+        })
+
+        service.notifyHarnessFinished(
+            harness: .codex,
+            summary: "Completed\nMore details",
+            projectId: "project-1",
+            worktreeId: "worktree-1",
+            sessionId: "session-1"
+        )
+
+        #expect(requests.count == 1)
+        #expect(requests[0].identifier == "session-1")
+        #expect(requests[0].content.title == "Codex finished")
+        #expect(requests[0].content.body == "Completed")
+    }
+
+    @Test func finishEnabledFlagDoesNotDisableAwaitingNotifications() {
+        var requests: [UNNotificationRequest] = []
+        let service = NotificationService(notificationAdder: { request in
+            requests.append(request)
+        })
+        service.setEnabled(false)
+
+        service.notifyHarnessAwaiting(
+            harness: .aider,
+            projectId: "project-1",
+            worktreeId: "worktree-1",
+            sessionId: "session-1"
+        )
+        service.notifyHarnessFinished(
+            harness: .aider,
+            summary: nil,
+            projectId: "project-1",
+            worktreeId: "worktree-1",
+            sessionId: "session-1"
+        )
+
+        #expect(requests.count == 1)
+        #expect(requests[0].identifier == "session-1-awaiting")
+    }
+}

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -104,6 +104,15 @@
 7. Trigger another hook-backed completion, close the originating tab, then click the old notification. Confirm Alas focuses without a visible error or crash.
 8. Trigger a heuristic/unsupported harness detection without a validated hook payload. Confirm it does not route to a tab through notification click-through.
 
+## Harness Waiting Notifications
+
+1. Enable finish and awaiting harness notifications in Terminal settings.
+2. Install the Claude Code hook from Terminal settings, then restart Claude Code or reload hooks as required by Claude Code.
+3. Trigger a Claude Code permission prompt or leave the prompt input idle until Claude emits a `Notification` hook. Confirm Alas shows a clickable "needs input" macOS notification and clicking it focuses the originating worktree/session.
+4. Let Claude Code finish a response. Confirm the existing completion notification still appears and still clicks through correctly.
+5. For Codex or Aider, wire the wrapper from Terminal settings only when the local integration can reliably detect waiting. Invoke the wrapper with `--kind awaiting` for waiting states and without `--kind` for completion. If the upstream tool cannot emit reliable waiting hooks, do not synthesize waiting from terminal text scraping.
+6. OpenCode is currently supported through ACP in Alas, not as a terminal `HarnessKind`; ACP waiting-state notifications are deferred to separate ACP notification work.
+
 ## Terminal Emulator Behavior
 
 1. Shell basics: type, edit prompt, arrows/history, backspace/delete, Tab, Escape, and Ctrl-C.


### PR DESCRIPTION
## Summary

- Convert harness `awaiting` events from a local ping-only signal into clickable macOS notifications that route back to the originating worktree/session.
- Install Claude Code hooks for both `Stop` and `Notification` events, so Claude permission/idle notifications can become Alas `awaiting` events.
- Extend Codex and Aider hook wrappers to accept `--kind awaiting` when their integrations can reliably emit waiting state.
- Add focused coverage for awaiting notification requests, Claude hook installation, and state-transition deduplication.

## Validation

- [x] `git diff --check main..HEAD`
- [x] Smoke-tested `claude-code.sh` with a `Notification` payload and confirmed it emits `kind: "awaiting"`.
- [x] Smoke-tested `codex-cli.sh --kind awaiting` and `aider.sh awaiting` output.
- [ ] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test` is currently blocked locally because `.build/ghostty/GhosttyKit.xcframework` is missing before compilation reaches these changes.

Follow-up to task #774.