### PR TITLE
Add Edit Project to project context menu

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -96,27 +96,11 @@ final class AppState {
         saveProjects()
     }
 
-    func renameProject(id: String) {
-        guard let project = projects.first(where: { $0.id == id }) else { return }
+    func updateProject(id: String, name: String, color: String) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
 
-        let alert = NSAlert()
-        alert.messageText = "Rename Project"
-        alert.informativeText = "Choose a new name for this project."
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "Rename")
-        alert.addButton(withTitle: "Cancel")
-
-        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
-        field.stringValue = project.name
-        field.lineBreakMode = .byTruncatingTail
-        alert.accessoryView = field
-
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
-
-        let name = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty, name != project.name else { return }
-
-        projectsManager.renameProject(id: id, name: name)
+        projectsManager.updateProject(id: id, update: ProjectUpdate(name: trimmedName, color: color))
         saveProjects()
     }
 

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Observation
 
+struct ProjectUpdate: Equatable {
+    var name: String
+    var color: String
+}
+
 @Observable
 @MainActor
 final class ProjectsManager {
@@ -36,9 +41,10 @@ final class ProjectsManager {
         worktreesByProject.removeValue(forKey: id)
     }
 
-    func renameProject(id: String, name: String) {
+    func updateProject(id: String, update: ProjectUpdate) {
         guard let idx = projects.firstIndex(where: { $0.id == id }) else { return }
-        projects[idx].name = name
+        projects[idx].name = update.name
+        projects[idx].color = update.color
     }
 
     func worktrees(projectId: String) -> [Worktree] {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct RootView: View {
     @Bindable var state: AppState
     @State private var showNewProject = false
+    @State private var showEditProject = false
+    @State private var editingProjectId: String?
     @State private var showNewWorktree = false
     @State private var newWorktreePresetProjectId: String?
     @State private var collapsedProjects: Set<String> = []
@@ -36,6 +38,10 @@ struct RootView: View {
                                 collapsedProjects: $collapsedProjects,
                                 onSettings: { openSettingsWindow() },
                                 onAddProject: { showNewProject = true },
+                                onEditProject: { projectId in
+                                    editingProjectId = projectId
+                                    showEditProject = true
+                                },
                                 onNewWorktree: { projectId in
                                     newWorktreePresetProjectId = projectId
                                     showNewWorktree = true
@@ -89,6 +95,11 @@ struct RootView: View {
         .sheet(isPresented: $showNewProject) {
             NewProjectDialog(state: state, presented: $showNewProject)
         }
+        .sheet(isPresented: $showEditProject, onDismiss: { editingProjectId = nil }) {
+            if let project = editingProject() {
+                EditProjectDialog(state: state, presented: $showEditProject, project: project)
+            }
+        }
         .sheet(isPresented: $showNewWorktree, onDismiss: { newWorktreePresetProjectId = nil }) {
             NewWorktreeDialog(
                 state: state,
@@ -112,6 +123,11 @@ struct RootView: View {
 
     private func openSettingsWindow() {
         openWindow(id: "settings")
+    }
+
+    private func editingProject() -> ProjectConfig? {
+        guard let editingProjectId else { return nil }
+        return state.projects.first { $0.id == editingProjectId }
     }
 
     private func selectedWorktree() -> Worktree? {

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -5,6 +5,32 @@ struct NewProjectDialog: View {
     @Bindable var state: AppState
     @Binding var presented: Bool
 
+    var body: some View {
+        ProjectDialog(state: state, presented: $presented, mode: .add)
+    }
+}
+
+struct EditProjectDialog: View {
+    @Bindable var state: AppState
+    @Binding var presented: Bool
+    let project: ProjectConfig
+
+    var body: some View {
+        ProjectDialog(state: state, presented: $presented, mode: .edit(project))
+    }
+}
+
+private enum ProjectDialogMode {
+    case add
+    case edit(ProjectConfig)
+}
+
+private struct ProjectDialog: View {
+    @Bindable var state: AppState
+    @Binding var presented: Bool
+    let mode: ProjectDialogMode
+    @Environment(\.theme) var theme
+
     @State private var path: String = ""
     @State private var name: String = ""
     @State private var color: String = "#5fb7c4"
@@ -15,13 +41,18 @@ struct NewProjectDialog: View {
 
     var body: some View {
         DialogContainer(
-            title: "Add project",
-            subtitle: "Register a git repository as an Alas project.",
+            title: title,
+            subtitle: subtitle,
             content: {
                 DialogField(label: "Repository path") {
-                    HStack(spacing: 6) {
-                        AlasField(text: $path, placeholder: "/path/to/repo", monospaced: true)
-                        AlasButton(title: "Choose…", action: choose)
+                    switch mode {
+                    case .add:
+                        HStack(spacing: 6) {
+                            AlasField(text: $path, placeholder: "/path/to/repo", monospaced: true)
+                            AlasButton(title: "Choose…", action: choose)
+                        }
+                    case .edit:
+                        readOnlyPath
                     }
                 }
                 DialogField(label: "Display name") {
@@ -29,7 +60,7 @@ struct NewProjectDialog: View {
                 }
                 DialogField(label: "Color") {
                     HStack(spacing: 8) {
-                        ForEach(palette, id: \.self) { hex in
+                        ForEach(availablePalette, id: \.self) { hex in
                             Button { color = hex } label: {
                                 Circle()
                                     .fill(Color(hex: hex))
@@ -47,15 +78,75 @@ struct NewProjectDialog: View {
                 }
             },
             cancelTitle: "Cancel",
-            confirmTitle: isValidating ? "Adding…" : "Add project",
+            confirmTitle: confirmTitle,
             confirmStyle: .primary,
             onCancel: { presented = false },
             onConfirm: confirm,
-            confirmEnabled: !path.isEmpty && !name.isEmpty && !isValidating
+            confirmEnabled: confirmEnabled
         )
+        .onAppear(perform: populateInitialValues)
         .onChange(of: path) { _, new in
-            Task { await suggestName(for: new) }
+            if case .add = mode {
+                Task { await suggestName(for: new) }
+            }
         }
+    }
+
+    private var title: String {
+        switch mode {
+        case .add: "Add project"
+        case .edit: "Edit project"
+        }
+    }
+
+    private var subtitle: String {
+        switch mode {
+        case .add: "Register a git repository as an Alas project."
+        case .edit: "Update this project's name and color."
+        }
+    }
+
+    private var confirmTitle: String {
+        switch mode {
+        case .add: isValidating ? "Adding…" : "Add project"
+        case .edit: "Save changes"
+        }
+    }
+
+    private var confirmEnabled: Bool {
+        switch mode {
+        case .add:
+            !path.isEmpty && !name.isEmpty && !isValidating
+        case .edit:
+            !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    private var availablePalette: [String] {
+        palette.contains(color) ? palette : [color] + palette
+    }
+
+    private var readOnlyPath: some View {
+        Text(path)
+            .foregroundColor(theme.color("fg"))
+            .font(.system(size: 12, design: .monospaced))
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+            .background(theme.color("bg-1"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func populateInitialValues() {
+        guard case .edit(let project) = mode else { return }
+        path = project.path
+        name = project.name
+        color = project.color
     }
 
     private func choose() {
@@ -80,17 +171,23 @@ struct NewProjectDialog: View {
     }
 
     private func confirm() {
-        isValidating = true
-        errorMessage = nil
-        Task {
-            do {
-                let url = URL(fileURLWithPath: path)
-                try await state.addProject(path: url, displayName: name, color: color)
-                presented = false
-            } catch {
-                errorMessage = error.localizedDescription
+        switch mode {
+        case .add:
+            isValidating = true
+            errorMessage = nil
+            Task {
+                do {
+                    let url = URL(fileURLWithPath: path)
+                    try await state.addProject(path: url, displayName: name, color: color)
+                    presented = false
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
+                isValidating = false
             }
-            isValidating = false
+        case .edit(let project):
+            state.updateProject(id: project.id, name: name, color: color)
+            presented = false
         }
     }
 }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -7,7 +7,7 @@ struct RepoGroupView: View {
     let selectedWorktreeId: String?
     let onSelect: (Worktree) -> Void
     let onNewWorktree: () -> Void
-    let onRenameProject: () -> Void
+    let onEditProject: () -> Void
     let onOpenTerminal: (Worktree) -> Void
     let onCopyPath: (Worktree) -> Void
     let onCopyBranch: (Worktree) -> Void
@@ -37,7 +37,7 @@ struct RepoGroupView: View {
             .contentShape(Rectangle())
             .onTapGesture { collapsed.toggle() }
             .contextMenu {
-                Button("Rename Project…", action: onRenameProject)
+                Button("Edit Project…", action: onEditProject)
             }
             .overlay(alignment: .trailing) {
                 ZStack {

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -6,6 +6,7 @@ struct SidebarView: View {
     @Binding var collapsedProjects: Set<String>
     let onSettings: () -> Void
     let onAddProject: () -> Void
+    let onEditProject: (_ projectId: String) -> Void
     let onNewWorktree: (_ projectId: String?) -> Void
     @Environment(\.theme) var theme
 
@@ -36,7 +37,7 @@ struct SidebarView: View {
                                 selectedWorktreeId: state.selectedWorktreeId,
                                 onSelect: { wt in state.selectedWorktreeId = wt.id },
                                 onNewWorktree: { onNewWorktree(project.id) },
-                                onRenameProject: { state.renameProject(id: project.id) },
+                                onEditProject: { onEditProject(project.id) },
                                 onOpenTerminal: { wt in
                                     state.selectedWorktreeId = wt.id
                                     _ = try? state.openTerminalTab(for: wt)

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -47,7 +47,7 @@ struct ProjectsManagerTests {
         #expect(mgr.worktrees(projectId: project.id).isEmpty)
     }
 
-    @Test func renameProjectUpdatesOnlyTheProjectName() {
+    @Test func updateProjectUpdatesNameAndColorOnly() {
         let addedAt = Date(timeIntervalSince1970: 1_700_000_000)
         let project = ProjectConfig(
             id: "project-1",
@@ -67,19 +67,26 @@ struct ProjectsManagerTests {
         )
         let mgr = ProjectsManager(persistedProjects: [project, other])
 
-        mgr.renameProject(id: project.id, name: "After")
+        mgr.updateProject(
+            id: project.id,
+            update: ProjectUpdate(name: "After", color: "#d77b88")
+        )
 
         #expect(mgr.projects[0].id == project.id)
         #expect(mgr.projects[0].name == "After")
         #expect(mgr.projects[0].path == project.path)
-        #expect(mgr.projects[0].color == project.color)
+        #expect(mgr.projects[0].color == "#d77b88")
         #expect(mgr.projects[0].addedAt == project.addedAt)
         #expect(mgr.projects[0].hiddenWorktreePaths == project.hiddenWorktreePaths)
         #expect(mgr.projects[1] == other)
 
-        mgr.renameProject(id: "missing", name: "Ignored")
+        mgr.updateProject(
+            id: "missing",
+            update: ProjectUpdate(name: "Ignored", color: "#7fb978")
+        )
 
         #expect(mgr.projects[0].name == "After")
+        #expect(mgr.projects[0].color == "#d77b88")
         #expect(mgr.projects[1] == other)
     }
 }


### PR DESCRIPTION
## Summary

- Adds **Edit Project…** to the project context menu (right-click), replacing the old ad-hoc **Rename Project…** NSAlert flow
- The edit dialog reuses the add-project dialog pattern, pre-populated with the selected project's name and color, with the repository path shown as read-only
- Removes the competing Rename Project context-menu action; renaming is now done exclusively through the edit dialog
- Adds `ProjectsManager.updateProject` with focused tests for name/color updates while preserving immutable fields (id, path, addedAt, hiddenWorktreePaths)

Closes #784