### PR TITLE
feat(sidebar): harness activity badge in worktree rows

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
+		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
@@ -270,6 +271,7 @@
 		02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.SurfaceView.swift; sourceTree = "<group>"; };
 		0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCache.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
+		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
@@ -806,6 +808,7 @@
 		697AACFEA2DCEBE4CEB2CD4E /* Sidebar */ = {
 			isa = PBXGroup;
 			children = (
+				0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */,
 				563B664D082A9523260AA2EF /* RepoDot.swift */,
 				768D12909DD5233659AC4E03 /* RepoGroupView.swift */,
 				B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */,
@@ -1352,6 +1355,7 @@
 				7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */,
 				B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */,
 				3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */,
+				18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */,
 				90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */,
 				C512EC7827D3C46907DDB7A1 /* HighlightCapture.swift in Sources */,
 				387EF12B6875648E422956F7 /* Highlighted.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -172,10 +172,26 @@ final class AppState {
                 self?.config.harness.notifyOnAwaiting ?? true
             }
         )
-        harness.onClickThrough = { [weak self] _, worktreeId, _ in
-            self?.selectedWorktreeId = worktreeId
-            NSApp.activate(ignoringOtherApps: true)
+        harness.onClickThrough = { [weak self] projectId, worktreeId, sessionId in
+            self?.activateHarnessSession(
+                projectId: projectId, worktreeId: worktreeId, sessionId: sessionId
+            )
         }
+    }
+
+    /// Activate a specific harness session: bring the app to front, select
+    /// the worktree, and activate the terminal tab hosting `sessionId`.
+    /// If the tab is no longer present (session was closed mid-flight) the
+    /// worktree is still selected so the user lands somewhere sensible.
+    func activateHarnessSession(projectId _: String, worktreeId: String, sessionId: String) {
+        selectedWorktreeId = worktreeId
+        if let tab = tabs.tabs(forWorktree: worktreeId).first(where: {
+            if case .terminal(let s) = $0 { return s.sessionId == sessionId }
+            return false
+        }) {
+            tabs.activate(worktreeId: worktreeId, tabId: tab.id)
+        }
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     @discardableResult

--- a/Alas/Sources/Harness/HarnessDetector.swift
+++ b/Alas/Sources/Harness/HarnessDetector.swift
@@ -42,8 +42,12 @@ final class HarnessDetector {
     }
 
     static func matchKind(processName: String) -> HarnessKind? {
-        for kind in HarnessKind.allCases where kind.processNames.contains(processName) {
-            return kind
+        for kind in HarnessKind.allCases {
+            for name in kind.processNames {
+                if processName == name || processName.hasPrefix(name + "-") {
+                    return kind
+                }
+            }
         }
         return nil
     }

--- a/Alas/Sources/Harness/HarnessKind.swift
+++ b/Alas/Sources/Harness/HarnessKind.swift
@@ -18,8 +18,8 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable {
     /// Process names (basename of executable) used for detection.
     var processNames: [String] {
         switch self {
-        case .claudeCode: return ["claude", "claude-code"]
-        case .codex:      return ["codex", "codex-cli"]
+        case .claudeCode: return ["claude"]
+        case .codex:      return ["codex"]
         case .aider:      return ["aider"]
         }
     }

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -105,4 +105,62 @@ final class HarnessService {
         harnessBySession.removeValue(forKey: sessionId)
         stateBySession.removeValue(forKey: sessionId)
     }
+
+    enum AggregatedState: String, Equatable {
+        case running, awaiting
+    }
+
+    struct WorktreeHarnessSummary: Equatable {
+        let state: AggregatedState
+        let kind: HarnessKind
+        let primarySessionId: String
+        let sessionCount: Int
+    }
+
+    /// Roll up per-session harness state to a single summary for a worktree.
+    /// Returns nil if no session in `ids` is running or awaiting (or none have
+    /// a detected kind to attribute the summary to).
+    func summary(forSessionIds ids: [String]) -> WorktreeHarnessSummary? {
+        // Partition candidate ids by state, preserving caller order.
+        var awaitingIds: [String] = []
+        var runningIds: [String] = []
+        for id in ids {
+            switch stateBySession[id] {
+            case "awaiting": awaitingIds.append(id)
+            case "running":  runningIds.append(id)
+            default: break
+            }
+        }
+
+        // Try awaiting first; fall back to running if no awaiting session has a kind.
+        if let s = pickSummary(state: .awaiting, ids: awaitingIds) { return s }
+        if let s = pickSummary(state: .running,  ids: runningIds)  { return s }
+        return nil
+    }
+
+    private func pickSummary(state: AggregatedState, ids: [String]) -> WorktreeHarnessSummary? {
+        guard !ids.isEmpty else { return nil }
+        // First id whose kind is known wins as primary. Skip ids missing a kind.
+        guard let primary = ids.first(where: { harnessBySession[$0] != nil }),
+              let kind = harnessBySession[primary] else { return nil }
+        return WorktreeHarnessSummary(
+            state: state,
+            kind: kind,
+            primarySessionId: primary,
+            sessionCount: ids.count
+        )
+    }
+
+    // MARK: - Test seams (debug only)
+
+    #if DEBUG
+    func setStateForTesting(sessionId: String, kind: HarnessKind, state: String) {
+        harnessBySession[sessionId] = kind
+        stateBySession[sessionId] = state
+    }
+
+    func setStateOnlyForTesting(sessionId: String, state: String) {
+        stateBySession[sessionId] = state
+    }
+    #endif
 }

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -111,10 +111,17 @@ final class HarnessService {
     }
 
     struct WorktreeHarnessSummary: Equatable {
+        /// Priority-resolved state for the pill/dot color: awaiting wins.
         let state: AggregatedState
+        /// Kind of the primary session (the one click-through routes to).
         let kind: HarnessKind
         let primarySessionId: String
-        let sessionCount: Int
+        /// Per-state session counts, always populated regardless of which
+        /// state was chosen as the priority. Lets callers (e.g. the
+        /// collapsed-header tooltip) accurately enumerate mixed-state
+        /// activity even when one state would normally mask the other.
+        let runningSessionCount: Int
+        let awaitingSessionCount: Int
     }
 
     /// Roll up per-session harness state to a single summary for a worktree.
@@ -133,12 +140,19 @@ final class HarnessService {
         }
 
         // Try awaiting first; fall back to running if no awaiting session has a kind.
-        if let s = pickSummary(state: .awaiting, ids: awaitingIds) { return s }
-        if let s = pickSummary(state: .running,  ids: runningIds)  { return s }
+        if let s = pickSummary(state: .awaiting, ids: awaitingIds,
+                               runningCount: runningIds.count, awaitingCount: awaitingIds.count) { return s }
+        if let s = pickSummary(state: .running, ids: runningIds,
+                               runningCount: runningIds.count, awaitingCount: awaitingIds.count) { return s }
         return nil
     }
 
-    private func pickSummary(state: AggregatedState, ids: [String]) -> WorktreeHarnessSummary? {
+    private func pickSummary(
+        state: AggregatedState,
+        ids: [String],
+        runningCount: Int,
+        awaitingCount: Int
+    ) -> WorktreeHarnessSummary? {
         guard !ids.isEmpty else { return nil }
         // First id whose kind is known wins as primary. Skip ids missing a kind.
         guard let primary = ids.first(where: { harnessBySession[$0] != nil }),
@@ -147,7 +161,8 @@ final class HarnessService {
             state: state,
             kind: kind,
             primarySessionId: primary,
-            sessionCount: ids.count
+            runningSessionCount: runningCount,
+            awaitingSessionCount: awaitingCount
         )
     }
 

--- a/Alas/Sources/Sidebar/HarnessPill.swift
+++ b/Alas/Sources/Sidebar/HarnessPill.swift
@@ -9,12 +9,14 @@ struct HarnessPill: View {
     let summary: HarnessService.WorktreeHarnessSummary
     let variant: Variant
     let tooltip: String
+    var isSelected: Bool = false
 
     @Environment(\.theme) var theme
 
     var body: some View {
         switch variant {
         case .full:
+            let background = isSelected ? theme.color("bg-3") : theme.color("bg-4")
             HStack(spacing: 4) {
                 Circle()
                     .fill(dotColor)
@@ -25,7 +27,7 @@ struct HarnessPill: View {
             }
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(theme.color("bg-4"))
+            .background(background)
             .clipShape(RoundedRectangle(cornerRadius: 4))
             .help(tooltip)
 

--- a/Alas/Sources/Sidebar/HarnessPill.swift
+++ b/Alas/Sources/Sidebar/HarnessPill.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Sidebar badge for harness activity.
+/// - `.full` renders a pill `[• run]` / `[• wait]` for worktree rows.
+/// - `.dotOnly` renders a bare colored dot for collapsed repo headers.
+struct HarnessPill: View {
+    enum Variant { case full, dotOnly }
+
+    let summary: HarnessService.WorktreeHarnessSummary
+    let variant: Variant
+    let tooltip: String
+
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        switch variant {
+        case .full:
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: 5, height: 5)
+                Text(label)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(theme.color("bg-4"))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .help(tooltip)
+
+        case .dotOnly:
+            Circle()
+                .fill(dotColor)
+                .frame(width: 6, height: 6)
+                .help(tooltip)
+        }
+    }
+
+    private var dotColor: Color {
+        switch summary.state {
+        case .running:  return theme.color("add")
+        case .awaiting: return theme.color("mod")
+        }
+    }
+
+    private var label: String {
+        switch summary.state {
+        case .running:  return "run"
+        case .awaiting: return "wait"
+        }
+    }
+}

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -115,15 +115,12 @@ struct RepoGroupView: View {
     }
 
     /// Tooltip for the collapsed-header dot. Counts busy sessions (not
-    /// worktrees) independently per state, lists distinct harness kinds in
+    /// worktrees) independently per state — so mixed activity in a single
+    /// worktree still reports both states. Lists distinct harness kinds in
     /// `HarnessKind.allCases` order.
     private func headerTooltip() -> String {
-        let runningCount = summaries
-            .filter { $0.state == .running }
-            .reduce(0) { $0 + $1.sessionCount }
-        let awaitingCount = summaries
-            .filter { $0.state == .awaiting }
-            .reduce(0) { $0 + $1.sessionCount }
+        let runningCount = summaries.reduce(0) { $0 + $1.runningSessionCount }
+        let awaitingCount = summaries.reduce(0) { $0 + $1.awaitingSessionCount }
         let distinctKinds = HarnessKind.allCases.filter { kind in
             summaries.contains { $0.kind == kind }
         }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -42,36 +42,39 @@ struct RepoGroupView: View {
                 Button("Edit Project…", action: onEditProject)
             }
             .overlay(alignment: .trailing) {
-                ZStack {
-                    HStack(spacing: 6) {
-                        if collapsed, let summary = projectSummary() {
-                            HarnessPill(
-                                summary: summary,
-                                variant: .dotOnly,
-                                tooltip: headerTooltip()
-                            )
-                        }
+                // The header dot lives OUTSIDE the count/plus swap group so
+                // it stays visible — and its tooltip stays reachable — when
+                // the user hovers the row.
+                HStack(spacing: 6) {
+                    if collapsed, let summary = projectSummary() {
+                        HarnessPill(
+                            summary: summary,
+                            variant: .dotOnly,
+                            tooltip: headerTooltip()
+                        )
+                    }
+                    ZStack {
                         Text("\(worktrees.count)")
                             .font(.system(size: 10, weight: .medium))
                             .foregroundColor(theme.color("fg-faint"))
                             .monospacedDigit()
+                            .opacity(hovering ? 0 : 1)
+                            .allowsHitTesting(false)
+                        Button(action: onNewWorktree) {
+                            Icon(name: "plus", size: 11,
+                                 color: plusHovering ? theme.color("fg") : theme.color("fg-faint"))
+                                .frame(width: 18, height: 18)
+                                .background(plusHovering ? theme.color("bg-4") : .clear)
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                        .buttonStyle(.plain)
+                        .onHover { plusHovering = $0 }
+                        .help("New worktree in \(project.name)")
+                        .opacity(hovering ? 1 : 0)
+                        .allowsHitTesting(hovering)
                     }
-                    .opacity(hovering ? 0 : 1)
-                    .allowsHitTesting(false)
-                    Button(action: onNewWorktree) {
-                        Icon(name: "plus", size: 11,
-                             color: plusHovering ? theme.color("fg") : theme.color("fg-faint"))
-                            .frame(width: 18, height: 18)
-                            .background(plusHovering ? theme.color("bg-4") : .clear)
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
-                    }
-                    .buttonStyle(.plain)
-                    .onHover { plusHovering = $0 }
-                    .help("New worktree in \(project.name)")
-                    .opacity(hovering ? 1 : 0)
-                    .allowsHitTesting(hovering)
+                    .frame(width: 18, height: 18)
                 }
-                .frame(height: 18)
                 .padding(.trailing, 12)
             }
             .onHover { hovering = $0 }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -114,11 +114,16 @@ struct RepoGroupView: View {
         return summaries.first(where: { $0.state == .running })
     }
 
-    /// Tooltip for the collapsed-header dot. Counts independently across
-    /// worktrees, lists distinct harness kinds in `HarnessKind.allCases` order.
+    /// Tooltip for the collapsed-header dot. Counts busy sessions (not
+    /// worktrees) independently per state, lists distinct harness kinds in
+    /// `HarnessKind.allCases` order.
     private func headerTooltip() -> String {
-        let runningCount = summaries.filter { $0.state == .running }.count
-        let awaitingCount = summaries.filter { $0.state == .awaiting }.count
+        let runningCount = summaries
+            .filter { $0.state == .running }
+            .reduce(0) { $0 + $1.sessionCount }
+        let awaitingCount = summaries
+            .filter { $0.state == .awaiting }
+            .reduce(0) { $0 + $1.sessionCount }
         let distinctKinds = HarnessKind.allCases.filter { kind in
             summaries.contains { $0.kind == kind }
         }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -5,6 +5,7 @@ struct RepoGroupView: View {
     let worktrees: [Worktree]
     @Binding var collapsed: Bool
     let selectedWorktreeId: String?
+    let harnessSummary: (String) -> HarnessService.WorktreeHarnessSummary?
     let onSelect: (Worktree) -> Void
     let onNewWorktree: () -> Void
     let onEditProject: () -> Void
@@ -14,16 +15,13 @@ struct RepoGroupView: View {
     let onRevealInFinder: (Worktree) -> Void
     let onArchive: (Worktree) -> Void
     let onDelete: (Worktree) -> Void
+    let onActivateHarness: (Worktree) -> Void
     @Environment(\.theme) var theme
     @State private var hovering = false
     @State private var plusHovering = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Collapse toggle and the inline + are independent controls in the
-            // same row. Don't wrap the row in a parent Button — that nests the
-            // + inside another button's hit region and clicking the + can also
-            // fire the collapse action.
             HStack(spacing: 7) {
                 Icon(name: collapsed ? "chev-right" : "chev-down", size: 10, color: theme.color("fg-faint"))
                 RepoDot(color: project.color, letter: letter)
@@ -41,12 +39,21 @@ struct RepoGroupView: View {
             }
             .overlay(alignment: .trailing) {
                 ZStack {
-                    Text("\(worktrees.count)")
-                        .font(.system(size: 10, weight: .medium))
-                        .foregroundColor(theme.color("fg-faint"))
-                        .monospacedDigit()
-                        .opacity(hovering ? 0 : 1)
-                        .allowsHitTesting(false)
+                    HStack(spacing: 6) {
+                        if collapsed, let summary = projectSummary() {
+                            HarnessPill(
+                                summary: summary,
+                                variant: .dotOnly,
+                                tooltip: headerTooltip()
+                            )
+                        }
+                        Text("\(worktrees.count)")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(theme.color("fg-faint"))
+                            .monospacedDigit()
+                    }
+                    .opacity(hovering ? 0 : 1)
+                    .allowsHitTesting(false)
                     Button(action: onNewWorktree) {
                         Icon(name: "plus", size: 11,
                              color: plusHovering ? theme.color("fg") : theme.color("fg-faint"))
@@ -60,7 +67,7 @@ struct RepoGroupView: View {
                     .opacity(hovering ? 1 : 0)
                     .allowsHitTesting(hovering)
                 }
-                .frame(width: 18, height: 18)
+                .frame(height: 18)
                 .padding(.trailing, 12)
             }
             .onHover { hovering = $0 }
@@ -70,13 +77,15 @@ struct RepoGroupView: View {
                         WorktreeRowView(
                             worktree: wt,
                             isSelected: wt.id == selectedWorktreeId,
+                            harnessSummary: harnessSummary(wt.id),
                             onTap: { onSelect(wt) },
                             onOpenTerminal: { onOpenTerminal(wt) },
                             onCopyPath: { onCopyPath(wt) },
                             onCopyBranch: { onCopyBranch(wt) },
                             onRevealInFinder: { onRevealInFinder(wt) },
                             onArchive: { onArchive(wt) },
-                            onDelete: { onDelete(wt) }
+                            onDelete: { onDelete(wt) },
+                            onActivateHarness: { onActivateHarness(wt) }
                         )
                     }
                 }
@@ -88,5 +97,35 @@ struct RepoGroupView: View {
     private var letter: String {
         let after = project.name.split(separator: "/").last ?? Substring(project.name)
         return after.prefix(1).uppercased()
+    }
+
+    /// Project-level rollup: awaiting wins across worktrees, else running.
+    /// Returns nil if no worktree in this project has any busy session.
+    private func projectSummary() -> HarnessService.WorktreeHarnessSummary? {
+        let perWorktree = worktrees.compactMap { harnessSummary($0.id) }
+        if let s = perWorktree.first(where: { $0.state == .awaiting }) { return s }
+        return perWorktree.first(where: { $0.state == .running })
+    }
+
+    /// Tooltip for the collapsed-header dot. Counts independently across
+    /// worktrees, lists distinct harness kinds in `HarnessKind.allCases` order.
+    private func headerTooltip() -> String {
+        let summaries = worktrees.compactMap { harnessSummary($0.id) }
+        let runningCount  = summaries.filter { $0.state == .running  }.count
+        let awaitingCount = summaries.filter { $0.state == .awaiting }.count
+        let distinctKinds = HarnessKind.allCases.filter { kind in
+            summaries.contains { $0.kind == kind }
+        }
+        let kindList = distinctKinds.map(\.displayName).joined(separator: ", ")
+
+        var parts: [String] = []
+        if runningCount > 0 {
+            parts.append("\(runningCount) worktree\(runningCount == 1 ? "" : "s") running")
+        }
+        if awaitingCount > 0 {
+            parts.append("\(awaitingCount) awaiting")
+        }
+        let head = parts.joined(separator: ", ")
+        return kindList.isEmpty ? head : "\(head) (\(kindList))"
     }
 }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -22,6 +22,10 @@ struct RepoGroupView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            // Collapse toggle and the inline + are independent controls in the
+            // same row. Don't wrap the row in a parent Button — that nests the
+            // + inside another button's hit region and clicking the + can also
+            // fire the collapse action.
             HStack(spacing: 7) {
                 Icon(name: collapsed ? "chev-right" : "chev-down", size: 10, color: theme.color("fg-faint"))
                 RepoDot(color: project.color, letter: letter)
@@ -99,19 +103,21 @@ struct RepoGroupView: View {
         return after.prefix(1).uppercased()
     }
 
+    private var summaries: [HarnessService.WorktreeHarnessSummary] {
+        worktrees.compactMap { harnessSummary($0.id) }
+    }
+
     /// Project-level rollup: awaiting wins across worktrees, else running.
     /// Returns nil if no worktree in this project has any busy session.
     private func projectSummary() -> HarnessService.WorktreeHarnessSummary? {
-        let perWorktree = worktrees.compactMap { harnessSummary($0.id) }
-        if let s = perWorktree.first(where: { $0.state == .awaiting }) { return s }
-        return perWorktree.first(where: { $0.state == .running })
+        if let s = summaries.first(where: { $0.state == .awaiting }) { return s }
+        return summaries.first(where: { $0.state == .running })
     }
 
     /// Tooltip for the collapsed-header dot. Counts independently across
     /// worktrees, lists distinct harness kinds in `HarnessKind.allCases` order.
     private func headerTooltip() -> String {
-        let summaries = worktrees.compactMap { harnessSummary($0.id) }
-        let runningCount  = summaries.filter { $0.state == .running  }.count
+        let runningCount = summaries.filter { $0.state == .running }.count
         let awaitingCount = summaries.filter { $0.state == .awaiting }.count
         let distinctKinds = HarnessKind.allCases.filter { kind in
             summaries.contains { $0.kind == kind }
@@ -120,7 +126,7 @@ struct RepoGroupView: View {
 
         var parts: [String] = []
         if runningCount > 0 {
-            parts.append("\(runningCount) worktree\(runningCount == 1 ? "" : "s") running")
+            parts.append("\(runningCount) running")
         }
         if awaitingCount > 0 {
             parts.append("\(awaitingCount) awaiting")

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -35,6 +35,13 @@ struct SidebarView: View {
                                     }
                                 ),
                                 selectedWorktreeId: state.selectedWorktreeId,
+                                harnessSummary: { worktreeId in
+                                    let ids = state.tabs.tabs(forWorktree: worktreeId).compactMap { tab -> String? in
+                                        if case .terminal(let s) = tab { return s.sessionId }
+                                        return nil
+                                    }
+                                    return state.harness.summary(forSessionIds: ids)
+                                },
                                 onSelect: { wt in state.selectedWorktreeId = wt.id },
                                 onNewWorktree: { onNewWorktree(project.id) },
                                 onEditProject: { onEditProject(project.id) },
@@ -56,7 +63,19 @@ struct SidebarView: View {
                                     NSWorkspace.shared.activateFileViewerSelecting([wt.path])
                                 },
                                 onArchive: { wt in state.archiveWorktree(wt) },
-                                onDelete: { wt in state.deleteWorktree(wt) }
+                                onDelete: { wt in state.deleteWorktree(wt) },
+                                onActivateHarness: { wt in
+                                    let ids = state.tabs.tabs(forWorktree: wt.id).compactMap { tab -> String? in
+                                        if case .terminal(let s) = tab { return s.sessionId }
+                                        return nil
+                                    }
+                                    guard let summary = state.harness.summary(forSessionIds: ids) else { return }
+                                    state.activateHarnessSession(
+                                        projectId: project.id,
+                                        worktreeId: wt.id,
+                                        sessionId: summary.primarySessionId
+                                    )
+                                }
                             )
                         }
                     }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -15,62 +15,59 @@ struct WorktreeRowView: View {
     @Environment(\.theme) var theme
 
     var body: some View {
-        Button(action: onTap) {
-            ZStack(alignment: .leading) {
-                if isSelected {
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(theme.color("bg-4"))
-                    Rectangle()
-                        .fill(theme.color("accent"))
-                        .frame(width: 3, height: 14)
-                        .cornerRadius(2)
-                        .offset(x: 2, y: 0)
-                }
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
-                        Icon(name: "branch", size: 11, color: theme.color("fg-faint"))
-                        Text(worktree.branch)
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
-                            .foregroundColor(theme.color("fg"))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                    HStack(spacing: 8) {
-                        Text(relative(worktree.lastActivity))
-                            .font(.system(size: 10.5))
-                            .foregroundColor(theme.color("fg-faint"))
-                        if worktree.addedLines > 0 {
-                            Text("+\(worktree.addedLines)")
-                                .font(.system(size: 10.5, design: .monospaced))
-                                .foregroundColor(theme.color("add"))
-                        }
-                        if worktree.deletedLines > 0 {
-                            Text("−\(worktree.deletedLines)")
-                                .font(.system(size: 10.5, design: .monospaced))
-                                .foregroundColor(theme.color("del"))
-                        }
-                        if let summary = harnessSummary {
-                            Spacer(minLength: 6)
-                            Button(action: onActivateHarness) {
-                                HarnessPill(
-                                    summary: summary,
-                                    variant: .full,
-                                    tooltip: pillTooltip(for: summary)
-                                )
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-                }
-                .padding(.leading, 32)
-                .padding(.trailing, 10)
-                .padding(.vertical, 7)
+        ZStack(alignment: .leading) {
+            if isSelected {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(theme.color("bg-4"))
+                Rectangle()
+                    .fill(theme.color("accent"))
+                    .frame(width: 3, height: 14)
+                    .cornerRadius(2)
+                    .offset(x: 2, y: 0)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Icon(name: "branch", size: 11, color: theme.color("fg-faint"))
+                    Text(worktree.branch)
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+                HStack(spacing: 8) {
+                    Text(relative(worktree.lastActivity))
+                        .font(.system(size: 10.5))
+                        .foregroundColor(theme.color("fg-faint"))
+                    if worktree.addedLines > 0 {
+                        Text("+\(worktree.addedLines)")
+                            .font(.system(size: 10.5, design: .monospaced))
+                            .foregroundColor(theme.color("add"))
+                    }
+                    if worktree.deletedLines > 0 {
+                        Text("−\(worktree.deletedLines)")
+                            .font(.system(size: 10.5, design: .monospaced))
+                            .foregroundColor(theme.color("del"))
+                    }
+                    if let summary = harnessSummary {
+                        Spacer()
+                        Button(action: onActivateHarness) {
+                            HarnessPill(
+                                summary: summary,
+                                variant: .full,
+                                tooltip: pillTooltip(for: summary)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .padding(.leading, 32)
+            .padding(.trailing, 10)
+            .padding(.vertical, 7)
         }
-        .buttonStyle(.plain)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
         .contextMenu {
             Button("Open in Terminal", action: onOpenTerminal)
             Button("Copy Path", action: onCopyPath)

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -54,7 +54,8 @@ struct WorktreeRowView: View {
                             HarnessPill(
                                 summary: summary,
                                 variant: .full,
-                                tooltip: pillTooltip(for: summary)
+                                tooltip: pillTooltip(for: summary),
+                                isSelected: isSelected
                             )
                         }
                         .buttonStyle(.plain)
@@ -89,7 +90,7 @@ struct WorktreeRowView: View {
         let stateText: String
         switch summary.state {
         case .running:  stateText = "running"
-        case .awaiting: stateText = "awaiting input"
+        case .awaiting: stateText = "awaiting"
         }
         return "\(summary.kind.displayName) · \(stateText)"
     }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct WorktreeRowView: View {
     let worktree: Worktree
     let isSelected: Bool
+    let harnessSummary: HarnessService.WorktreeHarnessSummary?
     let onTap: () -> Void
     let onOpenTerminal: () -> Void
     let onCopyPath: () -> Void
@@ -10,6 +11,7 @@ struct WorktreeRowView: View {
     let onRevealInFinder: () -> Void
     let onArchive: () -> Void
     let onDelete: () -> Void
+    let onActivateHarness: () -> Void
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -47,6 +49,17 @@ struct WorktreeRowView: View {
                                 .font(.system(size: 10.5, design: .monospaced))
                                 .foregroundColor(theme.color("del"))
                         }
+                        if let summary = harnessSummary {
+                            Spacer(minLength: 6)
+                            Button(action: onActivateHarness) {
+                                HarnessPill(
+                                    summary: summary,
+                                    variant: .full,
+                                    tooltip: pillTooltip(for: summary)
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
                     }
                 }
                 .padding(.leading, 32)
@@ -73,5 +86,14 @@ struct WorktreeRowView: View {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func pillTooltip(for summary: HarnessService.WorktreeHarnessSummary) -> String {
+        let stateText: String
+        switch summary.state {
+        case .running:  stateText = "running"
+        case .awaiting: stateText = "awaiting input"
+        }
+        return "\(summary.kind.displayName) · \(stateText)"
     }
 }

--- a/AlasTests/HarnessDetectorTests.swift
+++ b/AlasTests/HarnessDetectorTests.swift
@@ -12,4 +12,20 @@ struct HarnessDetectorTests {
     @Test func unknownReturnsNil() {
         #expect(HarnessDetector.matchKind(processName: "zsh") == nil)
     }
+
+    @Test func matchesCodexHomebrewBinary() {
+        #expect(HarnessDetector.matchKind(processName: "codex-aarch64-apple-darwin") == .codex)
+        #expect(HarnessDetector.matchKind(processName: "codex-x86_64-apple-darwin") == .codex)
+    }
+
+    @Test func matchesAnyDashSuffix() {
+        #expect(HarnessDetector.matchKind(processName: "claude-code") == .claudeCode)
+        #expect(HarnessDetector.matchKind(processName: "codex-cli") == .codex)
+    }
+
+    @Test func doesNotMatchSubstring() {
+        // "claudefoo" must NOT match — only the exact name or name-DASH prefix.
+        #expect(HarnessDetector.matchKind(processName: "claudefoo") == nil)
+        #expect(HarnessDetector.matchKind(processName: "aiderbot") == nil)
+    }
 }

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -97,7 +97,8 @@ struct HarnessServiceTests {
         #expect(summary?.state == .running)
         #expect(summary?.kind == .claudeCode)
         #expect(summary?.primarySessionId == "s1")
-        #expect(summary?.sessionCount == 1)
+        #expect(summary?.runningSessionCount == 1)
+        #expect(summary?.awaitingSessionCount == 0)
     }
 
     @Test func summary_prefersAwaiting_overRunning() {
@@ -108,7 +109,11 @@ struct HarnessServiceTests {
         #expect(summary?.state == .awaiting)
         #expect(summary?.kind == .codex)
         #expect(summary?.primarySessionId == "s2")
-        #expect(summary?.sessionCount == 1) // only awaiting sessions counted
+        // Both counts are populated regardless of which state was chosen, so
+        // callers (e.g. the collapsed-header tooltip) can enumerate mixed
+        // activity even when awaiting masks running.
+        #expect(summary?.runningSessionCount == 1)
+        #expect(summary?.awaitingSessionCount == 1)
     }
 
     @Test func summary_picksFirstAwaitingSession_asPrimary() {
@@ -117,7 +122,8 @@ struct HarnessServiceTests {
         service.setStateForTesting(sessionId: "b", kind: .codex,      state: "awaiting")
         let summary = service.summary(forSessionIds: ["a", "b"])
         #expect(summary?.primarySessionId == "a")
-        #expect(summary?.sessionCount == 2)
+        #expect(summary?.runningSessionCount == 0)
+        #expect(summary?.awaitingSessionCount == 2)
     }
 
     @Test func summary_skipsSession_whenKindMissing() {

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -74,4 +74,76 @@ struct HarnessServiceTests {
         #expect(requests[0].content.title == "Aider finished")
         #expect(requests[0].content.body == "Done")
     }
+
+    @Test func summary_returnsNil_whenIdsEmpty() {
+        let service = HarnessService()
+        #expect(service.summary(forSessionIds: []) == nil)
+    }
+
+    @Test func summary_returnsNil_whenAllSessionsDone() {
+        let service = HarnessService()
+        service.handleHookEvent(
+            HookEvent(sessionId: "s1", kind: "stop", timestamp: Date(), summary: nil),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        #expect(service.stateBySession["s1"] == "done")
+        #expect(service.summary(forSessionIds: ["s1"]) == nil)
+    }
+
+    @Test func summary_returnsRunning_whenSingleSessionRunning() {
+        let service = HarnessService()
+        service.setStateForTesting(sessionId: "s1", kind: .claudeCode, state: "running")
+        let summary = service.summary(forSessionIds: ["s1"])
+        #expect(summary?.state == .running)
+        #expect(summary?.kind == .claudeCode)
+        #expect(summary?.primarySessionId == "s1")
+        #expect(summary?.sessionCount == 1)
+    }
+
+    @Test func summary_prefersAwaiting_overRunning() {
+        let service = HarnessService()
+        service.setStateForTesting(sessionId: "s1", kind: .claudeCode, state: "running")
+        service.setStateForTesting(sessionId: "s2", kind: .codex,      state: "awaiting")
+        let summary = service.summary(forSessionIds: ["s1", "s2"])
+        #expect(summary?.state == .awaiting)
+        #expect(summary?.kind == .codex)
+        #expect(summary?.primarySessionId == "s2")
+        #expect(summary?.sessionCount == 1) // only awaiting sessions counted
+    }
+
+    @Test func summary_picksFirstAwaitingSession_asPrimary() {
+        let service = HarnessService()
+        service.setStateForTesting(sessionId: "a", kind: .claudeCode, state: "awaiting")
+        service.setStateForTesting(sessionId: "b", kind: .codex,      state: "awaiting")
+        let summary = service.summary(forSessionIds: ["a", "b"])
+        #expect(summary?.primarySessionId == "a")
+        #expect(summary?.sessionCount == 2)
+    }
+
+    @Test func summary_skipsSession_whenKindMissing() {
+        let service = HarnessService()
+        // session "a" has state but no kind (race condition)
+        service.setStateOnlyForTesting(sessionId: "a", state: "awaiting")
+        service.setStateForTesting(sessionId: "b", kind: .codex, state: "awaiting")
+        let summary = service.summary(forSessionIds: ["a", "b"])
+        #expect(summary?.kind == .codex)
+        #expect(summary?.primarySessionId == "b")
+    }
+
+    @Test func summary_fallsBackToRunning_whenAllAwaitingLackKind() {
+        let service = HarnessService()
+        service.setStateOnlyForTesting(sessionId: "a", state: "awaiting")
+        service.setStateForTesting(sessionId: "b", kind: .claudeCode, state: "running")
+        let summary = service.summary(forSessionIds: ["a", "b"])
+        #expect(summary?.state == .running)
+        #expect(summary?.kind == .claudeCode)
+        #expect(summary?.primarySessionId == "b")
+    }
+
+    @Test func summary_returnsNil_whenNoCandidateSessionHasKind() {
+        let service = HarnessService()
+        service.setStateOnlyForTesting(sessionId: "a", state: "awaiting")
+        service.setStateOnlyForTesting(sessionId: "b", state: "running")
+        #expect(service.summary(forSessionIds: ["a", "b"]) == nil)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a small `run` / `wait` pill to each worktree row whenever any terminal session inside has a detected harness (Claude Code / Codex / Aider) in `running` or `awaiting` state. Priority: awaiting wins.
- When the parent repo group is collapsed, a single colored dot bubbles up to the repo header (priority-resolved across the project's worktrees), with a tooltip like `"2 running, 1 awaiting (Claude Code, Codex)"`.
- Clicking the worktree pill routes through `AppState.activateHarnessSession(...)` — same path used by the upstream macOS notification click-through (selects worktree, activates the hosting terminal tab, brings the app to front).
- Also fixes Codex detection for Homebrew installs: `HarnessDetector.matchKind` now allows `name-DASH-anything` so `codex-aarch64-apple-darwin` resolves to `.codex` (previously only exact `codex` / `codex-cli` matched).

## Implementation notes

- New aggregation helper `HarnessService.summary(forSessionIds:)` plus types `AggregatedState` and `WorktreeHarnessSummary`. Decoupled from `AppState` — takes a list of session ids, returns a single summary. Skips ids missing a kind (race between detector tick and hook event); falls back from awaiting → running if no awaiting session has a kind. 8 new unit tests cover the rules.
- New `HarnessPill` view with `.full` (pill + label) and `.dotOnly` (bare dot) variants. Theme tokens: `add` (running, green), `mod` (awaiting, yellow), `bg-4` background (`bg-3` when selected so it contrasts against the highlighted row).
- `WorktreeRowView` row wrapper changed from `Button(action:)` to `onTapGesture` + `contentShape` to avoid the nested-Button hit-region issue the codebase already documents in `RepoGroupView`.
- `RepoGroupView` derives a project-level rollup (awaiting > running > nil) and renders the header dot only when collapsed; per-row pills carry the signal when expanded.
- `AppState.activateHarnessSession(projectId:worktreeId:sessionId:)` is the single click-through entry point — the existing `harness.onClickThrough` notification path now delegates to it.

## Test plan

- [ ] Build + tests green in CI.
- [ ] In an open worktree, run `claude` — pill turns `run` (green) within ~2s. Hover shows `"Claude Code · running"`.
- [ ] Trigger an awaiting state (Claude asks something) — pill switches to `wait` (yellow). Hover shows `"Claude Code · awaiting"`. Tink sound plays. Banner shows (from upstream PR #85).
- [ ] Select the busy worktree — pill stays visible against the highlighted row (the `bg-3` selected-state contrast fix).
- [ ] Collapse the repo group — small colored dot appears next to the worktree count. Hover lists count + distinct kinds.
- [ ] From another worktree, click the pill — selected worktree switches, terminal tab activates, window comes to front.
- [ ] Exit the harness — pill and header dot disappear within ~2s.
- [ ] Verify Codex detection: run `codex` (Homebrew install resolves to `codex-aarch64-apple-darwin`) — pill should appear.
- [ ] Existing terminal tab dot indicator and notification banners still work (no regressions in the click-through path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)