### PR TITLE
Stop alas from contending with terminal git for .git/index.lock

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
 		9782C5866410EFE13E670AFF /* FilesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A3B9B1103346242438940 /* FilesTabView.swift */; };
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
+		98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
@@ -313,6 +314,7 @@
 		2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficLights.swift; sourceTree = "<group>"; };
 		2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDiffView.swift; sourceTree = "<group>"; };
 		30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorCoordinator.swift; sourceTree = "<group>"; };
+		321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherTests.swift; sourceTree = "<group>"; };
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
 		3375A79ACFD3567389DA855C /* FileResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileResultRow.swift; sourceTree = "<group>"; };
 		339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeBuilder.swift; sourceTree = "<group>"; };
@@ -609,6 +611,7 @@
 				88379ACE40F42BE4A3257659 /* ThemeTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
+				321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 			);
 			path = AlasTests;
@@ -1524,6 +1527,7 @@
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
+				98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -129,13 +129,41 @@ extension Process {
         )
     }
 
-    /// Convenience wrapper that always uses `/usr/bin/env git`.
+    /// Builds the environment for every git invocation Alas spawns.
+    ///
+    /// Starts from the parent process env (so `PATH`, `HOME`, etc. work) and
+    /// sets `GIT_OPTIONAL_LOCKS=0`. The latter tells git not to take
+    /// optional locks like `.git/index.lock` on read-class commands
+    /// (`status`, `diff`, ...). Without it, alas's background monitoring
+    /// loop fights terminal git (`gg sync`, `git commit`) for the index
+    /// lock and the terminal call fails with
+    /// `fatal: Unable to create '.git/index.lock': File exists.`
+    ///
+    /// This dict is applied to the *child* process only — we never
+    /// `setenv` on Alas itself — so the embedded Ghostty terminal (which
+    /// builds its env from `ProcessInfo.processInfo.environment` via
+    /// `EnvBuilder`) is unaffected and user-typed `git` commands behave
+    /// exactly as they would in any other terminal.
+    static func gitEnv() -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        env["GIT_OPTIONAL_LOCKS"] = "0"
+        return env
+    }
+
+    /// Convenience wrapper that always uses `/usr/bin/env git` with the
+    /// optional-locks-suppressed env from `gitEnv()`.
     static func git(
         _ args: [String],
         cwd: URL? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResult {
-        try await run("/usr/bin/env", args: ["git"] + args, cwd: cwd, timeout: timeout)
+        try await run(
+            "/usr/bin/env",
+            args: ["git"] + args,
+            cwd: cwd,
+            env: gitEnv(),
+            timeout: timeout
+        )
     }
 }
 

--- a/Alas/Sources/Watch/WorktreeWatcher.swift
+++ b/Alas/Sources/Watch/WorktreeWatcher.swift
@@ -62,10 +62,26 @@ final class WorktreeWatcher {
             info: Unmanaged.passUnretained(self).toOpaque(),
             retain: nil, release: nil, copyDescription: nil
         )
-        let cb: FSEventStreamCallback = { _, ctx, _, _, _, _ in
+        let cb: FSEventStreamCallback = { _, ctx, numEvents, eventPaths, _, _ in
             guard let ctx else { return }
             let watcher = Unmanaged<WorktreeWatcher>.fromOpaque(ctx).takeUnretainedValue()
-            watcher.debouncer.poke()
+
+            // With `kFSEventStreamCreateFlagUseCFTypes` set on the stream,
+            // `eventPaths` is a `CFArrayRef` of `CFStringRef`. Bridge to
+            // Swift `[String]`, then ask the filter whether anything in this
+            // batch is worth a refresh. If the bridge ever fails (unexpected
+            // — would only happen if the flag was lost), fall back to the
+            // previous always-poke behavior so we never silently drop real
+            // change events.
+            let cfArray = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue()
+            guard let paths = cfArray as? [String], paths.count == numEvents else {
+                watcher.debouncer.poke()
+                return
+            }
+
+            if WorktreeWatcher.shouldRefresh(forEventPaths: paths) {
+                watcher.debouncer.poke()
+            }
         }
         return FSEventStreamCreate(
             kCFAllocatorDefault,
@@ -74,7 +90,11 @@ final class WorktreeWatcher {
             paths as CFArray,
             FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
             0.5,
-            FSEventStreamCreateFlags(kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer)
+            FSEventStreamCreateFlags(
+                kFSEventStreamCreateFlagFileEvents
+                | kFSEventStreamCreateFlagNoDefer
+                | kFSEventStreamCreateFlagUseCFTypes
+            )
         )
     }
 

--- a/Alas/Sources/Watch/WorktreeWatcher.swift
+++ b/Alas/Sources/Watch/WorktreeWatcher.swift
@@ -108,8 +108,7 @@ final class WorktreeWatcher {
     /// changes and DO trigger a refresh.
     static func shouldRefresh(forEventPaths paths: [String]) -> Bool {
         for path in paths {
-            let base = (path as NSString).lastPathComponent
-            if base.hasSuffix(".lock") && path.contains("/.git/") {
+            if path.hasSuffix(".lock") && path.contains("/.git/") {
                 continue
             }
             return true

--- a/Alas/Sources/Watch/WorktreeWatcher.swift
+++ b/Alas/Sources/Watch/WorktreeWatcher.swift
@@ -78,6 +78,25 @@ final class WorktreeWatcher {
         )
     }
 
+    /// Returns `true` iff at least one event path represents a change we want
+    /// to react to. Git lockfiles (`*.lock` inside any `.git/` directory) are
+    /// filtered out: they appear when another git process is mid-write
+    /// (commit, rebase, fetch); reacting would (a) trigger a redundant
+    /// refresh during the user's operation and (b) historically caused
+    /// `.git/index.lock` contention with terminal git. Project lockfiles
+    /// outside `.git/` (e.g. `Cargo.lock`, `package-lock.json`) are real
+    /// changes and DO trigger a refresh.
+    static func shouldRefresh(forEventPaths paths: [String]) -> Bool {
+        for path in paths {
+            let base = (path as NSString).lastPathComponent
+            if base.hasSuffix(".lock") && path.contains("/.git/") {
+                continue
+            }
+            return true
+        }
+        return false
+    }
+
     /// Resolves the real git-dir for a worktree. For a normal repo this is
     /// `<worktree>/.git`; for a linked worktree it points into
     /// `<repo>/.git/worktrees/<name>/` instead. Returns nil if `git

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -67,6 +67,18 @@ struct ProcessGitTests {
         #expect(env["HOME"] != nil)
     }
 
+    @Test func gitEnvPreservesAllParentVariables() {
+        // Stronger than the keyed tests above: a broken implementation that
+        // returned a hardcoded minimal dict (PATH/HOME only) would pass the
+        // single-key checks. Verify the whole parent env round-trips, with
+        // the single deliberate exception of GIT_OPTIONAL_LOCKS.
+        let parent = ProcessInfo.processInfo.environment
+        let env = Process.gitEnv()
+        for (key, value) in parent where key != "GIT_OPTIONAL_LOCKS" {
+            #expect(env[key] == value, "key \(key) was dropped or changed")
+        }
+    }
+
     @Test func gitConvenienceCallStillWorks() async throws {
         // Sanity: after switching to the explicit env dict (no longer
         // passing env: nil), `Process.git` must still successfully locate

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -45,4 +45,34 @@ struct ProcessGitTests {
             Issue.record("wrong error: \(error)")
         }
     }
+
+    @Test func gitEnvSetsOptionalLocksToZero() {
+        let env = Process.gitEnv()
+        #expect(env["GIT_OPTIONAL_LOCKS"] == "0")
+    }
+
+    @Test func gitEnvInheritsPath() {
+        // The parent process always has PATH set (xcodebuild guarantees this).
+        // If we accidentally clear inherited env when adding overrides, git
+        // can't be located and every git call breaks.
+        let env = Process.gitEnv()
+        #expect(env["PATH"] != nil)
+        #expect(env["PATH"]?.isEmpty == false)
+    }
+
+    @Test func gitEnvInheritsHome() {
+        // git resolves global config via HOME. Without inheritance, every
+        // `git` call would run with the wrong identity / no config.
+        let env = Process.gitEnv()
+        #expect(env["HOME"] != nil)
+    }
+
+    @Test func gitConvenienceCallStillWorks() async throws {
+        // Sanity: after switching to the explicit env dict (no longer
+        // passing env: nil), `Process.git` must still successfully locate
+        // and run /usr/bin/env git.
+        let result = try await Process.git(["--version"])
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.contains("git version"))
+    }
 }

--- a/AlasTests/WorktreeWatcherTests.swift
+++ b/AlasTests/WorktreeWatcherTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct WorktreeWatcherTests {
+    @Test func emptyEventListSkipsRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(forEventPaths: []) == false)
+    }
+
+    @Test func gitIndexLockSkipsRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: ["/Users/x/repo/.git/index.lock"]
+        ) == false)
+    }
+
+    @Test func gitHeadLockSkipsRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: ["/Users/x/repo/.git/HEAD.lock"]
+        ) == false)
+    }
+
+    @Test func gitPackedRefsLockSkipsRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: ["/Users/x/repo/.git/packed-refs.lock"]
+        ) == false)
+    }
+
+    @Test func linkedWorktreeIndexLockSkipsRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: ["/Users/x/repo/.git/worktrees/feat-foo/index.lock"]
+        ) == false)
+    }
+
+    @Test func gitIndexUpdateTriggersRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: ["/Users/x/repo/.git/index"]
+        ) == true)
+    }
+
+    @Test func gitHeadUpdateTriggersRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: ["/Users/x/repo/.git/HEAD"]
+        ) == true)
+    }
+
+    @Test func projectCargoLockTriggersRefresh() {
+        // Project lockfiles outside .git/ are real changes.
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: ["/Users/x/repo/Cargo.lock"]
+        ) == true)
+    }
+
+    @Test func projectPackageLockTriggersRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: ["/Users/x/repo/package-lock.json"]
+        ) == true)
+    }
+
+    @Test func mixedBatchWithRealEventTriggersRefresh() {
+        // If at least one event is a real change, we refresh.
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: [
+                "/Users/x/repo/.git/index.lock",
+                "/Users/x/repo/src/foo.swift",
+            ]
+        ) == true)
+    }
+
+    @Test func multipleLockOnlyBatchSkipsRefresh() {
+        #expect(WorktreeWatcher.shouldRefresh(
+            forEventPaths: [
+                "/Users/x/repo/.git/index.lock",
+                "/Users/x/repo/.git/HEAD.lock",
+            ]
+        ) == false)
+    }
+}


### PR DESCRIPTION
## Summary

Fix `fatal: Unable to create '.git/index.lock': File exists.` that triggers whenever terminal git (especially `gg sync`) is run while alas is open on the same repo.

Two-part fix, both directly addressing the spec's root-cause analysis:

- **`GIT_OPTIONAL_LOCKS=0` on every git child process.** `Process.git` now seeds the child env from `ProcessInfo.processInfo.environment` and sets `GIT_OPTIONAL_LOCKS=0`. This stops `git status` from taking `.git/index.lock` to refresh the index stat cache — the canonical fix used by VS Code / GitHub Desktop. Applied at the `Process.git` boundary so alas's own env (and therefore the embedded Ghostty terminal's inherited env) is untouched.
- **Filter `.git/*.lock` FSEvents in `WorktreeWatcher`.** Added `kFSEventStreamCreateFlagUseCFTypes` so `eventPaths` is bridgeable to `[String]`, then a pure `shouldRefresh(forEventPaths:)` predicate that suppresses wake-ups for `*.lock` files inside any `.git/` directory (including linked-worktree gitdirs). Project lockfiles outside `.git/` (`Cargo.lock`, `package-lock.json`) still trigger refresh. Bridge-failure path falls back to the previous always-poke behavior so we never silently drop real change events.

Design doc: `docs/superpowers/specs/2026-05-12-git-lock-contention-fix-design.md`
Plan: `docs/superpowers/plans/2026-05-12-git-lock-contention-fix.md`

## Test plan

- [x] `xcodebuild test` — 432/432 pass
- [x] 11 new unit tests for `shouldRefresh` (empty batch, single `.git/*.lock`, linked-worktree lockfile, project `Cargo.lock`/`package-lock.json`, mixed batch, lock-only batch)
- [x] 5 new unit tests for `Process.gitEnv()` (sets `GIT_OPTIONAL_LOCKS=0`, inherits `PATH`/`HOME`, round-trips full parent env, smoke-tests `Process.git(["--version"])`)
- [x] Regression suite for git-touching code (`GitServiceTests`, `GitStatusCacheTests`, `CommitsAheadTests`, `CommitDetailsTests`, `WorktreeServiceTests`) — all pass
- [ ] Manual repro: open alas, run `gg sync` from terminal → no `index.lock` errors
- [ ] Manual repro: `git commit` from terminal → Changes pane updates within ~0.5s, no errors
- [ ] Manual: `env | grep GIT_OPTIONAL_LOCKS` inside embedded Ghostty terminal returns nothing (the override is child-process-scoped only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)