### PR TITLE
fix(shortcuts): reserve Cmd+1 through Cmd+9 for app tab switching

### DIFF
--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -335,7 +335,8 @@ extension AlasGhostty {
                 .subtracting(.capsLock)
             guard flags == .command else { return false }
 
-            return event.charactersIgnoringModifiers?.lowercased() == "t"
+            guard let chars = event.charactersIgnoringModifiers?.lowercased() else { return false }
+            return chars == "t" || ("1"..."9").contains(chars)
         }
 
         // MARK: - Mouse events

--- a/AlasTests/SurfaceViewShortcutTests.swift
+++ b/AlasTests/SurfaceViewShortcutTests.swift
@@ -37,6 +37,61 @@ struct SurfaceViewShortcutTests {
         #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
     }
 
+    @Test func commandDigitOneIsReservedForAppCommand() throws {
+        let event = try keyEvent(
+            characters: "1",
+            ignoringModifiers: "1",
+            modifiers: .command,
+            keyCode: 18
+        )
+
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func commandDigitNineIsReservedForAppCommand() throws {
+        let event = try keyEvent(
+            characters: "9",
+            ignoringModifiers: "9",
+            modifiers: .command,
+            keyCode: 25
+        )
+
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func commandDigitAllowsCapsLock() throws {
+        let event = try keyEvent(
+            characters: "1",
+            ignoringModifiers: "1",
+            modifiers: [.command, .capsLock],
+            keyCode: 18
+        )
+
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func modifiedCommandDigitIsNotReserved() throws {
+        let event = try keyEvent(
+            characters: "!",
+            ignoringModifiers: "1",
+            modifiers: [.command, .shift],
+            keyCode: 18
+        )
+
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func commandZeroIsNotReserved() throws {
+        let event = try keyEvent(
+            characters: "0",
+            ignoringModifiers: "0",
+            modifiers: .command,
+            keyCode: 29
+        )
+
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
     @Test func otherCommandKeysAreNotReserved() throws {
         let event = try keyEvent(
             characters: "w",


### PR DESCRIPTION
Ghostty's performKeyEquivalent was intercepting Cmd+1..Cmd+9
before they could reach SwiftUI menu commands, causing the
current-worktree tab switching regression.
