### PR TITLE
Group changed files by directory tree

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
 		5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12340A649892955245BECB7 /* DefinitionFeature.swift */; };
+		59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
 		5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C486F9097A2B145D101E2C /* AlasButton.swift */; };
 		5EA1AA5C8D9DE003BACE8291 /* AlasGhostty.Surface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */; };
@@ -220,6 +221,7 @@
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
+		D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */; };
 		D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */; };
 		D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
@@ -403,6 +405,7 @@
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
+		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
@@ -489,6 +492,7 @@
 		E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibilityTests.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilderTests.swift; sourceTree = "<group>"; };
 		E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClientTests.swift; sourceTree = "<group>"; };
 		E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionTests.swift; sourceTree = "<group>"; };
 		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
@@ -559,6 +563,7 @@
 				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
+				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
 				DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */,
 				9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */,
@@ -643,6 +648,7 @@
 			isa = PBXGroup;
 			children = (
 				EBBBF87CC508451B2C0F3A66 /* .gitkeep */,
+				910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */,
 				6AF335AB8B3061C889A348B3 /* CommitDetails.swift */,
 				3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */,
 				E1703FC5CD7DF16F4450E274 /* DiffParser.swift */,
@@ -1308,6 +1314,7 @@
 				40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */,
 				8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */,
 				23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */,
+				D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */,
 				EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */,
 				41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */,
 				A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */,
@@ -1466,6 +1473,7 @@
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
+				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
 				E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */,
 				F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */,
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,

--- a/Alas/Sources/Git/ChangesTreeBuilder.swift
+++ b/Alas/Sources/Git/ChangesTreeBuilder.swift
@@ -35,11 +35,12 @@ enum ChangesTreeBuilder {
 
         let isLeaf = parts.count == 1
         let nodePath = prefix.isEmpty ? head : "\(prefix)/\(head)"
-        let existing = map[head]
 
         if isLeaf {
+            let key = nodeKey(name: head, isDir: false)
+            let existing = map[key]
             if existing == nil {
-                map[head] = TreeBuildNode(
+                map[key] = TreeBuildNode(
                     name: head,
                     path: file.path,
                     isDir: false,
@@ -47,10 +48,16 @@ enum ChangesTreeBuilder {
                 )
             }
         } else {
+            let key = nodeKey(name: head, isDir: true)
+            let existing = map[key]
             let dir = existing ?? TreeBuildNode(name: head, path: nodePath, isDir: true, badge: nil)
-            map[head] = dir
+            map[key] = dir
             insert(parts: Array(parts.dropFirst()), into: &dir.children, file: file, prefix: nodePath)
         }
+    }
+
+    private static func nodeKey(name: String, isDir: Bool) -> String {
+        "\(isDir ? "dir" : "file"):\(name)"
     }
 
     private static func finalise(_ map: [String: TreeBuildNode]) -> [FileTreeNode] {

--- a/Alas/Sources/Git/ChangesTreeBuilder.swift
+++ b/Alas/Sources/Git/ChangesTreeBuilder.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+enum ChangesTreeBuilder {
+    static func build(files: [ChangedFile]) -> [FileTreeNode] {
+        var roots: [String: TreeBuildNode] = [:]
+        for file in files {
+            let parts = file.path.split(separator: "/").map(String.init)
+            insert(parts: parts, into: &roots, file: file, prefix: "")
+        }
+        return compact(finalise(roots)).sorted(by: nodeOrder)
+    }
+
+    private final class TreeBuildNode {
+        let name: String
+        let path: String
+        let isDir: Bool
+        var badge: String?
+        var children: [String: TreeBuildNode] = [:]
+
+        init(name: String, path: String, isDir: Bool, badge: String?) {
+            self.name = name
+            self.path = path
+            self.isDir = isDir
+            self.badge = badge
+        }
+    }
+
+    private static func insert(
+        parts: [String],
+        into map: inout [String: TreeBuildNode],
+        file: ChangedFile,
+        prefix: String
+    ) {
+        guard let head = parts.first else { return }
+
+        let isLeaf = parts.count == 1
+        let nodePath = prefix.isEmpty ? head : "\(prefix)/\(head)"
+        let existing = map[head]
+
+        if isLeaf {
+            if existing == nil {
+                map[head] = TreeBuildNode(
+                    name: head,
+                    path: file.path,
+                    isDir: false,
+                    badge: file.status.isEmpty ? nil : file.status
+                )
+            }
+        } else {
+            let dir = existing ?? TreeBuildNode(name: head, path: nodePath, isDir: true, badge: nil)
+            map[head] = dir
+            insert(parts: Array(parts.dropFirst()), into: &dir.children, file: file, prefix: nodePath)
+        }
+    }
+
+    private static func finalise(_ map: [String: TreeBuildNode]) -> [FileTreeNode] {
+        map.values.map { node -> FileTreeNode in
+            let kids = node.isDir ? finalise(node.children).sorted(by: nodeOrder) : nil
+            return FileTreeNode(
+                name: node.name,
+                path: node.path,
+                kind: node.isDir ? .dir : .file,
+                children: kids,
+                badge: node.badge
+            )
+        }
+    }
+
+    private static func compact(_ nodes: [FileTreeNode]) -> [FileTreeNode] {
+        nodes.map { node in
+            guard node.kind == .dir else { return node }
+
+            var compacted = FileTreeNode(
+                name: node.name,
+                path: node.path,
+                kind: node.kind,
+                children: compact(node.children ?? []),
+                badge: node.badge
+            )
+
+            while
+                let children = compacted.children,
+                children.count == 1,
+                let child = children.first,
+                child.kind == .dir
+            {
+                compacted = FileTreeNode(
+                    name: "\(compacted.name)/\(child.name)",
+                    path: child.path,
+                    kind: .dir,
+                    children: child.children,
+                    badge: nil
+                )
+            }
+
+            return compacted
+        }
+    }
+
+    private static func nodeOrder(_ a: FileTreeNode, _ b: FileTreeNode) -> Bool {
+        if a.kind != b.kind { return a.kind == .dir }
+        return a.name.localizedStandardCompare(b.name) == .orderedAscending
+    }
+}

--- a/Alas/Sources/Git/GitTypes.swift
+++ b/Alas/Sources/Git/GitTypes.swift
@@ -36,7 +36,7 @@ enum ChangeStage: String, Codable {
 }
 
 struct FileTreeNode: Identifiable, Equatable, Codable {
-    var id: String { path }
+    var id: String { "\(kind.rawValue):\(path)" }
     let name: String
     let path: String          // relative to repo root
     let kind: Kind

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ChangedRow: View {
     let file: ChangedFile
+    var depth: Int = 0
     let onSelect: () -> Void
     @Environment(\.theme) var theme
 
@@ -20,7 +21,9 @@ struct ChangedRow: View {
                 StatusBadge(status: file.status)
             }
             .font(.system(size: 11, design: .monospaced))
-            .padding(.horizontal, 12).padding(.vertical, 4)
+            .padding(.leading, CGFloat(12 + (depth == 0 ? 0 : depth * 14 + 14)))
+            .padding(.trailing, 12)
+            .padding(.vertical, 4)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -9,6 +9,7 @@ struct WorkingTreeSectionView: View {
 
     @State private var stagedExpanded: Bool = true
     @State private var unstagedExpanded: Bool = true
+    @State private var collapsedChangePaths: Set<String> = []
 
     private var staged:   [ChangedFile] { changes.filter { $0.stage == .staged   } }
     private var unstaged: [ChangedFile] { changes.filter { $0.stage == .unstaged } }
@@ -60,40 +61,53 @@ struct WorkingTreeSectionView: View {
             onToggle: { expanded.wrappedValue.toggle() }
         )
         if expanded.wrappedValue {
-            ForEach(directoryGroups(files), id: \.0) { (dir, items) in
-                if !dir.isEmpty || shouldShowRootHeader(in: files) {
-                    DirectoryRowLabel(title: dir.isEmpty ? "(root)" : dir)
-                }
-                ForEach(items) { file in
-                    ChangedRow(file: file, onSelect: { onSelect(file) })
-                }
+            let filesByPath = Dictionary(uniqueKeysWithValues: files.map { ($0.path, $0) })
+            ForEach(ChangesTreeBuilder.build(files: files)) { node in
+                renderNode(node, filesByPath: filesByPath, depth: 0)
             }
         }
     }
 
-    /// Show "(root)" only when at least one file is in a subdirectory —
-    /// otherwise the lone label is noisy.
-    private func shouldShowRootHeader(in files: [ChangedFile]) -> Bool {
-        files.contains(where: { $0.path.contains("/") })
-    }
-
-    private func directoryGroups(_ files: [ChangedFile]) -> [(String, [ChangedFile])] {
-        let dict = Dictionary(grouping: files) { f -> String in
-            let comps = f.path.split(separator: "/")
-            return comps.dropLast().joined(separator: "/")
+    private func renderNode(_ node: FileTreeNode, filesByPath: [String: ChangedFile], depth: Int) -> AnyView {
+        if node.kind == .dir {
+            let open = !collapsedChangePaths.contains(node.path)
+            return AnyView(
+                Group {
+                    Button {
+                        if open {
+                            collapsedChangePaths.insert(node.path)
+                        } else {
+                            collapsedChangePaths.remove(node.path)
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+                            Icon(name: "folder", size: 11, color: open ? theme.color("accent") : theme.color("fg-dim"))
+                            Text(node.name)
+                                .font(.system(size: 11.5, design: .monospaced))
+                                .foregroundColor(theme.color("fg"))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                        }
+                        .padding(.leading, CGFloat(12 + depth * 14))
+                        .padding(.trailing, 12)
+                        .padding(.vertical, 4)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    if open, let kids = node.children {
+                        ForEach(kids) { renderNode($0, filesByPath: filesByPath, depth: depth + 1) }
+                    }
+                }
+            )
+        } else if let file = filesByPath[node.path] {
+            return AnyView(
+                ChangedRow(file: file, depth: depth, onSelect: { onSelect(file) })
+            )
+        } else {
+            return AnyView(EmptyView())
         }
-        return dict.sorted { $0.key < $1.key }
-    }
-}
-
-private struct DirectoryRowLabel: View {
-    let title: String
-    @Environment(\.theme) private var theme
-    var body: some View {
-        Text(title)
-            .font(.system(size: 10.5, design: .monospaced))
-            .foregroundColor(theme.color("fg-faint"))
-            .padding(.horizontal, 12).padding(.top, 6).padding(.bottom, 2)
-            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -42,10 +42,10 @@ struct WorkingTreeSectionView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else {
                     if !staged.isEmpty {
-                        subsection(title: "Staged", files: staged, expanded: $stagedExpanded)
+                        subsection(title: "Staged", files: staged, expanded: $stagedExpanded, collapseNamespace: "staged")
                     }
                     if !unstaged.isEmpty {
-                        subsection(title: "Unstaged", files: unstaged, expanded: $unstagedExpanded)
+                        subsection(title: "Unstaged", files: unstaged, expanded: $unstagedExpanded, collapseNamespace: "unstaged")
                     }
                 }
             }
@@ -53,7 +53,12 @@ struct WorkingTreeSectionView: View {
     }
 
     @ViewBuilder
-    private func subsection(title: String, files: [ChangedFile], expanded: Binding<Bool>) -> some View {
+    private func subsection(
+        title: String,
+        files: [ChangedFile],
+        expanded: Binding<Bool>,
+        collapseNamespace: String
+    ) -> some View {
         SubHeader(
             title: title,
             count: files.count,
@@ -63,21 +68,27 @@ struct WorkingTreeSectionView: View {
         if expanded.wrappedValue {
             let filesByPath = Dictionary(uniqueKeysWithValues: files.map { ($0.path, $0) })
             ForEach(ChangesTreeBuilder.build(files: files)) { node in
-                renderNode(node, filesByPath: filesByPath, depth: 0)
+                renderNode(node, filesByPath: filesByPath, depth: 0, collapseNamespace: collapseNamespace)
             }
         }
     }
 
-    private func renderNode(_ node: FileTreeNode, filesByPath: [String: ChangedFile], depth: Int) -> AnyView {
+    private func renderNode(
+        _ node: FileTreeNode,
+        filesByPath: [String: ChangedFile],
+        depth: Int,
+        collapseNamespace: String
+    ) -> AnyView {
         if node.kind == .dir {
-            let open = !collapsedChangePaths.contains(node.path)
+            let collapseKey = "\(collapseNamespace):\(node.path)"
+            let open = !collapsedChangePaths.contains(collapseKey)
             return AnyView(
                 Group {
                     Button {
                         if open {
-                            collapsedChangePaths.insert(node.path)
+                            collapsedChangePaths.insert(collapseKey)
                         } else {
-                            collapsedChangePaths.remove(node.path)
+                            collapsedChangePaths.remove(collapseKey)
                         }
                     } label: {
                         HStack(spacing: 6) {
@@ -98,7 +109,14 @@ struct WorkingTreeSectionView: View {
                     }
                     .buttonStyle(.plain)
                     if open, let kids = node.children {
-                        ForEach(kids) { renderNode($0, filesByPath: filesByPath, depth: depth + 1) }
+                        ForEach(kids) {
+                            renderNode(
+                                $0,
+                                filesByPath: filesByPath,
+                                depth: depth + 1,
+                                collapseNamespace: collapseNamespace
+                            )
+                        }
                     }
                 }
             )

--- a/AlasTests/ChangesTreeBuilderTests.swift
+++ b/AlasTests/ChangesTreeBuilderTests.swift
@@ -1,0 +1,78 @@
+import Testing
+@testable import Alas
+
+struct ChangesTreeBuilderTests {
+    @Test func buildsNestedTree() {
+        let tree = ChangesTreeBuilder.build(files: [
+            changedFile("a/b/c.swift", status: "M"),
+            changedFile("a/d.swift", status: "A"),
+            changedFile("e.swift", status: "D")
+        ])
+
+        #expect(tree.map(\.name) == ["a", "e.swift"])
+        let aDir = tree.first { $0.name == "a" }!
+        #expect(aDir.kind == .dir)
+        #expect(aDir.children?.map(\.name) == ["b", "d.swift"])
+        let bDir = aDir.children!.first { $0.name == "b" }!
+        #expect(bDir.children?.first?.name == "c.swift")
+        #expect(bDir.children?.first?.badge == "M")
+    }
+
+    @Test func compactsSingleChildDirectoryChains() {
+        let tree = ChangesTreeBuilder.build(files: [
+            changedFile("d/e/f/g/ThisIsDeep.ext")
+        ])
+
+        #expect(tree.count == 1)
+        #expect(tree[0].name == "d/e/f/g")
+        #expect(tree[0].path == "d/e/f/g")
+        #expect(tree[0].children?.first?.name == "ThisIsDeep.ext")
+    }
+
+    @Test func preservesBranchesWhileCompactingNestedChains() {
+        let tree = ChangesTreeBuilder.build(files: [
+            changedFile("a/b/c/MyFileWithChanges.ext"),
+            changedFile("a/b/d/MyOtherFile.ext"),
+            changedFile("a/b/d/e/f/g/ThisIsDeep.ext")
+        ])
+
+        #expect(tree.map(\.name) == ["a/b"])
+        let ab = tree[0]
+        #expect(ab.children?.map(\.name) == ["c", "d"])
+        let d = ab.children!.first { $0.name == "d" }!
+        #expect(d.children?.map(\.name) == ["e/f/g", "MyOtherFile.ext"])
+    }
+
+    @Test func handlesRootFilesAndEmptyInput() {
+        #expect(ChangesTreeBuilder.build(files: []).isEmpty)
+
+        let tree = ChangesTreeBuilder.build(files: [
+            changedFile("Root.swift"),
+            changedFile("Sources/App.swift")
+        ])
+
+        #expect(tree.map(\.name) == ["Sources", "Root.swift"])
+        #expect(tree.first { $0.name == "Root.swift" }?.kind == .file)
+    }
+
+    @Test func propagatesStatusBadgeToFileLeaves() {
+        let tree = ChangesTreeBuilder.build(files: [
+            changedFile("Sources/App.swift", status: "R")
+        ])
+
+        let file = tree[0].children![0]
+        #expect(file.name == "App.swift")
+        #expect(file.path == "Sources/App.swift")
+        #expect(file.badge == "R")
+    }
+
+    private func changedFile(
+        _ path: String,
+        status: String = "M",
+        stage: ChangeStage = .unstaged,
+        add: Int = 1,
+        del: Int = 0
+    ) -> ChangedFile {
+        ChangedFile(path: path, status: status, stage: stage, add: add, del: del, renameFrom: nil)
+    }
+}

--- a/AlasTests/ChangesTreeBuilderTests.swift
+++ b/AlasTests/ChangesTreeBuilderTests.swift
@@ -66,6 +66,35 @@ struct ChangesTreeBuilderTests {
         #expect(file.badge == "R")
     }
 
+    @Test func preservesFileAndDirectoryPathCollisions() {
+        assertPreservesFileAndDirectoryPathCollisions([
+            changedFile("foo", status: "D"),
+            changedFile("foo/bar.swift", status: "A")
+        ])
+
+        assertPreservesFileAndDirectoryPathCollisions([
+            changedFile("foo/bar.swift", status: "A"),
+            changedFile("foo", status: "D")
+        ])
+    }
+
+    private func assertPreservesFileAndDirectoryPathCollisions(_ files: [ChangedFile]) {
+        let tree = ChangesTreeBuilder.build(files: files)
+
+        #expect(tree.count == 2)
+        #expect(tree[0].name == "foo")
+        #expect(tree[0].path == "foo")
+        #expect(tree[0].kind == .dir)
+        #expect(tree[0].id == "dir:foo")
+        #expect(tree[0].children?.first?.name == "bar.swift")
+
+        #expect(tree[1].name == "foo")
+        #expect(tree[1].path == "foo")
+        #expect(tree[1].kind == .file)
+        #expect(tree[1].id == "file:foo")
+        #expect(tree[1].badge == "D")
+    }
+
     private func changedFile(
         _ path: String,
         status: String = "M",

--- a/docs/research/785-changes-panel-directory-tree-grouping.md
+++ b/docs/research/785-changes-panel-directory-tree-grouping.md
@@ -1,0 +1,205 @@
+---
+task_id: 785
+title: "Group changed files by directory tree in Changes panel"
+date: 2026-05-12
+project: alas
+phase: groomed
+prior_art:
+  - Alas/Sources/Right/WorkingTreeSectionView.swift
+  - Alas/Sources/Right/FilesTabView.swift
+  - Alas/Sources/Git/FileTreeBuilder.swift
+  - Alas/Sources/Git/GitTypes.swift (FileTreeNode, ChangedFile)
+  - AlasTests/FileTreeBuilderTests.swift
+---
+
+## TL;DR
+
+The Changes panel currently shows a flat list with directory-path labels.
+The Files panel already renders a full nested tree via `FileTreeBuilder` +
+`FilesTabView`. This task reuses that infrastructure to render changed files
+as a collapsible directory tree, adding **path compaction** (fusing
+single-child intermediate directories like `a/b/c/` into one row) which
+neither panel has today. Scope is well-contained: one new pure function
+(`ChangesTreeBuilder`), edits to `WorkingTreeSectionView`, and new tests.
+No Git-layer changes needed.
+
+## Scope confirmation
+
+### In scope (v1)
+
+- Build a `ChangesTreeBuilder` that converts `[ChangedFile]` into a
+  `[FileTreeNode]` tree, with compaction of single-child directory chains.
+- Replace the flat `directoryGroups` rendering in `WorkingTreeSectionView`
+  with recursive tree rendering (expand/collapse per directory).
+- Track expanded directory state — either reuse `RightPaneState.openPaths`
+  or add a separate `changesOpenPaths: Set<String>` to avoid colliding with
+  the Files tab's expand state.
+- Preserve existing change summary/count behavior (`+add −del`, status
+  badges, staged/unstaged subsections).
+- Add focused tests for tree-building and compaction logic.
+
+### Out of scope (v1)
+
+- **Drag-and-drop staging/unstaging** — orthogonal UX feature, not related
+  to grouping. Can be added later on tree rows.
+- **Inline directory-level aggregate counts** (e.g., `+12 −3` on a
+  directory row) — nice-to-have but adds complexity; defer until UX
+  feedback requests it.
+- **Shared tree component** between Files tab and Changes tab — the
+  rendering needs differ enough (Changes rows carry `+add −del` and status
+  badges; Files rows carry only optional badge) that factoring a shared
+  component is premature. Revisit if they converge.
+- **Path compaction in the Files tab** — out of scope, separate task if
+  desired.
+
+## Architectural alignment
+
+### Current state
+
+**WorkingTreeSectionView** (`:1–99`)
+- `directoryGroups(_:)` at line 80 groups files by their parent directory
+  string, returning `[(String, [ChangedFile])]`.
+- `subsection(title:files:expanded:)` at line 54 renders each group with a
+  `DirectoryRowLabel` header followed by `ChangedRow` entries.
+- No nesting, no expand/collapse per directory.
+
+**FileTreeBuilder** (`:1–67`)
+- `build(paths:badges:)` converts flat path strings into nested
+  `[FileTreeNode]` with `.dir` / `.file` kinds.
+- Does **not** compact single-child chains — each directory level is its
+  own node.
+- Used only by the Files tab today.
+
+**FileTreeNode** (GitTypes.swift `:38–47`)
+- Already has `name`, `path`, `kind`, `children`, `badge` fields.
+- `name` is the display label — for compacted paths this would become
+  `"d/e/f"` instead of just `"d"`.
+
+**FilesTabView** (`:1–72`)
+- `renderNode(_:depth:)` recursively renders directories (with
+  chevron + folder icon, toggle on `openPaths`) and files.
+- Uses `AnyView` type erasure for the recursive return.
+
+**RightPaneState** (`:1–80`)
+- `changes: [ChangedFile]` — the flat list, already split by `.stage`.
+- `openPaths: Set<String>` — currently used by Files tab only.
+
+### Reuse plan
+
+1. **New `ChangesTreeBuilder`** — a pure `enum` similar to
+   `FileTreeBuilder` but:
+   - Input: `[ChangedFile]` (not raw paths).
+   - Output: `[FileTreeNode]` with compacted single-child dirs.
+   - Badges derived from `ChangedFile.status`.
+   - Each leaf `FileTreeNode.path` maps back to the `ChangedFile.path`
+     for the `onSelect` callback.
+
+2. **Compaction algorithm**: After building the nested tree, walk it
+   top-down. If a `.dir` node has exactly one child and that child is also
+   a `.dir`, merge them: `name = "parent/child"`, `path = child.path`,
+   `children = child.children`. Repeat until stable.
+
+3. **WorkingTreeSectionView** gets a recursive `renderNode` function
+   (similar to `FilesTabView`) that renders:
+   - **Directory rows**: chevron + folder icon + compacted name, toggle
+     expand/collapse. Styled consistently with Files tab but using the
+     existing Changes panel spacing.
+   - **File rows**: existing `ChangedRow` component, with added left
+     padding based on depth.
+
+4. **State**: Add `changesOpenPaths: Set<String>` to
+   `WorkingTreeSectionView` as `@State` (local to the view, does not need
+   persistence across refreshes — directories re-expand is fine). This
+   avoids polluting the shared `openPaths` used by Files tab.
+
+## Acceptance criteria
+
+1. Changed files in the Working Tree section are grouped under a
+   collapsible directory hierarchy matching the repo path structure.
+2. Staged and Unstaged subsections each render their own independent tree.
+3. Single-child directory chains are compacted (e.g., `a/b/c/` shows as
+   one row when `a/` and `b/` have no other children).
+4. File rows preserve existing behavior: file-type icon, basename,
+   `+add −del` counts, status badge (`A`/`M`/`D`/`R`).
+5. Directory rows are expand/collapse toggleable with chevron indicator.
+6. Root-level files (no parent directory) render without a directory
+   wrapper, same as today.
+7. `ChangesTreeBuilder` has unit tests covering:
+   - Basic nesting (files in different directories).
+   - Compaction of single-child chains.
+   - Mixed depth: root files + nested files.
+   - Empty input returns empty output.
+   - Badge propagation from `ChangedFile.status`.
+8. Existing `FileTreeBuilderTests` continue to pass unchanged.
+9. Build succeeds: `xcodebuild build -scheme Alas -destination 'platform=macOS'`.
+10. Tests pass: `xcodebuild test -scheme Alas -destination 'platform=macOS'`.
+
+## Open questions
+
+1. **Should directories start expanded or collapsed?**
+   Recommendation: Start all expanded (matches current flat-list behavior
+   where all files are visible). Users can collapse to reduce noise.
+
+2. **Should compaction apply when a directory has one file child (not dir)?**
+   Recommendation: No — only compact chains of directories. A directory
+   with a single file should still show as `dir/ > file` so the file row
+   retains its own click target and status badge.
+
+3. **Should `openPaths` persist across refreshes?**
+   Recommendation: Use `@State` in the view. On refresh the tree rebuilds
+   and all dirs re-expand. This is simpler and matches the "start expanded"
+   default. If users complain about losing collapse state, we can promote
+   to `RightPaneState` later.
+
+## Implementation order
+
+1. **`Alas/Sources/Git/ChangesTreeBuilder.swift`** (new file)
+   - Pure function: `static func build(files: [ChangedFile]) -> [FileTreeNode]`
+   - Internal helper for compaction pass.
+
+2. **`AlasTests/ChangesTreeBuilderTests.swift`** (new file)
+   - Tests per AC #7.
+
+3. **`Alas/Sources/Right/WorkingTreeSectionView.swift`** (edit)
+   - Replace `directoryGroups` + flat rendering with tree-based rendering.
+   - Add `@State private var openPaths: Set<String> = []` (or start with
+     all paths open).
+   - Add recursive `renderNode(_:depth:)` function.
+   - Adjust `ChangedRow` usage to pass depth for indentation.
+
+4. **`Alas/Sources/Right/ChangedRow.swift`** (edit)
+   - Add optional `depth: Int = 0` parameter for left-padding calculation.
+   - Default preserves existing call sites.
+
+5. **Verify build + tests.**
+
+## Risks / things to watch
+
+- **`AnyView` type erasure**: `FilesTabView` uses `AnyView` for recursive
+  rendering. This is a known SwiftUI performance concern for large trees.
+  Changes panel trees are small (typically <100 files) so this is fine, but
+  if the Files tab ever moves away from `AnyView`, the Changes tree should
+  follow.
+
+- **Compaction edge case**: Paths like `a/b` where `a/` has two children
+  (`b/` and a file) must NOT compact `a/`. The compaction predicate must
+  check that the dir has exactly one child AND that child is a dir.
+
+- **`openPaths` collision**: If we reuse `RightPaneState.openPaths`,
+  expanding a directory in Changes would also expand it in Files and vice
+  versa. Using view-local `@State` avoids this entirely.
+
+- **Refresh rebuilds the tree**: `WorkingTreeSectionView` receives
+  `changes` as a `let` — when `RightPaneState.refresh()` fires, SwiftUI
+  will re-render with new data. The tree is rebuilt each render. For
+  typical change counts (<100 files) this is negligible. If it becomes
+  an issue, memoize in `RightPaneState`.
+
+## Definition of done (handoff sign-off)
+
+- Grooming doc reviewed and accepted.
+- All architectural claims verified against current code (line numbers,
+  type signatures, existing helpers).
+- No blockers or unresolved questions that would prevent a designer or
+  implementer from starting immediately.
+- Task is ready for Design/Implementation phase.


### PR DESCRIPTION
## Summary

- Add a `ChangesTreeBuilder` for changed-file hierarchies with single-child directory chain compaction.
- Render staged/unstaged Changes entries as expandable directory trees while preserving existing changed-file rows and metadata.
- Add focused tree-builder tests for nested paths, compacted deep paths, root files, and status badges.
- Preserve the task research/design note for the rescued implementation.

## Validation

- [x] `git diff --check`
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test`

Rescues task #785 from the stale/dirty Mission Control run.