### PR TITLE
Fix New Worktree creation for existing branches

### DIFF
--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -167,6 +167,7 @@ struct NewWorktreeDialog: View {
         let runStartupAfter = runStartup
         let openTerminalAfter = openTerminal
         Task {
+            defer { isCreating = false }
             do {
                 let svc = WorktreeService()
                 let dest = URL(fileURLWithPath: pathOverride.isEmpty ? renderedPath : pathOverride)
@@ -216,7 +217,6 @@ struct NewWorktreeDialog: View {
             } catch {
                 errorMessage = error.localizedDescription
             }
-            isCreating = false
         }
     }
 

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -1,7 +1,17 @@
 import Foundation
 
 struct WorktreeService {
-    enum WorktreeError: Error { case gitFailed(String) }
+    enum WorktreeError: Error, LocalizedError {
+        case gitFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .gitFailed(stderr):
+                let msg = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                return msg.isEmpty ? "Git worktree operation failed." : msg
+            }
+        }
+    }
 
     /// Parse `git worktree list --porcelain` into Worktree records.
     func list(repoPath: URL, projectId: String) async throws -> [Worktree] {
@@ -53,10 +63,20 @@ struct WorktreeService {
         destination: URL,
         projectId: String
     ) async throws -> Worktree {
-        let result = try await Process.git(
-            ["worktree", "add", destination.path, "-b", branch, base],
+        let refCheck = try await Process.git(
+            ["show-ref", "--verify", "--quiet", "refs/heads/\(branch)"],
             cwd: repoPath
         )
+        let branchExists = refCheck.exitCode == 0
+
+        let args: [String]
+        if branchExists {
+            args = ["worktree", "add", destination.path, branch]
+        } else {
+            args = ["worktree", "add", destination.path, "-b", branch, base]
+        }
+
+        let result = try await Process.git(args, cwd: repoPath)
         guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
         return Worktree(
             id: Worktree.makeId(path: destination),

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -125,3 +125,46 @@ extension WorktreeServiceTests {
         #expect(listed.count == 1) // only main remains
     }
 }
+
+extension WorktreeServiceTests {
+    @Test func addForExistingBranchSucceedsWithoutDashB() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["branch", "nacho/starfin-deprecation"], cwd: repo)
+        let dest = repo.deletingLastPathComponent().appendingPathComponent("\(repo.lastPathComponent)-existing")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "nacho/starfin-deprecation",
+            destination: dest, projectId: "p"
+        )
+        #expect(wt.branch == "nacho/starfin-deprecation")
+        #expect(FileManager.default.fileExists(atPath: dest.path))
+        let listed = try await svc.list(repoPath: repo, projectId: "p")
+        #expect(listed.count == 2)
+    }
+
+    @Test func errorMessagePropagatesGitStderr() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let dest = repo.deletingLastPathComponent().appendingPathComponent("\(repo.lastPathComponent)-conflict")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        // Create a file at the destination so git worktree add fails.
+        try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "block".write(to: dest, atomically: true, encoding: .utf8)
+        let svc = WorktreeService()
+        do {
+            _ = try await svc.add(
+                repoPath: repo, base: "main", branch: "feat/conflict",
+                destination: dest, projectId: "p"
+            )
+            Issue.record("expected worktree add to fail")
+        } catch let error as WorktreeService.WorktreeError {
+            let msg = error.localizedDescription
+            #expect(!msg.contains("WorktreeError error"))
+            #expect(msg.count > 10)
+        } catch {
+            Issue.record("unexpected error type: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Detect existing local branches before creating a worktree and omit `-b` for that checkout path.
- Surface git stderr via `WorktreeError.localizedDescription` instead of the opaque Swift error text.
- Ensure the New Worktree dialog always clears its creating state after success or failure.
- Add regression coverage for existing-branch worktree creation and git error message propagation.

## Validation

- [x] `git diff --check`
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet test`

Rescues task #790 from the stale/dirty Mission Control run.