### PR TITLE
Terminal pane splits (recursive horizontal/vertical, persistent)

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */; };
 		41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */; };
 		4239885256AB11FE8207D31E /* TextEditCoordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8062405A67C934905EE61D98 /* TextEditCoordinates.swift */; };
+		42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */; };
 		42C0AE388E5CF8B2AAEADE3C /* SearchEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */; };
 		43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
@@ -384,6 +385,7 @@
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		7116359F27BF0A139E0F643B /* HookWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookWatcher.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
+		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
 		71E3734FE56F51B4615EF1A5 /* HookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookEvent.swift; sourceTree = "<group>"; };
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
 		768D12909DD5233659AC4E03 /* RepoGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupView.swift; sourceTree = "<group>"; };
@@ -612,6 +614,7 @@
 				D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
+				71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */,
 				1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */,
 				88379ACE40F42BE4A3257659 /* ThemeTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
@@ -1529,6 +1532,7 @@
 				CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
+				42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */,
 				F20871AEC0E533818C8E1B95 /* TextEditCoordinatesTests.swift in Sources */,
 				59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */,
 				BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		F20871AEC0E533818C8E1B95 /* TextEditCoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF73FD04363A737BB67F6E4 /* TextEditCoordinatesTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
+		F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -425,6 +426,7 @@
 		A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabStateTests.swift; sourceTree = "<group>"; };
 		A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileTypeTests.swift; sourceTree = "<group>"; };
 		A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClient.swift; sourceTree = "<group>"; };
+		A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDirectionTests.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimer.swift; sourceTree = "<group>"; };
 		A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailView.swift; sourceTree = "<group>"; };
@@ -581,6 +583,7 @@
 				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
 				3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */,
 				2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */,
+				A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */,
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
 				039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */,
@@ -1493,6 +1496,7 @@
 				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
 				6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */,
+				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */,
 				E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
+		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
@@ -209,6 +210,7 @@
 		C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDEA496740F5B0B5EE808B /* Process+Git.swift */; };
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
+		CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */; };
 		CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */; };
 		CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */; };
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
@@ -291,6 +293,7 @@
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
 		1688AB1B49758FAB5BF0AF2F /* light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = light.json; sourceTree = "<group>"; };
+		16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -416,6 +419,7 @@
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
+		A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTree.swift; sourceTree = "<group>"; };
 		A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabStateTests.swift; sourceTree = "<group>"; };
 		A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileTypeTests.swift; sourceTree = "<group>"; };
 		A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClient.swift; sourceTree = "<group>"; };
@@ -595,6 +599,7 @@
 				C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
+				16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */,
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
 				7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */,
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
@@ -1101,6 +1106,7 @@
 				159FE807399835B0821E1CAB /* EnvBuilder.swift */,
 				BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */,
 				215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */,
+				A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */,
 				2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */,
 				C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */,
 				1AFC62A30044F71F0F16C3FB /* TerminalService.swift */,
@@ -1394,6 +1400,7 @@
 				004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */,
 				7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */,
 				74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */,
+				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
 				671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */,
 				C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */,
@@ -1509,6 +1516,7 @@
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,
+				CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */,
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -118,6 +118,9 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasSplitDown, object: nil)
                 }
                 .keyboardShortcut("d", modifiers: [.command, .shift])
+                Button("Close Pane") {
+                    NotificationCenter.default.post(name: .alasCloseTab, object: nil)
+                }
                 Divider()
                 Button("Focus Pane Left") {
                     NotificationCenter.default.post(name: .alasFocusPaneLeft, object: nil)

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -109,6 +109,50 @@ struct AlasApp: App {
                 }
                 .keyboardShortcut("9", modifiers: .command)
             }
+            CommandMenu("Terminal") {
+                Button("Split Right") {
+                    NotificationCenter.default.post(name: .alasSplitRight, object: nil)
+                }
+                .keyboardShortcut("d", modifiers: .command)
+                Button("Split Down") {
+                    NotificationCenter.default.post(name: .alasSplitDown, object: nil)
+                }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
+                Divider()
+                Button("Focus Pane Left") {
+                    NotificationCenter.default.post(name: .alasFocusPaneLeft, object: nil)
+                }
+                .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+                Button("Focus Pane Right") {
+                    NotificationCenter.default.post(name: .alasFocusPaneRight, object: nil)
+                }
+                .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+                Button("Focus Pane Up") {
+                    NotificationCenter.default.post(name: .alasFocusPaneUp, object: nil)
+                }
+                .keyboardShortcut(.upArrow, modifiers: [.command, .option])
+                Button("Focus Pane Down") {
+                    NotificationCenter.default.post(name: .alasFocusPaneDown, object: nil)
+                }
+                .keyboardShortcut(.downArrow, modifiers: [.command, .option])
+                Divider()
+                Button("Resize Pane Left") {
+                    NotificationCenter.default.post(name: .alasResizePaneLeft, object: nil)
+                }
+                .keyboardShortcut(.leftArrow, modifiers: [.command, .control])
+                Button("Resize Pane Right") {
+                    NotificationCenter.default.post(name: .alasResizePaneRight, object: nil)
+                }
+                .keyboardShortcut(.rightArrow, modifiers: [.command, .control])
+                Button("Resize Pane Up") {
+                    NotificationCenter.default.post(name: .alasResizePaneUp, object: nil)
+                }
+                .keyboardShortcut(.upArrow, modifiers: [.command, .control])
+                Button("Resize Pane Down") {
+                    NotificationCenter.default.post(name: .alasResizePaneDown, object: nil)
+                }
+                .keyboardShortcut(.downArrow, modifiers: [.command, .control])
+            }
             CommandGroup(after: .toolbar) {
                 Divider()
                 Button("Increase Font Size") {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -186,7 +186,9 @@ final class AppState {
     func activateHarnessSession(projectId _: String, worktreeId: String, sessionId: String) {
         selectedWorktreeId = worktreeId
         if let tab = tabs.tabs(forWorktree: worktreeId).first(where: {
-            if case .terminal(let s) = $0 { return s.sessionId == sessionId }
+            if case .terminal(let s) = $0 {
+                return s.root.leaves().contains(where: { $0.sessionId == sessionId })
+            }
             return false
         }) {
             tabs.activate(worktreeId: worktreeId, tabId: tab.id)
@@ -217,8 +219,11 @@ final class AppState {
     func restoreTerminalTabIfNeeded(worktreeId: String, tabId: TabID, sessionId: String) throws -> Tab? {
         guard let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
               case .terminal(let state) = tab,
-              state.sessionId == sessionId else { return nil }
+              state.root.leaves().contains(where: { $0.sessionId == sessionId }) else { return nil }
         if terminal.registry.session(for: sessionId) != nil { return tab }
+        // Task 3 stop-gap: only handle the focused-leaf case. Task 12 generalizes this.
+        guard let focused = state.root.find(leafId: state.focusedLeafId)?.leaf,
+              focused.sessionId == sessionId else { return nil }
         return try replaceMissingTerminalSession(worktreeId: worktreeId, tab: state)
     }
 
@@ -339,9 +344,11 @@ final class AppState {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         if let tab = allTabs.first(where: { $0.id == tabId }) {
             if case .terminal(let s) = tab {
-                harness.detector.unregister(sessionId: s.sessionId)
-                harness.forgetSession(s.sessionId)
-                terminal.closeSession(id: s.sessionId)
+                for leaf in s.root.leaves() {
+                    harness.detector.unregister(sessionId: leaf.sessionId)
+                    harness.forgetSession(leaf.sessionId)
+                    terminal.closeSession(id: leaf.sessionId)
+                }
             }
             if case .editor = tab {
                 tabs.discardBuffer(worktreeId: worktreeId, tabId: tabId)
@@ -354,9 +361,11 @@ final class AppState {
         for id in tabIds {
             if let tab = allTabs.first(where: { $0.id == id }),
                case .terminal(let s) = tab {
-                harness.detector.unregister(sessionId: s.sessionId)
-                harness.forgetSession(s.sessionId)
-                terminal.closeSession(id: s.sessionId)
+                for leaf in s.root.leaves() {
+                    harness.detector.unregister(sessionId: leaf.sessionId)
+                    harness.forgetSession(leaf.sessionId)
+                    terminal.closeSession(id: leaf.sessionId)
+                }
             }
         }
     }
@@ -411,7 +420,7 @@ final class AppState {
             throw NSError(domain: "AppState", code: 2)
         }
 
-        let oldSessionId = tab.sessionId
+        let oldSessionId = tab.root.find(leafId: tab.focusedLeafId)?.leaf.sessionId ?? ""
         let session = try terminal.openSession(
             worktree: worktree, project: project,
             cfg: config.terminal, theme: themeStore.current

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -362,15 +362,30 @@ final class AppState {
     }
 
     @discardableResult
-    func restoreTerminalTabIfNeeded(worktreeId: String, tabId: TabID, sessionId: String) throws -> Tab? {
+    func restoreTerminalTabIfNeeded(worktreeId: String, tabId: TabID) throws -> Tab? {
         guard let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
               case .terminal(let state) = tab,
-              state.root.leaves().contains(where: { $0.sessionId == sessionId }) else { return nil }
-        if terminal.registry.session(for: sessionId) != nil { return tab }
-        // Task 3 stop-gap: only handle the focused-leaf case. Task 12 generalizes this.
-        guard let focused = state.root.find(leafId: state.focusedLeafId)?.leaf,
-              focused.sessionId == sessionId else { return nil }
-        return try replaceMissingTerminalSession(worktreeId: worktreeId, tab: state)
+              let worktree = worktree(withId: worktreeId),
+              let project = projects.first(where: { $0.id == worktree.projectId }) else { return nil }
+
+        for leaf in state.root.leaves() {
+            if terminal.registry.session(for: leaf.sessionId) != nil { continue }
+            let forcedCwd = leaf.lastCwd.map { URL(fileURLWithPath: $0) }
+            let session = try terminal.openSession(
+                worktree: worktree, project: project,
+                cfg: config.terminal, theme: themeStore.current,
+                forcedCwd: forcedCwd
+            )
+            harness.detector.unregister(sessionId: leaf.sessionId)
+            harness.forgetSession(leaf.sessionId)
+            harness.detector.register(sessionId: session.id) { [weak session] in
+                session?.surface.foregroundPid
+            }
+            _ = tabs.replaceLeafSession(
+                worktreeId: worktreeId, tabId: tabId, leafId: leaf.id, sessionId: session.id
+            )
+        }
+        return tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId })
     }
 
     func saveActiveTab(worktreeId: String) {
@@ -557,34 +572,6 @@ final class AppState {
         let closed = tabs.closeToRight(worktreeId: worktreeId, of: tabId)
         cleanupTerminals(allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
-    }
-
-    @discardableResult
-    private func replaceMissingTerminalSession(worktreeId: String, tab: TerminalTabState) throws -> Tab {
-        guard let worktree = worktree(withId: worktreeId),
-              let project = projects.first(where: { $0.id == worktree.projectId }) else {
-            throw NSError(domain: "AppState", code: 2)
-        }
-
-        let oldSessionId = tab.root.find(leafId: tab.focusedLeafId)?.leaf.sessionId ?? ""
-        let session = try terminal.openSession(
-            worktree: worktree, project: project,
-            cfg: config.terminal, theme: themeStore.current
-        )
-        harness.detector.unregister(sessionId: oldSessionId)
-        harness.forgetSession(oldSessionId)
-        harness.detector.register(sessionId: session.id) { [weak session] in
-            session?.surface.foregroundPid
-        }
-        guard let replacement = tabs.replaceTerminalSession(
-            worktreeId: worktreeId,
-            tabId: tab.id,
-            sessionId: session.id
-        ) else {
-            terminal.closeSession(id: session.id)
-            throw NSError(domain: "AppState", code: 3)
-        }
-        return replacement
     }
 
     private func defaultTerminalTitle(for worktree: Worktree) -> String {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -361,6 +361,13 @@ final class AppState {
         return false
     }
 
+    /// Walk every leaf in the tab's tree and recreate any session whose
+    /// `TerminalSession` is no longer alive (e.g., after relaunch).
+    ///
+    /// **Partial-failure contract:** if `openSession` throws midway through the
+    /// walk, leaves processed up to that point have already been persisted with
+    /// their new sessionIds. Re-calling this method is safe — already-restored
+    /// leaves are skipped, and the failing leaf is retried.
     @discardableResult
     func restoreTerminalTabIfNeeded(worktreeId: String, tabId: TabID) throws -> Tab? {
         guard let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -267,8 +267,6 @@ final class AppState {
               case .terminal = tab else { return }
         guard let outcome = tabs.removeFocusedLeaf(worktreeId: worktreeId, tabId: activeId) else { return }
         if case .tabRemoved = outcome {
-            // Tab still in storage with its original single-leaf root; closeTab
-            // walks the tree and tears down every session itself.
             closeTab(worktreeId: worktreeId, tabId: activeId)
         } else {
             let closedSessionId = outcome.closedSessionId

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -220,6 +220,7 @@ final class AppState {
     /// Per-tab cache of leaf frames, written by `SplitContainer` during layout
     /// and read by `focusPane`. Keyed by tab id; inner dictionary maps leaf id
     /// to its on-screen rect within the tab's coordinate space.
+    @ObservationIgnored
     var terminalLeafFrames: [TabID: [String: CGRect]] = [:]
 
     /// Split the focused pane of the active terminal tab on `worktreeId`. The
@@ -265,12 +266,15 @@ final class AppState {
               let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == activeId }),
               case .terminal = tab else { return }
         guard let outcome = tabs.removeFocusedLeaf(worktreeId: worktreeId, tabId: activeId) else { return }
-        let closedSessionId = outcome.closedSessionId
-        terminal.closeSession(id: closedSessionId)
-        harness.detector.unregister(sessionId: closedSessionId)
-        harness.forgetSession(closedSessionId)
         if case .tabRemoved = outcome {
+            // Tab still in storage with its original single-leaf root; closeTab
+            // walks the tree and tears down every session itself.
             closeTab(worktreeId: worktreeId, tabId: activeId)
+        } else {
+            let closedSessionId = outcome.closedSessionId
+            terminal.closeSession(id: closedSessionId)
+            harness.detector.unregister(sessionId: closedSessionId)
+            harness.forgetSession(closedSessionId)
         }
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -180,18 +180,27 @@ final class AppState {
     }
 
     /// Activate a specific harness session: bring the app to front, select
-    /// the worktree, and activate the terminal tab hosting `sessionId`.
+    /// the worktree, activate the terminal tab hosting `sessionId`, and
+    /// focus the pane within that tab that owns the session (so keyboard
+    /// input and the tab-bar harness badge follow the user's intent).
     /// If the tab is no longer present (session was closed mid-flight) the
     /// worktree is still selected so the user lands somewhere sensible.
     func activateHarnessSession(projectId _: String, worktreeId: String, sessionId: String) {
         selectedWorktreeId = worktreeId
-        if let tab = tabs.tabs(forWorktree: worktreeId).first(where: {
-            if case .terminal(let s) = $0 {
-                return s.root.leaves().contains(where: { $0.sessionId == sessionId })
+        var matchedTabId: TabID?
+        var matchedLeafId: String?
+        for tab in tabs.tabs(forWorktree: worktreeId) {
+            guard case .terminal(let s) = tab,
+                  let leaf = s.root.leaves().first(where: { $0.sessionId == sessionId }) else { continue }
+            matchedTabId = tab.id
+            matchedLeafId = leaf.id
+            break
+        }
+        if let tabId = matchedTabId {
+            if let leafId = matchedLeafId {
+                _ = tabs.setFocusedLeaf(worktreeId: worktreeId, tabId: tabId, leafId: leafId)
             }
-            return false
-        }) {
-            tabs.activate(worktreeId: worktreeId, tabId: tab.id)
+            tabs.activate(worktreeId: worktreeId, tabId: tabId)
         }
         NSApp.activate(ignoringOtherApps: true)
     }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -215,6 +215,148 @@ final class AppState {
         return tabs.appendTerminal(worktreeId: worktree.id, title: title, sessionId: session.id)
     }
 
+    // MARK: - Pane splits
+
+    /// Per-tab cache of leaf frames, written by `SplitContainer` during layout
+    /// and read by `focusPane`. Keyed by tab id; inner dictionary maps leaf id
+    /// to its on-screen rect within the tab's coordinate space.
+    var terminalLeafFrames: [TabID: [String: CGRect]] = [:]
+
+    /// Split the focused pane of the active terminal tab on `worktreeId`. The
+    /// new pane gains focus, inherits the focused pane's current OSC-7 cwd
+    /// (falling back to its lastCwd, then the worktree root) and runs a plain
+    /// shell — harness state is not inherited.
+    func splitFocusedPane(worktreeId: String, axis: SplitAxis) {
+        guard let activeId = tabs.activeTabId(forWorktree: worktreeId),
+              let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == activeId }),
+              case .terminal(let state) = tab,
+              let focused = state.root.find(leafId: state.focusedLeafId)?.leaf,
+              let worktree = worktree(withId: worktreeId),
+              let project = projects.first(where: { $0.id == worktree.projectId }),
+              let focusedSession = terminal.registry.session(for: focused.sessionId) else { return }
+
+        let cwd = focusedSession.surface.currentWorkingDirectory
+            ?? focused.lastCwd.map { URL(fileURLWithPath: $0) }
+            ?? worktree.path
+
+        do {
+            let session = try terminal.openSession(
+                worktree: worktree, project: project,
+                cfg: config.terminal, theme: themeStore.current,
+                forcedCwd: cwd
+            )
+            harness.detector.register(sessionId: session.id) { [weak session] in
+                session?.surface.foregroundPid
+            }
+            _ = tabs.splitFocusedLeaf(
+                worktreeId: worktreeId, tabId: activeId, axis: axis,
+                newLeafId: UUID().uuidString, newSessionId: session.id
+            )
+        } catch {
+            AlasGhostty.logger.error("splitFocusedPane failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Close the focused pane. If it was the last leaf, also closes the tab
+    /// via the existing close-tab path (preserves today's ⌘W-on-unsplit
+    /// behavior).
+    func closeFocusedPane(worktreeId: String) {
+        guard let activeId = tabs.activeTabId(forWorktree: worktreeId),
+              let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == activeId }),
+              case .terminal = tab else { return }
+        guard let outcome = tabs.removeFocusedLeaf(worktreeId: worktreeId, tabId: activeId) else { return }
+        let closedSessionId = outcome.closedSessionId
+        terminal.closeSession(id: closedSessionId)
+        harness.detector.unregister(sessionId: closedSessionId)
+        harness.forgetSession(closedSessionId)
+        if case .tabRemoved = outcome {
+            closeTab(worktreeId: worktreeId, tabId: activeId)
+        }
+    }
+
+    /// Move focus to the geometrically nearest leaf in `direction`. No-op when
+    /// no candidate exists (no wrap-around).
+    func focusPane(worktreeId: String, direction: PaneFocusDirection) {
+        guard let activeId = tabs.activeTabId(forWorktree: worktreeId),
+              let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == activeId }),
+              case .terminal(let state) = tab,
+              let frames = terminalLeafFrames[activeId],
+              let next = PaneFocusFinder.nearestLeaf(
+                from: state.focusedLeafId, direction: direction, frames: frames
+              ) else { return }
+        _ = tabs.setFocusedLeaf(worktreeId: worktreeId, tabId: activeId, leafId: next)
+    }
+
+    /// Resize the focused leaf's enclosing split by ±0.05 toward `direction`.
+    /// Picks the innermost split on the focused-leaf's path whose axis matches
+    /// the direction's axis; nudges its fraction (positive when the focused
+    /// pane is the first child and direction is right/down).
+    func resizePane(worktreeId: String, direction: PaneFocusDirection) {
+        guard let activeId = tabs.activeTabId(forWorktree: worktreeId),
+              let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == activeId }),
+              case .terminal(let state) = tab,
+              let pathLeaf = state.root.find(leafId: state.focusedLeafId) else { return }
+        let axis: SplitAxis = (direction == .left || direction == .right) ? .vertical : .horizontal
+        guard let target = innermostSplit(matching: axis, path: pathLeaf.path, in: state.root) else { return }
+        let isFirstChildOfTarget = isLeafInFirstChild(of: target, leafId: state.focusedLeafId)
+        let delta = 0.05
+        let signed: Double = {
+            switch direction {
+            case .right, .down: return isFirstChildOfTarget ? delta : -delta
+            case .left, .up:    return isFirstChildOfTarget ? -delta : delta
+            }
+        }()
+        let newFraction = target.fraction + signed
+        _ = tabs.setSplitFraction(worktreeId: worktreeId, tabId: activeId, splitId: target.id, fraction: newFraction)
+    }
+
+    /// ⌘W router: if the active tab is a multi-pane terminal, close the focused
+    /// pane; otherwise fall through to the existing tab-close behavior.
+    func handleCloseShortcut(worktreeId: String) {
+        if let activeId = tabs.activeTabId(forWorktree: worktreeId),
+           let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == activeId }),
+           case .terminal(let state) = tab,
+           case .split = state.root {
+            closeFocusedPane(worktreeId: worktreeId)
+            return
+        }
+        if let activeId = tabs.activeTabId(forWorktree: worktreeId) {
+            closeTab(worktreeId: worktreeId, tabId: activeId)
+        }
+    }
+
+    /// Walk down `path` collecting splits; return the innermost one whose
+    /// axis matches `axis`. `path` is the list of split ids from root to (but
+    /// not including) the focused leaf.
+    private func innermostSplit(matching axis: SplitAxis, path: [String], in root: PaneNode) -> PaneSplit? {
+        var current: PaneNode = root
+        var match: PaneSplit? = nil
+        for (index, splitId) in path.enumerated() {
+            guard case .split(let s) = current, s.id == splitId else { return match }
+            if s.axis == axis { match = s }
+            let nextId: String? = (index + 1 < path.count) ? path[index + 1] : nil
+            if let next = nextId {
+                guard let child = s.children.first(where: { containsNode(id: next, in: $0) }) else { return match }
+                current = child
+            } else {
+                return match
+            }
+        }
+        return match
+    }
+
+    private func isLeafInFirstChild(of split: PaneSplit, leafId: String) -> Bool {
+        split.children.first?.find(leafId: leafId) != nil
+    }
+
+    private func containsNode(id: String, in node: PaneNode) -> Bool {
+        if node.id == id { return true }
+        if case .split(let s) = node {
+            return s.children.contains(where: { containsNode(id: id, in: $0) })
+        }
+        return false
+    }
+
     @discardableResult
     func restoreTerminalTabIfNeeded(worktreeId: String, tabId: TabID, sessionId: String) throws -> Tab? {
         guard let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -200,6 +200,27 @@ private struct RootCommandHandlers: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .modifier(RootBaseHandlers(
+                state: state,
+                showNewWorktree: $showNewWorktree,
+                selectedWorktree: selectedWorktree,
+                openSettings: openSettings
+            ))
+            .modifier(RootPaneHandlers(
+                state: state,
+                selectedWorktree: selectedWorktree
+            ))
+    }
+}
+
+private struct RootBaseHandlers: ViewModifier {
+    @Bindable var state: AppState
+    @Binding var showNewWorktree: Bool
+    let selectedWorktree: () -> Worktree?
+    let openSettings: () -> Void
+
+    func body(content: Content) -> some View {
+        content
             .onReceive(NotificationCenter.default.publisher(for: .alasToggleRightPane)) { _ in
                 state.config.rightPaneVisible.toggle()
                 state.saveConfig()
@@ -211,8 +232,8 @@ private struct RootCommandHandlers: ViewModifier {
                 if let wt = selectedWorktree() { _ = try? state.openTerminalTab(for: wt) }
             }
             .onReceive(NotificationCenter.default.publisher(for: .alasCloseTab)) { _ in
-                if let wt = selectedWorktree(), let active = state.tabs.activeTabId(forWorktree: wt.id) {
-                    state.closeTab(worktreeId: wt.id, tabId: active)
+                if let wt = selectedWorktree() {
+                    state.handleCloseShortcut(worktreeId: wt.id)
                 }
             }
             .onReceive(NotificationCenter.default.publisher(for: .alasActivateTabByNumber)) { notification in
@@ -261,6 +282,45 @@ private struct RootCommandHandlers: ViewModifier {
     }
 }
 
+private struct RootPaneHandlers: ViewModifier {
+    @Bindable var state: AppState
+    let selectedWorktree: () -> Worktree?
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(NotificationCenter.default.publisher(for: .alasSplitRight)) { _ in
+                if let wt = selectedWorktree() { state.splitFocusedPane(worktreeId: wt.id, axis: .vertical) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasSplitDown)) { _ in
+                if let wt = selectedWorktree() { state.splitFocusedPane(worktreeId: wt.id, axis: .horizontal) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasFocusPaneLeft)) { _ in
+                if let wt = selectedWorktree() { state.focusPane(worktreeId: wt.id, direction: .left) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasFocusPaneRight)) { _ in
+                if let wt = selectedWorktree() { state.focusPane(worktreeId: wt.id, direction: .right) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasFocusPaneUp)) { _ in
+                if let wt = selectedWorktree() { state.focusPane(worktreeId: wt.id, direction: .up) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasFocusPaneDown)) { _ in
+                if let wt = selectedWorktree() { state.focusPane(worktreeId: wt.id, direction: .down) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasResizePaneLeft)) { _ in
+                if let wt = selectedWorktree() { state.resizePane(worktreeId: wt.id, direction: .left) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasResizePaneRight)) { _ in
+                if let wt = selectedWorktree() { state.resizePane(worktreeId: wt.id, direction: .right) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasResizePaneUp)) { _ in
+                if let wt = selectedWorktree() { state.resizePane(worktreeId: wt.id, direction: .up) }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .alasResizePaneDown)) { _ in
+                if let wt = selectedWorktree() { state.resizePane(worktreeId: wt.id, direction: .down) }
+            }
+    }
+}
+
 extension Notification.Name {
     static let alasToggleRightPane = Notification.Name("AlasToggleRightPane")
     static let alasNewWorktree     = Notification.Name("AlasNewWorktree")
@@ -275,4 +335,14 @@ extension Notification.Name {
     static let alasRevertActiveTab = Notification.Name("AlasRevertActiveTab")
     static let alasNewFile         = Notification.Name("AlasNewFile")
     static let alasRenameActiveFile = Notification.Name("AlasRenameActiveFile")
+    static let alasSplitRight       = Notification.Name("AlasSplitRight")
+    static let alasSplitDown        = Notification.Name("AlasSplitDown")
+    static let alasFocusPaneLeft    = Notification.Name("AlasFocusPaneLeft")
+    static let alasFocusPaneRight   = Notification.Name("AlasFocusPaneRight")
+    static let alasFocusPaneUp      = Notification.Name("AlasFocusPaneUp")
+    static let alasFocusPaneDown    = Notification.Name("AlasFocusPaneDown")
+    static let alasResizePaneLeft   = Notification.Name("AlasResizePaneLeft")
+    static let alasResizePaneRight  = Notification.Name("AlasResizePaneRight")
+    static let alasResizePaneUp     = Notification.Name("AlasResizePaneUp")
+    static let alasResizePaneDown   = Notification.Name("AlasResizePaneDown")
 }

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -15,8 +15,9 @@ struct CenterPaneView: View {
                 activeId: active,
                 harnessLookup: { tabId in
                     if case .terminal(let s) = tabs.first(where: { $0.id == tabId }),
-                       let kind = state.harness.harnessBySession[s.sessionId] {
-                        let st = state.harness.stateBySession[s.sessionId] ?? "running"
+                       let focusedSessionId = s.root.find(leafId: s.focusedLeafId)?.leaf.sessionId,
+                       let kind = state.harness.harnessBySession[focusedSessionId] {
+                        let st = state.harness.stateBySession[focusedSessionId] ?? "running"
                         return (kind: kind, state: st)
                     }
                     return nil
@@ -64,7 +65,7 @@ struct CenterPaneView: View {
                         TerminalTabView(state: state,
                                         worktreeId: worktree.id,
                                         tabId: tab.id,
-                                        sessionId: s.sessionId)
+                                        sessionId: s.root.find(leafId: s.focusedLeafId)?.leaf.sessionId ?? "")
                     case .editor(let s):
                         if MarkdownFileType.isMarkdown(relativePath: s.isExternal
                                                         ? (s.externalAbsolutePath ?? "")

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -61,11 +61,10 @@ struct CenterPaneView: View {
                 } else if let activeId = active,
                           let tab = tabs.first(where: { $0.id == activeId }) {
                     switch tab {
-                    case .terminal(let s):
+                    case .terminal:
                         TerminalTabView(state: state,
                                         worktreeId: worktree.id,
-                                        tabId: tab.id,
-                                        sessionId: s.root.find(leafId: s.focusedLeafId)?.leaf.sessionId ?? "")
+                                        tabId: tab.id)
                     case .editor(let s):
                         if MarkdownFileType.isMarkdown(relativePath: s.isExternal
                                                         ? (s.externalAbsolutePath ?? "")

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -64,8 +64,54 @@ struct CommitTabState: Codable, Equatable, Identifiable {
 
 struct TerminalTabState: Codable, Equatable, Identifiable {
     let id: TabID
-    var title: String       // e.g. branch name, "main", or "+ N"
-    var sessionId: String   // matches TerminalSession.id (re-attached on launch)
+    var title: String
+    var root: PaneNode
+    var focusedLeafId: String
+
+    init(id: TabID, title: String, root: PaneNode, focusedLeafId: String) {
+        self.id = id
+        self.title = title
+        self.root = root
+        self.focusedLeafId = focusedLeafId
+    }
+
+    /// Convenience for callers that still create a single-leaf tab.
+    init(id: TabID, title: String, sessionId: String) {
+        let leafId = UUID().uuidString
+        self.id = id
+        self.title = title
+        self.root = .leaf(PaneLeaf(id: leafId, sessionId: sessionId, lastCwd: nil))
+        self.focusedLeafId = leafId
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, root, focusedLeafId, sessionId
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(TabID.self, forKey: .id)
+        self.title = try c.decode(String.self, forKey: .title)
+        if let root = try c.decodeIfPresent(PaneNode.self, forKey: .root) {
+            self.root = root
+            self.focusedLeafId = try c.decodeIfPresent(String.self, forKey: .focusedLeafId)
+                ?? root.firstLeaf().id
+        } else {
+            // Legacy shape: {id, title, sessionId}. Migrate to a single-leaf tree.
+            let legacy = try c.decode(String.self, forKey: .sessionId)
+            let leafId = UUID().uuidString
+            self.root = .leaf(PaneLeaf(id: leafId, sessionId: legacy, lastCwd: nil))
+            self.focusedLeafId = leafId
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(title, forKey: .title)
+        try c.encode(root, forKey: .root)
+        try c.encode(focusedLeafId, forKey: .focusedLeafId)
+    }
 }
 
 struct EditorTabState: Codable, Equatable, Identifiable {

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -17,6 +17,12 @@ struct TabBarView: View {
     let onNewTerminal: () -> Void
     @Environment(\.theme) var theme
 
+    private var isTerminalActive: Bool {
+        guard let activeId, let active = tabs.first(where: { $0.id == activeId }) else { return false }
+        if case .terminal = active { return true }
+        return false
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
@@ -50,6 +56,14 @@ struct TabBarView: View {
                 }
             }
             Spacer()
+            if isTerminalActive {
+                ToolbarIconButton(iconName: "split", tooltip: "Split Right (⌘D)") {
+                    NotificationCenter.default.post(name: .alasSplitRight, object: nil)
+                }
+                ToolbarIconButton(iconName: "split-down", tooltip: "Split Down (⇧⌘D)") {
+                    NotificationCenter.default.post(name: .alasSplitDown, object: nil)
+                }
+            }
             Button(action: onNewTerminal) {
                 Icon(name: "plus", size: 13)
                     .frame(width: 26, height: 22)
@@ -131,5 +145,24 @@ private struct TabButton: View {
         case "awaiting": return theme.color("mod")
         default:         return theme.color("fg-faint")
         }
+    }
+}
+
+private struct ToolbarIconButton: View {
+    let iconName: String
+    let tooltip: String
+    let action: () -> Void
+    @Environment(\.theme) var theme
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Icon(name: iconName, size: 13,
+                 color: hovering ? theme.color("fg") : theme.color("fg-faint"))
+                .frame(width: 26, height: 22)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .help(tooltip)
     }
 }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -131,6 +131,136 @@ final class TabsManager {
         return tab
     }
 
+    // MARK: - Pane tree mutations
+
+    @discardableResult
+    func setFocusedLeaf(worktreeId: String, tabId: TabID, leafId: String) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .terminal(var state) = file.tabs[idx],
+              state.root.find(leafId: leafId) != nil else { return nil }
+        state.focusedLeafId = leafId
+        let tab = Tab.terminal(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
+    /// Split the focused leaf into a 2-child split. The freshly-spawned session id
+    /// is wrapped in a new leaf, which becomes the focused one.
+    @discardableResult
+    func splitFocusedLeaf(
+        worktreeId: String, tabId: TabID, axis: SplitAxis,
+        newLeafId: String, newSessionId: String
+    ) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .terminal(var state) = file.tabs[idx],
+              let existing = state.root.find(leafId: state.focusedLeafId)?.leaf else { return nil }
+        let newLeaf = PaneLeaf(id: newLeafId, sessionId: newSessionId, lastCwd: nil)
+        let replacement: PaneNode = .split(PaneSplit(
+            id: UUID().uuidString,
+            axis: axis,
+            fraction: 0.5,
+            children: [.leaf(existing), .leaf(newLeaf)]
+        ))
+        state.root = state.root.replacingLeaf(id: existing.id, with: replacement)
+        state.focusedLeafId = newLeafId
+        let tab = Tab.terminal(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
+    struct RemoveFocusedLeafOutcome {
+        let tab: Tab?
+        let tabRemoved: Bool
+        let closedSessionId: String
+    }
+
+    /// Remove the focused leaf. If it was the last leaf, the tab is removed via
+    /// the regular close-tab path and `tabRemoved` is true. Otherwise the sibling
+    /// collapses up and a sensible focus replacement is picked (first leaf in the
+    /// remaining tree).
+    @discardableResult
+    func removeFocusedLeaf(worktreeId: String, tabId: TabID) -> RemoveFocusedLeafOutcome? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .terminal(var state) = file.tabs[idx],
+              let focused = state.root.find(leafId: state.focusedLeafId)?.leaf else { return nil }
+        let closedSessionId = focused.sessionId
+        if let newRoot = state.root.removingLeaf(id: state.focusedLeafId) {
+            state.root = newRoot
+            state.focusedLeafId = newRoot.firstLeaf().id
+            let tab = Tab.terminal(state)
+            file.tabs[idx] = tab
+            byWorktree[worktreeId] = file
+            persist(worktreeId)
+            return RemoveFocusedLeafOutcome(tab: tab, tabRemoved: false, closedSessionId: closedSessionId)
+        } else {
+            return RemoveFocusedLeafOutcome(tab: nil, tabRemoved: true, closedSessionId: closedSessionId)
+        }
+    }
+
+    @discardableResult
+    func setSplitFraction(worktreeId: String, tabId: TabID, splitId: String, fraction: Double) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .terminal(var state) = file.tabs[idx] else { return nil }
+        state.root = updatingSplit(state.root, splitId: splitId) { s in
+            var copy = s
+            copy.fraction = max(0.1, min(0.9, fraction))
+            return copy
+        }
+        let tab = Tab.terminal(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
+    @discardableResult
+    func setLeafCwd(worktreeId: String, tabId: TabID, leafId: String, cwd: String) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .terminal(var state) = file.tabs[idx] else { return nil }
+        state.root = updatingLeaf(state.root, leafId: leafId) { l in
+            var copy = l
+            copy.lastCwd = cwd
+            return copy
+        }
+        let tab = Tab.terminal(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
+    /// Walks the tree and applies `transform` to the split with `splitId`.
+    private func updatingSplit(_ node: PaneNode, splitId: String,
+                               transform: (PaneSplit) -> PaneSplit) -> PaneNode {
+        switch node {
+        case .leaf: return node
+        case .split(var s):
+            if s.id == splitId { return .split(transform(s)) }
+            s.children = s.children.map { updatingSplit($0, splitId: splitId, transform: transform) }
+            return .split(s)
+        }
+    }
+
+    private func updatingLeaf(_ node: PaneNode, leafId: String,
+                              transform: (PaneLeaf) -> PaneLeaf) -> PaneNode {
+        switch node {
+        case .leaf(let l):
+            return l.id == leafId ? .leaf(transform(l)) : .leaf(l)
+        case .split(var s):
+            s.children = s.children.map { updatingLeaf($0, leafId: leafId, transform: transform) }
+            return .split(s)
+        }
+    }
+
     @discardableResult
     func appendEditor(worktreeId: String, title: String, relativePath: String) -> Tab {
         let state = EditorTabState(id: UUID().uuidString, title: title, relativePath: relativePath)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -131,6 +131,26 @@ final class TabsManager {
         return tab
     }
 
+    /// Replace a specific leaf's `sessionId` (preserving its `lastCwd`).
+    /// Used by `AppState.restoreTerminalTabIfNeeded` to patch the tree after
+    /// recreating a dropped session.
+    @discardableResult
+    func replaceLeafSession(worktreeId: String, tabId: TabID, leafId: String, sessionId: String) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .terminal(var state) = file.tabs[idx],
+              let existing = state.root.find(leafId: leafId)?.leaf else { return nil }
+        let replacement: PaneNode = .leaf(PaneLeaf(
+            id: leafId, sessionId: sessionId, lastCwd: existing.lastCwd
+        ))
+        state.root = state.root.replacingLeaf(id: leafId, with: replacement)
+        let tab = Tab.terminal(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
     // MARK: - Pane tree mutations
 
     @discardableResult

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -174,10 +174,17 @@ final class TabsManager {
         return tab
     }
 
-    struct RemoveFocusedLeafOutcome {
-        let tab: Tab?
-        let tabRemoved: Bool
-        let closedSessionId: String
+    enum RemoveFocusedLeafOutcome {
+        /// A non-focused-leaf sibling collapsed up; the tab persists.
+        case leafRemoved(tab: Tab, closedSessionId: String)
+        /// The focused leaf was the last leaf; caller must run the regular close-tab path.
+        case tabRemoved(closedSessionId: String)
+
+        var closedSessionId: String {
+            switch self {
+            case .leafRemoved(_, let id), .tabRemoved(let id): return id
+            }
+        }
     }
 
     /// Remove the focused leaf. If it was the last leaf, the tab is removed via
@@ -198,9 +205,9 @@ final class TabsManager {
             file.tabs[idx] = tab
             byWorktree[worktreeId] = file
             persist(worktreeId)
-            return RemoveFocusedLeafOutcome(tab: tab, tabRemoved: false, closedSessionId: closedSessionId)
+            return .leafRemoved(tab: tab, closedSessionId: closedSessionId)
         } else {
-            return RemoveFocusedLeafOutcome(tab: nil, tabRemoved: true, closedSessionId: closedSessionId)
+            return .tabRemoved(closedSessionId: closedSessionId)
         }
     }
 
@@ -254,7 +261,7 @@ final class TabsManager {
                               transform: (PaneLeaf) -> PaneLeaf) -> PaneNode {
         switch node {
         case .leaf(let l):
-            return l.id == leafId ? .leaf(transform(l)) : .leaf(l)
+            return l.id == leafId ? .leaf(transform(l)) : node
         case .split(var s):
             s.children = s.children.map { updatingLeaf($0, leafId: leafId, transform: transform) }
             return .split(s)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -121,7 +121,9 @@ final class TabsManager {
         guard var file = byWorktree[worktreeId],
               let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
               case .terminal(var state) = file.tabs[idx] else { return nil }
-        state.sessionId = sessionId
+        state.root = state.root.replacingLeaf(id: state.focusedLeafId, with: .leaf(
+            PaneLeaf(id: state.focusedLeafId, sessionId: sessionId, lastCwd: nil)
+        ))
         let tab = Tab.terminal(state)
         file.tabs[idx] = tab
         byWorktree[worktreeId] = file

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -127,6 +127,7 @@ private struct SplitContainer: View {
 
     private let dividerThickness: CGFloat = 4
     @State private var isDividerHovering = false
+    @State private var dragStartFraction: Double? = nil
 
     var body: some View {
         GeometryReader { geo in
@@ -190,13 +191,19 @@ private struct SplitContainer: View {
             .gesture(
                 DragGesture(minimumDistance: 1)
                     .onChanged { value in
+                        // Capture the fraction at drag start so subsequent events that
+                        // re-render the view with an updated fraction don't compound.
+                        let start = dragStartFraction ?? split.fraction
+                        if dragStartFraction == nil { dragStartFraction = start }
                         let delta: CGFloat = isVertical ? value.translation.width : value.translation.height
-                        let initialFirst = split.fraction * totalForFraction
-                        let newFraction = (initialFirst + delta) / totalForFraction
+                        let newFraction = start + Double(delta / totalForFraction)
                         _ = state.tabs.setSplitFraction(
                             worktreeId: worktreeId, tabId: tabId,
                             splitId: split.id, fraction: newFraction
                         )
+                    }
+                    .onEnded { _ in
+                        dragStartFraction = nil
                     }
             )
     }

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -42,11 +42,12 @@ private struct TerminalRecoverPlaceholder: View {
                 .foregroundColor(theme.color("fg-muted"))
             AlasButton(title: "Open new terminal", style: .primary) {
                 Task {
-                    if case .terminal(let terminal) = state.tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }) {
+                    if case .terminal(let terminal) = state.tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
+                       let focused = terminal.root.find(leafId: terminal.focusedLeafId)?.leaf {
                         _ = try? state.restoreTerminalTabIfNeeded(
                             worktreeId: worktreeId,
                             tabId: tabId,
-                            sessionId: terminal.sessionId
+                            sessionId: focused.sessionId
                         )
                     }
                 }

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -18,11 +18,10 @@ struct TerminalTabView: View {
                 TerminalRecoverPlaceholder(state: state, worktreeId: worktreeId, tabId: tabId)
             }
         }
-        .task(id: sessionId) {
+        .task(id: tabId) {
             _ = try? state.restoreTerminalTabIfNeeded(
                 worktreeId: worktreeId,
-                tabId: tabId,
-                sessionId: sessionId
+                tabId: tabId
             )
         }
         .background(theme.color("bg-0"))
@@ -41,16 +40,7 @@ private struct TerminalRecoverPlaceholder: View {
                 .font(.system(size: 14))
                 .foregroundColor(theme.color("fg-muted"))
             AlasButton(title: "Open new terminal", style: .primary) {
-                Task {
-                    if case .terminal(let terminal) = state.tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }),
-                       let focused = terminal.root.find(leafId: terminal.focusedLeafId)?.leaf {
-                        _ = try? state.restoreTerminalTabIfNeeded(
-                            worktreeId: worktreeId,
-                            tabId: tabId,
-                            sessionId: focused.sessionId
-                        )
-                    }
-                }
+                Task { _ = try? state.restoreTerminalTabIfNeeded(worktreeId: worktreeId, tabId: tabId) }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -1,30 +1,204 @@
 import SwiftUI
+import AppKit
 
 struct TerminalTabView: View {
     @Bindable var state: AppState
     let worktreeId: String
     let tabId: TabID
-    let sessionId: String
 
     @Environment(\.theme) var theme
 
     var body: some View {
         Group {
-            if let session = state.terminal.registry.session(for: sessionId) {
-                GhosttyHost(session: session)
-                    .id(sessionId)
+            if let tab = currentTab() {
+                PaneNodeView(
+                    state: state,
+                    worktreeId: worktreeId,
+                    tabId: tabId,
+                    node: tab.root,
+                    focusedLeafId: tab.focusedLeafId
+                )
             } else {
-                // Session was lost (likely after relaunch). Recreate.
                 TerminalRecoverPlaceholder(state: state, worktreeId: worktreeId, tabId: tabId)
             }
         }
+        .coordinateSpace(name: tabCoordinateSpace)
+        .onPreferenceChange(LeafFramesKey.self) { frames in
+            state.terminalLeafFrames[tabId] = frames
+        }
         .task(id: tabId) {
-            _ = try? state.restoreTerminalTabIfNeeded(
-                worktreeId: worktreeId,
-                tabId: tabId
-            )
+            _ = try? state.restoreTerminalTabIfNeeded(worktreeId: worktreeId, tabId: tabId)
         }
         .background(theme.color("bg-0"))
+    }
+
+    private var tabCoordinateSpace: String { "alas-tab-\(tabId)" }
+
+    private func currentTab() -> TerminalTabState? {
+        state.tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }).flatMap {
+            if case .terminal(let s) = $0 { return s } else { return nil }
+        }
+    }
+}
+
+private struct PaneNodeView: View {
+    @Bindable var state: AppState
+    let worktreeId: String
+    let tabId: TabID
+    let node: PaneNode
+    let focusedLeafId: String
+
+    var body: some View {
+        switch node {
+        case .leaf(let leaf):
+            PaneLeafView(
+                state: state,
+                worktreeId: worktreeId,
+                tabId: tabId,
+                leaf: leaf,
+                isFocused: leaf.id == focusedLeafId
+            )
+        case .split(let split):
+            SplitContainer(
+                state: state,
+                worktreeId: worktreeId,
+                tabId: tabId,
+                split: split,
+                focusedLeafId: focusedLeafId
+            )
+        }
+    }
+}
+
+private struct PaneLeafView: View {
+    @Bindable var state: AppState
+    let worktreeId: String
+    let tabId: TabID
+    let leaf: PaneLeaf
+    let isFocused: Bool
+
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        Group {
+            if let session = state.terminal.registry.session(for: leaf.sessionId) {
+                GhosttyHost(session: session, isFocused: isFocused)
+                    .id(leaf.sessionId)
+                    .onAppear { wireCwdHandler(session: session) }
+            } else {
+                Color.clear
+            }
+        }
+        .overlay(
+            Rectangle()
+                .strokeBorder(isFocused ? theme.color("accent") : Color.clear, lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            _ = state.tabs.setFocusedLeaf(worktreeId: worktreeId, tabId: tabId, leafId: leaf.id)
+        }
+        .background(
+            GeometryReader { geo in
+                Color.clear.preference(
+                    key: LeafFramesKey.self,
+                    value: [leaf.id: geo.frame(in: .named("alas-tab-\(tabId)"))]
+                )
+            }
+        )
+    }
+
+    private func wireCwdHandler(session: TerminalSession) {
+        session.surface.cwdHandler = { [worktreeId, tabId, leafId = leaf.id] url in
+            _ = state.tabs.setLeafCwd(
+                worktreeId: worktreeId, tabId: tabId, leafId: leafId, cwd: url.path
+            )
+        }
+    }
+}
+
+private struct SplitContainer: View {
+    @Bindable var state: AppState
+    let worktreeId: String
+    let tabId: TabID
+    let split: PaneSplit
+    let focusedLeafId: String
+
+    @Environment(\.theme) var theme
+
+    private let dividerThickness: CGFloat = 4
+
+    var body: some View {
+        GeometryReader { geo in
+            let total: CGFloat = split.axis == .vertical ? geo.size.width : geo.size.height
+            let usable = max(0, total - dividerThickness)
+            let firstSize = max(20, usable * split.fraction)
+            let secondSize = max(20, usable - firstSize)
+            let totalForFraction = total
+            content(firstSize: firstSize, secondSize: secondSize, totalForFraction: totalForFraction)
+        }
+    }
+
+    @ViewBuilder
+    private func content(firstSize: CGFloat, secondSize: CGFloat, totalForFraction: CGFloat) -> some View {
+        if split.axis == .vertical {
+            HStack(spacing: 0) {
+                PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
+                             node: split.children[0], focusedLeafId: focusedLeafId)
+                    .frame(width: firstSize)
+                dividerView(totalForFraction: totalForFraction)
+                PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
+                             node: split.children[1], focusedLeafId: focusedLeafId)
+                    .frame(width: secondSize)
+            }
+        } else {
+            VStack(spacing: 0) {
+                PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
+                             node: split.children[0], focusedLeafId: focusedLeafId)
+                    .frame(height: firstSize)
+                dividerView(totalForFraction: totalForFraction)
+                PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
+                             node: split.children[1], focusedLeafId: focusedLeafId)
+                    .frame(height: secondSize)
+            }
+        }
+    }
+
+    private func dividerView(totalForFraction: CGFloat) -> some View {
+        let isVertical = split.axis == .vertical
+        return Rectangle()
+            .fill(theme.color("bg-3"))
+            .frame(
+                width: isVertical ? dividerThickness : nil,
+                height: isVertical ? nil : dividerThickness
+            )
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                if hovering {
+                    if isVertical { NSCursor.resizeLeftRight.push() }
+                    else          { NSCursor.resizeUpDown.push() }
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .gesture(
+                DragGesture(minimumDistance: 1)
+                    .onChanged { value in
+                        let delta: CGFloat = isVertical ? value.translation.width : value.translation.height
+                        let initialFirst = split.fraction * totalForFraction
+                        let newFraction = (initialFirst + delta) / totalForFraction
+                        _ = state.tabs.setSplitFraction(
+                            worktreeId: worktreeId, tabId: tabId,
+                            splitId: split.id, fraction: newFraction
+                        )
+                    }
+            )
+    }
+}
+
+private struct LeafFramesKey: PreferenceKey {
+    static var defaultValue: [String: CGRect] = [:]
+    static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, b in b })
     }
 }
 

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -16,7 +16,8 @@ struct TerminalTabView: View {
                     worktreeId: worktreeId,
                     tabId: tabId,
                     node: tab.root,
-                    focusedLeafId: tab.focusedLeafId
+                    focusedLeafId: tab.focusedLeafId,
+                    inSplit: false
                 )
             } else {
                 TerminalRecoverPlaceholder(state: state, worktreeId: worktreeId, tabId: tabId)
@@ -47,6 +48,7 @@ private struct PaneNodeView: View {
     let tabId: TabID
     let node: PaneNode
     let focusedLeafId: String
+    let inSplit: Bool
 
     var body: some View {
         switch node {
@@ -56,7 +58,8 @@ private struct PaneNodeView: View {
                 worktreeId: worktreeId,
                 tabId: tabId,
                 leaf: leaf,
-                isFocused: leaf.id == focusedLeafId
+                isFocused: leaf.id == focusedLeafId,
+                showFocusBorder: inSplit
             )
         case .split(let split):
             SplitContainer(
@@ -76,6 +79,7 @@ private struct PaneLeafView: View {
     let tabId: TabID
     let leaf: PaneLeaf
     let isFocused: Bool
+    let showFocusBorder: Bool
 
     @Environment(\.theme) var theme
 
@@ -91,7 +95,10 @@ private struct PaneLeafView: View {
         }
         .overlay(
             Rectangle()
-                .strokeBorder(isFocused ? theme.color("accent") : Color.clear, lineWidth: 1)
+                .strokeBorder(
+                    showFocusBorder && isFocused ? theme.color("accent") : Color.clear,
+                    lineWidth: 1
+                )
         )
         .contentShape(Rectangle())
         .onTapGesture {
@@ -145,24 +152,24 @@ private struct SplitContainer: View {
         if split.axis == .vertical {
             HStack(spacing: 0) {
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
-                             node: split.children[0], focusedLeafId: focusedLeafId)
+                             node: split.children[0], focusedLeafId: focusedLeafId, inSplit: true)
                     .frame(width: firstSize)
                     .clipped()
                 dividerView(totalForFraction: totalForFraction)
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
-                             node: split.children[1], focusedLeafId: focusedLeafId)
+                             node: split.children[1], focusedLeafId: focusedLeafId, inSplit: true)
                     .frame(width: secondSize)
                     .clipped()
             }
         } else {
             VStack(spacing: 0) {
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
-                             node: split.children[0], focusedLeafId: focusedLeafId)
+                             node: split.children[0], focusedLeafId: focusedLeafId, inSplit: true)
                     .frame(height: firstSize)
                     .clipped()
                 dividerView(totalForFraction: totalForFraction)
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
-                             node: split.children[1], focusedLeafId: focusedLeafId)
+                             node: split.children[1], focusedLeafId: focusedLeafId, inSplit: true)
                     .frame(height: secondSize)
                     .clipped()
             }

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -126,6 +126,7 @@ private struct SplitContainer: View {
     @Environment(\.theme) var theme
 
     private let dividerThickness: CGFloat = 4
+    @State private var isDividerHovering = false
 
     var body: some View {
         GeometryReader { geo in
@@ -133,7 +134,7 @@ private struct SplitContainer: View {
             let usable = max(0, total - dividerThickness)
             let firstSize = max(20, usable * split.fraction)
             let secondSize = max(20, usable - firstSize)
-            let totalForFraction = total
+            let totalForFraction = usable
             content(firstSize: firstSize, secondSize: secondSize, totalForFraction: totalForFraction)
         }
     }
@@ -145,20 +146,24 @@ private struct SplitContainer: View {
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
                              node: split.children[0], focusedLeafId: focusedLeafId)
                     .frame(width: firstSize)
+                    .clipped()
                 dividerView(totalForFraction: totalForFraction)
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
                              node: split.children[1], focusedLeafId: focusedLeafId)
                     .frame(width: secondSize)
+                    .clipped()
             }
         } else {
             VStack(spacing: 0) {
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
                              node: split.children[0], focusedLeafId: focusedLeafId)
                     .frame(height: firstSize)
+                    .clipped()
                 dividerView(totalForFraction: totalForFraction)
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
                              node: split.children[1], focusedLeafId: focusedLeafId)
                     .frame(height: secondSize)
+                    .clipped()
             }
         }
     }
@@ -172,8 +177,10 @@ private struct SplitContainer: View {
                 height: isVertical ? nil : dividerThickness
             )
             .contentShape(Rectangle())
-            .onHover { hovering in
-                if hovering {
+            .onHover { nowHovering in
+                guard nowHovering != isDividerHovering else { return }
+                isDividerHovering = nowHovering
+                if nowHovering {
                     if isVertical { NSCursor.resizeLeftRight.push() }
                     else          { NSCursor.resizeUpDown.push() }
                 } else {

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -87,7 +87,6 @@ private struct PaneLeafView: View {
         Group {
             if let session = state.terminal.registry.session(for: leaf.sessionId) {
                 GhosttyHost(session: session, isFocused: isFocused)
-                    .id(leaf.sessionId)
                     .onAppear { wireCwdHandler(session: session) }
             } else {
                 Color.clear

--- a/Alas/Sources/Icons/Icon.swift
+++ b/Alas/Sources/Icons/Icon.swift
@@ -30,6 +30,7 @@ struct Icon: View {
         case "file":       return "doc"
         case "menu":       return "ellipsis"
         case "split":      return "rectangle.split.2x1"
+        case "split-down": return "rectangle.split.1x2"
         case "palette":    return "paintpalette"
         case "keyboard":   return "keyboard"
         case "github":     return "circle.hexagongrid"

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -36,9 +36,9 @@ struct SidebarView: View {
                                 ),
                                 selectedWorktreeId: state.selectedWorktreeId,
                                 harnessSummary: { worktreeId in
-                                    let ids = state.tabs.tabs(forWorktree: worktreeId).compactMap { tab -> String? in
-                                        if case .terminal(let s) = tab { return s.sessionId }
-                                        return nil
+                                    let ids = state.tabs.tabs(forWorktree: worktreeId).flatMap { tab -> [String] in
+                                        if case .terminal(let s) = tab { return s.root.leaves().map(\.sessionId) }
+                                        return []
                                     }
                                     return state.harness.summary(forSessionIds: ids)
                                 },
@@ -65,9 +65,9 @@ struct SidebarView: View {
                                 onArchive: { wt in state.archiveWorktree(wt) },
                                 onDelete: { wt in state.deleteWorktree(wt) },
                                 onActivateHarness: { wt in
-                                    let ids = state.tabs.tabs(forWorktree: wt.id).compactMap { tab -> String? in
-                                        if case .terminal(let s) = tab { return s.sessionId }
-                                        return nil
+                                    let ids = state.tabs.tabs(forWorktree: wt.id).flatMap { tab -> [String] in
+                                        if case .terminal(let s) = tab { return s.root.leaves().map(\.sessionId) }
+                                        return []
                                     }
                                     guard let summary = state.harness.summary(forSessionIds: ids) else { return }
                                     state.activateHarnessSession(

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
@@ -170,7 +170,12 @@ private func alasGhosttyAction(
         return true
 
     case GHOSTTY_ACTION_PWD:
-        return true // Alas doesn't display CWD badges — silently accept.
+        guard let sv = surfaceView else { return true }
+        let pwd = action.action.pwd.pwd.map { String(cString: $0) } ?? ""
+        guard !pwd.isEmpty else { return true }
+        let url = URL(fileURLWithPath: pwd)
+        DispatchQueue.main.async { sv.setCurrentWorkingDirectory(url) }
+        return true
 
     case GHOSTTY_ACTION_MOUSE_SHAPE:
         guard let sv = surfaceView else { return false }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
@@ -173,7 +173,15 @@ private func alasGhosttyAction(
         guard let sv = surfaceView else { return true }
         let pwd = action.action.pwd.pwd.map { String(cString: $0) } ?? ""
         guard !pwd.isEmpty else { return true }
-        let url = URL(fileURLWithPath: pwd)
+        // OSC 7 emits a file:// URL when shell integration is active. Parse
+        // it as a URL first and fall back to treating the string as a raw
+        // filesystem path for any shell that emits one directly.
+        let url: URL = {
+            if let parsed = URL(string: pwd), parsed.isFileURL {
+                return URL(fileURLWithPath: parsed.path)
+            }
+            return URL(fileURLWithPath: pwd)
+        }()
         DispatchQueue.main.async { sv.setCurrentWorkingDirectory(url) }
         return true
 

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -345,9 +345,22 @@ extension AlasGhostty {
             let flags = event.modifierFlags
                 .intersection(.deviceIndependentFlagsMask)
                 .subtracting(.capsLock)
-            guard flags == .command else { return false }
+            let chars = event.charactersIgnoringModifiers?.lowercased() ?? ""
 
-            return event.charactersIgnoringModifiers?.lowercased() == "t"
+            // ⌘T — reserved for the app's New Terminal Tab.
+            if flags == .command && chars == "t" { return true }
+            // ⌘D / ⇧⌘D — Split Right / Split Down.
+            if flags == .command && chars == "d" { return true }
+            if flags == [.command, .shift] && chars == "d" { return true }
+            // ⌘W — Close Pane / Close Tab (AppState decides).
+            if flags == .command && chars == "w" { return true }
+            // Arrow shortcuts: focus (⌥⌘) and resize (⌃⌘).
+            let arrows: Set<UInt16> = [123, 124, 125, 126]  // left, right, down, up
+            if (flags == [.command, .option] || flags == [.command, .control])
+                && arrows.contains(event.keyCode) {
+                return true
+            }
+            return false
         }
 
         // MARK: - Mouse events

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -31,6 +31,18 @@ extension AlasGhostty {
         /// Called (on main thread) when the child process exits or the surface is closed.
         var processExitHandler: (() -> Void)?
 
+        // Current working directory, derived from Ghostty's GHOSTTY_ACTION_PWD events
+        // (which fire when the shell emits OSC 7). Nil until the shell reports one.
+        private(set) var currentWorkingDirectory: URL?
+
+        /// Fired on the main queue when the shell reports a new working directory.
+        var cwdHandler: ((URL) -> Void)?
+
+        func setCurrentWorkingDirectory(_ url: URL) {
+            currentWorkingDirectory = url
+            cwdHandler?(url)
+        }
+
         // MARK: - Internal state
 
         /// The raw C surface pointer. Nil only if surface creation failed.

--- a/Alas/Sources/Terminal/GhosttyConfigBuilder.swift
+++ b/Alas/Sources/Terminal/GhosttyConfigBuilder.swift
@@ -64,6 +64,19 @@ enum GhosttyConfigBuilder {
         lines.append("background = \(bg)")
         lines.append("foreground = \(fg)")
 
+        // Defense-in-depth: prevent libghostty from acting on shortcuts Alas owns.
+        // SurfaceView.isReservedAppKeyEquivalent already intercepts these before
+        // they reach libghostty, but emitting unbinds ensures Ghostty's own
+        // keybindings don't fire even if the wrapper changes.
+        let alasReservedKeybinds = [
+            "cmd+d", "cmd+shift+d", "cmd+w",
+            "cmd+alt+left", "cmd+alt+right", "cmd+alt+up", "cmd+alt+down",
+            "cmd+ctrl+left", "cmd+ctrl+right", "cmd+ctrl+up", "cmd+ctrl+down",
+        ]
+        for kb in alasReservedKeybinds {
+            lines.append("keybind = \(kb)=unbind")
+        }
+
         let body = lines.joined(separator: "\n") + "\n"
         try Paths.ensureDirectoryExists(destination.deletingLastPathComponent())
         try body.write(to: destination, atomically: true, encoding: .utf8)

--- a/Alas/Sources/Terminal/GhosttyHost.swift
+++ b/Alas/Sources/Terminal/GhosttyHost.swift
@@ -3,9 +3,12 @@ import AppKit
 
 /// Hosts an existing AlasGhostty.SurfaceView (already attached to a TerminalSession)
 /// inside SwiftUI. The surface is never recreated — we move it between containers
-/// when the active tab changes.
+/// when the active tab changes. `isFocused` controls whether this host promotes
+/// the surface to first responder on attach; with multiple panes per tab, only
+/// the focused leaf should grab keyboard focus.
 struct GhosttyHost: NSViewRepresentable {
     let session: TerminalSession
+    var isFocused: Bool = true
 
     @MainActor
     func makeNSView(context: Context) -> NSView {
@@ -42,7 +45,7 @@ struct GhosttyHost: NSViewRepresentable {
                 session.surface.trailingAnchor.constraint(equalTo: container.trailingAnchor),
             ])
         }
-        // Make the surface first responder when displayed
+        guard isFocused else { return }
         DispatchQueue.main.async {
             container.window?.makeFirstResponder(session.surface)
         }

--- a/Alas/Sources/Terminal/GhosttyHost.swift
+++ b/Alas/Sources/Terminal/GhosttyHost.swift
@@ -14,13 +14,19 @@ struct GhosttyHost: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let container = NSView()
         container.wantsLayer = true
-        attach(container)
+        attach(container, mayStealFromOtherContainer: true)
         return container
     }
 
     @MainActor
     func updateNSView(_ nsView: NSView, context: Context) {
-        attach(nsView)
+        // updateNSView is a passenger: it may NOT steal the surface from another
+        // container. During a structural transition (e.g. split→leaf collapse),
+        // SwiftUI fires a final updateNSView on the about-to-dismantle GhosttyHost
+        // before its dismantleNSView runs. The newly-made GhosttyHost has already
+        // adopted the surface — re-parenting it back here would orphan the surface
+        // during the imminent dismantle. Only makeNSView claims ownership.
+        attach(nsView, mayStealFromOtherContainer: false)
     }
 
     @MainActor
@@ -29,12 +35,16 @@ struct GhosttyHost: NSViewRepresentable {
     }
 
     @MainActor
-    private func attach(_ container: NSView) {
+    private func attach(_ container: NSView, mayStealFromOtherContainer: Bool) {
         for subview in container.subviews where subview !== session.surface {
             subview.removeFromSuperview()
         }
 
         if session.surface.superview !== container {
+            if session.surface.superview != nil && !mayStealFromOtherContainer {
+                // Another container owns the surface; we're a stale updateNSView.
+                return
+            }
             session.surface.removeFromSuperview()
             session.surface.translatesAutoresizingMaskIntoConstraints = false
             container.addSubview(session.surface)

--- a/Alas/Sources/Terminal/PaneTree.swift
+++ b/Alas/Sources/Terminal/PaneTree.swift
@@ -25,6 +25,9 @@ struct PaneSplit: Codable, Equatable, Identifiable {
     let id: String
     var axis: SplitAxis
     var fraction: Double
+    /// v1 always contains exactly two children. The array type leaves room for
+    /// future N-way splits; `removingLeaf` already collapses single-child splits
+    /// so callers never observe a degenerate 0/1-child state.
     var children: [PaneNode]
 }
 

--- a/Alas/Sources/Terminal/PaneTree.swift
+++ b/Alas/Sources/Terminal/PaneTree.swift
@@ -165,3 +165,55 @@ extension PaneNode {
         }
     }
 }
+
+// MARK: - Focus-by-direction
+
+enum PaneFocusDirection { case left, right, up, down }
+
+enum PaneFocusFinder {
+    /// Find the nearest leaf in `direction` from the source leaf.
+    /// Returns nil if no candidate exists (e.g. source is at the edge or unknown).
+    static func nearestLeaf(
+        from sourceId: String,
+        direction: PaneFocusDirection,
+        frames: [String: CGRect]
+    ) -> String? {
+        guard let source = frames[sourceId] else { return nil }
+        let candidates = frames.filter { id, rect in
+            guard id != sourceId else { return false }
+            return isInDirection(source: source, candidate: rect, direction: direction)
+                && hasPerpendicularOverlap(source: source, candidate: rect, direction: direction)
+        }
+        return candidates.min(by: { lhs, rhs in
+            distance(source: source, target: lhs.value, direction: direction)
+                < distance(source: source, target: rhs.value, direction: direction)
+        })?.key
+    }
+
+    private static func isInDirection(source: CGRect, candidate: CGRect, direction: PaneFocusDirection) -> Bool {
+        switch direction {
+        case .left:  return candidate.midX < source.midX
+        case .right: return candidate.midX > source.midX
+        case .up:    return candidate.midY < source.midY
+        case .down:  return candidate.midY > source.midY
+        }
+    }
+
+    private static func hasPerpendicularOverlap(source: CGRect, candidate: CGRect, direction: PaneFocusDirection) -> Bool {
+        switch direction {
+        case .left, .right:
+            return max(source.minY, candidate.minY) < min(source.maxY, candidate.maxY)
+        case .up, .down:
+            return max(source.minX, candidate.minX) < min(source.maxX, candidate.maxX)
+        }
+    }
+
+    private static func distance(source: CGRect, target: CGRect, direction: PaneFocusDirection) -> CGFloat {
+        switch direction {
+        case .left, .right:
+            return abs(target.midX - source.midX)
+        case .up, .down:
+            return abs(target.midY - source.midY)
+        }
+    }
+}

--- a/Alas/Sources/Terminal/PaneTree.swift
+++ b/Alas/Sources/Terminal/PaneTree.swift
@@ -7,6 +7,7 @@
 // data; session lifetime is managed by `TerminalService`.
 
 import Foundation
+import CoreGraphics
 
 enum SplitAxis: String, Codable, Equatable {
     // horizontal: divider runs horizontally → children stacked top/bottom (Split Down).

--- a/Alas/Sources/Terminal/PaneTree.swift
+++ b/Alas/Sources/Terminal/PaneTree.swift
@@ -169,7 +169,7 @@ extension PaneNode {
 
 // MARK: - Focus-by-direction
 
-enum PaneFocusDirection { case left, right, up, down }
+enum PaneFocusDirection: Equatable, Sendable { case left, right, up, down }
 
 enum PaneFocusFinder {
     /// Find the nearest leaf in `direction` from the source leaf.
@@ -193,10 +193,10 @@ enum PaneFocusFinder {
 
     private static func isInDirection(source: CGRect, candidate: CGRect, direction: PaneFocusDirection) -> Bool {
         switch direction {
-        case .left:  return candidate.midX < source.midX
-        case .right: return candidate.midX > source.midX
-        case .up:    return candidate.midY < source.midY
-        case .down:  return candidate.midY > source.midY
+        case .left:  return candidate.maxX <= source.minX
+        case .right: return candidate.minX >= source.maxX
+        case .up:    return candidate.maxY <= source.minY
+        case .down:  return candidate.minY >= source.maxY
         }
     }
 

--- a/Alas/Sources/Terminal/PaneTree.swift
+++ b/Alas/Sources/Terminal/PaneTree.swift
@@ -1,0 +1,164 @@
+// PaneTree.swift
+// Recursive split-tree model for terminal tabs.
+//
+// A `.terminal` tab's `root` is a single `PaneNode`. Leaves reference live
+// `TerminalSession`s by `sessionId`; splits hold a fraction (0…1, size of the
+// first child along the axis) and two children. Tree mutations are pure on the
+// data; session lifetime is managed by `TerminalService`.
+
+import Foundation
+
+enum SplitAxis: String, Codable, Equatable {
+    // horizontal: divider runs horizontally → children stacked top/bottom (Split Down).
+    // vertical:   divider runs vertically   → children side-by-side       (Split Right).
+    case horizontal
+    case vertical
+}
+
+struct PaneLeaf: Codable, Equatable, Identifiable {
+    let id: String
+    var sessionId: String
+    var lastCwd: String?
+}
+
+struct PaneSplit: Codable, Equatable, Identifiable {
+    let id: String
+    var axis: SplitAxis
+    var fraction: Double
+    var children: [PaneNode]
+}
+
+enum PaneNode: Codable, Equatable, Identifiable {
+    case leaf(PaneLeaf)
+    case split(PaneSplit)
+
+    var id: String {
+        switch self {
+        case .leaf(let l):  return l.id
+        case .split(let s): return s.id
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey { case kind }
+    private enum Kind: String, Codable { case leaf, split }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        let single = try decoder.singleValueContainer()
+        switch kind {
+        case .leaf:
+            self = .leaf(try single.decode(PaneLeafCodable.self).asLeaf)
+        case .split:
+            self = .split(try single.decode(PaneSplitCodable.self).asSplit)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var single = encoder.singleValueContainer()
+        switch self {
+        case .leaf(let l):
+            try single.encode(PaneLeafCodable(kind: .leaf, id: l.id, sessionId: l.sessionId, lastCwd: l.lastCwd))
+        case .split(let s):
+            try single.encode(PaneSplitCodable(
+                kind: .split, id: s.id, axis: s.axis, fraction: s.fraction, children: s.children
+            ))
+        }
+    }
+}
+
+// MARK: - Codable wire shapes
+
+private struct PaneLeafCodable: Codable {
+    enum Kind: String, Codable { case leaf }
+    let kind: Kind
+    let id: String
+    let sessionId: String
+    let lastCwd: String?
+
+    var asLeaf: PaneLeaf {
+        PaneLeaf(id: id, sessionId: sessionId, lastCwd: lastCwd)
+    }
+}
+
+private struct PaneSplitCodable: Codable {
+    enum Kind: String, Codable { case split }
+    let kind: Kind
+    let id: String
+    let axis: SplitAxis
+    let fraction: Double
+    let children: [PaneNode]
+
+    var asSplit: PaneSplit {
+        PaneSplit(id: id, axis: axis, fraction: fraction, children: children)
+    }
+}
+
+// MARK: - Tree helpers
+
+extension PaneNode {
+    /// Left-to-right, top-to-bottom traversal of every leaf in render order.
+    func leaves() -> [PaneLeaf] {
+        switch self {
+        case .leaf(let l):  return [l]
+        case .split(let s): return s.children.flatMap { $0.leaves() }
+        }
+    }
+
+    /// The leftmost / topmost leaf — used as a focus fallback.
+    func firstLeaf() -> PaneLeaf {
+        switch self {
+        case .leaf(let l):  return l
+        case .split(let s): return s.children[0].firstLeaf()
+        }
+    }
+
+    /// Locate a leaf by id and return the path of containing split ids.
+    /// Path is empty when the root itself is the leaf.
+    func find(leafId: String) -> (path: [String], leaf: PaneLeaf)? {
+        switch self {
+        case .leaf(let l):
+            return l.id == leafId ? (path: [], leaf: l) : nil
+        case .split(let s):
+            for child in s.children {
+                if let inner = child.find(leafId: leafId) {
+                    return (path: [s.id] + inner.path, leaf: inner.leaf)
+                }
+            }
+            return nil
+        }
+    }
+
+    /// Replace the leaf with the given id by `replacement` anywhere in the tree.
+    /// If no leaf matches, returns the tree unchanged.
+    func replacingLeaf(id: String, with replacement: PaneNode) -> PaneNode {
+        switch self {
+        case .leaf(let l):
+            return l.id == id ? replacement : self
+        case .split(var s):
+            s.children = s.children.map { $0.replacingLeaf(id: id, with: replacement) }
+            return .split(s)
+        }
+    }
+
+    /// Remove the leaf with `id`. If a parent split is left with a single child,
+    /// collapse the split up to that child. Returns nil if removing this leaf
+    /// would leave the tree empty.
+    func removingLeaf(id: String) -> PaneNode? {
+        switch self {
+        case .leaf(let l):
+            return l.id == id ? nil : self
+        case .split(var s):
+            var newChildren: [PaneNode] = []
+            for child in s.children {
+                if let kept = child.removingLeaf(id: id) {
+                    newChildren.append(kept)
+                }
+            }
+            if newChildren.isEmpty { return nil }
+            if newChildren.count == 1 { return newChildren[0] }
+            s.children = newChildren
+            return .split(s)
+        }
+    }
+}

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -36,7 +36,8 @@ final class TerminalService {
         worktree: Worktree,
         project: ProjectConfig,
         cfg: AppConfig.Terminal,
-        theme: Theme
+        theme: Theme,
+        forcedCwd: URL? = nil
     ) throws -> TerminalSession {
         try ensureApp(cfg: cfg, theme: theme)
         guard let app else { throw NSError(domain: "TerminalService", code: 1) }
@@ -55,7 +56,7 @@ final class TerminalService {
         // Plan-supplied env overrides (e.g. ZDOTDIR for zsh startup scripts)
         // win over inherited env.
         for (k, v) in plan.envOverrides { env[k] = v }
-        let cwd = resolveWorkingDirectory(
+        let cwd = forcedCwd ?? resolveWorkingDirectory(
             preference: cfg.workingDirectory,
             worktree: worktree,
             project: project

--- a/AlasTests/FocusDirectionTests.swift
+++ b/AlasTests/FocusDirectionTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import Alas
 
 struct FocusDirectionTests {
-    // Layout (2-pane horizontal-axis split, i.e. side-by-side):
+    // Layout (2-pane vertical-axis split, i.e. side-by-side):
     //  ┌─────┬─────┐
     //  │  A  │  B  │
     //  └─────┴─────┘
@@ -63,5 +63,42 @@ struct FocusDirectionTests {
     @Test func missingSourceReturnsNil() {
         let r = PaneFocusFinder.nearestLeaf(from: "missing", direction: .right, frames: twoPaneHorizontal)
         #expect(r == nil)
+    }
+
+    // L-shape (one wide pane on top, two equal panes below):
+    //  ┌─────────┐
+    //  │    T    │
+    //  ├────┬────┤
+    //  │ BL │ BR │
+    //  └────┴────┘
+    private let lShape: [String: CGRect] = [
+        "T":  CGRect(x: 0,   y: 0,   width: 200, height: 100),
+        "BL": CGRect(x: 0,   y: 100, width: 100, height: 100),
+        "BR": CGRect(x: 100, y: 100, width: 100, height: 100),
+    ]
+
+    @Test func rightFromBLInLShapeReturnsBR_notT() {
+        // Even though T's midX (100) is rightward of BL's midX (50), T is NOT
+        // to the right of BL — its rect is above. Only BR qualifies.
+        let r = PaneFocusFinder.nearestLeaf(from: "BL", direction: .right, frames: lShape)
+        #expect(r == "BR")
+    }
+
+    @Test func upFromBLInLShapeReturnsT() {
+        let r = PaneFocusFinder.nearestLeaf(from: "BL", direction: .up, frames: lShape)
+        #expect(r == "T")
+    }
+
+    @Test func downFromTInLShapeReturnsBLorBR() {
+        // T is above both BL and BR; both are equidistant. Either is a valid
+        // answer; the algorithm picks deterministically based on dictionary
+        // ordering, so we accept either.
+        let r = PaneFocusFinder.nearestLeaf(from: "T", direction: .down, frames: lShape)
+        #expect(r == "BL" || r == "BR")
+    }
+
+    @Test func leftFromBRInLShapeReturnsBL() {
+        let r = PaneFocusFinder.nearestLeaf(from: "BR", direction: .left, frames: lShape)
+        #expect(r == "BL")
     }
 }

--- a/AlasTests/FocusDirectionTests.swift
+++ b/AlasTests/FocusDirectionTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct FocusDirectionTests {
+    // Layout (2-pane horizontal-axis split, i.e. side-by-side):
+    //  ┌─────┬─────┐
+    //  │  A  │  B  │
+    //  └─────┴─────┘
+    private let twoPaneHorizontal: [String: CGRect] = [
+        "A": CGRect(x: 0,   y: 0, width: 100, height: 100),
+        "B": CGRect(x: 100, y: 0, width: 100, height: 100),
+    ]
+
+    // 2x2 grid:
+    //  ┌──┬──┐
+    //  │A │B │
+    //  ├──┼──┤
+    //  │C │D │
+    //  └──┴──┘
+    private let twoByTwoGrid: [String: CGRect] = [
+        "A": CGRect(x: 0,   y: 0,   width: 100, height: 100),
+        "B": CGRect(x: 100, y: 0,   width: 100, height: 100),
+        "C": CGRect(x: 0,   y: 100, width: 100, height: 100),
+        "D": CGRect(x: 100, y: 100, width: 100, height: 100),
+    ]
+
+    @Test func rightFromAReturnsB() {
+        let r = PaneFocusFinder.nearestLeaf(from: "A", direction: .right, frames: twoPaneHorizontal)
+        #expect(r == "B")
+    }
+
+    @Test func leftFromBReturnsA() {
+        let r = PaneFocusFinder.nearestLeaf(from: "B", direction: .left, frames: twoPaneHorizontal)
+        #expect(r == "A")
+    }
+
+    @Test func upFromAInTwoPaneHorizontalIsNil() {
+        let r = PaneFocusFinder.nearestLeaf(from: "A", direction: .up, frames: twoPaneHorizontal)
+        #expect(r == nil)
+    }
+
+    @Test func downFromAInGridReturnsC() {
+        let r = PaneFocusFinder.nearestLeaf(from: "A", direction: .down, frames: twoByTwoGrid)
+        #expect(r == "C")
+    }
+
+    @Test func rightFromCInGridReturnsD() {
+        let r = PaneFocusFinder.nearestLeaf(from: "C", direction: .right, frames: twoByTwoGrid)
+        #expect(r == "D")
+    }
+
+    @Test func upFromDInGridReturnsB() {
+        let r = PaneFocusFinder.nearestLeaf(from: "D", direction: .up, frames: twoByTwoGrid)
+        #expect(r == "B")
+    }
+
+    @Test func directionAtEdgeReturnsNil() {
+        let r = PaneFocusFinder.nearestLeaf(from: "B", direction: .right, frames: twoPaneHorizontal)
+        #expect(r == nil)
+    }
+
+    @Test func missingSourceReturnsNil() {
+        let r = PaneFocusFinder.nearestLeaf(from: "missing", direction: .right, frames: twoPaneHorizontal)
+        #expect(r == nil)
+    }
+}

--- a/AlasTests/GhosttyConfigBuilderTests.swift
+++ b/AlasTests/GhosttyConfigBuilderTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 
@@ -38,5 +39,33 @@ struct GhosttyConfigBuilderTests {
 
     @Test func posixQuoteEmptyStringIsEmptyQuotes() {
         #expect(GhosttyConfigBuilder.posixQuote("") == "''")
+    }
+
+    @Test @MainActor func writeGlobalConfigEmitsKeybindUnbinds() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("ghostty-config-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let cfg = AppConfig.defaults.terminal
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        try GhosttyConfigBuilder.writeGlobalConfigFile(cfg: cfg, theme: theme, to: url)
+        let body = try String(contentsOf: url, encoding: .utf8)
+
+        let expected = [
+            "keybind = cmd+d=unbind",
+            "keybind = cmd+shift+d=unbind",
+            "keybind = cmd+w=unbind",
+            "keybind = cmd+alt+left=unbind",
+            "keybind = cmd+alt+right=unbind",
+            "keybind = cmd+alt+up=unbind",
+            "keybind = cmd+alt+down=unbind",
+            "keybind = cmd+ctrl+left=unbind",
+            "keybind = cmd+ctrl+right=unbind",
+            "keybind = cmd+ctrl+up=unbind",
+            "keybind = cmd+ctrl+down=unbind",
+        ]
+        for line in expected {
+            #expect(body.contains(line), "config missing line: \(line)")
+        }
     }
 }

--- a/AlasTests/PaneTreeTests.swift
+++ b/AlasTests/PaneTreeTests.swift
@@ -56,9 +56,9 @@ struct PaneTreeTests {
         #expect(inner.id == "new-split")
     }
 
-    @Test func removingLeafCollapsesSingleChildSplit() {
+    @Test func removingLeafCollapsesSingleChildSplit() throws {
         let tree = split("s1", .vertical, 0.5, [leaf("a"), leaf("b")])
-        let result = try? #require(tree.removingLeaf(id: "b"))
+        let result = try #require(tree.removingLeaf(id: "b"))
         if case .leaf(let only) = result {
             #expect(only.id == "a")
         } else {
@@ -71,12 +71,12 @@ struct PaneTreeTests {
         #expect(tree.removingLeaf(id: "a") == nil)
     }
 
-    @Test func removingLeafFromNestedSplitCollapsesUpwards() {
+    @Test func removingLeafFromNestedSplitCollapsesUpwards() throws {
         let tree = split("s1", .vertical, 0.5, [
             leaf("a"),
             split("s2", .horizontal, 0.5, [leaf("b"), leaf("c")]),
         ])
-        let result = try? #require(tree.removingLeaf(id: "c"))
+        let result = try #require(tree.removingLeaf(id: "c"))
         if case .split(let root) = result,
            case .leaf(let l0) = root.children[0],
            case .leaf(let l1) = root.children[1] {

--- a/AlasTests/PaneTreeTests.swift
+++ b/AlasTests/PaneTreeTests.swift
@@ -1,0 +1,89 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct PaneTreeTests {
+    private func leaf(_ id: String, session: String = "s") -> PaneNode {
+        .leaf(PaneLeaf(id: id, sessionId: session, lastCwd: nil))
+    }
+
+    private func split(_ id: String, _ axis: SplitAxis, _ fraction: Double, _ children: [PaneNode]) -> PaneNode {
+        .split(PaneSplit(id: id, axis: axis, fraction: fraction, children: children))
+    }
+
+    @Test func firstLeafReturnsLeftmostLeaf() {
+        let tree = split("s1", .vertical, 0.5, [
+            split("s2", .horizontal, 0.5, [leaf("a"), leaf("b")]),
+            leaf("c"),
+        ])
+        #expect(tree.firstLeaf().id == "a")
+    }
+
+    @Test func leavesEnumeratesInRenderOrder() {
+        let tree = split("s1", .vertical, 0.5, [
+            split("s2", .horizontal, 0.5, [leaf("a"), leaf("b")]),
+            split("s3", .horizontal, 0.5, [leaf("c"), leaf("d")]),
+        ])
+        #expect(tree.leaves().map(\.id) == ["a", "b", "c", "d"])
+    }
+
+    @Test func findReturnsLeafAndPath() throws {
+        let tree = split("s1", .vertical, 0.5, [
+            leaf("a"),
+            split("s2", .horizontal, 0.5, [leaf("b"), leaf("c")]),
+        ])
+        let result = try #require(tree.find(leafId: "c"))
+        #expect(result.leaf.id == "c")
+        #expect(result.path == ["s1", "s2"])
+    }
+
+    @Test func findReturnsNilForMissingLeaf() {
+        let tree: PaneNode = .leaf(PaneLeaf(id: "a", sessionId: "s", lastCwd: nil))
+        #expect(tree.find(leafId: "missing") == nil)
+    }
+
+    @Test func replacingLeafSwapsTheTargetedLeaf() {
+        let tree = split("s1", .vertical, 0.5, [leaf("a"), leaf("b")])
+        let replacement = split("new-split", .horizontal, 0.5, [leaf("b"), leaf("c")])
+        let result = tree.replacingLeaf(id: "b", with: replacement)
+        guard case .split(let root) = result,
+              case .leaf(let l0) = root.children[0],
+              case .split(let inner) = root.children[1] else {
+            Issue.record("expected split with leaf + split")
+            return
+        }
+        #expect(l0.id == "a")
+        #expect(inner.id == "new-split")
+    }
+
+    @Test func removingLeafCollapsesSingleChildSplit() {
+        let tree = split("s1", .vertical, 0.5, [leaf("a"), leaf("b")])
+        let result = try? #require(tree.removingLeaf(id: "b"))
+        if case .leaf(let only) = result {
+            #expect(only.id == "a")
+        } else {
+            Issue.record("expected collapse to leaf 'a'")
+        }
+    }
+
+    @Test func removingLeafReturnsNilWhenRemovingLastLeaf() {
+        let tree: PaneNode = .leaf(PaneLeaf(id: "a", sessionId: "s", lastCwd: nil))
+        #expect(tree.removingLeaf(id: "a") == nil)
+    }
+
+    @Test func removingLeafFromNestedSplitCollapsesUpwards() {
+        let tree = split("s1", .vertical, 0.5, [
+            leaf("a"),
+            split("s2", .horizontal, 0.5, [leaf("b"), leaf("c")]),
+        ])
+        let result = try? #require(tree.removingLeaf(id: "c"))
+        if case .split(let root) = result,
+           case .leaf(let l0) = root.children[0],
+           case .leaf(let l1) = root.children[1] {
+            #expect(l0.id == "a")
+            #expect(l1.id == "b")
+        } else {
+            Issue.record("expected split[leaf a, leaf b]")
+        }
+    }
+}

--- a/AlasTests/SurfaceViewShortcutTests.swift
+++ b/AlasTests/SurfaceViewShortcutTests.swift
@@ -38,11 +38,12 @@ struct SurfaceViewShortcutTests {
     }
 
     @Test func otherCommandKeysAreNotReserved() throws {
+        // Cmd+E is not reserved by Alas, so libghostty should still see it.
         let event = try keyEvent(
-            characters: "w",
-            ignoringModifiers: "w",
+            characters: "e",
+            ignoringModifiers: "e",
             modifiers: .command,
-            keyCode: 13
+            keyCode: 14
         )
 
         #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
@@ -68,6 +69,54 @@ struct SurfaceViewShortcutTests {
             keyCode: 17
         )
 
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func commandDIsReserved() throws {
+        let event = try keyEvent(
+            characters: "d", ignoringModifiers: "d",
+            modifiers: .command, keyCode: 2
+        )
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func commandShiftDIsReserved() throws {
+        let event = try keyEvent(
+            characters: "D", ignoringModifiers: "d",
+            modifiers: [.command, .shift], keyCode: 2
+        )
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func commandWIsReserved() throws {
+        let event = try keyEvent(
+            characters: "w", ignoringModifiers: "w",
+            modifiers: .command, keyCode: 13
+        )
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func commandOptionLeftArrowIsReserved() throws {
+        let event = try keyEvent(
+            characters: "\u{F702}", ignoringModifiers: "\u{F702}",
+            modifiers: [.command, .option], keyCode: 123
+        )
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func commandCtrlRightArrowIsReserved() throws {
+        let event = try keyEvent(
+            characters: "\u{F703}", ignoringModifiers: "\u{F703}",
+            modifiers: [.command, .control], keyCode: 124
+        )
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+    }
+
+    @Test func plainArrowIsNotReserved() throws {
+        let event = try keyEvent(
+            characters: "\u{F702}", ignoringModifiers: "\u{F702}",
+            modifiers: [], keyCode: 123
+        )
         #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
     }
 

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -340,12 +340,12 @@ struct TabsManagerPaneTests {
         _ = mgr.splitFocusedLeaf(worktreeId: "wt", tabId: tab.id, axis: .vertical,
                                   newLeafId: "new-leaf", newSessionId: "s2")
 
-        let updated = mgr.setFocusedLeaf(worktreeId: "wt", tabId: tab.id, leafId: originalFocus)
-        if case .terminal(let s) = updated {
-            #expect(s.focusedLeafId == originalFocus)
-        } else {
-            Issue.record("expected terminal tab")
+        _ = mgr.setFocusedLeaf(worktreeId: "wt", tabId: tab.id, leafId: originalFocus)
+        guard let reread = mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id }),
+              case .terminal(let s) = reread else {
+            Issue.record("expected terminal tab in store after setFocusedLeaf"); return
         }
+        #expect(s.focusedLeafId == originalFocus)
     }
 
     @Test func splitFocusedLeafReplacesFocusedLeafWithSplit() {
@@ -363,6 +363,15 @@ struct TabsManagerPaneTests {
         #expect(split.fraction == 0.5)
         #expect(split.children.count == 2)
         #expect(s.focusedLeafId == "new")
+        // Re-read to confirm persistence
+        guard let reread = mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id }),
+              case .terminal(let persisted) = reread,
+              case .split(let persistedSplit) = persisted.root else {
+            Issue.record("split did not persist into byWorktree"); return
+        }
+        #expect(persistedSplit.axis == .horizontal)
+        #expect(persistedSplit.children.count == 2)
+        #expect(persisted.focusedLeafId == "new")
     }
 
     @Test func removeFocusedLeafReturnsClosedSessionId() throws {
@@ -372,29 +381,35 @@ struct TabsManagerPaneTests {
             worktreeId: "wt", tabId: tab.id, axis: .vertical,
             newLeafId: "new", newSessionId: "s2"
         )
-        // Focus is on "new". Remove it.
         let outcome = try #require(mgr.removeFocusedLeaf(worktreeId: "wt", tabId: tab.id))
-        #expect(outcome.closedSessionId == "s2")
-        #expect(outcome.tabRemoved == false)
-        // The remaining leaf with sessionId "s1" should be focused.
-        if let updated = outcome.tab, case .terminal(let s) = updated {
-            if case .leaf(let l) = s.root {
-                #expect(l.sessionId == "s1")
-                #expect(s.focusedLeafId == l.id)
-            } else {
-                Issue.record("expected leaf root after collapse")
-            }
-        } else {
-            Issue.record("outcome.tab missing")
+        guard case .leafRemoved(let outcomeTab, let closedSessionId) = outcome else {
+            Issue.record("expected .leafRemoved"); return
         }
+        #expect(closedSessionId == "s2")
+        if case .terminal(let s) = outcomeTab, case .leaf(let l) = s.root {
+            #expect(l.sessionId == "s1")
+            #expect(s.focusedLeafId == l.id)
+        } else {
+            Issue.record("expected leaf root after collapse")
+        }
+        // Re-read to confirm persistence
+        guard let reread = mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id }),
+              case .terminal(let persisted) = reread,
+              case .leaf(let persistedLeaf) = persisted.root else {
+            Issue.record("collapse did not persist into byWorktree"); return
+        }
+        #expect(persistedLeaf.sessionId == "s1")
+        #expect(persisted.focusedLeafId == persistedLeaf.id)
     }
 
     @Test func removeFocusedLeafSignalsLastLeafRemoval() throws {
         let mgr = TabsManager()
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
         let outcome = try #require(mgr.removeFocusedLeaf(worktreeId: "wt", tabId: tab.id))
-        #expect(outcome.closedSessionId == "s1")
-        #expect(outcome.tabRemoved == true)
+        guard case .tabRemoved(let closedSessionId) = outcome else {
+            Issue.record("expected .tabRemoved"); return
+        }
+        #expect(closedSessionId == "s1")
     }
 
     @Test func setSplitFractionClampsBetween0_1And0_9() {

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -100,7 +100,7 @@ struct TabsManagerTests {
             Issue.record("Expected terminal tab")
             return
         }
-        #expect(state.sessionId == "new")
+        #expect(state.root.find(leafId: state.focusedLeafId)?.leaf.sessionId == "new")
         #expect(state.title == "x")
     }
 

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -448,4 +448,27 @@ struct TabsManagerPaneTests {
             #expect(l.lastCwd == "/Users/test")
         }
     }
+
+    @Test func replaceLeafSessionPreservesLastCwd() {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "old")
+        guard case .terminal(let initial) = tab else { Issue.record("not terminal"); return }
+
+        // Seed a lastCwd on the leaf via setLeafCwd.
+        _ = mgr.setLeafCwd(worktreeId: "wt", tabId: tab.id,
+                           leafId: initial.focusedLeafId, cwd: "/tmp/work")
+
+        // Swap the session for that leaf.
+        _ = mgr.replaceLeafSession(worktreeId: "wt", tabId: tab.id,
+                                   leafId: initial.focusedLeafId, sessionId: "new")
+
+        guard let reread = mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id }),
+              case .terminal(let s) = reread,
+              case .leaf(let l) = s.root else {
+            Issue.record("expected single-leaf tab after replaceLeafSession"); return
+        }
+        #expect(l.sessionId == "new")
+        #expect(l.lastCwd == "/tmp/work",
+                "lastCwd should be preserved across session replacement")
+    }
 }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -332,7 +332,8 @@ struct TabsManagerPaneTests {
         let mgr = TabsManager()
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
         guard case .terminal(let initialState) = tab else {
-            Issue.record("expected terminal tab"); return
+            Issue.record("expected terminal tab")
+            return
         }
         let originalFocus = initialState.focusedLeafId
 
@@ -343,7 +344,8 @@ struct TabsManagerPaneTests {
         _ = mgr.setFocusedLeaf(worktreeId: "wt", tabId: tab.id, leafId: originalFocus)
         guard let reread = mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id }),
               case .terminal(let s) = reread else {
-            Issue.record("expected terminal tab in store after setFocusedLeaf"); return
+            Issue.record("expected terminal tab in store after setFocusedLeaf")
+            return
         }
         #expect(s.focusedLeafId == originalFocus)
     }
@@ -357,7 +359,8 @@ struct TabsManagerPaneTests {
         )
         guard case .terminal(let s) = result,
               case .split(let split) = s.root else {
-            Issue.record("expected a split at root"); return
+            Issue.record("expected a split at root")
+            return
         }
         #expect(split.axis == .horizontal)
         #expect(split.fraction == 0.5)
@@ -367,7 +370,8 @@ struct TabsManagerPaneTests {
         guard let reread = mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id }),
               case .terminal(let persisted) = reread,
               case .split(let persistedSplit) = persisted.root else {
-            Issue.record("split did not persist into byWorktree"); return
+            Issue.record("split did not persist into byWorktree")
+            return
         }
         #expect(persistedSplit.axis == .horizontal)
         #expect(persistedSplit.children.count == 2)
@@ -383,7 +387,8 @@ struct TabsManagerPaneTests {
         )
         let outcome = try #require(mgr.removeFocusedLeaf(worktreeId: "wt", tabId: tab.id))
         guard case .leafRemoved(let outcomeTab, let closedSessionId) = outcome else {
-            Issue.record("expected .leafRemoved"); return
+            Issue.record("expected .leafRemoved")
+            return
         }
         #expect(closedSessionId == "s2")
         if case .terminal(let s) = outcomeTab, case .leaf(let l) = s.root {
@@ -396,7 +401,8 @@ struct TabsManagerPaneTests {
         guard let reread = mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id }),
               case .terminal(let persisted) = reread,
               case .leaf(let persistedLeaf) = persisted.root else {
-            Issue.record("collapse did not persist into byWorktree"); return
+            Issue.record("collapse did not persist into byWorktree")
+            return
         }
         #expect(persistedLeaf.sessionId == "s1")
         #expect(persisted.focusedLeafId == persistedLeaf.id)
@@ -407,7 +413,8 @@ struct TabsManagerPaneTests {
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
         let outcome = try #require(mgr.removeFocusedLeaf(worktreeId: "wt", tabId: tab.id))
         guard case .tabRemoved(let closedSessionId) = outcome else {
-            Issue.record("expected .tabRemoved"); return
+            Issue.record("expected .tabRemoved")
+            return
         }
         #expect(closedSessionId == "s1")
     }
@@ -421,7 +428,8 @@ struct TabsManagerPaneTests {
         )
         guard case .terminal(let s) = (mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id })!),
               case .split(let split) = s.root else {
-            Issue.record("expected split"); return
+            Issue.record("expected split")
+            return
         }
 
         _ = mgr.setSplitFraction(worktreeId: "wt", tabId: tab.id, splitId: split.id, fraction: 1.5)
@@ -440,7 +448,8 @@ struct TabsManagerPaneTests {
     @Test func setLeafCwdUpdatesLastCwd() {
         let mgr = TabsManager()
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
-        guard case .terminal(let initialState) = tab else { Issue.record("not terminal"); return }
+        guard case .terminal(let initialState) = tab else { Issue.record("not terminal")
+        return }
         _ = mgr.setLeafCwd(worktreeId: "wt", tabId: tab.id,
                            leafId: initialState.focusedLeafId, cwd: "/Users/test")
         if case .terminal(let s) = (mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id })!),
@@ -452,7 +461,8 @@ struct TabsManagerPaneTests {
     @Test func replaceLeafSessionPreservesLastCwd() {
         let mgr = TabsManager()
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "old")
-        guard case .terminal(let initial) = tab else { Issue.record("not terminal"); return }
+        guard case .terminal(let initial) = tab else { Issue.record("not terminal")
+        return }
 
         // Seed a lastCwd on the leaf via setLeafCwd.
         _ = mgr.setLeafCwd(worktreeId: "wt", tabId: tab.id,
@@ -465,7 +475,8 @@ struct TabsManagerPaneTests {
         guard let reread = mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id }),
               case .terminal(let s) = reread,
               case .leaf(let l) = s.root else {
-            Issue.record("expected single-leaf tab after replaceLeafSession"); return
+            Issue.record("expected single-leaf tab after replaceLeafSession")
+            return
         }
         #expect(l.sessionId == "new")
         #expect(l.lastCwd == "/tmp/work",

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -323,3 +323,114 @@ struct TabsManagerTests {
         }
     }
 }
+
+// MARK: - Pane tree mutations
+
+@MainActor
+struct TabsManagerPaneTests {
+    @Test func setFocusedLeafUpdatesState() {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        guard case .terminal(let initialState) = tab else {
+            Issue.record("expected terminal tab"); return
+        }
+        let originalFocus = initialState.focusedLeafId
+
+        // Split the focused leaf so there's a second leaf to focus.
+        _ = mgr.splitFocusedLeaf(worktreeId: "wt", tabId: tab.id, axis: .vertical,
+                                  newLeafId: "new-leaf", newSessionId: "s2")
+
+        let updated = mgr.setFocusedLeaf(worktreeId: "wt", tabId: tab.id, leafId: originalFocus)
+        if case .terminal(let s) = updated {
+            #expect(s.focusedLeafId == originalFocus)
+        } else {
+            Issue.record("expected terminal tab")
+        }
+    }
+
+    @Test func splitFocusedLeafReplacesFocusedLeafWithSplit() {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        let result = mgr.splitFocusedLeaf(
+            worktreeId: "wt", tabId: tab.id, axis: .horizontal,
+            newLeafId: "new", newSessionId: "s2"
+        )
+        guard case .terminal(let s) = result,
+              case .split(let split) = s.root else {
+            Issue.record("expected a split at root"); return
+        }
+        #expect(split.axis == .horizontal)
+        #expect(split.fraction == 0.5)
+        #expect(split.children.count == 2)
+        #expect(s.focusedLeafId == "new")
+    }
+
+    @Test func removeFocusedLeafReturnsClosedSessionId() throws {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        _ = mgr.splitFocusedLeaf(
+            worktreeId: "wt", tabId: tab.id, axis: .vertical,
+            newLeafId: "new", newSessionId: "s2"
+        )
+        // Focus is on "new". Remove it.
+        let outcome = try #require(mgr.removeFocusedLeaf(worktreeId: "wt", tabId: tab.id))
+        #expect(outcome.closedSessionId == "s2")
+        #expect(outcome.tabRemoved == false)
+        // The remaining leaf with sessionId "s1" should be focused.
+        if let updated = outcome.tab, case .terminal(let s) = updated {
+            if case .leaf(let l) = s.root {
+                #expect(l.sessionId == "s1")
+                #expect(s.focusedLeafId == l.id)
+            } else {
+                Issue.record("expected leaf root after collapse")
+            }
+        } else {
+            Issue.record("outcome.tab missing")
+        }
+    }
+
+    @Test func removeFocusedLeafSignalsLastLeafRemoval() throws {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        let outcome = try #require(mgr.removeFocusedLeaf(worktreeId: "wt", tabId: tab.id))
+        #expect(outcome.closedSessionId == "s1")
+        #expect(outcome.tabRemoved == true)
+    }
+
+    @Test func setSplitFractionClampsBetween0_1And0_9() {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        _ = mgr.splitFocusedLeaf(
+            worktreeId: "wt", tabId: tab.id, axis: .vertical,
+            newLeafId: "new", newSessionId: "s2"
+        )
+        guard case .terminal(let s) = (mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id })!),
+              case .split(let split) = s.root else {
+            Issue.record("expected split"); return
+        }
+
+        _ = mgr.setSplitFraction(worktreeId: "wt", tabId: tab.id, splitId: split.id, fraction: 1.5)
+        if case .terminal(let s2) = (mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id })!),
+           case .split(let s2split) = s2.root {
+            #expect(s2split.fraction == 0.9)
+        }
+
+        _ = mgr.setSplitFraction(worktreeId: "wt", tabId: tab.id, splitId: split.id, fraction: -0.5)
+        if case .terminal(let s3) = (mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id })!),
+           case .split(let s3split) = s3.root {
+            #expect(s3split.fraction == 0.1)
+        }
+    }
+
+    @Test func setLeafCwdUpdatesLastCwd() {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        guard case .terminal(let initialState) = tab else { Issue.record("not terminal"); return }
+        _ = mgr.setLeafCwd(worktreeId: "wt", tabId: tab.id,
+                           leafId: initialState.focusedLeafId, cwd: "/Users/test")
+        if case .terminal(let s) = (mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id })!),
+           case .leaf(let l) = s.root {
+            #expect(l.lastCwd == "/Users/test")
+        }
+    }
+}

--- a/AlasTests/TerminalTabStateCodableTests.swift
+++ b/AlasTests/TerminalTabStateCodableTests.swift
@@ -49,7 +49,7 @@ struct TerminalTabStateCodableTests {
         }
     }
 
-    @Test func encodingAlwaysIncludesRootAndFocusedLeafId() throws {
+    @Test func encodingNeverEmitsTopLevelSessionIdKey() throws {
         let state = TerminalTabState(
             id: "tab-1",
             title: "main",
@@ -57,8 +57,18 @@ struct TerminalTabStateCodableTests {
             focusedLeafId: "leaf-1"
         )
         let data = try JSONEncoder().encode(state)
-        let raw = String(data: data, encoding: .utf8) ?? ""
-        #expect(raw.contains("\"root\""))
-        #expect(raw.contains("\"focusedLeafId\""))
+        let parsed = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(parsed["root"] != nil)
+        #expect(parsed["focusedLeafId"] != nil)
+        #expect(parsed["sessionId"] == nil,
+                "Top-level sessionId leaked into the new shape — encode(to:) should never emit it.")
+    }
+
+    @Test func decodeWithRootButNoFocusedLeafIdFallsBackToFirstLeaf() throws {
+        let json = #"""
+        {"id":"t","title":"x","root":{"kind":"leaf","id":"leaf-1","sessionId":"s","lastCwd":null}}
+        """#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(TerminalTabState.self, from: json)
+        #expect(decoded.focusedLeafId == "leaf-1")
     }
 }

--- a/AlasTests/TerminalTabStateCodableTests.swift
+++ b/AlasTests/TerminalTabStateCodableTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct TerminalTabStateCodableTests {
+    @Test func newShapeRoundTripsLeafOnly() throws {
+        let state = TerminalTabState(
+            id: "tab-1",
+            title: "main",
+            root: .leaf(PaneLeaf(id: "leaf-1", sessionId: "sess-1", lastCwd: "/tmp")),
+            focusedLeafId: "leaf-1"
+        )
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(TerminalTabState.self, from: data)
+        #expect(decoded == state)
+    }
+
+    @Test func newShapeRoundTripsNestedTree() throws {
+        let nested: PaneNode = .split(PaneSplit(
+            id: "s1", axis: .vertical, fraction: 0.5,
+            children: [
+                .leaf(PaneLeaf(id: "a", sessionId: "sa", lastCwd: nil)),
+                .split(PaneSplit(id: "s2", axis: .horizontal, fraction: 0.3,
+                                 children: [
+                                    .leaf(PaneLeaf(id: "b", sessionId: "sb", lastCwd: "/home")),
+                                    .leaf(PaneLeaf(id: "c", sessionId: "sc", lastCwd: nil)),
+                                 ]))
+            ]
+        ))
+        let state = TerminalTabState(id: "tab", title: "t", root: nested, focusedLeafId: "b")
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(TerminalTabState.self, from: data)
+        #expect(decoded == state)
+    }
+
+    @Test func legacyShapeDecodesIntoSingleLeaf() throws {
+        let legacyJSON = #"""
+        {"id":"tab-1","title":"main","sessionId":"sess-1"}
+        """#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(TerminalTabState.self, from: legacyJSON)
+        #expect(decoded.id == "tab-1")
+        #expect(decoded.title == "main")
+        if case .leaf(let l) = decoded.root {
+            #expect(l.sessionId == "sess-1")
+            #expect(decoded.focusedLeafId == l.id)
+            #expect(l.lastCwd == nil)
+        } else {
+            Issue.record("legacy state should decode to a single leaf")
+        }
+    }
+
+    @Test func encodingAlwaysIncludesRootAndFocusedLeafId() throws {
+        let state = TerminalTabState(
+            id: "tab-1",
+            title: "main",
+            root: .leaf(PaneLeaf(id: "leaf-1", sessionId: "sess-1", lastCwd: nil)),
+            focusedLeafId: "leaf-1"
+        )
+        let data = try JSONEncoder().encode(state)
+        let raw = String(data: data, encoding: .utf8) ?? ""
+        #expect(raw.contains("\"root\""))
+        #expect(raw.contains("\"focusedLeafId\""))
+    }
+}


### PR DESCRIPTION
## Summary

- Recursive horizontal/vertical split panes for terminal tabs, persistent across relaunch (tree shape, sizes, focused pane, per-leaf cwd via OSC-7).
- New Terminal menu (Split Right ⌘D, Split Down ⇧⌘D, Close Pane, Focus Pane ⌥⌘arrows, Resize Pane ⌃⌘arrows) and tab-bar Split buttons.
- New session inherits the focused pane's current OSC-7 cwd; harness state is not inherited.
- ⌘W now closes the focused pane in a multi-pane terminal tab and the whole tab otherwise.

## Architecture

- `PaneTree.swift`: recursive `PaneNode` (leaf/split), Codable with `kind` discriminator, tree helpers (`leaves`, `firstLeaf`, `find`, `replacingLeaf`, `removingLeaf`), edge-comparison `PaneFocusFinder.nearestLeaf`.
- `TerminalTabState`: replaces `sessionId: String` with `root: PaneNode` + `focusedLeafId`. Custom `init(from:)` decodes the legacy `{id,title,sessionId}` shape into a single-leaf tree on first read; encode always writes the new shape.
- `TabsManager`: `setFocusedLeaf` / `splitFocusedLeaf` / `removeFocusedLeaf` (returns `RemoveFocusedLeafOutcome` enum) / `setSplitFraction` / `setLeafCwd` / `replaceLeafSession`.
- `AppState`: `splitFocusedPane`, `closeFocusedPane`, `focusPane`, `resizePane`, `handleCloseShortcut`, generalized `restoreTerminalTabIfNeeded` that walks every leaf and recreates dropped sessions at their `lastCwd`. Per-tab `terminalLeafFrames` cache is `@ObservationIgnored` to avoid render loops.
- `AlasGhostty.SurfaceView`: extends `isReservedAppKeyEquivalent` to reserve ⌘D / ⇧⌘D / ⌘W / ⌥⌘+arrows / ⌃⌘+arrows; exposes `currentWorkingDirectory` + `cwdHandler` populated from `GHOSTTY_ACTION_PWD`.
- `GhosttyConfigBuilder`: emits `keybind = …=unbind` for Alas-owned shortcuts as defense-in-depth.
- `TerminalTabView`: recursive renderer (`PaneNodeView` / `SplitContainer` / `PaneLeafView`). Custom `GeometryReader` split with draggable 4 px divider, clipped pane children, hover-cursor toggle, drag-start fraction snapshot (no quadratic acceleration), per-leaf frame collection via `PreferenceKey` for focus-by-direction. Focus ring (`accent` color) only shown when a tab actually has multiple panes.
- `GhosttyHost.isFocused` gates first-responder promotion. `updateNSView` is a passenger — it never steals the surface from another container, which fixes the orphaned-surface bug seen on split→leaf collapse where SwiftUI fires a stale final update on the about-to-dismantle host.

## Test plan

- [ ] `xcodegen && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` — green.
- [ ] Open terminal tab → ⌘D → two panes side-by-side; ⇧⌘D → top/bottom.
- [ ] Click into either pane → focus border moves; typing goes to the focused pane only.
- [ ] ⌥⌘← / → / ↑ / ↓ moves focus correctly across a 2×2 grid; edges no-op.
- [ ] ⌃⌘arrows resizes by 5%; clamps at 10/90%.
- [ ] Drag divider live with cursor — no jump, no acceleration.
- [ ] ⌘W with two panes closes the focused pane, sibling expands and remains responsive; ⌘W with one pane closes the tab.
- [ ] Quit and relaunch a split tab → tree, sizes, focused pane, and per-leaf `cd`-into-subdirs all restored.
- [ ] Tab-bar Split buttons appear only when a terminal tab is active; disappear for editor / diff / commit / image tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)