### PR TITLE
Fix empty Edit Project dialog and expand color palette

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -4,8 +4,7 @@ import SwiftUI
 struct RootView: View {
     @Bindable var state: AppState
     @State private var showNewProject = false
-    @State private var showEditProject = false
-    @State private var editingProjectId: String?
+    @State private var editingProject: ProjectConfig?
     @State private var showNewWorktree = false
     @State private var newWorktreePresetProjectId: String?
     @State private var collapsedProjects: Set<String> = []
@@ -39,8 +38,7 @@ struct RootView: View {
                                 onSettings: { openSettingsWindow() },
                                 onAddProject: { showNewProject = true },
                                 onEditProject: { projectId in
-                                    editingProjectId = projectId
-                                    showEditProject = true
+                                    editingProject = state.projects.first { $0.id == projectId }
                                 },
                                 onNewWorktree: { projectId in
                                     newWorktreePresetProjectId = projectId
@@ -95,10 +93,15 @@ struct RootView: View {
         .sheet(isPresented: $showNewProject) {
             NewProjectDialog(state: state, presented: $showNewProject)
         }
-        .sheet(isPresented: $showEditProject, onDismiss: { editingProjectId = nil }) {
-            if let project = editingProject() {
-                EditProjectDialog(state: state, presented: $showEditProject, project: project)
-            }
+        .sheet(item: $editingProject) { project in
+            EditProjectDialog(
+                state: state,
+                presented: Binding(
+                    get: { editingProject != nil },
+                    set: { if !$0 { editingProject = nil } }
+                ),
+                project: project
+            )
         }
         .sheet(isPresented: $showNewWorktree, onDismiss: { newWorktreePresetProjectId = nil }) {
             NewWorktreeDialog(
@@ -123,11 +126,6 @@ struct RootView: View {
 
     private func openSettingsWindow() {
         openWindow(id: "settings")
-    }
-
-    private func editingProject() -> ProjectConfig? {
-        guard let editingProjectId else { return nil }
-        return state.projects.first { $0.id == editingProjectId }
     }
 
     private func selectedWorktree() -> Worktree? {

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -37,7 +37,11 @@ private struct ProjectDialog: View {
     @State private var isValidating = false
     @State private var errorMessage: String?
 
-    private let palette = ["#5fb7c4", "#c89d6f", "#9789c7", "#7fb978", "#d77b88"]
+    private let palette = [
+        "#5fb7c4", "#c89d6f", "#9789c7", "#7fb978", "#d77b88",
+        "#6f9bd1", "#e0b86f", "#b87fc4", "#7fc4b0", "#c4b87f",
+        "#d49960", "#8fb4d4",
+    ]
 
     var body: some View {
         DialogContainer(


### PR DESCRIPTION
## Summary
- Right-click → **Edit Project** opened an empty dialog. The sheet was driven by two `@State` vars (`showEditProject: Bool` + `editingProjectId: String?`); SwiftUI could evaluate the sheet content closure before `editingProjectId` propagated, so the `if let project = editingProject()` guard failed and the sheet rendered empty.
- Collapsed to a single `@State editingProject: ProjectConfig?` and switched to `.sheet(item:)` — only presents when non-nil, passes the unwrapped value to the content. No race possible.
- Expanded project color palette from 5 to 12 swatches (kept the existing muted aesthetic).

## Test plan
- [ ] Right-click a repo in the sidebar → **Edit Project…** shows the populated dialog with current name/color/path
- [ ] Save changes persists name and color
- [ ] Cancel dismisses cleanly; opening Edit again works
- [ ] Add Project flow still works end-to-end
- [ ] New colors render correctly in the swatch row

🤖 Generated with [Claude Code](https://claude.com/claude-code)