### PR TITLE
Improve repository picker in New Worktree dialog

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02E429B37288215EBC89571 /* CommitHeaderView.swift */; };
 		4BE29AA0D4CBFF3FF4B61C9F /* HookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E3734FE56F51B4615EF1A5 /* HookEvent.swift */; };
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
+		4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */; };
 		523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE8B45ECF898B83A616586D /* SubHeader.swift */; };
@@ -235,6 +236,7 @@
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
+		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
 		E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373D587E3153D902EB10208B /* MarkdownParserTests.swift */; };
 		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
@@ -271,6 +273,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPickerTests.swift; sourceTree = "<group>"; };
 		008E982C8526670670425AB8 /* EmptyTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabView.swift; sourceTree = "<group>"; };
 		010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowConfigurator.swift; sourceTree = "<group>"; };
 		019A03B92542169A6595D432 /* HoverHighlightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeature.swift; sourceTree = "<group>"; };
@@ -340,6 +343,7 @@
 		3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeBuilderTests.swift; sourceTree = "<group>"; };
 		3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilderTests.swift; sourceTree = "<group>"; };
 		3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfo.swift; sourceTree = "<group>"; };
+		3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPicker.swift; sourceTree = "<group>"; };
 		3DCEFADD952DB870B8BAB890 /* CommitRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRow.swift; sourceTree = "<group>"; };
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
 		3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
@@ -614,6 +618,7 @@
 				7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */,
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
 				5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */,
+				00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
@@ -642,6 +647,7 @@
 				B24ABE96ED3C62146A3CED62 /* EmptyState.swift */,
 				EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */,
 				711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */,
+				3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */,
 			);
 			path = Dialogs;
 			sourceTree = "<group>";
@@ -1418,6 +1424,7 @@
 				671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */,
 				C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */,
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
+				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
@@ -1536,6 +1543,7 @@
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
 				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,
+				4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -33,8 +33,10 @@ struct NewWorktreeDialog: View {
                     }
                 } else if showsRepositorySelector {
                     DialogField(label: "Repository") {
-                        Seg(value: $projectId,
-                            options: state.projects.map { ($0.id, $0.name) })
+                        ProjectPicker(
+                            selection: $projectId,
+                            projects: state.projects
+                        )
                     }
                 }
                 DialogField(label: "Base branch") {

--- a/Alas/Sources/Dialogs/ProjectPicker.swift
+++ b/Alas/Sources/Dialogs/ProjectPicker.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+struct ProjectPicker: View {
+    @Binding var selection: String
+    let projects: [ProjectConfig]
+
+    @Environment(\.theme) var theme
+    @State private var open = false
+    @State private var search = ""
+
+    private var selectedProject: ProjectConfig? {
+        projects.first { $0.id == selection }
+    }
+
+    private var filteredProjects: [ProjectConfig] {
+        Self.filteredProjects(projects, search: search)
+    }
+
+    var body: some View {
+        Button(action: { open.toggle() }) {
+            HStack(spacing: 6) {
+                if let project = selectedProject {
+                    Circle()
+                        .fill(Color(hex: project.color))
+                        .frame(width: 8, height: 8)
+                }
+                Text(selectedProject?.name ?? "Choose a repository")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 8)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 28)
+            .background(theme.color("bg-1"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $open, arrowEdge: .bottom) {
+            popoverBody
+        }
+    }
+
+    @ViewBuilder
+    private var popoverBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            AlasField(text: $search, placeholder: "Search repositories...")
+                .padding(8)
+
+            Divider().background(theme.color("line"))
+
+            if projects.isEmpty {
+                Text("No repositories")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding(12)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(filteredProjects) { project in
+                            row(project: project)
+                        }
+                    }
+                }
+                .frame(maxHeight: 320)
+            }
+        }
+        .frame(width: 320)
+    }
+
+    private func row(project: ProjectConfig) -> some View {
+        Button(action: {
+            selection = project.id
+            open = false
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                    .opacity(project.id == selection ? 1 : 0)
+                Circle()
+                    .fill(Color(hex: project.color))
+                    .frame(width: 8, height: 8)
+                Text(project.name)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    nonisolated static func filteredProjects(
+        _ projects: [ProjectConfig],
+        search: String
+    ) -> [ProjectConfig] {
+        if search.isEmpty { return projects }
+        return projects.filter { $0.name.localizedCaseInsensitiveContains(search) }
+    }
+}

--- a/AlasTests/ProjectPickerTests.swift
+++ b/AlasTests/ProjectPickerTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ProjectPickerTests {
+    @Test func emptySearchReturnsAllProjectsInOrder() {
+        let projects = [
+            Self.project(name: "Alpha"),
+            Self.project(name: "Beta"),
+            Self.project(name: "Gamma")
+        ]
+
+        let result = ProjectPicker.filteredProjects(projects, search: "")
+
+        #expect(result.map(\.name) == ["Alpha", "Beta", "Gamma"])
+    }
+
+    @Test func searchFiltersCaseInsensitively() {
+        let projects = [
+            Self.project(name: "Alpha"),
+            Self.project(name: "beta"),
+            Self.project(name: "GAMMA"),
+            Self.project(name: "Delta")
+        ]
+
+        let result = ProjectPicker.filteredProjects(projects, search: "ALP")
+        #expect(result.map(\.name) == ["Alpha"])
+    }
+
+    @Test func searchPreservesRelativeOrder() {
+        let projects = [
+            Self.project(name: "Alpha"),
+            Self.project(name: "App"),
+            Self.project(name: "Beta"),
+            Self.project(name: "Another")
+        ]
+
+        let result = ProjectPicker.filteredProjects(projects, search: "a")
+        #expect(result.map(\.name) == ["Alpha", "App", "Beta", "Another"])
+    }
+
+    @Test func searchWithNoMatchesReturnsEmpty() {
+        let projects = [
+            Self.project(name: "Alpha"),
+            Self.project(name: "Beta")
+        ]
+
+        let result = ProjectPicker.filteredProjects(projects, search: "zzz")
+        #expect(result.isEmpty)
+    }
+
+    private static func project(name: String) -> ProjectConfig {
+        ProjectConfig(
+            id: UUID().uuidString,
+            name: name,
+            path: "/tmp/\(name)",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the inline `Seg` segmented-control repository selector in `NewWorktreeDialog` with a compact popover-style `ProjectPicker`, modeled on the existing `BranchPicker` component.
- The new picker scales to many repositories via a searchable, scrollable popover list with color dots and checkmarks.
- Preserves all existing behavior: preset project hiding, default selection, branch loading, and worktree creation flow unchanged.

## Changes

- **New**: `Alas/Sources/Dialogs/ProjectPicker.swift` — popover trigger button (repo name, color dot, chevron) with searchable scrollable list. Includes `filteredProjects(_:search:)` for testable filtering logic.
- **Changed**: `Alas/Sources/Dialogs/NewWorktreeDialog.swift` — `Seg(value:options:)` replaced with `ProjectPicker(selection:projects:)`.
- **New**: `AlasTests/ProjectPickerTests.swift` — 4 unit tests (empty search, case-insensitive match, order preservation, no-match).

## Test plan

- [x] All 488 existing tests pass
- [x] `xcodegen` regenerates project cleanly
- [x] `xcodebuild build` passes
- [ ] Manual: global New Worktree shows selector, preset New Worktree hides it
- [ ] Manual: selecting a different repo reloads branches and worktree creation still works
- [ ] Manual: long repo lists stay contained in the popover with search

Closes #789