### PR TITLE
Add Projects application menu

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
 		0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB91379591DA21D216A894 /* RelativeTime.swift */; };
+		0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */; };
 		0F560F9B2458B94C807E96A1 /* CodeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */; };
 		1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8B52175A7F6144B4C52010 /* EditorTabView.swift */; };
 		11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCEFADD952DB870B8BAB890 /* CommitRow.swift */; };
@@ -354,6 +355,7 @@
 		413CE0B0BBC96D412D048B1D /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		4261E417947C1A21E77C1587 /* GitStatusCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCache.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
+		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
 		4501413979E60464DCE5602C /* claude-code.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "claude-code.sh"; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
+				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
 				DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */,
@@ -1499,6 +1502,7 @@
 				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
+				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
 				E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -109,6 +109,22 @@ struct AlasApp: App {
                 }
                 .keyboardShortcut("9", modifiers: .command)
             }
+            CommandMenu("Projects") {
+                Button("Create Project…") {
+                    NotificationCenter.default.post(name: .alasCreateProject, object: nil)
+                }
+                .keyboardShortcut("n", modifiers: [.command, .shift])
+                Button("New Worktree…") {
+                    NotificationCenter.default.post(name: .alasNewWorktree, object: nil)
+                }
+                .keyboardShortcut("n", modifiers: [.command, .option])
+                .disabled(state.projects.isEmpty)
+                Divider()
+                Button("Refresh Worktrees") {
+                    NotificationCenter.default.post(name: .alasRefreshWorktrees, object: nil)
+                }
+                .disabled(state.projects.isEmpty)
+            }
             CommandMenu("Terminal") {
                 Button("Split Right") {
                     NotificationCenter.default.post(name: .alasSplitRight, object: nil)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -627,6 +627,15 @@ final class AppState {
         return nil
     }
 
+    func firstVisibleWorktreeId() -> String? {
+        for project in projects {
+            if let first = projectsManager.visibleWorktrees(projectId: project.id).first {
+                return first.id
+            }
+        }
+        return nil
+    }
+
     private func makeSearchEnvironment() -> SearchEnvironment {
         // Invariant: the two synchronous closures below are only invoked
         // from `SearchModel`, which is `@MainActor` — so `assumeIsolated`

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -63,6 +63,28 @@ final class AppState {
         // refreshAll() returns.
     }
 
+    /// All worktree IDs currently known to the projects manager (including
+    /// hidden/archived ones).
+    func allWorktreeIds() -> Set<String> {
+        Set(projectsManager.projects.flatMap {
+            projectsManager.worktrees(projectId: $0.id).map(\.id)
+        })
+    }
+
+    /// Tear down tabs, terminals, harness state, and editor buffers for any
+    /// worktree IDs that existed in `beforeIds` but are absent after a refresh.
+    /// Also re-points selection if the selected worktree was removed.
+    func cleanupMissingWorktrees(beforeIds: Set<String>) {
+        let afterIds = allWorktreeIds()
+        let disappeared = beforeIds.subtracting(afterIds)
+        for id in disappeared {
+            cleanupWorktreeState(worktreeId: id)
+        }
+        if let current = selectedWorktreeId, !afterIds.contains(current) {
+            selectedWorktreeId = firstVisibleWorktreeId()
+        }
+    }
+
     /// Re-scan persisted tab JSONs for every currently-known worktree id. Call
     /// after `projectsManager.refreshAll()` so worktrees actually exist.
     func reloadTabs() {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -87,6 +87,7 @@ struct RootView: View {
         .modifier(RootCommandHandlers(
             state: state,
             showNewWorktree: $showNewWorktree,
+            showNewProject: $showNewProject,
             selectedWorktree: selectedWorktree,
             openSettings: openSettingsWindow
         ))
@@ -193,6 +194,7 @@ struct RootView: View {
 private struct RootCommandHandlers: ViewModifier {
     @Bindable var state: AppState
     @Binding var showNewWorktree: Bool
+    @Binding var showNewProject: Bool
     let selectedWorktree: () -> Worktree?
     let openSettings: () -> Void
 
@@ -201,6 +203,7 @@ private struct RootCommandHandlers: ViewModifier {
             .modifier(RootBaseHandlers(
                 state: state,
                 showNewWorktree: $showNewWorktree,
+                showNewProject: $showNewProject,
                 selectedWorktree: selectedWorktree,
                 openSettings: openSettings
             ))
@@ -214,66 +217,92 @@ private struct RootCommandHandlers: ViewModifier {
 private struct RootBaseHandlers: ViewModifier {
     @Bindable var state: AppState
     @Binding var showNewWorktree: Bool
+    @Binding var showNewProject: Bool
     let selectedWorktree: () -> Worktree?
     let openSettings: () -> Void
 
     func body(content: Content) -> some View {
-        content
+        let a = content
             .onReceive(NotificationCenter.default.publisher(for: .alasToggleRightPane)) { _ in
                 state.config.rightPaneVisible.toggle()
                 state.saveConfig()
             }
+        let b = a
+            .onReceive(NotificationCenter.default.publisher(for: .alasCreateProject)) { _ in
+                showNewProject = true
+            }
+        let c = b
             .onReceive(NotificationCenter.default.publisher(for: .alasNewWorktree)) { _ in
                 showNewWorktree = true
             }
+        let d = c
             .onReceive(NotificationCenter.default.publisher(for: .alasNewTerminalTab)) { _ in
                 if let wt = selectedWorktree() { _ = try? state.openTerminalTab(for: wt) }
             }
+        let e = d
             .onReceive(NotificationCenter.default.publisher(for: .alasCloseTab)) { _ in
                 if let wt = selectedWorktree() {
                     state.handleCloseShortcut(worktreeId: wt.id)
                 }
             }
+        let f = e
             .onReceive(NotificationCenter.default.publisher(for: .alasActivateTabByNumber)) { notification in
                 guard let number = notification.object as? Int,
                       let wt = selectedWorktree() else { return }
                 state.tabs.activateTabNumber(number, worktreeId: wt.id)
             }
+        let g = f
             .onReceive(NotificationCenter.default.publisher(for: .alasSaveActiveTab)) { _ in
                 if let wt = selectedWorktree() {
                     state.saveActiveTab(worktreeId: wt.id)
                 }
             }
+        let h = g
             .onReceive(NotificationCenter.default.publisher(for: .alasSaveActiveTabAs)) { _ in
                 if let wt = selectedWorktree() {
                     state.saveActiveTabAs(worktreeId: wt.id)
                 }
             }
+        let i = h
             .onReceive(NotificationCenter.default.publisher(for: .alasSaveAllTabs)) { _ in
                 state.saveAllTabs()
             }
+        let j = i
             .onReceive(NotificationCenter.default.publisher(for: .alasRevertActiveTab)) { _ in
                 if let wt = selectedWorktree() {
                     state.revertActiveTab(worktreeId: wt.id)
                 }
             }
+        let k = j
             .onReceive(NotificationCenter.default.publisher(for: .alasNewFile)) { _ in
                 if let wt = selectedWorktree() {
                     state.newFile(in: wt.id)
                 }
             }
+        let l = k
             .onReceive(NotificationCenter.default.publisher(for: .alasRenameActiveFile)) { _ in
                 if let wt = selectedWorktree() {
                     state.renameActiveFile(worktreeId: wt.id)
                 }
             }
+        let m = l
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenSettings)) { _ in
                 openSettings()
             }
+        let n = m
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenSearch)) { _ in
                 state.search.open()
                 state.isSearchOpen = true
             }
+        let o = n
+            .onReceive(NotificationCenter.default.publisher(for: .alasRefreshWorktrees)) { _ in
+                Task {
+                    if await state.projectsManager.refreshAll() {
+                        state.saveProjects()
+                    }
+                }
+            }
+        return o
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                 state.tabs.snapshotDirtyBuffersForQuit()
             }
@@ -320,8 +349,10 @@ private struct RootPaneHandlers: ViewModifier {
 }
 
 extension Notification.Name {
-    static let alasToggleRightPane = Notification.Name("AlasToggleRightPane")
-    static let alasNewWorktree     = Notification.Name("AlasNewWorktree")
+    static let alasToggleRightPane   = Notification.Name("AlasToggleRightPane")
+    static let alasCreateProject     = Notification.Name("AlasCreateProject")
+    static let alasNewWorktree       = Notification.Name("AlasNewWorktree")
+    static let alasRefreshWorktrees  = Notification.Name("AlasRefreshWorktrees")
     static let alasNewTerminalTab  = Notification.Name("AlasNewTerminalTab")
     static let alasCloseTab        = Notification.Name("AlasCloseTab")
     static let alasActivateTabByNumber = Notification.Name("AlasActivateTabByNumber")

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -291,14 +291,13 @@ private struct RootBaseHandlers: ViewModifier {
             }
         let o = n
             .onReceive(NotificationCenter.default.publisher(for: .alasRefreshWorktrees)) { _ in
+                let beforeIds = state.allWorktreeIds()
                 Task {
                     let changed = await state.projectsManager.refreshAll()
                     if changed {
                         state.saveProjects()
                     }
-                    if state.selectedWorktreeId != nil, selectedWorktree() == nil {
-                        state.selectedWorktreeId = state.firstVisibleWorktreeId()
-                    }
+                    state.cleanupMissingWorktrees(beforeIds: beforeIds)
                 }
             }
         return o

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -140,12 +140,7 @@ struct RootView: View {
     }
 
     private func firstWorktreeId() -> String? {
-        for project in state.projects {
-            if let worktree = state.projectsManager.visibleWorktrees(projectId: project.id).first {
-                return worktree.id
-            }
-        }
-        return nil
+        state.firstVisibleWorktreeId()
     }
 
     private func openOrFocusDiff(worktree: Worktree, path: String, staged: Bool) {
@@ -297,8 +292,12 @@ private struct RootBaseHandlers: ViewModifier {
         let o = n
             .onReceive(NotificationCenter.default.publisher(for: .alasRefreshWorktrees)) { _ in
                 Task {
-                    if await state.projectsManager.refreshAll() {
+                    let changed = await state.projectsManager.refreshAll()
+                    if changed {
                         state.saveProjects()
+                    }
+                    if state.selectedWorktreeId != nil, selectedWorktree() == nil {
+                        state.selectedWorktreeId = state.firstVisibleWorktreeId()
                     }
                 }
             }

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct AppStateCleanupTests {
+    private func makeRepo(name: String) async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cleanup-\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: dir)
+        return dir
+    }
+
+    @Test func allWorktreeIdsReturnsIdsAfterRefresh() async throws {
+        let repo = try await makeRepo(name: "all-ids")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let ids = state.allWorktreeIds()
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(!ids.isEmpty)
+        #expect(ids == Set(trees.map(\.id)))
+    }
+
+    @Test func allWorktreeIdsEmptyBeforeRefresh() async throws {
+        let repo = try await makeRepo(name: "empty-ids")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        _ = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#5fb7c4"
+        )
+
+        let ids = state.allWorktreeIds()
+        #expect(ids.isEmpty)
+    }
+
+    @Test func cleanupMissingWorktreesClosesTabsForDisappearedWorktree() async throws {
+        let repo = try await makeRepo(name: "cleanup-tabs")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "cleanup", color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        let wt = trees[0]
+
+        state.tabs.appendTerminal(worktreeId: wt.id, title: "term", sessionId: "s1")
+        #expect(state.tabs.tabs(forWorktree: wt.id).count == 1)
+
+        let beforeIds = state.allWorktreeIds()
+        #expect(beforeIds.contains(wt.id))
+
+        state.projectsManager.removeProject(id: project.id)
+        #expect(state.allWorktreeIds().isEmpty)
+
+        state.cleanupMissingWorktrees(beforeIds: beforeIds)
+
+        #expect(state.tabs.tabs(forWorktree: wt.id).isEmpty)
+    }
+
+    @Test func cleanupMissingWorktreesResetsSelection() async throws {
+        let repoA = try await makeRepo(name: "sel-a")
+        let repoB = try await makeRepo(name: "sel-b")
+        defer {
+            try? FileManager.default.removeItem(at: repoA)
+            try? FileManager.default.removeItem(at: repoB)
+        }
+
+        let state = AppState()
+        let projectA = try await state.projectsManager.addProject(
+            path: repoA, displayName: "projA", color: "#5fb7c4"
+        )
+        let projectB = try await state.projectsManager.addProject(
+            path: repoB, displayName: "projB", color: "#c89d6f"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: projectA.id)
+        try await state.projectsManager.refreshWorktrees(projectId: projectB.id)
+
+        let treesA = state.projectsManager.worktrees(projectId: projectA.id)
+        let treesB = state.projectsManager.worktrees(projectId: projectB.id)
+        #expect(treesA.count == 1)
+        #expect(treesB.count == 1)
+
+        state.selectedWorktreeId = treesA[0].id
+        #expect(state.selectedWorktreeId == treesA[0].id)
+
+        let beforeIds = state.allWorktreeIds()
+
+        state.projectsManager.removeProject(id: projectA.id)
+        #expect(!state.allWorktreeIds().contains(treesA[0].id))
+
+        state.cleanupMissingWorktrees(beforeIds: beforeIds)
+
+        #expect(state.selectedWorktreeId == treesB[0].id)
+    }
+
+    @Test func cleanupMissingWorktreesPreservesExistingWorktreeTabs() async throws {
+        let repoA = try await makeRepo(name: "keep-a")
+        let repoB = try await makeRepo(name: "keep-b")
+        defer {
+            try? FileManager.default.removeItem(at: repoA)
+            try? FileManager.default.removeItem(at: repoB)
+        }
+
+        let state = AppState()
+        let projectA = try await state.projectsManager.addProject(
+            path: repoA, displayName: "keepA", color: "#5fb7c4"
+        )
+        let projectB = try await state.projectsManager.addProject(
+            path: repoB, displayName: "keepB", color: "#c89d6f"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: projectA.id)
+        try await state.projectsManager.refreshWorktrees(projectId: projectB.id)
+
+        let treesA = state.projectsManager.worktrees(projectId: projectA.id)
+        let treesB = state.projectsManager.worktrees(projectId: projectB.id)
+        #expect(treesA.count == 1)
+        #expect(treesB.count == 1)
+
+        state.tabs.appendTerminal(worktreeId: treesA[0].id, title: "termA", sessionId: "sA")
+        state.tabs.appendTerminal(worktreeId: treesB[0].id, title: "termB", sessionId: "sB")
+        #expect(state.tabs.tabs(forWorktree: treesA[0].id).count == 1)
+        #expect(state.tabs.tabs(forWorktree: treesB[0].id).count == 1)
+
+        let beforeIds = state.allWorktreeIds()
+
+        state.projectsManager.removeProject(id: projectA.id)
+
+        state.cleanupMissingWorktrees(beforeIds: beforeIds)
+
+        #expect(state.tabs.tabs(forWorktree: treesA[0].id).isEmpty)
+        #expect(state.tabs.tabs(forWorktree: treesB[0].id).count == 1)
+    }
+}

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -130,6 +130,55 @@ extension ProjectsManagerTests {
         #expect(!mgr.isWorktreeHidden(projectId: project.id, path: bogus))
     }
 
+    @Test func refreshAllPopulatesMultipleProjects() async throws {
+        let repoA = try await makeRepo(name: "eta")
+        defer { try? FileManager.default.removeItem(at: repoA) }
+        let repoB = try await makeRepo(name: "theta")
+        defer { try? FileManager.default.removeItem(at: repoB) }
+
+        let mgr = ProjectsManager(persistedProjects: [])
+        let projectA = try await mgr.addProject(path: repoA, displayName: "eta", color: "#5fb7c4")
+        let projectB = try await mgr.addProject(path: repoB, displayName: "theta", color: "#c89d6f")
+
+        // Verify no worktrees are loaded yet.
+        #expect(mgr.worktrees(projectId: projectA.id).isEmpty)
+        #expect(mgr.worktrees(projectId: projectB.id).isEmpty)
+
+        let gcDropped = await mgr.refreshAll()
+
+        let treesA = mgr.worktrees(projectId: projectA.id)
+        let treesB = mgr.worktrees(projectId: projectB.id)
+        #expect(treesA.count == 1)
+        #expect(treesA.first?.branch == "main")
+        #expect(treesB.count == 1)
+        #expect(treesB.first?.branch == "main")
+        #expect(!gcDropped)
+    }
+
+    @Test func refreshAllReturnsTrueWhenAnyProjectGarbageCollects() async throws {
+        let repoA = try await makeRepo(name: "iota")
+        defer { try? FileManager.default.removeItem(at: repoA) }
+        let repoB = try await makeRepo(name: "kappa")
+        defer { try? FileManager.default.removeItem(at: repoB) }
+
+        let mgr = ProjectsManager(persistedProjects: [])
+        let projectA = try await mgr.addProject(path: repoA, displayName: "iota", color: "#5fb7c4")
+        let projectB = try await mgr.addProject(path: repoB, displayName: "kappa", color: "#c89d6f")
+
+        // Seed an orphan hidden path only on projectA.
+        let bogus = URL(fileURLWithPath: "/nonexistent/orphan-worktree")
+        mgr.setWorktreeHidden(projectId: projectA.id, path: bogus, hidden: true)
+
+        let gcDropped = await mgr.refreshAll()
+
+        // Should return true because projectA GC'd the orphan.
+        #expect(gcDropped)
+        #expect(!mgr.isWorktreeHidden(projectId: projectA.id, path: bogus))
+        // Both projects should still have their main worktree.
+        #expect(mgr.worktrees(projectId: projectA.id).count == 1)
+        #expect(mgr.worktrees(projectId: projectB.id).count == 1)
+    }
+
     @Test func refreshWithNoOrphansReturnsFalse() async throws {
         let repo = try await makeRepo(name: "zeta")
         defer { try? FileManager.default.removeItem(at: repo) }


### PR DESCRIPTION
## Summary

- Add a top-level **Projects** menu to the macOS menu bar with three actions: Create Project, New Worktree, and Refresh Worktrees
- All actions route through existing code paths (NotificationCenter → RootView handlers → existing dialogs/managers)
- Two new tests cover `refreshAll()` multi-project and GC boolean OR behavior

## Changes

- **AlasApp.swift**: Added `CommandMenu("Projects")` with Create Project (⌘⇧N), New Worktree (⌘⌥N, disabled when no projects), and Refresh Worktrees (disabled when no projects)
- **RootView.swift**: Added `.alasCreateProject` and `.alasRefreshWorktrees` notification constants; threaded `$showNewProject` through command handlers; added `.onReceive` handlers for both notifications
- **ProjectsManagerTests.swift**: Added `refreshAllPopulatesMultipleProjects` and `refreshAllReturnsTrueWhenAnyProjectGarbageCollects` tests

Closes #791