### PR TITLE
Context-aware app menus

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D759586280250330A9A04 /* FontSizeCommands.swift */; };
 		9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */; };
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
+		956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */; };
 		9782C5866410EFE13E670AFF /* FilesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A3B9B1103346242438940 /* FilesTabView.swift */; };
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
 		98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */; };
@@ -317,6 +318,7 @@
 		2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.App.swift; sourceTree = "<group>"; };
 		215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyHost.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
+		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
 		27A92711BC1D9A78D8A80561 /* GitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypes.swift; sourceTree = "<group>"; };
 		27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitFilesListView.swift; sourceTree = "<group>"; };
 		29313DDC46A0CCA2FA42CDE9 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
@@ -586,6 +588,7 @@
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
+				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
 				DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */,
@@ -1510,6 +1513,7 @@
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,
+				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
 				E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -37,7 +37,7 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasSaveAllTabs, object: nil)
                 }
                 .keyboardShortcut("s", modifiers: [.command, .option])
-                .disabled(!state.hasActiveEditorTab)
+                .disabled(!state.hasAnyDirtyEditorTab)
                 Divider()
                 Button("Revert") {
                     NotificationCenter.default.post(name: .alasRevertActiveTab, object: nil)

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -27,22 +27,27 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasSaveActiveTab, object: nil)
                 }
                 .keyboardShortcut("s", modifiers: .command)
+                .disabled(!state.hasActiveEditorTab)
                 Button("Save As…") {
                     NotificationCenter.default.post(name: .alasSaveActiveTabAs, object: nil)
                 }
                 .keyboardShortcut("s", modifiers: [.command, .shift])
+                .disabled(!state.hasActiveEditorTab)
                 Button("Save All") {
                     NotificationCenter.default.post(name: .alasSaveAllTabs, object: nil)
                 }
                 .keyboardShortcut("s", modifiers: [.command, .option])
+                .disabled(!state.hasActiveEditorTab)
                 Divider()
                 Button("Revert") {
                     NotificationCenter.default.post(name: .alasRevertActiveTab, object: nil)
                 }
+                .disabled(!state.hasActiveEditorTab)
                 Divider()
                 Button("Rename File…") {
                     NotificationCenter.default.post(name: .alasRenameActiveFile, object: nil)
                 }
+                .disabled(!state.hasActiveEditorTab)
             }
             CommandGroup(replacing: .appSettings) {
                 Button("Settings…") {
@@ -50,15 +55,17 @@ struct AlasApp: App {
                 }
                 .keyboardShortcut(",", modifiers: .command)
             }
+            CommandGroup(after: .pasteboard) {
+                Button("Search Files…") {
+                    NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
+                }
+                .keyboardShortcut("p", modifiers: .command)
+            }
             CommandGroup(after: .toolbar) {
                 Button("Toggle Right Pane") {
                     NotificationCenter.default.post(name: .alasToggleRightPane, object: nil)
                 }
                 .keyboardShortcut(.return, modifiers: [.command, .option])
-                Button("Search Files…") {
-                    NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
-                }
-                .keyboardShortcut("p", modifiers: .command)
                 Button("New Worktree…") {
                     NotificationCenter.default.post(name: .alasNewWorktree, object: nil)
                 }
@@ -71,43 +78,6 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasCloseTab, object: nil)
                 }
                 .keyboardShortcut("w", modifiers: .command)
-                Divider()
-                Button("Select Tab 1") {
-                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 1)
-                }
-                .keyboardShortcut("1", modifiers: .command)
-                Button("Select Tab 2") {
-                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 2)
-                }
-                .keyboardShortcut("2", modifiers: .command)
-                Button("Select Tab 3") {
-                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 3)
-                }
-                .keyboardShortcut("3", modifiers: .command)
-                Button("Select Tab 4") {
-                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 4)
-                }
-                .keyboardShortcut("4", modifiers: .command)
-                Button("Select Tab 5") {
-                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 5)
-                }
-                .keyboardShortcut("5", modifiers: .command)
-                Button("Select Tab 6") {
-                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 6)
-                }
-                .keyboardShortcut("6", modifiers: .command)
-                Button("Select Tab 7") {
-                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 7)
-                }
-                .keyboardShortcut("7", modifiers: .command)
-                Button("Select Tab 8") {
-                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 8)
-                }
-                .keyboardShortcut("8", modifiers: .command)
-                Button("Select Tab 9") {
-                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 9)
-                }
-                .keyboardShortcut("9", modifiers: .command)
             }
             CommandMenu("Projects") {
                 Button("Create Project…") {

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -78,6 +78,43 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasCloseTab, object: nil)
                 }
                 .keyboardShortcut("w", modifiers: .command)
+                Divider()
+                Button("Select Tab 1") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 1)
+                }
+                .keyboardShortcut("1", modifiers: .command)
+                Button("Select Tab 2") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 2)
+                }
+                .keyboardShortcut("2", modifiers: .command)
+                Button("Select Tab 3") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 3)
+                }
+                .keyboardShortcut("3", modifiers: .command)
+                Button("Select Tab 4") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 4)
+                }
+                .keyboardShortcut("4", modifiers: .command)
+                Button("Select Tab 5") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 5)
+                }
+                .keyboardShortcut("5", modifiers: .command)
+                Button("Select Tab 6") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 6)
+                }
+                .keyboardShortcut("6", modifiers: .command)
+                Button("Select Tab 7") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 7)
+                }
+                .keyboardShortcut("7", modifiers: .command)
+                Button("Select Tab 8") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 8)
+                }
+                .keyboardShortcut("8", modifiers: .command)
+                Button("Select Tab 9") {
+                    NotificationCenter.default.post(name: .alasActivateTabByNumber, object: 9)
+                }
+                .keyboardShortcut("9", modifiers: .command)
             }
             CommandMenu("Projects") {
                 Button("Create Project…") {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -635,6 +635,16 @@ final class AppState {
         return nil
     }
 
+    var activeTab: Tab? {
+        guard let worktreeId = selectedWorktreeId else { return nil }
+        return tabs.activeTab(forWorktree: worktreeId)
+    }
+
+    var hasActiveEditorTab: Bool {
+        guard case .editor = activeTab else { return false }
+        return true
+    }
+
     /// Pick a sensible new selection after a worktree was removed (archived or
     /// deleted) from the given project at the given index in its visible list.
     /// Prefers the entry now occupying that index in the same project (i.e.

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -645,6 +645,17 @@ final class AppState {
         return true
     }
 
+    var hasAnyDirtyEditorTab: Bool {
+        for project in projects {
+            for worktree in projectsManager.worktrees(projectId: project.id) {
+                if !tabs.tabIdsWithUnsavedChanges(forWorktree: worktree.id).isEmpty {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
     /// Pick a sensible new selection after a worktree was removed (archived or
     /// deleted) from the given project at the given index in its visible list.
     /// Prefers the entry now occupying that index in the same project (i.e.

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -646,14 +646,19 @@ final class AppState {
     }
 
     var hasAnyDirtyEditorTab: Bool {
+        var result = false
         for project in projects {
             for worktree in projectsManager.worktrees(projectId: project.id) {
-                if !tabs.tabIdsWithUnsavedChanges(forWorktree: worktree.id).isEmpty {
-                    return true
+                for tab in tabs.tabs(forWorktree: worktree.id) {
+                    guard case .editor(let state) = tab else { continue }
+                    if let buffer = tabs.peekBuffer(tabId: state.id) {
+                        _ = buffer.editGeneration
+                        if buffer.dirty { result = true }
+                    }
                 }
             }
         }
-        return false
+        return result
     }
 
     /// Pick a sensible new selection after a worktree was removed (archived or

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -58,6 +58,11 @@ final class TabsManager {
         byWorktree[id]?.activeTabId
     }
 
+    func activeTab(forWorktree id: String) -> Tab? {
+        guard let activeId = activeTabId(forWorktree: id) else { return nil }
+        return tabs(forWorktree: id).first(where: { $0.id == activeId })
+    }
+
     @discardableResult
     func activateTabNumber(_ number: Int, worktreeId: String) -> TabID? {
         guard number > 0 else { return nil }

--- a/AlasTests/AppStateTabAvailabilityTests.swift
+++ b/AlasTests/AppStateTabAvailabilityTests.swift
@@ -1,0 +1,127 @@
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct AppStateTabAvailabilityTests {
+    private func makeRepo(name: String) async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-availability-\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: dir)
+        return dir
+    }
+
+    @Test func hasActiveEditorTabFalseWhenNoWorktreeSelected() {
+        let state = AppState()
+        #expect(!state.hasActiveEditorTab)
+    }
+
+    @Test func hasActiveEditorTabFalseWhenNoActiveTab() async throws {
+        let repo = try await makeRepo(name: "no-tab")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        #expect(state.activeTab == nil)
+        #expect(!state.hasActiveEditorTab)
+    }
+
+    @Test func hasActiveEditorTabTrueForEditor() async throws {
+        let repo = try await makeRepo(name: "editor")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        _ = state.tabs.appendEditor(worktreeId: trees[0].id, title: "a.txt", relativePath: "a.txt")
+
+        #expect(state.hasActiveEditorTab)
+    }
+
+    @Test func hasActiveEditorTabFalseForTerminal() async throws {
+        let repo = try await makeRepo(name: "terminal")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        _ = state.tabs.appendTerminal(worktreeId: trees[0].id, title: "main", sessionId: "s1")
+
+        #expect(!state.hasActiveEditorTab)
+    }
+
+    @Test func hasActiveEditorTabFalseForDiff() async throws {
+        let repo = try await makeRepo(name: "diff")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        _ = state.tabs.appendDiff(worktreeId: trees[0].id, title: "a.txt", relativePath: "a.txt")
+
+        #expect(!state.hasActiveEditorTab)
+    }
+
+    @Test func hasActiveEditorTabFalseForCommit() async throws {
+        let repo = try await makeRepo(name: "commit")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        _ = state.tabs.appendCommit(worktreeId: trees[0].id, sha: "abc", title: "abc msg")
+
+        #expect(!state.hasActiveEditorTab)
+    }
+
+    @Test func hasActiveEditorTabFalseForImagePreview() async throws {
+        let repo = try await makeRepo(name: "image")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        _ = state.tabs.openImagePreview(worktreeId: trees[0].id, relativePath: "logo.png")
+
+        #expect(!state.hasActiveEditorTab)
+    }
+}

--- a/AlasTests/AppStateTabAvailabilityTests.swift
+++ b/AlasTests/AppStateTabAvailabilityTests.swift
@@ -125,4 +125,75 @@ struct AppStateTabAvailabilityTests {
 
         #expect(!state.hasActiveEditorTab)
     }
+
+    @Test func hasAnyDirtyEditorTabFalseWhenEmpty() {
+        let state = AppState()
+        #expect(!state.hasAnyDirtyEditorTab)
+    }
+
+    @Test func hasAnyDirtyEditorTabTrueWhenBufferDirty() async throws {
+        let repo = try await makeRepo(name: "dirty")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "hello\n".write(
+            to: repo.appendingPathComponent("a.txt"),
+            atomically: true, encoding: .utf8
+        )
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        let tab = state.tabs.appendEditor(
+            worktreeId: trees[0].id, title: "a.txt", relativePath: "a.txt"
+        )
+        let buffer = state.tabs.buffer(
+            worktreeId: trees[0].id,
+            tabId: tab.id,
+            worktreeRoot: trees[0].path,
+            relativePath: "a.txt"
+        )
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 5), with: "HELLO")
+
+        #expect(state.hasAnyDirtyEditorTab)
+    }
+
+    @Test func hasAnyDirtyEditorTabTrueEvenWhenActiveTabIsTerminal() async throws {
+        let repo = try await makeRepo(name: "dirty-terminal")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "hello\n".write(
+            to: repo.appendingPathComponent("a.txt"),
+            atomically: true, encoding: .utf8
+        )
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        let editorTab = state.tabs.appendEditor(
+            worktreeId: trees[0].id, title: "a.txt", relativePath: "a.txt"
+        )
+        let buffer = state.tabs.buffer(
+            worktreeId: trees[0].id,
+            tabId: editorTab.id,
+            worktreeRoot: trees[0].path,
+            relativePath: "a.txt"
+        )
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 5), with: "HELLO")
+        _ = state.tabs.appendTerminal(worktreeId: trees[0].id, title: "main", sessionId: "s1")
+
+        #expect(!state.hasActiveEditorTab)
+        #expect(state.hasAnyDirtyEditorTab)
+    }
 }

--- a/AlasTests/AppStateTabAvailabilityTests.swift
+++ b/AlasTests/AppStateTabAvailabilityTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 

--- a/docs/research/789-improve-repository-picker-new-worktree.md
+++ b/docs/research/789-improve-repository-picker-new-worktree.md
@@ -1,0 +1,121 @@
+---
+task_id: 789
+title: "Improve repository picker in New Worktree dialog"
+date: 2026-05-12
+project: alas
+phase: groomed
+prior_art:
+  - Alas/Sources/Dialogs/NewWorktreeDialog.swift
+  - Alas/Sources/Dialogs/BranchPicker.swift
+  - Alas/Sources/UI/Seg.swift
+  - Alas/Sources/Persistence/ProjectConfig.swift
+  - Alas/Sources/App/ProjectsManager.swift
+  - AlasTests/NewWorktreeDialogTests.swift
+---
+
+## TL;DR
+
+The repository selector in `NewWorktreeDialog` uses `Seg` — a horizontal
+segmented control that renders every project as a button in an `HStack`.
+This breaks with many repos: buttons overflow horizontally with no scroll,
+truncation, or search. The fix replaces `Seg` with a popover-based picker
+modeled on the existing `BranchPicker` pattern, which already handles
+arbitrarily long lists with search, scroll, and a compact trigger button.
+
+## Current state
+
+### Seg component (`Alas/Sources/UI/Seg.swift`)
+
+- Generic `HStack`-based segmented control, 32 lines.
+- Renders **all** options as inline buttons — no max width, no scroll, no
+  overflow handling.
+- Works fine for ≤5 items; becomes cramped/clipped with 10+.
+
+### NewWorktreeDialog usage (line 36-38)
+
+```swift
+Seg(value: $projectId,
+    options: state.projects.map { ($0.id, $0.name) })
+```
+
+- Shown when `presetProject == nil` (global "New worktree" action).
+- Hidden when a valid preset project is provided (context-menu creation).
+- `projectId` drives branch loading and worktree creation downstream.
+
+### BranchPicker (existing scalable pattern)
+
+- Compact trigger button showing current selection + chevron.
+- Popover with editable text field, search field, `ScrollView` + `LazyVStack`
+  capped at 320pt height.
+- Already battle-tested in the same dialog for branches.
+
+## Proposed approach: `ProjectPicker` popover
+
+Create a new `ProjectPicker` view following the `BranchPicker` pattern:
+
+### Trigger button
+- Shows selected project name (with optional color dot from `ProjectConfig.color`).
+- Chevron down indicator, same styling as `BranchPicker`.
+
+### Popover content
+- **Search field** — filters projects by name (same `AlasField` pattern).
+- **Scrollable list** — `ScrollView` + `LazyVStack`, `maxHeight: 320`.
+- Each row: color dot + project name + checkmark for current selection.
+- Click selects and dismisses popover.
+
+### Ordering
+- Default order: `state.projects` as-is (insertion order via `addedAt`).
+- No frequency tracking exists today; adding `lastUsedAt` to `ProjectConfig`
+  is out of scope for v1 — it would require persistence migration and touches
+  every worktree-creation and terminal-open path. Can revisit in a follow-up.
+- If a "most used first" tier is desired later, it layers cleanly on top of
+  the picker's sort without UI changes.
+
+### What NOT to do
+- Don't add a "show 2 + more" hybrid — it introduces two selection modes
+  for the same field, which is confusing when the popover alone handles all
+  scales (1-100+ repos) uniformly.
+- Don't modify `Seg` itself — it's still appropriate for small fixed option
+  sets elsewhere (if any).
+
+## Scope confirmation
+
+### In scope (v1)
+- New `ProjectPicker` view (popover-based, with search).
+- Replace `Seg` usage in `NewWorktreeDialog` with `ProjectPicker`.
+- Preserve all existing behavior: preset project hiding, `projectId` binding,
+  `onChange` branch reloading, default selection logic.
+- Unit tests for filtering/selection logic (pure functions, testable without
+  UI harness).
+
+### Out of scope
+- Usage-frequency tracking / "most used" sorting (needs `ProjectConfig`
+  schema change + persistence migration).
+- Removing or changing the `Seg` component itself (may be used elsewhere or
+  useful for other small option sets).
+- Visual redesign of the dialog beyond the repository field.
+
+## Key files to change
+
+| File | Change |
+|------|--------|
+| `Alas/Sources/Dialogs/ProjectPicker.swift` | **New** — popover picker view |
+| `Alas/Sources/Dialogs/NewWorktreeDialog.swift` | Replace `Seg` with `ProjectPicker` (lines 35-38) |
+| `AlasTests/NewWorktreeDialogTests.swift` | Add tests for `ProjectPicker` filtering logic |
+
+## Risks & considerations
+
+- **Binding contract**: `ProjectPicker` must bind `$projectId` the same way
+  `Seg` does — a `@Binding var value: String`. The `onChange(of: projectId)`
+  in the dialog triggers branch reloading; this must keep working.
+- **Popover stacking**: The dialog already uses `BranchPicker` with a popover.
+  Two `.popover()` modifiers on different fields in the same sheet should work
+  fine in SwiftUI (each is anchored to its own view), but worth a quick manual
+  test.
+- **Color dot**: `ProjectConfig.color` is a hex string. Need a small helper
+  to convert to `Color` if one doesn't exist. Check before adding.
+
+## Estimate
+
+Small — ~150 lines of new code (mostly mirroring `BranchPicker`), a few-line
+edit in the dialog, and a handful of new test cases. Single-PR scope.

--- a/docs/research/791-projects-application-menu.md
+++ b/docs/research/791-projects-application-menu.md
@@ -1,0 +1,176 @@
+---
+task_id: 791
+title: "Add Projects application menu"
+date: 2026-05-12
+project: alas
+phase: groomed
+prior_art:
+  - Alas/Sources/App/AlasApp.swift
+  - Alas/Sources/App/RootView.swift
+  - Alas/Sources/App/AppState.swift
+  - Alas/Sources/App/ProjectsManager.swift
+  - Alas/Sources/Dialogs/NewProjectDialog.swift
+  - Alas/Sources/Dialogs/NewWorktreeDialog.swift
+  - AlasTests/ProjectsManagerTests.swift
+---
+
+## TL;DR
+
+Straightforward feature. The app already has a `CommandMenu("Terminal")` and
+several `CommandGroup` blocks in `AlasApp.swift`, plus notification-based
+dispatch handled in `RootView.swift`. Adding a `CommandMenu("Projects")` follows
+the identical pattern. All three requested actions — Create Project, New
+Worktree, and Refresh Worktrees — already have code paths that can be triggered
+via new notifications. The only net-new behavior is a "Refresh Worktrees" action
+that calls `ProjectsManager.refreshAll()` from a menu item.
+
+## Scope confirmation
+
+### In scope (v1)
+
+- New `CommandMenu("Projects")` in `AlasApp.swift` with three items:
+  - "Create Project..." — opens the add-project dialog
+  - "New Worktree..." — opens the new-worktree dialog (move from current
+    toolbar group to Projects menu, or duplicate as a second entry)
+  - "Refresh Worktrees" — forces a full worktree list refresh
+- Two new `Notification.Name` constants: `.alasCreateProject`,
+  `.alasRefreshWorktrees`
+- Corresponding `.onReceive` handlers in `RootView.swift`
+- Keyboard shortcuts for the new items
+- Unit test for `ProjectsManager.refreshAll()` round-trip (already partially
+  covered, but the explicit "force refresh from menu" path should be tested)
+
+### Out of scope (v1)
+
+- **Enable/disable based on selection state** — SwiftUI `CommandMenu` buttons
+  don't have direct access to `@State` from the `App` struct. Doing this
+  properly requires either `FocusedValue`-based key commands or passing state
+  through the environment. This is a meaningful design effort and can follow
+  in a separate task. For v1, all three items stay always-enabled; actions
+  that require a project (New Worktree, Refresh) gracefully no-op when no
+  projects exist.
+- **Per-project worktree refresh** — Refresh Worktrees refreshes all projects
+  via `refreshAll()`. A targeted "refresh worktrees for selected project"
+  refinement can come later.
+- **Moving the existing "New Worktree..." out of the toolbar group** — Keep
+  it in both places to avoid breaking existing muscle memory (Cmd+Option+N).
+  The Projects menu entry can share the same notification.
+
+## Architectural alignment
+
+### Menu definition pattern
+
+All menus are defined in `AlasApp.swift` (lines 18-174) inside the `.commands`
+modifier on the main `Window`. The existing `CommandMenu("Terminal")` at line
+112 is the exact template — a standalone top-level menu with buttons posting
+notifications.
+
+### Notification dispatch pattern
+
+1. **Define** a `Notification.Name` constant in `RootView.swift` (lines
+   322-346).
+2. **Post** it from the `Button` action in `AlasApp.swift`.
+3. **Handle** it via `.onReceive` in `RootView.CommandsModifier` (lines
+   219-319).
+
+### Code paths to reuse
+
+| Action | Trigger | Existing handler |
+|--------|---------|------------------|
+| Create Project | `showNewProject = true` | `RootView` line 7, sheet at line 19 |
+| New Worktree | `.alasNewWorktree` notification | `RootView` line 226-228 |
+| Refresh Worktrees | `projectsManager.refreshAll()` | `ProjectsManager` lines 101-110, `AppState.saveProjects()` line 82-84 |
+
+For **Refresh Worktrees**, the handler should call:
+```swift
+Task {
+    if await state.projectsManager.refreshAll() {
+        state.saveProjects()
+    }
+}
+```
+This mirrors the refresh pattern already used in `AppState.addProject()` (line
+89).
+
+### Keyboard shortcuts
+
+| Action | Suggested shortcut | Rationale |
+|--------|-------------------|-----------|
+| Create Project... | Cmd+Shift+N | Parallels "New File" (Cmd+N), "New Worktree" (Cmd+Opt+N) |
+| New Worktree... | Cmd+Option+N | Same as existing, shared notification |
+| Refresh Worktrees | Cmd+Shift+R | Common "refresh" convention |
+
+Verify no collisions with existing shortcuts before finalizing.
+
+## Acceptance criteria
+
+1. A "Projects" menu appears in the macOS menu bar between View and Terminal
+   (or after Terminal — whichever reads better).
+2. "Create Project..." opens the same dialog as the sidebar "+" button.
+3. "New Worktree..." opens the same dialog as the existing Cmd+Option+N.
+4. "Refresh Worktrees" calls `refreshAll()` and the sidebar updates without
+   app restart.
+5. All three items work when triggered via keyboard shortcut.
+6. Existing "New Worktree..." shortcut (Cmd+Option+N) in the toolbar group
+   continues to work.
+7. Tests: `ProjectsManagerTests` covers the refresh-all-then-save round-trip.
+8. Project builds with no warnings (`xcodebuild` clean build).
+
+## Open questions
+
+1. **Menu ordering**: Should "Projects" appear before or after "Terminal"?
+   - Recommendation: **before** Terminal, since projects are a higher-level
+     concept. `CommandMenu` ordering in SwiftUI is declaration order, so
+     place the `CommandMenu("Projects")` block before `CommandMenu("Terminal")`.
+
+2. **Should "New Worktree..." move out of the toolbar group?**
+   - Recommendation: **keep it in both** for now. Removing it from the
+     toolbar group changes discoverability for existing users.
+
+3. **Should "Refresh Worktrees" show a progress indicator?**
+   - Recommendation: **no** for v1. `refreshAll()` is fast (sequential
+     `git worktree list --porcelain` per project). If it becomes slow
+     with many projects, add a spinner later.
+
+## Implementation order
+
+1. **Add notification constants** — `RootView.swift`, add `.alasCreateProject`
+   and `.alasRefreshWorktrees` to the `Notification.Name` extension (line 346).
+
+2. **Add `CommandMenu("Projects")`** — `AlasApp.swift`, insert a new
+   `CommandMenu` block before the `CommandMenu("Terminal")` at line 112.
+   Three buttons posting the three notifications.
+
+3. **Add `.onReceive` handlers** — `RootView.swift`, inside
+   `CommandsModifier.body`:
+   - `.alasCreateProject` → `showNewProject = true`
+   - `.alasRefreshWorktrees` → `Task { ... refreshAll() ... }`
+
+4. **Verify keyboard shortcuts** — check no collision with existing bindings
+   in `SurfaceViewShortcutTests.swift`.
+
+5. **Add/update tests** — `ProjectsManagerTests.swift`:
+   - Test that `refreshAll()` returns expected worktree state after external
+     worktree creation.
+
+6. **Build & smoke test** — `xcodebuild`, launch app, verify menu appears
+   and all three items work.
+
+## Risks / things to watch
+
+- **SwiftUI CommandMenu ordering** — the position of custom menus in the menu
+  bar depends on declaration order, but SwiftUI may reorder relative to system
+  menus. Verify at runtime that "Projects" lands where expected.
+- **FocusedValue for enable/disable** — deferred to a follow-up, but worth
+  noting that without it, "Refresh Worktrees" will silently no-op if called
+  with zero projects. This is acceptable but not ideal UX.
+- **Shortcut collisions** — Cmd+Shift+R might collide with browser-style
+  "hard refresh" expectations if users have muscle memory from web dev. Low
+  risk in a native macOS code editor context.
+
+## Definition of done (handoff sign-off)
+
+- All code paths referenced above verified against current source.
+- No ambiguity in the implementation — an implementer can follow the
+  implementation order step-by-step with no design decisions left open.
+- Ready for design phase.


### PR DESCRIPTION
## Summary

- **File menu**: Disable Save, Save As, Save All, Revert, and Rename File when the active tab is not an editor (terminal, diff, commit, image preview). New File remains enabled when a worktree is selected.
- **View menu**: Remove Select Tab 1–9 items (they add no value in that menu).
- **Edit menu**: Move Search Files (⌘P) from View to Edit, preserving shortcut and behavior.
- **AppState/TabsManager**: Add `activeTab` and `hasActiveEditorTab` computed properties for menu enablement.
- **Tests**: 6 new tests covering all tab types + nil states for `hasActiveEditorTab`.

Closes #799