### PR TITLE
Repository-level startup scripts

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A34259DE8E978943E8BE16 /* OKLCH.swift */; };
 		75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */; };
 		7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3855FBA3E4444960418639E9 /* FileIndexTests.swift */; };
+		771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */; };
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
 		7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159FE807399835B0821E1CAB /* EnvBuilder.swift */; };
@@ -146,6 +147,7 @@
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
 		8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */; };
+		899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */; };
 		89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */; };
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
 		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
@@ -400,6 +402,7 @@
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
 		71E3734FE56F51B4615EF1A5 /* HookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookEvent.swift; sourceTree = "<group>"; };
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
+		743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolver.swift; sourceTree = "<group>"; };
 		768D12909DD5233659AC4E03 /* RepoGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupView.swift; sourceTree = "<group>"; };
 		76F2498E56CBAF84CB67166C /* HarnessKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessKind.swift; sourceTree = "<group>"; };
 		781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionPicker.swift; sourceTree = "<group>"; };
@@ -433,6 +436,7 @@
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
+		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
 		A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTree.swift; sourceTree = "<group>"; };
 		A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabStateTests.swift; sourceTree = "<group>"; };
@@ -631,6 +635,7 @@
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
+				9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
 				D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
@@ -1136,6 +1141,7 @@
 				A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */,
 				2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */,
 				C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */,
+				743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */,
 				1AFC62A30044F71F0F16C3FB /* TerminalService.swift */,
 				9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */,
 				A79B23DE77D9512D04B58860 /* Ghostty */,
@@ -1464,6 +1470,7 @@
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,
 				115C50272D2037FB24B8536F /* SidebarView.swift in Sources */,
 				514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */,
+				899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */,
 				EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */,
 				523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */,
 				4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */,
@@ -1560,6 +1567,7 @@
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
+				771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,
 				CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -118,11 +118,18 @@ final class AppState {
         saveProjects()
     }
 
-    func updateProject(id: String, name: String, color: String) {
+    func updateProject(id: String, name: String, color: String, startupScripts: ProjectStartupScripts) {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedName.isEmpty else { return }
 
-        projectsManager.updateProject(id: id, update: ProjectUpdate(name: trimmedName, color: color))
+        projectsManager.updateProject(
+            id: id,
+            update: ProjectUpdate(
+                name: trimmedName,
+                color: color,
+                startupScripts: startupScripts
+            )
+        )
         saveProjects()
     }
 

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -4,6 +4,7 @@ import Observation
 struct ProjectUpdate: Equatable {
     var name: String
     var color: String
+    var startupScripts: ProjectStartupScripts = .defaults
 }
 
 @Observable
@@ -45,6 +46,7 @@ final class ProjectsManager {
         guard let idx = projects.firstIndex(where: { $0.id == id }) else { return }
         projects[idx].name = update.name
         projects[idx].color = update.color
+        projects[idx].startupScripts = update.startupScripts
     }
 
     func worktrees(projectId: String) -> [Worktree] {

--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -34,6 +34,10 @@ private struct ProjectDialog: View {
     @State private var path: String = ""
     @State private var name: String = ""
     @State private var color: String = "#5fb7c4"
+    @State private var sessionOpenMode: ProjectStartupScriptMode = .useGlobal
+    @State private var sessionOpenScript: String = ""
+    @State private var worktreeCreateMode: ProjectStartupScriptMode = .useGlobal
+    @State private var worktreeCreateScript: String = ""
     @State private var isValidating = false
     @State private var errorMessage: String?
 
@@ -41,6 +45,13 @@ private struct ProjectDialog: View {
         "#5fb7c4", "#c89d6f", "#9789c7", "#7fb978", "#d77b88",
         "#6f9bd1", "#e0b86f", "#b87fc4", "#7fc4b0", "#c4b87f",
         "#d49960", "#8fb4d4",
+    ]
+
+    private let startupOptions: [(ProjectStartupScriptMode, String)] = [
+        (.useGlobal, "Use global"),
+        (.appendToGlobal, "Append to global"),
+        (.overrideGlobal, "Override global"),
+        (.disabled, "Disabled"),
     ]
 
     var body: some View {
@@ -77,6 +88,10 @@ private struct ProjectDialog: View {
                         }
                     }
                 }
+                if case .edit = mode {
+                    Divider().padding(.vertical, 4)
+                    startupScriptsSection
+                }
                 if let errorMessage {
                     Text(errorMessage).font(.system(size: 11)).foregroundColor(.red)
                 }
@@ -106,7 +121,7 @@ private struct ProjectDialog: View {
     private var subtitle: String {
         switch mode {
         case .add: "Register a git repository as an Alas project."
-        case .edit: "Update this project's name and color."
+        case .edit: "Update this project's settings."
         }
     }
 
@@ -146,11 +161,59 @@ private struct ProjectDialog: View {
             .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
+    private var startupScriptsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Startup scripts")
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Session open script")
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundColor(theme.color("fg"))
+                Seg(value: $sessionOpenMode, options: startupOptions)
+                if sessionOpenMode == .appendToGlobal || sessionOpenMode == .overrideGlobal {
+                    TextEditor(text: $sessionOpenScript)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(theme.color("fg"))
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 60)
+                        .padding(8)
+                        .background(theme.color("bg-0"))
+                        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5))
+                }
+            }
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Worktree create script")
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundColor(theme.color("fg"))
+                Seg(value: $worktreeCreateMode, options: startupOptions)
+                if worktreeCreateMode == .appendToGlobal || worktreeCreateMode == .overrideGlobal {
+                    TextEditor(text: $worktreeCreateScript)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(theme.color("fg"))
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 60)
+                        .padding(8)
+                        .background(theme.color("bg-0"))
+                        .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.5))
+                }
+            }
+        }
+    }
+
     private func populateInitialValues() {
-        guard case .edit(let project) = mode else { return }
-        path = project.path
-        name = project.name
-        color = project.color
+        switch mode {
+        case .add:
+            break
+        case .edit(let project):
+            path = project.path
+            name = project.name
+            color = project.color
+            sessionOpenMode = project.startupScripts.sessionOpenMode
+            sessionOpenScript = project.startupScripts.sessionOpenScript
+            worktreeCreateMode = project.startupScripts.worktreeCreateMode
+            worktreeCreateScript = project.startupScripts.worktreeCreateScript
+        }
     }
 
     private func choose() {
@@ -190,7 +253,17 @@ private struct ProjectDialog: View {
                 isValidating = false
             }
         case .edit(let project):
-            state.updateProject(id: project.id, name: name, color: color)
+            state.updateProject(
+                id: project.id,
+                name: name,
+                color: color,
+                startupScripts: ProjectStartupScripts(
+                    sessionOpenMode: sessionOpenMode,
+                    sessionOpenScript: sessionOpenScript,
+                    worktreeCreateMode: worktreeCreateMode,
+                    worktreeCreateScript: worktreeCreateScript
+                )
+            )
             presented = false
         }
     }

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -192,7 +192,10 @@ struct NewWorktreeDialog: View {
                 // Run worktree-create script if requested. Best-effort: errors
                 // in the user-supplied script don't roll back the worktree.
                 if runStartupAfter {
-                    let script = state.config.terminal.worktreeCreateScript
+                    let script = StartupScriptResolver.worktreeCreateScript(
+                        global: state.config.terminal,
+                        project: project
+                    )
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                     if !script.isEmpty {
                         _ = try? await Process.run(

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -1,10 +1,38 @@
 import Foundation
 
+// MARK: - ProjectStartupScriptMode
+/// How a project's per-repository startup script combines with the global default.
+enum ProjectStartupScriptMode: String, Codable, Equatable, CaseIterable {
+    case useGlobal
+    case appendToGlobal
+    case overrideGlobal
+    case disabled
+}
+
+// MARK: - ProjectStartupScripts
+/// Per-repository startup-script configuration for terminal session open and
+/// worktree creation. Global settings in `AppConfig.Terminal` act as defaults.
+struct ProjectStartupScripts: Codable, Equatable {
+    var sessionOpenMode: ProjectStartupScriptMode
+    var sessionOpenScript: String
+    var worktreeCreateMode: ProjectStartupScriptMode
+    var worktreeCreateScript: String
+
+    static let defaults = ProjectStartupScripts(
+        sessionOpenMode: .useGlobal,
+        sessionOpenScript: "",
+        worktreeCreateMode: .useGlobal,
+        worktreeCreateScript: ""
+    )
+}
+
+// MARK: - ProjectsFile
 struct ProjectsFile: Codable, Equatable {
     var version: Int = 1
     var projects: [ProjectConfig]
 }
 
+// MARK: - ProjectConfig
 struct ProjectConfig: Codable, Equatable, Identifiable {
     let id: String           // UUID string
     var name: String         // e.g. nlopez/alas
@@ -12,9 +40,10 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var color: String        // hex string, e.g. "#5fb7c4"
     var addedAt: Date
     var hiddenWorktreePaths: [String] = []
+    var startupScripts: ProjectStartupScripts = .defaults
 
     enum CodingKeys: String, CodingKey {
-        case id, name, path, color, addedAt, hiddenWorktreePaths
+        case id, name, path, color, addedAt, hiddenWorktreePaths, startupScripts
     }
 
     init(
@@ -23,7 +52,8 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         path: String,
         color: String,
         addedAt: Date,
-        hiddenWorktreePaths: [String] = []
+        hiddenWorktreePaths: [String] = [],
+        startupScripts: ProjectStartupScripts = .defaults
     ) {
         self.id = id
         self.name = name
@@ -31,10 +61,11 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.color = color
         self.addedAt = addedAt
         self.hiddenWorktreePaths = hiddenWorktreePaths
+        self.startupScripts = startupScripts
     }
 
-    // Tolerant decode: older projects.json files predate hiddenWorktreePaths,
-    // so fall back to an empty array. Encode is still synthesized.
+    // Tolerant decode: older projects.json files predate hiddenWorktreePaths
+    // and startupScripts, so fall back to known defaults.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         id = try c.decode(String.self, forKey: .id)
@@ -43,5 +74,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         color = try c.decode(String.self, forKey: .color)
         addedAt = try c.decode(Date.self, forKey: .addedAt)
         hiddenWorktreePaths = (try? c.decode([String].self, forKey: .hiddenWorktreePaths)) ?? []
+        startupScripts = (try? c.decode(ProjectStartupScripts.self, forKey: .startupScripts))
+            ?? .defaults
     }
 }

--- a/Alas/Sources/Terminal/StartupScriptResolver.swift
+++ b/Alas/Sources/Terminal/StartupScriptResolver.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Pure helper that resolves the effective startup script for a project by
+/// combining the global `AppConfig.Terminal` setting with the project's own
+/// `startupScripts`.
+enum StartupScriptResolver {
+    /// Compute the effective "session open" script for a terminal pane.
+    static func sessionOpenScript(
+        global: AppConfig.Terminal,
+        project: ProjectConfig
+    ) -> String {
+        resolve(globalScript: global.startupScript, projectConfig: project.startupScripts.sessionOpenMode, projectScript: project.startupScripts.sessionOpenScript)
+    }
+
+    /// Compute the effective "worktree create" script for a newly-created worktree.
+    static func worktreeCreateScript(
+        global: AppConfig.Terminal,
+        project: ProjectConfig
+    ) -> String {
+        resolve(globalScript: global.worktreeCreateScript, projectConfig: project.startupScripts.worktreeCreateMode, projectScript: project.startupScripts.worktreeCreateScript)
+    }
+
+    private static func resolve(globalScript: String, projectConfig: ProjectStartupScriptMode, projectScript: String) -> String {
+        let global = globalScript.trimmingCharacters(in: .whitespacesAndNewlines)
+        let local = projectScript.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        switch projectConfig {
+        case .useGlobal:
+            return global
+        case .appendToGlobal:
+            if global.isEmpty {
+                return local
+            }
+            if local.isEmpty {
+                return global
+            }
+            return global + "\n" + local
+        case .overrideGlobal:
+            return local
+        case .disabled:
+            return ""
+        }
+    }
+}

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -48,9 +48,13 @@ final class TerminalService {
             project: project, worktree: worktree, sessionId: sessionId,
             hookDir: Paths.hookDir, inheritParent: cfg.inheritParentEnv
         )
+        let effectiveScript = StartupScriptResolver.sessionOpenScript(
+            global: cfg,
+            project: project
+        )
         let plan = try StartupScriptInstaller.plan(
             shell: cfg.shell,
-            startupScript: cfg.startupScript,
+            startupScript: effectiveScript,
             sessionId: sessionId
         )
         // Plan-supplied env overrides (e.g. ZDOTDIR for zsh startup scripts)

--- a/AlasTests/ProjectConfigTests.swift
+++ b/AlasTests/ProjectConfigTests.swift
@@ -22,6 +22,7 @@ struct ProjectConfigTests {
         let file = try decoder.decode(ProjectsFile.self, from: json)
         #expect(file.projects.count == 1)
         #expect(file.projects[0].hiddenWorktreePaths == [])
+        #expect(file.projects[0].startupScripts == .defaults)
     }
 
     @Test func roundTripPreservesHiddenPaths() throws {
@@ -38,5 +39,52 @@ struct ProjectConfigTests {
         decoder.dateDecodingStrategy = .secondsSince1970
         let decoded = try decoder.decode(ProjectsFile.self, from: data)
         #expect(decoded.projects[0].hiddenWorktreePaths == ["/tmp/alpha/wt-a", "/tmp/alpha/wt-b"])
+    }
+
+    @Test func roundTripPreservesStartupScripts() throws {
+        let project = ProjectConfig(
+            id: "abc", name: "alpha", path: "/tmp/alpha",
+            color: "#5fb7c4", addedAt: Date(timeIntervalSince1970: 0),
+            startupScripts: ProjectStartupScripts(
+                sessionOpenMode: .appendToGlobal,
+                sessionOpenScript: "mise install",
+                worktreeCreateMode: .overrideGlobal,
+                worktreeCreateScript: "pnpm install"
+            )
+        )
+        let file = ProjectsFile(projects: [project])
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(file)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(ProjectsFile.self, from: data)
+        let scripts = decoded.projects[0].startupScripts
+        #expect(scripts.sessionOpenMode == .appendToGlobal)
+        #expect(scripts.sessionOpenScript == "mise install")
+        #expect(scripts.worktreeCreateMode == .overrideGlobal)
+        #expect(scripts.worktreeCreateScript == "pnpm install")
+    }
+
+    @Test func decodingOlderProjectWithHiddenPathsButNoStartupScripts() throws {
+        let json = """
+        {
+          "version": 1,
+          "projects": [{
+            "id": "abc",
+            "name": "alpha",
+            "path": "/tmp/alpha",
+            "color": "#5fb7c4",
+            "addedAt": 0,
+            "hiddenWorktreePaths": ["/tmp/alpha/wt"]
+          }]
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let file = try decoder.decode(ProjectsFile.self, from: json)
+        #expect(file.projects.count == 1)
+        #expect(file.projects[0].hiddenWorktreePaths == ["/tmp/alpha/wt"])
+        #expect(file.projects[0].startupScripts == .defaults)
     }
 }

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -78,6 +78,7 @@ struct ProjectsManagerTests {
         #expect(mgr.projects[0].color == "#d77b88")
         #expect(mgr.projects[0].addedAt == project.addedAt)
         #expect(mgr.projects[0].hiddenWorktreePaths == project.hiddenWorktreePaths)
+        #expect(mgr.projects[0].startupScripts == .defaults)
         #expect(mgr.projects[1] == other)
 
         mgr.updateProject(

--- a/AlasTests/StartupScriptResolverTests.swift
+++ b/AlasTests/StartupScriptResolverTests.swift
@@ -1,0 +1,126 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct StartupScriptResolverTests {
+    // MARK: - Helpers
+
+    private func makeProject(mode: ProjectStartupScriptMode, script: String, worktreeMode: ProjectStartupScriptMode = .useGlobal, worktreeScript: String = "") -> ProjectConfig {
+        ProjectConfig(
+            id: "p1",
+            name: "test",
+            path: "/tmp/test",
+            color: "#5fb7c4",
+            addedAt: Date(),
+            startupScripts: ProjectStartupScripts(
+                sessionOpenMode: mode,
+                sessionOpenScript: script,
+                worktreeCreateMode: worktreeMode,
+                worktreeCreateScript: worktreeScript
+            )
+        )
+    }
+
+    private func makeTerminal(startupScript: String, worktreeCreateScript: String = "") -> AppConfig.Terminal {
+        var t = AppConfig.defaults.terminal
+        t.startupScript = startupScript
+        t.worktreeCreateScript = worktreeCreateScript
+        return t
+    }
+
+    // MARK: - useGlobal
+
+    @Test func useGlobalReturnsGlobalScript() {
+        let t = makeTerminal(startupScript: "echo global")
+        let p = makeProject(mode: .useGlobal, script: "echo local")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "echo global")
+    }
+
+    @Test func useGlobalReturnsEmptyWhenGlobalEmpty() {
+        let t = makeTerminal(startupScript: "")
+        let p = makeProject(mode: .useGlobal, script: "echo local")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "")
+    }
+
+    // MARK: - appendToGlobal
+
+    @Test func appendToGlobalConcatenatesBoth() {
+        let t = makeTerminal(startupScript: "echo global")
+        let p = makeProject(mode: .appendToGlobal, script: "echo local")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "echo global\necho local")
+    }
+
+    @Test func appendToGlobalReturnsGlobalOnlyWhenLocalEmpty() {
+        let t = makeTerminal(startupScript: "echo global")
+        let p = makeProject(mode: .appendToGlobal, script: "")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "echo global")
+    }
+
+    @Test func appendToGlobalReturnsLocalOnlyWhenGlobalEmpty() {
+        let t = makeTerminal(startupScript: "")
+        let p = makeProject(mode: .appendToGlobal, script: "echo local")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "echo local")
+    }
+
+    @Test func appendToGlobalReturnsEmptyWhenBothEmpty() {
+        let t = makeTerminal(startupScript: "")
+        let p = makeProject(mode: .appendToGlobal, script: "")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "")
+    }
+
+    // MARK: - overrideGlobal
+
+    @Test func overrideGlobalReturnsLocalScript() {
+        let t = makeTerminal(startupScript: "echo global")
+        let p = makeProject(mode: .overrideGlobal, script: "echo local")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "echo local")
+    }
+
+    @Test func overrideGlobalReturnsEmptyWhenLocalEmpty() {
+        let t = makeTerminal(startupScript: "echo global")
+        let p = makeProject(mode: .overrideGlobal, script: "")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "")
+    }
+
+    // MARK: - disabled
+
+    @Test func disabledReturnsEmptyRegardlessOfScripts() {
+        let t = makeTerminal(startupScript: "echo global")
+        let p = makeProject(mode: .disabled, script: "echo local")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "")
+    }
+
+    // MARK: - Whitespace trimming
+
+    @Test func trimsLeadingAndTrailingWhitespace() {
+        let t = makeTerminal(startupScript: "  echo global  ")
+        let p = makeProject(mode: .useGlobal, script: "  echo local  ")
+        #expect(StartupScriptResolver.sessionOpenScript(global: t, project: p) == "echo global")
+    }
+
+    // MARK: - Worktree create scripts
+
+    @Test func worktreeCreateUseGlobal() {
+        let t = makeTerminal(startupScript: "", worktreeCreateScript: "echo wt-global")
+        let p = makeProject(mode: .useGlobal, script: "", worktreeMode: .useGlobal, worktreeScript: "echo wt-local")
+        #expect(StartupScriptResolver.worktreeCreateScript(global: t, project: p) == "echo wt-global")
+    }
+
+    @Test func worktreeCreateAppendToGlobal() {
+        let t = makeTerminal(startupScript: "", worktreeCreateScript: "echo wt-global")
+        let p = makeProject(mode: .useGlobal, script: "", worktreeMode: .appendToGlobal, worktreeScript: "echo wt-local")
+        #expect(StartupScriptResolver.worktreeCreateScript(global: t, project: p) == "echo wt-global\necho wt-local")
+    }
+
+    @Test func worktreeCreateOverrideGlobal() {
+        let t = makeTerminal(startupScript: "", worktreeCreateScript: "echo wt-global")
+        let p = makeProject(mode: .useGlobal, script: "", worktreeMode: .overrideGlobal, worktreeScript: "echo wt-local")
+        #expect(StartupScriptResolver.worktreeCreateScript(global: t, project: p) == "echo wt-local")
+    }
+
+    @Test func worktreeCreateDisabled() {
+        let t = makeTerminal(startupScript: "", worktreeCreateScript: "echo wt-global")
+        let p = makeProject(mode: .useGlobal, script: "", worktreeMode: .disabled, worktreeScript: "echo wt-local")
+        #expect(StartupScriptResolver.worktreeCreateScript(global: t, project: p) == "")
+    }
+}


### PR DESCRIPTION
## Summary

- Add per-project startup script configuration (session open + worktree create) with explicit merge modes: **Use global**, **Append to global**, **Override global**, **Disabled**
- Backward-compatible — existing `projects.json` decodes with defaults so current behavior is unchanged
- Pure `StartupScriptResolver` centralizes effective-script resolution; wired into `TerminalService` and `NewWorktreeDialog`
- `EditProjectDialog` exposes mode pickers and conditional script editors

## Test plan

- [x] 14 `StartupScriptResolverTests` covering all modes, whitespace trimming, empty-string edge cases
- [x] `ProjectConfigTests` for round-trip and backward-compat decode
- [x] All 517 tests pass, build succeeds