### PR TITLE
Set Alas app version to 0.1.0

### DIFF
--- a/Alas/Resources/Info.plist
+++ b/Alas/Resources/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -48,7 +48,7 @@ struct SettingsNavView: View {
                 .buttonStyle(.plain)
             }
             Spacer()
-            Text("Alas 0.5.0")
+            Text("Alas 0.1.0")
                 .font(.system(size: 10.5, design: .monospaced))
                 .foregroundColor(theme.color("fg-faint"))
                 .padding(.horizontal, 10).padding(.vertical, 8)

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -48,7 +48,7 @@ struct SettingsNavView: View {
                 .buttonStyle(.plain)
             }
             Spacer()
-            Text("Alas 0.1.0")
+            Text("Alas \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—")")
                 .font(.system(size: 10.5, design: .monospaced))
                 .foregroundColor(theme.color("fg-faint"))
                 .padding(.horizontal, 10).padding(.vertical, 8)

--- a/project.yml
+++ b/project.yml
@@ -46,7 +46,7 @@ targets:
       path: Alas/Resources/Info.plist
       properties:
         CFBundleDevelopmentRegion: en
-        CFBundleShortVersionString: "0.5.0"
+        CFBundleShortVersionString: "0.1.0"
         CFBundleVersion: "1"
         LSMinimumSystemVersion: "14.0"
         NSHumanReadableCopyright: "Copyright © 2026 Nacho Lopez"


### PR DESCRIPTION
## Summary
- Updated app version from `0.5.0` to `0.1.0` across all sources of truth (`project.yml`, `SettingsNavView.swift`, `Info.plist`)
- The previous `0.5.0` version was not deliberately set and did not reflect the project's actual state

## Test plan
- Verify `0.1.0` appears in project.yml, SettingsNavView UI text, and Info.plist
- Confirm no remaining `0.5.0` references via grep
- Run `xcodegen` and verify no uncommitted changes