### PR TITLE
Remove duplicate New Worktree from View menu

### DIFF
--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -66,10 +66,6 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasToggleRightPane, object: nil)
                 }
                 .keyboardShortcut(.return, modifiers: [.command, .option])
-                Button("New Worktree…") {
-                    NotificationCenter.default.post(name: .alasNewWorktree, object: nil)
-                }
-                .keyboardShortcut("n", modifiers: [.command, .option])
                 Button("New Terminal Tab") {
                     NotificationCenter.default.post(name: .alasNewTerminalTab, object: nil)
                 }


### PR DESCRIPTION
## Summary

- Removes the duplicate "New Worktree…" menu item from the **View** menu
- The same action is already available in the **Projects** menu with the same keyboard shortcut (`Cmd+Option+N`)
- No functionality is lost — just eliminates menu duplication

## Changes

- `Alas/Sources/App/AlasApp.swift`: 4-line deletion from `CommandGroup(after: .toolbar)` under `CommandMenu("View")`