### PR TITLE
Add configurable sidebar material to Appearance settings

### DIFF
--- a/Alas/Sources/App/WindowChrome/VisualEffectView.swift
+++ b/Alas/Sources/App/WindowChrome/VisualEffectView.swift
@@ -1,6 +1,99 @@
 import SwiftUI
 import AppKit
 
+enum SidebarMaterialChoice: String, CaseIterable, Codable, Equatable {
+    case appKitAppearanceBased
+    case appKitLight
+    case appKitDark
+    case appKitTitlebar
+    case appKitSelection
+    case appKitMenu
+    case appKitPopover
+    case appKitSidebar
+    case appKitMediumLight
+    case appKitUltraDark
+    case appKitHeaderView
+    case appKitSheet
+    case appKitWindowBackground
+    case appKitHudWindow
+    case appKitFullScreenUI
+    case appKitToolTip
+    case appKitContentBackground
+    case appKitUnderWindowBackground
+    case appKitUnderPageBackground
+    case swiftUIUltraThin
+    case swiftUIThin
+    case swiftUIRegular
+    case swiftUIThick
+    case swiftUIUltraThick
+
+    var displayName: String {
+        switch self {
+        case .appKitAppearanceBased: return "AppKit: Appearance Based"
+        case .appKitLight: return "AppKit: Light"
+        case .appKitDark: return "AppKit: Dark"
+        case .appKitTitlebar: return "AppKit: Titlebar"
+        case .appKitSelection: return "AppKit: Selection"
+        case .appKitMenu: return "AppKit: Menu"
+        case .appKitPopover: return "AppKit: Popover"
+        case .appKitSidebar: return "AppKit: Sidebar"
+        case .appKitMediumLight: return "AppKit: Medium Light"
+        case .appKitUltraDark: return "AppKit: Ultra Dark"
+        case .appKitHeaderView: return "AppKit: Header View"
+        case .appKitSheet: return "AppKit: Sheet"
+        case .appKitWindowBackground: return "AppKit: Window Background"
+        case .appKitHudWindow: return "AppKit: HUD Window"
+        case .appKitFullScreenUI: return "AppKit: Full Screen UI"
+        case .appKitToolTip: return "AppKit: Tool Tip"
+        case .appKitContentBackground: return "AppKit: Content Background"
+        case .appKitUnderWindowBackground: return "AppKit: Under Window Background"
+        case .appKitUnderPageBackground: return "AppKit: Under Page Background"
+        case .swiftUIUltraThin: return "SwiftUI: Ultra Thin"
+        case .swiftUIThin: return "SwiftUI: Thin"
+        case .swiftUIRegular: return "SwiftUI: Regular"
+        case .swiftUIThick: return "SwiftUI: Thick"
+        case .swiftUIUltraThick: return "SwiftUI: Ultra Thick"
+        }
+    }
+
+    var appKitMaterial: NSVisualEffectView.Material? {
+        switch self {
+        case .appKitAppearanceBased: return NSVisualEffectView.Material(rawValue: 0)
+        case .appKitLight: return NSVisualEffectView.Material(rawValue: 1)
+        case .appKitDark: return NSVisualEffectView.Material(rawValue: 2)
+        case .appKitTitlebar: return .titlebar
+        case .appKitSelection: return .selection
+        case .appKitMenu: return .menu
+        case .appKitPopover: return .popover
+        case .appKitSidebar: return .sidebar
+        case .appKitMediumLight: return NSVisualEffectView.Material(rawValue: 8)
+        case .appKitUltraDark: return NSVisualEffectView.Material(rawValue: 9)
+        case .appKitHeaderView: return .headerView
+        case .appKitSheet: return .sheet
+        case .appKitWindowBackground: return .windowBackground
+        case .appKitHudWindow: return .hudWindow
+        case .appKitFullScreenUI: return .fullScreenUI
+        case .appKitToolTip: return .toolTip
+        case .appKitContentBackground: return .contentBackground
+        case .appKitUnderWindowBackground: return .underWindowBackground
+        case .appKitUnderPageBackground: return .underPageBackground
+        case .swiftUIUltraThin, .swiftUIThin, .swiftUIRegular, .swiftUIThick, .swiftUIUltraThick:
+            return nil
+        }
+    }
+
+    var swiftUIMaterial: Material? {
+        switch self {
+        case .swiftUIUltraThin: return .ultraThin
+        case .swiftUIThin: return .thin
+        case .swiftUIRegular: return .regular
+        case .swiftUIThick: return .thick
+        case .swiftUIUltraThick: return .ultraThick
+        default: return nil
+        }
+    }
+}
+
 struct VisualEffectView: NSViewRepresentable {
     let material: NSVisualEffectView.Material
     let blendingMode: NSVisualEffectView.BlendingMode
@@ -22,5 +115,19 @@ struct VisualEffectView: NSViewRepresentable {
     func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
         nsView.material = material
         nsView.blendingMode = blendingMode
+    }
+}
+
+struct SidebarMaterialBackground: View {
+    let choice: SidebarMaterialChoice
+
+    var body: some View {
+        if let material = choice.appKitMaterial {
+            VisualEffectView(material: material, blendingMode: .behindWindow)
+        } else if let material = choice.swiftUIMaterial {
+            Rectangle()
+                .fill(.clear)
+                .background(material)
+        }
     }
 }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -160,7 +160,7 @@ extension AppConfig {
         accent = try c.decode(String.self, forKey: .accent)
         density = try c.decode(String.self, forKey: .density)
         matchSystemTheme = try c.decode(Bool.self, forKey: .matchSystemTheme)
-        sidebarMaterial = (try? c.decode(SidebarMaterialChoice.self, forKey: .sidebarMaterial)) ?? .appKitSidebar
+        sidebarMaterial = (try? c.decode(SidebarMaterialChoice.self, forKey: .sidebarMaterial)) ?? .appKitFullScreenUI
         sidebarWidth = try c.decode(Double.self, forKey: .sidebarWidth)
         rightPaneWidth = try c.decode(Double.self, forKey: .rightPaneWidth)
         rightPaneVisible = try c.decode(Bool.self, forKey: .rightPaneVisible)

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -5,6 +5,7 @@ struct AppConfig: Codable, Equatable {
     var accent: String
     var density: String          // compact | comfortable | spacious
     var matchSystemTheme: Bool
+    var sidebarMaterial: SidebarMaterialChoice
     var sidebarWidth: Double
     var rightPaneWidth: Double
     var rightPaneVisible: Bool
@@ -95,6 +96,7 @@ struct AppConfig: Codable, Equatable {
         accent: "teal",
         density: "comfortable",
         matchSystemTheme: false,
+        sidebarMaterial: .appKitSidebar,
         sidebarWidth: 244,
         rightPaneWidth: 320,
         rightPaneVisible: true,
@@ -141,7 +143,7 @@ struct AppConfig: Codable, Equatable {
 extension AppConfig {
     enum CodingKeys: String, CodingKey {
         case themeId, accent, density, matchSystemTheme,
-             sidebarWidth, rightPaneWidth, rightPaneVisible,
+             sidebarMaterial, sidebarWidth, rightPaneWidth, rightPaneVisible,
              commitDetailSplitRatio,
              general, worktrees, terminal, harness, code, markdown
     }
@@ -158,6 +160,7 @@ extension AppConfig {
         accent = try c.decode(String.self, forKey: .accent)
         density = try c.decode(String.self, forKey: .density)
         matchSystemTheme = try c.decode(Bool.self, forKey: .matchSystemTheme)
+        sidebarMaterial = (try? c.decode(SidebarMaterialChoice.self, forKey: .sidebarMaterial)) ?? .appKitSidebar
         sidebarWidth = try c.decode(Double.self, forKey: .sidebarWidth)
         rightPaneWidth = try c.decode(Double.self, forKey: .rightPaneWidth)
         rightPaneVisible = try c.decode(Bool.self, forKey: .rightPaneVisible)

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -11,7 +11,7 @@ struct RightPaneView: View {
     var body: some View {
         let rps = state.rightPaneStore.state(for: worktree, baseBranch: state.config.worktrees.baseBranch)
         ZStack {
-            VisualEffectView(material: .fullScreenUI, blendingMode: .behindWindow)
+            SidebarMaterialBackground(choice: state.config.sidebarMaterial)
             VStack(spacing: 0) {
                 RightPaneTabBar(
                     activeTab: Binding(

--- a/Alas/Sources/Settings/AppearancePane.swift
+++ b/Alas/Sources/Settings/AppearancePane.swift
@@ -93,6 +93,42 @@ struct AppearancePane: View {
                             }
                         ))
                     }
+                    SettingsRow(name: "Sidebar material",
+                                desc: "Applied to the left and right sidebars.") {
+                        HStack(spacing: 8) {
+                            Button {
+                                cycleSidebarMaterial(by: -1)
+                            } label: {
+                                Image(systemName: "chevron.left")
+                                    .frame(width: 24, height: 24)
+                            }
+                            .buttonStyle(.borderless)
+                            .help("Previous material")
+
+                            Picker("", selection: Binding(
+                                get: { state.config.sidebarMaterial },
+                                set: {
+                                    state.config.sidebarMaterial = $0
+                                    state.saveConfig()
+                                }
+                            )) {
+                                ForEach(SidebarMaterialChoice.allCases, id: \.self) { material in
+                                    Text(material.displayName).tag(material)
+                                }
+                            }
+                            .labelsHidden()
+                            .frame(width: 240)
+
+                            Button {
+                                cycleSidebarMaterial(by: 1)
+                            } label: {
+                                Image(systemName: "chevron.right")
+                                    .frame(width: 24, height: 24)
+                            }
+                            .buttonStyle(.borderless)
+                            .help("Next material")
+                        }
+                    }
                 }
                 SettingsGroup(title: "Layout") {
                     SettingsRow(name: "Density") {
@@ -140,5 +176,17 @@ struct AppearancePane: View {
             set: { state.config[keyPath: kp] = $0
             state.saveConfig() }
         )
+    }
+
+    private func cycleSidebarMaterial(by delta: Int) {
+        let choices = SidebarMaterialChoice.allCases
+        guard let index = choices.firstIndex(of: state.config.sidebarMaterial) else {
+            state.config.sidebarMaterial = .appKitSidebar
+            state.saveConfig()
+            return
+        }
+        let next = (index + delta + choices.count) % choices.count
+        state.config.sidebarMaterial = choices[next]
+        state.saveConfig()
     }
 }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -12,7 +12,7 @@ struct SidebarView: View {
 
     var body: some View {
         ZStack {
-            VisualEffectView(material: .fullScreenUI, blendingMode: .behindWindow)
+            SidebarMaterialBackground(choice: state.config.sidebarMaterial)
             VStack(spacing: 0) {
                 SidebarHeaderView(
                     onSettings: onSettings,

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -66,6 +66,42 @@ struct AppConfigTests {
         #expect(cfg.harness.notifyOnAwaiting == true)
     }
 
+    @Test func decodeOldConfigPreservesPreviousSidebarMaterial() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "density": "comfortable",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/code/.worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.sidebarMaterial == .appKitFullScreenUI)
+    }
+
     @Test func decodePreservesConfiguredWorktreeRoot() throws {
         var cfg = AppConfig.defaults
         cfg.worktrees.rootPath = "~/code/worktrees"

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -18,6 +18,7 @@ struct AppConfigTests {
         let cfg = AppConfig.defaults
         #expect(cfg.themeId == "cool-slate")
         #expect(cfg.accent == "teal")
+        #expect(cfg.sidebarMaterial == .appKitSidebar)
         #expect(cfg.sidebarWidth == 244)
         #expect(cfg.rightPaneWidth == 320)
         #expect(cfg.rightPaneVisible == true)


### PR DESCRIPTION
<!-- gg:managed:start -->
Introduces a SidebarMaterialChoice enum covering AppKit and SwiftUI materials, persisted in AppConfig and applied to both the left sidebar and right pane backgrounds. The Appearance pane gains a picker with prev/next chevrons to cycle through options, defaulting to the previous full-screen UI material.
<!-- gg:managed:end -->