### PR TITLE
Remove numeric sidebar width input from Appearance settings

### DIFF
--- a/Alas/Sources/Settings/AppearancePane.swift
+++ b/Alas/Sources/Settings/AppearancePane.swift
@@ -138,14 +138,6 @@ struct AppearancePane: View {
                             ("spacious", "spacious"),
                         ])
                     }
-                    SettingsRow(name: "Sidebar width",
-                                desc: "Width of the repos/worktrees sidebar.") {
-                        AlasField(text: Binding(
-                            get: { String(Int(state.config.sidebarWidth)) },
-                            set: { state.config.sidebarWidth = Double($0) ?? 244
-                            state.saveConfig() }
-                        ), monospaced: true).frame(width: 100)
-                    }
                 }
                 SettingsGroup(title: "Markdown") {
                     SettingsRow(name: "Default view mode",


### PR DESCRIPTION
## Summary

- Removes the numeric **"Sidebar width"** `SettingsRow` input from **Settings → Appearance → Layout**.
- The `sidebarWidth` property on `AppConfig` remains intact — it's still driven by the visual drag handle in `ThreePaneLayout.swift`, preserving interactive resize behavior.
- Only 8 lines deleted, single file touched, no side effects.

## Context

Task #803: The numeric sidebar width setting provides no value as a number input since sidebar size is a visual/interactive preference. Only the drag-handle resize behavior is retained.

## Verification

- ✅ Build passes (`xcodebuild`)
- ✅ All 566 tests pass
- ✅ `xcodegen` produces no tracked changes