### PR TITLE
Use directory basename for default project names

### DIFF
--- a/Alas/Sources/Dialogs/NewProjectDialog.swift
+++ b/Alas/Sources/Dialogs/NewProjectDialog.swift
@@ -71,7 +71,7 @@ private struct ProjectDialog: View {
                     }
                 }
                 DialogField(label: "Display name") {
-                    AlasField(text: $name, placeholder: "owner/repo")
+                    AlasField(text: $name, placeholder: "repo-folder")
                 }
                 DialogField(label: "Color") {
                     HStack(spacing: 8) {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -7,12 +7,9 @@ struct GitService {
             result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "true"
     }
 
-    /// Parses `<owner>/<repo>` from `origin` remote URL, falls back to folder name.
+    /// Returns the directory name of the repository path as the default project name.
     func suggestProjectName(_ path: URL) async throws -> String {
-        let result = try await Process.git(["remote", "get-url", "origin"], cwd: path)
-        guard result.exitCode == 0 else { return path.lastPathComponent }
-        let url = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        return Self.parseRemote(url) ?? path.lastPathComponent
+        path.lastPathComponent
     }
 
     func branches(at repoPath: URL) async throws -> [String] {
@@ -48,28 +45,6 @@ struct GitService {
             branches.append(branch)
         }
         return branches
-    }
-
-    static func parseRemote(_ url: String) -> String? {
-        // https://host/owner/repo(.git)?  or  git@host:owner/repo(.git)?
-        var trimmed = url
-        if trimmed.hasSuffix(".git") { trimmed.removeLast(4) }
-        if trimmed.contains("://") {
-            // https://github.com/owner/repo
-            let parts = trimmed.split(separator: "/")
-            guard parts.count >= 2 else { return nil }
-            return "\(parts[parts.count - 2])/\(parts[parts.count - 1])"
-        }
-        if trimmed.contains("@") && trimmed.contains(":") {
-            // git@github.com:owner/repo
-            let parts = trimmed.split(separator: ":", maxSplits: 1)
-            guard parts.count == 2 else { return nil }
-            let pathPart = parts[1]
-            let segs = pathPart.split(separator: "/")
-            guard segs.count >= 2 else { return nil }
-            return "\(segs[segs.count - 2])/\(segs[segs.count - 1])"
-        }
-        return nil
     }
 }
 

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -35,7 +35,7 @@ struct ProjectsFile: Codable, Equatable {
 // MARK: - ProjectConfig
 struct ProjectConfig: Codable, Equatable, Identifiable {
     let id: String           // UUID string
-    var name: String         // e.g. nlopez/alas
+    var name: String         // display name, defaulting to the repo directory name
     var path: String         // absolute repo path
     var color: String        // hex string, e.g. "#5fb7c4"
     var addedAt: Date

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -36,24 +36,16 @@ struct GitServiceTests {
         #expect(valid == false)
     }
 
-    @Test func suggestNameFromHttpsRemote() async throws {
-        let repo = try await makeRepo(remote: "https://github.com/nlopez/alas.git")
-        defer { try? FileManager.default.removeItem(at: repo) }
-        let svc = GitService()
-        let name = try await svc.suggestProjectName(repo)
-        #expect(name == "nlopez/alas")
-    }
-
-    @Test func suggestNameFromSshRemote() async throws {
-        let repo = try await makeRepo(remote: "git@github.com:nlopez/git-gud.git")
-        defer { try? FileManager.default.removeItem(at: repo) }
-        let svc = GitService()
-        let name = try await svc.suggestProjectName(repo)
-        #expect(name == "nlopez/git-gud")
-    }
-
-    @Test func suggestNameFallsBackToFolder() async throws {
+    @Test func suggestNameUsesDirectoryName() async throws {
         let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let svc = GitService()
+        let name = try await svc.suggestProjectName(repo)
+        #expect(name == repo.lastPathComponent)
+    }
+
+    @Test func suggestNameIgnoresOriginRemote() async throws {
+        let repo = try await makeRepo(remote: "https://github.com/nlopez/a-longer-remote-name.git")
         defer { try? FileManager.default.removeItem(at: repo) }
         let svc = GitService()
         let name = try await svc.suggestProjectName(repo)


### PR DESCRIPTION
## Summary

- `GitService.suggestProjectName(_:)` now uses only `path.lastPathComponent` instead of deriving names from remote URLs
- Removed dead `parseRemote` method and its associated tests
- Updated add-project dialog placeholder from `owner/repo` to `repo-folder`
- Updated `ProjectConfig.name` doc comment to match the new basename convention
- Added regression test proving `origin` remote is ignored for default naming

Closes #804