### PR TITLE
fix: restrict LFS fallback to missing filter errors

### DIFF
--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -90,8 +90,8 @@ struct WorktreeService {
         }
 
         let stderr = result.stderr.lowercased()
-        let lfsMissing = stderr.contains("command not found")
-            || stderr.contains("not found") && (stderr.contains("git-lfs") || stderr.contains("filter-process"))
+        let lfsMissing = (stderr.contains("command not found") || stderr.contains("not found"))
+            && (stderr.contains("git-lfs") || stderr.contains("filter-process"))
 
         guard lfsMissing else {
             throw WorktreeError.gitFailed(result.stderr)

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -90,9 +90,10 @@ struct WorktreeService {
         }
 
         let stderr = result.stderr.lowercased()
-        let isLfsError = stderr.contains("git-lfs") || stderr.contains("filter-process") || stderr.contains("smudge filter")
+        let lfsMissing = stderr.contains("command not found")
+            || stderr.contains("not found") && (stderr.contains("git-lfs") || stderr.contains("filter-process"))
 
-        guard isLfsError else {
+        guard lfsMissing else {
             throw WorktreeError.gitFailed(result.stderr)
         }
 


### PR DESCRIPTION
## Summary
- Narrows the LFS error detection in `WorktreeService.add()` to only trigger the fallback when `git-lfs` command is not found, not when git-lfs is installed but fails to download objects.
- Addresses Codex review feedback from PR #109: the previous broad detection (`git-lfs`, `filter-process`, `smudge filter`) would also match download/auth failures and silently check out raw LFS pointer files.

## Test plan
- Existing `addSucceedsWhenLfsFilterIsMissing` test continues to pass (uses `/nonexistent/git-lfs` which produces "command not found").
- When git-lfs IS installed but encounters download errors, the original error is now properly propagated instead of being swallowed.