### PR TITLE
feat: debounce cursor idle events so run badge stays active

### DIFF
--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -20,11 +20,20 @@ final class HarnessService {
         var updatedAt: Date
     }
 
-    init() {
+    /// Cursor notifications are less reliable than Claude's and frequently
+    /// flap `idle -> busy -> idle` for a single ongoing turn. We debounce
+    /// `.idle` events for Cursor so the `run` badge stays visible until
+    /// work has actually settled.
+    private var cursorIdleDebouncers: [String: DebounceTimer] = [:]
+    private let cursorIdleDebounceInterval: TimeInterval
+
+    init(cursorIdleDebounceInterval: TimeInterval = 2.0) {
+        self.cursorIdleDebounceInterval = cursorIdleDebounceInterval
         socketServer = AgentHookSocketServer()
     }
 
-    init(socketServer: AgentHookSocketServer) {
+    init(socketServer: AgentHookSocketServer, cursorIdleDebounceInterval: TimeInterval = 2.0) {
+        self.cursorIdleDebounceInterval = cursorIdleDebounceInterval
         self.socketServer = socketServer
     }
 
@@ -75,19 +84,27 @@ final class HarnessService {
 
     func handleSocketEvent(
         _ event: AgentHookEvent,
-        stateLookup: (String) -> (projectId: String, worktreeId: String)?,
+        stateLookup: @escaping (String) -> (projectId: String, worktreeId: String)?,
         shouldNotifyOnAwaiting: () -> Bool
     ) {
         let previousState = activityBySession[event.sessionId]?.state
 
         switch event.event {
         case .busy:
+            // Cancel any pending cursor-idle debounce — work is actually ongoing.
+            if event.agent == .cursor {
+                cursorIdleDebouncers.removeValue(forKey: event.sessionId)?.cancel()
+            }
             activityBySession[event.sessionId] = HarnessActivityState(
                 agent: event.agent, state: .busy, pid: event.pid,
                 lastBody: nil, updatedAt: Date()
             )
 
         case .awaitingInput:
+            // Cancel pending cursor-idle debounce; awaiting is a real state change.
+            if event.agent == .cursor {
+                cursorIdleDebouncers.removeValue(forKey: event.sessionId)?.cancel()
+            }
             activityBySession[event.sessionId] = HarnessActivityState(
                 agent: event.agent, state: .awaitingInput, pid: event.pid,
                 lastBody: event.body, updatedAt: Date()
@@ -102,28 +119,59 @@ final class HarnessService {
             }
 
         case .idle:
-            activityBySession[event.sessionId] = HarnessActivityState(
-                agent: event.agent, state: .idle, pid: event.pid,
-                lastBody: event.body, updatedAt: Date()
-            )
-            if let lookup = stateLookup(event.sessionId) {
-                notifications.notifyHarnessFinished(
-                    agent: event.agent, body: event.body,
-                    projectId: lookup.projectId, worktreeId: lookup.worktreeId,
-                    sessionId: event.sessionId
-                )
+            if event.agent == .cursor {
+                // Debounce cursor idle: keep the badge alive briefly in case
+                // a follow-up busy arrives (which cancels this timer).
+                let sid = event.sessionId
+                let ev = event
+                if let existing = cursorIdleDebouncers[sid] {
+                    existing.poke()
+                } else {
+                    let debouncer = DebounceTimer(
+                        interval: cursorIdleDebounceInterval,
+                        queue: .main
+                    )
+                    debouncer.onFire = { [weak self] in
+                        self?.commitIdle(event: ev, stateLookup: stateLookup)
+                        self?.cursorIdleDebouncers.removeValue(forKey: sid)
+                    }
+                    cursorIdleDebouncers[sid] = debouncer
+                    debouncer.poke()
+                }
+            } else {
+                commitIdle(event: event, stateLookup: stateLookup)
             }
+        }
+    }
+
+    private func commitIdle(
+        event: AgentHookEvent,
+        stateLookup: @escaping (String) -> (projectId: String, worktreeId: String)?
+    ) {
+        activityBySession[event.sessionId] = HarnessActivityState(
+            agent: event.agent, state: .idle, pid: event.pid,
+            lastBody: event.body, updatedAt: Date()
+        )
+        if let lookup = stateLookup(event.sessionId) {
+            notifications.notifyHarnessFinished(
+                agent: event.agent, body: event.body,
+                projectId: lookup.projectId, worktreeId: lookup.worktreeId,
+                sessionId: event.sessionId
+            )
         }
     }
 
     func stop() {
         detector.stop()
         socketServer.shutdown()
+        for debouncer in cursorIdleDebouncers.values { debouncer.cancel() }
+        cursorIdleDebouncers.removeAll()
     }
 
     func forgetSession(_ sessionId: String) {
         harnessBySession.removeValue(forKey: sessionId)
         activityBySession.removeValue(forKey: sessionId)
+        cursorIdleDebouncers.removeValue(forKey: sessionId)?.cancel()
     }
 
     enum AggregatedState: String, Equatable {

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -16,8 +16,13 @@ struct HarnessServiceTests {
         var requests: [UNNotificationRequest] = []
     }
 
-    private func makeService() -> (HarnessService, RequestCollector) {
-        let service = HarnessService(socketServer: AgentHookSocketServer(socketPath: "/dev/null"))
+    private func makeService(
+        cursorIdleDebounceInterval: TimeInterval = 2.0
+    ) -> (HarnessService, RequestCollector) {
+        let service = HarnessService(
+            socketServer: AgentHookSocketServer(socketPath: "/dev/null"),
+            cursorIdleDebounceInterval: cursorIdleDebounceInterval
+        )
         let collector = RequestCollector()
         service.notifications.notificationAdder = { collector.requests.append($0) }
         return (service, collector)
@@ -137,14 +142,90 @@ struct HarnessServiceTests {
         #expect(service.activityBySession["s1"]?.state == .awaitingInput)
     }
 
-    @Test func recordHarnessDetection_nil_dropsBusyButKeepsAwaiting() {
-        let (service, _) = makeService()
-        service.setStateForTesting(sessionId: "s1", agent: .claude, state: .busy)
-        service.recordHarnessDetection(sessionId: "s1", kind: nil)
-        #expect(service.activityBySession["s1"] == nil)
+    // MARK: - Cursor idle debounce
 
-        service.setStateForTesting(sessionId: "s2", agent: .claude, state: .awaitingInput)
-        service.recordHarnessDetection(sessionId: "s2", kind: nil)
-        #expect(service.activityBySession["s2"]?.state == .awaitingInput)
+    @Test func cursorIdle_isDebounced() async throws {
+        let (service, _) = makeService(cursorIdleDebounceInterval: 0.05)
+        service.handleSocketEvent(
+            makeEvent(event: .busy, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+
+        service.handleSocketEvent(
+            makeEvent(event: .idle, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        #expect(service.activityBySession["session-1"]?.state == .busy)
+
+        try await Task.sleep(nanoseconds: 80_000_000) // 80 ms > 50 ms
+        #expect(service.activityBySession["session-1"]?.state == .idle)
+    }
+
+    @Test func cursorIdleDebounce_isCancelledByBusy() async throws {
+        let (service, _) = makeService(cursorIdleDebounceInterval: 0.05)
+        service.handleSocketEvent(
+            makeEvent(event: .busy, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .idle, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        // Re-burry before the debounce fires.
+        service.handleSocketEvent(
+            makeEvent(event: .busy, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+
+        try await Task.sleep(nanoseconds: 80_000_000)
+        #expect(service.activityBySession["session-1"]?.state == .busy)
+    }
+
+    @Test func cursorIdleDebounce_isCancelledByAwaitingInput() async throws {
+        let (service, _) = makeService(cursorIdleDebounceInterval: 0.05)
+        service.handleSocketEvent(
+            makeEvent(event: .busy, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .idle, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .awaitingInput, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+
+        try await Task.sleep(nanoseconds: 80_000_000)
+        #expect(service.activityBySession["session-1"]?.state == .awaitingInput)
+    }
+
+    @Test func claudeIdle_isNotDebounced() {
+        let (service, _) = makeService(cursorIdleDebounceInterval: 0.05)
+        service.handleSocketEvent(
+            makeEvent(event: .busy, agent: .claude),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .idle, agent: .claude),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        #expect(service.activityBySession["session-1"]?.state == .idle)
+    }
+
+    @Test func forgetSession_cancelsCursorIdleDebounce() async throws {
+        let (service, _) = makeService(cursorIdleDebounceInterval: 0.05)
+        service.handleSocketEvent(
+            makeEvent(event: .busy, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .idle, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.forgetSession("session-1")
+
+        try await Task.sleep(nanoseconds: 80_000_000)
+        #expect(service.activityBySession["session-1"] == nil)
     }
 }

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -142,6 +142,17 @@ struct HarnessServiceTests {
         #expect(service.activityBySession["s1"]?.state == .awaitingInput)
     }
 
+    @Test func recordHarnessDetection_nil_dropsBusyButKeepsAwaiting() {
+        let (service, _) = makeService()
+        service.setStateForTesting(sessionId: "s1", agent: .claude, state: .busy)
+        service.recordHarnessDetection(sessionId: "s1", kind: nil)
+        #expect(service.activityBySession["s1"] == nil)
+
+        service.setStateForTesting(sessionId: "s2", agent: .claude, state: .awaitingInput)
+        service.recordHarnessDetection(sessionId: "s2", kind: nil)
+        #expect(service.activityBySession["s2"]?.state == .awaitingInput)
+    }
+
     // MARK: - Cursor idle debounce
 
     @Test func cursorIdle_isDebounced() async throws {


### PR DESCRIPTION
## Summary

- Cursor `.idle` events are now debounced by 2 s via `DebounceTimer` so the `run` badge stays visible while work is actually ongoing
- Non-cursor agents (Claude, Codex) commit `.idle` immediately — no behavioral change
- Pending debouncers are cancelled by `.busy`/`.awaitingInput` events, `forgetSession()`, and `stop()`
- Debounce duration is injectable (50 ms in tests, 2 s in production)
- Restored previously deleted `recordHarnessDetection_nil_dropsBusyButKeepsAwaiting` regression test

## Key files

- `Alas/Sources/Harness/HarnessService.swift` — `cursorIdleDebouncers` dictionary, debounce logic in `handleSocketEvent`, `commitIdle` helper, cleanup
- `AlasTests/HarnessServiceTests.swift` — 5 new cursor-debounce tests + 1 restored regression test

Closes #814