### PR TITLE
Fix New Worktree failure when Git LFS hook exists but git-lfs is missing

### DIFF
--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -78,23 +78,20 @@ struct WorktreeService {
 
         let result = try await Process.git(args, cwd: repoPath)
         if result.exitCode == 0 {
-            return Worktree(
-                id: Worktree.makeId(path: destination),
-                projectId: projectId,
-                name: branch,
-                branch: branch,
-                path: destination,
-                status: .clean,
-                lastActivity: Date()
-            )
+            return makeWorktree(destination: destination, branch: branch, projectId: projectId)
         }
 
-        let stderr = result.stderr.lowercased()
-        let lfsMissing = (stderr.contains("command not found") || stderr.contains("not found"))
-            && (stderr.contains("git-lfs") || stderr.contains("filter-process"))
-
-        guard lfsMissing else {
+        guard Self.looksLikeMissingLFS(result.stderr) else {
             throw WorktreeError.gitFailed(result.stderr)
+        }
+
+        // The worktree may already exist if the failure came from a
+        // post-checkout hook rather than the checkout itself (e.g. LFS hook
+        // detecting missing git-lfs after files are already checked out).
+        if let existing = try await existingWorktree(
+            repoPath: repoPath, destination: destination, projectId: projectId
+        ) {
+            return existing
         }
 
         let recheck = try await Process.git(
@@ -114,19 +111,12 @@ struct WorktreeService {
             "-c", "filter.lfs.process=",
             "-c", "filter.lfs.smudge=",
             "-c", "filter.lfs.clean=",
-            "-c", "filter.lfs.required=false"
+            "-c", "filter.lfs.required=false",
+            "-c", "core.hooksPath=/dev/null"
         ]
         let fallbackResult = try await Process.git(lfsOverride + fallbackArgs, cwd: repoPath)
         guard fallbackResult.exitCode == 0 else { throw WorktreeError.gitFailed(fallbackResult.stderr) }
-        return Worktree(
-            id: Worktree.makeId(path: destination),
-            projectId: projectId,
-            name: branch,
-            branch: branch,
-            path: destination,
-            status: .clean,
-            lastActivity: Date()
-        )
+        return makeWorktree(destination: destination, branch: branch, projectId: projectId)
     }
 
     /// Remove a worktree. Pass the full `Worktree` (not just a path) so we can
@@ -154,5 +144,35 @@ struct WorktreeService {
     func prune(repoPath: URL) async throws {
         let result = try await Process.git(["worktree", "prune"], cwd: repoPath)
         guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
+    }
+
+    // MARK: - Helpers
+
+    private static func looksLikeMissingLFS(_ stderr: String) -> Bool {
+        let lower = stderr.lowercased()
+        return (lower.contains("command not found") || lower.contains("not found"))
+            && (lower.contains("git-lfs") || lower.contains("filter-process"))
+    }
+
+    private func existingWorktree(
+        repoPath: URL,
+        destination: URL,
+        projectId: String
+    ) async throws -> Worktree? {
+        let listed = try await list(repoPath: repoPath, projectId: projectId)
+        let normalizedDest = destination.standardizedFileURL.path
+        return listed.first { $0.path.standardizedFileURL.path == normalizedDest }
+    }
+
+    private func makeWorktree(destination: URL, branch: String, projectId: String) -> Worktree {
+        Worktree(
+            id: Worktree.makeId(path: destination),
+            projectId: projectId,
+            name: branch,
+            branch: branch,
+            path: destination,
+            status: .clean,
+            lastActivity: Date()
+        )
     }
 }

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -215,4 +215,45 @@ extension WorktreeServiceTests {
         #expect(wt.branch == "feat/lfs")
         #expect(FileManager.default.fileExists(atPath: dest.path))
     }
+
+    @Test func addSucceedsWhenLfsHookFailsAfterCheckout() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        // Add a real committed file so checkout has work to do.
+        try "hello".write(
+            to: repo.appendingPathComponent("dummy.txt"),
+            atomically: true, encoding: .utf8
+        )
+        _ = try await Process.git(["add", "."], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add file"], cwd: repo)
+
+        // Set up a custom hooks directory with a post-checkout hook that
+        // mimics Git LFS failing because git-lfs is missing.
+        let hooksDir = repo.appendingPathComponent("custom-hooks")
+        try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+        let hook = hooksDir.appendingPathComponent("post-checkout")
+        let hookScript = """
+        #!/bin/bash
+        echo "This repository is configured for Git LFS but git-lfs was not found on your path."
+        exit 1
+        """
+        try hookScript.write(to: hook, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["config", "--local", "core.hooksPath", hooksDir.path], cwd: repo)
+        // Make the hook executable.
+        _ = try await Process.run("/bin/chmod", args: ["+x", hook.path], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-hook")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/hook",
+            destination: dest, projectId: "p"
+        )
+        #expect(wt.branch == "feat/hook")
+        #expect(FileManager.default.fileExists(atPath: dest.path))
+        let listed = try await svc.list(repoPath: repo, projectId: "p")
+        #expect(listed.count == 2)
+    }
 }


### PR DESCRIPTION
## Summary
- `WorktreeService.add()` now checks whether a worktree is already registered via `git worktree list --porcelain` when `git worktree add` fails with a missing-LFS error, returning success if checkout completed before the hook failed
- Added `-c core.hooksPath=/dev/null` to the filter-override fallback retry so hooks can't trip the second attempt either
- Extracted `looksLikeMissingLFS()`, `existingWorktree()`, and `makeWorktree()` helpers for clarity
- Added regression test `addSucceedsWhenLfsHookFailsAfterCheckout` that sets up a `post-checkout` hook mimicking the missing-LFS error

Fixes #815