### PR TITLE
feat: show creating/deleting worktree states asynchronously in the UI

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -105,6 +105,117 @@ final class AppState {
         try? store.write(ProjectsFile(projects: projectsManager.projects), to: Paths.projectsFile)
     }
 
+    /// Optimistically insert a worktree row and run the git operation async.
+    /// Returns the optimistic worktree id so the dialog can close immediately.
+    @discardableResult
+    func createWorktree(
+        projectId: String,
+        base: String,
+        branch: String,
+        destination: URL,
+        runStartup: Bool,
+        openTerminal: Bool
+    ) -> String {
+        guard let project = projects.first(where: { $0.id == projectId }) else {
+            // Should not happen if the dialog validated the project; fail silently.
+            return ""
+        }
+        let optimistic = Worktree(
+            id: Worktree.makeId(path: destination),
+            projectId: projectId,
+            name: branch,
+            branch: branch,
+            path: destination,
+            status: .clean,
+            lastActivity: Date()
+        )
+        projectsManager.insertOptimisticWorktree(optimistic)
+        projectsManager.setOperationState(id: optimistic.id, state: .creating)
+
+        let repoPath = URL(fileURLWithPath: project.path)
+        let startupScript = StartupScriptResolver.worktreeCreateScript(
+            global: config.terminal,
+            project: project
+        )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        Task { @MainActor in
+            do {
+                let newWorktree = try await Self.performCreateWorktree(
+                    repoPath: repoPath,
+                    base: base, branch: branch, destination: destination, projectId: projectId
+                )
+                if runStartup && !startupScript.isEmpty {
+                    _ = try? await Process.run(
+                        "/bin/zsh",
+                        args: ["-c", startupScript],
+                        cwd: newWorktree.path
+                    )
+                }
+
+                do {
+                    let wasHidden = projectsManager.isWorktreeHidden(
+                        projectId: project.id,
+                        path: newWorktree.path
+                    )
+                    projectsManager.setWorktreeHidden(
+                        projectId: project.id,
+                        path: newWorktree.path,
+                        hidden: false
+                    )
+                    let gcDropped = try await projectsManager.refreshWorktrees(projectId: project.id)
+                    if wasHidden || gcDropped {
+                        saveProjects()
+                    }
+
+                    selectedWorktreeId = newWorktree.id
+                    if openTerminal {
+                        _ = try? openTerminalTab(for: newWorktree)
+                    }
+                } catch {
+                    projectsManager.setOperationState(
+                        id: optimistic.id,
+                        state: .createFailed(message: error.localizedDescription)
+                    )
+                }
+            } catch {
+                let msg = error.localizedDescription
+                projectsManager.setOperationState(id: optimistic.id, state: .createFailed(message: msg))
+            }
+        }
+        return optimistic.id
+    }
+
+    nonisolated private static func performCreateWorktree(
+        repoPath: URL,
+        base: String,
+        branch: String,
+        destination: URL,
+        projectId: String
+    ) async throws -> Worktree {
+        try await Task.detached {
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            return try await WorktreeService().add(
+                repoPath: repoPath,
+                base: base,
+                branch: branch,
+                destination: destination,
+                projectId: projectId
+            )
+        }.value
+    }
+
+    func removeFailedOptimisticWorktree(id: String, projectId: String) {
+        cleanupWorktreeState(worktreeId: id)
+        projectsManager.removeOptimisticWorktree(id: id, projectId: projectId)
+        if selectedWorktreeId == id {
+            selectedWorktreeId = firstVisibleWorktreeId()
+        }
+    }
+
     func addProject(path: URL, displayName: String, color: String) async throws {
         _ = try await projectsManager.addProject(path: path, displayName: displayName, color: color)
         saveProjects()
@@ -827,17 +938,15 @@ final class AppState {
         let repoPath = URL(fileURLWithPath: project.path)
         let deleteBranch = config.worktrees.deleteBranchOnRemove
 
-        // Snapshot for selection follow-up. The index must be captured BEFORE
-        // the await because the worktree won't be in `visibleWorktrees` after
-        // `refreshWorktrees`. We re-check selection (live) post-await so a
-        // selection change during the dialog/await flow isn't clobbered.
         let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
         let removedIndex = siblingsBefore.firstIndex(where: { $0.id == worktree.id }) ?? 0
 
+        // Mark deleting immediately so the UI dims the row.
+        projectsManager.setOperationState(id: worktree.id, state: .deleting)
+
         Task { @MainActor in
-            let svc = WorktreeService()
             do {
-                try await svc.remove(
+                try await Self.performRemoveWorktree(
                     repoPath: repoPath,
                     worktree: worktree,
                     deleteBranchIfMerged: deleteBranch,
@@ -845,27 +954,43 @@ final class AppState {
                 )
             } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
                 if Self.looksLikeDirtyWorktreeError(stderr) {
+                    // Clear deleting so the user can see the row again while deciding.
+                    projectsManager.setOperationState(id: worktree.id, state: nil)
                     guard confirmForceDeleteWorktree(branch: worktree.branch) else { return }
+                    // Re-mark deleting before force attempt.
+                    projectsManager.setOperationState(id: worktree.id, state: .deleting)
                     do {
-                        try await svc.remove(
+                        try await Self.performRemoveWorktree(
                             repoPath: repoPath,
                             worktree: worktree,
                             deleteBranchIfMerged: deleteBranch,
                             force: true
                         )
-                    } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
-                        showFileActionError(title: "Delete Failed", message: stderr)
+                    } catch let WorktreeService.WorktreeError.gitFailed(stderr2) {
+                        projectsManager.setOperationState(
+                            id: worktree.id,
+                            state: .deleteFailed(message: stderr2)
+                        )
                         return
                     } catch {
-                        showFileActionError(title: "Delete Failed", message: "\(error)")
+                        projectsManager.setOperationState(
+                            id: worktree.id,
+                            state: .deleteFailed(message: "\(error)")
+                        )
                         return
                     }
                 } else {
-                    showFileActionError(title: "Delete Failed", message: stderr)
+                    projectsManager.setOperationState(
+                        id: worktree.id,
+                        state: .deleteFailed(message: stderr)
+                    )
                     return
                 }
             } catch {
-                showFileActionError(title: "Delete Failed", message: "\(error)")
+                projectsManager.setOperationState(
+                    id: worktree.id,
+                    state: .deleteFailed(message: "\(error)")
+                )
                 return
             }
 
@@ -882,10 +1007,26 @@ final class AppState {
         }
     }
 
+    nonisolated private static func performRemoveWorktree(
+        repoPath: URL,
+        worktree: Worktree,
+        deleteBranchIfMerged: Bool,
+        force: Bool
+    ) async throws {
+        try await Task.detached {
+            try await WorktreeService().remove(
+                repoPath: repoPath,
+                worktree: worktree,
+                deleteBranchIfMerged: deleteBranchIfMerged,
+                force: force
+            )
+        }.value
+    }
+
     /// Permissive substring check: git's exact wording around dirty/locked
     /// worktrees varies by version. If the match misses, the caller surfaces
     /// the raw stderr instead, which is acceptable degradation.
-    private static func looksLikeDirtyWorktreeError(_ stderr: String) -> Bool {
+    nonisolated private static func looksLikeDirtyWorktreeError(_ stderr: String) -> Bool {
         let s = stderr.lowercased()
         return s.contains("is dirty")
             || s.contains("contains modified or untracked files")

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -175,12 +175,12 @@ final class AppState {
                 } catch {
                     projectsManager.setOperationState(
                         id: optimistic.id,
-                        state: .createFailed(message: error.localizedDescription)
+                        state: .createFailed(message: error.localizedDescription, base: base)
                     )
                 }
             } catch {
                 let msg = error.localizedDescription
-                projectsManager.setOperationState(id: optimistic.id, state: .createFailed(message: msg))
+                projectsManager.setOperationState(id: optimistic.id, state: .createFailed(message: msg, base: base))
             }
         }
         return optimistic.id

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -995,6 +995,9 @@ final class AppState {
             }
 
             cleanupWorktreeState(worktreeId: worktree.id)
+            // Always clear the deleting state after a successful remove,
+            // even if the subsequent refresh fails.
+            projectsManager.setOperationState(id: worktree.id, state: nil)
             if (try? await projectsManager.refreshWorktrees(projectId: worktree.projectId)) == true {
                 saveProjects()
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -122,7 +122,15 @@ final class AppState {
         }
         let optimisticId = Worktree.makeId(path: destination)
         if projectsManager.worktrees(projectId: projectId).contains(where: { $0.id == optimisticId }) {
-            return ""
+            let isRetryingFailedCreate: Bool
+            if case .createFailed = projectsManager.operationState(for: optimisticId) {
+                isRetryingFailedCreate = true
+            } else {
+                isRetryingFailedCreate = false
+            }
+            if !isRetryingFailedCreate {
+                return ""
+            }
         }
         let optimistic = Worktree(
             id: optimisticId,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -120,8 +120,12 @@ final class AppState {
             // Should not happen if the dialog validated the project; fail silently.
             return ""
         }
+        let optimisticId = Worktree.makeId(path: destination)
+        if projectsManager.worktrees(projectId: projectId).contains(where: { $0.id == optimisticId }) {
+            return ""
+        }
         let optimistic = Worktree(
-            id: Worktree.makeId(path: destination),
+            id: optimisticId,
             projectId: projectId,
             name: branch,
             branch: branch,

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -147,11 +147,12 @@ final class ProjectsManager {
                     clearOperationIds.append(id)
                 }
             case .createFailed:
-                // Preserve failed rows so they remain visible.
-                if let existing = previousById[id] {
-                    if !liveIds.contains(id) {
-                        reconciled.append(existing)
-                    }
+                if liveIds.contains(id) {
+                    // Worktree exists in git — transient failure is resolved; clear state.
+                    clearOperationIds.append(id)
+                } else if let existing = previousById[id] {
+                    // Preserve failed rows so they remain visible for retry/removal.
+                    reconciled.append(existing)
                 }
             case .deleteFailed:
                 // If git still sees the worktree, keep it visible with the failed

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -10,7 +10,7 @@ struct ProjectUpdate: Equatable {
 enum WorktreeOperationState: Equatable {
     case creating
     case deleting
-    case createFailed(message: String)
+    case createFailed(message: String, base: String)
     case deleteFailed(message: String)
 }
 

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -7,11 +7,19 @@ struct ProjectUpdate: Equatable {
     var startupScripts: ProjectStartupScripts = .defaults
 }
 
+enum WorktreeOperationState: Equatable {
+    case creating
+    case deleting
+    case createFailed(message: String)
+    case deleteFailed(message: String)
+}
+
 @Observable
 @MainActor
 final class ProjectsManager {
     private(set) var projects: [ProjectConfig]
     private(set) var worktreesByProject: [String: [Worktree]] = [:]
+    private(set) var worktreeOperationStates: [String: WorktreeOperationState] = [:]
 
     private let git = GitService()
     private let worktreeSvc = WorktreeService()
@@ -38,8 +46,10 @@ final class ProjectsManager {
     }
 
     func removeProject(id: String) {
+        let ids = Set(worktreesByProject[id, default: []].map(\.id))
         projects.removeAll { $0.id == id }
         worktreesByProject.removeValue(forKey: id)
+        worktreeOperationStates = worktreeOperationStates.filter { !ids.contains($0.key) }
     }
 
     func updateProject(id: String, update: ProjectUpdate) {
@@ -51,6 +61,29 @@ final class ProjectsManager {
 
     func worktrees(projectId: String) -> [Worktree] {
         worktreesByProject[projectId] ?? []
+    }
+
+    func operationState(for worktreeId: String) -> WorktreeOperationState? {
+        worktreeOperationStates[worktreeId]
+    }
+
+    func setOperationState(id: String, state: WorktreeOperationState?) {
+        if let state {
+            worktreeOperationStates[id] = state
+        } else {
+            worktreeOperationStates.removeValue(forKey: id)
+        }
+    }
+
+    func insertOptimisticWorktree(_ worktree: Worktree) {
+        let projectId = worktree.projectId
+        worktreesByProject[projectId, default: []].removeAll { $0.id == worktree.id }
+        worktreesByProject[projectId, default: []].append(worktree)
+    }
+
+    func removeOptimisticWorktree(id: String, projectId: String) {
+        worktreesByProject[projectId]?.removeAll { $0.id == id }
+        worktreeOperationStates.removeValue(forKey: id)
     }
 
     func visibleWorktrees(projectId: String) -> [Worktree] {
@@ -87,10 +120,48 @@ final class ProjectsManager {
         guard let project = projects.first(where: { $0.id == projectId }) else { return false }
         let url = URL(fileURLWithPath: project.path)
         let trees = try await worktreeSvc.list(repoPath: url, projectId: projectId)
-        worktreesByProject[projectId] = trees
-        // GC orphan hidden entries: drop any hidden path that doesn't match a
-        // live worktree path. Prevents stale entries accumulating when worktrees
-        // get removed externally (e.g. `git worktree remove` from a terminal).
+
+        // Reconcile optimistic rows: preserve creating rows that still aren't in git,
+        // replace them with real rows when they appear, and clear operation state.
+        let previous = worktreesByProject[projectId, default: []]
+        let previousById = Dictionary(uniqueKeysWithValues: previous.map { ($0.id, $0) })
+        let liveIds = Set(trees.map(\.id))
+        var reconciled = trees
+        var clearOperationIds: [String] = []
+        for (id, opState) in Array(worktreeOperationStates) {
+            guard previousById[id] != nil || liveIds.contains(id) else { continue }
+            switch opState {
+            case .creating:
+                if !liveIds.contains(id) {
+                    // Still pending; keep the optimistic row visible.
+                    if let optimistic = previousById[id] {
+                        reconciled.append(optimistic)
+                    }
+                } else {
+                    // Creation succeeded; clear the pending state.
+                    clearOperationIds.append(id)
+                }
+            case .deleting:
+                // If the row is gone from git, the deletion succeeded.
+                if !liveIds.contains(id) {
+                    clearOperationIds.append(id)
+                }
+            case .createFailed, .deleteFailed:
+                // Preserve failed rows so they remain visible.
+                if let existing = previousById[id] {
+                    if !liveIds.contains(id) {
+                        reconciled.append(existing)
+                    }
+                }
+            }
+        }
+        for id in clearOperationIds {
+            worktreeOperationStates.removeValue(forKey: id)
+        }
+        // Sort deterministically so optimistic rows don't jump position.
+        reconciled.sort { $0.path.path < $1.path.path }
+        worktreesByProject[projectId] = reconciled
+
         guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return false }
         let live = Set(trees.map { canonical($0.path) })
         let before = projects[idx].hiddenWorktreePaths.count

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -146,12 +146,19 @@ final class ProjectsManager {
                 if !liveIds.contains(id) {
                     clearOperationIds.append(id)
                 }
-            case .createFailed, .deleteFailed:
+            case .createFailed:
                 // Preserve failed rows so they remain visible.
                 if let existing = previousById[id] {
                     if !liveIds.contains(id) {
                         reconciled.append(existing)
                     }
+                }
+            case .deleteFailed:
+                // If git still sees the worktree, keep it visible with the failed
+                // state so the user can retry or remove. If the worktree is gone
+                // (user fixed it externally), clear the ghost state.
+                if !liveIds.contains(id) {
+                    clearOperationIds.append(id)
                 }
             }
         }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -133,6 +133,11 @@ struct RootView: View {
         guard let id = state.selectedWorktreeId else { return nil }
         for project in state.projects {
             if let wt = state.projectsManager.visibleWorktrees(projectId: project.id).first(where: { $0.id == id }) {
+                // Do not treat a creating/deleting row as the active worktree.
+                if let op = state.projectsManager.operationState(for: wt.id),
+                   case .creating = op { return nil }
+                if let op = state.projectsManager.operationState(for: wt.id),
+                   case .deleting = op { return nil }
                 return wt
             }
         }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -133,11 +133,15 @@ struct RootView: View {
         guard let id = state.selectedWorktreeId else { return nil }
         for project in state.projects {
             if let wt = state.projectsManager.visibleWorktrees(projectId: project.id).first(where: { $0.id == id }) {
-                // Do not treat a creating/deleting row as the active worktree.
-                if let op = state.projectsManager.operationState(for: wt.id),
-                   case .creating = op { return nil }
-                if let op = state.projectsManager.operationState(for: wt.id),
-                   case .deleting = op { return nil }
+                // Do not treat a creating/deleting/failed-create row as the active worktree.
+                if let op = state.projectsManager.operationState(for: wt.id) {
+                    switch op {
+                    case .creating, .deleting, .createFailed:
+                        return nil
+                    case .deleteFailed:
+                        break
+                    }
+                }
                 return wt
             }
         }

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -16,8 +16,6 @@ struct NewWorktreeDialog: View {
     @State private var branches: [String] = []
     @State private var isLoadingBranches = false
     @State private var branchLoadError: String?
-    @State private var isCreating = false
-    @State private var errorMessage: String?
 
     @Environment(\.theme) var theme
 
@@ -60,16 +58,13 @@ struct NewWorktreeDialog: View {
                     Text("Open in new terminal pane").font(.system(size: 12))
                         .foregroundColor(theme.color("fg"))
                 }
-                if let errorMessage {
-                    Text(errorMessage).font(.system(size: 11)).foregroundColor(.red)
-                }
             },
             cancelTitle: "Cancel",
-            confirmTitle: isCreating ? "Creating…" : "Create worktree",
+            confirmTitle: "Create worktree",
             confirmStyle: .primary,
             onCancel: { presented = false },
             onConfirm: create,
-            confirmEnabled: Self.canCreate(projectsEmpty: state.projects.isEmpty, branchEmpty: branch.isEmpty, isCreating: isCreating)
+            confirmEnabled: Self.canCreate(projectsEmpty: state.projects.isEmpty, branchEmpty: branch.isEmpty)
         )
         .onAppear {
             if projectId.isEmpty {
@@ -157,67 +152,25 @@ struct NewWorktreeDialog: View {
 
     private func create() {
         guard let project = state.projects.first(where: { $0.id == projectId }) else { return }
-        isCreating = true
-        errorMessage = nil
-        let runStartupAfter = runStartup
-        let openTerminalAfter = openTerminal
-        Task {
-            defer { isCreating = false }
-            do {
-                let svc = WorktreeService()
-                let dest = URL(fileURLWithPath: renderedPath)
-                try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
-                let newWorktree = try await svc.add(
-                    repoPath: URL(fileURLWithPath: project.path),
-                    base: base, branch: branch, destination: dest, projectId: project.id
-                )
-                let wasHidden = state.projectsManager.isWorktreeHidden(
-                    projectId: project.id,
-                    path: newWorktree.path
-                )
-                state.projectsManager.setWorktreeHidden(
-                    projectId: project.id,
-                    path: newWorktree.path,
-                    hidden: false
-                )
-                let gcDropped = try await state.projectsManager.refreshWorktrees(projectId: project.id)
-                if wasHidden || gcDropped {
-                    state.saveProjects()
-                }
-
-                if runStartupAfter {
-                    let script = StartupScriptResolver.worktreeCreateScript(
-                        global: state.config.terminal,
-                        project: project
-                    )
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !script.isEmpty {
-                        _ = try? await Process.run(
-                            "/bin/zsh",
-                            args: ["-c", script],
-                            cwd: newWorktree.path
-                        )
-                    }
-                }
-
-                state.selectedWorktreeId = newWorktree.id
-                if openTerminalAfter {
-                    _ = try? state.openTerminalTab(for: newWorktree)
-                }
-                presented = false
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-        }
+        let dest = URL(fileURLWithPath: renderedPath)
+        state.createWorktree(
+            projectId: project.id,
+            base: base,
+            branch: branch,
+            destination: dest,
+            runStartup: runStartup,
+            openTerminal: openTerminal
+        )
+        presented = false
     }
 
     private func submitCreate() {
-        guard Self.canCreate(projectsEmpty: state.projects.isEmpty, branchEmpty: branch.isEmpty, isCreating: isCreating) else { return }
+        guard Self.canCreate(projectsEmpty: state.projects.isEmpty, branchEmpty: branch.isEmpty) else { return }
         create()
     }
 
-    nonisolated static func canCreate(projectsEmpty: Bool, branchEmpty: Bool, isCreating: Bool) -> Bool {
-        !projectsEmpty && !branchEmpty && !isCreating
+    nonisolated static func canCreate(projectsEmpty: Bool, branchEmpty: Bool) -> Bool {
+        !projectsEmpty && !branchEmpty
     }
 
     nonisolated static func resolvedPresetProject(

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -16,6 +16,7 @@ struct NewWorktreeDialog: View {
     @State private var branches: [String] = []
     @State private var isLoadingBranches = false
     @State private var branchLoadError: String?
+    @State private var createErrorMessage: String?
 
     @Environment(\.theme) var theme
 
@@ -58,6 +59,9 @@ struct NewWorktreeDialog: View {
                     Text("Open in new terminal pane").font(.system(size: 12))
                         .foregroundColor(theme.color("fg"))
                 }
+                if let createErrorMessage {
+                    Text(createErrorMessage).font(.system(size: 11)).foregroundColor(.red)
+                }
             },
             cancelTitle: "Cancel",
             confirmTitle: "Create worktree",
@@ -84,6 +88,9 @@ struct NewWorktreeDialog: View {
         }
         .onChange(of: projectId) { _, _ in
             loadBranchesForSelectedProject()
+        }
+        .onChange(of: branch) { _, _ in
+            createErrorMessage = nil
         }
     }
 
@@ -114,6 +121,7 @@ struct NewWorktreeDialog: View {
     }
 
     private func loadBranchesForSelectedProject() {
+        createErrorMessage = nil
         guard let project = state.projects.first(where: { $0.id == projectId }) else {
             branches = []
             branchLoadError = nil
@@ -153,7 +161,7 @@ struct NewWorktreeDialog: View {
     private func create() {
         guard let project = state.projects.first(where: { $0.id == projectId }) else { return }
         let dest = URL(fileURLWithPath: renderedPath)
-        state.createWorktree(
+        let id = state.createWorktree(
             projectId: project.id,
             base: base,
             branch: branch,
@@ -161,6 +169,11 @@ struct NewWorktreeDialog: View {
             runStartup: runStartup,
             openTerminal: openTerminal
         )
+        guard !id.isEmpty else {
+            createErrorMessage = "A worktree already exists at this path."
+            return
+        }
+        createErrorMessage = nil
         presented = false
     }
 

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -5,6 +5,7 @@ struct RepoGroupView: View {
     let worktrees: [Worktree]
     @Binding var collapsed: Bool
     let selectedWorktreeId: String?
+    let operationState: (Worktree) -> WorktreeOperationState?
     let harnessSummary: (String) -> HarnessService.WorktreeHarnessSummary?
     let onSelect: (Worktree) -> Void
     let onNewWorktree: () -> Void
@@ -16,6 +17,10 @@ struct RepoGroupView: View {
     let onArchive: (Worktree) -> Void
     let onDelete: (Worktree) -> Void
     let onActivateHarness: (Worktree) -> Void
+    let onCopyError: (String) -> Void
+    let onRetryCreate: (Worktree) -> Void
+    let onRetryDelete: (Worktree) -> Void
+    let onRemoveFailed: (Worktree) -> Void
     @Environment(\.theme) var theme
     @State private var hovering = false
     @State private var plusHovering = false
@@ -84,6 +89,7 @@ struct RepoGroupView: View {
                         WorktreeRowView(
                             worktree: wt,
                             isSelected: wt.id == selectedWorktreeId,
+                            operationState: operationState(wt),
                             harnessSummary: harnessSummary(wt.id),
                             onTap: { onSelect(wt) },
                             onOpenTerminal: { onOpenTerminal(wt) },
@@ -92,7 +98,11 @@ struct RepoGroupView: View {
                             onRevealInFinder: { onRevealInFinder(wt) },
                             onArchive: { onArchive(wt) },
                             onDelete: { onDelete(wt) },
-                            onActivateHarness: { onActivateHarness(wt) }
+                            onActivateHarness: { onActivateHarness(wt) },
+                            onCopyError: onCopyError,
+                            onRemoveFailed: { onRemoveFailed(wt) },
+                            onRetryCreate: { onRetryCreate(wt) },
+                            onRetryDelete: { onRetryDelete(wt) }
                         )
                     }
                 }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -85,9 +85,16 @@ struct SidebarView: View {
                                     pb.setString(message, forType: .string)
                                 },
                                 onRetryCreate: { wt in
+                                    let retryBase: String
+                                    if let op = state.projectsManager.operationState(for: wt.id),
+                                       case .createFailed(_, let base) = op {
+                                        retryBase = base
+                                    } else {
+                                        retryBase = state.config.worktrees.baseBranch
+                                    }
                                     state.createWorktree(
                                         projectId: project.id,
-                                        base: state.config.worktrees.baseBranch,
+                                        base: retryBase,
                                         branch: wt.branch,
                                         destination: wt.path,
                                         runStartup: false,

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -35,6 +35,9 @@ struct SidebarView: View {
                                     }
                                 ),
                                 selectedWorktreeId: state.selectedWorktreeId,
+                                operationState: { wt in
+                                    state.projectsManager.operationState(for: wt.id)
+                                },
                                 harnessSummary: { worktreeId in
                                     let ids = state.tabs.tabs(forWorktree: worktreeId).flatMap { tab -> [String] in
                                         if case .terminal(let s) = tab { return s.root.leaves().map(\.sessionId) }
@@ -75,6 +78,25 @@ struct SidebarView: View {
                                         worktreeId: wt.id,
                                         sessionId: summary.primarySessionId
                                     )
+                                },
+                                onCopyError: { message in
+                                    let pb = NSPasteboard.general
+                                    pb.clearContents()
+                                    pb.setString(message, forType: .string)
+                                },
+                                onRetryCreate: { wt in
+                                    state.createWorktree(
+                                        projectId: project.id,
+                                        base: state.config.worktrees.baseBranch,
+                                        branch: wt.branch,
+                                        destination: wt.path,
+                                        runStartup: false,
+                                        openTerminal: false
+                                    )
+                                },
+                                onRetryDelete: { wt in state.deleteWorktree(wt) },
+                                onRemoveFailed: { wt in
+                                    state.removeFailedOptimisticWorktree(id: wt.id, projectId: project.id)
                                 }
                             )
                         }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct WorktreeRowView: View {
     let worktree: Worktree
     let isSelected: Bool
+    let operationState: WorktreeOperationState?
     let harnessSummary: HarnessService.WorktreeHarnessSummary?
     let onTap: () -> Void
     let onOpenTerminal: () -> Void
@@ -12,7 +13,37 @@ struct WorktreeRowView: View {
     let onArchive: () -> Void
     let onDelete: () -> Void
     let onActivateHarness: () -> Void
+    let onCopyError: (String) -> Void
+    let onRemoveFailed: () -> Void
+    let onRetryCreate: () -> Void
+    let onRetryDelete: () -> Void
     @Environment(\.theme) var theme
+
+    private var isPending: Bool {
+        switch operationState {
+        case .creating, .deleting: return true
+        default: return false
+        }
+    }
+
+    private var statusText: String {
+        switch operationState {
+        case .creating: return "Creating…"
+        case .deleting: return "Deleting…"
+        case .createFailed(let msg): return "Create failed: \(msg.trimmedForDisplay)"
+        case .deleteFailed(let msg): return "Delete failed: \(msg.trimmedForDisplay)"
+        case .none: return ""
+        }
+    }
+
+    private var errorMessage: String? {
+        switch operationState {
+        case .createFailed(let message), .deleteFailed(let message):
+            return message
+        case .creating, .deleting, .none:
+            return nil
+        }
+    }
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -30,35 +61,43 @@ struct WorktreeRowView: View {
                     Icon(name: "branch", size: 11, color: theme.color("fg-faint"))
                     Text(worktree.branch)
                         .font(.system(size: 12, weight: .medium, design: .monospaced))
-                        .foregroundColor(theme.color("fg"))
+                        .foregroundColor(theme.color(isPending ? "fg-faint" : "fg"))
                         .lineLimit(1)
                         .truncationMode(.tail)
                 }
-                HStack(spacing: 8) {
-                    Text(relative(worktree.lastActivity))
+                if operationState != nil {
+                    Text(statusText)
                         .font(.system(size: 10.5))
-                        .foregroundColor(theme.color("fg-faint"))
-                    if worktree.addedLines > 0 {
-                        Text("+\(worktree.addedLines)")
-                            .font(.system(size: 10.5, design: .monospaced))
-                            .foregroundColor(theme.color("add"))
-                    }
-                    if worktree.deletedLines > 0 {
-                        Text("−\(worktree.deletedLines)")
-                            .font(.system(size: 10.5, design: .monospaced))
-                            .foregroundColor(theme.color("del"))
-                    }
-                    if let summary = harnessSummary {
-                        Spacer()
-                        Button(action: onActivateHarness) {
-                            HarnessPill(
-                                summary: summary,
-                                variant: .full,
-                                tooltip: pillTooltip(for: summary),
-                                isSelected: isSelected
-                            )
+                        .foregroundColor(theme.color("warning"))
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                } else {
+                    HStack(spacing: 8) {
+                        Text(relative(worktree.lastActivity))
+                            .font(.system(size: 10.5))
+                            .foregroundColor(theme.color("fg-faint"))
+                        if worktree.addedLines > 0 {
+                            Text("+\(worktree.addedLines)")
+                                .font(.system(size: 10.5, design: .monospaced))
+                                .foregroundColor(theme.color("add"))
                         }
-                        .buttonStyle(.plain)
+                        if worktree.deletedLines > 0 {
+                            Text("−\(worktree.deletedLines)")
+                                .font(.system(size: 10.5, design: .monospaced))
+                                .foregroundColor(theme.color("del"))
+                        }
+                        if let summary = harnessSummary {
+                            Spacer()
+                            Button(action: onActivateHarness) {
+                                HarnessPill(
+                                    summary: summary,
+                                    variant: .full,
+                                    tooltip: pillTooltip(for: summary),
+                                    isSelected: isSelected
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
                     }
                 }
             }
@@ -68,15 +107,38 @@ struct WorktreeRowView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
-        .onTapGesture(perform: onTap)
+        .opacity(isPending ? 0.55 : 1)
+        .onTapGesture {
+            if !isPending {
+                onTap()
+            }
+        }
         .contextMenu {
-            Button("Open in Terminal", action: onOpenTerminal)
-            Button("Copy Path", action: onCopyPath)
-            Button("Copy Branch Name", action: onCopyBranch)
-            Button("Reveal in Finder", action: onRevealInFinder)
-            Divider()
-            Button("Archive", action: onArchive)
-            Button("Delete Worktree…", role: .destructive, action: onDelete)
+            if case .createFailed = operationState {
+                Button("Retry Create", action: onRetryCreate)
+                Button("Remove from List", role: .destructive, action: onRemoveFailed)
+                Divider()
+                if let errorMessage {
+                    Button("Copy Error") { onCopyError(errorMessage) }
+                }
+                Button("Copy Path", action: onCopyPath)
+            } else if case .deleteFailed = operationState {
+                Button("Retry Delete", action: onRetryDelete)
+                Divider()
+                if let errorMessage {
+                    Button("Copy Error") { onCopyError(errorMessage) }
+                }
+                Button("Copy Path", action: onCopyPath)
+                Button("Copy Branch Name", action: onCopyBranch)
+            } else if !isPending {
+                Button("Open in Terminal", action: onOpenTerminal)
+                Button("Copy Path", action: onCopyPath)
+                Button("Copy Branch Name", action: onCopyBranch)
+                Button("Reveal in Finder", action: onRevealInFinder)
+                Divider()
+                Button("Archive", action: onArchive)
+                Button("Delete Worktree…", role: .destructive, action: onDelete)
+            }
         }
     }
 
@@ -93,5 +155,11 @@ struct WorktreeRowView: View {
         case .awaiting: stateText = "awaiting"
         }
         return "\(summary.agent.displayName) · \(stateText)"
+    }
+}
+
+private extension String {
+    var trimmedForDisplay: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -30,7 +30,7 @@ struct WorktreeRowView: View {
         switch operationState {
         case .creating: return "Creating…"
         case .deleting: return "Deleting…"
-        case .createFailed(let msg): return "Create failed: \(msg.trimmedForDisplay)"
+        case .createFailed(let msg, _): return "Create failed: \(msg.trimmedForDisplay)"
         case .deleteFailed(let msg): return "Delete failed: \(msg.trimmedForDisplay)"
         case .none: return ""
         }
@@ -38,7 +38,7 @@ struct WorktreeRowView: View {
 
     private var errorMessage: String? {
         switch operationState {
-        case .createFailed(let message), .deleteFailed(let message):
+        case .createFailed(let message, _), .deleteFailed(let message):
             return message
         case .creating, .deleting, .none:
             return nil

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -170,6 +170,32 @@ struct AppStateCleanupTests {
         #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == id })
     }
 
+    @Test func createWorktreeRejectsExistingDestination() async throws {
+        let repo = try await makeRepo(name: "create-existing-destination")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo,
+            displayName: "create-existing-destination",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let existing = try #require(state.projectsManager.worktrees(projectId: project.id).first)
+
+        let id = state.createWorktree(
+            projectId: project.id,
+            base: "main",
+            branch: "existing-path",
+            destination: existing.path,
+            runStartup: false,
+            openTerminal: false
+        )
+
+        #expect(id.isEmpty)
+        #expect(state.projectsManager.operationState(for: existing.id) == nil)
+        #expect(state.projectsManager.worktrees(projectId: project.id).filter { $0.id == existing.id }.count == 1)
+    }
+
     @Test func createWorktreeFailureLeavesFailedRow() async throws {
         let repo = try await makeRepo(name: "create-fail")
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -198,6 +224,42 @@ struct AppStateCleanupTests {
         } else {
             Issue.record("Expected createFailed state")
         }
+    }
+
+    @Test func createWorktreeRetryAllowsFailedOptimisticDestination() async throws {
+        let repo = try await makeRepo(name: "create-retry")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "create-retry", color: "#5fb7c4")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let dest = repo.appendingPathComponent("wt-retry")
+        let failedId = state.createWorktree(
+            projectId: project.id,
+            base: "missing-base",
+            branch: "retry-b",
+            destination: dest,
+            runStartup: false,
+            openTerminal: false
+        )
+        try await waitForOperationStateMatching(state.projectsManager, id: failedId) { state in
+            if case .createFailed = state { return true }
+            return false
+        }
+
+        let retryId = state.createWorktree(
+            projectId: project.id,
+            base: "main",
+            branch: "retry-b",
+            destination: dest,
+            runStartup: false,
+            openTerminal: false
+        )
+
+        #expect(retryId == failedId)
+        #expect(state.projectsManager.operationState(for: retryId) == .creating)
+        try await waitForOperationState(state.projectsManager, id: retryId, equals: nil)
+        #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == retryId })
     }
 
     @Test func deleteWorktreeMarksDeletingImmediately() async throws {

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -193,7 +193,7 @@ struct AppStateCleanupTests {
         }
 
         #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == id })
-        if case .createFailed(let message) = state.projectsManager.operationState(for: id) {
+        if case .createFailed(let message, _) = state.projectsManager.operationState(for: id) {
             #expect(!message.isEmpty)
         } else {
             Issue.record("Expected createFailed state")

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -144,4 +144,95 @@ struct AppStateCleanupTests {
         #expect(state.tabs.tabs(forWorktree: treesA[0].id).isEmpty)
         #expect(state.tabs.tabs(forWorktree: treesB[0].id).count == 1)
     }
+
+    @Test func createWorktreeInsertsOptimisticRowImmediately() async throws {
+        let repo = try await makeRepo(name: "create-opt")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "create-opt", color: "#5fb7c4")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let dest = repo.appendingPathComponent("wt-opt")
+        let id = state.createWorktree(
+            projectId: project.id,
+            base: "main",
+            branch: "opt-b",
+            destination: dest,
+            runStartup: false,
+            openTerminal: false
+        )
+        #expect(!id.isEmpty)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.contains { $0.id == id })
+        #expect(state.projectsManager.operationState(for: id) == .creating)
+
+        try await waitForOperationState(state.projectsManager, id: id, equals: nil)
+        #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == id })
+    }
+
+    @Test func createWorktreeFailureLeavesFailedRow() async throws {
+        let repo = try await makeRepo(name: "create-fail")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "create-fail", color: "#5fb7c4")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let dest = repo.appendingPathComponent("wt-fail")
+        let id = state.createWorktree(
+            projectId: project.id,
+            base: "missing-base",
+            branch: "fail-b",
+            destination: dest,
+            runStartup: false,
+            openTerminal: false
+        )
+
+        try await waitForOperationStateMatching(state.projectsManager, id: id) { state in
+            if case .createFailed = state { return true }
+            return false
+        }
+
+        #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == id })
+        if case .createFailed(let message) = state.projectsManager.operationState(for: id) {
+            #expect(!message.isEmpty)
+        } else {
+            Issue.record("Expected createFailed state")
+        }
+    }
+
+    @Test func deleteWorktreeMarksDeletingImmediately() async throws {
+        let repo = try await makeRepo(name: "delete-mark")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "delete-mark", color: "#5fb7c4")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        let wt = trees[0]
+
+        state.projectsManager.setOperationState(id: wt.id, state: .deleting)
+        #expect(state.projectsManager.operationState(for: wt.id) == .deleting)
+    }
+
+    private func waitForOperationState(
+        _ manager: ProjectsManager,
+        id: String,
+        equals expected: WorktreeOperationState?
+    ) async throws {
+        try await waitForOperationStateMatching(manager, id: id) { $0 == expected }
+    }
+
+    private func waitForOperationStateMatching(
+        _ manager: ProjectsManager,
+        id: String,
+        matches: (WorktreeOperationState?) -> Bool
+    ) async throws {
+        for _ in 0..<80 {
+            if matches(manager.operationState(for: id)) {
+                return
+            }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        Issue.record("Timed out waiting for operation state")
+    }
 }

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -95,19 +95,15 @@ struct NewWorktreeDialogTests {
     }
 
     @Test func canCreateRequiresProjects() {
-        #expect(!NewWorktreeDialog.canCreate(projectsEmpty: true, branchEmpty: false, isCreating: false))
+        #expect(!NewWorktreeDialog.canCreate(projectsEmpty: true, branchEmpty: false))
     }
 
     @Test func canCreateRequiresBranch() {
-        #expect(!NewWorktreeDialog.canCreate(projectsEmpty: false, branchEmpty: true, isCreating: false))
-    }
-
-    @Test func canCreateBlockWhileCreating() {
-        #expect(!NewWorktreeDialog.canCreate(projectsEmpty: false, branchEmpty: false, isCreating: true))
+        #expect(!NewWorktreeDialog.canCreate(projectsEmpty: false, branchEmpty: true))
     }
 
     @Test func canCreateSucceedsWithProjectsAndBranch() {
-        #expect(NewWorktreeDialog.canCreate(projectsEmpty: false, branchEmpty: false, isCreating: false))
+        #expect(NewWorktreeDialog.canCreate(projectsEmpty: false, branchEmpty: false))
     }
 
     private static func project(id: String) -> ProjectConfig {

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -293,12 +293,12 @@ extension ProjectsManagerTests {
             lastActivity: Date()
         )
         mgr.insertOptimisticWorktree(optimistic)
-        mgr.setOperationState(id: optimistic.id, state: .createFailed(message: "disk full"))
+        mgr.setOperationState(id: optimistic.id, state: .createFailed(message: "disk full", base: "main"))
 
         try await mgr.refreshWorktrees(projectId: project.id)
         let trees = mgr.worktrees(projectId: project.id)
         #expect(trees.contains { $0.id == optimistic.id })
-        #expect(mgr.operationState(for: optimistic.id) == .createFailed(message: "disk full"))
+        #expect(mgr.operationState(for: optimistic.id) == .createFailed(message: "disk full", base: "main"))
     }
 
     @Test func refreshClearsCreateFailedWhenWorktreeAppears() async throws {
@@ -319,7 +319,7 @@ extension ProjectsManagerTests {
         )
         try await mgr.refreshWorktrees(projectId: project.id)
 
-        mgr.setOperationState(id: worktree.id, state: .createFailed(message: "transient"))
+        mgr.setOperationState(id: worktree.id, state: .createFailed(message: "transient", base: "main"))
         try await mgr.refreshWorktrees(projectId: project.id)
 
         #expect(mgr.operationState(for: worktree.id) == nil)

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -341,4 +341,31 @@ extension ProjectsManagerTests {
         #expect(mgr.worktrees(projectId: project.id).contains { $0.id == worktree.id })
         #expect(mgr.operationState(for: worktree.id) == .deleteFailed(message: "permission denied"))
     }
+
+    @Test func refreshClearsDeleteFailedWhenWorktreeDisappears() async throws {
+        let repo = try await makeRepo(name: "delete-failed-gone")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "delete-failed-gone", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        let svc = WorktreeService()
+        let dest = repo.appendingPathComponent("wt-delete-fail")
+        let worktree = try await svc.add(
+            repoPath: repo,
+            base: "main",
+            branch: "delete-fail-b",
+            destination: dest,
+            projectId: project.id
+        )
+        try await mgr.refreshWorktrees(projectId: project.id)
+        mgr.setOperationState(id: worktree.id, state: .deleteFailed(message: "permission denied"))
+
+        // Simulate external removal; refresh should drop the ghost row.
+        try await svc.remove(repoPath: repo, worktree: worktree, deleteBranchIfMerged: false, force: false)
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        #expect(!mgr.worktrees(projectId: project.id).contains { $0.id == worktree.id })
+        #expect(mgr.operationState(for: worktree.id) == nil)
+    }
 }

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -301,6 +301,32 @@ extension ProjectsManagerTests {
         #expect(mgr.operationState(for: optimistic.id) == .createFailed(message: "disk full"))
     }
 
+    @Test func refreshClearsCreateFailedWhenWorktreeAppears() async throws {
+        let repo = try await makeRepo(name: "create-failed-live")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "create-failed-live", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        let svc = WorktreeService()
+        let dest = repo.appendingPathComponent("wt-cf-live")
+        let worktree = try await svc.add(
+            repoPath: repo,
+            base: "main",
+            branch: "cf-live-b",
+            destination: dest,
+            projectId: project.id
+        )
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        mgr.setOperationState(id: worktree.id, state: .createFailed(message: "transient"))
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        #expect(mgr.operationState(for: worktree.id) == nil)
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.contains { $0.id == worktree.id })
+    }
+
     @Test func refreshClearsDeletingStateWhenWorktreeDisappears() async throws {
         let repo = try await makeRepo(name: "delete-clear")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -188,4 +188,157 @@ extension ProjectsManagerTests {
         let gcDropped = try await mgr.refreshWorktrees(projectId: project.id)
         #expect(!gcDropped)
     }
+
+    @Test func optimisticWorktreeAppearsImmediately() async throws {
+        let repo = try await makeRepo(name: "optimistic")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "optimistic", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+        let before = mgr.worktrees(projectId: project.id)
+        #expect(before.count == 1)
+
+        let dest = repo.appendingPathComponent("wt-new")
+        let optimistic = Worktree(
+            id: Worktree.makeId(path: dest),
+            projectId: project.id,
+            name: "feat-x",
+            branch: "feat-x",
+            path: dest,
+            status: .clean,
+            lastActivity: Date()
+        )
+        mgr.insertOptimisticWorktree(optimistic)
+        mgr.setOperationState(id: optimistic.id, state: .creating)
+
+        let after = mgr.worktrees(projectId: project.id)
+        #expect(after.count == 2)
+        #expect(after.contains { $0.id == optimistic.id })
+        #expect(mgr.operationState(for: optimistic.id) == .creating)
+
+        mgr.insertOptimisticWorktree(optimistic)
+        #expect(mgr.worktrees(projectId: project.id).filter { $0.id == optimistic.id }.count == 1)
+    }
+
+    @Test func refreshReconcilesCreatingWorktree() async throws {
+        let repo = try await makeRepo(name: "reconcile")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "reconcile", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        let svc = WorktreeService()
+        let dest = repo.appendingPathComponent("wt-reconcile")
+        _ = try await svc.add(repoPath: repo, base: "main", branch: "reconcile-b", destination: dest, projectId: project.id)
+
+        let optimistic = Worktree(
+            id: Worktree.makeId(path: dest),
+            projectId: project.id,
+            name: "reconcile-b",
+            branch: "reconcile-b",
+            path: dest,
+            status: .clean,
+            lastActivity: Date()
+        )
+        mgr.insertOptimisticWorktree(optimistic)
+        mgr.setOperationState(id: optimistic.id, state: .creating)
+
+        try await mgr.refreshWorktrees(projectId: project.id)
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.contains { $0.id == optimistic.id })
+        #expect(mgr.operationState(for: optimistic.id) == nil)
+    }
+
+    @Test func refreshKeepsCreatingWorktreeUntilGitSeesIt() async throws {
+        let repo = try await makeRepo(name: "creating-pending")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "creating-pending", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        let dest = repo.appendingPathComponent("wt-pending")
+        let optimistic = Worktree(
+            id: Worktree.makeId(path: dest),
+            projectId: project.id,
+            name: "pending-b",
+            branch: "pending-b",
+            path: dest,
+            status: .clean,
+            lastActivity: Date()
+        )
+        mgr.insertOptimisticWorktree(optimistic)
+        mgr.setOperationState(id: optimistic.id, state: .creating)
+
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        #expect(mgr.worktrees(projectId: project.id).contains { $0.id == optimistic.id })
+        #expect(mgr.operationState(for: optimistic.id) == .creating)
+    }
+
+    @Test func refreshPreservesFailedWorktree() async throws {
+        let repo = try await makeRepo(name: "fail-preserve")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "fail-preserve", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        let dest = repo.appendingPathComponent("wt-fail")
+        let optimistic = Worktree(
+            id: Worktree.makeId(path: dest),
+            projectId: project.id,
+            name: "fail-b",
+            branch: "fail-b",
+            path: dest,
+            status: .clean,
+            lastActivity: Date()
+        )
+        mgr.insertOptimisticWorktree(optimistic)
+        mgr.setOperationState(id: optimistic.id, state: .createFailed(message: "disk full"))
+
+        try await mgr.refreshWorktrees(projectId: project.id)
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.contains { $0.id == optimistic.id })
+        #expect(mgr.operationState(for: optimistic.id) == .createFailed(message: "disk full"))
+    }
+
+    @Test func refreshClearsDeletingStateWhenWorktreeDisappears() async throws {
+        let repo = try await makeRepo(name: "delete-clear")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "delete-clear", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        let svc = WorktreeService()
+        let dest = repo.appendingPathComponent("wt-delete")
+        let worktree = try await svc.add(
+            repoPath: repo,
+            base: "main",
+            branch: "delete-b",
+            destination: dest,
+            projectId: project.id
+        )
+        try await mgr.refreshWorktrees(projectId: project.id)
+        mgr.setOperationState(id: worktree.id, state: .deleting)
+
+        try await svc.remove(repoPath: repo, worktree: worktree, deleteBranchIfMerged: false, force: false)
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        #expect(!mgr.worktrees(projectId: project.id).contains { $0.id == worktree.id })
+        #expect(mgr.operationState(for: worktree.id) == nil)
+    }
+
+    @Test func refreshPreservesDeleteFailedStateForLiveWorktree() async throws {
+        let repo = try await makeRepo(name: "delete-failed")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let mgr = ProjectsManager(persistedProjects: [])
+        let project = try await mgr.addProject(path: repo, displayName: "delete-failed", color: "#5fb7c4")
+        try await mgr.refreshWorktrees(projectId: project.id)
+        let worktree = try #require(mgr.worktrees(projectId: project.id).first)
+
+        mgr.setOperationState(id: worktree.id, state: .deleteFailed(message: "permission denied"))
+        try await mgr.refreshWorktrees(projectId: project.id)
+
+        #expect(mgr.worktrees(projectId: project.id).contains { $0.id == worktree.id })
+        #expect(mgr.operationState(for: worktree.id) == .deleteFailed(message: "permission denied"))
+    }
 }


### PR DESCRIPTION
## Summary

- Worktree create/delete operations are now fully asynchronous in the UI. Optimistic rows appear immediately with `Creating...` / `Deleting...` states while Git operations run in the background.
- The app stays interactive throughout. Failures explicitly surface as retry/remove row states instead of blocking or silently failing.
- `WorktreeOperationState` is a side-table in `ProjectsManager` keyed by worktree id — no Codable/persistence churn on `Worktree` or `WorktreeStatus`.
- `AppState.createWorktree(...)` returns immediately after optimistic insert; `NewWorktreeDialog` closes instantly.
- `AppState.deleteWorktree(_:)` marks `.deleting` before async task; force-delete prompt correctly transitions out of and back into `.deleting`.
- `RootView.selectedWorktree()` returns `nil` for `.creating`/`.deleting` rows, preventing content panes from accessing nonexistent paths.
- `WorktreeRowView` renders pending states as dimmed with status text, and failed states with error text and context-menu retry/remove/copy-error actions.
- Git/filesystem work runs in detached `Task` blocks; only state mutations are `@MainActor`.
- Added tests for optimistic insert, create success/failure reconciliation, deleting-state clearing, and failed-state persistence through refresh.

## Test plan

- [x] All 584 existing tests pass
- [x] New `AppStateTests` cover optimistic insert, reconciliation on success and pending, failed-state persistence through refresh, deleting-state clearing, and delete-failed preservation
- [ ] Manual: create a worktree and verify `Creating...` row appears immediately, transitions to normal on success
- [ ] Manual: create a worktree with an invalid branch and verify `Create failed` row with retry/remove/copy-error actions
- [ ] Manual: delete a worktree and verify `Deleting...` state, row removal on success
- [ ] Manual: delete a dirty worktree and verify force-delete prompt appears, `.deleting` transitions correctly