### PR TITLE
fix: prevent app hang when deleting a dirty worktree

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -24,6 +24,20 @@ final class AppState {
     private var lspManager: WorkspaceLSPManager?
 
     var isSearchOpen: Bool = false
+
+    /// Set when a worktree deletion fails because the tree is dirty.
+    /// The UI presents a confirmation dialog; confirming retries with force.
+    struct PendingForceDeleteWorktree: Identifiable, Equatable {
+        let id: String           // worktree id
+        let branch: String
+        let projectId: String
+        let repoPath: URL        // git root (project.path)
+        let worktreePath: URL    // actual worktree path
+        let deleteBranchIfMerged: Bool
+        let removedIndex: Int
+    }
+    var pendingForceDeleteWorktree: PendingForceDeleteWorktree?
+
     @ObservationIgnored
     lazy var search: SearchModel = SearchModel(environment: makeSearchEnvironment())
     @ObservationIgnored
@@ -921,7 +935,8 @@ final class AppState {
     }
 
     /// Delete a worktree from disk. Shows a confirm dialog; on dirty-tree
-    /// failure offers a force retry. Cleans up in-app state on success.
+    /// failure sets `pendingForceDeleteWorktree` so SwiftUI can present a
+    /// state-driven confirmation. Cleans up in-app state on success.
     func deleteWorktree(_ worktree: Worktree) {
         let dirty = dirtyEditorTabIds(worktreeId: worktree.id)
         let saveBuffersFirst: Bool
@@ -957,69 +972,112 @@ final class AppState {
         projectsManager.setOperationState(id: worktree.id, state: .deleting)
 
         Task { @MainActor in
-            do {
-                try await Self.performRemoveWorktree(
+            await performDeleteWorktree(
+                worktree: worktree,
+                repoPath: repoPath,
+                deleteBranchIfMerged: deleteBranch,
+                force: false,
+                removedIndex: removedIndex
+            )
+        }
+    }
+
+    /// Runs the git removal off the main actor, then resumes on MainActor
+    /// for state cleanup. On dirty-worktree failure publishes
+    /// `pendingForceDeleteWorktree` instead of showing a blocking modal.
+    private func performDeleteWorktree(
+        worktree: Worktree,
+        repoPath: URL,
+        deleteBranchIfMerged: Bool,
+        force: Bool,
+        removedIndex: Int
+    ) async {
+        do {
+            try await Self.performRemoveWorktree(
+                repoPath: repoPath,
+                worktree: worktree,
+                deleteBranchIfMerged: deleteBranchIfMerged,
+                force: force
+            )
+        } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
+            if !force && Self.looksLikeDirtyWorktreeError(stderr) {
+                // Clear deleting so the user can see the row again while deciding.
+                projectsManager.setOperationState(id: worktree.id, state: nil)
+                pendingForceDeleteWorktree = PendingForceDeleteWorktree(
+                    id: worktree.id,
+                    branch: worktree.branch,
+                    projectId: worktree.projectId,
                     repoPath: repoPath,
-                    worktree: worktree,
-                    deleteBranchIfMerged: deleteBranch,
-                    force: false
+                    worktreePath: worktree.path,
+                    deleteBranchIfMerged: deleteBranchIfMerged,
+                    removedIndex: removedIndex
                 )
-            } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
-                if Self.looksLikeDirtyWorktreeError(stderr) {
-                    // Clear deleting so the user can see the row again while deciding.
-                    projectsManager.setOperationState(id: worktree.id, state: nil)
-                    guard confirmForceDeleteWorktree(branch: worktree.branch) else { return }
-                    // Re-mark deleting before force attempt.
-                    projectsManager.setOperationState(id: worktree.id, state: .deleting)
-                    do {
-                        try await Self.performRemoveWorktree(
-                            repoPath: repoPath,
-                            worktree: worktree,
-                            deleteBranchIfMerged: deleteBranch,
-                            force: true
-                        )
-                    } catch let WorktreeService.WorktreeError.gitFailed(stderr2) {
-                        projectsManager.setOperationState(
-                            id: worktree.id,
-                            state: .deleteFailed(message: stderr2)
-                        )
-                        return
-                    } catch {
-                        projectsManager.setOperationState(
-                            id: worktree.id,
-                            state: .deleteFailed(message: "\(error)")
-                        )
-                        return
-                    }
-                } else {
-                    projectsManager.setOperationState(
-                        id: worktree.id,
-                        state: .deleteFailed(message: stderr)
-                    )
-                    return
-                }
-            } catch {
+                return
+            } else {
                 projectsManager.setOperationState(
                     id: worktree.id,
-                    state: .deleteFailed(message: "\(error)")
+                    state: .deleteFailed(message: stderr)
                 )
                 return
             }
-
-            cleanupWorktreeState(worktreeId: worktree.id)
-            // Always clear the deleting state after a successful remove,
-            // even if the subsequent refresh fails.
-            projectsManager.setOperationState(id: worktree.id, state: nil)
-            if (try? await projectsManager.refreshWorktrees(projectId: worktree.projectId)) == true {
-                saveProjects()
-            }
-            if selectedWorktreeId == worktree.id {
-                selectedWorktreeId = selectionAfterRemoval(
-                    removedFromProjectId: worktree.projectId,
-                    removedAtIndex: removedIndex
-                )
-            }
+        } catch {
+            projectsManager.setOperationState(
+                id: worktree.id,
+                state: .deleteFailed(message: "\(error)")
+            )
+            return
         }
+
+        cleanupWorktreeState(worktreeId: worktree.id)
+        // Always clear the deleting state after a successful remove,
+        // even if the subsequent refresh fails.
+        projectsManager.setOperationState(id: worktree.id, state: nil)
+        if (try? await projectsManager.refreshWorktrees(projectId: worktree.projectId)) == true {
+            saveProjects()
+        }
+        if selectedWorktreeId == worktree.id {
+            selectedWorktreeId = selectionAfterRemoval(
+                removedFromProjectId: worktree.projectId,
+                removedAtIndex: removedIndex
+            )
+        }
+    }
+
+    /// Called from the SwiftUI alert when the user confirms force delete.
+    func confirmForceDeletePendingWorktree() {
+        guard let pending = pendingForceDeleteWorktree else { return }
+        pendingForceDeleteWorktree = nil
+
+        guard let project = projects.first(where: { $0.id == pending.projectId }),
+              projectsManager.worktrees(projectId: pending.projectId).contains(where: { $0.id == pending.id })
+        else { return }
+
+        let worktree = Worktree(
+            id: pending.id,
+            projectId: pending.projectId,
+            name: pending.branch,
+            branch: pending.branch,
+            path: pending.worktreePath,
+            status: .clean,
+            lastActivity: Date()
+        )
+
+        projectsManager.setOperationState(id: pending.id, state: .deleting)
+
+        Task { @MainActor in
+            await performDeleteWorktree(
+                worktree: worktree,
+                repoPath: pending.repoPath,
+                deleteBranchIfMerged: pending.deleteBranchIfMerged,
+                force: true,
+                removedIndex: pending.removedIndex
+            )
+        }
+    }
+
+    /// Called from the SwiftUI alert when the user cancels force delete.
+    func cancelForceDeletePendingWorktree() {
+        pendingForceDeleteWorktree = nil
     }
 
     nonisolated private static func performRemoveWorktree(
@@ -1041,7 +1099,7 @@ final class AppState {
     /// Permissive substring check: git's exact wording around dirty/locked
     /// worktrees varies by version. If the match misses, the caller surfaces
     /// the raw stderr instead, which is acceptable degradation.
-    nonisolated private static func looksLikeDirtyWorktreeError(_ stderr: String) -> Bool {
+    nonisolated static func looksLikeDirtyWorktreeError(_ stderr: String) -> Bool {
         let s = stderr.lowercased()
         return s.contains("is dirty")
             || s.contains("contains modified or untracked files")
@@ -1056,17 +1114,6 @@ final class AppState {
         let deleteButton = alert.addButton(withTitle: "Delete")
         alert.addButton(withTitle: "Cancel")
         deleteButton.hasDestructiveAction = true
-        return alert.runModal() == .alertFirstButtonReturn
-    }
-
-    private func confirmForceDeleteWorktree(branch: String) -> Bool {
-        let alert = NSAlert()
-        alert.messageText = "'\(branch)' has uncommitted changes."
-        alert.informativeText = "Force delete? Any uncommitted work in this worktree will be lost."
-        alert.alertStyle = .warning
-        let forceButton = alert.addButton(withTitle: "Force Delete")
-        alert.addButton(withTitle: "Cancel")
-        forceButton.hasDestructiveAction = true
         return alert.runModal() == .alertFirstButtonReturn
     }
 

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -111,6 +111,24 @@ struct RootView: View {
                 presetProjectId: newWorktreePresetProjectId
             )
         }
+        .alert(
+            "'\(state.pendingForceDeleteWorktree?.branch ?? "")' has uncommitted changes.",
+            isPresented: Binding(
+                get: { state.pendingForceDeleteWorktree != nil },
+                set: { if !$0 { state.cancelForceDeletePendingWorktree() } }
+            ),
+            actions: {
+                Button("Force Delete", role: .destructive) {
+                    state.confirmForceDeletePendingWorktree()
+                }
+                Button("Cancel", role: .cancel) {
+                    state.cancelForceDeletePendingWorktree()
+                }
+            },
+            message: {
+                Text("Force delete? Any uncommitted work in this worktree will be lost.")
+            }
+        )
         .task {
             state.startHarness()
             if await state.projectsManager.refreshAll() {

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -290,9 +290,9 @@ struct AppStateCleanupTests {
         let repo = try await makeRepo(name: "cancel-force")
         defer { try? FileManager.default.removeItem(at: repo) }
         let state = AppState()
-        _ = try await state.projectsManager.addProject(path: repo, displayName: "cancel-force", color: "#5fb7c4")
-        try await state.projectsManager.refreshWorktrees(projectId: state.projects.projects[0].id)
-        let trees = state.projectsManager.worktrees(projectId: state.projects.projects[0].id)
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "cancel-force", color: "#5fb7c4")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
         let wt = try #require(trees.first)
 
         state.pendingForceDeleteWorktree = AppState.PendingForceDeleteWorktree(

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -276,6 +276,41 @@ struct AppStateCleanupTests {
         #expect(state.projectsManager.operationState(for: wt.id) == .deleting)
     }
 
+    // MARK: - Dirty-worktree force-delete state
+
+    @Test func looksLikeDirtyWorktreeErrorMatchesKnownPatterns() {
+        #expect(AppState.looksLikeDirtyWorktreeError("Cannot delete a dirty worktree"))
+        #expect(AppState.looksLikeDirtyWorktreeError("fatal: 'foo' contains modified or untracked files"))
+        #expect(AppState.looksLikeDirtyWorktreeError("worktree is dirty and cannot be removed"))
+        #expect(!AppState.looksLikeDirtyWorktreeError("fatal: not a git repository"))
+        #expect(!AppState.looksLikeDirtyWorktreeError(""))
+    }
+
+    @Test func cancelForceDeleteClearsPendingState() async throws {
+        let repo = try await makeRepo(name: "cancel-force")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState()
+        _ = try await state.projectsManager.addProject(path: repo, displayName: "cancel-force", color: "#5fb7c4")
+        try await state.projectsManager.refreshWorktrees(projectId: state.projects.projects[0].id)
+        let trees = state.projectsManager.worktrees(projectId: state.projects.projects[0].id)
+        let wt = try #require(trees.first)
+
+        state.pendingForceDeleteWorktree = AppState.PendingForceDeleteWorktree(
+            id: wt.id,
+            branch: wt.branch,
+            projectId: wt.projectId,
+            repoPath: repo,
+            worktreePath: wt.path,
+            deleteBranchIfMerged: false,
+            removedIndex: 0
+        )
+        #expect(state.pendingForceDeleteWorktree != nil)
+
+        state.cancelForceDeletePendingWorktree()
+        #expect(state.pendingForceDeleteWorktree == nil)
+        #expect(state.projectsManager.operationState(for: wt.id) == nil)
+    }
+
     private func waitForOperationState(
         _ manager: ProjectsManager,
         id: String,


### PR DESCRIPTION
## Summary

- Replace `NSAlert.runModal()` with state-driven SwiftUI confirmation for the dirty-worktree force-delete path, eliminating the main-thread deadlock beachball
- Fix critical path bug where `pending.repoPath` was used instead of `pending.worktreePath` in force-delete retry, which would have targeted the git root instead of the worktree
- Add `.alert` binding on `RootView` for `pendingForceDeleteWorktree` state so users actually see the force-delete prompt
- Remove dead `confirmForceDeleteWorktree(branch:)` method that used the blocking modal pattern
- Open up `looksLikeDirtyWorktreeError` to `internal` access for testability
- Add regression tests: dirty error pattern matching, cancel clears pending state

Fixes #816

## Root Cause

`NSAlert.runModal()` was called inside a `Task { @MainActor in }` block after an `await` suspension point. When `git worktree remove` failed with a "dirty worktree" error, the catch handler invoked the synchronous modal dialog, which spins a nested run loop conflicting with Swift concurrency's cooperative executor, causing a deadlock/beachball.

## Reproduction Path

Delete a worktree that has uncommitted changes → git returns "is dirty" error → code tries to show force-delete dialog inside async task → hang/beachball.

## Test plan

- [ ] Create a worktree with uncommitted changes, attempt delete, verify force-delete alert appears as SwiftUI dialog
- [ ] Confirm that the app remains responsive while the dialog is shown
- [ ] Cancel the force-delete dialog and verify the worktree is restored (no longer .deleting)
- [ ] Force-delete a dirty worktree and verify it gets removed correctly