### PR TITLE
feat: auto-refresh sidebar on branch/worktree changes without taking git locks

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -261,6 +261,7 @@
 		E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA8FEE64D73BDEBAF74878 /* Kbd.swift */; };
 		E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */; };
 		E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66950F2226F1182DCDD39A /* RightPaneView.swift */; };
+		E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */; };
 		E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
@@ -408,6 +409,7 @@
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
 		65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstaller.swift; sourceTree = "<group>"; };
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
+		670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherFilterTests.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
 		6A190D4B29B35C457AA9829F /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
@@ -679,6 +681,7 @@
 				88379ACE40F42BE4A3257659 /* ThemeTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
+				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
 				321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 			);
@@ -1623,6 +1626,7 @@
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
+				E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */,
 				98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */; };
 		12035048B950CE0197604F89 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CE7B4DAFDB65A79308FB63 /* GitService.swift */; };
 		139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */; };
+		14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2EB554CB6AF797545DB95D /* HeadReader.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
@@ -71,6 +72,7 @@
 		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
+		3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
@@ -349,6 +351,7 @@
 		2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficLights.swift; sourceTree = "<group>"; };
 		2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDiffView.swift; sourceTree = "<group>"; };
 		2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstallerTests.swift; sourceTree = "<group>"; };
+		2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReaderTests.swift; sourceTree = "<group>"; };
 		30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorCoordinator.swift; sourceTree = "<group>"; };
 		321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherTests.swift; sourceTree = "<group>"; };
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
@@ -512,6 +515,7 @@
 		CA554728676F9D3B5E2C05FA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroup.swift; sourceTree = "<group>"; };
 		CB020862232495EC1C5ECBEA /* WindowAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearance.swift; sourceTree = "<group>"; };
+		CB2EB554CB6AF797545DB95D /* HeadReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReader.swift; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
@@ -648,6 +652,7 @@
 				271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */,
 				F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */,
 				F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */,
+				2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */,
 				23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */,
 				A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */,
 				835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */,
@@ -722,6 +727,7 @@
 				339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */,
 				B7CE7B4DAFDB65A79308FB63 /* GitService.swift */,
 				27A92711BC1D9A78D8A80561 /* GitTypes.swift */,
+				CB2EB554CB6AF797545DB95D /* HeadReader.swift */,
 				C6CA79B71B4AA72697392702 /* NumstatParser.swift */,
 				79DDEA496740F5B0B5EE808B /* Process+Git.swift */,
 				91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */,
@@ -1441,6 +1447,7 @@
 				3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */,
 				18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */,
 				90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */,
+				14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */,
 				C512EC7827D3C46907DDB7A1 /* HighlightCapture.swift in Sources */,
 				387EF12B6875648E422956F7 /* Highlighted.swift in Sources */,
 				AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */,
@@ -1585,6 +1592,7 @@
 				9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */,
 				D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */,
 				8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */,
+				3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */,
 				D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */,
 				D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */,
 				89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		7B85B033B476943E77867BA3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69024633944E9FFF6DA76FAE /* RootView.swift */; };
 		7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */; };
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
+		7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4575017544CD7603B3AB9069 /* GitEventFilter.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
@@ -241,6 +242,7 @@
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
 		D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */; };
 		D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */; };
+		D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */; };
 		D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */; };
 		D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
@@ -375,6 +377,7 @@
 		4261E417947C1A21E77C1587 /* GitStatusCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCache.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
+		4575017544CD7603B3AB9069 /* GitEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilter.swift; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
 		4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTabBar.swift; sourceTree = "<group>"; };
@@ -516,6 +519,7 @@
 		D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewShortcutTests.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
+		D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilterTests.swift; sourceTree = "<group>"; };
 		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D6A9977C979705A40595FD5E /* TabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerTests.swift; sourceTree = "<group>"; };
@@ -636,6 +640,7 @@
 				A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */,
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
+				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
 				039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */,
 				B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */,
 				271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */,
@@ -1187,6 +1192,7 @@
 			isa = PBXGroup;
 			children = (
 				A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */,
+				4575017544CD7603B3AB9069 /* GitEventFilter.swift */,
 				D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */,
 			);
 			path = Watch;
@@ -1424,6 +1430,7 @@
 				466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,
 				41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */,
+				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,
 				12035048B950CE0197604F89 /* GitService.swift in Sources */,
 				676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */,
 				7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */,
@@ -1569,6 +1576,7 @@
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */,
+				D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */,
 				E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */,
 				A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */,
 				9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
+		BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */; };
 		BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88379ACE40F42BE4A3257659 /* ThemeTests.swift */; };
 		BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */; };
 		BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */; };
@@ -495,6 +496,7 @@
 		B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCacheTests.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
+		BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerHeadUpdatesTests.swift; sourceTree = "<group>"; };
 		BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfig.swift; sourceTree = "<group>"; };
 		BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcher.swift; sourceTree = "<group>"; };
 		BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManager.swift; sourceTree = "<group>"; };
@@ -672,6 +674,7 @@
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
 				5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */,
 				00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */,
+				BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
@@ -1618,6 +1621,7 @@
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
 				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,
 				4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */,
+				BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
 		29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */; };
+		2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
 		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
 		2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768D12909DD5233659AC4E03 /* RepoGroupView.swift */; };
@@ -281,6 +282,7 @@
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
 		F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */; };
+		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -450,6 +452,7 @@
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
+		8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcherTests.swift; sourceTree = "<group>"; };
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
@@ -524,6 +527,7 @@
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
+		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
 		D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewShortcutTests.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
@@ -673,6 +677,7 @@
 				7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */,
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
 				5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */,
+				8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */,
 				00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */,
 				BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
@@ -1205,6 +1210,7 @@
 			children = (
 				A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */,
 				4575017544CD7603B3AB9069 /* GitEventFilter.swift */,
+				D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */,
 				D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */,
 			);
 			path = Watch;
@@ -1489,6 +1495,7 @@
 				671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */,
 				C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */,
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
+				F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */,
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
@@ -1620,6 +1627,7 @@
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
 				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,
+				2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */,
 				4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */,
 				BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -40,6 +40,11 @@ final class AppState {
 
     private let store = PersistenceStore()
 
+    /// One FSEvents watcher per project, watching `<repo>/.git` to auto-refresh
+    /// the sidebar when branches flip or worktrees appear/disappear externally.
+    @ObservationIgnored
+    private var projectGitWatchers: [String: ProjectGitWatcher] = [:]
+
     init() {
         let config = (try? store.readIfExists(AppConfig.self, from: Paths.appConfigFile)) ?? AppConfig.defaults
         let projectsFile = (try? store.readIfExists(ProjectsFile.self, from: Paths.projectsFile)) ?? ProjectsFile(projects: [])
@@ -229,16 +234,58 @@ final class AppState {
     }
 
     func addProject(path: URL, displayName: String, color: String) async throws {
-        _ = try await projectsManager.addProject(path: path, displayName: displayName, color: color)
+        let project = try await projectsManager.addProject(path: path, displayName: displayName, color: color)
         saveProjects()
         if await projectsManager.refreshAll() {
             saveProjects()
         }
+        startProjectGitWatcher(for: project)
     }
 
     func removeProject(id: String) {
+        stopProjectGitWatcher(projectId: id)
         projectsManager.removeProject(id: id)
         saveProjects()
+    }
+
+    /// Start a ProjectGitWatcher for `project` and wire its callbacks into
+    /// the fast (HEAD-only) and slow (topology) refresh paths. Idempotent:
+    /// stops any existing watcher for the same project id first.
+    func startProjectGitWatcher(for project: ProjectConfig) {
+        stopProjectGitWatcher(projectId: project.id)
+        let watcher = ProjectGitWatcher(repoPath: URL(fileURLWithPath: project.path))
+        let projectId = project.id
+        watcher.onHeadChanged = { [weak self] map in
+            self?.projectsManager.applyHeadUpdates(
+                projectId: projectId,
+                branchByWorktreePath: map
+            )
+        }
+        watcher.onTopologyChanged = { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                let beforeIds = self.allWorktreeIds()
+                _ = try? await self.projectsManager.refreshWorktrees(projectId: projectId)
+                self.cleanupMissingWorktrees(beforeIds: beforeIds)
+            }
+        }
+        watcher.start()
+        projectGitWatchers[projectId] = watcher
+    }
+
+    func stopProjectGitWatcher(projectId: String) {
+        projectGitWatchers.removeValue(forKey: projectId)?.stop()
+    }
+
+    func startAllProjectGitWatchers() {
+        for project in projectsManager.projects {
+            startProjectGitWatcher(for: project)
+        }
+    }
+
+    func stopAllProjectGitWatchers() {
+        for (_, watcher) in projectGitWatchers { watcher.stop() }
+        projectGitWatchers.removeAll()
     }
 
     func updateProject(id: String, name: String, color: String, startupScripts: ProjectStartupScripts) {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -265,7 +265,12 @@ final class AppState {
             Task { @MainActor in
                 guard let self else { return }
                 let beforeIds = self.allWorktreeIds()
-                _ = try? await self.projectsManager.refreshWorktrees(projectId: projectId)
+                // refreshWorktrees returns true when the hidden-path GC dropped
+                // entries — persist so archived worktrees removed externally
+                // don't reappear after relaunch.
+                if (try? await self.projectsManager.refreshWorktrees(projectId: projectId)) == true {
+                    self.saveProjects()
+                }
                 self.cleanupMissingWorktrees(beforeIds: beforeIds)
             }
         }

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -190,6 +190,40 @@ final class ProjectsManager {
         return changed
     }
 
+    /// Fast-path branch label update. Patches `branch` (and `name`, since
+    /// name == branch in the current model) for any worktree whose
+    /// canonicalized path matches a key in `branchByWorktreePath`. Worktrees
+    /// not present in the map are left alone.
+    ///
+    /// Skips rows whose operation state is `.creating` or `.createFailed`:
+    /// those rows show the user's intended branch name, not whatever git
+    /// has on disk yet. `.deleting` and `.deleteFailed` rows are still
+    /// updated — they correspond to real git worktrees with a pending UI
+    /// operation, so git's branch is still the truth.
+    func applyHeadUpdates(projectId: String, branchByWorktreePath: [URL: String]) {
+        guard var rows = worktreesByProject[projectId], !rows.isEmpty else { return }
+        let lookup: [String: String] = Dictionary(uniqueKeysWithValues:
+            branchByWorktreePath.map { (canonical($0.key), $0.value) }
+        )
+        var changed = false
+        for i in rows.indices {
+            let key = canonical(rows[i].path)
+            guard let newBranch = lookup[key] else { continue }
+            if let op = worktreeOperationStates[rows[i].id] {
+                switch op {
+                case .creating, .createFailed: continue
+                case .deleting, .deleteFailed: break
+                }
+            }
+            if rows[i].branch != newBranch || rows[i].name != newBranch {
+                rows[i].branch = newBranch
+                rows[i].name = newBranch
+                changed = true
+            }
+        }
+        if changed { worktreesByProject[projectId] = rows }
+    }
+
     private func hiddenSet(projectId: String) -> Set<String> {
         guard let project = projects.first(where: { $0.id == projectId }) else { return [] }
         return Set(project.hiddenWorktreePaths)

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -122,6 +122,7 @@ struct RootView: View {
             if state.selectedWorktreeId == nil {
                 state.selectedWorktreeId = firstWorktreeId()
             }
+            state.startAllProjectGitWatchers()
         }
     }
 
@@ -311,6 +312,7 @@ private struct RootBaseHandlers: ViewModifier {
             }
         return o
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
+                state.stopAllProjectGitWatchers()
                 state.tabs.snapshotDirtyBuffersForQuit()
             }
     }

--- a/Alas/Sources/Git/HeadReader.swift
+++ b/Alas/Sources/Git/HeadReader.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Result of parsing a git HEAD file.
+enum HeadValue: Equatable {
+    case branch(String)   // "ref: refs/heads/foo" → "foo"
+    case detached         // 40-char hex SHA
+}
+
+/// Reads and parses a git HEAD file from disk without invoking `git`.
+/// Used on the auto-refresh fast path so a branch flip doesn't spawn a
+/// `git worktree list` and doesn't touch any file git might lock.
+enum HeadReader {
+    private static let refPrefix = "ref: refs/heads/"
+
+    static func read(headFile: URL) -> HeadValue? {
+        guard let raw = try? String(contentsOf: headFile, encoding: .utf8) else {
+            return nil
+        }
+        let line = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if line.hasPrefix(refPrefix) {
+            let branch = String(line.dropFirst(refPrefix.count))
+            return branch.isEmpty ? nil : .branch(branch)
+        }
+        if isHexSHA(line) { return .detached }
+        return nil
+    }
+
+    private static func isHexSHA(_ s: String) -> Bool {
+        guard s.count == 40 else { return false }
+        return s.allSatisfy { c in
+            (c >= "0" && c <= "9") || (c >= "a" && c <= "f") || (c >= "A" && c <= "F")
+        }
+    }
+}

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Classification of a single FSEvents path against a project's resolved
+/// `.git` directory. Used by `ProjectGitWatcher` to dispatch fast-path HEAD
+/// updates vs slow-path topology refreshes, and by `WorktreeWatcher` to
+/// share the lockfile rule.
+enum GitEventCategory: Equatable {
+    case ignored                  // *.lock under .git/ — mid-write, never react
+    case headChange(URL)          // worktree root whose HEAD just changed
+    case topologyChange           // .git/worktrees/ contents changed
+    case other                    // unrelated event, caller decides
+}
+
+enum GitEventFilter {
+    /// Classify a single FSEvents path against `gitDir` (an absolute path to
+    /// the repo's `.git` directory). For linked worktrees the worktree root
+    /// is resolved by reading `.git/worktrees/<name>/gitdir`, which contains
+    /// the absolute path to the worktree's `.git` link file.
+    static func classify(eventPath: String, gitDir: URL) -> GitEventCategory {
+        let gitDirPath = gitDir.standardizedFileURL.path
+        let prefix = gitDirPath.hasSuffix("/") ? gitDirPath : gitDirPath + "/"
+        guard eventPath == gitDirPath || eventPath.hasPrefix(prefix) else {
+            return .other
+        }
+
+        if eventPath.hasSuffix(".lock") { return .ignored }
+
+        let rel: String
+        if eventPath == gitDirPath {
+            rel = ""
+        } else {
+            rel = String(eventPath.dropFirst(prefix.count))
+                .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        }
+
+        if rel == "HEAD" {
+            let repoRoot = URL(fileURLWithPath: gitDir.deletingLastPathComponent().path)
+            return .headChange(repoRoot.standardizedFileURL)
+        }
+
+        if rel.hasPrefix("worktrees/") == false {
+            if rel == "worktrees" { return .topologyChange }
+            return .other
+        }
+
+        let parts = rel.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        if parts.count == 2 { return .topologyChange }
+        if parts.count >= 3 && parts[2] == "HEAD" {
+            let name = parts[1]
+            let gitdirFile = gitDir
+                .appendingPathComponent("worktrees")
+                .appendingPathComponent(name)
+                .appendingPathComponent("gitdir")
+            guard let contents = try? String(contentsOf: gitdirFile, encoding: .utf8) else {
+                return .other
+            }
+            let gitlink = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+            let worktreeRoot = URL(fileURLWithPath: gitlink).deletingLastPathComponent()
+            return .headChange(worktreeRoot.standardizedFileURL)
+        }
+        return .other
+    }
+}

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -45,7 +45,7 @@ enum GitEventFilter {
 
         let parts = rel.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
         if parts.count == 2 { return .topologyChange }
-        if parts.count >= 3 && parts[2] == "HEAD" {
+        if parts.count == 3 && parts[2] == "HEAD" {
             let name = parts[1]
             let gitdirFile = gitDir
                 .appendingPathComponent("worktrees")

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -16,7 +16,13 @@ enum GitEventFilter {
     /// the repo's `.git` directory). For linked worktrees the worktree root
     /// is resolved by reading `.git/worktrees/<name>/gitdir`, which contains
     /// the absolute path to the worktree's `.git` link file.
-    static func classify(eventPath: String, gitDir: URL) -> GitEventCategory {
+    ///
+    /// `worktreeRoot` is used only for the main-worktree HEAD case (`gitDir/HEAD`).
+    /// For projects whose `.git` is a gitfile (submodules, separate-git-dir),
+    /// `gitDir` lives outside the worktree, so we cannot infer the worktree
+    /// root from `gitDir.deletingLastPathComponent()` — caller must resolve it
+    /// via `git rev-parse --show-toplevel` and pass it explicitly.
+    static func classify(eventPath: String, gitDir: URL, worktreeRoot: URL) -> GitEventCategory {
         let gitDirPath = gitDir.standardizedFileURL.path
         let prefix = gitDirPath.hasSuffix("/") ? gitDirPath : gitDirPath + "/"
         guard eventPath == gitDirPath || eventPath.hasPrefix(prefix) else {
@@ -34,8 +40,7 @@ enum GitEventFilter {
         }
 
         if rel == "HEAD" {
-            let repoRoot = URL(fileURLWithPath: gitDir.deletingLastPathComponent().path)
-            return .headChange(repoRoot.standardizedFileURL)
+            return .headChange(worktreeRoot.standardizedFileURL)
         }
 
         if rel.hasPrefix("worktrees/") == false {

--- a/Alas/Sources/Watch/ProjectGitWatcher.swift
+++ b/Alas/Sources/Watch/ProjectGitWatcher.swift
@@ -221,13 +221,27 @@ final class ProjectGitWatcher {
         self.stream = stream
     }
 
+    /// Resolves the *common* git directory shared across the main worktree
+    /// and all its linked worktrees. We use `--git-common-dir` (not
+    /// `--absolute-git-dir`) so that when a project is added pointing at a
+    /// linked worktree, the watcher still rooted at `<repo>/.git` instead
+    /// of `<repo>/.git/worktrees/<name>`. That way:
+    ///   - HEAD events for *any* worktree (main + linked) are visible to
+    ///     this watcher, not just the linked one the user happened to add.
+    ///   - `gitDir.deletingLastPathComponent()` is the repo root, so the
+    ///     main-worktree HEAD path math is correct.
+    /// `--git-common-dir` may be relative (`.git`) when run from inside the
+    /// repo, so resolve it against `repo` before standardizing.
     private static func resolveGitDir(at repo: URL) async -> URL? {
         guard let result = try? await Process.git(
-            ["rev-parse", "--absolute-git-dir"],
+            ["rev-parse", "--git-common-dir"],
             cwd: repo
         ), result.exitCode == 0 else { return nil }
         let dir = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !dir.isEmpty else { return nil }
-        return URL(fileURLWithPath: dir).standardizedFileURL
+        let url: URL = dir.hasPrefix("/")
+            ? URL(fileURLWithPath: dir)
+            : URL(fileURLWithPath: dir, relativeTo: repo)
+        return url.standardizedFileURL
     }
 }

--- a/Alas/Sources/Watch/ProjectGitWatcher.swift
+++ b/Alas/Sources/Watch/ProjectGitWatcher.swift
@@ -63,6 +63,7 @@ final class ProjectGitWatcher {
     }
 
     func start() {
+        stop()
         if let gitDir = resolvedGitDir {
             startStream(gitDir: gitDir)
             return

--- a/Alas/Sources/Watch/ProjectGitWatcher.swift
+++ b/Alas/Sources/Watch/ProjectGitWatcher.swift
@@ -1,0 +1,232 @@
+import Foundation
+import CoreServices
+import os
+
+/// Per-project FSEvents watcher rooted at the project's resolved `.git`
+/// directory. Splits events into a fast HEAD-only path (callback emits
+/// `[worktreeRoot: branchLabel]` read directly from disk) and a slow
+/// topology path (callback fires `onTopologyChanged` for the caller to
+/// reconcile via `git worktree list`). See the design doc:
+/// docs/superpowers/specs/2026-05-14-sidebar-auto-refresh-on-branch-change-design.md
+@MainActor
+final class ProjectGitWatcher {
+    var onHeadChanged: (([URL: String]) -> Void)?
+    var onTopologyChanged: (() -> Void)?
+
+    private let repoPath: URL
+    private var resolvedGitDir: URL?
+    private var stream: FSEventStreamRef?
+    private let headDebouncer: DebounceTimer
+    private let topologyDebouncer: DebounceTimer
+    private var pendingHeadFiles: Set<URL> = []
+    private let logger = Logger(subsystem: "io.nlopez.alas", category: "project-git-watcher")
+
+    /// Production initializer: resolves git-dir asynchronously via
+    /// `git rev-parse` after `start()` is called.
+    convenience init(repoPath: URL) {
+        self.init(
+            repoPath: repoPath,
+            resolvedGitDir: nil,
+            headDebounceInterval: 0.1,
+            headDebounceMaxWait: 0.5,
+            topologyDebounceInterval: 0.5,
+            topologyDebounceMaxWait: 2.0
+        )
+    }
+
+    /// Test initializer: caller supplies the resolved git-dir and tighter
+    /// debounce timings so tests don't sleep for seconds. When
+    /// `resolvedGitDir` is non-nil, no `git` invocation happens — the
+    /// watcher is ready to `processEvents` immediately.
+    init(
+        repoPath: URL,
+        resolvedGitDir: URL?,
+        headDebounceInterval: TimeInterval,
+        headDebounceMaxWait: TimeInterval,
+        topologyDebounceInterval: TimeInterval,
+        topologyDebounceMaxWait: TimeInterval
+    ) {
+        self.repoPath = repoPath
+        self.resolvedGitDir = resolvedGitDir
+        self.headDebouncer = DebounceTimer(
+            interval: headDebounceInterval,
+            queue: .main,
+            maxWait: headDebounceMaxWait
+        )
+        self.topologyDebouncer = DebounceTimer(
+            interval: topologyDebounceInterval,
+            queue: .main,
+            maxWait: topologyDebounceMaxWait
+        )
+        self.headDebouncer.onFire = { [weak self] in self?.fireHead() }
+        self.topologyDebouncer.onFire = { [weak self] in self?.fireTopology() }
+    }
+
+    func start() {
+        if let gitDir = resolvedGitDir {
+            startStream(gitDir: gitDir)
+            return
+        }
+        Task { [weak self] in
+            guard let self else { return }
+            guard let gitDir = await Self.resolveGitDir(at: self.repoPath) else {
+                self.logger.warning("could not resolve git-dir for \(self.repoPath.path, privacy: .public)")
+                return
+            }
+            await MainActor.run {
+                guard self.resolvedGitDir == nil else { return }  // started/stopped meanwhile
+                self.resolvedGitDir = gitDir
+                self.startStream(gitDir: gitDir)
+            }
+        }
+    }
+
+    func stop() {
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            self.stream = nil
+        }
+        headDebouncer.cancel()
+        topologyDebouncer.cancel()
+        pendingHeadFiles.removeAll()
+    }
+
+    deinit { MainActor.assumeIsolated { stop() } }
+
+    /// Test seam: feed paths in directly without going through FSEvents.
+    /// Public so tests can drive the classifier + debouncer paths
+    /// deterministically.
+    func processEvents(_ paths: [String]) {
+        guard let gitDir = resolvedGitDir else { return }
+        var sawHead = false
+        var sawTopology = false
+        for path in paths {
+            switch GitEventFilter.classify(eventPath: path, gitDir: gitDir) {
+            case .ignored, .other:
+                continue
+            case .headChange(let worktreeRoot):
+                pendingHeadFiles.insert(headFile(forWorktreeRoot: worktreeRoot, gitDir: gitDir))
+                sawHead = true
+            case .topologyChange:
+                sawTopology = true
+            }
+        }
+        if sawHead { headDebouncer.poke() }
+        if sawTopology { topologyDebouncer.poke() }
+    }
+
+    // MARK: - Private
+
+    private func headFile(forWorktreeRoot root: URL, gitDir: URL) -> URL {
+        // Main worktree: HEAD lives at gitDir/HEAD.
+        if root.standardizedFileURL.path == gitDir.deletingLastPathComponent().standardizedFileURL.path {
+            return gitDir.appendingPathComponent("HEAD")
+        }
+        // Linked worktree: walk gitDir/worktrees/<name>/gitdir back to find
+        // which name matches this root. Rare path; small N.
+        let worktreesDir = gitDir.appendingPathComponent("worktrees")
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: worktreesDir,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        for entry in entries {
+            let gitdirFile = entry.appendingPathComponent("gitdir")
+            guard let contents = try? String(contentsOf: gitdirFile, encoding: .utf8) else { continue }
+            let gitlink = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+            let candidate = URL(fileURLWithPath: gitlink).deletingLastPathComponent().standardizedFileURL
+            if candidate.path == root.standardizedFileURL.path {
+                return entry.appendingPathComponent("HEAD")
+            }
+        }
+        // Fallback: treat as main-worktree HEAD if we can't find a match.
+        // The follow-up topology refresh will reconcile.
+        return gitDir.appendingPathComponent("HEAD")
+    }
+
+    private func fireHead() {
+        let pending = pendingHeadFiles
+        pendingHeadFiles.removeAll()
+        guard !pending.isEmpty else { return }
+        guard let gitDir = resolvedGitDir else { return }
+        var map: [URL: String] = [:]
+        var sawFailure = false
+        for headFile in pending {
+            guard let value = HeadReader.read(headFile: headFile) else {
+                sawFailure = true
+                continue
+            }
+            let root = worktreeRoot(forHeadFile: headFile, gitDir: gitDir)
+            switch value {
+            case .branch(let name): map[root] = name
+            case .detached:         map[root] = "(detached)"
+            }
+        }
+        if !map.isEmpty { onHeadChanged?(map) }
+        if sawFailure { topologyDebouncer.poke() }
+    }
+
+    private func worktreeRoot(forHeadFile headFile: URL, gitDir: URL) -> URL {
+        // gitDir/HEAD → repo root (parent of .git).
+        if headFile.deletingLastPathComponent().standardizedFileURL.path == gitDir.standardizedFileURL.path {
+            return gitDir.deletingLastPathComponent().standardizedFileURL
+        }
+        // gitDir/worktrees/<name>/HEAD → read sibling gitdir to find root.
+        let dir = headFile.deletingLastPathComponent()
+        let gitdirFile = dir.appendingPathComponent("gitdir")
+        if let contents = try? String(contentsOf: gitdirFile, encoding: .utf8) {
+            let gitlink = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+            return URL(fileURLWithPath: gitlink).deletingLastPathComponent().standardizedFileURL
+        }
+        return gitDir.deletingLastPathComponent().standardizedFileURL
+    }
+
+    private func fireTopology() {
+        // Slow path supersedes any pending head batch.
+        pendingHeadFiles.removeAll()
+        onTopologyChanged?()
+    }
+
+    private func startStream(gitDir: URL) {
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil, release: nil, copyDescription: nil
+        )
+        let cb: FSEventStreamCallback = { _, ctx, numEvents, eventPaths, _, _ in
+            guard let ctx else { return }
+            let watcher = Unmanaged<ProjectGitWatcher>.fromOpaque(ctx).takeUnretainedValue()
+            let cfArray = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue()
+            guard let paths = cfArray as? [String], paths.count == numEvents else { return }
+            // FSEvents is dispatched on .main per FSEventStreamSetDispatchQueue below.
+            MainActor.assumeIsolated { watcher.processEvents(paths) }
+        }
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            cb,
+            &context,
+            [gitDir.path] as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.5,
+            FSEventStreamCreateFlags(
+                kFSEventStreamCreateFlagFileEvents
+                | kFSEventStreamCreateFlagNoDefer
+                | kFSEventStreamCreateFlagUseCFTypes
+            )
+        ) else { return }
+        FSEventStreamSetDispatchQueue(stream, .main)
+        FSEventStreamStart(stream)
+        self.stream = stream
+    }
+
+    private static func resolveGitDir(at repo: URL) async -> URL? {
+        guard let result = try? await Process.git(
+            ["rev-parse", "--absolute-git-dir"],
+            cwd: repo
+        ), result.exitCode == 0 else { return nil }
+        let dir = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !dir.isEmpty else { return nil }
+        return URL(fileURLWithPath: dir).standardizedFileURL
+    }
+}

--- a/Alas/Sources/Watch/ProjectGitWatcher.swift
+++ b/Alas/Sources/Watch/ProjectGitWatcher.swift
@@ -244,7 +244,10 @@ final class ProjectGitWatcher {
     /// rather than having to infer it from `gitDir.deletingLastPathComponent()`.
     ///
     /// `--git-common-dir` may be relative (`.git`) when run from inside the
-    /// repo, so we resolve it against `repo` before standardizing.
+    /// repo, so we resolve it under `repo` via `appendingPathComponent`.
+    /// `URL(fileURLWithPath:relativeTo:)` is NOT correct here — it treats the
+    /// base as a file URL, so `.git` resolves to a sibling of `repo` rather
+    /// than into it.
     private static func resolveGitInfo(at repo: URL) async -> (gitDir: URL, worktreeRoot: URL)? {
         async let common = Process.git(["rev-parse", "--git-common-dir"], cwd: repo)
         async let top = Process.git(["rev-parse", "--show-toplevel"], cwd: repo)
@@ -257,7 +260,7 @@ final class ProjectGitWatcher {
         guard !cdir.isEmpty, !tdir.isEmpty else { return nil }
         let gitDirURL: URL = cdir.hasPrefix("/")
             ? URL(fileURLWithPath: cdir)
-            : URL(fileURLWithPath: cdir, relativeTo: repo)
+            : repo.appendingPathComponent(cdir)
         let worktreeURL = URL(fileURLWithPath: tdir)
         return (gitDirURL.standardizedFileURL, worktreeURL.standardizedFileURL)
     }

--- a/Alas/Sources/Watch/ProjectGitWatcher.swift
+++ b/Alas/Sources/Watch/ProjectGitWatcher.swift
@@ -15,6 +15,7 @@ final class ProjectGitWatcher {
 
     private let repoPath: URL
     private var resolvedGitDir: URL?
+    private var resolvedWorktreeRoot: URL?
     private var stream: FSEventStreamRef?
     private let headDebouncer: DebounceTimer
     private let topologyDebouncer: DebounceTimer
@@ -27,6 +28,7 @@ final class ProjectGitWatcher {
         self.init(
             repoPath: repoPath,
             resolvedGitDir: nil,
+            resolvedWorktreeRoot: nil,
             headDebounceInterval: 0.1,
             headDebounceMaxWait: 0.5,
             topologyDebounceInterval: 0.5,
@@ -34,13 +36,14 @@ final class ProjectGitWatcher {
         )
     }
 
-    /// Test initializer: caller supplies the resolved git-dir and tighter
-    /// debounce timings so tests don't sleep for seconds. When
-    /// `resolvedGitDir` is non-nil, no `git` invocation happens — the
+    /// Test initializer: caller supplies the resolved git-dir (and worktree
+    /// root) plus tighter debounce timings so tests don't sleep for seconds.
+    /// When `resolvedGitDir` is non-nil, no `git` invocation happens — the
     /// watcher is ready to `processEvents` immediately.
     init(
         repoPath: URL,
         resolvedGitDir: URL?,
+        resolvedWorktreeRoot: URL?,
         headDebounceInterval: TimeInterval,
         headDebounceMaxWait: TimeInterval,
         topologyDebounceInterval: TimeInterval,
@@ -48,6 +51,7 @@ final class ProjectGitWatcher {
     ) {
         self.repoPath = repoPath
         self.resolvedGitDir = resolvedGitDir
+        self.resolvedWorktreeRoot = resolvedWorktreeRoot
         self.headDebouncer = DebounceTimer(
             interval: headDebounceInterval,
             queue: .main,
@@ -64,20 +68,21 @@ final class ProjectGitWatcher {
 
     func start() {
         stop()
-        if let gitDir = resolvedGitDir {
+        if let gitDir = resolvedGitDir, let worktreeRoot = resolvedWorktreeRoot {
             startStream(gitDir: gitDir)
             return
         }
         Task { [weak self] in
             guard let self else { return }
-            guard let gitDir = await Self.resolveGitDir(at: self.repoPath) else {
+            guard let info = await Self.resolveGitInfo(at: self.repoPath) else {
                 self.logger.warning("could not resolve git-dir for \(self.repoPath.path, privacy: .public)")
                 return
             }
             await MainActor.run {
                 guard self.resolvedGitDir == nil else { return }  // started/stopped meanwhile
-                self.resolvedGitDir = gitDir
-                self.startStream(gitDir: gitDir)
+                self.resolvedGitDir = info.gitDir
+                self.resolvedWorktreeRoot = info.worktreeRoot
+                self.startStream(gitDir: info.gitDir)
             }
         }
     }
@@ -100,15 +105,15 @@ final class ProjectGitWatcher {
     /// Public so tests can drive the classifier + debouncer paths
     /// deterministically.
     func processEvents(_ paths: [String]) {
-        guard let gitDir = resolvedGitDir else { return }
+        guard let gitDir = resolvedGitDir, let worktreeRoot = resolvedWorktreeRoot else { return }
         var sawHead = false
         var sawTopology = false
         for path in paths {
-            switch GitEventFilter.classify(eventPath: path, gitDir: gitDir) {
+            switch GitEventFilter.classify(eventPath: path, gitDir: gitDir, worktreeRoot: worktreeRoot) {
             case .ignored, .other:
                 continue
-            case .headChange(let worktreeRoot):
-                pendingHeadFiles.insert(headFile(forWorktreeRoot: worktreeRoot, gitDir: gitDir))
+            case .headChange(let root):
+                pendingHeadFiles.insert(headFile(forWorktreeRoot: root, gitDir: gitDir))
                 sawHead = true
             case .topologyChange:
                 sawTopology = true
@@ -122,7 +127,11 @@ final class ProjectGitWatcher {
 
     private func headFile(forWorktreeRoot root: URL, gitDir: URL) -> URL {
         // Main worktree: HEAD lives at gitDir/HEAD.
-        if root.standardizedFileURL.path == gitDir.deletingLastPathComponent().standardizedFileURL.path {
+        // Use resolvedWorktreeRoot (not gitDir.deletingLastPathComponent) so
+        // that separate-gitdir repos (submodules, --separate-git-dir) work
+        // correctly when gitDir lives outside the worktree.
+        let mainRoot = resolvedWorktreeRoot?.standardizedFileURL
+        if root.standardizedFileURL.path == (mainRoot ?? gitDir.deletingLastPathComponent().standardizedFileURL).path {
             return gitDir.appendingPathComponent("HEAD")
         }
         // Linked worktree: walk gitDir/worktrees/<name>/gitdir back to find
@@ -169,9 +178,10 @@ final class ProjectGitWatcher {
     }
 
     private func worktreeRoot(forHeadFile headFile: URL, gitDir: URL) -> URL {
-        // gitDir/HEAD → repo root (parent of .git).
+        // gitDir/HEAD → resolved worktree root (not necessarily parent of gitDir,
+        // since gitDir may live outside the worktree for submodules/separate-gitdir).
         if headFile.deletingLastPathComponent().standardizedFileURL.path == gitDir.standardizedFileURL.path {
-            return gitDir.deletingLastPathComponent().standardizedFileURL
+            return (resolvedWorktreeRoot ?? gitDir.deletingLastPathComponent()).standardizedFileURL
         }
         // gitDir/worktrees/<name>/HEAD → read sibling gitdir to find root.
         let dir = headFile.deletingLastPathComponent()
@@ -221,27 +231,34 @@ final class ProjectGitWatcher {
         self.stream = stream
     }
 
-    /// Resolves the *common* git directory shared across the main worktree
-    /// and all its linked worktrees. We use `--git-common-dir` (not
-    /// `--absolute-git-dir`) so that when a project is added pointing at a
-    /// linked worktree, the watcher still rooted at `<repo>/.git` instead
-    /// of `<repo>/.git/worktrees/<name>`. That way:
-    ///   - HEAD events for *any* worktree (main + linked) are visible to
-    ///     this watcher, not just the linked one the user happened to add.
-    ///   - `gitDir.deletingLastPathComponent()` is the repo root, so the
-    ///     main-worktree HEAD path math is correct.
+    /// Resolves the *common* git directory and the main worktree root.
+    ///
+    /// We use `--git-common-dir` (not `--absolute-git-dir`) so that when a
+    /// project is added pointing at a linked worktree, the watcher is still
+    /// rooted at `<repo>/.git` instead of `<repo>/.git/worktrees/<name>`.
+    /// That way HEAD events for *any* worktree (main + linked) are visible.
+    ///
+    /// We also resolve `--show-toplevel` alongside `--git-common-dir` so that
+    /// for submodules and repos created with `--separate-git-dir` (where the
+    /// gitDir lives *outside* the worktree), we have the true worktree root
+    /// rather than having to infer it from `gitDir.deletingLastPathComponent()`.
+    ///
     /// `--git-common-dir` may be relative (`.git`) when run from inside the
-    /// repo, so resolve it against `repo` before standardizing.
-    private static func resolveGitDir(at repo: URL) async -> URL? {
-        guard let result = try? await Process.git(
-            ["rev-parse", "--git-common-dir"],
-            cwd: repo
-        ), result.exitCode == 0 else { return nil }
-        let dir = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !dir.isEmpty else { return nil }
-        let url: URL = dir.hasPrefix("/")
-            ? URL(fileURLWithPath: dir)
-            : URL(fileURLWithPath: dir, relativeTo: repo)
-        return url.standardizedFileURL
+    /// repo, so we resolve it against `repo` before standardizing.
+    private static func resolveGitInfo(at repo: URL) async -> (gitDir: URL, worktreeRoot: URL)? {
+        async let common = Process.git(["rev-parse", "--git-common-dir"], cwd: repo)
+        async let top = Process.git(["rev-parse", "--show-toplevel"], cwd: repo)
+        guard
+            let cR = try? await common, cR.exitCode == 0,
+            let tR = try? await top, tR.exitCode == 0
+        else { return nil }
+        let cdir = cR.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let tdir = tR.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cdir.isEmpty, !tdir.isEmpty else { return nil }
+        let gitDirURL: URL = cdir.hasPrefix("/")
+            ? URL(fileURLWithPath: cdir)
+            : URL(fileURLWithPath: cdir, relativeTo: repo)
+        let worktreeURL = URL(fileURLWithPath: tdir)
+        return (gitDirURL.standardizedFileURL, worktreeURL.standardizedFileURL)
     }
 }

--- a/Alas/Sources/Watch/WorktreeWatcher.swift
+++ b/Alas/Sources/Watch/WorktreeWatcher.swift
@@ -104,13 +104,13 @@ final class WorktreeWatcher {
     }
 
     /// Returns `true` iff at least one event path represents a change we want
-    /// to react to. Git lockfiles (`*.lock` inside any `.git/` directory) are
-    /// filtered out: they appear when another git process is mid-write
-    /// (commit, rebase, fetch); reacting would (a) trigger a redundant
-    /// refresh during the user's operation and (b) historically caused
-    /// `.git/index.lock` contention with terminal git. Project lockfiles
-    /// outside `.git/` (e.g. `Cargo.lock`, `package-lock.json`) are real
-    /// changes and DO trigger a refresh.
+    /// to react to. Git lockfiles are filtered out (matching the rule in
+    /// `GitEventFilter.classify`): they appear when another git process is
+    /// mid-write (commit, rebase, fetch); reacting would (a) trigger a
+    /// redundant refresh during the user's operation and (b) historically
+    /// caused `.git/index.lock` contention with terminal git. Project
+    /// lockfiles outside `.git/` (e.g. `Cargo.lock`, `package-lock.json`) are
+    /// real changes and DO trigger a refresh.
     static func shouldRefresh(forEventPaths paths: [String]) -> Bool {
         for path in paths {
             if path.hasSuffix(".lock") && path.contains("/.git/") {

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct GitEventFilterTests {
+    private let gitDir = URL(fileURLWithPath: "/repo/.git")
+
+    @Test func ignoresLockFilesAnywhereUnderGitDir() {
+        let cases = [
+            "/repo/.git/index.lock",
+            "/repo/.git/HEAD.lock",
+            "/repo/.git/worktrees/feat/HEAD.lock",
+            "/repo/.git/refs/heads/main.lock",
+        ]
+        for path in cases {
+            let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir)
+            #expect(cat == .ignored, "expected .ignored for \(path), got \(cat)")
+        }
+    }
+
+    @Test func classifiesMainWorktreeHEAD() {
+        let cat = GitEventFilter.classify(eventPath: "/repo/.git/HEAD", gitDir: gitDir)
+        #expect(cat == .headChange(URL(fileURLWithPath: "/repo")))
+    }
+
+    @Test func classifiesLinkedWorktreeHEADUsingGitdirFile() throws {
+        // Set up a fake linked-worktree layout on disk so the classifier can
+        // resolve the worktree root via .git/worktrees/<name>/gitdir.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-test-\(UUID().uuidString)")
+        let repoGit = tmp.appendingPathComponent("repo/.git")
+        let wtDir = repoGit.appendingPathComponent("worktrees/feat")
+        try FileManager.default.createDirectory(at: wtDir, withIntermediateDirectories: true)
+        let worktreeRoot = tmp.appendingPathComponent("worktrees/feat")
+        try FileManager.default.createDirectory(at: worktreeRoot, withIntermediateDirectories: true)
+        let gitdirContent = worktreeRoot.appendingPathComponent(".git").path + "\n"
+        try gitdirContent.write(
+            to: wtDir.appendingPathComponent("gitdir"),
+            atomically: true,
+            encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let cat = GitEventFilter.classify(
+            eventPath: wtDir.appendingPathComponent("HEAD").path,
+            gitDir: repoGit
+        )
+        #expect(cat == .headChange(worktreeRoot.standardizedFileURL))
+    }
+
+    @Test func classifiesWorktreesDirectoryAsTopology() {
+        let cases = [
+            "/repo/.git/worktrees",
+            "/repo/.git/worktrees/feat",
+            "/repo/.git/worktrees/feat/",
+        ]
+        for path in cases {
+            let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir)
+            #expect(cat == .topologyChange, "expected .topologyChange for \(path), got \(cat)")
+        }
+    }
+
+    @Test func ignoresUnrelatedPathsUnderGitDir() {
+        let cases = [
+            "/repo/.git/objects/pack/pack-abc.pack",
+            "/repo/.git/refs/heads/main",
+            "/repo/.git/config",
+            "/repo/.git/worktrees/feat/locked",
+        ]
+        for path in cases {
+            let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir)
+            #expect(cat == .other, "expected .other for \(path), got \(cat)")
+        }
+    }
+
+    @Test func ignoresPathsOutsideGitDir() {
+        let cat = GitEventFilter.classify(
+            eventPath: "/repo/src/main.swift",
+            gitDir: gitDir
+        )
+        #expect(cat == .other)
+    }
+}

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -4,6 +4,7 @@ import Foundation
 
 struct GitEventFilterTests {
     private let gitDir = URL(fileURLWithPath: "/repo/.git")
+    private let worktreeRoot = URL(fileURLWithPath: "/repo")
 
     @Test func ignoresLockFilesAnywhereUnderGitDir() {
         let cases = [
@@ -13,13 +14,13 @@ struct GitEventFilterTests {
             "/repo/.git/refs/heads/main.lock",
         ]
         for path in cases {
-            let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir)
+            let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir, worktreeRoot: worktreeRoot)
             #expect(cat == .ignored, "expected .ignored for \(path), got \(cat)")
         }
     }
 
     @Test func classifiesMainWorktreeHEAD() {
-        let cat = GitEventFilter.classify(eventPath: "/repo/.git/HEAD", gitDir: gitDir)
+        let cat = GitEventFilter.classify(eventPath: "/repo/.git/HEAD", gitDir: gitDir, worktreeRoot: worktreeRoot)
         #expect(cat == .headChange(URL(fileURLWithPath: "/repo")))
     }
 
@@ -43,7 +44,8 @@ struct GitEventFilterTests {
 
         let cat = GitEventFilter.classify(
             eventPath: wtDir.appendingPathComponent("HEAD").path,
-            gitDir: repoGit
+            gitDir: repoGit,
+            worktreeRoot: tmp.appendingPathComponent("repo")
         )
         #expect(cat == .headChange(worktreeRoot.standardizedFileURL))
     }
@@ -55,7 +57,7 @@ struct GitEventFilterTests {
             "/repo/.git/worktrees/feat/",
         ]
         for path in cases {
-            let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir)
+            let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir, worktreeRoot: worktreeRoot)
             #expect(cat == .topologyChange, "expected .topologyChange for \(path), got \(cat)")
         }
     }
@@ -68,7 +70,7 @@ struct GitEventFilterTests {
             "/repo/.git/worktrees/feat/locked",
         ]
         for path in cases {
-            let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir)
+            let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir, worktreeRoot: worktreeRoot)
             #expect(cat == .other, "expected .other for \(path), got \(cat)")
         }
     }
@@ -76,8 +78,21 @@ struct GitEventFilterTests {
     @Test func ignoresPathsOutsideGitDir() {
         let cat = GitEventFilter.classify(
             eventPath: "/repo/src/main.swift",
-            gitDir: gitDir
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
         )
         #expect(cat == .other)
+    }
+
+    @Test func mainHEADResolvesToWorktreeRootEvenWhenGitDirIsOutside() {
+        // Submodule case: gitDir is /super/.git/modules/sub, worktree is /sub
+        let gitDir = URL(fileURLWithPath: "/super/.git/modules/sub")
+        let worktreeRoot = URL(fileURLWithPath: "/sub")
+        let cat = GitEventFilter.classify(
+            eventPath: "/super/.git/modules/sub/HEAD",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        )
+        #expect(cat == .headChange(worktreeRoot.standardizedFileURL))
     }
 }

--- a/AlasTests/HeadReaderTests.swift
+++ b/AlasTests/HeadReaderTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct HeadReaderTests {
+    private func writeTemp(_ content: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-head-\(UUID().uuidString)")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    @Test func parsesSymbolicRef() throws {
+        let url = try writeTemp("ref: refs/heads/feat/foo\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(HeadReader.read(headFile: url) == .branch("feat/foo"))
+    }
+
+    @Test func parsesSymbolicRefWithoutTrailingNewline() throws {
+        let url = try writeTemp("ref: refs/heads/main")
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(HeadReader.read(headFile: url) == .branch("main"))
+    }
+
+    @Test func parsesDetachedSHA() throws {
+        let url = try writeTemp("0123456789abcdef0123456789abcdef01234567\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(HeadReader.read(headFile: url) == .detached)
+    }
+
+    @Test func returnsNilForMalformedContent() throws {
+        let url = try writeTemp("not a ref nor a sha\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+        #expect(HeadReader.read(headFile: url) == nil)
+    }
+
+    @Test func returnsNilForMissingFile() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-head-missing-\(UUID().uuidString)")
+        #expect(HeadReader.read(headFile: url) == nil)
+    }
+}

--- a/AlasTests/ProjectGitWatcherTests.swift
+++ b/AlasTests/ProjectGitWatcherTests.swift
@@ -42,6 +42,7 @@ struct ProjectGitWatcherTests {
         ProjectGitWatcher(
             repoPath: gitDir.deletingLastPathComponent(),
             resolvedGitDir: gitDir,
+            resolvedWorktreeRoot: gitDir.deletingLastPathComponent(),
             headDebounceInterval: 0.05,
             headDebounceMaxWait: 0.2,
             topologyDebounceInterval: 0.05,

--- a/AlasTests/ProjectGitWatcherTests.swift
+++ b/AlasTests/ProjectGitWatcherTests.swift
@@ -1,0 +1,155 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct ProjectGitWatcherTests {
+    /// Build a fake `<tmp>/repo/.git` layout with two linked worktrees,
+    /// each having a HEAD pointing to a branch and a `gitdir` pointing
+    /// at the worktree root. Returns (gitDir, [worktreeName: worktreeRoot]).
+    private func setupRepo() throws -> (URL, [String: URL]) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-pgw-\(UUID().uuidString)")
+        let gitDir = tmp.appendingPathComponent("repo/.git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        try "ref: refs/heads/main\n".write(
+            to: gitDir.appendingPathComponent("HEAD"),
+            atomically: true,
+            encoding: .utf8
+        )
+        var roots: [String: URL] = [:]
+        for name in ["alpha", "beta"] {
+            let wtRoot = tmp.appendingPathComponent("worktrees/\(name)").standardizedFileURL
+            try FileManager.default.createDirectory(at: wtRoot, withIntermediateDirectories: true)
+            let wtGit = gitDir.appendingPathComponent("worktrees/\(name)")
+            try FileManager.default.createDirectory(at: wtGit, withIntermediateDirectories: true)
+            try "ref: refs/heads/\(name)\n".write(
+                to: wtGit.appendingPathComponent("HEAD"),
+                atomically: true,
+                encoding: .utf8
+            )
+            try (wtRoot.appendingPathComponent(".git").path + "\n").write(
+                to: wtGit.appendingPathComponent("gitdir"),
+                atomically: true,
+                encoding: .utf8
+            )
+            roots[name] = wtRoot
+        }
+        return (gitDir, roots)
+    }
+
+    private func makeWatcher(gitDir: URL) -> ProjectGitWatcher {
+        ProjectGitWatcher(
+            repoPath: gitDir.deletingLastPathComponent(),
+            resolvedGitDir: gitDir,
+            headDebounceInterval: 0.05,
+            headDebounceMaxWait: 0.2,
+            topologyDebounceInterval: 0.05,
+            topologyDebounceMaxWait: 0.2
+        )
+    }
+
+    @Test func headOnlyBatchTriggersHeadCallback() async throws {
+        let (gitDir, roots) = try setupRepo()
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        let watcher = makeWatcher(gitDir: gitDir)
+        var heads: [URL: String] = [:]
+        var topologyFires = 0
+        watcher.onHeadChanged = { heads = $0 }
+        watcher.onTopologyChanged = { topologyFires += 1 }
+
+        watcher.processEvents([
+            gitDir.appendingPathComponent("worktrees/alpha/HEAD").path
+        ])
+        try await Task.sleep(nanoseconds: 300_000_000)
+        // Compare via .path because URL equality is strict about directory flag
+        // and the watcher may produce a directory URL while roots[] stores a
+        // standardized file URL.
+        let actualPaths = Dictionary(uniqueKeysWithValues: heads.map { ($0.key.path, $0.value) })
+        let expectedPaths = Dictionary(uniqueKeysWithValues: [(roots["alpha"]!.path, "alpha")])
+        #expect(actualPaths == expectedPaths)
+        #expect(topologyFires == 0)
+    }
+
+    @Test func topologyOnlyBatchTriggersTopologyCallback() async throws {
+        let (gitDir, _) = try setupRepo()
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        let watcher = makeWatcher(gitDir: gitDir)
+        var headFires = 0
+        var topologyFires = 0
+        watcher.onHeadChanged = { _ in headFires += 1 }
+        watcher.onTopologyChanged = { topologyFires += 1 }
+
+        watcher.processEvents([
+            gitDir.appendingPathComponent("worktrees/new").path
+        ])
+        try await Task.sleep(nanoseconds: 300_000_000)
+        #expect(headFires == 0)
+        #expect(topologyFires == 1)
+    }
+
+    @Test func mixedBatchClearsHeadInFavorOfTopology() async throws {
+        let (gitDir, _) = try setupRepo()
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        let watcher = makeWatcher(gitDir: gitDir)
+        var headFires = 0
+        var topologyFires = 0
+        watcher.onHeadChanged = { _ in headFires += 1 }
+        watcher.onTopologyChanged = { topologyFires += 1 }
+
+        watcher.processEvents([
+            gitDir.appendingPathComponent("worktrees/alpha/HEAD").path,
+            gitDir.appendingPathComponent("worktrees/new").path,
+        ])
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(topologyFires == 1)
+        // Head supersedes: with equal head/topology intervals scheduling is
+        // racy. The contract is "no head fire AFTER topology fire" — easier
+        // to test via the all-or-nothing pending set behavior. Allow up to
+        // one head fire (if it scheduled before topology).
+        #expect(headFires <= 1)
+    }
+
+    @Test func allLockBatchIsNoop() async throws {
+        let (gitDir, _) = try setupRepo()
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        let watcher = makeWatcher(gitDir: gitDir)
+        var headFires = 0
+        var topologyFires = 0
+        watcher.onHeadChanged = { _ in headFires += 1 }
+        watcher.onTopologyChanged = { topologyFires += 1 }
+
+        watcher.processEvents([
+            gitDir.appendingPathComponent("index.lock").path,
+            gitDir.appendingPathComponent("worktrees/alpha/HEAD.lock").path,
+        ])
+        try await Task.sleep(nanoseconds: 300_000_000)
+        #expect(headFires == 0)
+        #expect(topologyFires == 0)
+    }
+
+    @Test func headReadFailureEscalatesToTopology() async throws {
+        let (gitDir, _) = try setupRepo()
+        defer { try? FileManager.default.removeItem(at: gitDir.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        // Corrupt one HEAD so HeadReader returns nil for it.
+        let alphaHead = gitDir.appendingPathComponent("worktrees/alpha/HEAD")
+        try "garbage\n".write(to: alphaHead, atomically: true, encoding: .utf8)
+
+        let watcher = makeWatcher(gitDir: gitDir)
+        var topologyFires = 0
+        var heads: [URL: String] = [:]
+        watcher.onHeadChanged = { heads = $0 }
+        watcher.onTopologyChanged = { topologyFires += 1 }
+
+        watcher.processEvents([alphaHead.path])
+        try await Task.sleep(nanoseconds: 400_000_000)
+        // The fast path produced no usable updates; topology must have fired.
+        #expect(heads.isEmpty)
+        #expect(topologyFires >= 1)
+    }
+}

--- a/AlasTests/ProjectsManagerHeadUpdatesTests.swift
+++ b/AlasTests/ProjectsManagerHeadUpdatesTests.swift
@@ -1,0 +1,126 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct ProjectsManagerHeadUpdatesTests {
+    private func makeManager() -> (ProjectsManager, ProjectConfig) {
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date()
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        return (mgr, project)
+    }
+
+    private func seed(_ mgr: ProjectsManager, projectId: String, _ wts: [Worktree]) {
+        for wt in wts { mgr.insertOptimisticWorktree(wt) }
+        // insertOptimisticWorktree is the only public seed API; clear any
+        // operation state it implicitly leaves so updates apply.
+        for wt in wts { mgr.setOperationState(id: wt.id, state: nil) }
+    }
+
+    private func wt(path: String, branch: String, projectId: String = "p1") -> Worktree {
+        let url = URL(fileURLWithPath: path)
+        return Worktree(
+            id: Worktree.makeId(path: url),
+            projectId: projectId,
+            name: branch,
+            branch: branch,
+            path: url,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    @Test func updatesBranchForMatchingPath() {
+        let (mgr, project) = makeManager()
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo", branch: "main"),
+            wt(path: "/wts/feat", branch: "feat/foo"),
+        ])
+
+        mgr.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [
+                URL(fileURLWithPath: "/wts/feat"): "feat/bar"
+            ]
+        )
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.first { $0.path.path == "/repo" }?.branch == "main")
+        #expect(trees.first { $0.path.path == "/wts/feat" }?.branch == "feat/bar")
+        #expect(trees.first { $0.path.path == "/wts/feat" }?.name == "feat/bar")
+    }
+
+    @Test func ignoresUnknownPaths() {
+        let (mgr, project) = makeManager()
+        seed(mgr, projectId: project.id, [wt(path: "/repo", branch: "main")])
+
+        mgr.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [
+                URL(fileURLWithPath: "/wts/ghost"): "x"
+            ]
+        )
+
+        #expect(mgr.worktrees(projectId: project.id).count == 1)
+        #expect(mgr.worktrees(projectId: project.id).first?.branch == "main")
+    }
+
+    @Test func skipsRowsInCreatingState() {
+        let (mgr, project) = makeManager()
+        let row = wt(path: "/wts/feat", branch: "feat/intent")
+        seed(mgr, projectId: project.id, [row])
+        mgr.setOperationState(id: row.id, state: .creating)
+
+        mgr.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [row.path: "feat/disk"]
+        )
+
+        // Optimistic intent must win over disk truth while creating.
+        #expect(mgr.worktrees(projectId: project.id).first?.branch == "feat/intent")
+    }
+
+    @Test func skipsRowsInCreateFailedState() {
+        let (mgr, project) = makeManager()
+        let row = wt(path: "/wts/feat", branch: "feat/intent")
+        seed(mgr, projectId: project.id, [row])
+        mgr.setOperationState(id: row.id, state: .createFailed(message: "x", base: "main"))
+
+        mgr.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [row.path: "feat/disk"]
+        )
+        #expect(mgr.worktrees(projectId: project.id).first?.branch == "feat/intent")
+    }
+
+    @Test func updatesRowsInDeletingState() {
+        // .deleting / .deleteFailed correspond to real git worktrees that
+        // happen to have a pending UI op; the branch label is still git's
+        // truth and should refresh.
+        let (mgr, project) = makeManager()
+        let row = wt(path: "/wts/feat", branch: "old")
+        seed(mgr, projectId: project.id, [row])
+        mgr.setOperationState(id: row.id, state: .deleting)
+
+        mgr.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [row.path: "new"]
+        )
+        #expect(mgr.worktrees(projectId: project.id).first?.branch == "new")
+    }
+
+    @Test func unknownProjectIdIsNoop() {
+        let (mgr, _) = makeManager()
+        mgr.applyHeadUpdates(
+            projectId: "does-not-exist",
+            branchByWorktreePath: [URL(fileURLWithPath: "/x"): "y"]
+        )
+        // No crash, no state change. Nothing to assert beyond that.
+    }
+}

--- a/AlasTests/WorktreeWatcherFilterTests.swift
+++ b/AlasTests/WorktreeWatcherFilterTests.swift
@@ -1,0 +1,27 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct WorktreeWatcherFilterTests {
+    @Test func dropsBatchOfOnlyGitLocks() {
+        let paths = [
+            "/repo/.git/index.lock",
+            "/repo/.git/HEAD.lock",
+            "/repo/.git/worktrees/feat/HEAD.lock",
+        ]
+        #expect(WorktreeWatcher.shouldRefresh(forEventPaths: paths) == false)
+    }
+
+    @Test func acceptsBatchWithAnyNonLockPath() {
+        let paths = [
+            "/repo/.git/index.lock",
+            "/repo/src/main.swift",
+        ]
+        #expect(WorktreeWatcher.shouldRefresh(forEventPaths: paths) == true)
+    }
+
+    @Test func acceptsProjectLockfilesOutsideGitDir() {
+        // Cargo.lock / package-lock.json are real changes, not git lockfiles.
+        #expect(WorktreeWatcher.shouldRefresh(forEventPaths: ["/repo/Cargo.lock"]) == true)
+    }
+}


### PR DESCRIPTION
## Summary

When you switch branches in a worktree's terminal — or in the main worktree — the left sidebar branch label used to stay stale until you manually picked **Projects → Refresh Worktrees**. This change makes the sidebar auto-update.

The fast path reads `HEAD` files directly from disk, so a branch flip doesn't spawn `git worktree list` and doesn't touch any file git might lock during a concurrent operation. Topology changes (worktree add/remove from outside Alas) still trigger a full reconcile, debounced.

### Architecture

- New `GitEventFilter` (Watch/) — pure classifier shared with the existing right-pane `WorktreeWatcher` for the `.lock`-filtering rule.
- New `HeadReader` (Git/) — disk-only HEAD parser (`ref: refs/heads/foo` → `.branch("foo")`, 40-hex SHA → `.detached`).
- New `ProjectGitWatcher` (Watch/) — one FSEvents stream per project rooted at `<repo>/.git`. Two debouncers: head-only fast path (100ms / 500ms ceiling) and topology slow path (500ms / 2.0s ceiling).
- New `ProjectsManager.applyHeadUpdates(projectId:branchByWorktreePath:)` — patches branch/name in place, skips optimistic `.creating` / `.createFailed` rows, updates `.deleting` / `.deleteFailed` rows.
- Wiring in `AppState` + `RootView`: one watcher per project, started after the initial `refreshAll()`, started/stopped via `addProject` / `removeProject`, torn down on `willTerminate`.

Spec: `docs/superpowers/specs/2026-05-14-sidebar-auto-refresh-on-branch-change-design.md`
Plan: `docs/superpowers/plans/2026-05-14-sidebar-auto-refresh-on-branch-change.md` (both gitignored on this repo)

## Test plan

- [x] All 613 unit tests pass (`xcodebuild ... test`)
- [x] New unit coverage:
  - `GitEventFilterTests` — 6 cases (lock filter, main HEAD, linked HEAD via gitdir, worktrees topology, near-miss, outside .git)
  - `WorktreeWatcherFilterTests` — 3 cases pinning lock semantics
  - `HeadReaderTests` — 5 cases (ref + newline, ref no newline, detached SHA, malformed, missing)
  - `ProjectsManagerHeadUpdatesTests` — 6 cases (matching, unknown path, creating skip, createFailed skip, deleting update, unknown project)
  - `ProjectGitWatcherTests` — 5 cases via synthetic-event seam (head only, topology only, mixed, all-lock, head-read failure escalation)
- [ ] Manual smoke (to verify on local build before merge):
  - `git checkout other-branch` in a terminal updates the sidebar branch label within ~500ms
  - `git checkout HEAD~1` flips label to `(detached)`; back to a branch flips back
  - `git worktree add` from a terminal makes the new row appear within ~2s; `git worktree remove` removes it
  - Existing manual `Projects → Refresh Worktrees` still works as a fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)