### PR TITLE
feat: browse older commits in right sidebar

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
+		50AB83A42DC745ACA76186D1 /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50567E63676400394FE05D8 /* CommitsOlderTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
@@ -435,6 +436,7 @@
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
+		C50567E63676400394FE05D8 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
 		57713D7143CFD53124E0523F /* AlasHookCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommand.swift; sourceTree = "<group>"; };
 		57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledFontRegistrar.swift; sourceTree = "<group>"; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
@@ -690,6 +692,7 @@
 				DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */,
 				9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */,
 				576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */,
+				C50567E63676400394FE05D8 /* CommitsOlderTests.swift */,
 				A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */,
 				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
 				BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */,
@@ -1689,6 +1692,7 @@
 				F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */,
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,
 				17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */,
+				50AB83A42DC745ACA76186D1 /* CommitsOlderTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				42D8417781E790CA6AA49F7E /* CursorInstallerTests.swift in Sources */,
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
 		50AB83A42DC745ACA76186D1 /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50567E63676400394FE05D8 /* CommitsOlderTests.swift */; };
+		A2ECFAB592D84917837E3EAD /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6CC94C50D54A6193647601 /* RightPaneStateLoadOlderTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
@@ -437,6 +438,7 @@
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
 		C50567E63676400394FE05D8 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
+		3A6CC94C50D54A6193647601 /* RightPaneStateLoadOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateLoadOlderTests.swift; sourceTree = "<group>"; };
 		57713D7143CFD53124E0523F /* AlasHookCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommand.swift; sourceTree = "<group>"; };
 		57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledFontRegistrar.swift; sourceTree = "<group>"; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
@@ -744,6 +746,7 @@
 				BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
+				3A6CC94C50D54A6193647601 /* RightPaneStateLoadOlderTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
@@ -1751,6 +1754,7 @@
 				BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
+				A2ECFAB592D84917837E3EAD /* RightPaneStateLoadOlderTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -565,4 +565,77 @@ extension GitService {
 
         return (commits, comparisonRef)
     }
+
+    /// Older history for the "Load older" affordance in the right sidebar.
+    /// Returns up to `count` commits reachable from `beforeSha^`, following
+    /// only the first parent so merge-side ancestry doesn't drown the list.
+    /// Same record format as `commitsAhead`, so callers can reuse the same
+    /// `CommitInfo` shape and the divider/dimming lives in the view layer.
+    func commitsOlder(worktreePath: URL, beforeSha: String, count: Int) async throws -> [CommitInfo] {
+        let range = "\(beforeSha)^"
+        let format = "%x1e%H%x1f%h%x1f%an%x1f%aI%x1f%s"
+        let log = try await Process.git(
+            ["log", range, "-n", String(count), "--first-parent",
+             "--pretty=tformat:\(format)", "--numstat"],
+            cwd: worktreePath
+        )
+        guard log.exitCode == 0 else {
+            throw NSError(
+                domain: "GitService.commitsOlder",
+                code: Int(log.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: log.stderr.isEmpty ? "git log failed" : log.stderr]
+            )
+        }
+
+        let records = log.stdout
+            .split(separator: "\u{1e}", omittingEmptySubsequences: true)
+            .map { String($0) }
+
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime]
+
+        var commits: [CommitInfo] = []
+        for record in records {
+            let trimmed = record.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
+            guard let headerLine = lines.first else { continue }
+            let fields = headerLine.split(separator: "\u{1f}", maxSplits: 4, omittingEmptySubsequences: false)
+            guard fields.count == 5 else { continue }
+            let sha = String(fields[0])
+            let short = String(fields[1])
+            let author = String(fields[2])
+            let dateStr = String(fields[3])
+            let rawSubject = String(fields[4])
+            let date = isoFormatter.date(from: dateStr) ?? Date(timeIntervalSince1970: 0)
+            let (tag, subject) = CommitInfo.parseConventional(subject: rawSubject)
+
+            var filesChanged = 0
+            var adds = 0
+            var dels = 0
+            for line in lines.dropFirst() {
+                let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+                if trimmedLine.isEmpty { continue }
+                let parts = trimmedLine.split(separator: "\t", omittingEmptySubsequences: false)
+                guard parts.count >= 3 else { continue }
+                filesChanged += 1
+                if let a = Int(parts[0]) { adds += a }
+                if let d = Int(parts[1]) { dels += d }
+            }
+
+            commits.append(CommitInfo(
+                sha: sha,
+                shortSha: short,
+                author: author,
+                authorInitials: CommitInfo.initials(for: author),
+                date: date,
+                subject: subject,
+                conventionalTag: tag,
+                filesChanged: filesChanged,
+                insertions: adds,
+                deletions: dels
+            ))
+        }
+        return commits
+    }
 }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -44,9 +44,13 @@ struct ChangesTabView: View {
                 Divider().opacity(0.4)
                 CommitsSectionView(
                     commits: rps.commits,
+                    olderCommits: rps.olderCommits,
                     comparisonRef: rps.comparisonRef,
+                    hasMoreOlder: rps.hasMoreOlder,
+                    isLoadingOlder: rps.isLoadingOlder,
                     expanded: $rps.commitsExpanded,
-                    onSelect: onSelectCommit
+                    onSelect: onSelectCommit,
+                    onLoadOlder: { Task { @MainActor in await rps.loadOlder() } }
                 )
             }
         }

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CommitRow: View {
     let commit: CommitInfo
     let isLast: Bool
+    var isDimmed: Bool = false
     let onSelect: () -> Void
 
     @Environment(\.theme) private var theme
@@ -23,6 +24,7 @@ struct CommitRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .opacity(isDimmed ? 0.5 : 1.0)
     }
 
     private var rail: some View {
@@ -36,7 +38,7 @@ struct CommitRow: View {
             }
             .stroke(theme.color("line"), lineWidth: 1)
             Circle()
-                .fill(theme.color("accent"))
+                .fill(isDimmed ? theme.color("fg-muted") : theme.color("accent"))
                 .frame(width: dotSize, height: dotSize)
                 .position(x: 4, y: dotY + dotSize / 2)
         }

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -2,9 +2,13 @@ import SwiftUI
 
 struct CommitsSectionView: View {
     let commits: [CommitInfo]
+    let olderCommits: [CommitInfo]
     let comparisonRef: String?
+    let hasMoreOlder: Bool
+    let isLoadingOlder: Bool
     @Binding var expanded: Bool
     let onSelect: (CommitInfo) -> Void
+    let onLoadOlder: () -> Void
 
     @Environment(\.theme) private var theme
 
@@ -12,7 +16,7 @@ struct CommitsSectionView: View {
         VStack(spacing: 0) {
             SectionHeader(
                 title: "Commits",
-                count: commits.isEmpty ? nil : commits.count,
+                count: totalCount,
                 expanded: expanded,
                 onToggle: { expanded.toggle() }
             ) {
@@ -29,15 +33,52 @@ struct CommitsSectionView: View {
             }
 
             if expanded {
-                if commits.isEmpty {
-                    emptyPlaceholder
-                } else {
-                    ForEach(Array(commits.enumerated()), id: \.element.id) { idx, commit in
-                        CommitRow(commit: commit, isLast: idx == commits.count - 1, onSelect: { onSelect(commit) })
-                    }
-                }
+                body_expanded
             }
         }
+    }
+
+    private var totalCount: Int? {
+        let n = commits.count + olderCommits.count
+        return n == 0 ? nil : n
+    }
+
+    @ViewBuilder
+    private var body_expanded: some View {
+        // 1. Worktree commits ("your work") OR today's empty placeholder.
+        if !commits.isEmpty {
+            ForEach(Array(commits.enumerated()), id: \.element.id) { idx, commit in
+                CommitRow(
+                    commit: commit,
+                    isLast: idx == commits.count - 1 && olderCommits.isEmpty,
+                    isDimmed: false,
+                    onSelect: { onSelect(commit) }
+                )
+            }
+        } else if olderCommits.isEmpty, comparisonRef != nil {
+            emptyPlaceholder
+        }
+
+        // 2. Divider — only when older commits are shown AND we have a
+        // comparison ref to label the boundary against.
+        if !olderCommits.isEmpty, let ref = comparisonRef {
+            dividerRow(label: ref)
+        }
+
+        // 3. Older commits — dimmed when comparisonRef exists, plain when not.
+        if !olderCommits.isEmpty {
+            ForEach(Array(olderCommits.enumerated()), id: \.element.id) { idx, commit in
+                CommitRow(
+                    commit: commit,
+                    isLast: idx == olderCommits.count - 1,
+                    isDimmed: comparisonRef != nil,
+                    onSelect: { onSelect(commit) }
+                )
+            }
+        }
+
+        // 4. Footer.
+        footer
     }
 
     private var emptyPlaceholder: some View {
@@ -46,5 +87,53 @@ struct CommitsSectionView: View {
             .foregroundColor(theme.color("fg-faint"))
             .padding(.horizontal, 12).padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func dividerRow(label: String) -> some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(theme.color("line"))
+                .frame(height: 1)
+            Text(label)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(theme.color("fg-faint"))
+                .textCase(.uppercase)
+                .tracking(0.4)
+            Rectangle()
+                .fill(theme.color("line"))
+                .frame(height: 1)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        if isLoadingOlder {
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.mini)
+                Text("Loading…")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-faint"))
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 8)
+        } else if hasMoreOlder {
+            Button(action: onLoadOlder) {
+                Text("↓ Load older commits")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("accent"))
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        } else if !olderCommits.isEmpty {
+            Text("End of history")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-faint"))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 8)
+        }
     }
 }

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -33,7 +33,7 @@ struct CommitsSectionView: View {
             }
 
             if expanded {
-                body_expanded
+                expandedBody
             }
         }
     }
@@ -44,14 +44,13 @@ struct CommitsSectionView: View {
     }
 
     @ViewBuilder
-    private var body_expanded: some View {
+    private var expandedBody: some View {
         // 1. Worktree commits ("your work") OR today's empty placeholder.
         if !commits.isEmpty {
             ForEach(Array(commits.enumerated()), id: \.element.id) { idx, commit in
                 CommitRow(
                     commit: commit,
                     isLast: idx == commits.count - 1 && olderCommits.isEmpty,
-                    isDimmed: false,
                     onSelect: { onSelect(commit) }
                 )
             }

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -54,7 +54,7 @@ struct CommitsSectionView: View {
                     onSelect: { onSelect(commit) }
                 )
             }
-        } else if olderCommits.isEmpty, comparisonRef != nil {
+        } else if olderCommits.isEmpty {
             emptyPlaceholder
         }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -21,6 +21,14 @@ final class RightPaneState {
     var workingTreeExpanded: Bool = true
     var commitsExpanded: Bool = true
 
+    // Older-history paging — populated lazily by `loadOlder()`.
+    // Cleared (and `hasMoreOlder` reset to true) on any `refresh()`
+    // that re-fetches `commits`, because the divergence cursor may
+    // have moved.
+    var olderCommits: [CommitInfo] = []
+    var hasMoreOlder: Bool = true
+    var isLoadingOlder: Bool = false
+
     /// `true` once `refresh()` has decided the initial `activeTab`. After
     /// that, the user's tab choice is sticky and refreshes leave it alone.
     private var didInitDefaultTab: Bool = false
@@ -55,6 +63,12 @@ final class RightPaneState {
         loading = true
         defer { loading = false }
         do {
+            // Any refresh re-anchors the older-history cursor; drop the
+            // accumulated pages so we don't accidentally splice an old
+            // page onto a new HEAD.
+            self.olderCommits = []
+            self.hasMoreOlder = true
+            self.isLoadingOlder = false
             async let s = git.status(worktreePath: worktree.path)
             async let c = git.commitsAhead(at: worktree.path, baseBranch: baseBranch)
             let entries = try await s
@@ -267,6 +281,48 @@ final class RightPaneState {
                 self.composer.clearAmendPrefillIfUnchanged()
                 self.composer.amendWarning = false
             }
+        }
+    }
+
+    /// Load the next page of pre-divergence history. Uses the oldest
+    /// currently-visible SHA as the cursor; falls back to HEAD when the
+    /// section is sitting on base (or there's no comparison ref at all).
+    /// Concurrent re-entry is blocked by `isLoadingOlder` — the view
+    /// hides the tap target while a load is in flight.
+    @MainActor
+    func loadOlder() async {
+        guard !isLoadingOlder, hasMoreOlder else { return }
+        let cursor: String
+        if let last = olderCommits.last {
+            cursor = last.sha
+        } else if let last = commits.last {
+            cursor = last.sha
+        } else {
+            cursor = "HEAD"
+        }
+        let wt = worktree.path
+        isLoadingOlder = true
+        defer { isLoadingOlder = false }
+        do {
+            let page = try await git.commitsOlder(
+                worktreePath: wt,
+                beforeSha: cursor,
+                count: 20
+            )
+            // Discard the page if invalidation fired mid-flight (worktree
+            // changed, or refresh() wiped the cursor we were building on).
+            guard wt == self.worktree.path else { return }
+            let cursorStillValid = (olderCommits.last?.sha == cursor)
+                || (olderCommits.isEmpty && commits.last?.sha == cursor)
+                || (olderCommits.isEmpty && commits.isEmpty && cursor == "HEAD")
+            guard cursorStillValid else { return }
+            self.olderCommits.append(contentsOf: page)
+            if page.count < 20 {
+                self.hasMoreOlder = false
+            }
+        } catch {
+            logger.error("loadOlder failed for worktree \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            self.hasMoreOlder = false
         }
     }
 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -300,18 +300,14 @@ final class RightPaneState {
         } else {
             cursor = "HEAD"
         }
-        let wt = worktree.path
         isLoadingOlder = true
         defer { isLoadingOlder = false }
         do {
             let page = try await git.commitsOlder(
-                worktreePath: wt,
+                worktreePath: worktree.path,
                 beforeSha: cursor,
                 count: 20
             )
-            // Discard the page if invalidation fired mid-flight (worktree
-            // changed, or refresh() wiped the cursor we were building on).
-            guard wt == self.worktree.path else { return }
             let cursorStillValid = (olderCommits.last?.sha == cursor)
                 || (olderCommits.isEmpty && commits.last?.sha == cursor)
                 || (olderCommits.isEmpty && commits.isEmpty && cursor == "HEAD")
@@ -320,6 +316,8 @@ final class RightPaneState {
             if page.count < 20 {
                 self.hasMoreOlder = false
             }
+        } catch is CancellationError {
+            // user-cancelled
         } catch {
             logger.error("loadOlder failed for worktree \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             self.hasMoreOlder = false

--- a/AlasTests/CommitsOlderTests.swift
+++ b/AlasTests/CommitsOlderTests.swift
@@ -60,6 +60,7 @@ struct CommitsOlderTests {
 
         let svc = GitService()
         let result = try await svc.commitsOlder(worktreePath: repo, beforeSha: "HEAD", count: 10)
+        #expect(result.count == 3)
         #expect(!result.map(\.subject).contains("side work"))
         #expect(result.map(\.subject).contains("step 3"))
     }
@@ -70,6 +71,21 @@ struct CommitsOlderTests {
         let svc = GitService()
         await #expect(throws: (any Error).self) {
             _ = try await svc.commitsOlder(worktreePath: repo, beforeSha: "deadbeefdeadbeef", count: 5)
+        }
+    }
+
+    @Test func throwsAtRootCommit() async throws {
+        let repo = try await makeLinearRepo(commits: 3)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        // Resolve the root commit's SHA — there's exactly one ancestor-less commit.
+        let rootLog = try await Process.git(["rev-list", "--max-parents=0", "HEAD"], cwd: repo)
+        let rootSha = rootLog.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let svc = GitService()
+        // `git log <root>^` fails because the root has no parent. The caller
+        // in RightPaneState catches this and flips `hasMoreOlder` to false,
+        // producing the spec's "End of history" footer.
+        await #expect(throws: (any Error).self) {
+            _ = try await svc.commitsOlder(worktreePath: repo, beforeSha: rootSha, count: 5)
         }
     }
 }

--- a/AlasTests/CommitsOlderTests.swift
+++ b/AlasTests/CommitsOlderTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct CommitsOlderTests {
+    private func makeLinearRepo(commits: Int) async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-co-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "test@example.com"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "test"], cwd: tmp)
+        for i in 1...commits {
+            try "\(i)\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+            _ = try await Process.git(["add", "."], cwd: tmp)
+            _ = try await Process.git(["commit", "-q", "-m", "feat: step \(i)"], cwd: tmp)
+        }
+        return tmp
+    }
+
+    @Test func returnsExactlyNCommitsBeforeRef() async throws {
+        let repo = try await makeLinearRepo(commits: 25)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let svc = GitService()
+        let result = try await svc.commitsOlder(worktreePath: repo, beforeSha: "HEAD", count: 20)
+        #expect(result.count == 20)
+        #expect(result[0].subject == "step 24")
+        #expect(result[19].subject == "step 5")
+    }
+
+    @Test func returnsFewerWhenAncestorsRunOut() async throws {
+        let repo = try await makeLinearRepo(commits: 5)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let svc = GitService()
+        let result = try await svc.commitsOlder(worktreePath: repo, beforeSha: "HEAD", count: 20)
+        #expect(result.count == 4)
+        #expect(result.map(\.subject) == ["step 4", "step 3", "step 2", "step 1"])
+    }
+
+    @Test func cursorByShaStartsFromParent() async throws {
+        let repo = try await makeLinearRepo(commits: 10)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let log = try await Process.git(["log", "--grep", "step 5$", "--pretty=%H"], cwd: repo)
+        let step5 = log.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let svc = GitService()
+        let result = try await svc.commitsOlder(worktreePath: repo, beforeSha: step5, count: 3)
+        #expect(result.map(\.subject) == ["step 4", "step 3", "step 2"])
+    }
+
+    @Test func usesFirstParentOnMergeAncestry() async throws {
+        let repo = try await makeLinearRepo(commits: 3)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["checkout", "-q", "-b", "side"], cwd: repo)
+        try "side\n".write(to: repo.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "feat: side work"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        _ = try await Process.git(["merge", "-q", "--no-ff", "--no-edit", "side"], cwd: repo)
+
+        let svc = GitService()
+        let result = try await svc.commitsOlder(worktreePath: repo, beforeSha: "HEAD", count: 10)
+        #expect(!result.map(\.subject).contains("side work"))
+        #expect(result.map(\.subject).contains("step 3"))
+    }
+
+    @Test func throwsOnInvalidSha() async throws {
+        let repo = try await makeLinearRepo(commits: 3)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let svc = GitService()
+        await #expect(throws: (any Error).self) {
+            _ = try await svc.commitsOlder(worktreePath: repo, beforeSha: "deadbeefdeadbeef", count: 5)
+        }
+    }
+}

--- a/AlasTests/RightPaneStateLoadOlderTests.swift
+++ b/AlasTests/RightPaneStateLoadOlderTests.swift
@@ -124,4 +124,23 @@ struct RightPaneStateLoadOlderTests {
         #expect(state.olderCommits.isEmpty)
         #expect(state.isLoadingOlder == false)
     }
+
+    @Test func loadOlderWithNoComparisonRef() async throws {
+        // No remote (no upstream), and we set baseBranch to a name that
+        // doesn't resolve locally → commitsAhead returns ([], nil).
+        let repo = try await makeRepoOnMain(commits: 6)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: "main"),
+            baseBranch: "nonexistent-branch"
+        )
+        await state.refresh()
+        #expect(state.commits.isEmpty)
+        #expect(state.comparisonRef == nil)
+
+        await state.loadOlder()
+        // Cursor falls back to "HEAD", so we get HEAD^ and older = c5..c1.
+        #expect(state.olderCommits.map(\.subject) == ["c5", "c4", "c3", "c2", "c1"])
+        #expect(state.hasMoreOlder == false)
+    }
 }

--- a/AlasTests/RightPaneStateLoadOlderTests.swift
+++ b/AlasTests/RightPaneStateLoadOlderTests.swift
@@ -1,0 +1,127 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct RightPaneStateLoadOlderTests {
+    private func makeWorktree(at path: URL, branch: String) -> Worktree {
+        Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: "test-project",
+            name: branch,
+            branch: branch,
+            path: path,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    private func makeRepoOnMain(commits n: Int) async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-loadolder-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "t@e.com"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: tmp)
+        for i in 1...n {
+            try "\(i)\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+            _ = try await Process.git(["add", "."], cwd: tmp)
+            _ = try await Process.git(["commit", "-q", "-m", "feat: c\(i)"], cwd: tmp)
+        }
+        return tmp
+    }
+
+    private func makeBranchAhead(base: Int, ahead: Int) async throws -> URL {
+        let repo = try await makeRepoOnMain(commits: base)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        for i in 1...ahead {
+            try "f\(i)\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+            _ = try await Process.git(["add", "."], cwd: repo)
+            _ = try await Process.git(["commit", "-q", "-m", "feat: ahead\(i)"], cwd: repo)
+        }
+        return repo
+    }
+
+    @Test func firstPageUsesParentOfLastAheadCommit() async throws {
+        let repo = try await makeBranchAhead(base: 25, ahead: 3)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(worktree: makeWorktree(at: repo, branch: "feature"), baseBranch: "main")
+        await state.refresh()
+        #expect(state.commits.count == 3)
+        #expect(state.olderCommits.isEmpty)
+        #expect(state.hasMoreOlder)
+
+        await state.loadOlder()
+        #expect(state.olderCommits.count == 20)
+        #expect(state.hasMoreOlder)
+        // First older entry is the parent of the oldest ahead commit
+        // ("ahead1"), which is the latest base commit "c25".
+        #expect(state.olderCommits[0].subject == "c25")
+    }
+
+    @Test func subsequentPageContinuesFromOlderCursor() async throws {
+        let repo = try await makeBranchAhead(base: 50, ahead: 2)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(worktree: makeWorktree(at: repo, branch: "feature"), baseBranch: "main")
+        await state.refresh()
+        await state.loadOlder()
+        let firstPageTail = state.olderCommits.last!.subject
+        await state.loadOlder()
+        #expect(state.olderCommits.count == 40)
+        let pageTwoStartIndex = 20
+        #expect(state.olderCommits[pageTwoStartIndex].subject != firstPageTail)
+    }
+
+    @Test func endOfHistoryFlipsHasMoreOlder() async throws {
+        let repo = try await makeBranchAhead(base: 5, ahead: 1)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(worktree: makeWorktree(at: repo, branch: "feature"), baseBranch: "main")
+        await state.refresh()
+        await state.loadOlder()
+        // 5 base commits, ahead1's parent is c5, so older = c1..c5 → 5 entries.
+        #expect(state.olderCommits.count == 5)
+        #expect(state.hasMoreOlder == false)
+    }
+
+    @Test func atBaseUsesHeadAsCursor() async throws {
+        let repo = try await makeRepoOnMain(commits: 6)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(worktree: makeWorktree(at: repo, branch: "main"), baseBranch: "main")
+        await state.refresh()
+        #expect(state.commits.isEmpty)
+        await state.loadOlder()
+        // HEAD^ + ancestors = c1..c5
+        #expect(state.olderCommits.map(\.subject) == ["c5", "c4", "c3", "c2", "c1"])
+        #expect(state.hasMoreOlder == false)
+    }
+
+    @Test func refreshClearsOlderState() async throws {
+        let repo = try await makeBranchAhead(base: 25, ahead: 2)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(worktree: makeWorktree(at: repo, branch: "feature"), baseBranch: "main")
+        await state.refresh()
+        await state.loadOlder()
+        #expect(state.olderCommits.count == 20)
+        await state.refresh()
+        #expect(state.olderCommits.isEmpty)
+        #expect(state.hasMoreOlder)
+        #expect(state.isLoadingOlder == false)
+    }
+
+    @Test func errorPathDisablesFurtherLoads() async throws {
+        // Unborn-HEAD repo. We DO NOT call refresh() (it would also error).
+        // loadOlder() uses cursor = "HEAD" which doesn't resolve → git errors
+        // → hasMoreOlder = false.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-loadolder-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let state = RightPaneState(worktree: makeWorktree(at: tmp, branch: "main"), baseBranch: "main")
+        await state.loadOlder()
+        #expect(state.hasMoreOlder == false)
+        #expect(state.olderCommits.isEmpty)
+        #expect(state.isLoadingOlder == false)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an opt-in, lazy, paged "Load older commits" affordance below the right-sidebar Commits section.
- Pre-divergence commits render dimmed (50% opacity, fainter rail dot) under a divider labeled with the comparison ref. Worktree-ahead commits keep today's full-opacity styling.
- 20 commits per page, `--first-parent` traversal. The original `commitsAhead` fast path is untouched.
- New: `GitService.commitsOlder(worktreePath:beforeSha:count:)`, three fields on `RightPaneState`, `RightPaneState.loadOlder()`, divider + footer rendering rules in `CommitsSectionView`, `isDimmed` on `CommitRow`.

## Architecture
Two-arrays / two-queries model: `commits` (ahead-of-base, today) stays untouched; `olderCommits` is populated lazily by the new git method. Older state clears on any `refresh()` (worktree switch, branch change, new commit, comparison-ref change). Cursor invalidation discards stale pages if a mid-flight refresh lands. \`CancellationError\` is handled separately so a cancelled task doesn't permanently disable further loads.

## Tests
- \`CommitsOlderTests\` (6): page-of-N, runs-out, SHA cursor, --first-parent merge filtering, invalid SHA, root commit.
- \`RightPaneStateLoadOlderTests\` (7): first page from ahead cursor, subsequent paging, end of history, at-base HEAD cursor, refresh-clears, error path, no-comparison-ref.
- All 21 relevant tests pass via xcodebuild.

## Test plan
- [ ] Branch ahead of \`main\`: Load older walks history into dimmed rows under a \`main\` divider; repeat to End of history.
- [ ] Switch worktrees → older history clears.
- [ ] New commit on the branch → older history clears, top section gains one row.
- [ ] Worktree sitting on \`main\` directly: "up to date with main" placeholder + Load older footer visible; loading produces all-dimmed main history.
- [ ] Detached HEAD with no base: "no comparison branch" hint + Load older footer; loading produces undimmed history with no divider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)