### PR TITLE
Pin main worktree first per repository

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -32,8 +32,6 @@
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
-		50AB83A42DC745ACA76186D1 /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50567E63676400394FE05D8 /* CommitsOlderTests.swift */; };
-		A2ECFAB592D84917837E3EAD /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6CC94C50D54A6193647601 /* RightPaneStateLoadOlderTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
@@ -97,6 +95,7 @@
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
 		466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0240C5961343C3042D865570 /* GeneralPane.swift */; };
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
+		4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */; };
 		48E0B43B698544C1C4524242 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */; };
 		497D21A67A062CE6282008CD /* PathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295319DB8544C170DDD6328D /* PathsTests.swift */; };
 		49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */; };
@@ -127,6 +126,7 @@
 		629B98E07ED9A159A695707D /* JetBrainsMonoNerdFont-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */; };
 		62CE99A2AC8B0700EB2F42A2 /* CommitAIDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8EA1E2128F7ED14F9CF61C3 /* CommitAIDetectorTests.swift */; };
 		64ADA6AFE69C52F121A163E1 /* FileTypeIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F721FB733081A583D4053DDA /* FileTypeIconView.swift */; };
+		66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */; };
 		671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A17A797374500E1FDD2382C /* PersistenceStore.swift */; };
 		676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4261E417947C1A21E77C1587 /* GitStatusCache.swift */; };
 		67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */; };
@@ -310,6 +310,7 @@
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
 		F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */; };
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
+		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -399,6 +400,7 @@
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
 		36992F601C8EB6C3D45B584F /* SearchKbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKbd.swift; sourceTree = "<group>"; };
 		36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKind.swift; sourceTree = "<group>"; };
+		3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerWorktreeOrderingTests.swift; sourceTree = "<group>"; };
 		373D587E3153D902EB10208B /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
 		38499AFE31188908546EE222 /* LSPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransport.swift; sourceTree = "<group>"; };
 		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
@@ -437,8 +439,6 @@
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
-		C50567E63676400394FE05D8 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
-		3A6CC94C50D54A6193647601 /* RightPaneStateLoadOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateLoadOlderTests.swift; sourceTree = "<group>"; };
 		57713D7143CFD53124E0523F /* AlasHookCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommand.swift; sourceTree = "<group>"; };
 		57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledFontRegistrar.swift; sourceTree = "<group>"; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
@@ -490,6 +490,7 @@
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
+		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
@@ -532,6 +533,7 @@
 		B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
+		B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateLoadOlderTests.swift; sourceTree = "<group>"; };
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
 		B4C486F9097A2B145D101E2C /* AlasButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasButton.swift; sourceTree = "<group>"; };
 		B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInstaller.swift; sourceTree = "<group>"; };
@@ -694,7 +696,7 @@
 				DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */,
 				9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */,
 				576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */,
-				C50567E63676400394FE05D8 /* CommitsOlderTests.swift */,
+				8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */,
 				A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */,
 				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
 				BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */,
@@ -745,8 +747,9 @@
 				00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */,
 				BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
+				3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */,
+				B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
-				3A6CC94C50D54A6193647601 /* RightPaneStateLoadOlderTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
@@ -1695,7 +1698,7 @@
 				F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */,
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,
 				17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */,
-				50AB83A42DC745ACA76186D1 /* CommitsOlderTests.swift in Sources */,
+				4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				42D8417781E790CA6AA49F7E /* CursorInstallerTests.swift in Sources */,
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,
@@ -1753,8 +1756,9 @@
 				4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */,
 				BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
+				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
+				FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
-				A2ECFAB592D84917837E3EAD /* RightPaneStateLoadOlderTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1162,6 +1162,7 @@ final class AppState {
     nonisolated static func looksLikeDirtyWorktreeError(_ stderr: String) -> Bool {
         let s = stderr.lowercased()
         return s.contains("is dirty")
+            || s.contains("dirty worktree")
             || s.contains("contains modified or untracked files")
             || s.contains("modified or untracked")
     }

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -79,11 +79,13 @@ final class ProjectsManager {
         let projectId = worktree.projectId
         worktreesByProject[projectId, default: []].removeAll { $0.id == worktree.id }
         worktreesByProject[projectId, default: []].append(worktree)
+        applyWorktreeOrdering(projectId: projectId)
     }
 
     func removeOptimisticWorktree(id: String, projectId: String) {
         worktreesByProject[projectId]?.removeAll { $0.id == id }
         worktreeOperationStates.removeValue(forKey: id)
+        applyWorktreeOrdering(projectId: projectId)
     }
 
     func visibleWorktrees(projectId: String) -> [Worktree] {
@@ -94,6 +96,41 @@ final class ProjectsManager {
     func archivedWorktrees(projectId: String) -> [Worktree] {
         let hidden = hiddenSet(projectId: projectId)
         return worktrees(projectId: projectId).filter { hidden.contains(canonical($0.path)) }
+    }
+
+    func reorderWorktree(projectId: String, fromIndex: Int, toIndex: Int) {
+        guard let projectIndex = projects.firstIndex(where: { $0.id == projectId }),
+              var rows = worktreesByProject[projectId],
+              rows.indices.contains(fromIndex)
+        else { return }
+
+        applyWorktreeOrdering(projectId: projectId)
+        rows = worktreesByProject[projectId, default: []]
+        guard rows.indices.contains(fromIndex),
+              !isMainWorktree(rows[fromIndex], project: projects[projectIndex])
+        else { return }
+
+        let moving = rows.remove(at: fromIndex)
+        let clampedDestination = min(max(toIndex, 1), rows.count)
+        rows.insert(moving, at: clampedDestination)
+
+        worktreesByProject[projectId] = rows
+        projects[projectIndex].worktreeOrder = normalizedWorktreeOrder(
+            rows.map(\.id),
+            rows: rows,
+            project: projects[projectIndex]
+        )
+        applyWorktreeOrdering(projectId: projectId)
+    }
+
+    func reorderWorktree(projectId: String, movingId: String, destinationId: String) {
+        applyWorktreeOrdering(projectId: projectId)
+        let rows = worktreesByProject[projectId, default: []]
+        guard let fromIndex = rows.firstIndex(where: { $0.id == movingId }),
+              let toIndex = rows.firstIndex(where: { $0.id == destinationId })
+        else { return }
+
+        reorderWorktree(projectId: projectId, fromIndex: fromIndex, toIndex: toIndex)
     }
 
     func isWorktreeHidden(projectId: String, path: URL) -> Bool {
@@ -166,15 +203,14 @@ final class ProjectsManager {
         for id in clearOperationIds {
             worktreeOperationStates.removeValue(forKey: id)
         }
-        // Sort deterministically so optimistic rows don't jump position.
-        reconciled.sort { $0.path.path < $1.path.path }
         worktreesByProject[projectId] = reconciled
+        let orderChanged = applyWorktreeOrdering(projectId: projectId)
 
         guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return false }
         let live = Set(trees.map { canonical($0.path) })
         let before = projects[idx].hiddenWorktreePaths.count
         projects[idx].hiddenWorktreePaths.removeAll { !live.contains($0) }
-        return projects[idx].hiddenWorktreePaths.count != before
+        return orderChanged || projects[idx].hiddenWorktreePaths.count != before
     }
 
     /// Refresh every project. Returns `true` when at least one project's
@@ -221,7 +257,10 @@ final class ProjectsManager {
                 changed = true
             }
         }
-        if changed { worktreesByProject[projectId] = rows }
+        if changed {
+            worktreesByProject[projectId] = rows
+            applyWorktreeOrdering(projectId: projectId)
+        }
     }
 
     private func hiddenSet(projectId: String) -> Set<String> {
@@ -231,5 +270,66 @@ final class ProjectsManager {
 
     private func canonical(_ url: URL) -> String {
         Worktree.makeId(path: url)
+    }
+
+    @discardableResult
+    private func applyWorktreeOrdering(projectId: String) -> Bool {
+        guard let projectIndex = projects.firstIndex(where: { $0.id == projectId }),
+              let rows = worktreesByProject[projectId]
+        else { return false }
+
+        let project = projects[projectIndex]
+        let ordered = sortedWorktrees(rows, project: project)
+        worktreesByProject[projectId] = ordered
+
+        let normalized = normalizedWorktreeOrder(project.worktreeOrder, rows: ordered, project: project)
+        if projects[projectIndex].worktreeOrder != normalized {
+            projects[projectIndex].worktreeOrder = normalized
+            return true
+        }
+        return false
+    }
+
+    private func sortedWorktrees(_ rows: [Worktree], project: ProjectConfig) -> [Worktree] {
+        let order = normalizedWorktreeOrder(project.worktreeOrder, rows: rows, project: project)
+        let rank = Dictionary(uniqueKeysWithValues: order.enumerated().map { ($0.element, $0.offset) })
+        return rows.sorted { lhs, rhs in
+            let lhsIsMain = isMainWorktree(lhs, project: project)
+            let rhsIsMain = isMainWorktree(rhs, project: project)
+            if lhsIsMain != rhsIsMain { return lhsIsMain }
+
+            let lhsRank = rank[lhs.id]
+            let rhsRank = rank[rhs.id]
+            if let lhsRank, let rhsRank, lhsRank != rhsRank { return lhsRank < rhsRank }
+            if lhsRank != nil { return true }
+            if rhsRank != nil { return false }
+            return lhs.path.path < rhs.path.path
+        }
+    }
+
+    private func normalizedWorktreeOrder(
+        _ order: [String],
+        rows: [Worktree],
+        project: ProjectConfig
+    ) -> [String] {
+        let nonMainIds = Set(rows.filter { !isMainWorktree($0, project: project) }.map(\.id))
+        var seen: Set<String> = []
+        var normalized: [String] = []
+
+        for id in order where nonMainIds.contains(id) && !seen.contains(id) {
+            normalized.append(id)
+            seen.insert(id)
+        }
+
+        for row in rows where nonMainIds.contains(row.id) && !seen.contains(row.id) {
+            normalized.append(row.id)
+            seen.insert(row.id)
+        }
+
+        return normalized
+    }
+
+    private func isMainWorktree(_ worktree: Worktree, project: ProjectConfig) -> Bool {
+        canonical(worktree.path) == canonical(URL(fileURLWithPath: project.path))
     }
 }

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -40,10 +40,11 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var color: String        // hex string, e.g. "#5fb7c4"
     var addedAt: Date
     var hiddenWorktreePaths: [String] = []
+    var worktreeOrder: [String] = []
     var startupScripts: ProjectStartupScripts = .defaults
 
     enum CodingKeys: String, CodingKey {
-        case id, name, path, color, addedAt, hiddenWorktreePaths, startupScripts
+        case id, name, path, color, addedAt, hiddenWorktreePaths, worktreeOrder, startupScripts
     }
 
     init(
@@ -53,6 +54,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         color: String,
         addedAt: Date,
         hiddenWorktreePaths: [String] = [],
+        worktreeOrder: [String] = [],
         startupScripts: ProjectStartupScripts = .defaults
     ) {
         self.id = id
@@ -61,6 +63,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.color = color
         self.addedAt = addedAt
         self.hiddenWorktreePaths = hiddenWorktreePaths
+        self.worktreeOrder = worktreeOrder
         self.startupScripts = startupScripts
     }
 
@@ -74,6 +77,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         color = try c.decode(String.self, forKey: .color)
         addedAt = try c.decode(Date.self, forKey: .addedAt)
         hiddenWorktreePaths = (try? c.decode([String].self, forKey: .hiddenWorktreePaths)) ?? []
+        worktreeOrder = (try? c.decode([String].self, forKey: .worktreeOrder)) ?? []
         startupScripts = (try? c.decode(ProjectStartupScripts.self, forKey: .startupScripts))
             ?? .defaults
     }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -21,6 +21,7 @@ struct RepoGroupView: View {
     let onRetryCreate: (Worktree) -> Void
     let onRetryDelete: (Worktree) -> Void
     let onRemoveFailed: (Worktree) -> Void
+    let onDropWorktree: (_ draggedId: String, _ destinationId: String) -> Void
     @Environment(\.theme) var theme
     @State private var hovering = false
     @State private var plusHovering = false
@@ -104,6 +105,12 @@ struct RepoGroupView: View {
                             onRetryCreate: { onRetryCreate(wt) },
                             onRetryDelete: { onRetryDelete(wt) }
                         )
+                        .draggable(wt.id)
+                        .dropDestination(for: String.self) { ids, _ in
+                            guard let draggedId = ids.first, draggedId != wt.id else { return false }
+                            onDropWorktree(draggedId, wt.id)
+                            return true
+                        }
                     }
                 }
                 .padding(.horizontal, 6)

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -104,6 +104,14 @@ struct SidebarView: View {
                                 onRetryDelete: { wt in state.deleteWorktree(wt) },
                                 onRemoveFailed: { wt in
                                     state.removeFailedOptimisticWorktree(id: wt.id, projectId: project.id)
+                                },
+                                onDropWorktree: { draggedId, destinationId in
+                                    state.projectsManager.reorderWorktree(
+                                        projectId: project.id,
+                                        movingId: draggedId,
+                                        destinationId: destinationId
+                                    )
+                                    state.saveProjects()
                                 }
                             )
                         }

--- a/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
+++ b/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
@@ -1,0 +1,297 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct ProjectsManagerWorktreeOrderingTests {
+    private func makeManager(repoPath: String = "/repo") -> (ProjectsManager, ProjectConfig) {
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: repoPath,
+            color: "blue",
+            addedAt: Date()
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        return (mgr, project)
+    }
+
+    private func seed(_ mgr: ProjectsManager, projectId: String, _ wts: [Worktree]) {
+        for wt in wts { mgr.insertOptimisticWorktree(wt) }
+        for wt in wts { mgr.setOperationState(id: wt.id, state: nil) }
+    }
+
+    private func wt(path: String, branch: String, projectId: String = "p1") -> Worktree {
+        let url = URL(fileURLWithPath: path)
+        return Worktree(
+            id: Worktree.makeId(path: url),
+            projectId: projectId,
+            name: branch,
+            branch: branch,
+            path: url,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    // MARK: - main pinned first
+
+    @Test func mainWorktreeIsFirstByDefault() {
+        let (mgr, project) = makeManager()
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo/wts/feat", branch: "feat/foo"),
+            wt(path: "/repo", branch: "main"),
+            wt(path: "/repo/wts/fix", branch: "fix/bar"),
+        ])
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.first?.branch == "main")
+    }
+
+    @Test func mainWorktreeIsFirstEvenWithCustomOrder() {
+        let main = wt(path: "/repo", branch: "main")
+        let feat = wt(path: "/repo/wts/feat", branch: "feat")
+        let fix = wt(path: "/repo/wts/fix", branch: "fix")
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date(),
+            worktreeOrder: [feat.id, main.id, fix.id]
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        seed(mgr, projectId: project.id, [feat, main, fix])
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.first?.branch == "main")
+        // After main, custom order should apply for the remaining worktrees.
+        let afterMain = Array(trees.dropFirst())
+        #expect(afterMain.map(\.branch) == ["feat", "fix"])
+        #expect(mgr.projects[0].worktreeOrder == [feat.id, fix.id])
+    }
+
+    @Test func reorderNonMainWorktreesUpdatesOrder() {
+        let main = wt(path: "/repo", branch: "main")
+        let feat = wt(path: "/repo/wts/feat", branch: "feat")
+        let fix = wt(path: "/repo/wts/fix", branch: "fix")
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date(),
+            worktreeOrder: [feat.id, fix.id]
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        seed(mgr, projectId: project.id, [feat, main, fix])
+
+        mgr.reorderWorktree(projectId: project.id, fromIndex: 2, toIndex: 1)
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "fix", "feat"])
+        #expect(mgr.projects[0].worktreeOrder == [fix.id, feat.id])
+    }
+
+    @Test func reorderRefusesToMoveMainBelowOthers() {
+        let main = wt(path: "/repo", branch: "main")
+        let feat = wt(path: "/repo/wts/feat", branch: "feat")
+        let fix = wt(path: "/repo/wts/fix", branch: "fix")
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date(),
+            worktreeOrder: [feat.id, fix.id]
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        seed(mgr, projectId: project.id, [feat, main, fix])
+
+        mgr.reorderWorktree(projectId: project.id, fromIndex: 0, toIndex: 2)
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "feat", "fix"])
+        #expect(mgr.projects[0].worktreeOrder == [feat.id, fix.id])
+    }
+
+    @Test func reorderRefusesToMoveOthersAboveMain() {
+        let main = wt(path: "/repo", branch: "main")
+        let feat = wt(path: "/repo/wts/feat", branch: "feat")
+        let fix = wt(path: "/repo/wts/fix", branch: "fix")
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date(),
+            worktreeOrder: [feat.id, fix.id]
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        seed(mgr, projectId: project.id, [feat, main, fix])
+
+        mgr.reorderWorktree(projectId: project.id, fromIndex: 2, toIndex: 0)
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "fix", "feat"])
+        #expect(mgr.projects[0].worktreeOrder == [fix.id, feat.id])
+    }
+
+    // MARK: - refresh reconciliation
+
+    @Test func refreshReconciliationPreservesMainFirst() async throws {
+        let (mgr, _) = makeManager()
+        let svc = WorktreeService()
+
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-wt-order-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+
+        let projectLive = try await mgr.addProject(path: repo, displayName: "order", color: "blue")
+        try await mgr.refreshWorktrees(projectId: projectLive.id)
+
+        let destA = repo.appendingPathComponent("wt-a")
+        let destB = repo.appendingPathComponent("wt-b")
+        _ = try await svc.add(repoPath: repo, base: "main", branch: "feat-a", destination: destA, projectId: projectLive.id)
+        _ = try await svc.add(repoPath: repo, base: "main", branch: "feat-b", destination: destB, projectId: projectLive.id)
+
+        try await mgr.refreshWorktrees(projectId: projectLive.id)
+        let trees = mgr.worktrees(projectId: projectLive.id)
+        #expect(trees.first?.branch == "main")
+    }
+
+    @Test func refreshAppliesPersistedOrderAfterMain() async throws {
+        let svc = WorktreeService()
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-wt-order-refresh-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+
+        let destA = repo.appendingPathComponent("wt-a")
+        let destB = repo.appendingPathComponent("wt-b")
+        _ = try await svc.add(repoPath: repo, base: "main", branch: "feat-a", destination: destA, projectId: "p1")
+        _ = try await svc.add(repoPath: repo, base: "main", branch: "feat-b", destination: destB, projectId: "p1")
+
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: repo.path,
+            color: "blue",
+            addedAt: Date(),
+            worktreeOrder: [
+                Worktree.makeId(path: destB),
+                Worktree.makeId(path: repo),
+                Worktree.makeId(path: destA),
+            ]
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+
+        let changed = try await mgr.refreshWorktrees(projectId: project.id)
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "feat-b", "feat-a"])
+        #expect(mgr.projects[0].worktreeOrder == [Worktree.makeId(path: destB), Worktree.makeId(path: destA)])
+        #expect(changed)
+    }
+
+    @Test func applyHeadUpdatesPreservesMainFirst() {
+        let (mgr, project) = makeManager()
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo/wts/feat", branch: "feat/foo"),
+            wt(path: "/repo", branch: "main"),
+        ])
+
+        mgr.applyHeadUpdates(
+            projectId: project.id,
+            branchByWorktreePath: [URL(fileURLWithPath: "/repo/wts/feat"): "feat/bar"]
+        )
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.first?.branch == "main")
+        #expect(trees.first { $0.path.path == "/repo/wts/feat" }?.branch == "feat/bar")
+    }
+
+    // MARK: - visible / archived
+
+    @Test func visibleWorktreesAlsoHaveMainFirst() {
+        let main = wt(path: "/repo", branch: "main")
+        let feat = wt(path: "/repo/wts/feat", branch: "feat")
+        let fix = wt(path: "/repo/wts/fix", branch: "fix")
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date(),
+            worktreeOrder: [feat.id, fix.id]
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        seed(mgr, projectId: project.id, [feat, main, fix])
+
+        #expect(mgr.visibleWorktrees(projectId: project.id).map(\.branch) == ["main", "feat", "fix"])
+    }
+
+    @Test func archivedWorktreesAlsoHaveMainFirst() {
+        let main = wt(path: "/repo", branch: "main")
+        let feat = wt(path: "/repo/wts/feat", branch: "feat")
+        let fix = wt(path: "/repo/wts/fix", branch: "fix")
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date(),
+            hiddenWorktreePaths: ["/repo"],
+            worktreeOrder: [feat.id, fix.id]
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        seed(mgr, projectId: project.id, [feat, main, fix])
+
+        let archived = mgr.archivedWorktrees(projectId: project.id)
+        #expect(archived.first?.branch == "main")
+    }
+
+    // MARK: - tolerant decode
+
+    @Test func decodingOlderProjectConfigWithoutWorktreeOrderSuppliesEmptyArray() throws {
+        let json = """
+        {
+          "version": 1,
+          "projects": [{
+            "id": "abc",
+            "name": "alpha",
+            "path": "/tmp/alpha",
+            "color": "#5fb7c4",
+            "addedAt": 0,
+            "hiddenWorktreePaths": ["/tmp/alpha/wt"]
+          }]
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let file = try decoder.decode(ProjectsFile.self, from: json)
+        #expect(file.projects[0].worktreeOrder == [])
+    }
+
+    @Test func roundTripPreservesWorktreeOrder() throws {
+        let project = ProjectConfig(
+            id: "abc", name: "alpha", path: "/tmp/alpha",
+            color: "#5fb7c4", addedAt: Date(timeIntervalSince1970: 0),
+            worktreeOrder: ["/tmp/alpha/wt-feat", "/tmp/alpha/wt-fix"]
+        )
+        let file = ProjectsFile(projects: [project])
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(file)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(ProjectsFile.self, from: data)
+        #expect(decoded.projects[0].worktreeOrder == ["/tmp/alpha/wt-feat", "/tmp/alpha/wt-fix"])
+    }
+}


### PR DESCRIPTION
## Summary

- Main worktree is now always pinned as the first item in each repository's worktree list, regardless of persisted custom order
- Drag-and-drop cannot move main below other worktrees; non-main worktrees remain reorderable after main
- Persisted `worktreeOrder` stores only non-main IDs; main is always inferred first
- Every mutation path (add, remove, refresh, head change, reorder) calls `applyWorktreeOrdering` so refreshes cannot displace main
- Added 10 focused tests for ordering, reconciliation, reorder guards, visible/archived lists, and encoding round-trip

## Test plan

- `xcodegen && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
- Verify main worktree appears first in every repository's sidebar
- Verify drag-and-drop cannot reorder main below other worktrees
- Verify refreshing worktrees preserves main-first ordering