### PR TITLE
ci: distribute Alas via Homebrew cask on tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,9 @@ jobs:
             -destination 'platform=macOS,arch=arm64' \
             -quiet build
 
+      - name: Compute version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
       - name: Sign + notarize + staple .app
         env:
           MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
@@ -69,14 +72,14 @@ jobs:
         run: ./scripts/sign-and-notarize.sh build/Build/Products/Release/Alas.app
 
       - name: Package .app (zip + DMG)
-        run: ./scripts/package-app.sh build/Build/Products/Release/Alas.app Alas
+        run: ./scripts/package-app.sh build/Build/Products/Release/Alas.app "Alas-${VERSION}-arm64"
 
       - name: Notarize + staple DMG
         env:
           MACOS_NOTARY_APPLE_ID:     ${{ secrets.MACOS_NOTARY_APPLE_ID }}
           MACOS_NOTARY_APP_PASSWORD: ${{ secrets.MACOS_NOTARY_APP_PASSWORD }}
           MACOS_NOTARY_TEAM_ID:      ${{ secrets.MACOS_NOTARY_TEAM_ID }}
-        run: ./scripts/notarize-and-staple-dmg.sh build/Build/Products/Release/Alas.dmg
+        run: ./scripts/notarize-and-staple-dmg.sh "build/Build/Products/Release/Alas-${VERSION}-arm64.dmg"
 
       - name: Cleanup signing keychain
         if: always()
@@ -86,5 +89,5 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            build/Build/Products/Release/Alas.app.zip
-            build/Build/Products/Release/Alas.dmg
+            build/Build/Products/Release/Alas-*-arm64.app.zip
+            build/Build/Products/Release/Alas-*-arm64.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,46 @@ jobs:
           files: |
             build/Build/Products/Release/Alas-*-arm64.app.zip
             build/Build/Products/Release/Alas-*-arm64.dmg
+
+  update-homebrew:
+    name: Update Homebrew Cask
+    runs-on: ubuntu-latest
+    needs: macos-app
+    # Skip prereleases — those should ship a DMG for manual testing but
+    # must not bump the cask that brew users follow.
+    if: github.event.release.prerelease == false
+    steps:
+      - name: Get version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Download DMG and compute checksum
+        run: |
+          curl -fsSL "https://github.com/mrmans0n/alas/releases/download/v${VERSION}/Alas-${VERSION}-arm64.dmg" -o alas.dmg
+          echo "SHA_ARM=$(shasum -a 256 alas.dmg | cut -d' ' -f1)" >> "$GITHUB_ENV"
+
+      - name: Checkout homebrew-tap
+        run: |
+          git clone "https://x-access-token:${{ secrets.HOMEBREW_TAP_TOKEN }}@github.com/mrmans0n/homebrew-tap.git" homebrew-tap
+
+      - name: Download update script
+        # Pull the helper from this repo at the exact released tag so the
+        # cask body is reproducible from the release ref alone.
+        run: |
+          curl -fsSL "https://raw.githubusercontent.com/mrmans0n/alas/${{ github.ref_name }}/.github/workflows/update-cask.py" -o update-cask.py
+
+      - name: Update cask
+        working-directory: homebrew-tap
+        run: python3 ../update-cask.py
+
+      - name: Commit and push
+        working-directory: homebrew-tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- Casks/alas.rb; then
+            echo "Cask already up to date"
+            exit 0
+          fi
+          git add Casks/alas.rb
+          git commit -m "Update alas cask to ${VERSION}"
+          git push

--- a/.github/workflows/update-cask.py
+++ b/.github/workflows/update-cask.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Generate the alas Homebrew cask file."""
+import os
+import pathlib
+
+VERSION = os.environ["VERSION"]
+SHA_ARM = os.environ["SHA_ARM"]
+
+CASK = f'''\
+cask "alas" do
+  version "{VERSION}"
+  sha256 "{SHA_ARM}"
+
+  url "https://github.com/mrmans0n/alas/releases/download/v#{{version}}/Alas-#{{version}}-arm64.dmg"
+  name "Alas"
+  desc "AI parallel agent orchestrator"
+  homepage "https://github.com/mrmans0n/alas"
+
+  depends_on arch: :arm64
+  depends_on macos: :sonoma
+
+  app "Alas.app"
+
+  zap trash: [
+    "~/Library/Application Support/Alas",
+    "~/Library/Caches/io.nlopez.alas",
+    "~/Library/HTTPStorages/io.nlopez.alas",
+    "~/Library/Preferences/io.nlopez.alas.plist",
+    "~/Library/Saved Application State/io.nlopez.alas.savedState",
+    "~/Library/WebKit/io.nlopez.alas",
+  ]
+end
+'''
+
+pathlib.Path("Casks/alas.rb").write_text(CASK)
+print(f"Updated cask to {VERSION}")


### PR DESCRIPTION
## Summary
- Adds a `update-homebrew` job to `.github/workflows/release.yml` that publishes a Homebrew cask to `mrmans0n/homebrew-tap` on every stable (non-prerelease) GitHub release.
- Renames release artifacts to `Alas-<version>-arm64.{dmg,app.zip}` so the cask URL can embed the version (matches the `ai-review` pattern).
- Adds `.github/workflows/update-cask.py`, a tiny stdlib-only helper that renders `Casks/alas.rb` from `VERSION` + `SHA_ARM` env vars.

After merge, users will be able to install with:

```sh
brew install --cask mrmans0n/tap/alas
```

The cask declares `depends_on arch: :arm64` and `depends_on macos: :sonoma` (cask DSL bare-symbol form == "Sonoma or newer"; `brew style` enforces this over `">= :sonoma"`). No CLI shim, no `postflight xattr -cr` (the DMG is notarized and stapled).

The `update-homebrew` job is guarded by `if: github.event.release.prerelease == false` so prereleases still produce a DMG for manual testing without bumping the cask. Cask updates are idempotent via `git diff --quiet -- Casks/alas.rb`.

## Test plan
- [ ] CI passes on this PR.
- [ ] After merge, cut a prerelease tag (e.g. `v0.1.0-rc.1`) and confirm `macos-app` produces `Alas-0.1.0-rc.1-arm64.{dmg,app.zip}` and `update-homebrew` is **skipped**.
- [ ] Cut a stable tag (e.g. `v0.1.0`) and confirm `update-homebrew` runs and pushes `Casks/alas.rb` to `mrmans0n/homebrew-tap`.
- [ ] `brew install --cask mrmans0n/tap/alas` on a clean macOS account installs and launches Alas with no Gatekeeper prompt.
- [ ] `brew uninstall --zap --cask mrmans0n/tap/alas` removes `~/Library/Application Support/Alas`.