### PR TITLE
refine stage chip and add custom commit glyph icon

### DIFF
--- a/Alas/Sources/Icons/Icon.swift
+++ b/Alas/Sources/Icons/Icon.swift
@@ -6,10 +6,23 @@ struct Icon: View {
     var color: Color? = nil
     @Environment(\.theme) var theme
 
+    @ViewBuilder
     var body: some View {
-        Image(systemName: Self.symbol(for: name))
-            .font(.system(size: size))
-            .foregroundColor(color ?? theme.color("fg-muted"))
+        let resolved: Color = color ?? theme.color("fg-muted")
+        if name == "commit" {
+            CommitGlyph()
+                .stroke(style: StrokeStyle(
+                    lineWidth: max(1, size * (1.6 / 16.0)),
+                    lineCap: .round,
+                    lineJoin: .round
+                ))
+                .foregroundColor(resolved)
+                .frame(width: size, height: size)
+        } else {
+            Image(systemName: Self.symbol(for: name))
+                .font(.system(size: size))
+                .foregroundColor(resolved)
+        }
     }
 
     static func symbol(for name: String) -> String {
@@ -23,6 +36,7 @@ struct Icon: View {
         case "search":     return "magnifyingglass"
         case "plus":       return "plus"
         case "x":          return "xmark"
+        case "check":      return "checkmark"
         case "chev-down":  return "chevron.down"
         case "chev-right": return "chevron.right"
         case "folder":     return "folder"
@@ -37,5 +51,26 @@ struct Icon: View {
         case "alert":      return "exclamationmark.triangle"
         default:           return "questionmark"
         }
+    }
+}
+
+/// Git commit glyph: a stroked circle with two short vertical stems above
+/// and below — matches the design's 16x16 viewbox spec.
+struct CommitGlyph: Shape {
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        let s = min(rect.width, rect.height)
+        let unit = s / 16.0
+        let cx = rect.midX
+        let cy = rect.midY
+        let r = 2.5 * unit
+        p.addEllipse(in: CGRect(x: cx - r, y: cy - r, width: r * 2, height: r * 2))
+        // Top stem: y = 1.5 → 4.5 (in 16-unit coords)
+        p.move(to: CGPoint(x: cx, y: rect.minY + 1.5 * unit))
+        p.addLine(to: CGPoint(x: cx, y: rect.minY + 4.5 * unit))
+        // Bottom stem: y = 11.5 → 14.5
+        p.move(to: CGPoint(x: cx, y: rect.minY + 11.5 * unit))
+        p.addLine(to: CGPoint(x: cx, y: rect.minY + 14.5 * unit))
+        return p
     }
 }

--- a/Alas/Sources/Right/Commit/StageChip.swift
+++ b/Alas/Sources/Right/Commit/StageChip.swift
@@ -4,21 +4,54 @@ struct StageChip: View {
     let staged: Bool
     let action: () -> Void
     @Environment(\.theme) var theme
+    @State private var hovering = false
 
     var body: some View {
         Button(action: action) {
             ZStack {
-                Circle()
-                    .fill(staged ? theme.color("add").opacity(0.18) : theme.color("bg-3"))
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(fill)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 3)
+                            .strokeBorder(border, lineWidth: 0.5)
+                    )
                     .frame(width: 14, height: 14)
-                Icon(
-                    name: staged ? "check" : "plus",
-                    size: 9,
-                    color: staged ? theme.color("add") : theme.color("fg-dim")
-                )
+                Icon(name: glyph, size: 9, color: glyphColor)
             }
+            .opacity(staged || hovering ? 1.0 : 0.55)
         }
         .buttonStyle(.plain)
+        .onHover { hovering = $0 }
         .help(staged ? "Unstage" : "Stage")
+    }
+
+    private var glyph: String {
+        if staged { return hovering ? "x" : "check" }
+        return "plus"
+    }
+
+    private var glyphColor: Color {
+        if staged {
+            return hovering ? theme.color("del") : theme.color("add")
+        }
+        return hovering ? theme.color("fg") : theme.color("fg-faint")
+    }
+
+    private var fill: Color {
+        if staged {
+            return hovering
+                ? theme.color("del").opacity(0.18)
+                : theme.color("add").opacity(0.18)
+        }
+        return hovering ? theme.color("bg-4") : .clear
+    }
+
+    private var border: Color {
+        if staged {
+            return hovering
+                ? theme.color("del").opacity(0.5)
+                : theme.color("add").opacity(0.5)
+        }
+        return hovering ? theme.color("fg-dim") : theme.color("line")
     }
 }


### PR DESCRIPTION
<!-- gg:managed:start -->
Replaces the StageChip circle with a rounded square that reveals on hover, swapping the check glyph for an X to signal unstage. Adds a custom CommitGlyph shape rendered by Icon for the "commit" name, plus a "check" alias mapping to checkmark.
<!-- gg:managed:end -->