### PR TITLE
fix: detect and run commit-AI CLIs installed outside GUI app PATH

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3855FBA3E4444960418639E9 /* FileIndexTests.swift */; };
 		763947308C99E2D3CB565889 /* AgentKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C792D59DBFFF6C28F2D426 /* AgentKind.swift */; };
 		771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */; };
+		7874DA7AF40C98A843787280 /* CommitAIPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6101164936556F13A309169 /* CommitAIPathTests.swift */; };
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
 		7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159FE807399835B0821E1CAB /* EnvBuilder.swift */; };
@@ -296,6 +297,7 @@
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
 		E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A03B92542169A6595D432 /* HoverHighlightFeature.swift */; };
 		E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */; };
+		E98674993D9B162F9FE9467F /* CommitAIPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C2E3C790342D9B00B56938 /* CommitAIPath.swift */; };
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EB4CDF316D8F82BCCE6A1C5D /* ClaudeAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE4A3168ADBA1131A642681 /* ClaudeAdapter.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
@@ -514,6 +516,7 @@
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
 		9DCC5576ACD7C49EB6915992 /* CommitComposerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerStateTests.swift; sourceTree = "<group>"; };
+		A0C2E3C790342D9B00B56938 /* CommitAIPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitAIPath.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
 		A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTree.swift; sourceTree = "<group>"; };
 		A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabStateTests.swift; sourceTree = "<group>"; };
@@ -585,6 +588,7 @@
 		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
 		D565F731CAD15F6745C657B1 /* CodexAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAdapter.swift; sourceTree = "<group>"; };
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		D6101164936556F13A309169 /* CommitAIPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitAIPathTests.swift; sourceTree = "<group>"; };
 		D6A9977C979705A40595FD5E /* TabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerTests.swift; sourceTree = "<group>"; };
 		D733701E36E13A7A23748A37 /* CommitComposerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerState.swift; sourceTree = "<group>"; };
 		D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailability.swift; sourceTree = "<group>"; };
@@ -691,6 +695,7 @@
 				9434D7A01EF3F7DCD01B7688 /* CommitAIAdapterInvocationTests.swift */,
 				CC25D6E58AB1D01E6A7C46FB /* CommitAIAdapterParseTests.swift */,
 				C8EA1E2128F7ED14F9CF61C3 /* CommitAIDetectorTests.swift */,
+				D6101164936556F13A309169 /* CommitAIPathTests.swift */,
 				9DCC5576ACD7C49EB6915992 /* CommitComposerStateTests.swift */,
 				79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */,
 				DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */,
@@ -1322,6 +1327,7 @@
 				D565F731CAD15F6745C657B1 /* CodexAdapter.swift */,
 				E40B5332AD30BF8ED743FC2B /* CommitAIAdapter.swift */,
 				46D23BACE3FCC023D818BADD /* CommitAIDetector.swift */,
+				A0C2E3C790342D9B00B56938 /* CommitAIPath.swift */,
 				913A307FB0CBEF4E3FD32BCA /* CommitAITool.swift */,
 				4865995B2D4B92166321201F /* CommitContextBuilder.swift */,
 				EE6AC0534A8EC9C736BD915E /* CursorAgentAdapter.swift */,
@@ -1513,6 +1519,7 @@
 				C487C3AD43E7B5BBB45490DB /* CodexInstaller.swift in Sources */,
 				8A45A0BB0E8D25D8E4C42B22 /* CommitAIAdapter.swift in Sources */,
 				6E90B0C1B9D7CB647A6A1A87 /* CommitAIDetector.swift in Sources */,
+				E98674993D9B162F9FE9467F /* CommitAIPath.swift in Sources */,
 				427647A6DCE974E32D2F116E /* CommitAITool.swift in Sources */,
 				DAD02DC484C697D856B0CD6A /* CommitComposerState.swift in Sources */,
 				8C60AB3736F2160FC2A49281 /* CommitComposerView.swift in Sources */,
@@ -1692,6 +1699,7 @@
 				EDDA03AC6061A1B5FE061DA6 /* CommitAIAdapterInvocationTests.swift in Sources */,
 				E2CEB5EBCCD5792CAF460411 /* CommitAIAdapterParseTests.swift in Sources */,
 				62CE99A2AC8B0700EB2F42A2 /* CommitAIDetectorTests.swift in Sources */,
+				7874DA7AF40C98A843787280 /* CommitAIPathTests.swift in Sources */,
 				C02EB84F4343BD78984791EB /* CommitComposerStateTests.swift in Sources */,
 				21D97FBF7356BC50400E0265 /* CommitContextBuilderTests.swift in Sources */,
 				E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */,

--- a/Alas/Sources/Git/CommitAI/CommitAIAdapter.swift
+++ b/Alas/Sources/Git/CommitAI/CommitAIAdapter.swift
@@ -69,7 +69,9 @@ enum CommitAIRunner {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [binary] + args
-        process.environment = ProcessInfo.processInfo.environment
+        var env = ProcessInfo.processInfo.environment
+        env["PATH"] = CommitAIPath.augmented(base: env["PATH"])
+        process.environment = env
 
         let outPipe = Pipe()
         let errPipe = Pipe()

--- a/Alas/Sources/Git/CommitAI/CommitAIDetector.swift
+++ b/Alas/Sources/Git/CommitAI/CommitAIDetector.swift
@@ -17,11 +17,11 @@ enum CommitAIDetector {
         return found
     }
 
-    /// Scan the running process's `PATH`. Used at app launch and from
-    /// Settings.
+    /// Scan the running process's `PATH`, augmented with well-known CLI
+    /// install directories that the launchd-derived PATH for a GUI app
+    /// otherwise omits. Used at app launch and from Settings.
     static func scanCurrentEnvironment() async -> [CommitAITool] {
-        let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
-        return await scan(path: path)
+        return await scan(path: CommitAIPath.augmented())
     }
 
     private static func isExecutable(named name: String, in dirs: [String]) -> Bool {

--- a/Alas/Sources/Git/CommitAI/CommitAIPath.swift
+++ b/Alas/Sources/Git/CommitAI/CommitAIPath.swift
@@ -48,8 +48,9 @@ enum CommitAIPath {
             appended.append(expanded)
             seen.insert(expanded)
         }
-        if base.isEmpty { return appended.joined(separator: ":") }
-        if appended.isEmpty { return base }
-        return base + ":" + appended.joined(separator: ":")
+        let normalizedBase = baseEntries.joined(separator: ":")
+        if normalizedBase.isEmpty { return appended.joined(separator: ":") }
+        if appended.isEmpty { return normalizedBase }
+        return normalizedBase + ":" + appended.joined(separator: ":")
     }
 }

--- a/Alas/Sources/Git/CommitAI/CommitAIPath.swift
+++ b/Alas/Sources/Git/CommitAI/CommitAIPath.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Computes a PATH string suitable for finding commit-message AI CLIs from
+/// inside Alas. Needed because a macOS GUI app inherits launchd's minimal
+/// PATH (typically `/usr/bin:/bin:/usr/sbin:/sbin` + `/etc/paths.d/*`) and
+/// therefore can't see tools the user installed into `/opt/homebrew/bin`,
+/// `~/.local/bin`, etc.
+enum CommitAIPath {
+    /// Well-known directories where commit-AI CLIs are commonly installed.
+    /// Order is preserved when appending. Tilde-form entries are expanded
+    /// at lookup time.
+    static let wellKnownDirectories: [String] = [
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "~/.local/bin",
+        "~/.bun/bin",
+        "~/.cargo/bin",
+        "~/.deno/bin",
+        "~/Library/pnpm",
+        "~/.npm-global/bin",
+        "~/.volta/bin",
+    ]
+
+    /// Returns `base` (or the process PATH if `base` is nil) with the
+    /// well-known directories appended.
+    static func augmented(base: String? = nil) -> String {
+        let basePath = base ?? ProcessInfo.processInfo.environment["PATH"] ?? ""
+        return augment(base: basePath, wellKnown: wellKnownDirectories)
+    }
+
+    /// Pure: tilde-expands each `wellKnown` entry, drops those that don't
+    /// exist on disk, drops those whose expanded form already appears in
+    /// `base`, and appends the rest to `base` in order.
+    static func augment(base: String, wellKnown: [String]) -> String {
+        let baseEntries = base
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .map(String.init)
+        var seen = Set(baseEntries)
+        var appended: [String] = []
+        let fm = FileManager.default
+        for entry in wellKnown {
+            let expanded = (entry as NSString).expandingTildeInPath
+            if seen.contains(expanded) { continue }
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: expanded, isDirectory: &isDir), isDir.boolValue else {
+                continue
+            }
+            appended.append(expanded)
+            seen.insert(expanded)
+        }
+        if base.isEmpty { return appended.joined(separator: ":") }
+        if appended.isEmpty { return base }
+        return base + ":" + appended.joined(separator: ":")
+    }
+}

--- a/AlasTests/CommitAIPathTests.swift
+++ b/AlasTests/CommitAIPathTests.swift
@@ -65,4 +65,17 @@ struct CommitAIPathTests {
         let result = CommitAIPath.augmented()
         #expect(result.contains(processPath) || processPath.isEmpty)
     }
+
+    @Test func normalizesTrailingColonInBase() throws {
+        let dir = try makeDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let result = CommitAIPath.augment(base: "/usr/bin:", wellKnown: [dir])
+        #expect(result == "/usr/bin:\(dir)")
+    }
+
+    @Test func normalizesEmptyComponentsInBase() throws {
+        let result = CommitAIPath.augment(base: "::", wellKnown: [])
+        #expect(result == "")
+    }
 }

--- a/AlasTests/CommitAIPathTests.swift
+++ b/AlasTests/CommitAIPathTests.swift
@@ -1,0 +1,68 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct CommitAIPathTests {
+    /// Make a temporary directory that exists on disk, and return its path.
+    private func makeDir() throws -> String {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-path-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.path
+    }
+
+    @Test func appendsExistingWellKnownDirsToEmptyBase() throws {
+        let a = try makeDir()
+        let b = try makeDir()
+        defer {
+            try? FileManager.default.removeItem(atPath: a)
+            try? FileManager.default.removeItem(atPath: b)
+        }
+
+        let result = CommitAIPath.augment(base: "", wellKnown: [a, b])
+        #expect(result == "\(a):\(b)")
+    }
+
+    @Test func preservesBaseOrderAndAppendsAfter() throws {
+        let extra = try makeDir()
+        defer { try? FileManager.default.removeItem(atPath: extra) }
+
+        let result = CommitAIPath.augment(base: "/usr/bin:/bin", wellKnown: [extra])
+        #expect(result == "/usr/bin:/bin:\(extra)")
+    }
+
+    @Test func skipsWellKnownDirsThatDoNotExist() throws {
+        let existing = try makeDir()
+        let missing = "/definitely/does/not/exist/\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: existing) }
+
+        let result = CommitAIPath.augment(base: "", wellKnown: [missing, existing])
+        #expect(result == existing)
+    }
+
+    @Test func skipsWellKnownDirsAlreadyInBase() throws {
+        let dir = try makeDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let result = CommitAIPath.augment(base: "\(dir):/usr/bin", wellKnown: [dir])
+        #expect(result == "\(dir):/usr/bin")
+    }
+
+    @Test func expandsTildeInWellKnownPaths() throws {
+        let home = NSString("~").expandingTildeInPath
+        let result = CommitAIPath.augment(base: "", wellKnown: ["~"])
+        #expect(result == home)
+    }
+
+    @Test func dedupesByExpandedFormAgainstBase() throws {
+        let home = NSString("~").expandingTildeInPath
+        let result = CommitAIPath.augment(base: home, wellKnown: ["~"])
+        #expect(result == home)
+    }
+
+    @Test func augmentedDefaultsToProcessPath() {
+        let processPath = ProcessInfo.processInfo.environment["PATH"] ?? ""
+        let result = CommitAIPath.augmented()
+        #expect(result.contains(processPath) || processPath.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Settings → Changes → Tool dropdown was showing every supported CLI (Claude Code, Codex, Cursor Agent, Pi) as "(not detected)" even when installed. Root cause: macOS GUI apps inherit launchd's minimal PATH (typically `/usr/bin:/bin:/usr/sbin:/sbin` plus `/etc/paths.d/*`), so installs in `/opt/homebrew/bin`, `~/.local/bin`, etc. are invisible.
- Adds `CommitAIPath` helper that augments the process PATH with a curated list of well-known CLI install directories (`/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`, `~/.bun/bin`, `~/.cargo/bin`, `~/.deno/bin`, `~/Library/pnpm`, `~/.npm-global/bin`, `~/.volta/bin`). Tilde-expanded, existence-checked, deduped against the base.
- Wires the helper into `CommitAIDetector.scanCurrentEnvironment` (so Settings sees real installs) and `CommitAIRunner.run` (so selected tools actually execute).
- Normalizes empty PATH components so a trailing-colon base doesn't produce `::` (which `execvp` would treat as `.`).

## Test plan

- [ ] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` — full suite green (9 new `CommitAIPathTests`, existing `CommitAIDetectorTests` and `CommitAIAdapterInvocationTests` unchanged).
- [ ] Launch Alas from Finder/Spotlight (not the terminal — that would mask the bug). Open Settings → Changes → Tool. Confirm installed tools (e.g. via Homebrew on `/opt/homebrew/bin`) no longer show "(not detected)".
- [ ] Pick a tool, stage a change, click the sparkle button in the commit composer. Confirm a message is generated (no "tool not found").