### PR TITLE
fix(worktree): auto-retry removal of clean submodule worktrees with --force

### DIFF
--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -134,7 +134,22 @@ struct WorktreeService {
         var args = ["worktree", "remove", worktree.path.path]
         if force { args.append("--force") }
         let result = try await Process.git(args, cwd: repoPath)
-        guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
+        if result.exitCode != 0 {
+            guard !force,
+                  Self.looksLikeSubmoduleWorktreeRemoveError(result.stderr),
+                  try await isWorktreeClean(worktree.path),
+                  try await areInitializedSubmodulesClean(worktree.path),
+                  try await initializedSubmodulesHaveNoLocalState(worktree.path)
+            else {
+                throw WorktreeError.gitFailed(result.stderr)
+            }
+
+            let forceResult = try await Process.git(
+                ["worktree", "remove", worktree.path.path, "--force"],
+                cwd: repoPath
+            )
+            guard forceResult.exitCode == 0 else { throw WorktreeError.gitFailed(forceResult.stderr) }
+        }
         if deleteBranchIfMerged && worktree.branch != "(detached)" {
             // Best-effort delete. -d only succeeds if merged; ignore failures.
             _ = try? await Process.git(["branch", "-d", worktree.branch], cwd: repoPath)
@@ -152,6 +167,45 @@ struct WorktreeService {
         let lower = stderr.lowercased()
         return (lower.contains("command not found") || lower.contains("not found"))
             && (lower.contains("git-lfs") || lower.contains("filter-process"))
+    }
+
+    private static func looksLikeSubmoduleWorktreeRemoveError(_ stderr: String) -> Bool {
+        let lower = stderr.lowercased()
+        return lower.contains("working trees containing submodules")
+            && lower.contains("cannot be moved or removed")
+    }
+
+    private func isWorktreeClean(_ path: URL) async throws -> Bool {
+        let result = try await Process.git(
+            ["status", "--porcelain", "--ignore-submodules=none", "--untracked-files=all"],
+            cwd: path
+        )
+        guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func areInitializedSubmodulesClean(_ path: URL) async throws -> Bool {
+        let result = try await Process.git(
+            [
+                "submodule", "foreach", "--quiet", "--recursive",
+                "git status --porcelain --ignore-submodules=none --untracked-files=all"
+            ],
+            cwd: path
+        )
+        guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func initializedSubmodulesHaveNoLocalState(_ path: URL) async throws -> Bool {
+        let localStateScript = """
+        remote_refs=$(git for-each-ref --format="%(refname)" refs/remotes); default_branch=$(git symbolic-ref -q --short refs/remotes/origin/HEAD | sed 's#^origin/##'); is_remote_reachable() { oid="$1"; for remote in $remote_refs; do if git merge-base --is-ancestor "$oid" "$remote"; then return 0; fi; done; return 1; }; git for-each-ref --format="%(refname:short)" refs/heads | while read -r branch; do oid=$(git rev-parse -q --verify "refs/heads/$branch^{}") || continue; if test -z "$default_branch" || test "$branch" != "$default_branch" || ! is_remote_reachable "$oid"; then echo "refs/heads/$branch"; fi; done; git for-each-ref --format="%(refname)" refs/notes refs/stash | while read -r ref; do oid=$(git rev-parse -q --verify "$ref^{}") || continue; if ! is_remote_reachable "$oid"; then echo "$ref"; fi; done; git for-each-ref --format="%(refname:short)" refs/tags | while read -r tag; do local_oid=$(git rev-parse -q --verify "refs/tags/$tag") || continue; remote_oid=$(git ls-remote --tags origin "refs/tags/$tag" | awk 'NR == 1 {print $1}'); if test -z "$remote_oid" || test "$local_oid" != "$remote_oid"; then echo "refs/tags/$tag"; fi; done; git reflog --all --format="%H" | while read -r oid; do if test -n "$oid" && ! is_remote_reachable "$oid"; then echo "reflog $oid"; fi; done
+        """
+        let result = try await Process.git(
+            ["submodule", "foreach", "--quiet", "--recursive", localStateScript],
+            cwd: path
+        )
+        guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private func existingWorktree(

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -127,6 +127,525 @@ extension WorktreeServiceTests {
 }
 
 extension WorktreeServiceTests {
+    @Test func removeDeletesCleanWorktreeContainingSubmodule() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        try "initial".write(
+            to: submoduleRepo.appendingPathComponent("tracked.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = try await Process.git(["add", "tracked.txt"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "-m", "submodule init"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent().appendingPathComponent("\(repo.lastPathComponent)-submodule")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/submodule",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+
+        try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+
+        let listed = try await svc.list(repoPath: repo, projectId: "p")
+        #expect(listed.count == 1)
+        #expect(!FileManager.default.fileExists(atPath: dest.path))
+    }
+
+    @Test func removeDoesNotForceDeleteIgnoredDirtySubmodule() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "submodule init"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-ignored-dirty-submodule")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/ignored-dirty-submodule",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+        _ = try await Process.git(["config", "submodule.Deps/Submodule.ignore", "all"], cwd: dest)
+        try "dirty".write(
+            to: dest.appendingPathComponent("Deps/Submodule/tracked.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: dest.path))
+    }
+
+    @Test func removeDoesNotForceDeleteHiddenUntrackedFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "submodule init"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-hidden-untracked")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/hidden-untracked",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+        _ = try await Process.git(["config", "status.showUntrackedFiles", "no"], cwd: dest)
+        try "keep me".write(
+            to: dest.appendingPathComponent("untracked.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: dest.appendingPathComponent("untracked.txt").path))
+    }
+
+    @Test func removeDoesNotForceDeleteSubmoduleHiddenUntrackedFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "submodule init"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-submodule-hidden-untracked")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/submodule-hidden-untracked",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+        let submodulePath = dest.appendingPathComponent("Deps/Submodule")
+        _ = try await Process.git(["config", "status.showUntrackedFiles", "no"], cwd: submodulePath)
+        try "keep me".write(
+            to: submodulePath.appendingPathComponent("hidden.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: submodulePath.appendingPathComponent("hidden.txt").path))
+    }
+
+    @Test func removeDoesNotForceDeleteNestedSubmoduleGitlinkChangeHiddenByIgnoreConfig() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let nestedRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-nested-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: nestedRepo) }
+        try FileManager.default.createDirectory(at: nestedRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: nestedRepo)
+        try "one".write(to: nestedRepo.appendingPathComponent("nested.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "nested.txt"], cwd: nestedRepo)
+        _ = try await Process.git(["commit", "-q", "-m", "nested one"], cwd: nestedRepo)
+        let firstNestedSha = try await Process.git(["rev-parse", "HEAD"], cwd: nestedRepo)
+        try "two".write(to: nestedRepo.appendingPathComponent("nested.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["commit", "-q", "-am", "nested two"], cwd: nestedRepo)
+        let secondNestedSha = try await Process.git(["rev-parse", "HEAD"], cwd: nestedRepo)
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", nestedRepo.path, "Nested"],
+            cwd: submoduleRepo
+        )
+        _ = try await Process.git(["checkout", "-q", firstNestedSha.stdout.trimmingCharacters(in: .whitespacesAndNewlines)], cwd: submoduleRepo.appendingPathComponent("Nested"))
+        _ = try await Process.git(["add", "."], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "-m", "add nested submodule"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-nested-submodule-change")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/nested-submodule-change",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive", "-q"],
+            cwd: dest
+        )
+
+        let submodulePath = dest.appendingPathComponent("Deps/Submodule")
+        let nestedPath = submodulePath.appendingPathComponent("Nested")
+        _ = try await Process.git(["config", "submodule.Nested.ignore", "all"], cwd: submodulePath)
+        _ = try await Process.git(
+            ["checkout", "-q", secondNestedSha.stdout.trimmingCharacters(in: .whitespacesAndNewlines)],
+            cwd: nestedPath
+        )
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: nestedPath.path))
+    }
+
+    @Test func removeDoesNotForceDeleteSubmoduleLocalBranch() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "submodule init"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-submodule-local-branch")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/submodule-local-branch",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+
+        let submodulePath = dest.appendingPathComponent("Deps/Submodule")
+        let recordedSha = try await Process.git(["rev-parse", "HEAD"], cwd: submodulePath)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["switch", "-q", "-c", "local-only"], cwd: submodulePath)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "local submodule commit"], cwd: submodulePath)
+        _ = try await Process.git(["checkout", "-q", recordedSha], cwd: submodulePath)
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: submodulePath.path))
+    }
+
+    @Test func removeDoesNotForceDeleteSubmoduleExtraBranchAtRemoteCommit() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "submodule init"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-submodule-extra-branch")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/submodule-extra-branch",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+
+        let submodulePath = dest.appendingPathComponent("Deps/Submodule")
+        _ = try await Process.git(["branch", "keep-me", "HEAD"], cwd: submodulePath)
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: submodulePath.path))
+    }
+
+    @Test func removeDoesNotForceDeleteSubmoduleLocalOnlyTag() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "submodule init"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-submodule-local-tag")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/submodule-local-tag",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+
+        let submodulePath = dest.appendingPathComponent("Deps/Submodule")
+        let recordedSha = try await Process.git(["rev-parse", "HEAD"], cwd: submodulePath)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "tagged local commit"], cwd: submodulePath)
+        _ = try await Process.git(["tag", "local-only"], cwd: submodulePath)
+        _ = try await Process.git(["checkout", "-q", recordedSha], cwd: submodulePath)
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: submodulePath.path))
+    }
+
+    @Test func removeDoesNotForceDeleteSubmoduleLocalTagOnRemoteCommit() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "submodule init"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-submodule-local-remote-tag")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/submodule-local-remote-tag",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+
+        let submodulePath = dest.appendingPathComponent("Deps/Submodule")
+        _ = try await Process.git(["tag", "local-only"], cwd: submodulePath)
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: submodulePath.path))
+    }
+
+    @Test func removeDoesNotForceDeleteSubmoduleRetargetedRemoteTag() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "tagged remote commit"], cwd: submoduleRepo)
+        _ = try await Process.git(["tag", "shared"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "current remote commit"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-submodule-retargeted-tag")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/submodule-retargeted-tag",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+
+        let submodulePath = dest.appendingPathComponent("Deps/Submodule")
+        _ = try await Process.git(["tag", "-f", "shared", "HEAD"], cwd: submodulePath)
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: submodulePath.path))
+    }
+
+    @Test func removeDoesNotForceDeleteSubmoduleRetaggedAnnotatedRemoteTag() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "current remote commit"], cwd: submoduleRepo)
+        _ = try await Process.git(["tag", "-a", "shared", "-m", "remote annotation"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-submodule-retagged-annotated")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/submodule-retagged-annotated",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+
+        let submodulePath = dest.appendingPathComponent("Deps/Submodule")
+        _ = try await Process.git(["tag", "-f", "-a", "shared", "-m", "local annotation", "HEAD"], cwd: submodulePath)
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: submodulePath.path))
+    }
+
+    @Test func removeDoesNotForceDeleteSubmoduleReflogOnlyCommit() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "submodule init"], cwd: submoduleRepo)
+
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        let dest = repo.deletingLastPathComponent()
+            .appendingPathComponent("\(repo.lastPathComponent)-submodule-reflog")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/submodule-reflog",
+            destination: dest, projectId: "p"
+        )
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: dest
+        )
+
+        let submodulePath = dest.appendingPathComponent("Deps/Submodule")
+        let recordedSha = try await Process.git(["rev-parse", "HEAD"], cwd: submodulePath)
+            .stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "reflog only"], cwd: submodulePath)
+        _ = try await Process.git(["checkout", "-q", recordedSha], cwd: submodulePath)
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        }
+        #expect(FileManager.default.fileExists(atPath: submodulePath.path))
+    }
+
     @Test func addForExistingBranchSucceedsWithoutDashB() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }


### PR DESCRIPTION
<!-- gg:managed:start -->
Detects the git "working trees containing submodules cannot be moved or removed"
error and transparently retries with --force when the worktree has no
uncommitted changes. Adds an integration test covering removal of a clean
worktree that contains an initialized submodule.
<!-- gg:managed:end -->