### PR TITLE
fix(terminal): forward modified keys and layout symbols correctly to Ghostty

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C1705E68E97111E85D83F3 /* RightPaneState.swift */; };
 		3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */; };
 		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
+		3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
 		3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */; };
@@ -580,6 +581,7 @@
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
+		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
 		D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewShortcutTests.swift; sourceTree = "<group>"; };
@@ -763,6 +765,7 @@
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
+				CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */,
 				D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
@@ -1776,6 +1779,7 @@
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,
+				3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */,
 				CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -283,9 +283,46 @@ extension AlasGhostty {
 
             let action: ghostty_input_action_e = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
-            // Build the key event. We skip the full IME/preedit machinery for v1.
-            var keyEv = event.alasGhosttyKeyEvent(action)
-            let chars = event.alasGhosttyCharacters
+            // Ask Ghostty which modifiers should be used for text translation.
+            // This handles configs such as `macos-option-as-alt` correctly.
+            let rawMods = alasGhosttyMods(event.modifierFlags)
+            let translatedGhosttyMods = ghostty_surface_key_translation_mods(surface, rawMods)
+
+            // Convert translated Ghostty mods back to AppKit flags so we can
+            // derive the correct composed characters (e.g. Option+n → ~).
+            let translatedAppKitMods = alasAppKitModifierFlags(from: translatedGhosttyMods)
+            var translationFlags = event.modifierFlags
+            for flag in [NSEvent.ModifierFlags.shift, .control, .option, .command] {
+                if translatedAppKitMods.contains(flag) {
+                    translationFlags.insert(flag)
+                } else {
+                    translationFlags.remove(flag)
+                }
+            }
+
+            // If translation modifiers differ we must build a new event.
+            // Reusing the original event when they're equal is required for
+            // some IME behaviours (see upstream Ghostty comment).
+            let translationEvent: NSEvent
+            if translationFlags == event.modifierFlags {
+                translationEvent = event
+            } else {
+                translationEvent = NSEvent.keyEvent(
+                    with: event.type,
+                    location: event.locationInWindow,
+                    modifierFlags: translationFlags,
+                    timestamp: event.timestamp,
+                    windowNumber: event.windowNumber,
+                    context: nil,
+                    characters: event.characters(byApplyingModifiers: translationFlags) ?? "",
+                    charactersIgnoringModifiers: event.charactersIgnoringModifiers ?? "",
+                    isARepeat: event.isARepeat,
+                    keyCode: event.keyCode
+                ) ?? event
+            }
+
+            var keyEv = event.alasGhosttyKeyEvent(action, translationFlags: translationFlags)
+            let chars = translationEvent.alasGhosttyCharacters
 
             if let chars {
                 chars.withCString { ptr in
@@ -463,9 +500,16 @@ extension AlasGhostty {
 
 // MARK: - NSEvent key-translation helpers (ported from upstream NSEvent+Extension.swift)
 
-private extension NSEvent {
+extension NSEvent {
     /// Build a `ghostty_input_key_s` for the given action. Does NOT set `text` or `composing`.
-    func alasGhosttyKeyEvent(_ action: ghostty_input_action_e) -> ghostty_input_key_s {
+    ///
+    /// - Parameter translationFlags: AppKit modifiers used for text translation (may differ
+    ///   from the physical event modifiers when Ghostty translates them for configs such as
+    ///   `macos-option-as-alt`). Defaults to the event's own `modifierFlags`.
+    func alasGhosttyKeyEvent(
+        _ action: ghostty_input_action_e,
+        translationFlags: NSEvent.ModifierFlags? = nil
+    ) -> ghostty_input_key_s {
         var ev = ghostty_input_key_s()
         ev.action = action
         // Ghostty uses the macOS virtual key code directly as `keycode`.
@@ -473,8 +517,11 @@ private extension NSEvent {
         ev.text = nil
         ev.composing = false
         ev.mods = alasGhosttyMods(modifierFlags)
-        // Consumed mods: Ctrl and Cmd don't contribute to character translation.
-        ev.consumed_mods = alasGhosttyMods(modifierFlags.subtracting([.control, .command]))
+
+        // Consumed mods: the modifiers that contributed to the translated text.
+        // Control and Command never contribute to character translation.
+        let consumedFlags = (translationFlags ?? modifierFlags).subtracting([.control, .command])
+        ev.consumed_mods = alasGhosttyMods(consumedFlags)
 
         ev.unshifted_codepoint = 0
         if type == .keyDown || type == .keyUp {
@@ -487,14 +534,17 @@ private extension NSEvent {
     }
 
     /// The text string to pass as `ghostty_input_key_s.text`, filtering out
-    /// raw control characters and PUA function-key ranges.
+    /// control characters and PUA function-key ranges.
+    ///
+    /// Control characters (U+0000–U+001F) are encoded by Ghostty itself from the
+    /// keycode + mods, so we must not send them as text. This fixes Shift+Enter
+    /// and other modified control-key combinations.
     var alasGhosttyCharacters: String? {
         guard let characters else { return nil }
         if characters.count == 1, let scalar = characters.unicodeScalars.first {
             if scalar.value < 0x20 {
-                // Control character: return the characters without Ctrl so Ghostty
-                // handles the encoding itself.
-                return self.characters(byApplyingModifiers: modifierFlags.subtracting(.control))
+                // Control character — let Ghostty encode from keycode + mods.
+                return nil
             }
             if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
                 // PUA function key — don't send as text.
@@ -505,9 +555,24 @@ private extension NSEvent {
     }
 }
 
+// MARK: - Modifier translation helpers
+
+/// Convert Ghostty modifier bits back to AppKit `NSEvent.ModifierFlags`.
+/// Used when Ghostty's `ghostty_surface_key_translation_mods` tells us
+/// which modifiers should participate in character translation.
+func alasAppKitModifierFlags(from mods: ghostty_input_mods_e) -> NSEvent.ModifierFlags {
+    var flags: NSEvent.ModifierFlags = []
+    if mods.rawValue & GHOSTTY_MODS_SHIFT.rawValue   != 0 { flags.insert(.shift) }
+    if mods.rawValue & GHOSTTY_MODS_CTRL.rawValue    != 0 { flags.insert(.control) }
+    if mods.rawValue & GHOSTTY_MODS_ALT.rawValue     != 0 { flags.insert(.option) }
+    if mods.rawValue & GHOSTTY_MODS_SUPER.rawValue   != 0 { flags.insert(.command) }
+    if mods.rawValue & GHOSTTY_MODS_CAPS.rawValue     != 0 { flags.insert(.capsLock) }
+    return flags
+}
+
 // MARK: - Modifier translation (ported from upstream Ghostty.Input.swift)
 
-private func alasGhosttyMods(_ flags: NSEvent.ModifierFlags) -> ghostty_input_mods_e {
+func alasGhosttyMods(_ flags: NSEvent.ModifierFlags) -> ghostty_input_mods_e {
     var mods: UInt32 = GHOSTTY_MODS_NONE.rawValue
     if flags.contains(.shift)   { mods |= GHOSTTY_MODS_SHIFT.rawValue }
     if flags.contains(.control) { mods |= GHOSTTY_MODS_CTRL.rawValue }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -536,18 +536,24 @@ extension NSEvent {
     /// The text string to pass as `ghostty_input_key_s.text`, filtering out
     /// control characters and PUA function-key ranges.
     ///
-    /// Control characters (U+0000–U+001F) are encoded by Ghostty itself from the
-    /// keycode + mods, so we must not send them as text. This fixes Shift+Enter
-    /// and other modified control-key combinations.
+    /// For Ctrl-modified keys (e.g. Ctrl+A), we strip Ctrl and return the
+    /// layout-translated character so that alternative layouts (Dvorak etc.)
+    /// produce the correct control key.
+    ///
+    /// For Shift-modified keys that produce control characters natively
+    /// (e.g. Shift+Enter → \\r, Shift+Tab → \\t), we return nil so Ghostty
+    /// encodes them from keycode + mods. Otherwise Shift+Enter would be
+    /// flattened to a plain Enter text payload.
     var alasGhosttyCharacters: String? {
         guard let characters else { return nil }
         if characters.count == 1, let scalar = characters.unicodeScalars.first {
             if scalar.value < 0x20 {
-                // Control character — let Ghostty encode from keycode + mods.
+                if modifierFlags.contains(.control) {
+                    return self.characters(byApplyingModifiers: modifierFlags.subtracting(.control))
+                }
                 return nil
             }
             if scalar.value >= 0xF700 && scalar.value <= 0xF8FF {
-                // PUA function key — don't send as text.
                 return nil
             }
         }

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -1,0 +1,204 @@
+import AppKit
+import GhosttyKit
+import Testing
+@testable import Alas
+
+/// Tests for the NSEvent keyboard-translation helpers that feed Ghostty.
+/// These exercise the pure modifier/character logic without needing a live
+/// Ghostty surface.
+struct SurfaceViewKeyboardTests {
+
+    // MARK: - Modifier translation
+
+    @Test func noModifiersReturnsNone() {
+        let mods = alasGhosttyMods([])
+        #expect(mods == GHOSTTY_MODS_NONE)
+    }
+
+    @Test func shiftModifierReturnsShift() {
+        let mods = alasGhosttyMods(.shift)
+        #expect(mods == GHOSTTY_MODS_SHIFT)
+    }
+
+    @Test func controlModifierReturnsCtrl() {
+        let mods = alasGhosttyMods(.control)
+        #expect(mods == GHOSTTY_MODS_CTRL)
+    }
+
+    @Test func optionModifierReturnsAlt() {
+        let mods = alasGhosttyMods(.option)
+        #expect(mods == GHOSTTY_MODS_ALT)
+    }
+
+    @Test func commandModifierReturnsSuper() {
+        let mods = alasGhosttyMods(.command)
+        #expect(mods == GHOSTTY_MODS_SUPER)
+    }
+
+    @Test func capsLockModifierReturnsCaps() {
+        let mods = alasGhosttyMods(.capsLock)
+        #expect(mods == GHOSTTY_MODS_CAPS)
+    }
+
+    @Test func combinedModifiersReturnCombinedBits() {
+        let mods = alasGhosttyMods([.shift, .control, .option])
+        let expected = GHOSTTY_MODS_SHIFT.rawValue | GHOSTTY_MODS_CTRL.rawValue | GHOSTTY_MODS_ALT.rawValue
+        #expect(mods.rawValue == expected)
+    }
+
+    // MARK: - Key event builder (consumed_mods from translation flags)
+
+    @Test func keyEventUsesPhysicalModsAndTranslationConsumedMods() throws {
+        let event = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [.shift, .control],
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "a",
+                charactersIgnoringModifiers: "a",
+                isARepeat: false,
+                keyCode: 0
+            )
+        )
+
+        let keyEv = event.alasGhosttyKeyEvent(
+            GHOSTTY_ACTION_PRESS,
+            translationFlags: .shift
+        )
+
+        #expect(keyEv.action == GHOSTTY_ACTION_PRESS)
+        #expect(keyEv.mods == alasGhosttyMods([.shift, .control]))
+        #expect(keyEv.consumed_mods == alasGhosttyMods(.shift))
+    }
+
+    @Test func keyEventWithNoTranslationFlagsUsesPhysicalFlagsMinusCtrlCmd() throws {
+        let event = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [.shift, .control, .command],
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "a",
+                charactersIgnoringModifiers: "a",
+                isARepeat: false,
+                keyCode: 0
+            )
+        )
+
+        let keyEv = event.alasGhosttyKeyEvent(GHOSTTY_ACTION_PRESS)
+
+        #expect(keyEv.consumed_mods == alasGhosttyMods(.shift))
+    }
+
+    // MARK: - Character extraction
+
+    @Test func plainCharacterReturnsCharacters() throws {
+        let event = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "a",
+                charactersIgnoringModifiers: "a",
+                isARepeat: false,
+                keyCode: 0
+            )
+        )
+
+        #expect(event.alasGhosttyCharacters == "a")
+    }
+
+    @Test func puaFunctionKeyReturnsNil() throws {
+        let event = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "\u{F700}", // NSUpArrowFunctionKey
+                charactersIgnoringModifiers: "\u{F700}",
+                isARepeat: false,
+                keyCode: 126
+            )
+        )
+
+        #expect(event.alasGhosttyCharacters == nil)
+    }
+
+    @Test func controlCharacterReturnsNilForText() throws {
+        // Ctrl+A produces U+0001 — a control character.
+        let event = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: .control,
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "\u{01}",
+                charactersIgnoringModifiers: "a",
+                isARepeat: false,
+                keyCode: 0
+            )
+        )
+
+        // With the fix, control characters should return nil so Ghostty
+        // encodes them from the keycode + mods, not from text.
+        #expect(event.alasGhosttyCharacters == nil)
+    }
+
+    @Test func shiftEnterReturnsNilForText() throws {
+        // Enter keycode 0x24 with shift held produces \r (U+000D < 0x20).
+        let event = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: .shift,
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "\r",
+                charactersIgnoringModifiers: "\r",
+                isARepeat: false,
+                keyCode: 0x24
+            )
+        )
+
+        #expect(event.alasGhosttyCharacters == nil)
+    }
+
+    @Test func shiftEnterWithNoTextStillHasShiftInConsumedMods() throws {
+        let event = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: .shift,
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "\r",
+                charactersIgnoringModifiers: "\r",
+                isARepeat: false,
+                keyCode: 0x24
+            )
+        )
+
+        let keyEv = event.alasGhosttyKeyEvent(
+            GHOSTTY_ACTION_PRESS,
+            translationFlags: .shift
+        )
+
+        #expect(keyEv.mods == GHOSTTY_MODS_SHIFT)
+        #expect(keyEv.consumed_mods == GHOSTTY_MODS_SHIFT)
+    }
+}

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -134,8 +134,7 @@ struct SurfaceViewKeyboardTests {
         #expect(event.alasGhosttyCharacters == nil)
     }
 
-    @Test func controlCharacterReturnsNilForText() throws {
-        // Ctrl+A produces U+0001 — a control character.
+    @Test func ctrlPlusLetterReturnsLayoutCharacter() throws {
         let event = try #require(
             NSEvent.keyEvent(
                 with: .keyDown,
@@ -151,9 +150,7 @@ struct SurfaceViewKeyboardTests {
             )
         )
 
-        // With the fix, control characters should return nil so Ghostty
-        // encodes them from the keycode + mods, not from text.
-        #expect(event.alasGhosttyCharacters == nil)
+        #expect(event.alasGhosttyCharacters == "a")
     }
 
     @Test func shiftEnterReturnsNilForText() throws {

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -7,7 +7,6 @@ import Testing
 /// These exercise the pure modifier/character logic without needing a live
 /// Ghostty surface.
 struct SurfaceViewKeyboardTests {
-
     // MARK: - Modifier translation
 
     @Test func noModifiersReturnsNone() {


### PR DESCRIPTION
## Summary
- Fix terminal pane keyboard forwarding so layout-produced symbols (e.g. `~` via Option on non-US keyboards) reach Ghostty correctly instead of being interpreted as Alt-modified keys
- Fix Shift+Enter and other modified control keys by suppressing text for control characters (`< 0x20`), letting Ghostty encode from keycode + mods
- Call `ghostty_surface_key_translation_mods` to respect Ghostty's `macos-option-as-alt` config for Option key handling
- Add 14 unit tests covering modifier translation, consumed_mods derivation, control-character suppression, and PUA filtering

Fixes #836