### PR TITLE
Make expanded commit metadata text selectable

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
 		0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
+		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
@@ -610,6 +611,7 @@
 		E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndex.swift; sourceTree = "<group>"; };
 		E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialogTests.swift; sourceTree = "<group>"; };
 		E40B5332AD30BF8ED743FC2B /* CommitAIAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitAIAdapter.swift; sourceTree = "<group>"; };
+		E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderViewTests.swift; sourceTree = "<group>"; };
 		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
 		E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibilityTests.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -703,6 +705,7 @@
 				9DCC5576ACD7C49EB6915992 /* CommitComposerStateTests.swift */,
 				79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */,
 				DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */,
+				E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */,
 				9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */,
 				6D46BDE72E52818061452ECB /* CommitRowTests.swift */,
 				576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */,
@@ -1709,6 +1712,7 @@
 				C02EB84F4343BD78984791EB /* CommitComposerStateTests.swift in Sources */,
 				21D97FBF7356BC50400E0265 /* CommitContextBuilderTests.swift in Sources */,
 				E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */,
+				06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */,
 				F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */,
 				B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */,
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -101,6 +101,7 @@ struct CommitHeaderView: View {
             .foregroundColor(theme.color("fg-faint"))
         }
         .padding(.top, 8)
+        .textSelection(.enabled)
     }
 
     private func absoluteDate(_ date: Date) -> String {

--- a/AlasTests/CommitHeaderViewTests.swift
+++ b/AlasTests/CommitHeaderViewTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import Alas
+
+/// Smoke tests for CommitHeaderView to guard against crashes when rendering
+/// expanded/collapsed states. Actual text-selection behaviour is exercised
+/// at runtime; SwiftUI's `.textSelection(.enabled)` is a declarative modifier
+/// that does not expose inspectable state in a hosted test context.
+@Suite(.serialized)
+@MainActor
+struct CommitHeaderViewTests {
+    private func makeDetails(body: String = "") -> CommitDetails {
+        CommitDetails(
+            info: CommitInfo(
+                sha: "deadbeef1234567890abcdef1234567890abcdef",
+                shortSha: "deadbee",
+                author: "Nacho Lopez",
+                authorInitials: "NL",
+                date: Date(),
+                subject: "feat: wire tab drag",
+                conventionalTag: "feat",
+                filesChanged: 1,
+                insertions: 2,
+                deletions: 0
+            ),
+            body: body,
+            authorEmail: "nacho@example.com",
+            parents: ["parentsha1", "parentsha2"],
+            files: [
+                CommitChangedFile(path: "a.swift", originalPath: nil, status: "M", add: 1, del: 1)
+            ]
+        )
+    }
+
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test func collapsedHeaderRendersWithoutCrashing() {
+        let details = makeDetails(body: "Body")
+        let view = CommitHeaderView(details: details, expanded: .constant(false))
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func expandedHeaderWithBodyRendersWithoutCrashing() {
+        let details = makeDetails(body: "Detailed explanation")
+        let view = CommitHeaderView(details: details, expanded: .constant(true))
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func expandedHeaderWithParentsRendersWithoutCrashing() {
+        let details = makeDetails(body: "Body with parents")
+        let view = CommitHeaderView(details: details, expanded: .constant(true))
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func expandedHeaderWithEmptyBodyRendersWithoutCrashing() {
+        let details = makeDetails(body: "")
+        let view = CommitHeaderView(details: details, expanded: .constant(true))
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Applied `.textSelection(.enabled)` to the `expandedBlock` VStack in `CommitHeaderView.swift`, making all expanded metadata text (body, author/date, parent labels/SHAs, file counts, stats) selectable for copy/paste
- Added `CommitHeaderViewTests.swift` with smoke tests covering collapsed, expanded with body, expanded with parents, and expanded with empty body states
- Existing SHA tap-to-copy and expand/collapse interactions remain intact

Closes #838