### PR TITLE
Fix harness notification sounds

### DIFF
--- a/Alas/Sources/Harness/NotificationService.swift
+++ b/Alas/Sources/Harness/NotificationService.swift
@@ -44,6 +44,7 @@ final class NotificationService {
         let content = UNMutableNotificationContent()
         content.title = "\(agent.displayName) needs input"
         content.body = body ?? "Session is waiting for you."
+        content.sound = .default
         content.userInfo = [
             "projectId": projectId,
             "worktreeId": worktreeId,
@@ -59,6 +60,7 @@ final class NotificationService {
         let content = UNMutableNotificationContent()
         content.title = "\(agent.displayName) finished"
         content.body = body ?? "Session is done."
+        content.sound = .default
         content.userInfo = [
             "projectId": projectId,
             "worktreeId": worktreeId,

--- a/AlasTests/NotificationServiceTests.swift
+++ b/AlasTests/NotificationServiceTests.swift
@@ -21,6 +21,7 @@ struct NotificationServiceTests {
         #expect(requests.count == 1)
         #expect(requests[0].identifier == "session-1-awaiting")
         #expect(requests[0].content.title == "Claude Code needs input")
+        #expect(requests[0].content.sound != nil)
         #expect(requests[0].content.userInfo["projectId"] as? String == "project-1")
         #expect(requests[0].content.userInfo["worktreeId"] as? String == "worktree-1")
         #expect(requests[0].content.userInfo["sessionId"] as? String == "session-1")
@@ -44,6 +45,7 @@ struct NotificationServiceTests {
         #expect(requests[0].identifier == "session-1")
         #expect(requests[0].content.title == "Codex finished")
         #expect(requests[0].content.body == "Completed")
+        #expect(requests[0].content.sound != nil)
     }
 
     @Test func finishEnabledFlagDoesNotDisableAwaitingNotifications() {


### PR DESCRIPTION
## Summary

- Set the default notification sound on harness awaiting and finished notifications.
- Add regression coverage asserting notification requests include a sound.

## Root cause

The notification delegate allowed sound presentation, and the app requested sound authorization, but each local `UNMutableNotificationContent` omitted `sound`, so macOS had no notification sound to play.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`