### PR TITLE
Make three-pane sizing responsive

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		42D8417781E790CA6AA49F7E /* CursorInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */; };
 		43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
+		45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC68B05B719B9235865027F /* ThreePaneSizing.swift */; };
 		466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0240C5961343C3042D865570 /* GeneralPane.swift */; };
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
 		4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */; };
@@ -641,6 +642,7 @@
 		FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceUpstreamTests.swift; sourceTree = "<group>"; };
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
 		FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPane.swift; sourceTree = "<group>"; };
+		FEC68B05B719B9235865027F /* ThreePaneSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizing.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1268,6 +1270,7 @@
 			children = (
 				7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */,
 				5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */,
+				FEC68B05B719B9235865027F /* ThreePaneSizing.swift */,
 			);
 			path = Layout;
 			sourceTree = "<group>";
@@ -1667,6 +1670,7 @@
 				32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */,
 				D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */,
 				5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */,
+				45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */,
 				AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */,
 				6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */,
 				5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
 		41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */; };
 		41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */; };
+		422B560D70571FF42F0E78E6 /* ThreePaneSizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */; };
 		4239885256AB11FE8207D31E /* TextEditCoordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8062405A67C934905EE61D98 /* TextEditCoordinates.swift */; };
 		42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */; };
 		4272DA5A4AB30C72A694CAE5 /* CommitContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4865995B2D4B92166321201F /* CommitContextBuilder.swift */; };
@@ -559,6 +560,7 @@
 		C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
+		C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizingTests.swift; sourceTree = "<group>"; };
 		C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTabView.swift; sourceTree = "<group>"; };
 		C6CA79B71B4AA72697392702 /* NumstatParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParser.swift; sourceTree = "<group>"; };
 		C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
@@ -766,6 +768,7 @@
 				71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */,
 				1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */,
 				88379ACE40F42BE4A3257659 /* ThemeTests.swift */,
+				C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
@@ -1779,6 +1782,7 @@
 				F20871AEC0E533818C8E1B95 /* TextEditCoordinatesTests.swift in Sources */,
 				59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */,
 				BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */,
+				422B560D70571FF42F0E78E6 /* ThreePaneSizingTests.swift in Sources */,
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -82,7 +82,7 @@ struct RootView: View {
             WindowAppearance.apply(darkMode: state.themeStore.current.darkMode)
         }
         .background(WindowConfigurator())
-        .frame(minWidth: 900, minHeight: 600)
+        .frame(minWidth: 700, minHeight: 600)
         .ignoresSafeArea()
         .modifier(RootCommandHandlers(
             state: state,

--- a/Alas/Sources/Layout/ThreePaneLayout.swift
+++ b/Alas/Sources/Layout/ThreePaneLayout.swift
@@ -13,33 +13,54 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
     private let sidebarMax: Double = 420
     private let rightMin: Double = 240
     private let rightMax: Double = 560
+    private let centerMin: Double = 400
+    private let dividerWidth: Double = 6
 
     var body: some View {
-        HStack(spacing: 0) {
-            sidebar()
-                .frame(width: CGFloat(sidebarWidth))
-                .frame(maxHeight: .infinity)
-            DragHandle(axis: .horizontal) { delta in
-                sidebarWidth = DragHandle.clamp(
-                    value: sidebarWidth + Double(delta),
-                    min: sidebarMin, max: sidebarMax
+        GeometryReader { proxy in
+            let sizing = ThreePaneSizing.calculate(
+                availableWidth: Double(proxy.size.width),
+                preferredSidebarWidth: sidebarWidth,
+                preferredRightWidth: rightWidth,
+                rightPreferredVisible: rightVisible,
+                configuration: ThreePaneSizing.Configuration(
+                    sidebarMin: sidebarMin,
+                    sidebarMax: sidebarMax,
+                    rightMin: rightMin,
+                    rightMax: rightMax,
+                    centerMin: centerMin,
+                    dividerWidth: dividerWidth
                 )
-                onWidthsChanged()
-            }
-            center()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            if rightVisible {
+            )
+
+            HStack(spacing: 0) {
+                sidebar()
+                    .frame(width: CGFloat(sizing.sidebarWidth))
+                    .frame(maxHeight: .infinity)
                 DragHandle(axis: .horizontal) { delta in
-                    rightWidth = DragHandle.clamp(
-                        value: rightWidth - Double(delta),
-                        min: rightMin, max: rightMax
+                    sidebarWidth = DragHandle.clamp(
+                        value: sidebarWidth + Double(delta),
+                        min: sidebarMin, max: sidebarMax
                     )
                     onWidthsChanged()
                 }
-                right()
-                    .frame(width: CGFloat(rightWidth))
+                center()
+                    .frame(width: CGFloat(sizing.centerWidth))
                     .frame(maxHeight: .infinity)
+                if sizing.rightVisible {
+                    DragHandle(axis: .horizontal) { delta in
+                        rightWidth = DragHandle.clamp(
+                            value: rightWidth - Double(delta),
+                            min: rightMin, max: rightMax
+                        )
+                        onWidthsChanged()
+                    }
+                    right()
+                        .frame(width: CGFloat(sizing.rightWidth))
+                        .frame(maxHeight: .infinity)
+                }
             }
+            .frame(width: proxy.size.width, height: proxy.size.height, alignment: .leading)
         }
     }
 }

--- a/Alas/Sources/Layout/ThreePaneSizing.swift
+++ b/Alas/Sources/Layout/ThreePaneSizing.swift
@@ -137,8 +137,17 @@ enum ThreePaneSizing {
             sidebarWidth = preferredSidebarWidth
         } else if usableWidth >= sidebarMin + centerMin {
             sidebarWidth = max(sidebarMin, usableWidth - centerMin)
+        } else if usableWidth <= 0 {
+            sidebarWidth = 0
+        } else if usableWidth > centerMin {
+            sidebarWidth = max(0, usableWidth - centerMin)
         } else {
-            sidebarWidth = min(max(0, usableWidth), max(0, usableWidth - centerMin))
+            let denominator = sidebarMin + centerMin
+            if denominator > 0 {
+                sidebarWidth = usableWidth * (sidebarMin / denominator)
+            } else {
+                sidebarWidth = 0
+            }
         }
 
         let clampedSidebarWidth = max(0, sidebarWidth)

--- a/Alas/Sources/Layout/ThreePaneSizing.swift
+++ b/Alas/Sources/Layout/ThreePaneSizing.swift
@@ -139,8 +139,6 @@ enum ThreePaneSizing {
             sidebarWidth = max(sidebarMin, usableWidth - centerMin)
         } else if usableWidth <= 0 {
             sidebarWidth = 0
-        } else if usableWidth > centerMin {
-            sidebarWidth = max(0, usableWidth - centerMin)
         } else {
             let denominator = sidebarMin + centerMin
             if denominator > 0 {

--- a/Alas/Sources/Layout/ThreePaneSizing.swift
+++ b/Alas/Sources/Layout/ThreePaneSizing.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+enum ThreePaneSizing {
+    struct Configuration: Equatable {
+        var sidebarMin: Double
+        var sidebarMax: Double
+        var rightMin: Double
+        var rightMax: Double
+        var centerMin: Double
+        var dividerWidth: Double
+    }
+
+    struct Result: Equatable {
+        var sidebarWidth: Double
+        var centerWidth: Double
+        var rightWidth: Double
+        var rightVisible: Bool
+    }
+
+    static func calculate(
+        availableWidth rawAvailableWidth: Double,
+        preferredSidebarWidth rawPreferredSidebarWidth: Double,
+        preferredRightWidth rawPreferredRightWidth: Double,
+        rightPreferredVisible: Bool,
+        configuration: Configuration
+    ) -> Result {
+        let availableWidth = finiteNonNegative(rawAvailableWidth)
+        let dividerWidth = finiteNonNegative(configuration.dividerWidth)
+        let centerMin = finiteNonNegative(configuration.centerMin)
+        let sidebarMin = finiteNonNegative(configuration.sidebarMin)
+        let sidebarMax = max(sidebarMin, finiteNonNegative(configuration.sidebarMax))
+        let rightMin = finiteNonNegative(configuration.rightMin)
+        let rightMax = max(rightMin, finiteNonNegative(configuration.rightMax))
+
+        let preferredSidebarWidth = clamp(
+            finiteNonNegative(rawPreferredSidebarWidth),
+            min: sidebarMin,
+            max: sidebarMax
+        )
+        let preferredRightWidth = clamp(
+            finiteNonNegative(rawPreferredRightWidth),
+            min: rightMin,
+            max: rightMax
+        )
+
+        guard rightPreferredVisible else {
+            return calculateTwoPane(
+                availableWidth: availableWidth,
+                preferredSidebarWidth: preferredSidebarWidth,
+                sidebarMin: sidebarMin,
+                centerMin: centerMin,
+                dividerWidth: dividerWidth
+            )
+        }
+
+        let threePaneDividerWidth = dividerWidth * 2
+        let threePaneMinimumWidth = sidebarMin + centerMin + rightMin + threePaneDividerWidth
+
+        guard availableWidth >= threePaneMinimumWidth else {
+            return calculateTwoPane(
+                availableWidth: availableWidth,
+                preferredSidebarWidth: preferredSidebarWidth,
+                sidebarMin: sidebarMin,
+                centerMin: centerMin,
+                dividerWidth: dividerWidth
+            )
+        }
+
+        let usableWidth = max(0, availableWidth - threePaneDividerWidth)
+        let preferredSideTotal = preferredSidebarWidth + preferredRightWidth
+        let preferredCenterWidth = usableWidth - preferredSideTotal
+
+        guard preferredCenterWidth < centerMin else {
+            return Result(
+                sidebarWidth: preferredSidebarWidth,
+                centerWidth: max(0, preferredCenterWidth),
+                rightWidth: preferredRightWidth,
+                rightVisible: true
+            )
+        }
+
+        let sideBudget = max(0, usableWidth - centerMin)
+        let overflow = max(0, preferredSideTotal - sideBudget)
+        let sidebarShrinkCapacity = max(0, preferredSidebarWidth - sidebarMin)
+        let rightShrinkCapacity = max(0, preferredRightWidth - rightMin)
+        let totalShrinkCapacity = sidebarShrinkCapacity + rightShrinkCapacity
+
+        let sidebarShrink: Double
+        let rightShrink: Double
+        if totalShrinkCapacity > 0 {
+            sidebarShrink = min(sidebarShrinkCapacity, overflow * (sidebarShrinkCapacity / totalShrinkCapacity))
+            rightShrink = min(rightShrinkCapacity, overflow * (rightShrinkCapacity / totalShrinkCapacity))
+        } else {
+            sidebarShrink = 0
+            rightShrink = 0
+        }
+
+        var sidebarWidth = preferredSidebarWidth - sidebarShrink
+        var rightWidth = preferredRightWidth - rightShrink
+
+        let remainingOverflow = max(0, (sidebarWidth + rightWidth) - sideBudget)
+        if remainingOverflow > 0 {
+            if sidebarWidth > sidebarMin {
+                let extra = min(sidebarWidth - sidebarMin, remainingOverflow)
+                sidebarWidth -= extra
+            }
+            let stillRemaining = max(0, (sidebarWidth + rightWidth) - sideBudget)
+            if stillRemaining > 0, rightWidth > rightMin {
+                let extra = min(rightWidth - rightMin, stillRemaining)
+                rightWidth -= extra
+            }
+        }
+
+        sidebarWidth = max(sidebarMin, sidebarWidth)
+        rightWidth = max(rightMin, rightWidth)
+        let centerWidth = max(0, usableWidth - sidebarWidth - rightWidth)
+
+        return Result(
+            sidebarWidth: sidebarWidth,
+            centerWidth: centerWidth,
+            rightWidth: rightWidth,
+            rightVisible: true
+        )
+    }
+
+    private static func calculateTwoPane(
+        availableWidth: Double,
+        preferredSidebarWidth: Double,
+        sidebarMin: Double,
+        centerMin: Double,
+        dividerWidth: Double
+    ) -> Result {
+        let usableWidth = max(0, availableWidth - dividerWidth)
+        let sidebarWidth: Double
+
+        if usableWidth >= preferredSidebarWidth + centerMin {
+            sidebarWidth = preferredSidebarWidth
+        } else if usableWidth >= sidebarMin + centerMin {
+            sidebarWidth = max(sidebarMin, usableWidth - centerMin)
+        } else {
+            sidebarWidth = min(max(0, usableWidth), max(0, usableWidth - centerMin))
+        }
+
+        let clampedSidebarWidth = max(0, sidebarWidth)
+        return Result(
+            sidebarWidth: clampedSidebarWidth,
+            centerWidth: max(0, usableWidth - clampedSidebarWidth),
+            rightWidth: 0,
+            rightVisible: false
+        )
+    }
+
+    private static func finiteNonNegative(_ value: Double) -> Double {
+        guard value.isFinite else { return 0 }
+        return max(0, value)
+    }
+
+    private static func clamp(_ value: Double, min minValue: Double, max maxValue: Double) -> Double {
+        max(minValue, min(maxValue, value))
+    }
+}

--- a/AlasTests/ThreePaneSizingTests.swift
+++ b/AlasTests/ThreePaneSizingTests.swift
@@ -135,6 +135,23 @@ struct ThreePaneSizingTests {
         #expect(isApproximatelyEqual(result.centerWidth, 400))
     }
 
+    @Test func twoPaneAtCenterMinimumStillKeepsSidebarVisible() {
+        let availableWidth = config.centerMin + config.dividerWidth
+        let result = ThreePaneSizing.calculate(
+            availableWidth: availableWidth,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            rightPreferredVisible: false,
+            configuration: config
+        )
+
+        #expect(result.rightVisible == false)
+        #expect(isApproximatelyEqual(result.rightWidth, 0))
+        #expect(isApproximatelyEqual(result.sidebarWidth, 133.3333333333))
+        #expect(isApproximatelyEqual(result.centerWidth, 266.6666666667))
+        #expect(isApproximatelyEqual(result.sidebarWidth + result.centerWidth + config.dividerWidth, availableWidth))
+    }
+
     @Test func verySmallWidthsRemainNonNegative() {
         let result = ThreePaneSizing.calculate(
             availableWidth: 120,
@@ -149,6 +166,24 @@ struct ThreePaneSizingTests {
         #expect(result.rightWidth >= 0)
         #expect(result.rightVisible == false)
         #expect(isApproximatelyEqual(result.sidebarWidth + result.centerWidth + config.dividerWidth, 120))
+    }
+
+    @Test func nonFiniteWidthsRemainNonNegative() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: .nan,
+            preferredSidebarWidth: .infinity,
+            preferredRightWidth: -.infinity,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(result.sidebarWidth.isFinite)
+        #expect(result.centerWidth.isFinite)
+        #expect(result.rightWidth.isFinite)
+        #expect(result.sidebarWidth >= 0)
+        #expect(result.centerWidth >= 0)
+        #expect(result.rightWidth >= 0)
+        #expect(result.rightVisible == false)
     }
 
     @Test func preferredWidthsAreClampedBeforeCalculation() {

--- a/AlasTests/ThreePaneSizingTests.swift
+++ b/AlasTests/ThreePaneSizingTests.swift
@@ -1,0 +1,167 @@
+import Testing
+@testable import Alas
+
+struct ThreePaneSizingTests {
+    private let config = ThreePaneSizing.Configuration(
+        sidebarMin: 200,
+        sidebarMax: 420,
+        rightMin: 240,
+        rightMax: 560,
+        centerMin: 400,
+        dividerWidth: 6
+    )
+
+    private func isApproximatelyEqual(_ actual: Double, _ expected: Double, tolerance: Double = 0.001) -> Bool {
+        abs(actual - expected) < tolerance
+    }
+
+    @Test func wideWindowUsesPreferredWidths() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 1_200,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(isApproximatelyEqual(result.sidebarWidth, 244))
+        #expect(result.rightVisible == true)
+        #expect(isApproximatelyEqual(result.rightWidth, 320))
+        #expect(isApproximatelyEqual(result.centerWidth, 624))
+    }
+
+    @Test func compactWindowShrinksSidePanesProportionallyBeforeCollapsingRight() {
+        let preferredSidebarWidth = 244.0
+        let preferredRightWidth = 320.0
+        let overflow = 76.0
+        let sidebarShrinkCapacity = preferredSidebarWidth - 200.0
+        let rightShrinkCapacity = preferredRightWidth - 240.0
+        let totalShrinkCapacity = sidebarShrinkCapacity + rightShrinkCapacity
+        let expectedSidebarWidth = preferredSidebarWidth - overflow * (sidebarShrinkCapacity / totalShrinkCapacity)
+        let expectedRightWidth = preferredRightWidth - overflow * (rightShrinkCapacity / totalShrinkCapacity)
+
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 900,
+            preferredSidebarWidth: preferredSidebarWidth,
+            preferredRightWidth: preferredRightWidth,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(result.rightVisible == true)
+        #expect(isApproximatelyEqual(result.centerWidth, 400))
+        #expect(result.sidebarWidth > 200)
+        #expect(result.sidebarWidth < 244)
+        #expect(result.rightWidth > 240)
+        #expect(result.rightWidth < 320)
+        #expect(isApproximatelyEqual(result.sidebarWidth, expectedSidebarWidth))
+        #expect(isApproximatelyEqual(result.rightWidth, expectedRightWidth))
+        #expect(isApproximatelyEqual(result.sidebarWidth + result.rightWidth, 488))
+    }
+
+    @Test func wideWindowClampsPreferredWidthsUpToMinimums() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 1_200,
+            preferredSidebarWidth: 100,
+            preferredRightWidth: 100,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(isApproximatelyEqual(result.sidebarWidth, 200))
+        #expect(result.rightVisible == true)
+        #expect(isApproximatelyEqual(result.rightWidth, 240))
+        #expect(isApproximatelyEqual(result.centerWidth, 748))
+    }
+
+    @Test func exactThreePaneMinimumFitKeepsRightPaneVisible() {
+        let availableWidth = 200 + 240 + 400 + 2 * config.dividerWidth
+        let result = ThreePaneSizing.calculate(
+            availableWidth: availableWidth,
+            preferredSidebarWidth: 200,
+            preferredRightWidth: 240,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(result.rightVisible == true)
+        #expect(isApproximatelyEqual(result.sidebarWidth, 200))
+        #expect(isApproximatelyEqual(result.rightWidth, 240))
+        #expect(isApproximatelyEqual(result.centerWidth, 400))
+    }
+
+    @Test func rightPaneTemporarilyCollapsesWhenThreePaneMinimumsCannotFit() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 840,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(result.rightVisible == false)
+        #expect(isApproximatelyEqual(result.rightWidth, 0))
+        #expect(isApproximatelyEqual(result.sidebarWidth, 244))
+        #expect(isApproximatelyEqual(result.centerWidth, 590))
+    }
+
+    @Test func manuallyHiddenRightPaneStaysHiddenEvenWithEnoughRoom() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 1_200,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            rightPreferredVisible: false,
+            configuration: config
+        )
+
+        #expect(result.rightVisible == false)
+        #expect(isApproximatelyEqual(result.rightWidth, 0))
+        #expect(isApproximatelyEqual(result.sidebarWidth, 244))
+        #expect(isApproximatelyEqual(result.centerWidth, 950))
+    }
+
+    @Test func twoPaneModeShrinksSidebarOnlyAsNeededToProtectCenter() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 580,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            rightPreferredVisible: false,
+            configuration: config
+        )
+
+        #expect(result.rightVisible == false)
+        #expect(isApproximatelyEqual(result.rightWidth, 0))
+        #expect(isApproximatelyEqual(result.sidebarWidth, 174))
+        #expect(isApproximatelyEqual(result.centerWidth, 400))
+    }
+
+    @Test func verySmallWidthsRemainNonNegative() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 120,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(result.sidebarWidth >= 0)
+        #expect(result.centerWidth >= 0)
+        #expect(result.rightWidth >= 0)
+        #expect(result.rightVisible == false)
+        #expect(isApproximatelyEqual(result.sidebarWidth + result.centerWidth + config.dividerWidth, 120))
+    }
+
+    @Test func preferredWidthsAreClampedBeforeCalculation() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 1_800,
+            preferredSidebarWidth: 900,
+            preferredRightWidth: 900,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(isApproximatelyEqual(result.sidebarWidth, 420))
+        #expect(isApproximatelyEqual(result.rightWidth, 560))
+        #expect(isApproximatelyEqual(result.centerWidth, 808))
+    }
+}

--- a/AlasTests/ThreePaneSizingTests.swift
+++ b/AlasTests/ThreePaneSizingTests.swift
@@ -120,7 +120,7 @@ struct ThreePaneSizingTests {
         #expect(isApproximatelyEqual(result.centerWidth, 950))
     }
 
-    @Test func twoPaneModeShrinksSidebarOnlyAsNeededToProtectCenter() {
+    @Test func twoPaneModeSharesSpaceProportionallyBelowCombinedMinimum() {
         let result = ThreePaneSizing.calculate(
             availableWidth: 580,
             preferredSidebarWidth: 244,
@@ -131,8 +131,8 @@ struct ThreePaneSizingTests {
 
         #expect(result.rightVisible == false)
         #expect(isApproximatelyEqual(result.rightWidth, 0))
-        #expect(isApproximatelyEqual(result.sidebarWidth, 174))
-        #expect(isApproximatelyEqual(result.centerWidth, 400))
+        #expect(isApproximatelyEqual(result.sidebarWidth, 191.3333333333))
+        #expect(isApproximatelyEqual(result.centerWidth, 382.6666666667))
     }
 
     @Test func twoPaneAtCenterMinimumStillKeepsSidebarVisible() {
@@ -149,6 +149,23 @@ struct ThreePaneSizingTests {
         #expect(isApproximatelyEqual(result.rightWidth, 0))
         #expect(isApproximatelyEqual(result.sidebarWidth, 133.3333333333))
         #expect(isApproximatelyEqual(result.centerWidth, 266.6666666667))
+        #expect(isApproximatelyEqual(result.sidebarWidth + result.centerWidth + config.dividerWidth, availableWidth))
+    }
+
+    @Test func twoPaneJustAboveCenterMinimumKeepsSidebarVisible() {
+        let availableWidth = config.centerMin + config.dividerWidth + 1
+        let result = ThreePaneSizing.calculate(
+            availableWidth: availableWidth,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            rightPreferredVisible: false,
+            configuration: config
+        )
+
+        #expect(result.rightVisible == false)
+        #expect(isApproximatelyEqual(result.rightWidth, 0))
+        #expect(isApproximatelyEqual(result.sidebarWidth, 133.6666666667))
+        #expect(isApproximatelyEqual(result.centerWidth, 267.3333333333))
         #expect(isApproximatelyEqual(result.sidebarWidth + result.centerWidth + config.dividerWidth, availableWidth))
     }
 

--- a/docs/superpowers/specs/2026-05-16-responsive-three-pane-sizing-design.md
+++ b/docs/superpowers/specs/2026-05-16-responsive-three-pane-sizing-design.md
@@ -1,0 +1,136 @@
+# Responsive Three-Pane Sizing Design
+
+Date: 2026-05-16
+
+## Goal
+
+Make the main Alas window behave better at compact widths. The current layout keeps the left and right columns at their persisted absolute widths while the center pane absorbs nearly all window shrink. At smaller sizes this leaves an oversized pair of sidebars and an unusably narrow terminal/editor center.
+
+The target behavior is a balanced three-pane resize: sidebars and center all participate while the window narrows, and the right pane temporarily disappears only when all three panes can no longer stay readable.
+
+## Non-goals
+
+- Replacing the three-pane architecture.
+- Changing the user-facing manual width preferences.
+- Persisting width changes caused only by window resizing.
+- Redesigning the sidebar, right pane, tab bar, terminal, or editor contents.
+- Adding a new settings UI for responsive breakpoints.
+
+## Design Approach
+
+Use render-time adaptive sizing in `ThreePaneLayout`.
+
+`AppConfig.sidebarWidth`, `AppConfig.rightPaneWidth`, and `AppConfig.rightPaneVisible` remain the user's preferred expanded layout. `ThreePaneLayout` measures the available container width and derives effective widths for the current render. These effective widths can be narrower than the saved preferences, and the right pane can be temporarily hidden, but those adaptations do not mutate persisted config.
+
+Manual divider drags continue to update the saved preferred widths through the existing bindings and `onWidthsChanged`.
+
+## Layout Model
+
+Add a small layout calculation unit, either as a nested helper in `ThreePaneLayout` or as a package-private type in the layout module. It should be independent of SwiftUI view rendering so it can be tested directly.
+
+Inputs:
+
+- available container width,
+- preferred left sidebar width,
+- preferred right pane width,
+- saved right-pane visibility,
+- divider width,
+- minimum and maximum widths.
+
+Outputs:
+
+- effective left sidebar width,
+- effective right pane width,
+- whether the right pane is visible for this render,
+- center pane's remaining width.
+
+Preferred widths are clamped to their existing manual ranges before calculation.
+
+## Responsive Behavior
+
+When the right pane is manually hidden, the layout is two-pane:
+
+```text
+[ left sidebar ][ center ]
+```
+
+The left sidebar uses its preferred width when possible, then shrinks toward its minimum if the center pane would otherwise become too narrow.
+
+When the right pane is manually visible, the layout is three-pane as long as this minimum set fits:
+
+```text
+left minimum + center minimum + right minimum + divider widths
+```
+
+If that set fits, use all three panes. Start from preferred sidebar widths and give the center the remaining width. If the center would be below its useful minimum, shrink the left and right columns proportionally from their preferred widths toward their minimums until the center reaches its minimum or both sidebars are at minimum.
+
+If the three-pane minimum set does not fit, temporarily render as two-pane by hiding the right pane. This temporary collapse does not change `rightPaneVisible`.
+
+When the window grows and the three-pane minimum set fits again, the right pane reappears automatically if `rightPaneVisible` is still true.
+
+## Width Constants
+
+Keep current manual ranges:
+
+- left sidebar minimum: `200`
+- left sidebar maximum: `420`
+- right pane minimum: `240`
+- right pane maximum: `560`
+
+Add a center pane minimum of `400` for terminal/editor readability.
+
+Use the existing drag handle width as the divider width. Today the horizontal `DragHandle` renders at `6` points.
+
+## Drag Behavior
+
+Manual drag must operate on persisted preferred widths, not temporary effective widths.
+
+Dragging the left divider updates `sidebarWidth` and clamps it to `200...420`.
+
+Dragging the right divider updates `rightPaneWidth` and clamps it to `240...560`.
+
+If the right pane is temporarily collapsed because the window is too narrow, its divider is not visible and cannot be dragged. The saved `rightPaneWidth` remains intact and applies again when the pane reappears.
+
+## State and Data Flow
+
+No new persisted state is needed.
+
+State flow:
+
+1. `RootView` passes persisted width bindings and `rightPaneVisible` into `ThreePaneLayout`.
+2. `ThreePaneLayout` measures available width with `GeometryReader`.
+3. The layout helper computes effective widths and transient right-pane visibility.
+4. SwiftUI renders sidebar, center, optional right divider, and optional right pane from those effective values.
+5. User divider drags update persisted preferred widths through the existing bindings and save config through `onWidthsChanged`.
+
+## Error Handling
+
+The sizing helper must defensively handle very small, zero, or non-finite available widths by clamping outputs to non-negative values. SwiftUI must never receive negative frame widths.
+
+If there is not enough room for the left sidebar minimum plus center minimum, the layout must still render both panes with the best non-negative widths available rather than hiding the left sidebar or crashing.
+
+## Testing
+
+Add focused Swift Testing coverage for the layout math.
+
+Important cases:
+
+- wide window uses preferred left and right widths,
+- compact window shrinks left and right proportionally before collapsing right,
+- right pane temporarily collapses when the three-pane minimum set cannot fit,
+- temporary collapse does not require changing the saved visibility input,
+- manually hidden right pane stays hidden even when there is enough room,
+- two-pane mode shrinks the left sidebar only as needed to protect center width,
+- very small widths produce non-negative effective widths.
+
+The view implementation can stay thin enough that direct UI tests are not required for this pass.
+
+## Verification
+
+Run the standard project checks after implementation:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```


### PR DESCRIPTION
## Summary
- Add a pure `ThreePaneSizing` model for responsive left/center/right pane widths.
- Shrink side panes proportionally at compact widths and temporarily collapse the right pane when three panes cannot fit.
- Lower the app minimum width so the responsive collapse path is reachable, with focused sizing coverage for edge cases.

## Validation
- `rtk proxy xcodegen`
- `rtk proxy xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk proxy xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`