### PR TITLE
fix(ui): unify segmented controls under Seg

### DIFF
--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -154,18 +154,16 @@ struct MarkdownTabView: View {
         HStack(spacing: 6) {
             breadcrumbText
             Spacer()
-            Picker("", selection: Binding(
+            Seg(value: Binding(
                 get: { resolvedMode },
                 set: { newMode in
                     appState.tabs.setMarkdownViewMode(worktreeId: worktreeId, tabId: tabId, mode: newMode)
                 }
-            )) {
-                Image(systemName: "pencil").tag(MarkdownViewMode.editor)
-                Image(systemName: "rectangle.split.2x1").tag(MarkdownViewMode.split)
-                Image(systemName: "eye").tag(MarkdownViewMode.preview)
-            }
-            .pickerStyle(.segmented)
-            .frame(width: 120)
+            ), systemImageOptions: [
+                (MarkdownViewMode.editor, "pencil"),
+                (MarkdownViewMode.split, "rectangle.split.2x1"),
+                (MarkdownViewMode.preview, "eye"),
+            ])
         }
         .padding(.horizontal, 12).frame(height: 28)
         .background(theme.color("bg-1"))

--- a/Alas/Sources/Settings/AppearancePane.swift
+++ b/Alas/Sources/Settings/AppearancePane.swift
@@ -142,19 +142,17 @@ struct AppearancePane: View {
                 SettingsGroup(title: "Markdown") {
                     SettingsRow(name: "Default view mode",
                                 desc: "Initial mode when a markdown file is opened.") {
-                        Picker("", selection: Binding(
+                        Seg(value: Binding(
                             get: { state.config.markdown.defaultViewMode },
                             set: {
                                 state.config.markdown.defaultViewMode = $0
                                 state.saveConfig()
                             }
-                        )) {
-                            Text("Editor").tag(MarkdownViewMode.editor)
-                            Text("Split").tag(MarkdownViewMode.split)
-                            Text("Preview").tag(MarkdownViewMode.preview)
-                        }
-                        .pickerStyle(.segmented)
-                        .frame(width: 240)
+                        ), options: [
+                            (MarkdownViewMode.editor, "Editor"),
+                            (MarkdownViewMode.split, "Split"),
+                            (MarkdownViewMode.preview, "Preview"),
+                        ])
                     }
                 }
             }

--- a/Alas/Sources/UI/Seg.swift
+++ b/Alas/Sources/UI/Seg.swift
@@ -1,9 +1,24 @@
 import SwiftUI
 
 struct Seg<Value: Hashable>: View {
+    enum Content {
+        case text(String)
+        case systemImage(String)
+    }
+
     @Binding var value: Value
-    let options: [(Value, String)]
+    let options: [(Value, Content)]
     @Environment(\.theme) var theme
+
+    init(value: Binding<Value>, options: [(Value, String)]) {
+        self._value = value
+        self.options = options.map { ($0.0, .text($0.1)) }
+    }
+
+    init(value: Binding<Value>, systemImageOptions: [(Value, String)]) {
+        self._value = value
+        self.options = systemImageOptions.map { ($0.0, .systemImage($0.1)) }
+    }
 
     var body: some View {
         HStack(spacing: 1) {
@@ -11,7 +26,7 @@ struct Seg<Value: Hashable>: View {
                 Button {
                     value = item.0
                 } label: {
-                    Text(item.1)
+                    label(for: item.1)
                         .font(.system(size: 12))
                         .padding(.horizontal, 12).padding(.vertical, 5)
                         .background(value == item.0 ? theme.color("bg-3") : .clear)
@@ -28,5 +43,13 @@ struct Seg<Value: Hashable>: View {
                 .strokeBorder(theme.color("line"), lineWidth: 0.5)
         )
         .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    @ViewBuilder
+    private func label(for content: Content) -> some View {
+        switch content {
+        case .text(let s): Text(s)
+        case .systemImage(let name): Image(systemName: name)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- The Density picker uses our themed `Seg` control, but the Markdown default-view-mode setting and the markdown tab header still used SwiftUI's blue `.segmented` Picker — so the three controls looked unrelated.
- Extend `Seg` with a `systemImageOptions:` initializer (text or SF Symbol per item) and route both remaining call sites through it.

## Test plan
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build` succeeds
- [ ] Settings → Appearance → Density, Default view mode, and the markdown tab header picker all share the same look

🤖 Generated with [Claude Code](https://claude.com/claude-code)