### PR TITLE
feat(editor): Implement editor auto-pair delimiters

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
+		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
 		1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
@@ -492,6 +493,7 @@
 		79DDEA496740F5B0B5EE808B /* Process+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Process+Git.swift"; sourceTree = "<group>"; };
 		79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilderTests.swift; sourceTree = "<group>"; };
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
+		7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewAutoPairTests.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
 		7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCacheTests.swift; sourceTree = "<group>"; };
 		7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApp.swift; sourceTree = "<group>"; };
@@ -705,6 +707,7 @@
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
+				7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */,
 				2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */,
 				9434D7A01EF3F7DCD01B7688 /* CommitAIAdapterInvocationTests.swift */,
 				CC25D6E58AB1D01E6A7C46FB /* CommitAIAdapterParseTests.swift */,
@@ -1718,6 +1721,7 @@
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,
+				1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */,
 				6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */,
 				EDDA03AC6061A1B5FE061DA6 /* CommitAIAdapterInvocationTests.swift in Sources */,
 				E2CEB5EBCCD5792CAF460411 /* CommitAIAdapterParseTests.swift in Sources */,

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -6,6 +6,17 @@ import AppKit
 /// dirty tracking, save, file-watch, and LSP `didChange` are all
 /// orchestrated by the buffer + coordinator pair.
 final class CodeTextView: NSTextView, FontSizeResponder {
+    private static let pairedDelimiters: [Character: Character] = [
+        "(": ")",
+        "[": "]",
+        "{": "}",
+        "\"": "\"",
+        "'": "'",
+        "`": "`"
+    ]
+
+    private static let closingDelimiters: Set<Character> = [")", "]", "}"]
+
     var hoverHandler: ((NSPoint) -> Void)?
     var commandClickHandler: ((NSPoint) -> Void)?
     var flagsChangedHandler: ((NSEvent) -> Void)?
@@ -39,6 +50,36 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     }
 
     required init?(coder: NSCoder) { fatalError("not used") }
+
+    override func insertText(_ insertString: Any, replacementRange: NSRange) {
+        guard
+            isEditable,
+            let text = Self.string(from: insertString),
+            text.count == 1,
+            let character = text.first
+        else {
+            super.insertText(insertString, replacementRange: replacementRange)
+            return
+        }
+
+        let range = effectiveReplacementRange(replacementRange)
+        guard range.location != NSNotFound, NSMaxRange(range) <= (string as NSString).length else {
+            super.insertText(insertString, replacementRange: replacementRange)
+            return
+        }
+
+        if let closing = Self.pairedDelimiters[character], shouldInsertPair(opening: character, closing: closing, range: range) {
+            insertPairedDelimiter(opening: character, closing: closing, replacementRange: range)
+            return
+        }
+
+        if Self.closingDelimiters.contains(character), range.length == 0, nextCharacter(at: range.location) == character {
+            setSelectedRange(NSRange(location: range.location + 1, length: 0))
+            return
+        }
+
+        super.insertText(insertString, replacementRange: replacementRange)
+    }
 
     override func mouseMoved(with event: NSEvent) {
         super.mouseMoved(with: event)
@@ -74,5 +115,76 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             owner: self, userInfo: nil
         )
         addTrackingArea(area)
+    }
+
+    private static func string(from insertString: Any) -> String? {
+        if let string = insertString as? String { return string }
+        if let attributed = insertString as? NSAttributedString { return attributed.string }
+        return nil
+    }
+
+    private func effectiveReplacementRange(_ replacementRange: NSRange) -> NSRange {
+        replacementRange.location == NSNotFound ? selectedRange() : replacementRange
+    }
+
+    private func insertPairedDelimiter(opening: Character, closing: Character, replacementRange range: NSRange) {
+        let current = string as NSString
+        if opening == closing, range.length == 0, nextCharacter(at: range.location) == closing {
+            setSelectedRange(NSRange(location: range.location + 1, length: 0))
+            return
+        }
+
+        let selectedText = range.length > 0 ? current.substring(with: range) : ""
+        let replacement = "\(opening)\(selectedText)\(closing)"
+        super.insertText(replacement, replacementRange: range)
+
+        if range.length > 0 {
+            setSelectedRange(NSRange(location: range.location + 1, length: range.length))
+        } else {
+            setSelectedRange(NSRange(location: range.location + 1, length: 0))
+        }
+    }
+
+    private func shouldInsertPair(opening: Character, closing: Character, range: NSRange) -> Bool {
+        guard opening == closing, range.length == 0 else { return true }
+
+        if isEscapedByBackslash(at: range.location) { return false }
+        if isIdentifierLike(characterBefore: range.location) { return false }
+        if isIdentifierLike(characterAfter: range.location) { return false }
+
+        return true
+    }
+
+    private func nextCharacter(at location: Int) -> Character? {
+        let nsString = string as NSString
+        guard location < nsString.length else { return nil }
+        return Character(nsString.substring(with: NSRange(location: location, length: 1)))
+    }
+
+    private func previousCharacter(before location: Int) -> Character? {
+        guard location > 0 else { return nil }
+        let nsString = string as NSString
+        guard location <= nsString.length else { return nil }
+        return Character(nsString.substring(with: NSRange(location: location - 1, length: 1)))
+    }
+
+    private func isIdentifierLike(characterBefore location: Int) -> Bool {
+        guard let character = previousCharacter(before: location) else { return false }
+        return character.isLetter || character.isNumber || character == "_"
+    }
+
+    private func isIdentifierLike(characterAfter location: Int) -> Bool {
+        guard let character = nextCharacter(at: location) else { return false }
+        return character.isLetter || character.isNumber || character == "_"
+    }
+
+    private func isEscapedByBackslash(at location: Int) -> Bool {
+        var cursor = location
+        var backslashCount = 0
+        while previousCharacter(before: cursor) == "\\" {
+            backslashCount += 1
+            cursor -= 1
+        }
+        return backslashCount % 2 == 1
     }
 }

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -68,9 +68,15 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             return
         }
 
-        if let closing = Self.pairedDelimiters[character], shouldInsertPair(opening: character, closing: closing, range: range) {
-            insertPairedDelimiter(opening: character, closing: closing, replacementRange: range)
-            return
+        if let closing = Self.pairedDelimiters[character] {
+            if shouldInsertPair(opening: character, closing: closing, range: range) {
+                insertPairedDelimiter(opening: character, closing: closing, replacementRange: range)
+                return
+            }
+            if character == closing, range.length == 0, nextCharacter(at: range.location) == character {
+                setSelectedRange(NSRange(location: range.location + 1, length: 0))
+                return
+            }
         }
 
         if Self.closingDelimiters.contains(character), range.length == 0, nextCharacter(at: range.location) == character {

--- a/AlasTests/CodeTextViewAutoPairTests.swift
+++ b/AlasTests/CodeTextViewAutoPairTests.swift
@@ -55,6 +55,16 @@ struct CodeTextViewAutoPairTests {
         #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
     }
 
+    @Test func quoteStepsOverClosingQuoteAfterIdentifier() {
+        let textView = makeTextView("\"foo\"")
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+
+        textView.insertText("\"", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "\"foo\"")
+        #expect(textView.selectedRange() == NSRange(location: 5, length: 0))
+    }
+
     @Test func quoteAfterIdentifierFallsBackToNormalTextInsertion() {
         let textView = makeTextView("word")
 

--- a/AlasTests/CodeTextViewAutoPairTests.swift
+++ b/AlasTests/CodeTextViewAutoPairTests.swift
@@ -1,0 +1,94 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct CodeTextViewAutoPairTests {
+    private func makeTextView(_ text: String = "") -> CodeTextView {
+        let storage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        return textView
+    }
+
+    @Test func openingDelimiterInsertsPairAndPlacesCursorBetween() {
+        let textView = makeTextView()
+
+        textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "()")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
+    @Test func openingDelimiterWrapsSelectedText() {
+        let textView = makeTextView("value")
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+
+        textView.insertText("\"", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "\"value\"")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 5))
+    }
+
+    @Test func closingDelimiterStepsOverExistingCharacter() {
+        let textView = makeTextView("()")
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        textView.insertText(")", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "()")
+        #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+    }
+
+    @Test func quoteStepsOverExistingQuote() {
+        let textView = makeTextView("\"\"")
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+
+        textView.insertText("\"", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "\"\"")
+        #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+    }
+
+    @Test func quoteAfterIdentifierFallsBackToNormalTextInsertion() {
+        let textView = makeTextView("word")
+
+        textView.insertText("'", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "word'")
+        #expect(textView.selectedRange() == NSRange(location: 5, length: 0))
+    }
+
+    @Test func quoteBeforeIdentifierFallsBackToNormalTextInsertion() {
+        let textView = makeTextView("word")
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        textView.insertText("\"", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "\"word")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
+    @Test func escapedQuoteFallsBackToNormalTextInsertion() {
+        let textView = makeTextView("\\")
+
+        textView.insertText("\"", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "\\\"")
+        #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+    }
+
+    @Test func multiCharacterInsertionFallsBackToNormalTextInsertion() {
+        let textView = makeTextView()
+
+        textView.insertText("paste", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "paste")
+        #expect(textView.selectedRange() == NSRange(location: 5, length: 0))
+    }
+}


### PR DESCRIPTION
## Summary
- Add auto-pair behavior for brackets, braces, quotes, and backticks in `CodeTextView`.
- Wrap selected text with typed pair delimiters and keep the wrapped text selected.
- Step over existing closing delimiters instead of duplicating them.
- Add conservative quote handling to avoid pairing after identifiers or escaped backslashes.
- Add focused Swift Testing coverage for editor auto-pair behavior.

## Validation
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CodeTextViewAutoPairTests -quiet test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

## Notes
- Full suite was run during implementation and exposed unrelated intermittent failures in `ProjectGitWatcherTests/headReadFailureEscalatesToTopology` and `ProcessGitTests/gitEnvPreservesAllParentVariables`; both passed when rerun individually.