### PR TITLE
Add validation for branch and worktree names

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */; };
+		175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
@@ -109,6 +110,7 @@
 		4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25493E3B18A1AB94EA6985C3 /* EventHolder.swift */; };
+		513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */; };
 		514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */; };
 		523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE8B45ECF898B83A616586D /* SubHeader.swift */; };
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
@@ -379,6 +381,7 @@
 		215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyHost.swift; sourceTree = "<group>"; };
 		23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCommandShellTests.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
+		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
 		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
 		27A92711BC1D9A78D8A80561 /* GitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypes.swift; sourceTree = "<group>"; };
@@ -504,6 +507,7 @@
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
 		8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcherTests.swift; sourceTree = "<group>"; };
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
+		8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidatorTests.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
@@ -733,6 +737,7 @@
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
 				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
+				8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */,
 				38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
 				039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */,
@@ -821,6 +826,7 @@
 				3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */,
 				E1703FC5CD7DF16F4450E274 /* DiffParser.swift */,
 				339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */,
+				269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */,
 				B7CE7B4DAFDB65A79308FB63 /* GitService.swift */,
 				D2F90D03073708AA01531533 /* GitService+Staging.swift */,
 				27A92711BC1D9A78D8A80561 /* GitTypes.swift */,
@@ -1582,6 +1588,7 @@
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,
 				41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */,
 				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,
+				175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */,
 				0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */,
 				12035048B950CE0197604F89 /* GitService.swift in Sources */,
 				676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */,
@@ -1745,6 +1752,7 @@
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */,
 				D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */,
+				513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */,
 				1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,
 				E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */,

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -195,7 +195,7 @@ struct NewWorktreeDialog: View {
     }
 
     private func submitCreate() {
-        guard Self.canCreate(projectsEmpty: state.projects.isEmpty, branchEmpty: branch.isEmpty) else { return }
+        guard Self.canCreate(projectsEmpty: state.projects.isEmpty, branchEmpty: branch.isEmpty, branchValidation: branchValidationMessage) else { return }
         create()
     }
 

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -59,6 +59,9 @@ struct NewWorktreeDialog: View {
                     Text("Open in new terminal pane").font(.system(size: 12))
                         .foregroundColor(theme.color("fg"))
                 }
+                if let validationMessage = branchValidationMessage {
+                    Text(validationMessage).font(.system(size: 11)).foregroundColor(.red)
+                }
                 if let createErrorMessage {
                     Text(createErrorMessage).font(.system(size: 11)).foregroundColor(.red)
                 }
@@ -68,7 +71,11 @@ struct NewWorktreeDialog: View {
             confirmStyle: .primary,
             onCancel: { presented = false },
             onConfirm: create,
-            confirmEnabled: Self.canCreate(projectsEmpty: state.projects.isEmpty, branchEmpty: branch.isEmpty)
+            confirmEnabled: Self.canCreate(
+                projectsEmpty: state.projects.isEmpty,
+                branchEmpty: branch.isEmpty,
+                branchValidation: branchValidationMessage
+            )
         )
         .onAppear {
             if projectId.isEmpty {
@@ -100,6 +107,16 @@ struct NewWorktreeDialog: View {
 
     private var showsRepositorySelector: Bool {
         !state.projects.isEmpty && presetProject == nil
+    }
+
+    private var branchValidationMessage: String? {
+        let result = GitNameValidator.validateBranchName(branch)
+        switch result {
+        case .valid:
+            return nil
+        case .invalid(let message):
+            return message
+        }
     }
 
     private var subtitleText: String {
@@ -182,8 +199,8 @@ struct NewWorktreeDialog: View {
         create()
     }
 
-    nonisolated static func canCreate(projectsEmpty: Bool, branchEmpty: Bool) -> Bool {
-        !projectsEmpty && !branchEmpty
+    nonisolated static func canCreate(projectsEmpty: Bool, branchEmpty: Bool, branchValidation: String? = nil) -> Bool {
+        !projectsEmpty && !branchEmpty && branchValidation == nil
     }
 
     nonisolated static func resolvedPresetProject(

--- a/Alas/Sources/Git/GitNameValidator.swift
+++ b/Alas/Sources/Git/GitNameValidator.swift
@@ -81,7 +81,7 @@ struct GitNameValidator {
                 if ch == "\r" || ch == "\n" || ch == "\0" {
                     return .invalid("Name contains unsupported characters.")
                 }
-                if ch == "?" || ch == "*" {
+                if ch == "?" || ch == "*" || ch == "[" {
                     return .invalid("Name contains unsupported characters.")
                 }
             }

--- a/Alas/Sources/Git/GitNameValidator.swift
+++ b/Alas/Sources/Git/GitNameValidator.swift
@@ -41,6 +41,14 @@ struct GitNameValidator {
             return .invalid("Name cannot contain '@{' .")
         }
 
+        if name == "@" {
+            return .invalid("'@' is not a valid branch name.")
+        }
+
+        if name.hasPrefix("-") {
+            return .invalid("Name cannot start with '-' .")
+        }
+
         let components = name.split(separator: "/", omittingEmptySubsequences: false)
         for component in components {
             let comp = String(component)
@@ -55,10 +63,6 @@ struct GitNameValidator {
 
             if comp.contains("..") {
                 return .invalid("Name cannot contain '..'.")
-            }
-
-            if comp.hasPrefix("-") {
-                return .invalid("Path components cannot start with '-' .")
             }
 
             if comp.hasSuffix(".lock") {

--- a/Alas/Sources/Git/GitNameValidator.swift
+++ b/Alas/Sources/Git/GitNameValidator.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Validates git branch names and worktree names to prevent invalid refs
+/// and filesystem-unsafe paths before shelling out to git.
+struct GitNameValidator {
+    enum ValidationResult: Equatable {
+        case valid
+        case invalid(String)
+    }
+
+    /// Validate a git branch name according to git ref naming rules.
+    /// Allows path-style names such as `feature/foo`.
+    static func validateBranchName(_ name: String) -> ValidationResult {
+        // Do NOT trim spaces — if the user includes them, they are invalid.
+        // We only reject truly empty strings after stripping all characters.
+        if name.isEmpty {
+            return .invalid("Name cannot be empty.")
+        }
+
+        if name.count > 250 {
+            return .invalid("Name is too long (max 250 characters).")
+        }
+
+        if name.contains(" ") {
+            return .invalid("Name cannot contain spaces.")
+        }
+
+        if name.unicodeScalars.contains(where: { $0.isASCII && $0.properties.generalCategory == .control }) {
+            return .invalid("Name cannot contain control characters.")
+        }
+
+        if name.hasPrefix("/") || name.hasSuffix("/") {
+            return .invalid("Name cannot start or end with '/' .")
+        }
+
+        if name.contains("//") {
+            return .invalid("Name cannot contain consecutive '/' .")
+        }
+
+        if name.contains("@{") {
+            return .invalid("Name cannot contain '@{' .")
+        }
+
+        let components = name.split(separator: "/", omittingEmptySubsequences: false)
+        for component in components {
+            let comp = String(component)
+
+            if comp == "." || comp == ".." {
+                return .invalid("Name cannot contain '.' or '..' as a path component.")
+            }
+
+            if comp.hasPrefix(".") || comp.hasSuffix(".") {
+                return .invalid("Path components cannot start or end with '.'.")
+            }
+
+            if comp.contains("..") {
+                return .invalid("Name cannot contain '..'.")
+            }
+
+            if comp.hasPrefix("-") {
+                return .invalid("Path components cannot start with '-' .")
+            }
+
+            if comp.hasSuffix(".lock") {
+                return .invalid("Name cannot end with '.lock' .")
+            }
+
+            for ch in comp {
+                if ch == "~" || ch == "^" || ch == ":" || ch == "\\" || ch == "\t" {
+                    return .invalid("Name contains unsupported characters.")
+                }
+                if ch == "\r" || ch == "\n" || ch == "\0" || ch == "{" || ch == "}" {
+                    return .invalid("Name contains unsupported characters.")
+                }
+                if ch == "?" || ch == "*" {
+                    return .invalid("Name contains unsupported characters.")
+                }
+            }
+        }
+
+        return .valid
+    }
+
+    /// Validate a worktree directory name derived from a branch name.
+    static func validateWorktreeName(_ name: String) -> ValidationResult {
+        validateBranchName(name)
+    }
+}

--- a/Alas/Sources/Git/GitNameValidator.swift
+++ b/Alas/Sources/Git/GitNameValidator.swift
@@ -50,15 +50,20 @@ struct GitNameValidator {
         }
 
         let components = name.split(separator: "/", omittingEmptySubsequences: false)
-        for component in components {
+        for (index, component) in components.enumerated() {
             let comp = String(component)
+            let isLast = index == components.count - 1
 
             if comp == "." || comp == ".." {
                 return .invalid("Name cannot contain '.' or '..' as a path component.")
             }
 
-            if comp.hasPrefix(".") || comp.hasSuffix(".") {
-                return .invalid("Path components cannot start or end with '.'.")
+            if comp.hasPrefix(".") {
+                return .invalid("Path components cannot start with '.'.")
+            }
+
+            if isLast && comp.hasSuffix(".") {
+                return .invalid("Name cannot end with '.'.")
             }
 
             if comp.contains("..") {

--- a/Alas/Sources/Git/GitNameValidator.swift
+++ b/Alas/Sources/Git/GitNameValidator.swift
@@ -81,6 +81,33 @@ struct GitNameValidator {
         return .valid
     }
 
+    /// Validate a branch prefix (e.g. "feature/") which may end with a
+    /// trailing slash that separates the prefix from the rest of the
+    /// branch name. All other branch-name rules still apply.
+    static func validateBranchPrefix(_ prefix: String) -> ValidationResult {
+        if prefix.isEmpty {
+            return .valid
+        }
+
+        // Temporarily strip a trailing slash for validation, then
+        // re-check that the stripped form is a valid branch name.
+        let toValidate: String
+        if prefix.hasSuffix("/") {
+            let stripped = String(prefix.dropLast())
+            if stripped.isEmpty {
+                return .invalid("Prefix cannot be '/' only.")
+            }
+            if stripped.hasSuffix("/") {
+                return .invalid("Prefix cannot contain consecutive '/'.")
+            }
+            toValidate = stripped
+        } else {
+            toValidate = prefix
+        }
+
+        return validateBranchName(toValidate)
+    }
+
     /// Validate a worktree directory name derived from a branch name.
     static func validateWorktreeName(_ name: String) -> ValidationResult {
         validateBranchName(name)

--- a/Alas/Sources/Git/GitNameValidator.swift
+++ b/Alas/Sources/Git/GitNameValidator.swift
@@ -73,7 +73,7 @@ struct GitNameValidator {
                 if ch == "~" || ch == "^" || ch == ":" || ch == "\\" || ch == "\t" {
                     return .invalid("Name contains unsupported characters.")
                 }
-                if ch == "\r" || ch == "\n" || ch == "\0" || ch == "{" || ch == "}" {
+                if ch == "\r" || ch == "\n" || ch == "\0" {
                     return .invalid("Name contains unsupported characters.")
                 }
                 if ch == "?" || ch == "*" {

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -63,6 +63,12 @@ struct WorktreeService {
         destination: URL,
         projectId: String
     ) async throws -> Worktree {
+        switch GitNameValidator.validateBranchName(branch) {
+        case .valid:
+            break
+        case .invalid(let message):
+            throw WorktreeError.gitFailed("Invalid branch name: \(message)")
+        }
         let refCheck = try await Process.git(
             ["show-ref", "--verify", "--quiet", "refs/heads/\(branch)"],
             cwd: repoPath

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -25,7 +25,14 @@ struct WorktreesPane: View {
                 SettingsGroup(title: "Branch defaults") {
                     SettingsRow(name: "Branch prefix",
                                 desc: "Default prefix when creating a new worktree.") {
-                        AlasField(text: bind(\.worktrees.branchPrefix), monospaced: true)
+                        VStack(alignment: .leading, spacing: 2) {
+                            AlasField(text: branchPrefixBinding, monospaced: true)
+                            if let prefixError = branchPrefixError {
+                                Text(prefixError)
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.red)
+                            }
+                        }
                     }
                     SettingsRow(name: "Base branch",
                                 desc: "Default base branch for new worktrees; repo branches can be selected in the create dialog.") {
@@ -71,6 +78,28 @@ struct WorktreesPane: View {
             set: { state.config[keyPath: kp] = $0
             state.saveConfig() }
         )
+    }
+
+    private var branchPrefixBinding: Binding<String> {
+        Binding(
+            get: { state.config.worktrees.branchPrefix },
+            set: {
+                state.config.worktrees.branchPrefix = $0
+                state.saveConfig()
+            }
+        )
+    }
+
+    private var branchPrefixError: String? {
+        if state.config.worktrees.branchPrefix.isEmpty {
+            return nil
+        }
+        switch GitNameValidator.validateBranchName(state.config.worktrees.branchPrefix) {
+        case .valid:
+            return nil
+        case .invalid(let message):
+            return message
+        }
     }
 }
 

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -94,7 +94,7 @@ struct WorktreesPane: View {
         if state.config.worktrees.branchPrefix.isEmpty {
             return nil
         }
-        switch GitNameValidator.validateBranchName(state.config.worktrees.branchPrefix) {
+        switch GitNameValidator.validateBranchPrefix(state.config.worktrees.branchPrefix) {
         case .valid:
             return nil
         case .invalid(let message):

--- a/AlasTests/GitNameValidatorTests.swift
+++ b/AlasTests/GitNameValidatorTests.swift
@@ -134,6 +134,11 @@ struct GitNameValidatorTests {
         #expect(result == .valid)
     }
 
+    @Test func acceptsBracesWithoutAt() {
+        let result = GitNameValidator.validateBranchName("feature/{foo}")
+        #expect(result == .valid)
+    }
+
     @Test func acceptsHyphenInPathComponent() {
         let result = GitNameValidator.validateBranchName("feature/-dash")
         #expect(result == .valid)

--- a/AlasTests/GitNameValidatorTests.swift
+++ b/AlasTests/GitNameValidatorTests.swift
@@ -1,0 +1,147 @@
+import Testing
+@testable import Alas
+
+struct GitNameValidatorTests {
+    // MARK: - Accepted names
+    @Test func acceptsSimpleBranchName() {
+        let result = GitNameValidator.validateBranchName("feat-x")
+        #expect(result == .valid)
+    }
+
+    @Test func acceptsPathStyleBranchName() {
+        let result = GitNameValidator.validateBranchName("feature/foo-bar")
+        #expect(result == .valid)
+    }
+
+    @Test func acceptsBranchWithMultipleSlashes() {
+        let result = GitNameValidator.validateBranchName("release/v1/0")
+        #expect(result == .valid)
+    }
+
+    @Test func acceptsBranchWithHyphens() {
+        let result = GitNameValidator.validateBranchName("bug-fix-correct")
+        #expect(result == .valid)
+    }
+
+    @Test func acceptsBranchWithUnderscores() {
+        let result = GitNameValidator.validateBranchName("bug_fix_correct")
+        #expect(result == .valid)
+    }
+
+    @Test func acceptsBranchWithNumbers() {
+        let result = GitNameValidator.validateBranchName("v1.2.3")
+        #expect(result == .valid)
+    }
+
+    // MARK: - Rejected names
+    @Test func rejectsEmptyName() {
+        let result = GitNameValidator.validateBranchName("")
+        #expect(result == .invalid("Name cannot be empty."))
+    }
+
+    @Test func rejectsWhitespaceOnlyName() {
+        let result = GitNameValidator.validateBranchName("   ")
+        #expect(result == .invalid("Name cannot contain spaces."))
+    }
+
+    @Test func rejectsNameWithSpaces() {
+        let result = GitNameValidator.validateBranchName("bad name")
+        #expect(result == .invalid("Name cannot contain spaces."))
+    }
+
+    @Test func rejectsLeadingSpace() {
+        let result = GitNameValidator.validateBranchName(" leading")
+        #expect(result == .invalid("Name cannot contain spaces."))
+    }
+
+    @Test func rejectsTrailingSpace() {
+        let result = GitNameValidator.validateBranchName("trailing ")
+        #expect(result == .invalid("Name cannot contain spaces."))
+    }
+
+    @Test func rejectsDotComponent() {
+        let result = GitNameValidator.validateBranchName("feature/.secret")
+        #expect(result == .invalid("Path components cannot start or end with '.'."))
+    }
+
+    @Test func rejectsDotDotComponent() {
+        let result = GitNameValidator.validateBranchName("feature/..")
+        #expect(result == .invalid("Name cannot contain '.' or '..' as a path component."))
+    }
+
+    @Test func rejectsPathTraversal() {
+        let result = GitNameValidator.validateBranchName("../escape")
+        #expect(result == .invalid("Name cannot contain '.' or '..' as a path component."))
+    }
+
+    @Test func rejectsLeadingSlash() {
+        let result = GitNameValidator.validateBranchName("/leading")
+        #expect(result == .invalid("Name cannot start or end with '/' ."))
+    }
+
+    @Test func rejectsTrailingSlash() {
+        let result = GitNameValidator.validateBranchName("trailing/")
+        #expect(result == .invalid("Name cannot start or end with '/' ."))
+    }
+
+    @Test func rejectDoubleSlash() {
+        let result = GitNameValidator.validateBranchName("feature//double")
+        #expect(result == .invalid("Name cannot contain consecutive '/' ."))
+    }
+
+    @Test func rejectsTilde() {
+        let result = GitNameValidator.validateBranchName("fix~backup")
+        #expect(result == .invalid("Name contains unsupported characters."))
+    }
+
+    @Test func rejectsCaret() {
+        let result = GitNameValidator.validateBranchName("v1^2")
+        #expect(result == .invalid("Name contains unsupported characters."))
+    }
+
+    @Test func rejectsColon() {
+        let result = GitNameValidator.validateBranchName("feat:new")
+        #expect(result == .invalid("Name contains unsupported characters."))
+    }
+
+    @Test func rejectsBackslash() {
+        let result = GitNameValidator.validateBranchName("feat\\new")
+        #expect(result == .invalid("Name contains unsupported characters."))
+    }
+
+    @Test func rejectsQuestionMark() {
+        let result = GitNameValidator.validateBranchName("what?")
+        #expect(result == .invalid("Name contains unsupported characters."))
+    }
+
+    @Test func rejectsAsterisk() {
+        let result = GitNameValidator.validateBranchName("feat/*")
+        #expect(result == .invalid("Name contains unsupported characters."))
+    }
+
+    @Test func rejectsAtCurly() {
+        let result = GitNameValidator.validateBranchName("stash@{1}")
+        #expect(result == .invalid("Name cannot contain '@{' ."))
+    }
+
+    @Test func rejectsLeadingDashComponent() {
+        let result = GitNameValidator.validateBranchName("feature/-dash")
+        #expect(result == .invalid("Path components cannot start with '-' ."))
+    }
+
+    @Test func rejectsDotLock() {
+        let result = GitNameValidator.validateBranchName("fix.lock")
+        #expect(result == .invalid("Name cannot end with '.lock' ."))
+    }
+
+    @Test func rejectsVeryLongName() {
+        let result = GitNameValidator.validateBranchName(String(repeating: "a", count: 251))
+        #expect(result == .invalid("Name is too long (max 250 characters)."))
+    }
+
+    // MARK: - Worktree name alias
+    @Test func worktreeNameDelegatesToBranchValidator() {
+        let result = GitNameValidator.validateWorktreeName("feature/foo")
+        #expect(result == .valid)
+    }
+}

--- a/AlasTests/GitNameValidatorTests.swift
+++ b/AlasTests/GitNameValidatorTests.swift
@@ -129,6 +129,11 @@ struct GitNameValidatorTests {
         #expect(result == .invalid("Name contains unsupported characters."))
     }
 
+    @Test func rejectsBracket() {
+        let result = GitNameValidator.validateBranchName("feature/[wip]")
+        #expect(result == .invalid("Name contains unsupported characters."))
+    }
+
     @Test func rejectsAtCurly() {
         let result = GitNameValidator.validateBranchName("stash@{1}")
         #expect(result == .invalid("Name cannot contain '@{' ."))

--- a/AlasTests/GitNameValidatorTests.swift
+++ b/AlasTests/GitNameValidatorTests.swift
@@ -124,9 +124,24 @@ struct GitNameValidatorTests {
         #expect(result == .invalid("Name cannot contain '@{' ."))
     }
 
-    @Test func rejectsLeadingDashComponent() {
+    @Test func rejectsStandaloneAt() {
+        let result = GitNameValidator.validateBranchName("@")
+        #expect(result == .invalid("'@' is not a valid branch name."))
+    }
+
+    @Test func acceptsAtInComponent() {
+        let result = GitNameValidator.validateBranchName("user@branch")
+        #expect(result == .valid)
+    }
+
+    @Test func acceptsHyphenInPathComponent() {
         let result = GitNameValidator.validateBranchName("feature/-dash")
-        #expect(result == .invalid("Path components cannot start with '-' ."))
+        #expect(result == .valid)
+    }
+
+    @Test func rejectsLeadingDashShorthand() {
+        let result = GitNameValidator.validateBranchName("-dash")
+        #expect(result == .invalid("Name cannot start with '-' ."))
     }
 
     @Test func rejectsDotLock() {

--- a/AlasTests/GitNameValidatorTests.swift
+++ b/AlasTests/GitNameValidatorTests.swift
@@ -61,7 +61,17 @@ struct GitNameValidatorTests {
 
     @Test func rejectsDotComponent() {
         let result = GitNameValidator.validateBranchName("feature/.secret")
-        #expect(result == .invalid("Path components cannot start or end with '.'."))
+        #expect(result == .invalid("Path components cannot start with '.'."))
+    }
+
+    @Test func acceptsIntermediateDotSuffix() {
+        let result = GitNameValidator.validateBranchName("foo./bar")
+        #expect(result == .valid)
+    }
+
+    @Test func rejectsFinalDotSuffix() {
+        let result = GitNameValidator.validateBranchName("foo/bar.")
+        #expect(result == .invalid("Name cannot end with '.'."))
     }
 
     @Test func rejectsDotDotComponent() {

--- a/AlasTests/GitNameValidatorTests.swift
+++ b/AlasTests/GitNameValidatorTests.swift
@@ -144,4 +144,45 @@ struct GitNameValidatorTests {
         let result = GitNameValidator.validateWorktreeName("feature/foo")
         #expect(result == .valid)
     }
+
+    // MARK: - Branch prefix validation
+    @Test func acceptsFeatureSlashPrefix() {
+        let result = GitNameValidator.validateBranchPrefix("feature/")
+        #expect(result == .valid)
+    }
+
+    @Test func acceptsPrefixWithoutSlash() {
+        let result = GitNameValidator.validateBranchPrefix("feature")
+        #expect(result == .valid)
+    }
+
+    @Test func acceptsEmptyPrefix() {
+        let result = GitNameValidator.validateBranchPrefix("")
+        #expect(result == .valid)
+    }
+
+    @Test func acceptsNestedPrefixWithTrailingSlash() {
+        let result = GitNameValidator.validateBranchPrefix("release/v1/")
+        #expect(result == .valid)
+    }
+
+    @Test func rejectsSlashOnlyPrefix() {
+        let result = GitNameValidator.validateBranchPrefix("/")
+        #expect(result == .invalid("Prefix cannot be '/' only."))
+    }
+
+    @Test func rejectsDoubleTrailingSlash() {
+        let result = GitNameValidator.validateBranchPrefix("feature//")
+        #expect(result == .invalid("Prefix cannot contain consecutive '/'."))
+    }
+
+    @Test func rejectsPrefixWithSpaces() {
+        let result = GitNameValidator.validateBranchPrefix("bad name/")
+        #expect(result == .invalid("Name cannot contain spaces."))
+    }
+
+    @Test func rejectsPrefixWithTraversal() {
+        let result = GitNameValidator.validateBranchPrefix("../")
+        #expect(result == .invalid("Name cannot contain '.' or '..' as a path component."))
+    }
 }

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -102,6 +102,10 @@ struct NewWorktreeDialogTests {
         #expect(!NewWorktreeDialog.canCreate(projectsEmpty: false, branchEmpty: true))
     }
 
+    @Test func canCreateBlockedByInvalidBranch() {
+        #expect(!NewWorktreeDialog.canCreate(projectsEmpty: false, branchEmpty: false, branchValidation: "Name cannot contain spaces."))
+    }
+
     @Test func canCreateSucceedsWithProjectsAndBranch() {
         #expect(NewWorktreeDialog.canCreate(projectsEmpty: false, branchEmpty: false))
     }


### PR DESCRIPTION
## Summary

- Add `GitNameValidator` with `validateBranchName(_:)` implementing git ref-check rules (rejects spaces, control chars, leading/trailing slashes, consecutive slashes, `@{`, `.`/`..` traversal, `.lock` suffix, length > 250, forbidden chars `~ ^ : \\ ? * [ { }`, standalone `@`)
- Integrate validation into `NewWorktreeDialog` (inline errors, disabled Create button, Enter-key bypass fixed), `WorktreeService.add(...)` (defensive pre-check), and `WorktreesPane` (branch prefix inline feedback)
- Add 29 tests covering accepted/rejected names including edge cases (`@` alone, boundary lengths)

## Test plan

- Run `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
- Verify invalid branch/worktree names are blocked before git commands execute
- Verify valid path-style names like `feature/foo` still work
- Verify `feature/` prefix is accepted in settings