### PR TITLE
Add Python and shell script LSP support

### DIFF
--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -100,6 +100,7 @@ struct LanguageServerAvailability {
             "/opt/homebrew/bin",
             "\(NSHomeDirectory())/.cargo/bin",
             "\(NSHomeDirectory())/.local/bin",
+            "\(NSHomeDirectory())/.npm-global/bin",
             "\(NSHomeDirectory())/.bun/bin",
             "\(NSHomeDirectory())/.volta/bin"
         ]

--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -127,6 +127,24 @@ struct LanguageServerRegistry {
             env: [:],
             rootMarkers: ["package.json", ".git"],
             enabled: true
+        ),
+        LanguageServerConfig(
+            language: "python",
+            extensions: ["py", "pyi"],
+            command: "pyright-langserver",
+            args: ["--stdio"],
+            env: [:],
+            rootMarkers: ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", ".git"],
+            enabled: true
+        ),
+        LanguageServerConfig(
+            language: "shellscript",
+            extensions: ["sh", "bash", "zsh"],
+            command: "bash-language-server",
+            args: ["start"],
+            env: [:],
+            rootMarkers: [".git"],
+            enabled: true
         )
     ]
 

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -52,11 +52,26 @@ struct LanguageServerAvailabilityTests {
         let availability = LanguageServerAvailability(
             environment: ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"],
             xcrunFind: { _ in nil },
-            additionalPathDirectories: [dir.path]
+            additionalPathDirectories: ["\(NSHomeDirectory())/.npm-global/bin", dir.path]
         )
 
         #expect(availability.status(for: entry) == .available)
         #expect(availability.resolvedCommand(for: entry) == executable.path)
+    }
+
+    @Test("gui PATH includes npm-global directory")
+    func launchEnvironmentIncludesNpmGlobal() {
+        let entry = config(command: "custom-lsp")
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": "/usr/bin:/bin"],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: ["\(NSHomeDirectory())/.npm-global/bin", "/opt/homebrew/bin"]
+        )
+
+        let env = availability.launchEnvironment(for: entry)
+        let path = env["PATH"] ?? ""
+        #expect(path.contains("/.npm-global/bin"))
+        #expect(path.contains("/opt/homebrew/bin"))
     }
 
     @Test("Swift sourcekit-lsp falls back to xcrun")

--- a/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerRegistryTests.swift
@@ -51,6 +51,31 @@ struct LanguageServerRegistryTests {
         #expect(r.language(forFileExtension: "jsx") == "javascriptreact")
         #expect(r.language(forFileExtension: "json") == "json")
         #expect(r.language(forFileExtension: "jsonc") == "jsonc")
+        #expect(r.language(forFileExtension: "py") == "python")
+        #expect(r.language(forFileExtension: "pyi") == "python")
+        #expect(r.language(forFileExtension: "sh") == "shellscript")
+        #expect(r.language(forFileExtension: "bash") == "shellscript")
+        #expect(r.language(forFileExtension: "zsh") == "shellscript")
         #expect(r.language(forFileExtension: "xyz") == nil)
+    }
+
+    @Test("built-in Python entry exists")
+    func python() {
+        let r = LanguageServerRegistry(userDefined: [])
+        let entry = r.entry(forLanguage: "python")
+        #expect(entry != nil)
+        #expect(entry?.command == "pyright-langserver")
+        #expect(entry?.args == ["--stdio"])
+        #expect(entry?.extensions == ["py", "pyi"])
+    }
+
+    @Test("built-in Shell entry exists")
+    func shellscript() {
+        let r = LanguageServerRegistry(userDefined: [])
+        let entry = r.entry(forLanguage: "shellscript")
+        #expect(entry != nil)
+        #expect(entry?.command == "bash-language-server")
+        #expect(entry?.args == ["start"])
+        #expect(entry?.extensions == ["sh", "bash", "zsh"])
     }
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ Open the project in Xcode for normal development; rerun `xcodegen` after any cha
 
 Swift 5.9+ / SwiftUI on macOS 14+. Terminal embedded via the official Ghostty Swift package. Tree-sitter for syntax. Swift-markdown for rendering. Single Xcode app target generated from `project.yml` via [xcodegen](https://github.com/yonaskolb/XcodeGen).
 
+## Language Server Prerequisites
+
+Alas bundles built-in language server presets, but the actual servers must be installed separately. The app discovers them via `PATH`, `/usr/local/bin`, `/opt/homebrew/bin`, and common tool directories.
+
+- **Swift** – bundled with Xcode (`sourcekit-lsp`)
+- **Python** – [Pyright](https://github.com/microsoft/pyright)
+  ```bash
+  brew install pyright
+  # or: npm install -g pyright
+  ```
+- **Shell scripts** – [bash-language-server](https://github.com/bash-lsp/bash-language-server)
+  ```bash
+  npm install -g bash-language-server
+  ```
+  Also install [ShellCheck](https://github.com/koalaman/shellcheck) for diagnostics:
+  ```bash
+  brew install shellcheck
+  ```
+- **Rust** – `rust-analyzer`
+- **TypeScript / JavaScript / JSON** – `typescript-language-server`, `vscode-json-languageserver`
+- **Markdown** – `marksman`
+
+If a server is missing, Alas opens the file as a plain text buffer and shows **Not installed** in Settings → Code. You can also override commands and environment variables per language in the same settings pane.
+
 ## License
 
 [MIT](LICENSE).


### PR DESCRIPTION
## Summary

- Add built-in LSP presets for **Python** (Pyright: `pyright-langserver --stdio`) and **shell scripts** (bash-language-server: `bash-language-server start`)
- Extension mappings: `.py`/`.pyi` → `python`, `.sh`/`.bash`/`.zsh` → `shellscript`
- Add `~/.npm-global/bin` to default PATH discovery for GUI-launched app binary discovery
- Document required local binaries in README (`brew install pyright`, `npm i -g bash-language-server`, `brew install shellcheck`)
- Missing binaries degrade gracefully — files open as plain text, Settings shows `Not installed` badge

## Test plan

- [x] Extension lookup tests for `.py`, `.pyi`, `.sh`, `.bash`, `.zsh`
- [x] Dedicated `python()` and `shellscript()` test cases verifying command, args, extensions
- [x] npm-global PATH augmentation test
- [x] 744 tests run, 743 passed (1 pre-existing flaky failure unrelated to this change)
- [x] Build succeeds with no regressions