### PR TITLE
feat(editor): smart indentation in editor panes

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */; };
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
+		709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D105CB2C185958ED23164D1 /* IndentationMode.swift */; };
 		70FCC2B12AE446728EE7CF8D /* LSPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38499AFE31188908546EE222 /* LSPTransport.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
 		74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 77EF95AD63DDA8DB0504087B /* TreeSitterSwift */; };
@@ -214,6 +215,7 @@
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
+		9D6FE5A4589D73A7480CE2B2 /* IndentationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */; };
 		9E302329243407946D47DC91 /* BranchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */; };
 		9E4B32E154B18BD2285F0D34 /* CommitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */; };
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
@@ -275,9 +277,11 @@
 		CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */; };
 		CB6D9F5929D97FAB3A264F47 /* AppConfigAgentsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */; };
 		CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */; };
+		CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */; };
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
 		CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */; };
 		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
+		CF12433D8F30CEA05088FFB0 /* CodeTextViewIndentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */; };
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
@@ -423,6 +427,7 @@
 		345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistryTests.swift; sourceTree = "<group>"; };
 		3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputRow.swift; sourceTree = "<group>"; };
 		35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
+		35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelper.swift; sourceTree = "<group>"; };
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
 		36992F601C8EB6C3D45B584F /* SearchKbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKbd.swift; sourceTree = "<group>"; };
 		36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKind.swift; sourceTree = "<group>"; };
@@ -440,6 +445,7 @@
 		3BF2F213480B30034B25B2B8 /* AgentRunError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunError.swift; sourceTree = "<group>"; };
 		3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfo.swift; sourceTree = "<group>"; };
 		3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPicker.swift; sourceTree = "<group>"; };
+		3D105CB2C185958ED23164D1 /* IndentationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationMode.swift; sourceTree = "<group>"; };
 		3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
 		3DCEFADD952DB870B8BAB890 /* CommitRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRow.swift; sourceTree = "<group>"; };
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
@@ -589,6 +595,7 @@
 		BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletingWorktreeView.swift; sourceTree = "<group>"; };
 		BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcher.swift; sourceTree = "<group>"; };
 		BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManager.swift; sourceTree = "<group>"; };
+		BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelperTests.swift; sourceTree = "<group>"; };
 		BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstallerTests.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
@@ -657,6 +664,7 @@
 		EB52B59655B85764D85CFB7F /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
 		EBBBF87CC508451B2C0F3A66 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
+		ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewIndentationTests.swift; sourceTree = "<group>"; };
 		EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParserTests.swift; sourceTree = "<group>"; };
 		EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
 		EECB91379591DA21D216A894 /* RelativeTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTime.swift; sourceTree = "<group>"; };
@@ -742,6 +750,7 @@
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
 				7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */,
+				ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */,
 				2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */,
 				9DCC5576ACD7C49EB6915992 /* CommitComposerStateTests.swift */,
 				79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */,
@@ -782,6 +791,7 @@
 				2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */,
 				23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */,
 				A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */,
+				BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */,
 				835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */,
 				EB52B59655B85764D85CFB7F /* LineEndingTests.swift */,
 				19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */,
@@ -1234,6 +1244,8 @@
 				D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */,
 				BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
+				35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */,
+				3D105CB2C185958ED23164D1 /* IndentationMode.swift */,
 				FC4A215AF2876091E31F6F8A /* LineEnding.swift */,
 			);
 			path = Editor;
@@ -1658,6 +1670,8 @@
 				CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */,
 				B76AD708A9FD54304F84366A /* ImageFileType.swift in Sources */,
 				1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */,
+				9D6FE5A4589D73A7480CE2B2 /* IndentationHelper.swift in Sources */,
+				709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */,
 				BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */,
 				255E9EAE89D521E08EB90918 /* JSONHookSettingsFile.swift in Sources */,
 				E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */,
@@ -1781,6 +1795,7 @@
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,
 				1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */,
+				CF12433D8F30CEA05088FFB0 /* CodeTextViewIndentationTests.swift in Sources */,
 				6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */,
 				C02EB84F4343BD78984791EB /* CommitComposerStateTests.swift in Sources */,
 				21D97FBF7356BC50400E0265 /* CommitContextBuilderTests.swift in Sources */,
@@ -1824,6 +1839,7 @@
 				D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */,
 				D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */,
 				89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */,
+				CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */,
 				524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */,
 				79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */,
 				C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */,

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -364,6 +364,7 @@ final class CodeEditorCoordinator {
         self.currentRelativePath = buffer.relativePath
         let ext = (buffer.relativePath as NSString).pathExtension
         currentLanguage = appState.lsp.language(forFileExtension: ext)
+        applyIndentationMode()
         if let layoutManager {
             buffer.storage.addLayoutManager(layoutManager)
         }
@@ -466,6 +467,14 @@ final class CodeEditorCoordinator {
     }
 
     // MARK: - Highlight + base styling
+
+    private func applyIndentationMode() {
+        if let language = currentLanguage, !language.isEmpty {
+            textView?.indentationMode = .bracketAware
+        } else {
+            textView?.indentationMode = .plain
+        }
+    }
 
     private func applyBaseStyle(theme: Theme) {
         guard let buffer, let textView else { return }

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -21,6 +21,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     var commandClickHandler: ((NSPoint) -> Void)?
     var flagsChangedHandler: ((NSEvent) -> Void)?
     var mouseExitedHandler: (() -> Void)?
+    var indentationMode: IndentationMode = .plain
 
     /// Set by `CodeEditorCoordinator.attach`. Each closure mutates the shared
     /// `code.fontSize` config in response to the matching menu command.
@@ -68,6 +69,15 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             return
         }
 
+        // NEW: Closing delimiter dedent for whitespace-only lines
+        if Self.closingDelimiters.contains(character),
+           indentationMode == .bracketAware,
+           let edit = IndentationHelper.closingDelimiterEdit(in: string, selectedRange: range, delimiter: character, mode: indentationMode) {
+            super.insertText(edit.replacement, replacementRange: edit.replacementRange)
+            setSelectedRange(NSRange(location: edit.replacementRange.location + edit.selectedLocationDelta, length: 0))
+            return
+        }
+
         if let closing = Self.pairedDelimiters[character] {
             if shouldInsertPair(opening: character, closing: closing, range: range) {
                 insertPairedDelimiter(opening: character, closing: closing, replacementRange: range)
@@ -85,6 +95,24 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         }
 
         super.insertText(insertString, replacementRange: replacementRange)
+    }
+
+    override func insertNewline(_ sender: Any?) {
+        guard isEditable else {
+            super.insertNewline(sender)
+            return
+        }
+        let range = selectedRange()
+        if range.length > 0 {
+            super.insertNewline(sender)
+            return
+        }
+        if let edit = IndentationHelper.newlineEdit(in: string, selectedRange: range, mode: indentationMode) {
+            super.insertText(edit.replacement, replacementRange: range)
+            setSelectedRange(NSRange(location: range.location + edit.selectedLocationDelta, length: 0))
+        } else {
+            super.insertNewline(sender)
+        }
     }
 
     override func mouseMoved(with event: NSEvent) {

--- a/Alas/Sources/Code/Editor/IndentationHelper.swift
+++ b/Alas/Sources/Code/Editor/IndentationHelper.swift
@@ -2,7 +2,6 @@ import Foundation
 
 /// Pure helper for indentation decisions. Does not import AppKit.
 struct IndentationHelper {
-
     struct NewlineEdit: Equatable {
         let replacement: String
         let selectedLocationDelta: Int

--- a/Alas/Sources/Code/Editor/IndentationHelper.swift
+++ b/Alas/Sources/Code/Editor/IndentationHelper.swift
@@ -39,18 +39,21 @@ struct IndentationHelper {
         let leadingWhitespace = leadingWhitespace(of: linePrefix)
         let indentUnit = indentUnit(in: text)
 
-        let beforeCursor = String(linePrefix)
         let afterCursor = ns.substring(with: NSRange(location: cursor, length: NSMaxRange(currentLineRange) - cursor))
+
+        let trimmedBefore = linePrefix.reversed().drop(while: { $0 == " " || $0 == "\t" }).reversed()
+        let lastSignificant = trimmedBefore.last
 
         let endsWithOpener: Bool
         let isBetweenPair: Bool
 
         if mode == .bracketAware {
-            endsWithOpener = beforeCursor.last.map { Self.pairedDelimiters.keys.contains($0) } ?? false
+            endsWithOpener = lastSignificant.map { Self.pairedDelimiters.keys.contains($0) } ?? false
             isBetweenPair = {
-                guard let lastChar = beforeCursor.last,
+                guard let lastChar = lastSignificant,
                       let expectedCloser = Self.pairedDelimiters[lastChar] else { return false }
-                return afterCursor.first == expectedCloser
+                let trimmedAfter = afterCursor.drop(while: { $0 == " " || $0 == "\t" })
+                return trimmedAfter.first == expectedCloser
             }()
         } else {
             endsWithOpener = false

--- a/Alas/Sources/Code/Editor/IndentationHelper.swift
+++ b/Alas/Sources/Code/Editor/IndentationHelper.swift
@@ -99,14 +99,15 @@ struct IndentationHelper {
 
         let nextIsSameDelimiter = cursor < ns.length && Character(ns.substring(with: NSRange(location: cursor, length: 1))) == delimiter
 
+        if nextIsSameDelimiter { return nil }
+
         let indentUnit = indentUnit(in: text)
         let currentIndent = linePrefix
         let dedented = dedent(currentIndent, by: indentUnit)
 
         guard dedented.count < currentIndent.count else { return nil }
 
-        let consumeExtra = nextIsSameDelimiter ? 1 : 0
-        let replacementRange = NSRange(location: lineStart, length: currentIndent.count + consumeExtra)
+        let replacementRange = NSRange(location: lineStart, length: currentIndent.count)
         let replacement = dedented + String(delimiter)
         let selectedLocationDelta = dedented.count + 1
 

--- a/Alas/Sources/Code/Editor/IndentationHelper.swift
+++ b/Alas/Sources/Code/Editor/IndentationHelper.swift
@@ -167,10 +167,8 @@ struct IndentationHelper {
         // Snap to common indent widths
         if minSpace <= 2 {
             return String(repeating: " ", count: minSpace)
-        } else if minSpace <= 4 {
-            return "    "
         } else {
-            return String(repeating: " ", count: minSpace)
+            return "    "
         }
     }
 }

--- a/Alas/Sources/Code/Editor/IndentationHelper.swift
+++ b/Alas/Sources/Code/Editor/IndentationHelper.swift
@@ -94,13 +94,16 @@ struct IndentationHelper {
 
         guard isWhitespaceOnly(linePrefix) else { return nil }
 
+        let nextIsSameDelimiter = cursor < ns.length && Character(ns.substring(with: NSRange(location: cursor, length: 1))) == delimiter
+
         let indentUnit = indentUnit(in: text)
         let currentIndent = linePrefix
         let dedented = dedent(currentIndent, by: indentUnit)
 
         guard dedented.count < currentIndent.count else { return nil }
 
-        let replacementRange = NSRange(location: lineStart, length: currentIndent.count)
+        let consumeExtra = nextIsSameDelimiter ? 1 : 0
+        let replacementRange = NSRange(location: lineStart, length: currentIndent.count + consumeExtra)
         let replacement = dedented + String(delimiter)
         let selectedLocationDelta = dedented.count + 1
 

--- a/Alas/Sources/Code/Editor/IndentationHelper.swift
+++ b/Alas/Sources/Code/Editor/IndentationHelper.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// Pure helper for indentation decisions. Does not import AppKit.
+struct IndentationHelper {
+
+    struct NewlineEdit: Equatable {
+        let replacement: String
+        let selectedLocationDelta: Int
+    }
+
+    struct ClosingDelimiterEdit: Equatable {
+        let replacementRange: NSRange
+        let replacement: String
+        let selectedLocationDelta: Int
+    }
+
+    static let pairedDelimiters: [Character: Character] = [
+        "(": ")",
+        "[": "]",
+        "{": "}"
+    ]
+
+    static let closingDelimiters: Set<Character> = [")", "]", "}"]
+
+    // MARK: - Newline
+
+    static func newlineEdit(
+        in text: String,
+        selectedRange: NSRange,
+        mode: IndentationMode
+    ) -> NewlineEdit? {
+        guard selectedRange.length == 0 else { return nil }
+
+        let ns = text as NSString
+        let cursor = selectedRange.location
+        guard cursor >= 0, cursor <= ns.length else { return nil }
+
+        let currentLineRange = ns.lineRange(for: NSRange(location: cursor, length: 0))
+        let linePrefix = ns.substring(with: NSRange(location: currentLineRange.location, length: cursor - currentLineRange.location))
+        let leadingWhitespace = leadingWhitespace(of: linePrefix)
+        let indentUnit = indentUnit(in: text)
+
+        let beforeCursor = String(linePrefix)
+        let afterCursor = ns.substring(with: NSRange(location: cursor, length: NSMaxRange(currentLineRange) - cursor))
+
+        let endsWithOpener: Bool
+        let isBetweenPair: Bool
+
+        if mode == .bracketAware {
+            endsWithOpener = beforeCursor.last.map { Self.pairedDelimiters.keys.contains($0) } ?? false
+            isBetweenPair = {
+                guard let lastChar = beforeCursor.last,
+                      let expectedCloser = Self.pairedDelimiters[lastChar] else { return false }
+                return afterCursor.first == expectedCloser
+            }()
+        } else {
+            endsWithOpener = false
+            isBetweenPair = false
+        }
+
+        if mode == .bracketAware, isBetweenPair {
+            let innerIndent = leadingWhitespace + indentUnit
+            let replacement = "\n" + innerIndent + "\n" + leadingWhitespace
+            let middleLineStart = cursor + 1 + innerIndent.count
+            return NewlineEdit(replacement: replacement, selectedLocationDelta: middleLineStart - cursor)
+        } else if mode == .bracketAware, endsWithOpener {
+            let newIndent = leadingWhitespace + indentUnit
+            let replacement = "\n" + newIndent
+            return NewlineEdit(replacement: replacement, selectedLocationDelta: replacement.count)
+        } else {
+            let replacement = "\n" + leadingWhitespace
+            return NewlineEdit(replacement: replacement, selectedLocationDelta: replacement.count)
+        }
+    }
+
+    // MARK: - Closing delimiter
+
+    static func closingDelimiterEdit(
+        in text: String,
+        selectedRange: NSRange,
+        delimiter: Character,
+        mode: IndentationMode
+    ) -> ClosingDelimiterEdit? {
+        guard mode == .bracketAware,
+              Self.closingDelimiters.contains(delimiter),
+              selectedRange.length == 0 else { return nil }
+
+        let ns = text as NSString
+        let cursor = selectedRange.location
+        guard cursor >= 0, cursor <= ns.length else { return nil }
+
+        let currentLineRange = ns.lineRange(for: NSRange(location: cursor, length: 0))
+        let lineStart = currentLineRange.location
+        let linePrefix = ns.substring(with: NSRange(location: lineStart, length: cursor - lineStart))
+
+        guard isWhitespaceOnly(linePrefix) else { return nil }
+
+        let indentUnit = indentUnit(in: text)
+        let currentIndent = linePrefix
+        let dedented = dedent(currentIndent, by: indentUnit)
+
+        guard dedented.count < currentIndent.count else { return nil }
+
+        let replacementRange = NSRange(location: lineStart, length: currentIndent.count)
+        let replacement = dedented + String(delimiter)
+        let selectedLocationDelta = dedented.count + 1
+
+        return ClosingDelimiterEdit(
+            replacementRange: replacementRange,
+            replacement: replacement,
+            selectedLocationDelta: selectedLocationDelta
+        )
+    }
+
+    // MARK: - Utilities
+
+    static func leadingWhitespace(of string: String) -> String {
+        var result = ""
+        for char in string {
+            if char == " " || char == "\t" {
+                result.append(char)
+            } else {
+                break
+            }
+        }
+        return result
+    }
+
+    static func isWhitespaceOnly(_ string: String) -> Bool {
+        string.allSatisfy { $0 == " " || $0 == "\t" }
+    }
+
+    static func dedent(_ indent: String, by unit: String) -> String {
+        if indent.hasPrefix(unit) {
+            return String(indent.dropFirst(unit.count))
+        }
+        return indent
+    }
+
+    static func indentUnit(in text: String) -> String {
+        let ns = text as NSString
+        var hasTab = false
+        var spaceRuns: [Int] = []
+
+        ns.enumerateLines { line, _ in
+            let ws = leadingWhitespace(of: line)
+            if ws.contains("\t") {
+                hasTab = true
+            }
+            if !ws.isEmpty {
+                let spaces = ws.count - ws.reduce(0) { $0 + ($1 == "\t" ? 1 : 0) }
+                if spaces > 0 {
+                    spaceRuns.append(spaces)
+                }
+            }
+        }
+
+        if hasTab {
+            return "\t"
+        }
+
+        if spaceRuns.isEmpty {
+            return "    "
+        }
+
+        let minSpace = spaceRuns.min() ?? 4
+        // Snap to common indent widths
+        if minSpace <= 2 {
+            return String(repeating: " ", count: minSpace)
+        } else if minSpace <= 4 {
+            return "    "
+        } else {
+            return String(repeating: " ", count: minSpace)
+        }
+    }
+}

--- a/Alas/Sources/Code/Editor/IndentationMode.swift
+++ b/Alas/Sources/Code/Editor/IndentationMode.swift
@@ -1,0 +1,4 @@
+enum IndentationMode: Equatable {
+    case plain
+    case bracketAware
+}

--- a/AlasTests/CodeTextViewIndentationTests.swift
+++ b/AlasTests/CodeTextViewIndentationTests.swift
@@ -1,0 +1,89 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct CodeTextViewIndentationTests {
+    private func makeTextView(_ text: String = "", mode: IndentationMode = .bracketAware) -> CodeTextView {
+        let storage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        textView.indentationMode = mode
+        return textView
+    }
+
+    @Test func newlinePreservesIndent() {
+        let textView = makeTextView("    line")
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+        textView.insertNewline(nil)
+        #expect(textView.string == "    line\n    ")
+        #expect(textView.selectedRange() == NSRange(location: 13, length: 0))
+    }
+
+    @Test func newlineIncreasesIndentAfterOpener() {
+        let textView = makeTextView("    {")
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        textView.insertNewline(nil)
+        #expect(textView.string == "    {\n        ")
+        #expect(textView.selectedRange() == NSRange(location: 14, length: 0))
+    }
+
+    @Test func newlineExpandsPair() {
+        let textView = makeTextView("    {}")
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        textView.insertNewline(nil)
+        #expect(textView.string == "    {\n        \n    }")
+        #expect(textView.selectedRange() == NSRange(location: 14, length: 0))
+    }
+
+    @Test func closingDelimiterDedent() {
+        let textView = makeTextView("        ")
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+        textView.insertText("}", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(textView.string == "    }")
+        #expect(textView.selectedRange() == NSRange(location: 5, length: 0))
+    }
+
+    @Test func closingDelimiterStepOverStillWorks() {
+        let textView = makeTextView("()")
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+        textView.insertText(")", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(textView.string == "()")
+        #expect(textView.selectedRange() == NSRange(location: 2, length: 0))
+    }
+
+    @Test func closingDelimiterNoDedentWhenLineHasContent() {
+        let textView = makeTextView("    foo")
+        textView.setSelectedRange(NSRange(location: 7, length: 0))
+        textView.insertText("}", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(textView.string == "    foo}")
+        #expect(textView.selectedRange() == NSRange(location: 8, length: 0))
+    }
+
+    @Test func autoPairStillWorksWithIndentation() {
+        let textView = makeTextView()
+        textView.insertText("{", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(textView.string == "{}")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
+    @Test func plainModeNoBracketIndent() {
+        let textView = makeTextView("    {", mode: .plain)
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        textView.insertNewline(nil)
+        #expect(textView.string == "    {\n    ")
+        #expect(textView.selectedRange() == NSRange(location: 10, length: 0))
+    }
+
+    @Test func newlineWithSelectionFallsBackToNormal() {
+        let textView = makeTextView("hello world")
+        textView.setSelectedRange(NSRange(location: 5, length: 6))
+        textView.insertNewline(nil)
+        #expect(textView.string == "hello\n")
+    }
+}

--- a/AlasTests/CodeTextViewIndentationTests.swift
+++ b/AlasTests/CodeTextViewIndentationTests.swift
@@ -53,8 +53,8 @@ struct CodeTextViewIndentationTests {
         let textView = makeTextView("    }")
         textView.setSelectedRange(NSRange(location: 4, length: 0))
         textView.insertText("}", replacementRange: NSRange(location: NSNotFound, length: 0))
-        #expect(textView.string == "}")
-        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+        #expect(textView.string == "    }")
+        #expect(textView.selectedRange() == NSRange(location: 5, length: 0))
     }
 
     @Test func closingDelimiterDedentWithExistingCloserOnNextLine() {

--- a/AlasTests/CodeTextViewIndentationTests.swift
+++ b/AlasTests/CodeTextViewIndentationTests.swift
@@ -49,6 +49,22 @@ struct CodeTextViewIndentationTests {
         #expect(textView.selectedRange() == NSRange(location: 5, length: 0))
     }
 
+    @Test func closingDelimiterDedentOnWhitespaceBeforeExistingCloser() {
+        let textView = makeTextView("    }")
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+        textView.insertText("}", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(textView.string == "}")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
+    @Test func closingDelimiterDedentWithExistingCloserOnNextLine() {
+        let textView = makeTextView("    {\n        \n    }")
+        textView.setSelectedRange(NSRange(location: 14, length: 0))
+        textView.insertText("}", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(textView.string == "    {\n    }\n    }")
+        #expect(textView.selectedRange() == NSRange(location: 11, length: 0))
+    }
+
     @Test func closingDelimiterStepOverStillWorks() {
         let textView = makeTextView("()")
         textView.setSelectedRange(NSRange(location: 1, length: 0))

--- a/AlasTests/IndentationHelperTests.swift
+++ b/AlasTests/IndentationHelperTests.swift
@@ -3,7 +3,6 @@ import Testing
 @testable import Alas
 
 struct IndentationHelperTests {
-
     // MARK: - Newline plain mode
 
     @Test func plainNewlinePreservesIndent() {

--- a/AlasTests/IndentationHelperTests.swift
+++ b/AlasTests/IndentationHelperTests.swift
@@ -237,6 +237,42 @@ struct IndentationHelperTests {
         #expect(edit == nil)
     }
 
+    @Test func closingDelimiterStepOverConsumesExistingCloser() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "        }",
+            selectedRange: NSRange(location: 8, length: 0),
+            delimiter: "}",
+            mode: .bracketAware
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacementRange == NSRange(location: 0, length: 9))
+        #expect(edit?.replacement == "    }")
+        #expect(edit?.selectedLocationDelta == 5)
+    }
+
+    @Test func closingDelimiterStepOverParenthesis() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "        )",
+            selectedRange: NSRange(location: 8, length: 0),
+            delimiter: ")",
+            mode: .bracketAware
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacement == "    )")
+    }
+
+    @Test func closingDelimiterSameCharNoStepOverIfDifferentChar() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "        x",
+            selectedRange: NSRange(location: 8, length: 0),
+            delimiter: "}",
+            mode: .bracketAware
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacementRange == NSRange(location: 0, length: 8))
+        #expect(edit?.replacement == "    }")
+    }
+
     // MARK: - Indent unit detection
 
     @Test func indentUnitDetectsTab() {

--- a/AlasTests/IndentationHelperTests.swift
+++ b/AlasTests/IndentationHelperTests.swift
@@ -78,6 +78,26 @@ struct IndentationHelperTests {
         #expect(edit?.selectedLocationDelta == 5)
     }
 
+    @Test func bracketAwareNewlineAfterOpenerWithTrailingSpaces() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    {   ",
+            selectedRange: NSRange(location: 8, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacement == "\n        ")
+    }
+
+    @Test func bracketAwareExpandsPairWithTrailingSpaces() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    {   }",
+            selectedRange: NSRange(location: 8, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacement == "\n        \n    ")
+    }
+
     @Test func bracketAwareNewlineAfterOpener() {
         let edit = IndentationHelper.newlineEdit(
             in: "    {",

--- a/AlasTests/IndentationHelperTests.swift
+++ b/AlasTests/IndentationHelperTests.swift
@@ -257,17 +257,14 @@ struct IndentationHelperTests {
         #expect(edit == nil)
     }
 
-    @Test func closingDelimiterStepOverConsumesExistingCloser() {
+    @Test func closingDelimiterStepOverWhenExistingCloser() {
         let edit = IndentationHelper.closingDelimiterEdit(
             in: "        }",
             selectedRange: NSRange(location: 8, length: 0),
             delimiter: "}",
             mode: .bracketAware
         )
-        #expect(edit != nil)
-        #expect(edit?.replacementRange == NSRange(location: 0, length: 9))
-        #expect(edit?.replacement == "    }")
-        #expect(edit?.selectedLocationDelta == 5)
+        #expect(edit == nil)
     }
 
     @Test func closingDelimiterStepOverParenthesis() {
@@ -277,8 +274,7 @@ struct IndentationHelperTests {
             delimiter: ")",
             mode: .bracketAware
         )
-        #expect(edit != nil)
-        #expect(edit?.replacement == "    )")
+        #expect(edit == nil)
     }
 
     @Test func closingDelimiterSameCharNoStepOverIfDifferentChar() {

--- a/AlasTests/IndentationHelperTests.swift
+++ b/AlasTests/IndentationHelperTests.swift
@@ -1,0 +1,262 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct IndentationHelperTests {
+
+    // MARK: - Newline plain mode
+
+    @Test func plainNewlinePreservesIndent() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    line",
+            selectedRange: NSRange(location: 8, length: 0),
+            mode: .plain
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacement == "\n    ")
+        #expect(edit?.selectedLocationDelta == 5)
+    }
+
+    @Test func plainNewlineNoIndentOnEmptyLine() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "",
+            selectedRange: NSRange(location: 0, length: 0),
+            mode: .plain
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacement == "\n")
+        #expect(edit?.selectedLocationDelta == 1)
+    }
+
+    @Test func plainNewlinePreservesTabs() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "\tline",
+            selectedRange: NSRange(location: 5, length: 0),
+            mode: .plain
+        )
+        #expect(edit?.replacement == "\n\t")
+        #expect(edit?.selectedLocationDelta == 2)
+    }
+
+    @Test func plainNewlineDoesNotExpandPair() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    {}",
+            selectedRange: NSRange(location: 5, length: 0),
+            mode: .plain
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacement == "\n    ")
+    }
+
+    @Test func plainNewlineDoesNotIndentAfterOpener() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    {",
+            selectedRange: NSRange(location: 5, length: 0),
+            mode: .plain
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacement == "\n    ")
+    }
+
+    @Test func plainNewlineWithSelectionReturnsNil() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "hello world",
+            selectedRange: NSRange(location: 5, length: 6),
+            mode: .plain
+        )
+        #expect(edit == nil)
+    }
+
+    // MARK: - Newline bracket-aware mode
+
+    @Test func bracketAwareNewlinePreservesIndent() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    line",
+            selectedRange: NSRange(location: 8, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "\n    ")
+        #expect(edit?.selectedLocationDelta == 5)
+    }
+
+    @Test func bracketAwareNewlineAfterOpener() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    {",
+            selectedRange: NSRange(location: 5, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "\n        ")
+        #expect(edit?.selectedLocationDelta == 9)
+    }
+
+    @Test func bracketAwareNewlineAfterOpenerWithTab() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "\t{",
+            selectedRange: NSRange(location: 2, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "\n\t\t")
+        #expect(edit?.selectedLocationDelta == 3)
+    }
+
+    @Test func bracketAwareExpandsPair() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    {}",
+            selectedRange: NSRange(location: 5, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "\n        \n    ")
+        #expect(edit?.selectedLocationDelta == 9)
+    }
+
+    @Test func bracketAwareExpandsParenthesesPair() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    ()",
+            selectedRange: NSRange(location: 5, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "\n        \n    ")
+        #expect(edit?.selectedLocationDelta == 9)
+    }
+
+    @Test func bracketAwareExpandsBracketPair() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "    []",
+            selectedRange: NSRange(location: 5, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "\n        \n    ")
+        #expect(edit?.selectedLocationDelta == 9)
+    }
+
+    @Test func bracketAwareNewlineAfterOpenerNoIndentOnEmpty() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "{",
+            selectedRange: NSRange(location: 1, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "\n    ")
+        #expect(edit?.selectedLocationDelta == 5)
+    }
+
+    @Test func bracketAwareNewlineExpandsPairNoIndentOnEmpty() {
+        let edit = IndentationHelper.newlineEdit(
+            in: "{}",
+            selectedRange: NSRange(location: 1, length: 0),
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "\n    \n")
+        #expect(edit?.selectedLocationDelta == 5)
+    }
+
+    // MARK: - Closing delimiter
+
+    @Test func closingDelimiterDedentOnWhitespaceOnlyLine() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "        ",
+            selectedRange: NSRange(location: 8, length: 0),
+            delimiter: "}",
+            mode: .bracketAware
+        )
+        #expect(edit != nil)
+        #expect(edit?.replacementRange == NSRange(location: 0, length: 8))
+        #expect(edit?.replacement == "    }")
+        #expect(edit?.selectedLocationDelta == 5)
+    }
+
+    @Test func closingDelimiterDedentWithTab() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "\t\t",
+            selectedRange: NSRange(location: 2, length: 0),
+            delimiter: "}",
+            mode: .bracketAware
+        )
+        #expect(edit?.replacementRange == NSRange(location: 0, length: 2))
+        #expect(edit?.replacement == "\t}")
+        #expect(edit?.selectedLocationDelta == 2)
+    }
+
+    @Test func closingDelimiterNoDedentWhenLineHasContent() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "    foo",
+            selectedRange: NSRange(location: 7, length: 0),
+            delimiter: "}",
+            mode: .bracketAware
+        )
+        #expect(edit == nil)
+    }
+
+    @Test func closingDelimiterNoDedentInPlainMode() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "        ",
+            selectedRange: NSRange(location: 8, length: 0),
+            delimiter: "}",
+            mode: .plain
+        )
+        #expect(edit == nil)
+    }
+
+    @Test func closingDelimiterDedentParenthesis() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "        ",
+            selectedRange: NSRange(location: 8, length: 0),
+            delimiter: ")",
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "    )")
+        #expect(edit?.selectedLocationDelta == 5)
+    }
+
+    @Test func closingDelimiterDedentBracket() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "        ",
+            selectedRange: NSRange(location: 8, length: 0),
+            delimiter: "]",
+            mode: .bracketAware
+        )
+        #expect(edit?.replacement == "    ]")
+        #expect(edit?.selectedLocationDelta == 5)
+    }
+
+    @Test func closingDelimiterNoDedentIfAlreadyMinIndent() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "",
+            selectedRange: NSRange(location: 0, length: 0),
+            delimiter: "}",
+            mode: .bracketAware
+        )
+        #expect(edit == nil)
+    }
+
+    @Test func closingDelimiterNoDedentWithSelection() {
+        let edit = IndentationHelper.closingDelimiterEdit(
+            in: "        ",
+            selectedRange: NSRange(location: 2, length: 6),
+            delimiter: "}",
+            mode: .bracketAware
+        )
+        #expect(edit == nil)
+    }
+
+    // MARK: - Indent unit detection
+
+    @Test func indentUnitDetectsTab() {
+        let unit = IndentationHelper.indentUnit(in: "\tfoo\n\t\tbar")
+        #expect(unit == "\t")
+    }
+
+    @Test func indentUnitDefaultsToFourSpaces() {
+        let unit = IndentationHelper.indentUnit(in: "foo\nbar")
+        #expect(unit == "    ")
+    }
+
+    @Test func indentUnitDetectsTwoSpaces() {
+        let unit = IndentationHelper.indentUnit(in: "  a\n  b\n    c")
+        #expect(unit == "  ")
+    }
+
+    @Test func indentUnitDetectsFourSpaces() {
+        let unit = IndentationHelper.indentUnit(in: "    a\n    b\n        c")
+        #expect(unit == "    ")
+    }
+}

--- a/docs/research/840-smart-indentation-editor-panes.md
+++ b/docs/research/840-smart-indentation-editor-panes.md
@@ -1,0 +1,198 @@
+---
+task_id: 840
+title: "Smart indentation in editor panes"
+date: 2026-05-16
+project: alas
+phase: groomed
+prior_art:
+  - Alas/Sources/Code/Editor/CodeTextView.swift
+  - Alas/Sources/Code/Editor/EditorBuffer.swift
+  - Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+  - Alas/Sources/Code/Highlight/LanguageRegistry.swift
+  - Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+  - AlasTests/CodeTextViewAutoPairTests.swift
+---
+
+## TL;DR
+
+Well-scoped feature with a clear entry point. `CodeTextView` already overrides
+`insertText(_:replacementRange:)` for auto-pairing; smart indentation adds a
+parallel `insertNewline(_:)` override in the same class. No custom newline
+handling exists today — NSTextView's default just inserts `\n` with zero
+indentation awareness. The implementation is purely local to `CodeTextView`
+(with a small extracted helper for testability) and does not touch the buffer,
+coordinator, or LSP layers.
+
+## Scope confirmation
+
+### In scope (v1)
+
+1. **Preserve current indentation on newline** — copy leading whitespace from
+   the current line when Enter is pressed.
+2. **Increase indentation after block openers** — if the line ends with `{`,
+   `(`, `[`, `:` (for Python-style languages), or a trailing `{` before a
+   comment, add one extra indent level on the new line.
+3. **Dedent closing delimiters** — typing `}`, `)`, or `]` on a
+   whitespace-only line reduces indentation by one level to align with the
+   matching opener's line.
+4. **Newline between paired delimiters** — pressing Enter between `{}`, `()`,
+   or `[]` that were auto-paired produces a three-line expansion:
+   opener line / indented cursor / dedented closer.
+5. **Tab size detection** — detect whether the file uses tabs or spaces (and
+   how many) from the buffer content. Fall back to 4-space indent.
+
+### Out of scope (v1)
+
+- **Language-specific indent rules via tree-sitter AST** — tree-sitter is
+  available but only has a Swift grammar. Querying the AST for indent context
+  would be fragile and limited to one language. The heuristic approach
+  (trailing delimiter detection) works across all file types with acceptable
+  accuracy. Can revisit once more grammars are added.
+- **LSP `onTypeFormatting` / `onEnterFormatting`** — the LSP layer does not
+  currently implement formatting features. Wiring this up is a separate task.
+- **EditorConfig / per-project indent settings** — not yet modeled in alas.
+  A future settings feature would feed into the indent-width detection.
+- **Re-indenting pasted blocks** — paste indentation normalization is a
+  distinct feature.
+- **Smart indent in diff panes** — diff views are read-only.
+
+## Architectural alignment
+
+### Entry point: `CodeTextView` (`Alas/Sources/Code/Editor/CodeTextView.swift`)
+
+The class already:
+- Overrides `insertText(_:replacementRange:)` (line 54) for auto-pairing.
+- Maintains `pairedDelimiters` (line 9) and `closingDelimiters` (line 18) —
+  reusable for indent logic.
+- Has helper methods `previousCharacter(before:)` (line 170) and
+  `nextCharacter(at:)` (line 164).
+
+New code hooks into `override func insertNewline(_ sender: Any?)` — an
+NSTextView override that fires on Enter. This is the standard Cocoa extension
+point (used by Xcode, TextMate, etc.).
+
+For the dedent-on-close-delimiter case, the existing `insertText` override
+(line 54) gains a branch: when a closing delimiter is typed on a
+whitespace-only line, reduce the line's leading whitespace before inserting.
+
+### Extracted helper: `IndentationHelper`
+
+A small struct (new file `Alas/Sources/Code/Editor/IndentationHelper.swift`)
+with pure functions:
+
+- `leadingWhitespace(of line: String) -> String` — returns the whitespace
+  prefix.
+- `indentUnit(in text: String) -> String` — scans the buffer to detect
+  tab-vs-spaces and width. Falls back to 4 spaces.
+- `shouldIncreaseIndent(afterLine line: String) -> Bool` — checks for
+  trailing `{`, `(`, `[`, `:` (ignoring trailing comments/whitespace).
+- `shouldDecreaseIndent(forCharacter char: Character, currentLineText: String) -> Bool`
+  — returns true when a closing delimiter is typed on a whitespace-only line.
+- `expandBetweenPair(opener: Character, closer: Character, currentIndent: String, indentUnit: String, lineEnding: String) -> (text: String, cursorOffset: Int)`
+  — produces the three-line expansion for Enter between `{}` etc.
+
+All methods are pure `String → String` / `String → Bool`, making them trivially
+testable without NSTextView.
+
+### Test pattern
+
+`CodeTextViewAutoPairTests` (line 7) shows the exact pattern: create a
+`CodeTextView` with `NSTextStorage` + `NSLayoutManager` + `NSTextContainer`,
+call methods on it, assert `string` and `selectedRange()`. The same harness
+works for newline tests.
+
+Unit tests for `IndentationHelper` are even simpler — pure function calls.
+
+## Acceptance criteria
+
+1. Pressing Enter preserves the current line's leading whitespace on the new
+   line.
+2. Pressing Enter at the end of a line ending with `{` adds one indent level
+   beyond the current line's indentation.
+3. Same for `(`, `[`, and `:`.
+4. Pressing Enter between auto-paired `{}`, `()`, or `[]` produces a
+   three-line expansion with the cursor indented one level on the middle line
+   and the closer dedented on the third line.
+5. Typing `}`, `)`, or `]` on a whitespace-only line dedents that line by one
+   indent level.
+6. Indent unit is auto-detected from file content (tabs vs N-spaces). Falls
+   back to 4 spaces.
+7. Plain-text / unknown file types get behavior from criteria 1 only (preserve
+   indent). Block-opener heuristics still apply since they are
+   language-agnostic.
+8. Undo (⌘Z) after an auto-indented newline reverts the full insertion
+   (newline + whitespace) in one step.
+9. All existing `CodeTextViewAutoPairTests` continue to pass.
+10. `swift build` compiles with zero warnings; all tests pass.
+
+## Open questions
+
+1. **Should `:` trigger indent-increase?** It helps Python/YAML but is noisy
+   in Swift (case labels, dictionary literals). **Recommendation:** include `:`
+   only when it is the last non-whitespace character on the line (matches
+   Python `def foo():` and YAML keys). Swift `case .foo:` typically has more
+   content after the colon, so it won't false-trigger.
+
+2. **Should the feature be toggleable?** No settings infrastructure exists.
+   **Recommendation:** ship always-on for v1. If users complain, add a toggle
+   in a future settings task.
+
+3. **Indent width: detect per-file or use a global default?** **Recommendation:**
+   detect per-file from buffer content at load time. The detection is cheap
+   (scan first ~100 indented lines) and avoids needing a config system.
+
+## Implementation order
+
+1. **`IndentationHelper.swift`** — new file under
+   `Alas/Sources/Code/Editor/`. Implement `leadingWhitespace`,
+   `indentUnit`, `shouldIncreaseIndent`, `shouldDecreaseIndent`,
+   `expandBetweenPair`.
+
+2. **`IndentationHelperTests.swift`** — new file under `AlasTests/`.
+   Cover all pure-function cases: preserve indent, increase after openers,
+   dedent closers, tab detection, edge cases (empty line, line with only
+   whitespace, nested delimiters).
+
+3. **`CodeTextView.swift`** — add `override func insertNewline(_ sender: Any?)`
+   that uses `IndentationHelper` to compute the replacement text and cursor
+   position. Modify `insertText` to handle dedent-on-close-delimiter.
+
+4. **`CodeTextViewIndentTests.swift`** — new file under `AlasTests/`.
+   Integration tests using the `makeTextView` pattern from
+   `CodeTextViewAutoPairTests`: call `insertNewline` / `insertText` on a
+   wired-up `CodeTextView` and assert `string` + `selectedRange()`.
+
+5. **`xcodegen`** — regenerate `Alas.xcodeproj` to include new files.
+
+## Risks / things to watch
+
+- **Undo coalescing** — `insertText` calls on NSTextView register with the
+  undo manager automatically. `insertNewline` that manually replaces text must
+  group the newline + whitespace insertion into a single undo group
+  (`undoManager?.groupsByEvent` or explicit `beginUndoGrouping` /
+  `endUndoGrouping`). Verify with a manual test.
+
+- **`replacementRange` semantics** — `insertNewline` does not receive a
+  `replacementRange` like `insertText` does. Use `selectedRange()` directly.
+  If there is a selection, the newline replaces it (standard behavior).
+
+- **Performance on large files** — `indentUnit` scans the buffer. Capping at
+  ~100 lines and caching per buffer load makes this negligible.
+
+- **Interaction with auto-pair** — pressing Enter between `{}` must not
+  re-trigger the auto-pair `insertText` path. Since `insertNewline` is a
+  separate override, this should be clean — but verify with the paired test
+  case.
+
+- **Tree-sitter re-highlight** — the coordinator debounces highlight at 150ms.
+  Multi-line insertions (three-line expansion) produce a single
+  `didProcessEditing` callback, so highlighting works as-is.
+
+## Definition of done (handoff sign-off)
+
+- [ ] `IndentationHelper` pure-function tests green.
+- [ ] `CodeTextView` integration tests green for all acceptance criteria.
+- [ ] All pre-existing tests (794 at last count) still pass.
+- [ ] Manual verification: open a Swift file, press Enter after `{`, verify
+      indent. Type `}`, verify dedent. ⌘Z reverts cleanly.
+- [ ] `xcodegen` regenerated, project builds with zero new warnings.


### PR DESCRIPTION
## Smart Indentation in Editor Panes

Implements GitHub #130: smart indent behavior for code editor panes.

### What changed

- **`IndentationMode.swift`** — New enum (`.plain` / `.bracketAware`) controlling indent behavior per file type.
- **`IndentationHelper.swift`** — Pure logic helper (no AppKit dependency) computing newline replacements and closing-delimiter dedent edits. Detects indent units from nearby context (tabs, spaces, 4-space default).
- **`CodeTextView.swift`** — Added `indentationMode` property, `insertNewline(_:)` override for smart newline behavior, closing-delimiter dedent check inside `insertText` (runs before existing auto-pair logic).
- **`CodeEditorCoordinator.swift`** — `applyIndentationMode()` sets `.bracketAware` for known languages, `.plain` otherwise; called from `bindBuffer()`.
- **`IndentationHelperTests.swift`** — 26 unit tests covering all indentation logic.
- **`CodeTextViewIndentationTests.swift`** — 9 integration tests validating full CodeTextView wiring.

### Behavior

| Scenario | Mode | Result |
|---|---|---|
| Enter on indented line | Both | Preserves current indentation |
| Enter after ` {` | bracketAware | New line gets +1 indent unit |
| Enter between `{}` | bracketAware | Expands to `{\n    \n}` |
| `}` on whitespace-only line | bracketAware | Dedents one indent unit |
| `}` next to existing `)` | bracketAware | Step-over still works |
| Unknown/plain-text file | plain | Only indentation preservation |

### Key decisions

- **Heuristic-based, not AST-based** — Issue explicitly allows pragmatic bracket heuristic. Tree-sitter/LSP indentation deferred.
- **Conservative for plain text** — `.plain` mode preserves indentation but never applies bracket-aware behavior.
- **Single-string replacement** — Pair expansion inserts the full multi-line replacement as one string for clean undo.
- **Dedent before auto-pair** — Closing-delimiter dedent check runs before existing step-over logic.

### Verification

- Build: zero errors
- Tests: 882 pass (including 35 new indentation tests)