### PR TITLE
Render native markdown tables

### DIFF
--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -471,7 +471,7 @@ final class MarkdownRenderer {
             if fullRange.length > 0 {
                 mutable.addAttribute(.paragraphStyle, value: style, range: fullRange)
                 if cell.isHeader {
-                    mutable.addAttribute(.font, value: headerTableFont(), range: fullRange)
+                    applyHeaderTableFont(to: mutable, range: fullRange)
                 }
             } else {
                 mutable.append(NSAttributedString(string: " ", attributes: [
@@ -579,6 +579,29 @@ final class MarkdownRenderer {
 
     private func headerTableFont() -> NSFont {
         NSFont.systemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
+    }
+
+    private func applyHeaderTableFont(to mutable: NSMutableAttributedString, range: NSRange) {
+        mutable.enumerateAttribute(.font, in: range) { value, range, _ in
+            guard let font = value as? NSFont else {
+                mutable.addAttribute(.font, value: headerTableFont(), range: range)
+                return
+            }
+            guard !font.isFixedPitch else { return }
+
+            let traits = font.fontDescriptor.symbolicTraits
+            if traits.isEmpty {
+                mutable.addAttribute(.font, value: headerTableFont(), range: range)
+                return
+            }
+
+            let headerTraits = traits.union(.bold)
+            let descriptor = font.fontDescriptor.withSymbolicTraits(headerTraits)
+            guard let headerFont = NSFont(descriptor: descriptor, size: font.pointSize) else {
+                return
+            }
+            mutable.addAttribute(.font, value: headerFont, range: range)
+        }
     }
 
     private func monospaceFont(size: CGFloat) -> NSFont {

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -313,40 +313,175 @@ final class MarkdownRenderer {
         appendPlain("\n")
     }
 
-    private func visitTable(_ table: Markdown.Table) {
-        let header: [String] = table.head.cells.map { $0.plainText }
-        let bodyRows: [[String]] = table.body.rows.map { (row: Markdown.Table.Row) -> [String] in
-            row.cells.map { (cell: Markdown.Table.Cell) -> String in cell.plainText }
+    private struct RenderedTableCell {
+        let content: NSAttributedString
+        let row: Int
+        let column: Int
+        let isHeader: Bool
+        let alignment: NSTextAlignment
+    }
+
+    private func textAlignment(for alignment: Markdown.Table.ColumnAlignment?) -> NSTextAlignment {
+        switch alignment {
+        case .center: return .center
+        case .right: return .right
+        case .left, .none: return .left
         }
-        let allRows: [[String]] = [header] + bodyRows
-        let columnCount = allRows.map { (r: [String]) -> Int in r.count }.max() ?? 0
+    }
+
+    private func renderTableCell(_ cell: Markdown.Table.Cell) -> NSAttributedString {
+        let savedOutput = output
+        let savedTraits = currentTraits
+        let savedStrikethrough = inStrikethrough
+        let cellOutput = NSMutableAttributedString()
+
+        output = cellOutput
+        currentTraits = []
+        inStrikethrough = false
+
+        for child in cell.children {
+            if let paragraph = child as? Paragraph {
+                for inline in paragraph.children {
+                    visit(inline)
+                }
+            } else {
+                visit(child)
+            }
+        }
+
+        let rendered = cellOutput.copy() as! NSAttributedString
+        output = savedOutput
+        currentTraits = savedTraits
+        inStrikethrough = savedStrikethrough
+
+        if rendered.length > 0 {
+            return rendered
+        }
+        return NSAttributedString(string: "", attributes: bodyAttributes())
+    }
+
+    private func tableParagraphStyle(
+        table: NSTextTable,
+        row: Int,
+        column: Int,
+        columnCount: Int,
+        isHeader: Bool,
+        isBandedRow: Bool,
+        alignment: NSTextAlignment
+    ) -> NSParagraphStyle {
+        let block = NSTextTableBlock(
+            table: table,
+            startingRow: row,
+            rowSpan: 1,
+            startingColumn: column,
+            columnSpan: 1
+        )
+        block.verticalAlignment = .middleAlignment
+        block.setWidth(8, type: .absoluteValueType, for: .padding)
+        block.setWidth(0.5, type: .absoluteValueType, for: .border)
+        block.setBorderColor(NSColor(theme.color("fg-faint")))
+        let backgroundToken: String
+        if isHeader {
+            backgroundToken = "bg-3"
+        } else if isBandedRow {
+            backgroundToken = "bg-2"
+        } else {
+            backgroundToken = "bg-1"
+        }
+        block.backgroundColor = NSColor(theme.color(backgroundToken))
+
+        if columnCount > 0 {
+            block.setContentWidth(100 / CGFloat(columnCount), type: .percentageValueType)
+        }
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.textBlocks = [block]
+        paragraph.alignment = alignment
+        paragraph.paragraphSpacing = 0
+        paragraph.paragraphSpacingBefore = 0
+        paragraph.lineBreakMode = .byWordWrapping
+        return paragraph
+    }
+
+    private func visitTable(_ table: Markdown.Table) {
+        let headerCells = Array(table.head.cells)
+        let bodyRows = Array(table.body.rows)
+        let columnCount = max(
+            headerCells.count,
+            bodyRows.map { (row: Markdown.Table.Row) in Array(row.cells).count }.max() ?? 0
+        )
         guard columnCount > 0 else { return }
 
-        var widths = Array(repeating: 0, count: columnCount)
-        for row in allRows {
-            for (i, cell) in row.enumerated() where i < columnCount {
-                widths[i] = max(widths[i], cell.count)
+        let textTable = NSTextTable()
+        textTable.numberOfColumns = columnCount
+        textTable.layoutAlgorithm = .automaticLayoutAlgorithm
+        textTable.collapsesBorders = true
+        textTable.hidesEmptyCells = false
+
+        let alignments = table.columnAlignments
+        var renderedCells: [RenderedTableCell] = []
+
+        for column in 0..<columnCount {
+            let content: NSAttributedString
+            if column < headerCells.count {
+                content = renderTableCell(headerCells[column])
+            } else {
+                content = NSAttributedString(string: "", attributes: bodyAttributes())
+            }
+            renderedCells.append(RenderedTableCell(
+                content: content,
+                row: 0,
+                column: column,
+                isHeader: true,
+                alignment: textAlignment(for: column < alignments.count ? alignments[column] : nil)
+            ))
+        }
+
+        for (bodyIndex, row) in bodyRows.enumerated() {
+            let rowCells = Array(row.cells)
+            for column in 0..<columnCount {
+                let content: NSAttributedString
+                if column < rowCells.count {
+                    content = renderTableCell(rowCells[column])
+                } else {
+                    content = NSAttributedString(string: "", attributes: bodyAttributes())
+                }
+                renderedCells.append(RenderedTableCell(
+                    content: content,
+                    row: bodyIndex + 1,
+                    column: column,
+                    isHeader: false,
+                    alignment: textAlignment(for: column < alignments.count ? alignments[column] : nil)
+                ))
             }
         }
 
-        func formatRow(_ row: [String]) -> String {
-            let padded = (0..<columnCount).map { i -> String in
-                let cell = i < row.count ? row[i] : ""
-                return cell.padding(toLength: widths[i], withPad: " ", startingAt: 0)
+        for cell in renderedCells {
+            let mutable = NSMutableAttributedString(attributedString: cell.content)
+            let style = tableParagraphStyle(
+                table: textTable,
+                row: cell.row,
+                column: cell.column,
+                columnCount: columnCount,
+                isHeader: cell.isHeader,
+                isBandedRow: !cell.isHeader && cell.row.isMultiple(of: 2),
+                alignment: cell.alignment
+            )
+            let fullRange = NSRange(location: 0, length: mutable.length)
+            if fullRange.length > 0 {
+                mutable.addAttribute(.paragraphStyle, value: style, range: fullRange)
+                if cell.isHeader {
+                    mutable.addAttribute(.font, value: headerTableFont(), range: fullRange)
+                }
+            } else {
+                mutable.append(NSAttributedString(string: " ", attributes: [
+                    .font: cell.isHeader ? headerTableFont() : bodyFont(),
+                    .foregroundColor: NSColor(theme.color("fg")),
+                    .paragraphStyle: style
+                ]))
             }
-            return "| " + padded.joined(separator: " | ") + " |"
-        }
-
-        let separator = "|-" + widths.map { String(repeating: "-", count: $0) }.joined(separator: "-|-") + "-|"
-
-        let attrs: [NSAttributedString.Key: Any] = [
-            .font: monospaceFont(size: monoSize),
-            .foregroundColor: NSColor(theme.color("fg"))
-        ]
-        output.append(NSAttributedString(string: formatRow(header) + "\n", attributes: attrs))
-        output.append(NSAttributedString(string: separator + "\n", attributes: attrs))
-        for row in bodyRows {
-            output.append(NSAttributedString(string: formatRow(row) + "\n", attributes: attrs))
+            output.append(mutable)
+            output.append(NSAttributedString(string: "\n", attributes: [.paragraphStyle: style]))
         }
         appendPlain("\n")
     }
@@ -440,6 +575,10 @@ final class MarkdownRenderer {
         if currentTraits.isEmpty { return base }
         let desc = base.fontDescriptor.withSymbolicTraits(currentTraits)
         return NSFont(descriptor: desc, size: base.pointSize) ?? base
+    }
+
+    private func headerTableFont() -> NSFont {
+        NSFont.systemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
     }
 
     private func monospaceFont(size: CGFloat) -> NSFont {

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -258,6 +258,30 @@ struct MarkdownRendererTests {
         #expect(codeBackground != boldBackground)
     }
 
+    @Test func tableHeaderCellsPreserveInlineMarkdownFonts() throws {
+        let source = """
+        | `code` | *italic* |
+        | - | - |
+        | value | value |
+        """
+        let r = try MarkdownRendererTests.render(source)
+        let s = r.attributedString
+
+        let codeRange = (s.string as NSString).range(of: "code")
+        let codeFont = s.attribute(.font, at: codeRange.location, effectiveRange: nil) as? NSFont
+        let codeBackground = s.attribute(.backgroundColor, at: codeRange.location, effectiveRange: nil) as? NSColor
+        let codeBlock = tableBlock(at: "code", in: s)
+        #expect(codeBlock != nil)
+        #expect(codeFont?.isFixedPitch == true)
+        #expect(codeBackground != nil)
+
+        let italicRange = (s.string as NSString).range(of: "italic")
+        let italicFont = s.attribute(.font, at: italicRange.location, effectiveRange: nil) as? NSFont
+        let italicBlock = tableBlock(at: "italic", in: s)
+        #expect(italicBlock != nil)
+        #expect(italicFont?.fontDescriptor.symbolicTraits.contains(.italic) == true)
+    }
+
     @Test func tableCellsUseGFMColumnAlignment() throws {
         let source = """
         | Left | Center | Right |

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -237,17 +237,24 @@ struct MarkdownRendererTests {
 
         let linkRange = (s.string as NSString).range(of: "docs")
         let url = s.attribute(.link, at: linkRange.location, effectiveRange: nil) as? URL
+        let linkBlock = tableBlock(at: "docs", in: s)
+        #expect(linkBlock != nil)
         #expect(url?.absoluteString == "https://example.com")
 
         let boldRange = (s.string as NSString).range(of: "bold")
         let boldFont = s.attribute(.font, at: boldRange.location, effectiveRange: nil) as? NSFont
+        let boldBlock = tableBlock(at: "bold", in: s)
+        #expect(boldBlock != nil)
         #expect(boldFont?.fontDescriptor.symbolicTraits.contains(.bold) == true)
 
         let codeRange = (s.string as NSString).range(of: "code")
         let codeFont = s.attribute(.font, at: codeRange.location, effectiveRange: nil) as? NSFont
         let codeBackground = s.attribute(.backgroundColor, at: codeRange.location, effectiveRange: nil) as? NSColor
+        let codeBlock = tableBlock(at: "code", in: s)
+        let boldBackground = s.attribute(.backgroundColor, at: boldRange.location, effectiveRange: nil) as? NSColor
+        #expect(codeBlock != nil)
         #expect(codeFont?.isFixedPitch == true)
-        #expect(codeBackground != nil)
+        #expect(codeBackground != boldBackground)
     }
 
     @Test func tableCellsUseGFMColumnAlignment() throws {

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -193,7 +193,14 @@ struct MarkdownRendererTests {
         #expect(font?.isFixedPitch == true)
     }
 
-    @Test func rendersTableAsAlignedMonospaceText() throws {
+    private func tableBlock(at substring: String, in attributed: NSAttributedString) -> NSTextTableBlock? {
+        let range = (attributed.string as NSString).range(of: substring)
+        guard range.location != NSNotFound else { return nil }
+        let style = attributed.attribute(.paragraphStyle, at: range.location, effectiveRange: nil) as? NSParagraphStyle
+        return style?.textBlocks.compactMap { $0 as? NSTextTableBlock }.last
+    }
+
+    @Test func rendersTableAsNativeTextTable() throws {
         let source = """
         | h1 | h2 |
         | - | - |
@@ -202,13 +209,67 @@ struct MarkdownRendererTests {
         """
         let r = try MarkdownRendererTests.render(source)
         let s = r.attributedString.string
-        // All cells appear.
+
         #expect(s.contains("h1"))
         #expect(s.contains("h2"))
         #expect(s.contains("longer"))
-        // Aligned: the column for h1/longer is at least 6 wide, so "h1" is
-        // followed by trailing spaces before the next cell separator.
-        #expect(s.contains("h1    "))
+        #expect(!s.contains("|-"))
+
+        let headerBlock = tableBlock(at: "h1", in: r.attributedString)
+        let bodyBlock = tableBlock(at: "longer", in: r.attributedString)
+        #expect(headerBlock != nil)
+        #expect(bodyBlock != nil)
+        #expect(headerBlock?.startingRow == 0)
+        #expect(bodyBlock?.startingRow == 2)
+        #expect(headerBlock?.backgroundColor != nil)
+        #expect(bodyBlock?.backgroundColor != nil)
+        #expect(headerBlock?.borderColor(for: .minX) != nil)
+    }
+
+    @Test func tableCellsPreserveInlineMarkdownAttributes() throws {
+        let source = """
+        | Link | Styled |
+        | - | - |
+        | [docs](https://example.com) | **bold** `code` |
+        """
+        let r = try MarkdownRendererTests.render(source)
+        let s = r.attributedString
+
+        let linkRange = (s.string as NSString).range(of: "docs")
+        let url = s.attribute(.link, at: linkRange.location, effectiveRange: nil) as? URL
+        #expect(url?.absoluteString == "https://example.com")
+
+        let boldRange = (s.string as NSString).range(of: "bold")
+        let boldFont = s.attribute(.font, at: boldRange.location, effectiveRange: nil) as? NSFont
+        #expect(boldFont?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+
+        let codeRange = (s.string as NSString).range(of: "code")
+        let codeFont = s.attribute(.font, at: codeRange.location, effectiveRange: nil) as? NSFont
+        let codeBackground = s.attribute(.backgroundColor, at: codeRange.location, effectiveRange: nil) as? NSColor
+        #expect(codeFont?.isFixedPitch == true)
+        #expect(codeBackground != nil)
+    }
+
+    @Test func tableCellsUseGFMColumnAlignment() throws {
+        let source = """
+        | Left | Center | Right |
+        | :--- | :----: | ----: |
+        | L0 | C0 | R0 |
+        """
+        let r = try MarkdownRendererTests.render(source)
+        let s = r.attributedString
+
+        let leftRange = (s.string as NSString).range(of: "L0")
+        let centerRange = (s.string as NSString).range(of: "C0")
+        let rightRange = (s.string as NSString).range(of: "R0")
+
+        let leftStyle = s.attribute(.paragraphStyle, at: leftRange.location, effectiveRange: nil) as? NSParagraphStyle
+        let centerStyle = s.attribute(.paragraphStyle, at: centerRange.location, effectiveRange: nil) as? NSParagraphStyle
+        let rightStyle = s.attribute(.paragraphStyle, at: rightRange.location, effectiveRange: nil) as? NSParagraphStyle
+
+        #expect(leftStyle?.alignment == .left)
+        #expect(centerStyle?.alignment == .center)
+        #expect(rightStyle?.alignment == .right)
     }
 
     @Test func rendersLocalImageAsAttachment() throws {

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -254,6 +254,7 @@ struct MarkdownRendererTests {
         let boldBackground = s.attribute(.backgroundColor, at: boldRange.location, effectiveRange: nil) as? NSColor
         #expect(codeBlock != nil)
         #expect(codeFont?.isFixedPitch == true)
+        #expect(codeBackground != nil)
         #expect(codeBackground != boldBackground)
     }
 

--- a/docs/superpowers/specs/2026-05-16-markdown-native-tables-design.md
+++ b/docs/superpowers/specs/2026-05-16-markdown-native-tables-design.md
@@ -1,0 +1,127 @@
+# Markdown Native Tables Design
+
+## Context
+
+Alas already has a Markdown preview path built on `swift-markdown` and an AppKit `NSTextView`.
+Markdown files are parsed in `MarkdownTabView`, rendered by `MarkdownRenderer` into a single
+`MarkdownRenderResult.attributedString`, and installed by `MarkdownPreviewController`.
+
+GFM tables are already parsed as `Markdown.Table` nodes. The current renderer handles them by
+emitting aligned monospace pipe-table text. This is functional, but it does not look like a native
+Markdown preview table and makes table-heavy documents harder to scan.
+
+## Goal
+
+Render GFM tables in the Markdown preview pane as native-looking bordered tables while preserving
+inline Markdown inside cells.
+
+The chosen visual direction is a bordered table with:
+
+- a tinted header row,
+- subtle alternating body row backgrounds,
+- thin cell borders,
+- comfortable cell padding,
+- theme-derived colors,
+- GFM left, center, and right column alignment.
+
+## Non-Goals
+
+- Replacing the Markdown preview with a SwiftUI block renderer.
+- Adding nested horizontal scroll views for wide tables in this pass.
+- Making image-heavy table cells a first-class scenario.
+- Supporting arbitrary block Markdown layout inside table cells beyond reasonable inline flattening.
+- Changing Markdown parsing, tab state, settings, or preview mode behavior.
+
+## Architecture
+
+Keep the preview as a single `NSTextView` driven by `MarkdownRenderResult.attributedString`.
+The implementation should stay primarily in `MarkdownRenderer.visitTable`.
+
+`visitTable` will stop emitting pipe-delimited monospace text. Instead it will emit table cell
+paragraphs styled with TextKit table APIs:
+
+- `NSTextTable` to represent the table,
+- `NSTextTableBlock` values attached to paragraph styles for each cell,
+- paragraph alignment derived from `Markdown.Table.columnAlignments`,
+- paragraph background/border styling for header and body cells.
+
+This approach keeps the existing preview controller, selection behavior, scroll behavior, theme
+updates, and link handling intact.
+
+## Cell Rendering
+
+Each table cell must preserve these inline Markdown forms:
+
+- strong and emphasis font traits,
+- strikethrough,
+- inline code font/background,
+- links through the existing `.link` attribute,
+- plain text and soft/line breaks.
+
+The renderer should use a scoped helper to render a cell into a temporary attributed string rather
+than using `cell.plainText`. This avoids losing inline attributes and keeps table rendering consistent
+with the rest of the document.
+
+The helper must avoid paragraph-level blank lines inside cells. If unexpected block content appears
+inside a table cell, flatten it into inline text rather than attempting nested block layout.
+
+## Styling
+
+Table styling must use existing `Theme` colors instead of hard-coded colors. Use this mapping unless
+an existing theme key is missing, in which case use the closest existing theme color:
+
+- border: faint or muted foreground/background separator color,
+- header background: secondary preview background,
+- banded rows: two subtle background variants close to the preview background,
+- text: normal foreground,
+- header text: semibold foreground.
+
+Cell padding must be applied through TextKit table block margins or paragraph attributes. Borders
+should remain thin and unobtrusive so tables fit the existing app chrome.
+
+## Alignment
+
+Use `Markdown.Table.columnAlignments` for each column:
+
+- `.left` and `nil` map to left alignment,
+- `.center` maps to center alignment,
+- `.right` maps to right alignment.
+
+Header and body cells in the same column should use the same paragraph alignment.
+
+## Wide Tables
+
+The first implementation should rely on TextKit wrapping within cells and the existing preview
+scroll view. It should not introduce a nested horizontal scroller. If TextKit table layout proves
+unreadable for very wide tables, that should be handled as a follow-up design.
+
+## Tests
+
+Update `MarkdownRendererTests` around table rendering. Tests should verify:
+
+- table text is still present,
+- old pipe-table separator output is no longer emitted for rendered tables,
+- table cells carry paragraph styles with table blocks,
+- header/body cell styling is present enough to prove native table rendering is active,
+- inline links and bold/inline-code attributes survive inside cells,
+- GFM center and right alignment map to paragraph alignment.
+
+Existing parser tests for GFM table recognition should remain unchanged.
+
+## Risks
+
+`NSTextTable` behavior can be under-documented and may have layout quirks in `NSTextView`. If it
+cannot satisfy bordered, padded, selectable cells with link attributes intact, the fallback should be
+to keep the current preview architecture and either simplify the TextKit styling or write a follow-up
+design for a richer block renderer. Do not switch to image attachments for tables, because that would
+break the inline Markdown and link requirements.
+
+## Implementation Boundary
+
+Expected files:
+
+- `Alas/Sources/Code/Markdown/MarkdownRenderer.swift`
+- `AlasTests/MarkdownRendererTests.swift`
+
+No `project.yml` change is expected. If implementation discovers a source-file addition is needed,
+regenerate the Xcode project with `xcodegen` as required by project rules.


### PR DESCRIPTION
## Summary
- Render GFM markdown tables as native TextKit tables in the preview pane.
- Preserve inline markdown inside table cells, including links, bold, inline code, and header-cell inline styles.
- Add renderer tests for native table blocks, inline cell attributes, header inline formatting, and GFM alignment.

## Test Plan
- [x] `xcodegen`
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
