### PR TITLE
feat(editor): add find & replace support in editor

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
 		255E9EAE89D521E08EB90918 /* JSONHookSettingsFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */; };
 		2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF2F213480B30034B25B2B8 /* AgentRunError.swift */; };
+		25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
 		281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
@@ -88,6 +89,7 @@
 		3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
+		3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E62B501E0490F48CCA830 /* EditorFindBarView.swift */; };
 		3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
@@ -251,6 +253,7 @@
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
 		B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */; };
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
+		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
@@ -473,6 +476,7 @@
 		524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibility.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
+		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
 		57713D7143CFD53124E0523F /* AlasHookCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommand.swift; sourceTree = "<group>"; };
@@ -484,6 +488,7 @@
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstallerTests.swift; sourceTree = "<group>"; };
+		6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindControllerTests.swift; sourceTree = "<group>"; };
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
@@ -491,6 +496,7 @@
 		65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstaller.swift; sourceTree = "<group>"; };
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherFilterTests.swift; sourceTree = "<group>"; };
+		679E62B501E0490F48CCA830 /* EditorFindBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindBarView.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
 		6A190D4B29B35C457AA9829F /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
@@ -769,6 +775,7 @@
 				1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */,
 				35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */,
 				C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */,
+				6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */,
 				E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */,
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
 				25493E3B18A1AB94EA6985C3 /* EventHolder.swift */,
@@ -1243,6 +1250,8 @@
 				64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */,
 				D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */,
 				BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */,
+				679E62B501E0490F48CCA830 /* EditorFindBarView.swift */,
+				55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
 				35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */,
 				3D105CB2C185958ED23164D1 /* IndentationMode.swift */,
@@ -1635,6 +1644,8 @@
 				A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */,
 				B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */,
 				DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */,
+				3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */,
+				25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,
@@ -1816,6 +1827,7 @@
 				A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */,
 				3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */,
 				C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */,
+				B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */,
 				1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */,
 				C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */,
 				51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -65,7 +65,7 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasShowFindReplace, object: nil)
                 }
                 .keyboardShortcut("f", modifiers: [.command, .option])
-                .disabled(!state.hasActiveEditorTab)
+                .disabled(!state.hasActiveCodeEditorTab)
             }
             CommandGroup(after: .toolbar) {
                 Button("Toggle Right Pane") {

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -60,6 +60,12 @@ struct AlasApp: App {
                     NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
                 }
                 .keyboardShortcut("p", modifiers: .command)
+                Divider()
+                Button("Find and Replace") {
+                    NotificationCenter.default.post(name: .alasShowFindReplace, object: nil)
+                }
+                .keyboardShortcut("f", modifiers: [.command, .option])
+                .disabled(!state.hasActiveEditorTab)
             }
             CommandGroup(after: .toolbar) {
                 Button("Toggle Right Pane") {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -972,6 +972,12 @@ final class AppState {
         return true
     }
 
+    var hasActiveCodeEditorTab: Bool {
+        guard case .editor(let state) = activeTab else { return false }
+        let path = state.isExternal ? (state.externalAbsolutePath ?? "") : state.relativePath
+        return !MarkdownFileType.isMarkdown(relativePath: path)
+    }
+
     var hasAnyDirtyEditorTab: Bool {
         var result = false
         for project in projects {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -426,4 +426,7 @@ extension Notification.Name {
     static let alasResizePaneRight  = Notification.Name("AlasResizePaneRight")
     static let alasResizePaneUp     = Notification.Name("AlasResizePaneUp")
     static let alasResizePaneDown   = Notification.Name("AlasResizePaneDown")
+    static let alasShowFindReplace  = Notification.Name("AlasShowFindReplace")
+    static let codeEditorDidAttach  = Notification.Name("CodeEditorDidAttach")
+    static let codeEditorDidDetach  = Notification.Name("CodeEditorDidDetach")
 }

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct EditorTabView: View {
     let worktreePath: URL
@@ -12,13 +13,17 @@ struct EditorTabView: View {
     let originatingRelativePath: String?
     @Environment(\.theme) var theme
 
+    @State private var findBarVisible: Bool = false
+    @State private var findController = EditorFindController()
+    @State private var findText: String = ""
+    @State private var replaceText: String = ""
+    @State private var findBarMessage: String? = nil
+    @State private var activeTextView: CodeTextView? = nil
+
     var body: some View {
-        return VStack(spacing: 0) {
+        VStack(spacing: 0) {
             breadcrumb
             if externalAbsolutePath == nil {
-                // In-worktree tabs: create a normal buffer and show the
-                // conflict banner (external tabs are read-only and have no
-                // conflict semantics).
                 let buffer = appState.tabs.buffer(
                     worktreeId: worktreeId,
                     tabId: tabId,
@@ -26,6 +31,63 @@ struct EditorTabView: View {
                     relativePath: relativePath
                 )
                 EditorConflictBanner(buffer: buffer)
+            }
+            if findBarVisible {
+                EditorFindBarView(
+                    findText: $findText,
+                    replaceText: $replaceText,
+                    message: $findBarMessage,
+                    onFind: { direction in
+                        findController.findString = findText
+                        guard !findText.isEmpty else { return }
+                        guard let textView = activeTextView else { return }
+                        let start: Int
+                        switch direction {
+                        case .previous:
+                            start = max(0, textView.selectedRange().location - 1)
+                        case .next:
+                            start = textView.selectedRange().location + textView.selectedRange().length
+                        }
+                        let range: NSRange?
+                        switch direction {
+                        case .previous:
+                            range = findController.previousMatchRange(upTo: start)
+                        case .next:
+                            range = findController.nextMatchRange(startingAt: start)
+                        }
+                        if let range {
+                            textView.setSelectedRange(range)
+                            textView.scrollRangeToVisible(range)
+                        } else {
+                            findBarMessage = "No matches"
+                        }
+                    },
+                    onReplace: {
+                        findController.findString = findText
+                        findController.replacementString = replaceText
+                        if findController.replaceCurrent() {
+                            findBarMessage = nil
+                        } else {
+                            findBarMessage = "No matches"
+                        }
+                    },
+                    onReplaceAll: {
+                        findController.findString = findText
+                        findController.replacementString = replaceText
+                        let count = findController.replaceAll()
+                        if count == 0 {
+                            findBarMessage = "No matches"
+                        } else if count == 1 {
+                            findBarMessage = "Replaced 1 match"
+                        } else {
+                            findBarMessage = "Replaced \(count) matches"
+                        }
+                    },
+                    onDone: {
+                        findBarVisible = false
+                        findBarMessage = nil
+                    }
+                )
             }
             CodeEditorView(
                 worktreeId: worktreeId,
@@ -42,6 +104,35 @@ struct EditorTabView: View {
             )
         }
         .background(theme.color("bg-1"))
+        .onDisappear {
+            findBarVisible = false
+            findController.textView = nil
+            activeTextView = nil
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .codeEditorDidAttach)) { notification in
+            guard let info = notification.userInfo,
+                  let notifTabId = info["tabId"] as? TabID,
+                  notifTabId == tabId,
+                  let textView = info["textView"] as? CodeTextView else { return }
+            activeTextView = textView
+            findController.textView = textView
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .codeEditorDidDetach)) { notification in
+            guard let info = notification.userInfo,
+                  let notifTabId = info["tabId"] as? TabID,
+                  notifTabId == tabId else { return }
+            activeTextView = nil
+            findController.textView = nil
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .alasShowFindReplace)) { _ in
+            guard appState.tabs.activeTabId(forWorktree: worktreeId) == tabId else { return }
+            findBarVisible = true
+            DispatchQueue.main.async {
+                if let textView = activeTextView {
+                    textView.window?.makeFirstResponder(textView)
+                }
+            }
+        }
     }
 
     private var breadcrumb: some View {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -46,7 +46,7 @@ struct EditorTabView: View {
                         let start: Int
                         switch direction {
                         case .previous:
-                            start = max(0, textView.selectedRange().location - 1)
+                            start = textView.selectedRange().location
                         case .next:
                             start = textView.selectedRange().location + textView.selectedRange().length
                         }

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -19,6 +19,7 @@ struct EditorTabView: View {
     @State private var replaceText: String = ""
     @State private var findBarMessage: String? = nil
     @State private var activeTextView: CodeTextView? = nil
+    @FocusState private var findFieldFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -37,6 +38,7 @@ struct EditorTabView: View {
                     findText: $findText,
                     replaceText: $replaceText,
                     message: $findBarMessage,
+                    findFieldFocused: $findFieldFocused,
                     onFind: { direction in
                         findController.findString = findText
                         guard !findText.isEmpty else { return }
@@ -127,11 +129,7 @@ struct EditorTabView: View {
         .onReceive(NotificationCenter.default.publisher(for: .alasShowFindReplace)) { _ in
             guard appState.tabs.activeTabId(forWorktree: worktreeId) == tabId else { return }
             findBarVisible = true
-            DispatchQueue.main.async {
-                if let textView = activeTextView {
-                    textView.window?.makeFirstResponder(textView)
-                }
-            }
+            findFieldFocused = true
         }
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -16,6 +16,8 @@ final class CodeEditorCoordinator {
 
     private var currentTabId: TabID?
     private var currentWorktreeId: String?
+
+    var tabId: TabID? { currentTabId }
     private var currentRoot: URL?
     private var currentRelativePath: String?
     private var currentLanguage: String?
@@ -229,6 +231,12 @@ final class CodeEditorCoordinator {
         }
 
         applyRevealIfNeeded(tabId: tabId, line: revealLine, character: revealCharacter)
+
+        NotificationCenter.default.post(
+            name: .codeEditorDidAttach,
+            object: self,
+            userInfo: ["textView": textView, "tabId": tabId]
+        )
     }
 
     func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil, originatingRelativePath: String? = nil) {
@@ -426,6 +434,12 @@ final class CodeEditorCoordinator {
         buffer = nil
         // We deliberately do NOT close the LSP document or stop the file
         // watcher — the buffer owns those for as long as the tab is alive.
+
+        NotificationCenter.default.post(
+            name: .codeEditorDidDetach,
+            object: self,
+            userInfo: ["tabId": tabId as Any]
+        )
     }
 
     // MARK: - Edit propagation (highlight + didChange debouncer)

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -23,6 +23,8 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     var mouseExitedHandler: (() -> Void)?
     var indentationMode: IndentationMode = .plain
 
+    var autoPairDisabled: Bool = false
+
     /// Set by `CodeEditorCoordinator.attach`. Each closure mutates the shared
     /// `code.fontSize` config in response to the matching menu command.
     var increaseFontSizeHandler: (() -> Void)?
@@ -53,8 +55,12 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     required init?(coder: NSCoder) { fatalError("not used") }
 
     override func insertText(_ insertString: Any, replacementRange: NSRange) {
+        guard isEditable else { return }
+        if autoPairDisabled {
+            super.insertText(insertString, replacementRange: replacementRange)
+            return
+        }
         guard
-            isEditable,
             let text = Self.string(from: insertString),
             text.count == 1,
             let character = text.first

--- a/Alas/Sources/Code/Editor/EditorFindBarView.swift
+++ b/Alas/Sources/Code/Editor/EditorFindBarView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct EditorFindBarView: View {
+    @Binding var findText: String
+    @Binding var replaceText: String
+    @Binding var message: String?
+
+    let onFind: (_ direction: FindDirection) -> Void
+    let onReplace: () -> Void
+    let onReplaceAll: () -> Void
+    let onDone: () -> Void
+
+    enum FindDirection {
+        case previous
+        case next
+    }
+
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 4) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(theme.color("fg-muted"))
+                    .font(.system(size: 11))
+                TextField("Find", text: $findText)
+                    .textFieldStyle(PlainTextFieldStyle())
+                    .font(.system(size: 12))
+                    .frame(minWidth: 120)
+                    .onSubmit { onFind(.next) }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(theme.color("bg-2"))
+            .cornerRadius(6)
+
+            HStack(spacing: 4) {
+                TextField("Replace", text: $replaceText)
+                    .textFieldStyle(PlainTextFieldStyle())
+                    .font(.system(size: 12))
+                    .frame(minWidth: 120)
+                    .onSubmit { onReplace() }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(theme.color("bg-2"))
+            .cornerRadius(6)
+
+            Button("Replace") {
+                onReplace()
+            }
+            .font(.system(size: 11, weight: .medium))
+            .disabled(findText.isEmpty)
+
+            Button("All") {
+                onReplaceAll()
+            }
+            .font(.system(size: 11, weight: .medium))
+            .disabled(findText.isEmpty)
+
+            Spacer(minLength: 8)
+
+            if let msg = message {
+                Text(msg)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .lineLimit(1)
+            }
+
+            Button(action: onDone) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(theme.color("fg-muted"))
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-1"))
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+}

--- a/Alas/Sources/Code/Editor/EditorFindBarView.swift
+++ b/Alas/Sources/Code/Editor/EditorFindBarView.swift
@@ -4,6 +4,7 @@ struct EditorFindBarView: View {
     @Binding var findText: String
     @Binding var replaceText: String
     @Binding var message: String?
+    @FocusState.Binding var findFieldFocused: Bool
 
     let onFind: (_ direction: FindDirection) -> Void
     let onReplace: () -> Void
@@ -24,6 +25,7 @@ struct EditorFindBarView: View {
                     .foregroundColor(theme.color("fg-muted"))
                     .font(.system(size: 11))
                 TextField("Find", text: $findText)
+                    .focused($findFieldFocused)
                     .textFieldStyle(PlainTextFieldStyle())
                     .font(.system(size: 12))
                     .frame(minWidth: 120)

--- a/Alas/Sources/Code/Editor/EditorFindController.swift
+++ b/Alas/Sources/Code/Editor/EditorFindController.swift
@@ -53,16 +53,20 @@ final class EditorFindController {
     /// Returns `true` if a replacement occurred.
     func replaceCurrent() -> Bool {
         guard let textView = textView else { return false }
+        guard textView.isEditable else { return false }
         guard !findString.isEmpty else { return false }
 
         let text = textView.string as NSString
         var foundRange = textView.selectedRange()
 
-        // If the selection is not a valid match, search from the beginning.
+        // If the selection is not a valid match, search from cursor position,
+        // wrapping to the start if no match is found ahead.
         let selectionIsMatch = foundRange.length == findString.utf16.count
             && text.substring(with: foundRange) == findString
         if !selectionIsMatch {
-            if let match = nextMatchRange(startingAt: 0) {
+            let searchStart = foundRange.location
+            if let match = nextMatchRange(startingAt: searchStart)
+                ?? nextMatchRange(startingAt: 0) {
                 textView.setSelectedRange(match)
                 foundRange = match
             }
@@ -89,6 +93,7 @@ final class EditorFindController {
     /// Returns the number of replacements performed.
     func replaceAll() -> Int {
         guard let textView = textView else { return 0 }
+        guard textView.isEditable else { return 0 }
         guard !findString.isEmpty else { return 0 }
 
         let text = textView.string as NSString

--- a/Alas/Sources/Code/Editor/EditorFindController.swift
+++ b/Alas/Sources/Code/Editor/EditorFindController.swift
@@ -1,0 +1,163 @@
+import AppKit
+import Foundation
+
+/// Plain-text find/replace controller scoped to a single `CodeTextView`.
+/// Provides `replaceCurrent` and `replaceAll` using `NSTextView` editing
+/// APIs so undo, dirty tracking, highlighting, and LSP `didChange` all
+/// flow through the normal pipeline.
+@MainActor
+final class EditorFindController {
+    /// Set by the hosting `EditorTabView` after the coordinator attaches.
+    weak var textView: CodeTextView?
+
+    /// Find string used as search text.
+    var findString: String = ""
+
+    /// Replace string used as replacement text.
+    var replacementString: String = ""
+
+    /// Number of matches for current find string.
+    private(set) var matchCount: Int = 0
+
+    /// Whether there are any replacements.
+    var canReplace: Bool {
+        !findString.isEmpty && matchCount > 0
+    }
+
+    /// Find the next match starting from `searchLocation` and return its UTF-16
+    /// range. Returns `nil` when no match remains.
+    func nextMatchRange(startingAt searchLocation: Int) -> NSRange? {
+        guard let textView = textView, searchLocation >= 0 else { return nil }
+        guard !findString.isEmpty else { return nil }
+        let text = textView.string as NSString
+        guard searchLocation <= text.length else { return nil }
+        let range = NSRange(location: searchLocation, length: text.length - searchLocation)
+        let found = text.range(of: findString, options: [], range: range)
+        guard found.location != NSNotFound else { return nil }
+        return found
+    }
+
+    /// Find the previous match up to `searchLocation` and return its range.
+    func previousMatchRange(upTo searchLocation: Int) -> NSRange? {
+        guard let textView = textView, searchLocation > 0 else { return nil }
+        guard !findString.isEmpty else { return nil }
+        let text = textView.string as NSString
+        let searchEnd = min(searchLocation, text.length)
+        let range = NSRange(location: 0, length: searchEnd)
+        let found = text.range(of: findString, options: .backwards, range: range)
+        guard found.location != NSNotFound else { return nil }
+        return found
+    }
+
+    /// Replaces the current match (selected or next from the current selection).
+    /// Returns `true` if a replacement occurred.
+    func replaceCurrent() -> Bool {
+        guard let textView = textView else { return false }
+        guard !findString.isEmpty else { return false }
+
+        let text = textView.string as NSString
+        var foundRange = textView.selectedRange()
+
+        // If the selection is not a valid match, search from the beginning.
+        let selectionIsMatch = foundRange.length == findString.utf16.count
+            && text.substring(with: foundRange) == findString
+        if !selectionIsMatch {
+            if let match = nextMatchRange(startingAt: 0) {
+                textView.setSelectedRange(match)
+                foundRange = match
+            }
+        }
+
+        guard foundRange.length == findString.utf16.count,
+              text.substring(with: foundRange) == findString else { return false }
+
+        textView.autoPairDisabled = true
+        defer { textView.autoPairDisabled = false }
+
+        textView.insertText(replacementString, replacementRange: foundRange)
+
+        let updatedLength = (textView.string as NSString).length
+        let searchStart = min(foundRange.location + replacementString.utf16.count, updatedLength)
+        if let nextRange = nextMatchRange(startingAt: searchStart) {
+            textView.setSelectedRange(nextRange)
+            textView.scrollRangeToVisible(nextRange)
+        }
+        return true
+    }
+
+    /// Replaces all non-overlapping matches in the document.
+    /// Returns the number of replacements performed.
+    func replaceAll() -> Int {
+        guard let textView = textView else { return 0 }
+        guard !findString.isEmpty else { return 0 }
+
+        let text = textView.string as NSString
+        var locations: [Int] = []
+        var current = 0
+        while current <= text.length - findString.utf16.count {
+            let range = NSRange(location: current, length: text.length - current)
+            let found = text.range(of: findString, options: [], range: range)
+            if found.location == NSNotFound { break }
+            locations.append(found.location)
+            current = found.location + found.length
+        }
+        guard !locations.isEmpty else { return 0 }
+
+        let count: Int
+        if let undoManager = textView.undoManager {
+            undoManager.beginUndoGrouping()
+            undoManager.setActionName("Replace All")
+            defer { undoManager.endUndoGrouping() }
+
+            textView.autoPairDisabled = true
+            defer { textView.autoPairDisabled = false }
+
+            count = locations.reversed().reduce(0) { acc, loc in
+                let replacementNSRange = NSRange(location: loc, length: findString.utf16.count)
+                textView.insertText(replacementString, replacementRange: replacementNSRange)
+                return acc + 1
+            }
+        } else {
+            textView.autoPairDisabled = true
+            defer { textView.autoPairDisabled = false }
+
+            count = locations.reversed().reduce(0) { acc, loc in
+                let replacementNSRange = NSRange(location: loc, length: findString.utf16.count)
+                textView.insertText(replacementString, replacementRange: replacementNSRange)
+                return acc + 1
+            }
+        }
+
+        // After replace-all, move cursor to the first replacement.
+        if let firstLocation = locations.first {
+            let newNSRange = NSRange(location: firstLocation, length: replacementString.utf16.count)
+            if firstLocation <= (textView.string as NSString).length {
+                textView.setSelectedRange(newNSRange)
+            }
+        }
+        return count
+    }
+
+    /// Counts the number of non-overlapping matches for `findString`.
+    func countMatches() -> Int {
+        guard let textView = textView else { return 0 }
+        guard !findString.isEmpty else {
+            matchCount = 0
+            return 0
+        }
+
+        let text = textView.string as NSString
+        var count = 0
+        var current = 0
+
+        while current <= text.length - findString.utf16.count {
+            let range = NSRange(location: current, length: text.length - current)
+            let found = text.range(of: findString, options: [], range: range)
+            if found.location == NSNotFound { break }
+            count += 1
+            current = found.location + found.length
+        }
+        matchCount = count
+        return count
+    }
+}

--- a/AlasTests/AppStateTabAvailabilityTests.swift
+++ b/AlasTests/AppStateTabAvailabilityTests.swift
@@ -54,6 +54,68 @@ struct AppStateTabAvailabilityTests {
         #expect(state.hasActiveEditorTab)
     }
 
+    @Test func hasActiveCodeEditorTabTrueForCodeEditor() async throws {
+        let repo = try await makeRepo(name: "code-editor")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        _ = state.tabs.appendEditor(worktreeId: trees[0].id, title: "a.txt", relativePath: "a.txt")
+
+        #expect(state.hasActiveCodeEditorTab)
+    }
+
+    @Test func hasActiveCodeEditorTabFalseForMarkdownEditor() async throws {
+        let repo = try await makeRepo(name: "markdown-editor")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        _ = state.tabs.appendEditor(worktreeId: trees[0].id, title: "README.md", relativePath: "README.md")
+
+        #expect(state.hasActiveEditorTab)
+        #expect(!state.hasActiveCodeEditorTab)
+    }
+
+    @Test func hasActiveCodeEditorTabFalseForExternalMarkdownEditor() async throws {
+        let repo = try await makeRepo(name: "external-markdown-editor")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        state.selectedWorktreeId = trees[0].id
+
+        _ = state.tabs.openExternalEditor(
+            worktreeId: trees[0].id,
+            absoluteURL: repo.appendingPathComponent("../README.md").standardizedFileURL,
+            revealLine: nil,
+            revealCharacter: nil,
+            originatingRelativePath: nil
+        )
+
+        #expect(state.hasActiveEditorTab)
+        #expect(!state.hasActiveCodeEditorTab)
+    }
+
     @Test func hasActiveEditorTabFalseForTerminal() async throws {
         let repo = try await makeRepo(name: "terminal")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/EditorFindControllerTests.swift
+++ b/AlasTests/EditorFindControllerTests.swift
@@ -6,7 +6,6 @@ import AppKit
 @MainActor
 @Suite(.serialized)
 struct EditorFindControllerTests {
-
     private func makeTextView(_ text: String = "") -> CodeTextView {
         let storage = NSTextStorage(string: text)
         let layoutManager = NSLayoutManager()

--- a/AlasTests/EditorFindControllerTests.swift
+++ b/AlasTests/EditorFindControllerTests.swift
@@ -151,4 +151,56 @@ struct EditorFindControllerTests {
         #expect(range?.location == 12)
         #expect(range?.length == 5)
     }
+
+    @Test func replaceCurrentStartsFromCursor() {
+        let textView = makeTextView("aa bb aa bb")
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "aa"
+        controller.replacementString = "xx"
+
+        #expect(controller.replaceCurrent() == true)
+        #expect(textView.string == "xx bb aa bb")
+
+        textView.setSelectedRange(NSRange(location: 6, length: 0))
+        #expect(controller.replaceCurrent() == true)
+        #expect(textView.string == "xx bb xx bb")
+    }
+
+    @Test func replaceCurrentWrapsAround() {
+        let textView = makeTextView("aa bb aa")
+        textView.setSelectedRange(NSRange(location: 7, length: 0))
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "aa"
+        controller.replacementString = "xx"
+
+        #expect(controller.replaceCurrent() == true)
+        #expect(textView.string == "xx bb aa")
+    }
+
+    @Test func replaceCurrentNoOpOnReadOnly() {
+        let textView = makeTextView("hello world")
+        textView.isEditable = false
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "world"
+        controller.replacementString = "universe"
+
+        #expect(controller.replaceCurrent() == false)
+        #expect(textView.string == "hello world")
+    }
+
+    @Test func replaceAllNoOpOnReadOnly() {
+        let textView = makeTextView("hello hello")
+        textView.isEditable = false
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "hello"
+        controller.replacementString = "bye"
+
+        #expect(controller.replaceAll() == 0)
+        #expect(textView.string == "hello hello")
+    }
 }

--- a/AlasTests/EditorFindControllerTests.swift
+++ b/AlasTests/EditorFindControllerTests.swift
@@ -1,0 +1,155 @@
+// AlasTests/EditorFindControllerTests.swift
+import Testing
+import AppKit
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct EditorFindControllerTests {
+
+    private func makeTextView(_ text: String = "") -> CodeTextView {
+        let storage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        return textView
+    }
+
+    @Test func replaceCurrentUpdatesText() {
+        let textView = makeTextView("hello world")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "world"
+        controller.replacementString = "universe"
+
+        let didReplace = controller.replaceCurrent()
+
+        #expect(didReplace == true)
+        #expect(textView.string == "hello universe")
+    }
+
+    @Test func replaceCurrentMovesToNextMatch() {
+        let textView = makeTextView("cat cat cat")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "cat"
+        controller.replacementString = "dog"
+
+        let first = controller.replaceCurrent()
+        #expect(first == true)
+        #expect(textView.string == "dog cat cat")
+
+        let second = controller.replaceCurrent()
+        #expect(second == true)
+        #expect(textView.string == "dog dog cat")
+    }
+
+    @Test func replaceAllReplacesRepeatedMatches() {
+        let textView = makeTextView("a b a b a")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "a"
+        controller.replacementString = "x"
+
+        let count = controller.replaceAll()
+
+        #expect(count == 3)
+        #expect(textView.string == "x b x b x")
+    }
+
+    @Test func replaceAllReturnsZeroForNoMatches() {
+        let textView = makeTextView("hello world")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "xyz"
+        controller.replacementString = "abc"
+
+        let count = controller.replaceAll()
+
+        #expect(count == 0)
+        #expect(textView.string == "hello world")
+    }
+
+    @Test func emptyReplacementDeletesMatches() {
+        let textView = makeTextView("abcXYZabc")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "XYZ"
+        controller.replacementString = ""
+
+        let count = controller.replaceAll()
+
+        #expect(count == 1)
+        #expect(textView.string == "abcabc")
+    }
+
+    @Test func emptyFindTextPerformsNoMutation() {
+        let textView = makeTextView("hello world")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = ""
+        controller.replacementString = "x"
+
+        let didReplace = controller.replaceCurrent()
+        let count = controller.replaceAll()
+
+        #expect(didReplace == false)
+        #expect(count == 0)
+        #expect(textView.string == "hello world")
+    }
+
+    @Test func replaceCurrentWithSelectedMatch() {
+        let textView = makeTextView("foo bar baz")
+        textView.setSelectedRange(NSRange(location: 4, length: 3)) // select "bar"
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "bar"
+        controller.replacementString = "qux"
+
+        let didReplace = controller.replaceCurrent()
+
+        #expect(didReplace == true)
+        #expect(textView.string == "foo qux baz")
+    }
+
+    @Test func countMatchesReportsThree() {
+        let textView = makeTextView("one two one two one")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "one"
+
+        let count = controller.countMatches()
+
+        #expect(count == 3)
+        #expect(controller.matchCount == 3)
+    }
+
+    @Test func findNextJumpsToMatch() {
+        let textView = makeTextView("hello world hello")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "world"
+
+        let range = controller.nextMatchRange(startingAt: 0)
+
+        #expect(range != nil)
+        #expect(range?.location == 6)
+        #expect(range?.length == 5)
+    }
+
+    @Test func findPreviousJumpsBackwards() {
+        let textView = makeTextView("hello world hello")
+        let controller = EditorFindController()
+        controller.textView = textView
+        controller.findString = "hello"
+
+        let range = controller.previousMatchRange(upTo: 17)
+
+        #expect(range != nil)
+        #expect(range?.location == 12)
+        #expect(range?.length == 5)
+    }
+}


### PR DESCRIPTION
Implements GitHub issue #129: Find & Replace inside an editor.

## Changes

- **EditorFindController** — Plain-text find/replace controller scoped to a single `CodeTextView`. Uses `NSTextView.insertText(_:replacementRange:)` so undo, dirty tracking, highlighting, and LSP `didChange` flow through the normal pipeline. `replaceAll` wraps edits in a single undo grouping.

- **EditorFindBarView** — SwiftUI bar with find field, replace field, Replace/All/Done buttons, status message, and Enter key handling (`onSubmit` triggers Find Next / Replace Current).

- **CodeTextView** — Added `autoPairDisabled` guard: when set, `insertText` bypasses auto-pair logic, preventing single-character replacements from inserting paired delimiters.

- **EditorTabView** — Conditionally renders `EditorFindBarView`. Listens for `.codeEditorDidAttach`/`.codeEditorDidDetach` to wire the controller to the active `CodeTextView`. Wired `onFind` for directional navigation.

- **CodeEditorCoordinator** — Posts `.codeEditorDidAttach`/`.codeEditorDidDetach` notifications. Removed unused `detachedTabId` variable. Fixed `tabId as Any` coercion warning.

- **AlasApp** — Added **Edit > Find and Replace** (⌘⌥F) menu command, disabled when no editor tab is active.

- **RootView** — Added `Notification.Name` extensions for `.alasShowFindReplace`, `.codeEditorDidAttach`, `.codeEditorDidDetach`.

- **Tests** — 10 focused `EditorFindControllerTests` covering replace current, replace all, empty cases, match counting, and navigation.

## Review fixes applied

- `autoPairDisabled` now actually bypasses auto-pair in `CodeTextView.insertText` (was set but never checked)
- `replaceCurrent()` advances forward to next match instead of backward
- Stale `text.length` replaced with fresh document length after mutation
- Enter key handlers added to find/replace text fields
- Unused `detachedTabId` removed from `CodeEditorCoordinator.detach()`

Fixes #129