### PR TITLE
fix(delete): handle submodule worktree delete failures

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -125,7 +125,30 @@ final class AppState {
         installerHost = .detect()
     }
 
-    /// Set when a worktree deletion fails because the tree is dirty.
+    enum ForceDeleteReason: Equatable {
+        case dirty
+        case containsSubmodules
+
+        var alertTitleSuffix: String {
+            switch self {
+            case .dirty:
+                "has uncommitted changes."
+            case .containsSubmodules:
+                "contains submodules."
+            }
+        }
+
+        var alertMessage: String {
+            switch self {
+            case .dirty:
+                "Force delete? Any uncommitted work in this worktree will be lost."
+            case .containsSubmodules:
+                "Git requires force delete for worktrees containing initialized submodules. Any uncommitted work in this worktree will be lost."
+            }
+        }
+    }
+
+    /// Set when a worktree deletion fails because Git requires `--force`.
     /// The UI presents a confirmation dialog; confirming retries with force.
     struct PendingForceDeleteWorktree: Identifiable, Equatable {
         let id: String           // worktree id
@@ -135,6 +158,7 @@ final class AppState {
         let worktreePath: URL    // actual worktree path
         let deleteBranchIfMerged: Bool
         let removedIndex: Int
+        let reason: ForceDeleteReason
     }
     var pendingForceDeleteWorktree: PendingForceDeleteWorktree?
 
@@ -1209,7 +1233,7 @@ final class AppState {
                 force: force
             )
         } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
-            if !force && Self.looksLikeDirtyWorktreeError(stderr) {
+            if !force, let reason = Self.forceDeleteReason(for: stderr) {
                 // Clear deleting so the user can see the row again while deciding.
                 projectsManager.setOperationState(id: worktree.id, state: nil)
                 pendingForceDeleteWorktree = PendingForceDeleteWorktree(
@@ -1219,7 +1243,8 @@ final class AppState {
                     repoPath: repoPath,
                     worktreePath: worktree.path,
                     deleteBranchIfMerged: deleteBranchIfMerged,
-                    removedIndex: removedIndex
+                    removedIndex: removedIndex,
+                    reason: reason
                 )
                 return
             } else {
@@ -1305,15 +1330,24 @@ final class AppState {
         }.value
     }
 
-    /// Permissive substring check: git's exact wording around dirty/locked
+    /// Permissive substring check: git's exact wording around dirty/submodule
     /// worktrees varies by version. If the match misses, the caller surfaces
     /// the raw stderr instead, which is acceptable degradation.
-    nonisolated static func looksLikeDirtyWorktreeError(_ stderr: String) -> Bool {
+    nonisolated static func forceDeleteReason(for stderr: String) -> ForceDeleteReason? {
         let s = stderr.lowercased()
-        return s.contains("is dirty")
+        if s.contains("working trees containing submodules")
+            || (s.contains("containing submodules") && s.contains("cannot be moved or removed")) {
+            return .containsSubmodules
+        }
+
+        if s.contains("is dirty")
             || s.contains("dirty worktree")
             || s.contains("contains modified or untracked files")
-            || s.contains("modified or untracked")
+            || s.contains("modified or untracked") {
+            return .dirty
+        }
+
+        return nil
     }
 
     private func confirmDeleteWorktree(branch: String) -> Bool {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -108,7 +108,7 @@ struct RootView: View {
             )
         }
         .alert(
-            "'\(state.pendingForceDeleteWorktree?.branch ?? "")' has uncommitted changes.",
+            "'\(state.pendingForceDeleteWorktree?.branch ?? "")' \(state.pendingForceDeleteWorktree?.reason.alertTitleSuffix ?? "requires force delete.")",
             isPresented: Binding(
                 get: { state.pendingForceDeleteWorktree != nil },
                 set: { if !$0 { state.cancelForceDeletePendingWorktree() } }
@@ -122,7 +122,7 @@ struct RootView: View {
                 }
             },
             message: {
-                Text("Force delete? Any uncommitted work in this worktree will be lost.")
+                Text(state.pendingForceDeleteWorktree?.reason.alertMessage ?? "Force delete?")
             }
         )
         .task {

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -279,11 +279,12 @@ struct AppStateCleanupTests {
     // MARK: - Dirty-worktree force-delete state
 
     @Test func looksLikeDirtyWorktreeErrorMatchesKnownPatterns() {
-        #expect(AppState.looksLikeDirtyWorktreeError("Cannot delete a dirty worktree"))
-        #expect(AppState.looksLikeDirtyWorktreeError("fatal: 'foo' contains modified or untracked files"))
-        #expect(AppState.looksLikeDirtyWorktreeError("worktree is dirty and cannot be removed"))
-        #expect(!AppState.looksLikeDirtyWorktreeError("fatal: not a git repository"))
-        #expect(!AppState.looksLikeDirtyWorktreeError(""))
+        #expect(AppState.forceDeleteReason(for: "Cannot delete a dirty worktree") == .dirty)
+        #expect(AppState.forceDeleteReason(for: "fatal: 'foo' contains modified or untracked files") == .dirty)
+        #expect(AppState.forceDeleteReason(for: "worktree is dirty and cannot be removed") == .dirty)
+        #expect(AppState.forceDeleteReason(for: "fatal: working trees containing submodules cannot be moved or removed") == .containsSubmodules)
+        #expect(AppState.forceDeleteReason(for: "fatal: not a git repository") == nil)
+        #expect(AppState.forceDeleteReason(for: "") == nil)
     }
 
     @Test func cancelForceDeleteClearsPendingState() async throws {
@@ -302,7 +303,8 @@ struct AppStateCleanupTests {
             repoPath: repo,
             worktreePath: wt.path,
             deleteBranchIfMerged: false,
-            removedIndex: 0
+            removedIndex: 0,
+            reason: .dirty
         )
         #expect(state.pendingForceDeleteWorktree != nil)
 


### PR DESCRIPTION
## Summary

Handle Git worktree removal failures for linked worktrees that contain initialized submodules.

## Root cause

`git worktree remove <path>` fails with `fatal: working trees containing submodules cannot be moved or removed` when the worktree has initialized submodules. Alas only treated dirty worktree failures as force-delete retry cases, so submodule worktrees ended in a hard delete failure instead of offering the existing explicit force-delete flow.

## Changes

- Classify force-delete retry reasons as dirty worktree or initialized-submodule worktree.
- Route the submodule failure into the existing force-delete confirmation path.
- Show specific alert copy for submodule worktrees.
- Add coverage for the exact Git error string.

## Validation

- `xcodegen`
- `xcrun swiftc -parse Alas/Sources/App/AppState.swift Alas/Sources/App/RootView.swift AlasTests/AppStateCleanupTests.swift`
- `git diff --check`

Build/test commands were attempted but blocked locally because `.build/ghostty/GhosttyKit.xcframework` is missing in this worktree:

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`