### PR TITLE
feat(changelog): add changelog-driven release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
             body && index($0, "## [") == 1 { exit }
             body { print }
           ' CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
-          test -s "$RUNNER_TEMP/release-notes.md" || {
+          grep -q '[^[:space:]]' "$RUNNER_TEMP/release-notes.md" || {
             echo "::error::No CHANGELOG.md section found for v$VERSION"
             exit 1
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,22 @@ jobs:
         if: always()
         run: ./scripts/cleanup-signing-keychain.sh
 
+      - name: Extract release notes
+        run: |
+          awk -v v="## [$VERSION]" '
+            index($0, v) == 1 { body = 1; next }
+            body && index($0, "## [") == 1 { exit }
+            body { print }
+          ' CHANGELOG.md > "$RUNNER_TEMP/release-notes.md"
+          test -s "$RUNNER_TEMP/release-notes.md" || {
+            echo "::error::No CHANGELOG.md section found for v$VERSION"
+            exit 1
+          }
+
       - name: Upload macOS artifacts to release
         uses: softprops/action-gh-release@v3
         with:
+          body_path: ${{ runner.temp }}/release-notes.md
           files: |
             build/Build/Products/Release/Alas-*-arm64.app.zip
             build/Build/Products/Release/Alas-*-arm64.dmg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### ✨ Features
+
+- --write splices generated notes into [Unreleased].
+- render grouped release notes from conventional commits.
+- add draft-release-notes.sh skeleton with flag parsing.
+
+### 🐛 Fixes
+
+- detect and run commit-AI CLIs installed outside GUI app PATH (#123).
+- rename isDimmed to isHistorical and use warn color for dot (#121).
+
+### 📚 Docs
+
+- seed CHANGELOG.md with [Unreleased] and [0.1.1] section.
+- rewrite README in landing-page style with brew install.
+
 ## [0.1.1] - 2026-05-15
 
 ### 🏗️ Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to alas are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - 2026-05-15
+
+### 🏗️ Internal
+- Detect new Alas cask file in release workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### ✨ Features
 
+- --target with --write promotes [Unreleased] to versioned section.
 - --write splices generated notes into [Unreleased].
 - render grouped release notes from conventional commits.
 - add draft-release-notes.sh skeleton with flag parsing.
@@ -19,6 +20,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### 📚 Docs
 
+- add RELEASING.md covering the changelog + tag flow.
 - seed CHANGELOG.md with [Unreleased] and [0.1.1] section.
 - rewrite README in landing-page style with brew install.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### 🐛 Fixes
 
+- preserve curated changelog notes during release promotion.
 - detect and run commit-AI CLIs installed outside GUI app PATH (#123).
 - rename isDimmed to isHistorical and use warn color for dot (#121).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,11 +12,11 @@ This doc covers the human side: cutting `CHANGELOG.md` and bumping the version.
 # 1. Draft entries from commits since the last v* tag.
 ./scripts/draft-release-notes.sh --write
 
-# 2. Promote the draft notes into the new version section.
-./scripts/draft-release-notes.sh --target 0.1.2 --write
-
-# 3. Open CHANGELOG.md and polish the new [0.1.2] section.
+# 2. Open CHANGELOG.md and polish the [Unreleased] section.
 $EDITOR CHANGELOG.md
+
+# 3. Promote the curated notes into the new version section.
+./scripts/draft-release-notes.sh --target 0.1.2 --write
 
 # 4. Bump the version in project.yml, regenerate Xcode project.
 $EDITOR project.yml   # bump CFBundleShortVersionString + CFBundleVersion
@@ -36,7 +36,7 @@ workflow hard-fails — fix and re-tag.
 
 ## Draft script flags
 
-- `--since <ref>` — override the base ref (default: latest `v*` tag).
+- `--since <ref>` — override the base ref (default: latest reachable `v*` tag).
 - `--target <version>` — render under a versioned heading instead of `[Unreleased]`.
 - `--write` — splice into `CHANGELOG.md` rather than printing.
 - `--include-internal` — include `ci`/`test`/`build`/`style` commits under

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,55 @@
+# Releasing alas
+
+Alas releases ship a signed + notarized macOS DMG, an `Alas-X.Y.Z-arm64.app.zip`,
+and a Homebrew cask bump in `mrmans0n/homebrew-tap`. All of that runs from
+`.github/workflows/release.yml` on tag push.
+
+This doc covers the human side: cutting `CHANGELOG.md` and bumping the version.
+
+## Cutting a release
+
+```bash
+# 1. Draft entries from commits since the last v* tag.
+./scripts/draft-release-notes.sh --write
+
+# 2. Promote the draft notes into the new version section.
+./scripts/draft-release-notes.sh --target 0.1.2 --write
+
+# 3. Open CHANGELOG.md and polish the new [0.1.2] section.
+$EDITOR CHANGELOG.md
+
+# 4. Bump the version in project.yml, regenerate Xcode project.
+$EDITOR project.yml   # bump CFBundleShortVersionString + CFBundleVersion
+xcodegen
+
+# 5. Commit and tag.
+git add CHANGELOG.md project.yml Alas.xcodeproj
+git commit -m "Bump version to 0.1.2"
+git tag v0.1.2
+git push origin main v0.1.2
+```
+
+The `Release Artifacts` workflow will pick up `v0.1.2`, build/sign/notarize
+the app, extract the `[0.1.2]` section from `CHANGELOG.md`, and publish a
+GitHub Release with that body. If `CHANGELOG.md` has no matching section the
+workflow hard-fails — fix and re-tag.
+
+## Draft script flags
+
+- `--since <ref>` — override the base ref (default: latest `v*` tag).
+- `--target <version>` — render under a versioned heading instead of `[Unreleased]`.
+- `--write` — splice into `CHANGELOG.md` rather than printing.
+- `--include-internal` — include `ci`/`test`/`build`/`style` commits under
+  `🏗️ Internal` (default skips them).
+
+## Conventional commit prefixes
+
+| Prefix | Where it lands |
+|---|---|
+| `feat:` | ✨ Features |
+| `fix:` | 🐛 Fixes |
+| `refactor:`, `perf:`, `chore:` | 🏗️ Internal |
+| `docs:` | 📚 Docs |
+| `ci:`, `test:`, `build:`, `style:` | dropped unless `--include-internal` |
+
+PR titles follow the same convention since the repo uses squash merges.

--- a/scripts/draft-release-notes.sh
+++ b/scripts/draft-release-notes.sh
@@ -18,7 +18,7 @@ while [[ $# -gt 0 ]]; do
     --write)             WRITE=1;     shift ;;
     --include-internal)  INCLUDE_INTERNAL=1; shift ;;
     -h|--help)
-      sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,6p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)
@@ -48,10 +48,39 @@ preflight_promote_to_target() {
     exit 1
   }
 
-  if grep -qF "## [$target]" "$file"; then
+  if has_target_section "$target" "$file"; then
     echo "CHANGELOG.md already has a [$target] section." >&2
     exit 1
   fi
+}
+
+has_target_section() {
+  local target="$1"
+  local file="$2"
+  local line
+  while IFS= read -r line; do
+    case "$line" in
+      "## [$target]"*) return 0 ;;
+    esac
+  done < "$file"
+  return 1
+}
+
+current_unreleased_body() {
+  local file="CHANGELOG.md"
+  awk '
+    /^## \[Unreleased\]$/ { in_unr = 1; next }
+    in_unr && /^## \[/ { exit }
+    in_unr { print }
+  ' "$file" | awk '
+    NF { seen = 1 }
+    seen { lines = lines $0 ORS }
+    END { printf "%s", lines }
+  '
+}
+
+has_non_whitespace() {
+  awk 'NF { found = 1; exit } END { exit found ? 0 : 1 }'
 }
 
 if [[ "$WRITE" == 1 && -z "$TARGET" ]]; then
@@ -66,13 +95,60 @@ find_base_ref() {
     return
   fi
   local tag
-  tag=$(git tag --list 'v*' --sort=-v:refname | head -n1 || true)
+  tag=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)
   if [[ -n "$tag" ]]; then
     echo "$tag"
     return
   fi
   git rev-list --max-parents=0 HEAD | head -n1
 }
+
+if [[ "$WRITE" == 1 && -n "$TARGET" ]]; then
+  body=$(current_unreleased_body)
+  if ! printf '%s\n' "$body" | has_non_whitespace; then
+    echo "No release-note-worthy commits to promote into [$TARGET]; refusing." >&2
+    exit 1
+  fi
+
+  promote_to_target() {
+    local target="$1"
+    local release_body="$2"
+    local file="CHANGELOG.md"
+    local today
+    today=$(date +%Y-%m-%d)
+
+    local tmp
+    tmp=$(mktemp)
+    target="$target" today="$today" release_body="$release_body" awk '
+      BEGIN {
+        in_unr = 0
+        target = ENVIRON["target"]
+        today = ENVIRON["today"]
+        release_body = ENVIRON["release_body"]
+      }
+      /^## \[Unreleased\]$/ {
+        print "## [Unreleased]"
+        print ""
+        print "## [" target "] - " today
+        print ""
+        print release_body
+        print ""
+        in_unr = 1
+        next
+      }
+      in_unr && /^## \[/ { in_unr = 0 }
+      in_unr { next }
+      { print }
+    ' "$file" > "$tmp"
+
+    awk 'BEGIN{b=0} /^$/{b++; if(b<=1) print; next} {b=0; print}' "$tmp" > "$file"
+    rm -f "$tmp"
+  }
+
+  promote_to_target "$TARGET" "$body"
+  echo "Promoted [Unreleased] to [$TARGET] in CHANGELOG.md." >&2
+  exit 0
+fi
 
 BASE=$(find_base_ref)
 
@@ -211,58 +287,6 @@ write_unreleased() {
   rm -f "$tmp"
 }
 
-promote_to_target() {
-  local target="$1"
-  local new_body="$2"
-  local file="CHANGELOG.md"
-  local today
-  today=$(date +%Y-%m-%d)
-
-  test -f "$file" || { echo "$file not found" >&2; exit 1; }
-
-  grep -qE '^## \[Unreleased\]$' "$file" || {
-    echo "No '## [Unreleased]' heading in $file." >&2
-    exit 1
-  }
-
-  if grep -qF "## [$target]" "$file"; then
-    echo "CHANGELOG.md already has a [$target] section." >&2
-    exit 1
-  fi
-
-  if [[ -z "$new_body" ]]; then
-    echo "No release-note-worthy commits to promote into [$target]; refusing." >&2
-    exit 1
-  fi
-
-  local tmp
-  tmp=$(mktemp)
-  target="$target" today="$today" new_body="$new_body" awk '
-    BEGIN {
-      in_unr = 0
-      target = ENVIRON["target"]
-      today = ENVIRON["today"]
-      new_body = ENVIRON["new_body"]
-    }
-    /^## \[Unreleased\]$/ {
-      print "## [Unreleased]"
-      print ""
-      print "## [" target "] - " today
-      print ""
-      print new_body
-      print ""
-      in_unr = 1
-      next
-    }
-    in_unr && /^## \[/ { in_unr = 0 }
-    in_unr { next }
-    { print }
-  ' "$file" > "$tmp"
-
-  awk 'BEGIN{b=0} /^$/{b++; if(b<=1) print; next} {b=0; print}' "$tmp" > "$file"
-  rm -f "$tmp"
-}
-
 emit_for_unreleased() {
   # Body without a heading (heading stays in CHANGELOG.md).
   echo "$body"
@@ -275,12 +299,7 @@ emit_for_target() {
 }
 
 if [[ -n "$TARGET" ]]; then
-  if [[ "$WRITE" == 1 ]]; then
-    promote_to_target "$TARGET" "$body"
-    echo "Promoted [Unreleased] to [$TARGET] in CHANGELOG.md." >&2
-  else
-    emit_for_target
-  fi
+  emit_for_target
 elif [[ "$WRITE" == 1 ]]; then
   write_unreleased "$body"
   echo "Updated [Unreleased] body in CHANGELOG.md." >&2

--- a/scripts/draft-release-notes.sh
+++ b/scripts/draft-release-notes.sh
@@ -28,6 +28,25 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ "$WRITE" == 1 && -n "$TARGET" ]]; then
+  echo "--target with --write is implemented in the next task." >&2
+  exit 2
+fi
+
+preflight_write_unreleased() {
+  local file="CHANGELOG.md"
+  test -f "$file" || { echo "$file not found" >&2; exit 1; }
+
+  grep -qE '^## \[Unreleased\]$' "$file" || {
+    echo "No '## [Unreleased]' heading in $file." >&2
+    exit 1
+  }
+}
+
+if [[ "$WRITE" == 1 && -z "$TARGET" ]]; then
+  preflight_write_unreleased
+fi
+
 find_base_ref() {
   if [[ -n "$SINCE" ]]; then
     echo "$SINCE"
@@ -143,11 +162,60 @@ if [[ -z "$body" ]]; then
   exit 0
 fi
 
-# stdout path (write path comes in later tasks)
-if [[ -n "$TARGET" ]]; then
+write_unreleased() {
+  local new_body="$1"
+  local file="CHANGELOG.md"
+  test -f "$file" || { echo "$file not found" >&2; exit 1; }
+
+  # Verify [Unreleased] heading exists.
+  grep -qE '^## \[Unreleased\]$' "$file" || {
+    echo "No '## [Unreleased]' heading in $file." >&2
+    exit 1
+  }
+
+  local tmp
+  tmp=$(mktemp)
+  new_body="$new_body" awk '
+    BEGIN { in_unr = 0; printed_body = 0; new_body = ENVIRON["new_body"] }
+    /^## \[Unreleased\]$/ {
+      print
+      print ""
+      if (length(new_body) > 0) {
+        print new_body
+        print ""
+      }
+      in_unr = 1
+      printed_body = 1
+      next
+    }
+    in_unr && /^## \[/ { in_unr = 0 }
+    in_unr { next }   # drop existing Unreleased body
+    { print }
+  ' "$file" > "$tmp"
+
+  # Collapse any run of >2 blank lines that the splice may have left behind.
+  awk 'BEGIN{b=0} /^$/{b++; if(b<=1) print; next} {b=0; print}' "$tmp" > "$file"
+  rm -f "$tmp"
+}
+
+emit_for_unreleased() {
+  # Body without a heading (heading stays in CHANGELOG.md).
+  echo "$body"
+}
+
+emit_for_target() {
   echo "## [$TARGET] - $(date +%Y-%m-%d)"
+  echo
+  echo "$body"
+}
+
+if [[ -n "$TARGET" ]]; then
+  emit_for_target
+elif [[ "$WRITE" == 1 ]]; then
+  write_unreleased "$body"
+  echo "Updated [Unreleased] body in CHANGELOG.md." >&2
 else
   echo "## [Unreleased]"
+  echo
+  echo "$body"
 fi
-echo
-echo "$body"

--- a/scripts/draft-release-notes.sh
+++ b/scripts/draft-release-notes.sh
@@ -44,4 +44,110 @@ find_base_ref() {
 
 BASE=$(find_base_ref)
 
-echo "base=$BASE target=${TARGET:-<unreleased>} write=$WRITE include_internal=$INCLUDE_INTERNAL" >&2
+# Conventional Commit type -> group label.
+# Types not in this map are dropped.
+group_for_type() {
+  case "$1" in
+    feat)                            echo "✨ Features" ;;
+    fix)                             echo "🐛 Fixes" ;;
+    refactor|perf|chore)             echo "🏗️ Internal" ;;
+    docs)                            echo "📚 Docs" ;;
+    ci|test|build|style)
+      if [[ "$INCLUDE_INTERNAL" == 1 ]]; then
+        echo "🏗️ Internal"
+      else
+        echo ""
+      fi
+      ;;
+    *) echo "" ;;
+  esac
+}
+
+# Ordered list so output is deterministic.
+GROUP_ORDER=("✨ Features" "🐛 Fixes" "🏗️ Internal" "📚 Docs")
+
+# Per-group bullet accumulators.
+FEATURES_BUCKET=""
+FIXES_BUCKET=""
+INTERNAL_BUCKET=""
+DOCS_BUCKET=""
+
+append_to_group() {
+  local group="$1"
+  local bullet="$2"
+
+  case "$group" in
+    "✨ Features") FEATURES_BUCKET+="$bullet"$'\n' ;;
+    "🐛 Fixes") FIXES_BUCKET+="$bullet"$'\n' ;;
+    "🏗️ Internal") INTERNAL_BUCKET+="$bullet"$'\n' ;;
+    "📚 Docs") DOCS_BUCKET+="$bullet"$'\n' ;;
+  esac
+}
+
+# Subject regex: type(scope)?!?: rest
+# Examples matched:
+#   feat: x
+#   fix(ui): y
+#   refactor!: z
+#   feat(core)!: w
+SUBJECT_RE='^([a-z]+)(\([^)]+\))?!?:[[:space:]]+(.+)$'
+
+subjects=$(git log --pretty=%s --no-merges "$BASE"..HEAD)
+
+while IFS= read -r subject; do
+  [[ -z "$subject" ]] && continue
+  if [[ "$subject" =~ $SUBJECT_RE ]]; then
+    type="${BASH_REMATCH[1]}"
+    rest="${BASH_REMATCH[3]}"
+  else
+    echo "skip (not conventional): $subject" >&2
+    continue
+  fi
+
+  group=$(group_for_type "$type")
+  if [[ -z "$group" ]]; then
+    continue
+  fi
+
+  # Trim, append period if missing.
+  rest="${rest%"${rest##*[![:space:]]}"}"
+  [[ "$rest" != *[.!?] ]] && rest="$rest."
+
+  append_to_group "$group" "- $rest"
+done <<< "$subjects"
+
+render_body() {
+  local emitted=0
+  for group in "${GROUP_ORDER[@]}"; do
+    local bullets
+    case "$group" in
+      "✨ Features") bullets="$FEATURES_BUCKET" ;;
+      "🐛 Fixes") bullets="$FIXES_BUCKET" ;;
+      "🏗️ Internal") bullets="$INTERNAL_BUCKET" ;;
+      "📚 Docs") bullets="$DOCS_BUCKET" ;;
+    esac
+    if [[ -n "$bullets" ]]; then
+      [[ $emitted -gt 0 ]] && echo
+      echo "### $group"
+      echo
+      printf '%s' "$bullets"
+      emitted=1
+    fi
+  done
+}
+
+body=$(render_body)
+
+if [[ -z "$body" ]]; then
+  echo "No release-note-worthy commits since $BASE." >&2
+  exit 0
+fi
+
+# stdout path (write path comes in later tasks)
+if [[ -n "$TARGET" ]]; then
+  echo "## [$TARGET] - $(date +%Y-%m-%d)"
+else
+  echo "## [Unreleased]"
+fi
+echo
+echo "$body"

--- a/scripts/draft-release-notes.sh
+++ b/scripts/draft-release-notes.sh
@@ -28,11 +28,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ "$WRITE" == 1 && -n "$TARGET" ]]; then
-  echo "--target with --write is implemented in the next task." >&2
-  exit 2
-fi
-
 preflight_write_unreleased() {
   local file="CHANGELOG.md"
   test -f "$file" || { echo "$file not found" >&2; exit 1; }
@@ -43,8 +38,26 @@ preflight_write_unreleased() {
   }
 }
 
+preflight_promote_to_target() {
+  local target="$1"
+  local file="CHANGELOG.md"
+  test -f "$file" || { echo "$file not found" >&2; exit 1; }
+
+  grep -qE '^## \[Unreleased\]$' "$file" || {
+    echo "No '## [Unreleased]' heading in $file." >&2
+    exit 1
+  }
+
+  if grep -qF "## [$target]" "$file"; then
+    echo "CHANGELOG.md already has a [$target] section." >&2
+    exit 1
+  fi
+}
+
 if [[ "$WRITE" == 1 && -z "$TARGET" ]]; then
   preflight_write_unreleased
+elif [[ "$WRITE" == 1 && -n "$TARGET" ]]; then
+  preflight_promote_to_target "$TARGET"
 fi
 
 find_base_ref() {
@@ -157,7 +170,7 @@ render_body() {
 
 body=$(render_body)
 
-if [[ -z "$body" ]]; then
+if [[ -z "$body" && ! ( "$WRITE" == 1 && -n "$TARGET" ) ]]; then
   echo "No release-note-worthy commits since $BASE." >&2
   exit 0
 fi
@@ -198,6 +211,58 @@ write_unreleased() {
   rm -f "$tmp"
 }
 
+promote_to_target() {
+  local target="$1"
+  local new_body="$2"
+  local file="CHANGELOG.md"
+  local today
+  today=$(date +%Y-%m-%d)
+
+  test -f "$file" || { echo "$file not found" >&2; exit 1; }
+
+  grep -qE '^## \[Unreleased\]$' "$file" || {
+    echo "No '## [Unreleased]' heading in $file." >&2
+    exit 1
+  }
+
+  if grep -qF "## [$target]" "$file"; then
+    echo "CHANGELOG.md already has a [$target] section." >&2
+    exit 1
+  fi
+
+  if [[ -z "$new_body" ]]; then
+    echo "No release-note-worthy commits to promote into [$target]; refusing." >&2
+    exit 1
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  target="$target" today="$today" new_body="$new_body" awk '
+    BEGIN {
+      in_unr = 0
+      target = ENVIRON["target"]
+      today = ENVIRON["today"]
+      new_body = ENVIRON["new_body"]
+    }
+    /^## \[Unreleased\]$/ {
+      print "## [Unreleased]"
+      print ""
+      print "## [" target "] - " today
+      print ""
+      print new_body
+      print ""
+      in_unr = 1
+      next
+    }
+    in_unr && /^## \[/ { in_unr = 0 }
+    in_unr { next }
+    { print }
+  ' "$file" > "$tmp"
+
+  awk 'BEGIN{b=0} /^$/{b++; if(b<=1) print; next} {b=0; print}' "$tmp" > "$file"
+  rm -f "$tmp"
+}
+
 emit_for_unreleased() {
   # Body without a heading (heading stays in CHANGELOG.md).
   echo "$body"
@@ -210,7 +275,12 @@ emit_for_target() {
 }
 
 if [[ -n "$TARGET" ]]; then
-  emit_for_target
+  if [[ "$WRITE" == 1 ]]; then
+    promote_to_target "$TARGET" "$body"
+    echo "Promoted [Unreleased] to [$TARGET] in CHANGELOG.md." >&2
+  else
+    emit_for_target
+  fi
 elif [[ "$WRITE" == 1 ]]; then
   write_unreleased "$body"
   echo "Updated [Unreleased] body in CHANGELOG.md." >&2

--- a/scripts/draft-release-notes.sh
+++ b/scripts/draft-release-notes.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Draft release notes from Conventional Commits.
+#
+# Usage:
+#   ./scripts/draft-release-notes.sh [--since <ref>] [--target <version>]
+#                                    [--write] [--include-internal]
+set -euo pipefail
+
+SINCE=""
+TARGET=""
+WRITE=0
+INCLUDE_INTERNAL=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since)             SINCE="$2"; shift 2 ;;
+    --target)            TARGET="$2"; shift 2 ;;
+    --write)             WRITE=1;     shift ;;
+    --include-internal)  INCLUDE_INTERNAL=1; shift ;;
+    -h|--help)
+      sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+find_base_ref() {
+  if [[ -n "$SINCE" ]]; then
+    echo "$SINCE"
+    return
+  fi
+  local tag
+  tag=$(git tag --list 'v*' --sort=-v:refname | head -n1 || true)
+  if [[ -n "$tag" ]]; then
+    echo "$tag"
+    return
+  fi
+  git rev-list --max-parents=0 HEAD | head -n1
+}
+
+BASE=$(find_base_ref)
+
+echo "base=$BASE target=${TARGET:-<unreleased>} write=$WRITE include_internal=$INCLUDE_INTERNAL" >&2


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` plus `scripts/draft-release-notes.sh` for Conventional Commit release-note drafting and curated promotion.
- Document the release flow in `RELEASING.md`.
- Update the release workflow to publish GitHub Release bodies from the matching changelog section.

## Test Plan
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
- Focused smoke checks for changelog writing, target promotion, and release-note extraction.