### PR TITLE
fix(icons): pass unknown icon names through as SF Symbol names

### DIFF
--- a/Alas/Sources/Icons/Icon.swift
+++ b/Alas/Sources/Icons/Icon.swift
@@ -50,7 +50,7 @@ struct Icon: View {
         case "github":     return "circle.hexagongrid"
         case "alert":      return "exclamationmark.triangle"
         case "sparkle":    return "sparkle"
-        default:           return "questionmark"
+        default:           return name
         }
     }
 }


### PR DESCRIPTION
## Summary
- `Icon.symbol(for:)` defaulted unknown names to `questionmark`, which made views passing SF Symbol names directly (e.g. `DeleteFailedWorktreeView`'s `doc.on.doc` and `arrow.clockwise`) render as `?` glyphs.
- Default branch now returns the name as-is so any SF Symbol passes through to `Image(systemName:)`.

## Test plan
- [ ] Trigger a submodule worktree delete failure and confirm "Copy Error" and "Retry Delete" buttons render proper icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)