### PR TITLE
Add multi-cursor editing in editor panes

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDEA496740F5B0B5EE808B /* Process+Git.swift */; };
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
+		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
 		CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */; };
 		CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */; };
 		CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */; };
@@ -589,6 +590,7 @@
 		A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileTypeTests.swift; sourceTree = "<group>"; };
 		A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClient.swift; sourceTree = "<group>"; };
 		A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDirectionTests.swift; sourceTree = "<group>"; };
+		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimer.swift; sourceTree = "<group>"; };
 		A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailView.swift; sourceTree = "<group>"; };
@@ -788,6 +790,7 @@
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
 				7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */,
 				ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */,
+				A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */,
 				2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */,
 				9DCC5576ACD7C49EB6915992 /* CommitComposerStateTests.swift */,
 				79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */,
@@ -1877,6 +1880,7 @@
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,
 				1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */,
 				CF12433D8F30CEA05088FFB0 /* CodeTextViewIndentationTests.swift in Sources */,
+				C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */,
 				6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */,
 				C02EB84F4343BD78984791EB /* CommitComposerStateTests.swift in Sources */,
 				21D97FBF7356BC50400E0265 /* CommitContextBuilderTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -61,6 +61,12 @@ struct AlasApp: App {
                 }
                 .keyboardShortcut("p", modifiers: .command)
                 Divider()
+                Button("Split Selection into Lines") {
+                    NSApp.sendAction(#selector(CodeTextView.splitSelectionIntoLines(_:)), to: nil, from: nil)
+                }
+                .keyboardShortcut("l", modifiers: [.command, .shift])
+                .disabled(!state.hasActiveCodeEditorTab)
+                Divider()
                 Button("Find and Replace") {
                     NotificationCenter.default.post(name: .alasShowFindReplace, object: nil)
                 }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -384,6 +384,7 @@ final class CodeEditorCoordinator {
             // because the NSUndoManager belongs to the (reused) NSTextView.
             diagnosticsFeature.reset()
             textView?.undoManager?.removeAllActions()
+            textView?.setSelectedRange(NSRange(location: 0, length: 0))
         }
         applyBaseStyle(theme: theme)
         runHighlight(theme: theme)

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -239,7 +239,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             return
         }
 
-        if hasMultipleSelections {
+        if hasMultipleSelections && replacementRange.location == NSNotFound {
             let ranges = normalizedSelectedRanges()
             var edits: [MultiCursorEdit] = []
             let character = text.count == 1 ? text.first : nil
@@ -430,18 +430,18 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             return
         }
 
+        if event.modifierFlags.contains(.command) {
+            let p = convert(event.locationInWindow, from: nil)
+            commandClickHandler?(p)
+            return
+        }
+
         // Normal click clears multi-cursor
         if hasMultipleSelections {
             super.mouseDown(with: event)
             if selectedRanges.count > 1, let first = selectedRanges.first {
                 setSelectedRanges([first], affinity: .downstream, stillSelecting: false)
             }
-            return
-        }
-
-        if event.modifierFlags.contains(.command) {
-            let p = convert(event.locationInWindow, from: nil)
-            commandClickHandler?(p)
             return
         }
         super.mouseDown(with: event)

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -31,6 +31,8 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     var decreaseFontSizeHandler: (() -> Void)?
     var resetFontSizeHandler: (() -> Void)?
 
+    private var multiCursorSelectedRanges: [NSValue]?
+
     @objc func increaseFontSize(_ sender: Any?) { increaseFontSizeHandler?() }
     @objc func decreaseFontSize(_ sender: Any?) { decreaseFontSizeHandler?() }
     @objc func resetFontSize(_ sender: Any?)    { resetFontSizeHandler?() }
@@ -54,17 +56,213 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     required init?(coder: NSCoder) { fatalError("not used") }
 
+    // MARK: - Multi-cursor editing
+
+    override var selectedRanges: [NSValue] {
+        get { multiCursorSelectedRanges ?? super.selectedRanges }
+        set { setSelectedRanges(newValue, affinity: .downstream, stillSelecting: false) }
+    }
+
+    override func setSelectedRange(_ charRange: NSRange) {
+        multiCursorSelectedRanges = nil
+        super.setSelectedRange(charRange)
+    }
+
+    override func setSelectedRanges(_ ranges: [NSValue], affinity: NSSelectionAffinity, stillSelecting stillSelectingFlag: Bool) {
+        let normalized = normalizedRanges(from: ranges)
+        guard normalized.count > 1 else {
+            multiCursorSelectedRanges = nil
+            super.setSelectedRanges(normalized.map { NSValue(range: $0) }, affinity: affinity, stillSelecting: stillSelectingFlag)
+            return
+        }
+
+        super.setSelectedRange(normalized[0])
+        multiCursorSelectedRanges = normalized.map { NSValue(range: $0) }
+    }
+
+    @objc func splitSelectionIntoLines(_ sender: Any?) {
+        guard isEditable else { return }
+        splitSelectionIntoLineCursors()
+    }
+
+    private var hasMultipleSelections: Bool {
+        selectedRanges.count > 1
+    }
+
+    private struct MultiCursorEdit {
+        let originalRange: NSRange
+        let replacement: String
+        let resultingSelection: NSRange
+    }
+
+    private func normalizedRanges(from values: [NSValue]) -> [NSRange] {
+        let nsLength = (string as NSString).length
+        let ranges = values.map { $0.rangeValue }
+        let valid = ranges.filter { $0.location != NSNotFound && NSMaxRange($0) <= nsLength }
+        let sorted = valid.sorted {
+            $0.location < $1.location || ($0.location == $1.location && $0.length < $1.length)
+        }
+        var result: [NSRange] = []
+        for range in sorted {
+            if let last = result.last, NSMaxRange(last) >= range.location {
+                let merged = NSRange(
+                    location: last.location,
+                    length: max(NSMaxRange(last), NSMaxRange(range)) - last.location
+                )
+                result[result.count - 1] = merged
+            } else {
+                result.append(range)
+            }
+        }
+        return result
+    }
+
+    private func normalizedSelectedRanges() -> [NSRange] {
+        normalizedRanges(from: selectedRanges)
+    }
+
+    private func setNormalizedSelectedRanges(_ ranges: [NSRange]) {
+        let values = ranges.map { NSValue(range: $0) }
+        setSelectedRanges(values, affinity: .downstream, stillSelecting: false)
+    }
+
+    func appendCursor(at location: Int) {
+        var ranges = selectedRanges
+        ranges.append(NSValue(range: NSRange(location: location, length: 0)))
+        setSelectedRanges(ranges, affinity: .downstream, stillSelecting: false)
+    }
+
+    func appendSelection(_ range: NSRange) {
+        var ranges = selectedRanges
+        ranges.append(NSValue(range: range))
+        setSelectedRanges(ranges, affinity: .downstream, stillSelecting: false)
+    }
+
+    private func splitSelectionIntoLineCursors() {
+        let current = selectedRange()
+        guard current.length > 0 else { return }
+
+        let ns = string as NSString
+        var ranges: [NSRange] = []
+        var lineStart = current.location
+        let end = NSMaxRange(current)
+
+        while lineStart < end {
+            let lineRange = ns.lineRange(for: NSRange(location: lineStart, length: 0))
+            let effectiveStart = max(lineRange.location, current.location)
+            var effectiveEnd = min(NSMaxRange(lineRange), end)
+            while effectiveEnd > effectiveStart {
+                let trailing = ns.substring(with: NSRange(location: effectiveEnd - 1, length: 1))
+                guard trailing == "\n" || trailing == "\r" else { break }
+                effectiveEnd -= 1
+            }
+            let length = effectiveEnd - effectiveStart
+            ranges.append(NSRange(location: effectiveStart, length: length))
+            lineStart = NSMaxRange(lineRange)
+        }
+
+        if ranges.isEmpty {
+            ranges.append(NSRange(location: current.location, length: 0))
+        }
+
+        setNormalizedSelectedRanges(ranges)
+    }
+
+    private func applyMultiCursorEdits(_ edits: [MultiCursorEdit]) {
+        let sorted = edits.sorted { $0.originalRange.location < $1.originalRange.location }
+        var delta = 0
+        var finalSelections: [NSValue] = []
+
+        undoManager?.beginUndoGrouping()
+        for edit in sorted {
+            let effectiveRange = NSRange(
+                location: edit.originalRange.location + delta,
+                length: edit.originalRange.length
+            )
+            super.insertText(edit.replacement, replacementRange: effectiveRange)
+            let finalSelection = NSRange(
+                location: edit.resultingSelection.location + delta,
+                length: edit.resultingSelection.length
+            )
+            finalSelections.append(NSValue(range: finalSelection))
+            delta += (edit.replacement as NSString).length - edit.originalRange.length
+        }
+        undoManager?.endUndoGrouping()
+        setSelectedRanges(finalSelections, affinity: .downstream, stillSelecting: false)
+    }
+
+    private func editForCharacter(_ character: Character, at range: NSRange) -> MultiCursorEdit? {
+        // Closing delimiter dedent
+        if Self.closingDelimiters.contains(character),
+           indentationMode == .bracketAware,
+           let edit = IndentationHelper.closingDelimiterEdit(in: string, selectedRange: range, delimiter: character, mode: indentationMode) {
+            return MultiCursorEdit(
+                originalRange: edit.replacementRange,
+                replacement: edit.replacement,
+                resultingSelection: NSRange(location: edit.replacementRange.location + edit.selectedLocationDelta, length: 0)
+            )
+        }
+
+        // Paired delimiter
+        if let closing = Self.pairedDelimiters[character] {
+            if shouldInsertPair(opening: character, closing: closing, range: range) {
+                let current = string as NSString
+                let selectedText = range.length > 0 ? current.substring(with: range) : ""
+                let replacement = "\(character)\(selectedText)\(closing)"
+                let resultingSelection: NSRange
+                if range.length > 0 {
+                    resultingSelection = NSRange(location: range.location + 1, length: range.length)
+                } else {
+                    resultingSelection = NSRange(location: range.location + 1, length: 0)
+                }
+                return MultiCursorEdit(originalRange: range, replacement: replacement, resultingSelection: resultingSelection)
+            }
+            if character == closing, range.length == 0, nextCharacter(at: range.location) == character {
+                return MultiCursorEdit(originalRange: range, replacement: "", resultingSelection: NSRange(location: range.location + 1, length: 0))
+            }
+        }
+
+        // Closing delimiter step-over (non-paired)
+        if Self.closingDelimiters.contains(character), range.length == 0, nextCharacter(at: range.location) == character {
+            return MultiCursorEdit(originalRange: range, replacement: "", resultingSelection: NSRange(location: range.location + 1, length: 0))
+        }
+
+        return nil
+    }
+
+    // MARK: - Text insertion overrides
+
     override func insertText(_ insertString: Any, replacementRange: NSRange) {
         guard isEditable else { return }
+        guard let text = Self.string(from: insertString) else {
+            super.insertText(insertString, replacementRange: replacementRange)
+            return
+        }
+
+        if hasMultipleSelections {
+            let ranges = normalizedSelectedRanges()
+            var edits: [MultiCursorEdit] = []
+            let character = text.count == 1 ? text.first : nil
+            for range in ranges {
+                if let character, !autoPairDisabled, let edit = editForCharacter(character, at: range) {
+                    edits.append(edit)
+                } else {
+                    edits.append(MultiCursorEdit(
+                        originalRange: range,
+                        replacement: text,
+                        resultingSelection: NSRange(location: range.location + (text as NSString).length, length: 0)
+                    ))
+                }
+            }
+            applyMultiCursorEdits(edits)
+            return
+        }
+
         if autoPairDisabled {
             super.insertText(insertString, replacementRange: replacementRange)
             return
         }
-        guard
-            let text = Self.string(from: insertString),
-            text.count == 1,
-            let character = text.first
-        else {
+        guard text.count == 1, let character = text.first else {
             super.insertText(insertString, replacementRange: replacementRange)
             return
         }
@@ -108,6 +306,62 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             super.insertNewline(sender)
             return
         }
+
+        if !hasMultipleSelections {
+            insertNewlineSingleCursor(sender)
+            return
+        }
+
+        let ranges = normalizedSelectedRanges()
+
+        // If any range has non-zero length, let AppKit handle it natively
+        if ranges.contains(where: { $0.length > 0 }) {
+            super.insertNewline(sender)
+            return
+        }
+
+        // If cursors share a line, fall back to native to avoid conflicting edits
+        if cursorsShareLine(ranges, in: string) {
+            super.insertNewline(sender)
+            return
+        }
+
+        var edits: [MultiCursorEdit] = []
+        for range in ranges {
+            if let edit = IndentationHelper.newlineEdit(in: string, selectedRange: range, mode: indentationMode) {
+                edits.append(MultiCursorEdit(
+                    originalRange: range,
+                    replacement: edit.replacement,
+                    resultingSelection: NSRange(location: range.location + edit.selectedLocationDelta, length: 0)
+                ))
+            } else {
+                edits.append(MultiCursorEdit(
+                    originalRange: range,
+                    replacement: "\n",
+                    resultingSelection: NSRange(location: range.location + 1, length: 0)
+                ))
+            }
+        }
+
+        applyMultiCursorEdits(edits)
+    }
+
+    private func indexAtPoint(_ point: NSPoint) -> Int {
+        guard let lm = self.layoutManager,
+              let container = self.textContainer else { return NSNotFound }
+        let containerPoint = NSPoint(
+            x: point.x - textContainerInset.width,
+            y: point.y - textContainerInset.height
+        )
+        var fraction: CGFloat = 0
+        return lm.characterIndex(
+            for: containerPoint,
+            in: container,
+            fractionOfDistanceBetweenInsertionPoints: &fraction
+        )
+    }
+
+    private func insertNewlineSingleCursor(_ sender: Any?) {
         let range = selectedRange()
         if range.length > 0 {
             super.insertNewline(sender)
@@ -121,6 +375,20 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         }
     }
 
+    private func cursorsShareLine(_ ranges: [NSRange], in text: String) -> Bool {
+        let nsString = text as NSString
+        var lines = Set<Int>()
+        for range in ranges {
+            let lineRange = nsString.lineRange(for: NSRange(location: range.location, length: 0))
+            if !lines.insert(lineRange.location).inserted {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Mouse / gesture handling
+
     override func mouseMoved(with event: NSEvent) {
         super.mouseMoved(with: event)
         let p = convert(event.locationInWindow, from: nil)
@@ -128,6 +396,49 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     }
 
     override func mouseDown(with event: NSEvent) {
+        let isOption = event.modifierFlags.contains(.option)
+        let isShift = event.modifierFlags.contains(.shift)
+
+        if isOption, !isShift {
+            let p = convert(event.locationInWindow, from: nil)
+            let charIndex = indexAtPoint(p)
+            if charIndex != NSNotFound {
+                appendCursor(at: charIndex)
+            }
+            return
+        }
+
+        if isOption, isShift {
+            let p = convert(event.locationInWindow, from: nil)
+            let charIndex = indexAtPoint(p)
+            if charIndex != NSNotFound {
+                let current = normalizedSelectedRanges()
+                if let anchor = current.last {
+                    let newRange: NSRange
+                    if charIndex >= anchor.location {
+                        newRange = NSRange(location: anchor.location, length: charIndex - anchor.location)
+                    } else {
+                        newRange = NSRange(location: charIndex, length: anchor.location - charIndex)
+                    }
+                    var updated = current
+                    updated[updated.count - 1] = newRange
+                    setNormalizedSelectedRanges(updated)
+                } else {
+                    appendCursor(at: charIndex)
+                }
+            }
+            return
+        }
+
+        // Normal click clears multi-cursor
+        if hasMultipleSelections {
+            super.mouseDown(with: event)
+            if selectedRanges.count > 1, let first = selectedRanges.first {
+                setSelectedRanges([first], affinity: .downstream, stillSelecting: false)
+            }
+            return
+        }
+
         if event.modifierFlags.contains(.command) {
             let p = convert(event.locationInWindow, from: nil)
             commandClickHandler?(p)
@@ -156,6 +467,8 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         )
         addTrackingArea(area)
     }
+
+    // MARK: - Private helpers
 
     private static func string(from insertString: Any) -> String? {
         if let string = insertString as? String { return string }

--- a/AlasTests/CodeTextViewMultiCursorTests.swift
+++ b/AlasTests/CodeTextViewMultiCursorTests.swift
@@ -203,5 +203,4 @@ struct CodeTextViewMultiCursorTests {
 
         #expect(textView.selectedRanges.count == 1)
     }
-
 }

--- a/AlasTests/CodeTextViewMultiCursorTests.swift
+++ b/AlasTests/CodeTextViewMultiCursorTests.swift
@@ -1,0 +1,207 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct CodeTextViewMultiCursorTests {
+    private func makeTextView(_ text: String = "") -> CodeTextView {
+        let storage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        return textView
+    }
+
+    // MARK: - Cursor creation
+
+    @Test func appendCursorAddsToSelectedRanges() {
+        let textView = makeTextView("hello world")
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        textView.appendCursor(at: 6)
+        #expect(textView.selectedRanges.count == 2)
+    }
+
+    @Test func appendSelectionAddsRange() {
+        let textView = makeTextView("hello world")
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        textView.appendSelection(NSRange(location: 6, length: 5))
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+        #expect(ranges.contains(NSRange(location: 6, length: 5)))
+    }
+
+    // MARK: - Typing with multiple cursors
+
+    @Test func typingInsertsAtAllCursors() {
+        let textView = makeTextView("ab")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 1, length: 0)),
+            NSValue(range: NSRange(location: 2, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+
+        textView.insertText("X", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "aXbX")
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+    }
+
+    @Test func typingWithMultipleSelectionsReplacesEach() {
+        let textView = makeTextView("hello world")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 5)),
+            NSValue(range: NSRange(location: 6, length: 5))
+        ], affinity: .downstream, stillSelecting: false)
+
+        textView.insertText("X", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "X X")
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+    }
+
+    // MARK: - Auto-pair with multi-cursor
+
+    @Test func autoPairInsertsAtAllCursors() {
+        let textView = makeTextView("ab")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 1, length: 0)),
+            NSValue(range: NSRange(location: 2, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+
+        textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "a()b()")
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+    }
+
+    @Test func autoPairWrapsSelections() {
+        let textView = makeTextView("ab cd")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 2)),
+            NSValue(range: NSRange(location: 3, length: 2))
+        ], affinity: .downstream, stillSelecting: false)
+
+        textView.insertText("\"", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "\"ab\" \"cd\"")
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+        let first = ranges.first(where: { $0.location == 1 })!
+        #expect(first.length == 2)
+        let second = ranges.first(where: { $0.location == 6 })!
+        #expect(second.length == 2)
+    }
+
+    @Test func closingDelimiterStepsOverAllCursors() {
+        let textView = makeTextView("()()")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 1, length: 0)),
+            NSValue(range: NSRange(location: 3, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+
+        textView.insertText(")", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "()()")
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+        #expect(ranges.contains(NSRange(location: 2, length: 0)))
+        #expect(ranges.contains(NSRange(location: 4, length: 0)))
+    }
+
+    // MARK: - Offset correctness
+
+    @Test func earlierEditsShiftLaterCursors() {
+        let textView = makeTextView("ab")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 0)),
+            NSValue(range: NSRange(location: 1, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+
+        textView.insertText("X", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "XaXb")
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+        #expect(ranges.contains(NSRange(location: 1, length: 0)))
+        #expect(ranges.contains(NSRange(location: 3, length: 0)))
+    }
+
+    // MARK: - Smart newline with multiple cursors
+
+    @Test func multiCursorNewlinePreservesIndent() {
+        let textView = makeTextView("    a\n    b")
+        textView.indentationMode = .bracketAware
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 5, length: 0)),
+            NSValue(range: NSRange(location: 11, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+
+        textView.insertNewline(nil)
+
+        #expect(textView.string == "    a\n    \n    b\n    ")
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+    }
+
+    @Test func multiCursorNewlineReplacesNonEmptyRanges() {
+        let textView = makeTextView("hello world")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 5)),
+            NSValue(range: NSRange(location: 6, length: 5))
+        ], affinity: .downstream, stillSelecting: false)
+
+        textView.insertNewline(nil)
+
+        #expect(textView.string == "\n \n")
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+    }
+
+    // MARK: - Split selection into lines
+
+    @Test func splitSelectionIntoLinesCreatesPerLineCursors() {
+        let textView = makeTextView("a\nb\nc")
+        textView.setSelectedRange(NSRange(location: 0, length: 5))
+
+        textView.splitSelectionIntoLines(nil)
+
+        let ranges = textView.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 3)
+        #expect(ranges[0] == NSRange(location: 0, length: 1))
+        #expect(ranges[1] == NSRange(location: 2, length: 1))
+        #expect(ranges[2] == NSRange(location: 4, length: 1))
+    }
+
+    // MARK: - Plain click clears multi-cursor
+
+    @Test func plainClickCollapsesToSingleSelection() {
+        let textView = makeTextView("hello world")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 0)),
+            NSValue(range: NSRange(location: 6, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+
+        // Simulate a plain mouse-down by calling mouseDown with no modifiers
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 50, y: 50),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1.0
+        )!
+        textView.mouseDown(with: event)
+
+        #expect(textView.selectedRanges.count == 1)
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add multi-cursor selection storage and edit propagation in `CodeTextView`
- Support adding cursors/selections, split-selection-into-lines, multi-cursor typing/newlines, and auto-pair behavior
- Add focused multi-cursor editor tests

## Validation
- `xcodebuild test -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CodeTextViewMultiCursorTests`
- `xcodebuild build -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS'`

Mission Control: #841
GitHub issue: #131