### PR TITLE
fix: render search line numbers without locale grouping

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		599A6D9A3A1CCF1F618146C8 /* LegacyHookSweepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
 		59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */; };
+		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
 		5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */; };
 		5D2A45DB652AD797E2276A7A /* AgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7544FD20BC61E587CAFAC099 /* AgentRegistry.swift */; };
 		5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C486F9097A2B145D101E2C /* AlasButton.swift */; };
@@ -576,6 +577,7 @@
 		9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfoTests.swift; sourceTree = "<group>"; };
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
+		97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroupViewTests.swift; sourceTree = "<group>"; };
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
 		97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshotTests.swift; sourceTree = "<group>"; };
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
@@ -801,6 +803,7 @@
 				576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */,
 				8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */,
 				A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */,
+				97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */,
 				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
 				BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */,
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
@@ -1891,6 +1894,7 @@
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,
 				17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */,
 				4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */,
+				5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				42D8417781E790CA6AA49F7E /* CursorInstallerTests.swift in Sources */,
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,

--- a/Alas/Sources/Search/Views/ContentResultGroup.swift
+++ b/Alas/Sources/Search/Views/ContentResultGroup.swift
@@ -57,10 +57,12 @@ struct ContentResultGroupView: View {
 
     private func hitRow(hit: ContentSearchHit, absIndex: Int, isSelected: Bool) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
-            Text("\(hit.line)")
+            Text(verbatim: Self.lineNumberLabel(for: hit.line))
                 .font(.system(size: 10.5, design: .monospaced).monospacedDigit())
                 .foregroundColor(theme.color("fg-faint"))
-                .frame(width: 32, alignment: .trailing)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 32, alignment: .trailing)
             snippet(for: hit)
                 .font(.system(size: 11.5, design: .monospaced))
                 .foregroundColor(theme.color("fg-dim"))
@@ -83,6 +85,10 @@ struct ContentResultGroupView: View {
         .contentShape(Rectangle())
         .onHover { if $0 { onHover(absIndex) } }
         .onTapGesture { onTap(hit) }
+    }
+
+    static func lineNumberLabel(for line: Int) -> String {
+        String(line)
     }
 
     @ViewBuilder

--- a/AlasTests/ContentResultGroupViewTests.swift
+++ b/AlasTests/ContentResultGroupViewTests.swift
@@ -1,0 +1,8 @@
+import Testing
+@testable import Alas
+
+struct ContentResultGroupViewTests {
+    @Test func lineNumberLabelUsesRawDigitsWithoutGrouping() {
+        #expect(ContentResultGroupView.lineNumberLabel(for: 1_080) == "1080")
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
Use `Text(verbatim:)` plus a dedicated label helper so line numbers
like 1080 render as raw digits instead of being formatted with the
user's locale grouping separator. Allow the column to grow past 32pt
for large line numbers so the digits aren't truncated.
<!-- gg:managed:end -->