### PR TITLE
fix(agents): only enable available agents whose binary is installed

### DIFF
--- a/Alas/Sources/Agents/AgentRegistry.swift
+++ b/Alas/Sources/Agents/AgentRegistry.swift
@@ -50,11 +50,10 @@ struct AgentRegistry: Equatable {
         agents.filter { installedIds.contains($0.id) }
     }
 
-    /// Picker-eligible agents: installed AND not user-disabled. Note
-    /// that `isEnabled` is already clamped against install state in
-    /// `init`, so the explicit `installedIds.contains` check is
-    /// redundant but kept defensively.
+    /// Picker-eligible agents: installed AND not user-disabled.
+    /// `isEnabled` is clamped against install state in `init`, so a
+    /// simple `isEnabled` filter suffices.
     func enabled() -> [AgentDefinition] {
-        agents.filter { $0.isEnabled && installedIds.contains($0.id) }
+        agents.filter { $0.isEnabled }
     }
 }

--- a/Alas/Sources/Agents/AgentRegistry.swift
+++ b/Alas/Sources/Agents/AgentRegistry.swift
@@ -24,13 +24,20 @@ struct AgentRegistry: Equatable {
     ) {
         var out: [AgentDefinition] = []
         for var builtin in AgentBuiltins.catalog {
+            let prefersEnabled: Bool
             if let state = builtinState[builtin.id] {
-                builtin.isEnabled = state.isEnabled
+                prefersEnabled = state.isEnabled
                 builtin.binaryOverride = state.binaryOverride
+            } else {
+                prefersEnabled = builtin.isEnabled
             }
+            builtin.isEnabled = prefersEnabled && installedIds.contains(builtin.id)
             out.append(builtin)
         }
-        out.append(contentsOf: customs)
+        for var c in customs {
+            c.isEnabled = c.isEnabled && installedIds.contains(c.id)
+            out.append(c)
+        }
         self.agents = out
         self.installedIds = installedIds
     }
@@ -43,6 +50,10 @@ struct AgentRegistry: Equatable {
         agents.filter { installedIds.contains($0.id) }
     }
 
+    /// Picker-eligible agents: installed AND not user-disabled. Note
+    /// that `isEnabled` is already clamped against install state in
+    /// `init`, so the explicit `installedIds.contains` check is
+    /// redundant but kept defensively.
     func enabled() -> [AgentDefinition] {
         agents.filter { $0.isEnabled && installedIds.contains($0.id) }
     }

--- a/Alas/Sources/Settings/AgentEditView.swift
+++ b/Alas/Sources/Settings/AgentEditView.swift
@@ -29,13 +29,25 @@ struct AgentEditView: View {
                 builtinLogoAssetName: nil
             ))
         case .existing(let id):
-            let agent = state.agentRegistry.agents.first(where: { $0.id == id })
-                ?? AgentBuiltins.entry(id: id)
-                ?? AgentDefinition(
+            // Source from config, not from `state.agentRegistry`. The registry
+            // clamps `isEnabled` against install detection, so reading the
+            // draft from there would silently persist `isEnabled = false`
+            // when the user opens a missing-binary card to fix its path.
+            let agent: AgentDefinition
+            if let custom = state.config.agents.custom.first(where: { $0.id == id }) {
+                agent = custom
+            } else if var builtin = AgentBuiltins.entry(id: id) {
+                let persisted = state.config.agents.builtinState[id]
+                builtin.isEnabled = persisted?.isEnabled ?? builtin.isEnabled
+                builtin.binaryOverride = persisted?.binaryOverride
+                agent = builtin
+            } else {
+                agent = AgentDefinition(
                     id: id, displayName: id, binary: "",
                     binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
                     isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
                 )
+            }
             _draft = State(initialValue: agent)
         }
     }

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -148,6 +148,8 @@ private struct AgentCard: View {
                         get: { agent.isEnabled },
                         set: { onToggle($0) }
                     ))
+                    .disabled(!installed)
+                    .opacity(installed ? 1 : 0.4)
                 }
                 Text(agent.resolvedBinary)
                     .font(.system(size: 11, design: .monospaced))

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -61,13 +61,10 @@ struct ChangesPane: View {
 
     private var menuItems: [MenuItem] {
         var items: [MenuItem] = []
-        // Show every enabled agent (installed or not). Disabled agents are
-        // hidden — they're managed from Settings → Agents. Append
-        // "(not installed)" to the label when the binary isn't detected.
-        let installedIds = Set(state.agentRegistry.installed().map(\.id))
+        // `agent.isEnabled` is clamped against install detection in
+        // AgentRegistry, so every entry here is both enabled and installed.
         for agent in state.agentRegistry.agents where agent.isEnabled {
-            let suffix = installedIds.contains(agent.id) ? "" : " (not installed)"
-            items.append(MenuItem(id: agent.id, label: agent.displayName + suffix))
+            items.append(MenuItem(id: agent.id, label: agent.displayName))
         }
         items.append(MenuItem(id: "none", label: "None"))
         return items

--- a/AlasTests/AgentRegistryTests.swift
+++ b/AlasTests/AgentRegistryTests.swift
@@ -107,9 +107,51 @@ struct AgentRegistryTests {
         )
         let ids = r.agents.map(\.id)
         #expect(ids == AgentBuiltins.catalog.map(\.id))
-        // All built-ins still default-enabled (the unknown overlay didn't leak in).
-        for agent in r.agents {
-            #expect(agent.isEnabled)
-        }
+        // Built-ins are now all disabled because nothing is installed; the
+        // important assertion is that the unknown overlay didn't change the
+        // set of agents (catalog identity).
+        #expect(r.agents.allSatisfy { !$0.isEnabled })
+    }
+
+    @Test func unconfiguredBuiltinIsEnabledOnlyWhenInstalled() {
+        let r = AgentRegistry(
+            builtinState: [:],
+            customs: [],
+            installedIds: ["claude"] // only claude is installed
+        )
+        let claude = r.agents.first(where: { $0.id == "claude" })!
+        let codex  = r.agents.first(where: { $0.id == "codex" })!
+        #expect(claude.isEnabled == true)
+        #expect(codex.isEnabled == false)
+    }
+
+    @Test func persistedEnabledBuiltinIsClampedWhenUninstalled() {
+        let r = AgentRegistry(
+            builtinState: ["gemini": BuiltinAgentState(isEnabled: true, binaryOverride: nil)],
+            customs: [],
+            installedIds: [] // gemini not installed
+        )
+        let gemini = r.agents.first(where: { $0.id == "gemini" })!
+        #expect(gemini.isEnabled == false)
+    }
+
+    @Test func customAgentIsEnabledOnlyWhenInstalled() {
+        let installed = AgentDefinition(
+            id: "c-installed", displayName: "C-In", binary: "c-in",
+            binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+            isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
+        )
+        let missing = AgentDefinition(
+            id: "c-missing", displayName: "C-Miss", binary: "c-miss",
+            binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+            isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
+        )
+        let r = AgentRegistry(
+            builtinState: [:],
+            customs: [installed, missing],
+            installedIds: ["c-installed"]
+        )
+        #expect(r.agents.first(where: { $0.id == "c-installed" })!.isEnabled == true)
+        #expect(r.agents.first(where: { $0.id == "c-missing"   })!.isEnabled == false)
     }
 }


### PR DESCRIPTION
## Summary
- `AgentRegistry` now ANDs persisted `isEnabled` (built-ins and customs) with `installedIds.contains(id)`, so an agent is "enabled" only when its binary is detected on PATH.
- `AgentCard` toggle in Settings → Agents is greyed out / non-interactive when the agent isn't installed, matching the existing "missing" pill.
- `ChangesPane` AI commit menu drops its now-unreachable `" (not installed)"` suffix branch.

## Why
First-launch users saw a green "enabled" toggle on every built-in agent card, including ones whose binary wasn't on PATH — the card simultaneously showed the "missing" pill and an "on" switch. `isEnabled` now semantically means *"installed and not user-disabled"*.

## Test plan
- [x] `xcodebuild -only-testing:AlasTests/AgentRegistryTests test` — all 12 tests pass (3 new + 9 existing, one updated)
- [x] Full `xcodebuild build` succeeds
- [ ] CI: full test suite green
- [ ] Manual: Settings → Agents shows greyed toggle on missing-agent cards, normal toggle on installed cards
- [ ] Manual: AI commit picker lists only installed-and-enabled agents, no `" (not installed)"` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)