### PR TITLE
test(agents): inject PATH via parameter instead of mutating env

### DIFF
--- a/Alas/Sources/Agents/AgentRunner.swift
+++ b/Alas/Sources/Agents/AgentRunner.swift
@@ -36,6 +36,7 @@ enum AgentRunner {
         agent: AgentDefinition,
         input: String,
         prompt: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
         timeout: TimeInterval = 120
     ) async throws -> GeneratedMessage {
         let binary = agent.resolvedBinary
@@ -48,7 +49,7 @@ enum AgentRunner {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [binary] + args
-        var env = ProcessInfo.processInfo.environment
+        var env = environment
         env["PATH"] = AgentPath.augmented(base: env["PATH"])
         process.environment = env
 

--- a/AlasTests/AgentRunnerInvocationTests.swift
+++ b/AlasTests/AgentRunnerInvocationTests.swift
@@ -2,7 +2,6 @@ import Testing
 import Foundation
 @testable import Alas
 
-@Suite(.serialized)
 struct AgentRunnerInvocationTests {
     private func shim(named name: String, in tmp: URL) throws -> (recordFile: URL, path: String) {
         let recordFile = tmp.appendingPathComponent("\(name).record")
@@ -21,13 +20,6 @@ struct AgentRunnerInvocationTests {
             ofItemAtPath: bin.path
         )
         return (recordFile, "\(tmp.path):/usr/bin:/bin")
-    }
-
-    private func withPath<T>(_ value: String, body: () async throws -> T) async throws -> T {
-        let prev = ProcessInfo.processInfo.environment["PATH"] ?? ""
-        setenv("PATH", value, 1)
-        defer { setenv("PATH", prev, 1) }
-        return try await body()
     }
 
     private func makeTmp() throws -> URL {
@@ -50,13 +42,12 @@ struct AgentRunnerInvocationTests {
         let tmp = try makeTmp()
         defer { try? FileManager.default.removeItem(at: tmp) }
         let (record, path) = try shim(named: "claude", in: tmp)
-        let result = try await withPath(path) {
-            try await AgentRunner.runPrompt(
-                agent: agent(id: "claude", binary: "claude", args: ["-p"]),
-                input: "DIFF GOES HERE\n",
-                prompt: "PROMPT"
-            )
-        }
+        let result = try await AgentRunner.runPrompt(
+            agent: agent(id: "claude", binary: "claude", args: ["-p"]),
+            input: "DIFF GOES HERE\n",
+            prompt: "PROMPT",
+            environment: ["PATH": path]
+        )
         #expect(result.subject == "subject from claude")
         let recorded = try String(contentsOf: record, encoding: .utf8)
         #expect(recorded.contains("-p\n"))
@@ -68,13 +59,12 @@ struct AgentRunnerInvocationTests {
         let tmp = try makeTmp()
         defer { try? FileManager.default.removeItem(at: tmp) }
         let (record, path) = try shim(named: "codex", in: tmp)
-        _ = try await withPath(path) {
-            try await AgentRunner.runPrompt(
-                agent: agent(id: "codex", binary: "codex", args: ["exec"]),
-                input: "DIFF\n",
-                prompt: "PROMPT"
-            )
-        }
+        _ = try await AgentRunner.runPrompt(
+            agent: agent(id: "codex", binary: "codex", args: ["exec"]),
+            input: "DIFF\n",
+            prompt: "PROMPT",
+            environment: ["PATH": path]
+        )
         let recorded = try String(contentsOf: record, encoding: .utf8)
         #expect(recorded.contains("exec\n"))
         #expect(recorded.contains("PROMPT\n"))
@@ -84,13 +74,12 @@ struct AgentRunnerInvocationTests {
         let tmp = try makeTmp()
         defer { try? FileManager.default.removeItem(at: tmp) }
         let (record, path) = try shim(named: "opencode", in: tmp)
-        _ = try await withPath(path) {
-            try await AgentRunner.runPrompt(
-                agent: agent(id: "opencode", binary: "opencode", args: ["run"]),
-                input: "DIFF\n",
-                prompt: "PROMPT"
-            )
-        }
+        _ = try await AgentRunner.runPrompt(
+            agent: agent(id: "opencode", binary: "opencode", args: ["run"]),
+            input: "DIFF\n",
+            prompt: "PROMPT",
+            environment: ["PATH": path]
+        )
         let recorded = try String(contentsOf: record, encoding: .utf8)
         #expect(recorded.contains("run\n"))
         #expect(recorded.contains("PROMPT\n"))
@@ -101,13 +90,12 @@ struct AgentRunnerInvocationTests {
         defer { try? FileManager.default.removeItem(at: tmp) }
         let path = "\(tmp.path):/usr/bin:/bin"  // empty: no shims
         do {
-            _ = try await withPath(path) {
-                try await AgentRunner.runPrompt(
-                    agent: agent(id: "ghost", binary: "no-such-binary", args: []),
-                    input: "x",
-                    prompt: "y"
-                )
-            }
+            _ = try await AgentRunner.runPrompt(
+                agent: agent(id: "ghost", binary: "no-such-binary", args: []),
+                input: "x",
+                prompt: "y",
+                environment: ["PATH": path]
+            )
             Issue.record("expected throw")
         } catch let AgentRunError.binaryNotFound(agentId, displayName) {
             #expect(agentId == "ghost")


### PR DESCRIPTION
<!-- gg:managed:start -->
Pass `environment` into `AgentRunner.runPrompt` so tests can supply a
custom PATH without `setenv`, removing the need for `.serialized` and
the `withPath` helper. Tests can now run in parallel safely.
<!-- gg:managed:end -->