### PR TITLE
fix(changes): expand untracked directories in Changes

### DIFF
--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -73,7 +73,10 @@ extension GitService {
     }
 
     func status(worktreePath: URL) async throws -> [ChangedFile] {
-        async let statusResult = Process.git(["status", "--porcelain=v2", "-z"], cwd: worktreePath)
+        async let statusResult = Process.git(
+            ["status", "--porcelain=v2", "-z", "--untracked-files=all"],
+            cwd: worktreePath
+        )
         let s = try await statusResult
         guard s.exitCode == 0 else { return [] }
         var entries = try StatusParser.parse(s.stdout)

--- a/AlasTests/GitServiceStagingTests.swift
+++ b/AlasTests/GitServiceStagingTests.swift
@@ -78,6 +78,28 @@ struct GitServiceStagingTests {
         #expect(status.filter { $0.stage == .staged }.count == 2)
     }
 
+    @Test func statusExpandsUntrackedDirectoriesIntoFiles() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let dir = repo.appendingPathComponent(".clawpatch")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try writeFile(repo, ".clawpatch/manifest.json", "{}\n")
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("nested"),
+            withIntermediateDirectories: true
+        )
+        try writeFile(repo, ".clawpatch/nested/change.json", "{\"ok\":true}\n")
+
+        let status = try await GitService().status(worktreePath: repo)
+        let paths = status.map(\.path).sorted()
+
+        #expect(paths == [
+            ".clawpatch/manifest.json",
+            ".clawpatch/nested/change.json"
+        ])
+        #expect(status.allSatisfy { $0.status == "A" && $0.stage == .unstaged })
+    }
+
     @Test func unstageAllClearsIndex() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }


### PR DESCRIPTION
## Summary

- Ask `git status` for all untracked files in the Changes pane.
- Add a regression test for an untracked `.clawpatch` directory with nested files.

## Why

Git can report a fully untracked directory as one `? dirname/` status entry. The Changes tree then renders that entry as a leaf file row, which makes a new directory look like a broken file item. Requesting `--untracked-files=all` keeps Git as the source of truth while giving the existing tree builder file-level paths to group into folders.

## Validation

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/GitServiceStagingTests` passed.
- `xcodegen` passed.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build` passed.
- Full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was attempted, but it failed on unrelated existing failures in `AgentHookSocketServerTests` and `CodeTextViewMultiCursorTests`; the test host then hung and had to be terminated.