### PR TITLE
fix(panetree): reject decoded splits without exactly two children

### DIFF
--- a/Alas/Sources/Terminal/PaneTree.swift
+++ b/Alas/Sources/Terminal/PaneTree.swift
@@ -54,7 +54,14 @@ enum PaneNode: Codable, Equatable, Identifiable {
         case .leaf:
             self = .leaf(try single.decode(PaneLeafCodable.self).asLeaf)
         case .split:
-            self = .split(try single.decode(PaneSplitCodable.self).asSplit)
+            let split = try single.decode(PaneSplitCodable.self)
+            guard split.children.count == 2 else {
+                throw DecodingError.dataCorrupted(.init(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Pane split must contain exactly two children"
+                ))
+            }
+            self = .split(split.asSplit)
         }
     }
 

--- a/AlasTests/PaneTreeTests.swift
+++ b/AlasTests/PaneTreeTests.swift
@@ -27,6 +27,39 @@ struct PaneTreeTests {
         #expect(tree.leaves().map(\.id) == ["a", "b", "c", "d"])
     }
 
+    @Test func decodingSplitWithEmptyChildrenThrows() {
+        let json = """
+        {
+          "kind": "split",
+          "id": "s1",
+          "axis": "vertical",
+          "fraction": 0.5,
+          "children": []
+        }
+        """
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(PaneNode.self, from: Data(json.utf8))
+        }
+    }
+
+    @Test func decodingValidSplitPreservesChildren() throws {
+        let json = """
+        {
+          "kind": "split",
+          "id": "s1",
+          "axis": "vertical",
+          "fraction": 0.5,
+          "children": [
+            { "kind": "leaf", "id": "a", "sessionId": "sa" },
+            { "kind": "leaf", "id": "b", "sessionId": "sb" }
+          ]
+        }
+        """
+        let decoded = try JSONDecoder().decode(PaneNode.self, from: Data(json.utf8))
+        #expect(decoded.leaves().map(\.id) == ["a", "b"])
+        #expect(decoded.firstLeaf().id == "a")
+    }
+
     @Test func findReturnsLeafAndPath() throws {
         let tree = split("s1", .vertical, 0.5, [
             leaf("a"),


### PR DESCRIPTION
<!-- gg:managed:start -->
Previously a malformed split with zero or one child would decode
successfully and crash later when code assumed two children. Validate
during decoding and throw a clear DecodingError instead.
<!-- gg:managed:end -->