### PR TITLE
test(EventHolder): support concurrent waiters

### DIFF
--- a/AlasTests/EventHolder.swift
+++ b/AlasTests/EventHolder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Testing
 @testable import Alas
 
 /// Test helper that converts the socket server's fire-and-forget
@@ -9,21 +10,28 @@ import Foundation
 /// times out). A composite hook command emits multiple events on one
 /// invocation; pass a predicate to wait for the one you care about.
 final class EventHolder: @unchecked Sendable {
+    private struct PendingWaiter {
+        let id: UUID
+        let predicate: (AgentHookEvent) -> Bool
+        let continuation: CheckedContinuation<AgentHookEvent?, Never>
+    }
+
     private let lock = NSLock()
     private var events: [AgentHookEvent] = []
-    private var pending: (predicate: (AgentHookEvent) -> Bool,
-                          continuation: CheckedContinuation<AgentHookEvent?, Never>)?
+    private var pending: [PendingWaiter] = []
 
     func deliver(_ event: AgentHookEvent) {
         lock.lock()
         events.append(event)
-        if let pending, pending.predicate(event) {
-            self.pending = nil
-            lock.unlock()
-            pending.continuation.resume(returning: event)
-            return
+        let matching = pending.filter { $0.predicate(event) }
+        pending.removeAll { waiter in
+            matching.contains { $0.id == waiter.id }
         }
         lock.unlock()
+
+        for waiter in matching {
+            waiter.continuation.resume(returning: event)
+        }
     }
 
     /// Waits up to `timeoutMs` for an event matching `predicate`. Returns
@@ -39,20 +47,50 @@ final class EventHolder: @unchecked Sendable {
                 cont.resume(returning: match)
                 return
             }
-            pending = (predicate, cont)
+            let id = UUID()
+            pending.append(PendingWaiter(id: id, predicate: predicate, continuation: cont))
             lock.unlock()
             Task { [weak self] in
                 try? await Task.sleep(nanoseconds: timeoutMs * 1_000_000)
-                self?.timeoutPendingWaiter()
+                self?.timeoutPendingWaiter(id: id)
             }
         }
     }
 
-    private func timeoutPendingWaiter() {
+    private func timeoutPendingWaiter(id: UUID) {
         lock.lock()
-        let p = pending
-        pending = nil
+        let index = pending.firstIndex { $0.id == id }
+        let waiter = index.map { pending.remove(at: $0) }
         lock.unlock()
-        p?.continuation.resume(returning: nil)
+        waiter?.continuation.resume(returning: nil)
+    }
+}
+
+struct EventHolderTests {
+    @Test func concurrentWaitersCompleteIndependently() async {
+        let holder = EventHolder()
+
+        async let busy = holder.wait(timeoutMs: 1000) { $0.event == .busy }
+        async let idle = holder.wait(timeoutMs: 1000) { $0.event == .idle }
+
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        holder.deliver(Self.event(.idle))
+        holder.deliver(Self.event(.busy))
+
+        let received = await (busy, idle)
+        #expect(received.0?.event == .busy)
+        #expect(received.1?.event == .idle)
+    }
+
+    private static func event(_ event: ActivityEvent) -> AgentHookEvent {
+        AgentHookEvent(
+            version: 1,
+            event: event,
+            agent: .codex,
+            sessionId: "test-session",
+            pid: nil,
+            timestamp: nil,
+            body: nil
+        )
     }
 }


### PR DESCRIPTION
<!-- gg:managed:start -->
Previously EventHolder only tracked a single pending waiter, so two
concurrent `wait` calls would clobber each other and one would hang
until timeout. Track waiters in a list keyed by UUID so each resumes
independently when its predicate matches.

Add a regression test that fires two overlapping waiters with
different predicates and confirms both receive their matching event.
<!-- gg:managed:end -->