### PR TITLE
fix(AgentHookEvent): guard against pid overflow when decoding

### DIFF
--- a/Alas/Sources/Harness/AgentHookEvent.swift
+++ b/Alas/Sources/Harness/AgentHookEvent.swift
@@ -47,7 +47,7 @@ extension AgentHookEvent {
         guard let sessionId = json["session_id"] as? String, !sessionId.isEmpty else {
             throw AgentHookEventError.malformed("Missing 'session_id'")
         }
-        let pid: pid_t? = (json["pid"] as? Int).flatMap { $0 > 0 ? pid_t($0) : nil }
+        let pid: pid_t? = (json["pid"] as? Int).flatMap { $0 > 0 ? pid_t(exactly: $0) : nil }
         let ts: Date? = (json["ts"] as? String).flatMap { try? Date($0, strategy: .iso8601) }
         let body = json["body"] as? String
         return AgentHookEvent(

--- a/AlasTests/AgentHookSocketServerTests.swift
+++ b/AlasTests/AgentHookSocketServerTests.swift
@@ -67,6 +67,14 @@ struct AgentHookSocketServerTests {
         #expect(response.contains("\"ok\":false") || response.contains("\"ok\": false"))
     }
 
+    @Test func oversizedPid_decodesAsNil() throws {
+        let json = #"{"v":1,"event":"busy","agent":"claude","session_id":"s1","pid":999999999999}"#
+
+        let event = try AgentHookEvent.decode(from: Data(json.utf8))
+
+        #expect(event.pid == nil)
+    }
+
     @Test func unknownEvent_acksOkButDoesNotDispatch() async throws {
         let (dir, cleanup) = tmpSocketDir()
         defer { cleanup() }


### PR DESCRIPTION
<!-- gg:managed:start -->
Use `pid_t(exactly:)` so JSON values larger than `pid_t` (Int32 on
Darwin) decode as `nil` instead of trapping. Add a regression test
for an oversized pid value.
<!-- gg:managed:end -->