### PR TITLE
feat(terminal): NSTextInputClient integration for dead keys, IME, and Opt+Delete

### DIFF
--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -99,6 +99,12 @@ extension AlasGhostty {
         /// time and never mutated afterward, so this is safe.
         nonisolated(unsafe) private(set) var cSurface: ghostty_surface_t?
 
+        /// Narrow IO seam around ghostty_surface_* calls used by the input
+        /// pipeline. Initialized after a successful ghostty_surface_new().
+        /// Force-unwrapping at use sites is unsafe — call sites must guard on
+        /// `cSurface != nil` first (already the existing pattern).
+        private var surfaceIO: GhosttySurfaceIO!
+
         /// Unretained back-reference to the owning App.
         private let app: App
 
@@ -136,6 +142,7 @@ extension AlasGhostty {
                 return
             }
             self.cSurface = surface
+            self.surfaceIO = LiveGhosttySurfaceIO(surface)
 
             // Set up mouse tracking so we receive mouseMoved events.
             updateTrackingAreas()
@@ -375,21 +382,21 @@ extension AlasGhostty {
             if let chars {
                 chars.withCString { ptr in
                     keyEv.text = ptr
-                    _ = ghostty_surface_key(surface, keyEv)
+                    _ = surfaceIO.sendKey(keyEv)
                 }
             } else {
-                _ = ghostty_surface_key(surface, keyEv)
+                _ = surfaceIO.sendKey(keyEv)
             }
         }
 
         override func keyUp(with event: NSEvent) {
-            guard let surface = cSurface else { return }
+            guard cSurface != nil else { return }
             let keyEv = event.alasGhosttyKeyEvent(GHOSTTY_ACTION_RELEASE)
-            _ = ghostty_surface_key(surface, keyEv)
+            _ = surfaceIO.sendKey(keyEv)
         }
 
         override func flagsChanged(with event: NSEvent) {
-            guard let surface = cSurface else { return }
+            guard cSurface != nil else { return }
 
             // Determine which modifier changed and whether it was pressed or released.
             let mod: UInt32
@@ -408,7 +415,7 @@ extension AlasGhostty {
                 : GHOSTTY_ACTION_RELEASE
 
             let keyEv = event.alasGhosttyKeyEvent(action)
-            _ = ghostty_surface_key(surface, keyEv)
+            _ = surfaceIO.sendKey(keyEv)
         }
 
         override func performKeyEquivalent(with event: NSEvent) -> Bool {

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -506,6 +506,19 @@ extension AlasGhostty {
             return false
         }
 
+        // MARK: - NSTextInputClient doCommand
+
+        // NSResponder declares doCommand(by:); the NSTextInputClient extension
+        // conforms our class to the protocol, but the override of NSResponder's
+        // method lives here in the main class body for conventional placement.
+        // The raw keyDown was already delivered to Ghostty before
+        // interpretKeyEvents fired, so we intentionally swallow the selector.
+        // Calling super would let AppKit beep or perform a default behavior
+        // that is wrong for a terminal.
+        override func doCommand(by selector: Selector) {
+            // intentionally empty
+        }
+
         // MARK: - Mouse events
 
         override func mouseDown(with event: NSEvent) {
@@ -825,10 +838,8 @@ extension AlasGhostty.SurfaceView: @preconcurrency NSTextInputClient {
         return window.convertToScreen(windowRect)
     }
 
-    override func doCommand(by selector: Selector) {
-        // Intentionally do nothing. The raw keyDown was already delivered to
-        // Ghostty before interpretKeyEvents fired. Calling super would let
-        // AppKit beep or perform a default behavior that is wrong for a
-        // terminal.
-    }
+    // doCommand(by:) lives in SurfaceView's main class body (above) — Swift's
+    // convention is to place NSResponder overrides on the class itself, not
+    // in extensions. NSTextInputClient.doCommand(by:) is satisfied by that
+    // override.
 }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -751,7 +751,18 @@ extension AlasGhostty.SurfaceView: NSTextInputClient {
     }
 
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
-        // Implemented in Task 6.
+        let text: String
+        if let s = string as? String { text = s }
+        else if let a = string as? NSAttributedString { text = a.string }
+        else { return }
+
+        if text.isEmpty {
+            markedText = nil
+            surfaceIO.setPreedit(nil)
+        } else {
+            markedText = text
+            surfaceIO.setPreedit(text)
+        }
     }
 
     func unmarkText() {

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -738,7 +738,16 @@ extension AlasGhostty.SurfaceView: NSTextInputClient {
     // MARK: Active methods — full bodies arrive in later tasks
 
     func insertText(_ string: Any, replacementRange: NSRange) {
-        // Implemented in Task 5.
+        let text: String
+        if let s = string as? String { text = s }
+        else if let a = string as? NSAttributedString { text = a.string }
+        else { return }
+
+        guard !text.isEmpty else { return }
+
+        surfaceIO.sendText(text)
+        markedText = nil
+        surfaceIO.setPreedit(nil)
     }
 
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -393,7 +393,31 @@ extension AlasGhostty {
             // special selectors. The NSTextInputClient callbacks
             // (insertText / setMarkedText / unmarkText / doCommand) forward
             // to the IO seam as appropriate.
-            interpretKeyEvents([event])
+            //
+            // When Ghostty's translation modifiers differ from the physical
+            // event (e.g. `macos-option-as-alt` strips Option), build a
+            // synthetic event with the adjusted modifiers — otherwise AppKit
+            // would still see physical Option and commit Option-glyphs like
+            // `ƒ` via insertText after the raw Alt-modified key was already
+            // delivered to Ghostty in Step A.
+            let translationEvent: NSEvent
+            if translationFlags == event.modifierFlags {
+                translationEvent = event
+            } else {
+                translationEvent = NSEvent.keyEvent(
+                    with: event.type,
+                    location: event.locationInWindow,
+                    modifierFlags: translationFlags,
+                    timestamp: event.timestamp,
+                    windowNumber: event.windowNumber,
+                    context: nil,
+                    characters: event.characters(byApplyingModifiers: translationFlags) ?? "",
+                    charactersIgnoringModifiers: event.charactersIgnoringModifiers ?? "",
+                    isARepeat: event.isARepeat,
+                    keyCode: event.keyCode
+                ) ?? event
+            }
+            interpretKeyEvents([translationEvent])
         }
 
         override func keyUp(with event: NSEvent) {

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -766,7 +766,8 @@ extension AlasGhostty.SurfaceView: NSTextInputClient {
     }
 
     func unmarkText() {
-        // Implemented in Task 7.
+        markedText = nil
+        surfaceIO.setPreedit(nil)
     }
 
     func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -16,6 +16,7 @@
 
 import AppKit
 import Metal
+import ObjectiveC
 import QuartzCore
 import GhosttyKit
 
@@ -691,5 +692,70 @@ private func alasGhosttyMomentum(_ phase: NSEvent.Phase) -> ghostty_input_mouse_
     case .cancelled:    return GHOSTTY_MOUSE_MOMENTUM_CANCELLED
     case .mayBegin:     return GHOSTTY_MOUSE_MOMENTUM_MAY_BEGIN
     default:            return GHOSTTY_MOUSE_MOMENTUM_NONE
+    }
+}
+
+// MARK: - NSTextInputClient
+
+extension AlasGhostty.SurfaceView: NSTextInputClient {
+    // State for tracking marked (composing) text. nil means "no composition active".
+    private static var markedTextKey: UInt8 = 0
+
+    private var markedText: String? {
+        get { objc_getAssociatedObject(self, &Self.markedTextKey) as? String }
+        set { objc_setAssociatedObject(self, &Self.markedTextKey, newValue, .OBJC_ASSOCIATION_COPY_NONATOMIC) }
+    }
+
+    // MARK: Query methods
+
+    func hasMarkedText() -> Bool {
+        return !(markedText ?? "").isEmpty
+    }
+
+    func selectedRange() -> NSRange {
+        return NSRange(location: NSNotFound, length: 0)
+    }
+
+    func markedRange() -> NSRange {
+        guard let marked = markedText, !marked.isEmpty else {
+            return NSRange(location: NSNotFound, length: 0)
+        }
+        return NSRange(location: 0, length: (marked as NSString).length)
+    }
+
+    func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {
+        return nil
+    }
+
+    func validAttributesForMarkedText() -> [NSAttributedString.Key] {
+        return []
+    }
+
+    func characterIndex(for point: NSPoint) -> Int {
+        return NSNotFound
+    }
+
+    // MARK: Active methods — full bodies arrive in later tasks
+
+    func insertText(_ string: Any, replacementRange: NSRange) {
+        // Implemented in Task 5.
+    }
+
+    func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
+        // Implemented in Task 6.
+    }
+
+    func unmarkText() {
+        // Implemented in Task 7.
+    }
+
+    func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
+        // Implemented in Task 8.
+        return .zero
+    }
+
+    override func doCommand(by selector: Selector) {
+        // Implemented in Task 9. Default: do nothing — the raw keyDown
+        // was already delivered to Ghostty.
     }
 }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -353,13 +353,12 @@ extension AlasGhostty {
 
             let action: ghostty_input_action_e = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
-            // Ask Ghostty which modifiers should be used for text translation.
-            // This handles configs such as `macos-option-as-alt` correctly.
+            // Translation-modifier dance: ask Ghostty which modifiers should
+            // participate in text translation for configs like
+            // `macos-option-as-alt`. The result feeds `consumed_mods` on the
+            // key event below.
             let rawMods = alasGhosttyMods(event.modifierFlags)
             let translatedGhosttyMods = ghostty_surface_key_translation_mods(surface, rawMods)
-
-            // Convert translated Ghostty mods back to AppKit flags so we can
-            // derive the correct composed characters (e.g. Option+n → ~).
             let translatedAppKitMods = alasAppKitModifierFlags(from: translatedGhosttyMods)
             var translationFlags = event.modifierFlags
             for flag in [NSEvent.ModifierFlags.shift, .control, .option, .command] {
@@ -370,38 +369,28 @@ extension AlasGhostty {
                 }
             }
 
-            // If translation modifiers differ we must build a new event.
-            // Reusing the original event when they're equal is required for
-            // some IME behaviours (see upstream Ghostty comment).
-            let translationEvent: NSEvent
-            if translationFlags == event.modifierFlags {
-                translationEvent = event
-            } else {
-                translationEvent = NSEvent.keyEvent(
-                    with: event.type,
-                    location: event.locationInWindow,
-                    modifierFlags: translationFlags,
-                    timestamp: event.timestamp,
-                    windowNumber: event.windowNumber,
-                    context: nil,
-                    characters: event.characters(byApplyingModifiers: translationFlags) ?? "",
-                    charactersIgnoringModifiers: event.charactersIgnoringModifiers ?? "",
-                    isARepeat: event.isARepeat,
-                    keyCode: event.keyCode
-                ) ?? event
-            }
-
+            // Step A: forward the raw key event to Ghostty so it can match a
+            // keybinding. composing = hasMarkedText() tells the backend that
+            // a text payload (if any) is part of an active IME composition.
+            // text is left nil here — the actual text payload is delivered
+            // separately via insertText → ghostty_surface_text.
             var keyEv = event.alasGhosttyKeyEvent(action, translationFlags: translationFlags)
-            let chars = translationEvent.alasGhosttyCharacters
+            keyEv.composing = hasMarkedText()
+            let consumed = surfaceIO.sendKey(keyEv)
+            if consumed { return }
 
-            if let chars {
-                chars.withCString { ptr in
-                    keyEv.text = ptr
-                    _ = surfaceIO.sendKey(keyEv)
-                }
-            } else {
-                _ = surfaceIO.sendKey(keyEv)
-            }
+            // Step B: Cmd/Ctrl events bypass interpretKeyEvents so menus and
+            // IMEs can't swallow Cmd+C / Ctrl+C. The raw key was already
+            // delivered above, which is all Ghostty needs for these shortcuts.
+            let cmdOrCtrl = event.modifierFlags.contains(.command)
+                || event.modifierFlags.contains(.control)
+            if cmdOrCtrl { return }
+
+            // Step C: let AppKit resolve dead keys, IME composition, and
+            // special selectors. The NSTextInputClient callbacks
+            // (insertText / setMarkedText / unmarkText / doCommand) forward
+            // to the IO seam as appropriate.
+            interpretKeyEvents([event])
         }
 
         override func keyUp(with event: NSEvent) {

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -105,8 +105,9 @@ extension AlasGhostty {
         /// `cSurface != nil` first (already the existing pattern).
         private var surfaceIO: GhosttySurfaceIO!
 
-        /// Unretained back-reference to the owning App.
-        private let app: App
+        /// Unretained back-reference to the owning App. Optional so the
+        /// test-only `init(testIO:)` can omit it.
+        private let app: App?
 
         /// Whether the surface currently has keyboard focus.
         private var isFocused: Bool = false
@@ -147,6 +148,19 @@ extension AlasGhostty {
             // Set up mouse tracking so we receive mouseMoved events.
             updateTrackingAreas()
         }
+
+        /// Test-only initializer that bypasses ghostty_surface_new and uses
+        /// the supplied IO seam. Never call from production code.
+        init(testIO: GhosttySurfaceIO) {
+            self.app = nil
+            super.init(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+            wantsLayer = true
+            self.cSurface = nil
+            self.surfaceIO = testIO
+        }
+
+        /// Test-only accessor for the IO seam.
+        var surfaceIOForTesting: GhosttySurfaceIO { surfaceIO }
 
         required init?(coder: NSCoder) {
             fatalError("SurfaceView does not support NSCoder")

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -788,7 +788,9 @@ extension AlasGhostty.SurfaceView: NSTextInputClient {
     }
 
     override func doCommand(by selector: Selector) {
-        // Implemented in Task 9. Default: do nothing — the raw keyDown
-        // was already delivered to Ghostty.
+        // Intentionally do nothing. The raw keyDown was already delivered to
+        // Ghostty before interpretKeyEvents fired. Calling super would let
+        // AppKit beep or perform a default behavior that is wrong for a
+        // terminal.
     }
 }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -827,6 +827,13 @@ extension AlasGhostty.SurfaceView: @preconcurrency NSTextInputClient {
     }
 
     func unmarkText() {
+        // Per Apple's NSTextInputClient.unmarkText contract, when an IME
+        // ends composition this way (without first sending insertText), the
+        // marked text must be accepted as normal text. Commit it before
+        // clearing so the composed character is not lost.
+        if let marked = markedText, !marked.isEmpty {
+            surfaceIO?.sendText(marked)
+        }
         markedText = nil
         surfaceIO?.setPreedit(nil)
     }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -392,9 +392,21 @@ extension AlasGhostty {
                 ) ?? event
             }
 
+            // Step 0: While an IME composition is active, defer the entire
+            // keystroke to AppKit. Forwarding Backspace/Enter/arrows/Ctrl-H
+            // to Ghostty mid-composition would also mutate the shell line
+            // behind the preedit (Ghostty's encoder doesn't know that those
+            // keys are meant to edit/commit the composition rather than
+            // reach the PTY). The NSTextInputClient callbacks
+            // (setMarkedText / unmarkText / insertText / doCommand) carry
+            // whatever should actually reach the surface.
+            if hasMarkedText() {
+                interpretKeyEvents([translationEvent])
+                return
+            }
+
             // Step A: forward the raw key event to Ghostty so it can match a
-            // keybinding. composing = hasMarkedText() tells the backend that
-            // any text payload is part of an active IME composition.
+            // keybinding.
             //
             // For Cmd/Ctrl-modified keys we attach the layout-translated text
             // (alasGhosttyCharacters strips Ctrl and returns the unshifted
@@ -405,7 +417,6 @@ extension AlasGhostty {
             // leave text nil so the insertText callback can deliver it
             // (avoids doubling).
             var keyEv = event.alasGhosttyKeyEvent(action, translationFlags: translationFlags)
-            keyEv.composing = hasMarkedText()
 
             let cmdOrCtrl = event.modifierFlags.contains(.command)
                 || event.modifierFlags.contains(.control)

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -19,6 +19,54 @@ import Metal
 import QuartzCore
 import GhosttyKit
 
+// MARK: - GhosttySurfaceIO
+
+/// Narrow seam around the four ghostty_surface_* C calls used by the input
+/// pipeline. Lets unit tests drive NSTextInputClient methods without standing
+/// up a real Ghostty surface.
+@MainActor
+protocol GhosttySurfaceIO {
+    func sendKey(_ event: ghostty_input_key_s) -> Bool
+    func sendText(_ text: String)
+    func setPreedit(_ text: String?)
+    func imePoint() -> CGRect
+}
+
+/// Production adapter that forwards to the C ABI of a real ghostty_surface_t.
+@MainActor
+final class LiveGhosttySurfaceIO: GhosttySurfaceIO {
+    nonisolated(unsafe) private let surface: ghostty_surface_t
+    init(_ surface: ghostty_surface_t) { self.surface = surface }
+
+    func sendKey(_ event: ghostty_input_key_s) -> Bool {
+        return ghostty_surface_key(surface, event)
+    }
+
+    func sendText(_ text: String) {
+        let bytes = text.utf8.count
+        text.withCString { ptr in
+            ghostty_surface_text(surface, ptr, UInt(bytes))
+        }
+    }
+
+    func setPreedit(_ text: String?) {
+        if let text {
+            let bytes = text.utf8.count
+            text.withCString { ptr in
+                ghostty_surface_preedit(surface, ptr, UInt(bytes))
+            }
+        } else {
+            ghostty_surface_preedit(surface, nil, 0)
+        }
+    }
+
+    func imePoint() -> CGRect {
+        var x: Double = 0, y: Double = 0, w: Double = 0, h: Double = 0
+        ghostty_surface_ime_point(surface, &x, &y, &w, &h)
+        return CGRect(x: x, y: y, width: w, height: h)
+    }
+}
+
 extension AlasGhostty {
     /// Terminal display view. Each session owns exactly one of these.
     @MainActor

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -101,10 +101,9 @@ extension AlasGhostty {
         nonisolated(unsafe) private(set) var cSurface: ghostty_surface_t?
 
         /// Narrow IO seam around ghostty_surface_* calls used by the input
-        /// pipeline. Initialized after a successful ghostty_surface_new().
-        /// Force-unwrapping at use sites is unsafe — call sites must guard on
-        /// `cSurface != nil` first (already the existing pattern).
-        private var surfaceIO: GhosttySurfaceIO!
+        /// pipeline. Initialized after a successful ghostty_surface_new();
+        /// `nil` when surface init failed. Call sites must guard before use.
+        private var surfaceIO: GhosttySurfaceIO?
 
         /// Unretained back-reference to the owning App. Optional so the
         /// test-only `init(testIO:)` can omit it.
@@ -161,7 +160,7 @@ extension AlasGhostty {
         }
 
         /// Test-only accessor for the IO seam.
-        var surfaceIOForTesting: GhosttySurfaceIO { surfaceIO }
+        var surfaceIOForTesting: GhosttySurfaceIO { surfaceIO! }
 
         required init?(coder: NSCoder) {
             fatalError("SurfaceView does not support NSCoder")
@@ -346,10 +345,10 @@ extension AlasGhostty {
         // MARK: - Keyboard events
 
         override func keyDown(with event: NSEvent) {
-            guard let surface = cSurface else {
-                interpretKeyEvents([event])
-                return
-            }
+            // If surface init failed, the view is in a broken state — drop the
+            // event rather than routing it into `interpretKeyEvents` and then
+            // crashing in an NSTextInputClient callback that needs surfaceIO.
+            guard let surface = cSurface, let io = surfaceIO else { return }
 
             let action: ghostty_input_action_e = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
@@ -376,12 +375,16 @@ extension AlasGhostty {
             // separately via insertText → ghostty_surface_text.
             var keyEv = event.alasGhosttyKeyEvent(action, translationFlags: translationFlags)
             keyEv.composing = hasMarkedText()
-            let consumed = surfaceIO.sendKey(keyEv)
+            let consumed = io.sendKey(keyEv)
             if consumed { return }
 
             // Step B: Cmd/Ctrl events bypass interpretKeyEvents so menus and
             // IMEs can't swallow Cmd+C / Ctrl+C. The raw key was already
             // delivered above, which is all Ghostty needs for these shortcuts.
+            // Option is intentionally NOT gated here — it must reach
+            // interpretKeyEvents so dead-key composition (Opt+e + letter on
+            // some layouts) and Opt+letter selectors (Opt+Backspace →
+            // deleteWordBackward:) can fire.
             let cmdOrCtrl = event.modifierFlags.contains(.command)
                 || event.modifierFlags.contains(.control)
             if cmdOrCtrl { return }
@@ -394,13 +397,13 @@ extension AlasGhostty {
         }
 
         override func keyUp(with event: NSEvent) {
-            guard cSurface != nil else { return }
+            guard let io = surfaceIO else { return }
             let keyEv = event.alasGhosttyKeyEvent(GHOSTTY_ACTION_RELEASE)
-            _ = surfaceIO.sendKey(keyEv)
+            _ = io.sendKey(keyEv)
         }
 
         override func flagsChanged(with event: NSEvent) {
-            guard cSurface != nil else { return }
+            guard let io = surfaceIO else { return }
 
             // Determine which modifier changed and whether it was pressed or released.
             let mod: UInt32
@@ -419,7 +422,7 @@ extension AlasGhostty {
                 : GHOSTTY_ACTION_RELEASE
 
             let keyEv = event.alasGhosttyKeyEvent(action)
-            _ = surfaceIO.sendKey(keyEv)
+            _ = io.sendKey(keyEv)
         }
 
         override func performKeyEquivalent(with event: NSEvent) -> Bool {
@@ -686,9 +689,9 @@ private func alasGhosttyMomentum(_ phase: NSEvent.Phase) -> ghostty_input_mouse_
 
 // MARK: - NSTextInputClient
 
-extension AlasGhostty.SurfaceView: NSTextInputClient {
+extension AlasGhostty.SurfaceView: @preconcurrency NSTextInputClient {
     // State for tracking marked (composing) text. nil means "no composition active".
-    private static var markedTextKey: UInt8 = 0
+    private nonisolated(unsafe) static var markedTextKey: UInt8 = 0
 
     private var markedText: String? {
         get { objc_getAssociatedObject(self, &Self.markedTextKey) as? String }
@@ -733,10 +736,11 @@ extension AlasGhostty.SurfaceView: NSTextInputClient {
         else { return }
 
         guard !text.isEmpty else { return }
+        guard let io = surfaceIO else { return }
 
-        surfaceIO.sendText(text)
+        io.sendText(text)
         markedText = nil
-        surfaceIO.setPreedit(nil)
+        io.setPreedit(nil)
     }
 
     func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
@@ -745,18 +749,20 @@ extension AlasGhostty.SurfaceView: NSTextInputClient {
         else if let a = string as? NSAttributedString { text = a.string }
         else { return }
 
+        guard let io = surfaceIO else { return }
+
         if text.isEmpty {
             markedText = nil
-            surfaceIO.setPreedit(nil)
+            io.setPreedit(nil)
         } else {
             markedText = text
-            surfaceIO.setPreedit(text)
+            io.setPreedit(text)
         }
     }
 
     func unmarkText() {
         markedText = nil
-        surfaceIO.setPreedit(nil)
+        surfaceIO?.setPreedit(nil)
     }
 
     func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
@@ -764,7 +770,8 @@ extension AlasGhostty.SurfaceView: NSTextInputClient {
         // (same convention used by mouseMoved which does `frame.height - y`).
         // AppKit's NSView coordinate system is bottom-left-origin, so flip
         // Y before converting to window/screen coordinates.
-        let ghosttyRect = surfaceIO.imePoint()
+        guard let io = surfaceIO else { return .zero }
+        let ghosttyRect = io.imePoint()
         let viewRect = NSRect(
             x: ghosttyRect.origin.x,
             y: frame.height - ghosttyRect.origin.y - ghosttyRect.size.height,

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -368,38 +368,12 @@ extension AlasGhostty {
                 }
             }
 
-            // Step A: forward the raw key event to Ghostty so it can match a
-            // keybinding. composing = hasMarkedText() tells the backend that
-            // a text payload (if any) is part of an active IME composition.
-            // text is left nil here — the actual text payload is delivered
-            // separately via insertText → ghostty_surface_text.
-            var keyEv = event.alasGhosttyKeyEvent(action, translationFlags: translationFlags)
-            keyEv.composing = hasMarkedText()
-            let consumed = io.sendKey(keyEv)
-            if consumed { return }
-
-            // Step B: Cmd/Ctrl events bypass interpretKeyEvents so menus and
-            // IMEs can't swallow Cmd+C / Ctrl+C. The raw key was already
-            // delivered above, which is all Ghostty needs for these shortcuts.
-            // Option is intentionally NOT gated here — it must reach
-            // interpretKeyEvents so dead-key composition (Opt+e + letter on
-            // some layouts) and Opt+letter selectors (Opt+Backspace →
-            // deleteWordBackward:) can fire.
-            let cmdOrCtrl = event.modifierFlags.contains(.command)
-                || event.modifierFlags.contains(.control)
-            if cmdOrCtrl { return }
-
-            // Step C: let AppKit resolve dead keys, IME composition, and
-            // special selectors. The NSTextInputClient callbacks
-            // (insertText / setMarkedText / unmarkText / doCommand) forward
-            // to the IO seam as appropriate.
-            //
-            // When Ghostty's translation modifiers differ from the physical
-            // event (e.g. `macos-option-as-alt` strips Option), build a
-            // synthetic event with the adjusted modifiers — otherwise AppKit
-            // would still see physical Option and commit Option-glyphs like
-            // `ƒ` via insertText after the raw Alt-modified key was already
-            // delivered to Ghostty in Step A.
+            // Build a translation event whose modifiers match what Ghostty
+            // wants for character translation (handles `macos-option-as-alt`
+            // and similar). Used in two places below: to extract the layout-
+            // translated character for Cmd/Ctrl forwarding, and as the event
+            // fed to interpretKeyEvents so AppKit doesn't commit Option-
+            // glyphs like `ƒ` after the raw Alt-modified key was delivered.
             let translationEvent: NSEvent
             if translationFlags == event.modifierFlags {
                 translationEvent = event
@@ -417,6 +391,50 @@ extension AlasGhostty {
                     keyCode: event.keyCode
                 ) ?? event
             }
+
+            // Step A: forward the raw key event to Ghostty so it can match a
+            // keybinding. composing = hasMarkedText() tells the backend that
+            // any text payload is part of an active IME composition.
+            //
+            // For Cmd/Ctrl-modified keys we attach the layout-translated text
+            // (alasGhosttyCharacters strips Ctrl and returns the unshifted
+            // character, e.g. Ctrl+L on Dvorak → "l") because Step B below
+            // returns before interpretKeyEvents — so this is Ghostty's only
+            // chance to see the layout character it needs to encode the
+            // control byte correctly on non-US layouts. For plain keys we
+            // leave text nil so the insertText callback can deliver it
+            // (avoids doubling).
+            var keyEv = event.alasGhosttyKeyEvent(action, translationFlags: translationFlags)
+            keyEv.composing = hasMarkedText()
+
+            let cmdOrCtrl = event.modifierFlags.contains(.command)
+                || event.modifierFlags.contains(.control)
+            let consumed: Bool
+            if cmdOrCtrl, let chars = translationEvent.alasGhosttyCharacters {
+                consumed = chars.withCString { ptr -> Bool in
+                    keyEv.text = ptr
+                    return io.sendKey(keyEv)
+                }
+            } else {
+                consumed = io.sendKey(keyEv)
+            }
+            if consumed { return }
+
+            // Step B: Cmd/Ctrl events bypass interpretKeyEvents so menus and
+            // IMEs can't swallow Cmd+C / Ctrl+C. The raw key (with text, see
+            // Step A) was already delivered above, which is all Ghostty needs
+            // for these shortcuts.
+            //
+            // Option is intentionally NOT gated here — it must reach
+            // interpretKeyEvents so dead-key composition (Opt+e + letter on
+            // some layouts) and Opt+letter selectors (Opt+Backspace →
+            // deleteWordBackward:) can fire.
+            if cmdOrCtrl { return }
+
+            // Step C: let AppKit resolve dead keys, IME composition, and
+            // special selectors. The NSTextInputClient callbacks
+            // (insertText / setMarkedText / unmarkText / doCommand) forward
+            // to the IO seam as appropriate.
             interpretKeyEvents([translationEvent])
         }
 

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -771,8 +771,20 @@ extension AlasGhostty.SurfaceView: NSTextInputClient {
     }
 
     func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
-        // Implemented in Task 8.
-        return .zero
+        // Ghostty reports the IME caret in top-left-origin view coordinates
+        // (same convention used by mouseMoved which does `frame.height - y`).
+        // AppKit's NSView coordinate system is bottom-left-origin, so flip
+        // Y before converting to window/screen coordinates.
+        let ghosttyRect = surfaceIO.imePoint()
+        let viewRect = NSRect(
+            x: ghosttyRect.origin.x,
+            y: frame.height - ghosttyRect.origin.y - ghosttyRect.size.height,
+            width: ghosttyRect.size.width,
+            height: ghosttyRect.size.height
+        )
+        guard let window else { return .zero }
+        let windowRect = convert(viewRect, to: nil)
+        return window.convertToScreen(windowRect)
     }
 
     override func doCommand(by selector: Selector) {

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -316,6 +316,15 @@ struct SurfaceViewKeyboardTests {
         #expect(view.hasMarkedText() == true)
     }
 
+    @Test @MainActor func unmarkText_clearsStateAndPreedit() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        view.setMarkedText("か" as NSString, selectedRange: NSRange(location: 1, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+        view.unmarkText()
+        #expect(io.calls == [.preedit("か"), .preedit(nil)])
+        #expect(view.hasMarkedText() == false)
+    }
+
     @Test @MainActor func testInitializerWiresFakeIO() {
         let io = FakeGhosttySurfaceIO()
         let view = AlasGhostty.SurfaceView(testIO: io)

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -351,6 +351,15 @@ struct SurfaceViewKeyboardTests {
         #expect(rect.origin != .zero)
     }
 
+    @Test @MainActor func doCommand_doesNotForwardToIO() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        view.doCommand(by: #selector(NSResponder.deleteWordBackward(_:)))
+        view.doCommand(by: #selector(NSResponder.insertNewline(_:)))
+        view.doCommand(by: #selector(NSResponder.moveLeft(_:)))
+        #expect(io.calls.isEmpty)
+    }
+
     @Test @MainActor func testInitializerWiresFakeIO() {
         let io = FakeGhosttySurfaceIO()
         let view = AlasGhostty.SurfaceView(testIO: io)

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -316,12 +316,22 @@ struct SurfaceViewKeyboardTests {
         #expect(view.hasMarkedText() == true)
     }
 
-    @Test @MainActor func unmarkText_clearsStateAndPreedit() {
+    @Test @MainActor func unmarkText_commitsMarkedTextAndClearsPreedit() {
         let io = FakeGhosttySurfaceIO()
         let view = AlasGhostty.SurfaceView(testIO: io)
         view.setMarkedText("か" as NSString, selectedRange: NSRange(location: 1, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
         view.unmarkText()
-        #expect(io.calls == [.preedit("か"), .preedit(nil)])
+        // Per Apple's contract: marked text is accepted (sent as text) and
+        // then preedit is cleared.
+        #expect(io.calls == [.preedit("か"), .text("か"), .preedit(nil)])
+        #expect(view.hasMarkedText() == false)
+    }
+
+    @Test @MainActor func unmarkText_withoutMarkedTextOnlyClearsPreedit() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        view.unmarkText()
+        #expect(io.calls == [.preedit(nil)])
         #expect(view.hasMarkedText() == false)
     }
 

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -325,6 +325,32 @@ struct SurfaceViewKeyboardTests {
         #expect(view.hasMarkedText() == false)
     }
 
+    @Test @MainActor func firstRect_noWindowReturnsZero() {
+        let io = FakeGhosttySurfaceIO()
+        io.imePointRect = CGRect(x: 10, y: 20, width: 8, height: 16)
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        let rect = view.firstRect(forCharacterRange: NSRange(location: 0, length: 0), actualRange: nil)
+        #expect(rect == .zero)
+    }
+
+    @Test @MainActor func firstRect_withWindowConvertsToScreen() {
+        let io = FakeGhosttySurfaceIO()
+        io.imePointRect = CGRect(x: 10, y: 20, width: 8, height: 16)
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        let window = NSWindow(
+            contentRect: NSRect(x: 100, y: 200, width: 800, height: 600),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(view)
+        view.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+
+        let rect = view.firstRect(forCharacterRange: NSRange(location: 0, length: 0), actualRange: nil)
+        #expect(rect.size == CGSize(width: 8, height: 16))
+        #expect(rect.origin != .zero)
+    }
+
     @Test @MainActor func testInitializerWiresFakeIO() {
         let io = FakeGhosttySurfaceIO()
         let view = AlasGhostty.SurfaceView(testIO: io)

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -262,6 +262,29 @@ struct SurfaceViewKeyboardTests {
         #expect(view.characterIndex(for: .zero) == NSNotFound)
     }
 
+    @Test @MainActor func insertText_sendsTextAndClearsPreedit() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        view.insertText("é" as NSString, replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(io.calls == [.text("é"), .preedit(nil)])
+        #expect(view.hasMarkedText() == false)
+    }
+
+    @Test @MainActor func insertText_acceptsAttributedString() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        let attr = NSAttributedString(string: "ñ")
+        view.insertText(attr, replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(io.calls == [.text("ñ"), .preedit(nil)])
+    }
+
+    @Test @MainActor func insertText_emptyStringIsNoop() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        view.insertText("" as NSString, replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(io.calls.isEmpty)
+    }
+
     @Test @MainActor func testInitializerWiresFakeIO() {
         let io = FakeGhosttySurfaceIO()
         let view = AlasGhostty.SurfaceView(testIO: io)

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -3,6 +3,45 @@ import GhosttyKit
 import Testing
 @testable import Alas
 
+/// Records calls made by SurfaceView to the Ghostty surface, so tests can
+/// drive NSTextInputClient methods without standing up a real surface.
+@MainActor
+final class FakeGhosttySurfaceIO: GhosttySurfaceIO {
+    enum Call: Equatable {
+        case key(action: UInt32, keycode: UInt32, mods: UInt32, text: String?, composing: Bool)
+        case text(String)
+        case preedit(String?)
+    }
+
+    private(set) var calls: [Call] = []
+    var keyConsumed: Bool = false
+    var imePointRect: CGRect = CGRect(x: 0, y: 0, width: 0, height: 0)
+
+    func sendKey(_ event: ghostty_input_key_s) -> Bool {
+        let textStr: String? = event.text.map { String(cString: $0) }
+        calls.append(.key(
+            action: event.action.rawValue,
+            keycode: event.keycode,
+            mods: event.mods.rawValue,
+            text: textStr,
+            composing: event.composing
+        ))
+        return keyConsumed
+    }
+
+    func sendText(_ text: String) {
+        calls.append(.text(text))
+    }
+
+    func setPreedit(_ text: String?) {
+        calls.append(.preedit(text))
+    }
+
+    func imePoint() -> CGRect {
+        return imePointRect
+    }
+}
+
 /// Tests for the NSEvent keyboard-translation helpers that feed Ghostty.
 /// These exercise the pure modifier/character logic without needing a live
 /// Ghostty surface.
@@ -196,5 +235,17 @@ struct SurfaceViewKeyboardTests {
 
         #expect(keyEv.mods == GHOSTTY_MODS_SHIFT)
         #expect(keyEv.consumed_mods == GHOSTTY_MODS_SHIFT)
+    }
+
+    @Test @MainActor func fakeIOConformsToProtocol() {
+        let io = FakeGhosttySurfaceIO()
+        io.sendText("hi")
+        io.setPreedit("か")
+        io.setPreedit(nil)
+        #expect(io.calls == [
+            .text("hi"),
+            .preedit("か"),
+            .preedit(nil),
+        ])
     }
 }

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -285,6 +285,37 @@ struct SurfaceViewKeyboardTests {
         #expect(io.calls.isEmpty)
     }
 
+    @Test @MainActor func setMarkedText_sendsPreeditAndTracksState() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        view.setMarkedText(
+            "か" as NSString,
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        #expect(io.calls == [.preedit("か")])
+        #expect(view.hasMarkedText() == true)
+        #expect(view.markedRange() == NSRange(location: 0, length: 1))
+    }
+
+    @Test @MainActor func setMarkedText_emptyClearsState() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        view.setMarkedText("か" as NSString, selectedRange: NSRange(location: 1, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+        view.setMarkedText("" as NSString, selectedRange: NSRange(location: 0, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(io.calls == [.preedit("か"), .preedit(nil)])
+        #expect(view.hasMarkedText() == false)
+    }
+
+    @Test @MainActor func setMarkedText_acceptsAttributedString() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        let attr = NSAttributedString(string: "한")
+        view.setMarkedText(attr, selectedRange: NSRange(location: 1, length: 0), replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(io.calls == [.preedit("한")])
+        #expect(view.hasMarkedText() == true)
+    }
+
     @Test @MainActor func testInitializerWiresFakeIO() {
         let io = FakeGhosttySurfaceIO()
         let view = AlasGhostty.SurfaceView(testIO: io)

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -248,4 +248,20 @@ struct SurfaceViewKeyboardTests {
             .preedit(nil),
         ])
     }
+
+    @Test @MainActor func testInitializerWiresFakeIO() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        var keyEv = ghostty_input_key_s()
+        keyEv.action = GHOSTTY_ACTION_PRESS
+        keyEv.keycode = 42
+        _ = view.surfaceIOForTesting.sendKey(keyEv)
+        #expect(io.calls == [.key(
+            action: GHOSTTY_ACTION_PRESS.rawValue,
+            keycode: 42,
+            mods: 0,
+            text: nil,
+            composing: false
+        )])
+    }
 }

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -249,6 +249,19 @@ struct SurfaceViewKeyboardTests {
         ])
     }
 
+    @Test @MainActor func textInputClient_defaultsAreEmpty() {
+        let io = FakeGhosttySurfaceIO()
+        let view = AlasGhostty.SurfaceView(testIO: io)
+        #expect(view.hasMarkedText() == false)
+        #expect(view.selectedRange().location == NSNotFound)
+        #expect(view.selectedRange().length == 0)
+        #expect(view.markedRange().location == NSNotFound)
+        #expect(view.markedRange().length == 0)
+        #expect(view.attributedSubstring(forProposedRange: NSRange(location: 0, length: 0), actualRange: nil) == nil)
+        #expect(view.validAttributesForMarkedText().isEmpty)
+        #expect(view.characterIndex(for: .zero) == NSNotFound)
+    }
+
     @Test @MainActor func testInitializerWiresFakeIO() {
         let io = FakeGhosttySurfaceIO()
         let view = AlasGhostty.SurfaceView(testIO: io)


### PR DESCRIPTION
## Summary

The embedded Ghostty terminal bypassed AppKit's text input pipeline, so:

- Dead-key composition silently dropped characters on layouts like U.S. International – PC. `Shift+\`` → no tilde, `Shift+'` → no double-quote, `' + e` → no `é`.
- `Opt+Delete` did not delete the previous word.
- CJK IMEs, the emoji palette, and the press-and-hold accent popover did not work at all.

This PR adopts `NSTextInputClient` on `SurfaceView` and routes `keyDown` through `interpretKeyEvents`, while keeping every existing Cmd/Ctrl shortcut behaving the same.

## Approach

```
keyDown(event)
    ├── ghostty_surface_key(... composing = hasMarkedText())   ← raw forward for keybindings
    ├── if consumed → return
    ├── if Cmd or Ctrl → return                                ← bypass IME for shortcuts
    └── interpretKeyEvents([event])
            ├── insertText(str)            → ghostty_surface_text(str)
            ├── setMarkedText(str, …)      → ghostty_surface_preedit(str)
            ├── unmarkText()               → ghostty_surface_preedit(nil)
            └── doCommand(selector:)       → swallow (raw key already delivered)
```

A thin `GhosttySurfaceIO` protocol wraps the four C calls used by the input pipeline (`surface_key`, `surface_text`, `surface_preedit`, `surface_ime_point`) so the `NSTextInputClient` methods are unit-testable via a recording fake.

`firstRect(forCharacterRange:)` uses `ghostty_surface_ime_point` (with a Y-flip from Ghostty's top-left view convention to AppKit's bottom-left) so the IME candidate popup / accent popover anchors at the cursor instead of the top-left of the terminal.

## What this fixes

| Symptom | Before | After |
|---|---|---|
| `Shift+\`` → ~ | Silently dropped | Resolves via `insertText` |
| `' + e` → é | Silently dropped | Resolves via `insertText` |
| `Opt+Delete` deletes a word | No | Yes (raw key → Ghostty encodes ESC+DEL; selector swallowed) |
| CJK IME / emoji palette / accent popover | Not functional | Functional, popups anchored to cursor |

## Test plan

- [x] `xcodebuild ... -only-testing:AlasTests/SurfaceViewKeyboardTests test` — 27/27 green
- [x] `xcodebuild ... -only-testing:AlasTests/SurfaceViewShortcutTests test` — 17/17 green
- [x] Manual matrix on U.S. International – PC: dead keys, Opt+Delete, Cmd shortcuts, Ctrl shortcuts, accent popover, emoji palette, plain typing
- [ ] CI green
- [ ] Codex review approved

## Notes for reviewers

- `surfaceIO` is optional and every call site guards before use, so events that arrive after a failed `ghostty_surface_new()` no longer route into `NSTextInputClient` callbacks.
- The NSTextInputClient conformance is marked `@preconcurrency` to silence the Swift 6 main-actor-isolation warning without changing runtime behavior — all calls already happen on the main thread.
- `Option` is intentionally *not* part of the Cmd/Ctrl bypass gate — it must reach `interpretKeyEvents` for dead-key composition and `doCommand` selectors (Opt+Backspace → `deleteWordBackward:`) to fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)