### PR TITLE
fix(LSP): drop stale hover/definition/symbols responses

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7159EED1183F784104B4F /* FuzzyMatch.swift */; };
 		B06544FDB162DD8CDCD9EAF2 /* AlasHookCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57713D7143CFD53124E0523F /* AlasHookCommand.swift */; };
 		B0861243A465A06EDA290722 /* AgentHookSocketServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78C23951DE157A38A9ED899 /* AgentHookSocketServerTests.swift */; };
+		B092D71B3D727B89EAF5D753 /* SymbolsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
 		B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46BDE72E52818061452ECB /* CommitRowTests.swift */; };
 		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
@@ -682,6 +683,7 @@
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
 		DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoader.swift; sourceTree = "<group>"; };
 		E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTabView.swift; sourceTree = "<group>"; };
+		E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeatureTests.swift; sourceTree = "<group>"; };
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
 		E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteFailedWorktreeView.swift; sourceTree = "<group>"; };
 		E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndex.swift; sourceTree = "<group>"; };
@@ -945,6 +947,7 @@
 				7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */,
 				412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */,
 				100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */,
+				E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -1972,6 +1975,7 @@
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,
 				3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */,
 				CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */,
+				B092D71B3D727B89EAF5D753 /* SymbolsFeatureTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
 				42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */,

--- a/Alas/Sources/Code/LSP/Features/DefinitionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/DefinitionFeature.swift
@@ -13,6 +13,8 @@ final class DefinitionFeature {
     private let getURI: () -> String?
     private let openTarget: (URL, Int, Int) -> Void
     private var popover: NSPopover?
+    private var requestID: UInt64 = 0
+    private var inFlight: Task<Void, Never>?
     private let snippetCache = DefinitionSnippetCache()
 
     init(
@@ -32,11 +34,19 @@ final class DefinitionFeature {
         popover?.close()
         guard let textView, let client = getClient(), let uri = getURI() else { return }
         guard let position = textView.lspPosition(at: point) else { return }
-        Task { [weak self] in
+        inFlight?.cancel()
+        requestID += 1
+        let currentRequestID = requestID
+        inFlight = Task { [weak self] in
             guard let self else { return }
             let locations: [LSPLocation] = (try? await client.definition(uri: uri, position: position)) ?? []
+            guard !Task.isCancelled else { return }
             await MainActor.run { [weak self] in
-                guard let self else { return }
+                guard let self,
+                      self.requestID == currentRequestID,
+                      self.getURI() == uri,
+                      self.textView?.lspPosition(at: point) == position
+                else { return }
                 self.handle(locations: locations, anchorPoint: point)
             }
         }

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -9,6 +9,7 @@ final class HoverFeature {
     private var debounce: Task<Void, Never>?
     private var popover: NSPopover?
     private var lastPosition: NSPoint?
+    private var requestID: UInt64 = 0
 
     init(textView: CodeTextView, getClient: @escaping () -> LSPClient?, getURI: @escaping () -> String?) {
         self.textView = textView
@@ -22,15 +23,17 @@ final class HoverFeature {
         if let last = lastPosition, hypot(last.x - point.x, last.y - point.y) < 3 { return }
         lastPosition = point
         debounce?.cancel()
+        requestID += 1
+        let currentRequestID = requestID
         let captured = point
         debounce = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 250_000_000)
             guard !Task.isCancelled else { return }
-            await self?.show(at: captured)
+            await self?.show(at: captured, requestID: currentRequestID)
         }
     }
 
-    private func show(at point: NSPoint) async {
+    private func show(at point: NSPoint, requestID currentRequestID: UInt64) async {
         guard let textView, let client = getClient(), let uri = getURI() else {
             closePopover()
             return
@@ -43,9 +46,11 @@ final class HoverFeature {
         do {
             result = try await client.hover(uri: uri, position: position)
         } catch {
+            guard isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
             closePopover()
             return
         }
+        guard isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
         guard let result else {
             closePopover()
             return
@@ -61,8 +66,18 @@ final class HoverFeature {
         }
         let textRect = textView.firstRect(for: position) ?? CGRect(origin: point, size: .zero)
         await MainActor.run {
+            guard self.isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
             self.presentPopover(text: body, anchor: textRect, in: textView)
         }
+    }
+
+    private func isCurrentRequest(_ currentRequestID: UInt64, uri: String, position: LSPPosition, point: NSPoint) -> Bool {
+        guard !Task.isCancelled,
+              requestID == currentRequestID,
+              getURI() == uri,
+              textView?.lspPosition(at: point) == position
+        else { return false }
+        return true
     }
 
     private func presentPopover(text: String, anchor: NSRect, in view: NSView) {

--- a/Alas/Sources/Code/LSP/Features/SymbolsFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/SymbolsFeature.swift
@@ -4,6 +4,7 @@ import Foundation
 final class SymbolsFeature {
     private(set) var symbols: [Item] = []
     var onChange: (() -> Void)?
+    private var requestID: UInt64 = 0
 
     struct Item: Identifiable, Hashable {
         let id = UUID()
@@ -15,10 +16,15 @@ final class SymbolsFeature {
     }
 
     func refresh(client: LSPClient?, uri: String) async {
-        guard let client else { symbols = []
-        onChange?()
-        return }
+        requestID += 1
+        let currentRequestID = requestID
+        guard let client else {
+            symbols = []
+            onChange?()
+            return
+        }
         let raw = (try? await client.documentSymbol(uri: uri)) ?? []
+        guard !Task.isCancelled, requestID == currentRequestID else { return }
         var flat: [Item] = []
         func walk(_ list: [LSPDocumentSymbol], depth: Int) {
             for s in list {

--- a/AlasTests/Code/LSP/Features/SymbolsFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/SymbolsFeatureTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct SymbolsFeatureTests {
+    @Test func ignoresStaleDocumentSymbolResponse() async throws {
+        let transport = FakeTransport()
+        let client = LSPClient(transport: transport, language: "swift", rootURI: "file:///tmp")
+        let feature = SymbolsFeature()
+
+        transport.onSend = { sent in
+            guard let id = Self.requestID(in: sent) else { return }
+            if sent.contains(#""uri":"file:///tmp/old.swift""#) {
+                Task {
+                    try? await Task.sleep(nanoseconds: 80_000_000)
+                    transport.deliverFrame(Self.symbolResponse(id: id, name: "OldSymbol"))
+                }
+            } else if sent.contains(#""uri":"file:///tmp/new.swift""#) {
+                transport.deliverFrame(Self.symbolResponse(id: id, name: "NewSymbol"))
+            }
+        }
+
+        let oldRefresh = Task { @MainActor in
+            await feature.refresh(client: client, uri: "file:///tmp/old.swift")
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+        let newRefresh = Task { @MainActor in
+            await feature.refresh(client: client, uri: "file:///tmp/new.swift")
+        }
+        await oldRefresh.value
+        await newRefresh.value
+
+        #expect(feature.symbols.map(\.name) == ["NewSymbol"])
+        transport.finish()
+    }
+
+    private static func symbolResponse(id: Int, name: String) -> String {
+        """
+        {"jsonrpc":"2.0","id":\(id),"result":[{"name":"\(name)","kind":12,"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":1}},"selectionRange":{"start":{"line":0,"character":0},"end":{"line":0,"character":1}}}]}
+        """
+    }
+
+    private static func requestID(in json: String) -> Int? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return object["id"] as? Int
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
Guard against out-of-order LSP replies clobbering newer UI state by
tracking a per-feature request ID and bailing when it no longer
matches (or the cursor/document has moved on).

- HoverFeature: validate request ID, URI, and position before
  presenting the popover.
- DefinitionFeature: cancel any in-flight task on re-trigger and
  re-check identity before opening the target.
- SymbolsFeature: ignore symbol responses superseded by a newer
  refresh.
- Add SymbolsFeatureTests covering the stale-response case.
<!-- gg:managed:end -->