### PR TITLE
fix(AppState): report persistence save failures

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		255E9EAE89D521E08EB90918 /* JSONHookSettingsFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */; };
 		2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF2F213480B30034B25B2B8 /* AgentRunError.swift */; };
 		25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */; };
+		25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
 		281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
@@ -561,6 +562,7 @@
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
 		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
+		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
 		8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcherTests.swift; sourceTree = "<group>"; };
@@ -787,6 +789,7 @@
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
+				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
 				71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */,
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
@@ -1879,6 +1882,7 @@
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,
+				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -176,14 +176,24 @@ final class AppState {
         return manager
     }
 
-    private let store = PersistenceStore()
+    @ObservationIgnored
+    private let store: any PersistenceStoreProtocol
+    @ObservationIgnored
+    private let persistenceErrorHandler: (String, String) -> Void
 
     /// One FSEvents watcher per project, watching `<repo>/.git` to auto-refresh
     /// the sidebar when branches flip or worktrees appear/disappear externally.
     @ObservationIgnored
     private var projectGitWatchers: [String: ProjectGitWatcher] = [:]
 
-    init() {
+    init(
+        store: any PersistenceStoreProtocol = PersistenceStore(),
+        persistenceErrorHandler: ((String, String) -> Void)? = nil
+    ) {
+        self.store = store
+        self.persistenceErrorHandler = persistenceErrorHandler ?? { title, message in
+            AppState.showWarningAlert(title: title, message: message)
+        }
         let config = (try? store.readIfExists(AppConfig.self, from: Paths.appConfigFile)) ?? AppConfig.defaults
         let projectsFile = (try? store.readIfExists(ProjectsFile.self, from: Paths.projectsFile)) ?? ProjectsFile(projects: [])
         self.config = config
@@ -239,13 +249,29 @@ final class AppState {
 
     var projects: [ProjectConfig] { projectsManager.projects }
 
-    func saveConfig() {
-        try? store.write(config, to: Paths.appConfigFile)
+    @discardableResult
+    func saveConfig() -> Bool {
+        let saved: Bool
+        do {
+            try store.write(config, to: Paths.appConfigFile)
+            saved = true
+        } catch {
+            saved = false
+            persistenceErrorHandler("Settings Save Failed", error.localizedDescription)
+        }
         lspManager?.updateRegistry(LanguageServerRegistry(userDefined: config.code.languageServers))
+        return saved
     }
 
-    func saveProjects() {
-        try? store.write(ProjectsFile(projects: projectsManager.projects), to: Paths.projectsFile)
+    @discardableResult
+    func saveProjects() -> Bool {
+        do {
+            try store.write(ProjectsFile(projects: projectsManager.projects), to: Paths.projectsFile)
+            return true
+        } catch {
+            persistenceErrorHandler("Projects Save Failed", error.localizedDescription)
+            return false
+        }
     }
 
     /// Optimistically insert a worktree row and run the git operation async.
@@ -1227,6 +1253,10 @@ final class AppState {
     }
 
     private func showFileActionError(title: String, message: String) {
+        Self.showWarningAlert(title: title, message: message)
+    }
+
+    private static func showWarningAlert(title: String, message: String) {
         let alert = NSAlert()
         alert.messageText = title
         alert.informativeText = message

--- a/Alas/Sources/Persistence/PersistenceStore.swift
+++ b/Alas/Sources/Persistence/PersistenceStore.swift
@@ -1,6 +1,11 @@
 import Foundation
 
-struct PersistenceStore {
+protocol PersistenceStoreProtocol {
+    func write<T: Encodable>(_ value: T, to url: URL) throws
+    func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T?
+}
+
+struct PersistenceStore: PersistenceStoreProtocol {
     private let encoder: JSONEncoder
     private let decoder = JSONDecoder()
 

--- a/AlasTests/AppStatePersistenceTests.swift
+++ b/AlasTests/AppStatePersistenceTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct AppStatePersistenceTests {
+    private struct FailingStore: PersistenceStoreProtocol {
+        let error = NSError(
+            domain: "AppStatePersistenceTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "write rejected"]
+        )
+
+        func write<T: Encodable>(_: T, to _: URL) throws {
+            throw error
+        }
+
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? {
+            nil
+        }
+    }
+
+    @Test func saveConfigReportsWriteFailure() {
+        var reports: [(title: String, message: String)] = []
+        let state = AppState(store: FailingStore()) { title, message in
+            reports.append((title, message))
+        }
+
+        let saved = state.saveConfig()
+
+        #expect(saved == false)
+        #expect(reports.map(\.title) == ["Settings Save Failed"])
+        #expect(reports.first?.message == "write rejected")
+    }
+
+    @Test func saveProjectsReportsWriteFailure() {
+        var reports: [(title: String, message: String)] = []
+        let state = AppState(store: FailingStore()) { title, message in
+            reports.append((title, message))
+        }
+
+        let saved = state.saveProjects()
+
+        #expect(saved == false)
+        #expect(reports.map(\.title) == ["Projects Save Failed"])
+        #expect(reports.first?.message == "write rejected")
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
Surface settings and projects write errors instead of silently ignoring
them so users know when their changes were not persisted.
<!-- gg:managed:end -->