### PR TITLE
fix(codex): commit message stdin mode

### DIFF
--- a/Alas/Sources/Agents/AgentRunner.swift
+++ b/Alas/Sources/Agents/AgentRunner.swift
@@ -24,8 +24,8 @@ enum AgentMessageParser {
     }
 }
 
-/// Spawns the agent's resolved binary with `agent.promptModeArgs + [prompt]`,
-/// pipes `input` on stdin, parses stdout. 120s timeout. Cancellation is
+/// Spawns the agent's resolved binary with its non-interactive prompt shape,
+/// pipes any stdin payload, and parses stdout. 120s timeout. Cancellation is
 /// delivered by Task cancellation, which `Process.run` propagates as SIGTERM.
 ///
 /// Pipe-management and process-lifecycle logic mirrors `Process.run` in
@@ -40,7 +40,11 @@ enum AgentRunner {
         timeout: TimeInterval = 120
     ) async throws -> GeneratedMessage {
         let binary = agent.resolvedBinary
-        let args = agent.promptModeArgs + [prompt]
+        let invocation = AgentPromptInvocation.make(
+            agent: agent,
+            input: input,
+            prompt: prompt
+        )
         let pipe = Pipe()
         // We can't use Process.run directly because it doesn't accept
         // stdin. Inline a minimal variant that does, reusing gitEnv()
@@ -48,7 +52,7 @@ enum AgentRunner {
         // for these CLIs, but the parent-env passthrough does).
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = [binary] + args
+        process.arguments = [binary] + invocation.arguments
         var env = environment
         env["PATH"] = AgentPath.augmented(base: env["PATH"])
         process.environment = env
@@ -127,7 +131,7 @@ enum AgentRunner {
         // reason: if the awaiting Task is cancelled while we're blocked
         // writing, `onCancel` terminates the child and the write unblocks.
         await withTaskCancellationHandler {
-            if let data = input.data(using: .utf8) {
+            if let data = invocation.stdin.data(using: .utf8) {
                 try? pipe.fileHandleForWriting.write(contentsOf: data)
             }
             try? pipe.fileHandleForWriting.close()
@@ -184,6 +188,41 @@ enum AgentRunner {
             throw AgentRunError.nonZeroExit(stderr: stderr, exitCode: process.terminationStatus)
         }
         return AgentMessageParser.parse(stdout)
+    }
+}
+
+private struct AgentPromptInvocation {
+    let arguments: [String]
+    let stdin: String
+
+    static func make(
+        agent: AgentDefinition,
+        input: String,
+        prompt: String
+    ) -> AgentPromptInvocation {
+        if isCodexExec(agent) {
+            return AgentPromptInvocation(
+                arguments: agent.promptModeArgs + ["-"],
+                stdin: combinedPrompt(prompt: prompt, input: input)
+            )
+        }
+
+        return AgentPromptInvocation(
+            arguments: agent.promptModeArgs + [prompt],
+            stdin: input
+        )
+    }
+
+    private static func combinedPrompt(prompt: String, input: String) -> String {
+        if input.isEmpty { return prompt }
+        if prompt.isEmpty { return input }
+        return "\(prompt)\n\n\(input)"
+    }
+
+    private static func isCodexExec(_ agent: AgentDefinition) -> Bool {
+        let binaryName = (agent.resolvedBinary as NSString).lastPathComponent
+        let subcommand = agent.promptModeArgs.first
+        return binaryName == "codex" && (subcommand == "exec" || subcommand == "e")
     }
 }
 

--- a/AlasTests/AgentRunnerInvocationTests.swift
+++ b/AlasTests/AgentRunnerInvocationTests.swift
@@ -67,7 +67,58 @@ struct AgentRunnerInvocationTests {
         )
         let recorded = try String(contentsOf: record, encoding: .utf8)
         #expect(recorded.contains("exec\n"))
-        #expect(recorded.contains("PROMPT\n"))
+        #expect(recorded.contains("-\n"))
+    }
+
+    @Test func codexReadsPromptAndContextFromStdin() async throws {
+        let tmp = try makeTmp()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let (record, path) = try shim(named: "codex", in: tmp)
+        _ = try await AgentRunner.runPrompt(
+            agent: agent(id: "codex", binary: "codex", args: ["exec"]),
+            input: "DIFF\n",
+            prompt: "PROMPT",
+            environment: ["PATH": path]
+        )
+        let recorded = try String(contentsOf: record, encoding: .utf8)
+        #expect(recorded.contains("exec\n"))
+        #expect(recorded.contains("-\n"))
+        #expect(!recorded.contains("PROMPT\nstdin="))
+        #expect(recorded.contains("stdin=\nPROMPT\n\nDIFF\n"))
+    }
+
+    @Test func customCodexExecDefinitionReadsPromptAndContextFromStdin() async throws {
+        let tmp = try makeTmp()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let (record, path) = try shim(named: "codex", in: tmp)
+        _ = try await AgentRunner.runPrompt(
+            agent: agent(id: "custom-codex-profile", binary: "codex", args: ["exec"]),
+            input: "DIFF\n",
+            prompt: "PROMPT",
+            environment: ["PATH": path]
+        )
+        let recorded = try String(contentsOf: record, encoding: .utf8)
+        #expect(recorded.contains("exec\n"))
+        #expect(recorded.contains("-\n"))
+        #expect(!recorded.contains("PROMPT\nstdin="))
+        #expect(recorded.contains("stdin=\nPROMPT\n\nDIFF\n"))
+    }
+
+    @Test func customCodexExecAliasDefinitionReadsPromptAndContextFromStdin() async throws {
+        let tmp = try makeTmp()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let (record, path) = try shim(named: "codex", in: tmp)
+        _ = try await AgentRunner.runPrompt(
+            agent: agent(id: "custom-codex-alias-profile", binary: "codex", args: ["e"]),
+            input: "DIFF\n",
+            prompt: "PROMPT",
+            environment: ["PATH": path]
+        )
+        let recorded = try String(contentsOf: record, encoding: .utf8)
+        #expect(recorded.contains("e\n"))
+        #expect(recorded.contains("-\n"))
+        #expect(!recorded.contains("PROMPT\nstdin="))
+        #expect(recorded.contains("stdin=\nPROMPT\n\nDIFF\n"))
     }
 
     @Test func opencodeUsesRunSubcommand() async throws {


### PR DESCRIPTION
## Summary

- Run Codex commit-message generation as `codex exec -` so Codex reads the complete prompt from stdin.
- Combine the user prompt and staged-diff context for Codex while preserving the existing argv prompt behavior for Claude and other agents.
- Add regression coverage for the Codex invocation shape.

## Root Cause

Alas treated every agent as if it accepted the prompt as an argv argument and additional context on stdin. Codex has a dedicated stdin prompt mode, and the previous shape could hit Codex's additional-stdin handling path and fail with `reading additional input from stdin`.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AgentRunnerInvocationTests -quiet test`
- `git diff --check`

Note: local full-suite `xcodebuild ... test` attempts got stuck in Xcode/RTK capture with orphaned `xcodebuild` processes before completion, so the focused regression suite and build are the completed local checks.