### PR TITLE
fix(EditorBuffer): restore snapshot path after dirty move

### DIFF
--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -629,8 +629,16 @@ final class TabsManager {
     /// hot-restore from snapshot) on first access.
     func buffer(worktreeId: String, tabId: TabID, worktreeRoot: URL, relativePath: String) -> EditorBuffer {
         if let key = bufferKeys[tabId], let existing = buffers[key] { return existing }
+        let snapshot = (try? bufferStore.read(worktreeId: worktreeId, tabId: tabId)) ?? nil
+        let restoresToDifferentPath = snapshot.map { $0.relativePath != relativePath } ?? false
+        if restoresToDifferentPath {
+            if let snapshot,
+               !canFollowBufferPathChange(worktreeId: worktreeId, oldPath: relativePath, newPath: snapshot.relativePath) {
+                bufferStore.discard(worktreeId: worktreeId, tabId: tabId)
+            }
+        }
         let key = BufferKey(worktreeId: worktreeId, relativePath: relativePath)
-        if let existing = buffers[key] {
+        if !restoresToDifferentPath, let existing = buffers[key] {
             bufferKeys[tabId] = key
             return existing
         }
@@ -669,8 +677,15 @@ final class TabsManager {
             guard let buffer else { return }
             self?.discardSnapshotsForAllTabs(buffer)
         }
-        buffers[key] = buffer
-        bufferKeys[tabId] = key
+        if let restoredPathChange = buffer.consumeRestoredPathChange() {
+            let restoredKey = BufferKey(worktreeId: worktreeId, relativePath: restoredPathChange.newPath)
+            buffers[restoredKey] = buffer
+            bufferKeys[tabId] = restoredKey
+            _ = updateEditorPath(worktreeId: worktreeId, tabId: tabId, relativePath: restoredPathChange.newPath)
+        } else {
+            buffers[key] = buffer
+            bufferKeys[tabId] = key
+        }
         return buffer
     }
 
@@ -933,25 +948,7 @@ final class TabsManager {
                 guard case .editor(let state) = tab,
                       peekBuffer(tabId: state.id) == nil,
                       (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) != nil else { continue }
-                let buffer: EditorBuffer
-                if let lsp {
-                    buffer = EditorBuffer(
-                        worktreeRoot: root,
-                        relativePath: state.relativePath,
-                        store: bufferStore,
-                        worktreeId: worktreeId,
-                        tabId: state.id,
-                        lsp: lsp
-                    )
-                } else {
-                    buffer = EditorBuffer(
-                        worktreeRoot: root,
-                        relativePath: state.relativePath,
-                        store: bufferStore,
-                        worktreeId: worktreeId,
-                        tabId: state.id
-                    )
-                }
+                guard let buffer = materializeSnapshotBufferForSave(worktreeId: worktreeId, tabId: state.id, worktreeRoot: root, relativePath: state.relativePath) else { continue }
                 do {
                     try buffer.saveRecordingError()
                     buffer.close(persistDirtySnapshot: false)
@@ -991,25 +988,7 @@ final class TabsManager {
             guard case .editor(let state) = tab,
                   peekBuffer(tabId: state.id) == nil,
                   (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) != nil else { continue }
-            let buffer: EditorBuffer
-            if let lsp {
-                buffer = EditorBuffer(
-                    worktreeRoot: root,
-                    relativePath: state.relativePath,
-                    store: bufferStore,
-                    worktreeId: worktreeId,
-                    tabId: state.id,
-                    lsp: lsp
-                )
-            } else {
-                buffer = EditorBuffer(
-                    worktreeRoot: root,
-                    relativePath: state.relativePath,
-                    store: bufferStore,
-                    worktreeId: worktreeId,
-                    tabId: state.id
-                )
-            }
+            guard let buffer = materializeSnapshotBufferForSave(worktreeId: worktreeId, tabId: state.id, worktreeRoot: root, relativePath: state.relativePath) else { continue }
             do {
                 try buffer.saveRecordingError()
                 buffer.close(persistDirtySnapshot: false)
@@ -1019,6 +998,38 @@ final class TabsManager {
             }
         }
         return errors
+    }
+
+    private func materializeSnapshotBufferForSave(worktreeId: String, tabId: TabID, worktreeRoot: URL, relativePath: String) -> EditorBuffer? {
+        guard let snapshot = (try? bufferStore.read(worktreeId: worktreeId, tabId: tabId)) ?? nil else { return nil }
+        if snapshot.relativePath != relativePath,
+           !canFollowBufferPathChange(worktreeId: worktreeId, oldPath: relativePath, newPath: snapshot.relativePath) {
+            bufferStore.discard(worktreeId: worktreeId, tabId: tabId)
+            return nil
+        }
+        let buffer: EditorBuffer
+        if let lsp {
+            buffer = EditorBuffer(
+                worktreeRoot: worktreeRoot,
+                relativePath: relativePath,
+                store: bufferStore,
+                worktreeId: worktreeId,
+                tabId: tabId,
+                lsp: lsp
+            )
+        } else {
+            buffer = EditorBuffer(
+                worktreeRoot: worktreeRoot,
+                relativePath: relativePath,
+                store: bufferStore,
+                worktreeId: worktreeId,
+                tabId: tabId
+            )
+        }
+        if buffer.relativePath != relativePath {
+            _ = updateEditorPath(worktreeId: worktreeId, tabId: tabId, relativePath: buffer.relativePath)
+        }
+        return buffer
     }
 
     /// Save the active editor tab's buffer for `worktreeId`. No-op if the
@@ -1077,13 +1088,17 @@ final class TabsManager {
         guard oldKey != newKey else { return true }
         guard buffers[newKey] == nil else { return false }
         guard let file = byWorktree[worktreeId] else { return true }
-        return !file.tabs.contains { tab in
+        for tab in file.tabs {
             guard case .editor(let state) = tab,
                   state.relativePath == newPath,
-                  bufferKeys[state.id] == nil,
-                  (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) != nil else { return false }
-            return true
+                  bufferKeys[state.id] == nil else { continue }
+            if let snapshot = (try? bufferStore.read(worktreeId: worktreeId, tabId: state.id)) ?? nil,
+               snapshot.relativePath != newPath {
+                continue
+            }
+            return false
         }
+        return true
     }
 
     /// Re-fires `didOpen` for every live buffer whose resolved LSP language

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -81,6 +81,8 @@ final class EditorBuffer {
     var onSnapshotRequested: (() -> Void)?
     @ObservationIgnored
     var onDiscardSnapshotsRequested: (() -> Void)?
+    @ObservationIgnored
+    private var pendingRestoredPathChange: (oldPath: String, newPath: String)?
     var persistenceTabId: String? { tabId }
 
     struct EditObserverToken { fileprivate let id: UUID }
@@ -154,7 +156,7 @@ final class EditorBuffer {
         }
         onEdit { [weak self] in self?.scheduleSnapshot() }
         if !isExternal, let lsp, let language {
-            let url = worktreeRoot.appendingPathComponent(relativePath)
+            let url = worktreeRoot.appendingPathComponent(self.relativePath)
             let text = storage.string
             Task { await lsp.openDocument(worktreeRoot: worktreeRoot, fileURL: url, languageId: language, text: text) }
         }
@@ -198,6 +200,12 @@ final class EditorBuffer {
         guard self.tabId != tabId else { return }
         self.tabId = tabId
         if dirty { snapshotNow() }
+    }
+
+    func consumeRestoredPathChange() -> (oldPath: String, newPath: String)? {
+        guard let change = pendingRestoredPathChange else { return nil }
+        pendingRestoredPathChange = nil
+        return change
     }
 
     private func handleEdit(edit: EditorTextEdit?) {
@@ -492,6 +500,24 @@ final class EditorBuffer {
         updateOriginalFileIdentity(from: url)
     }
 
+    private func updateOriginalFileAttributes(from url: URL) {
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) {
+            originalMtime = (attrs[.modificationDate] as? Date) ?? originalMtime
+            if let nsPerms = attrs[.posixPermissions] as? NSNumber {
+                permissions = mode_t(nsPerms.uint16Value)
+            }
+        }
+        updateOriginalFileIdentity(from: url)
+    }
+
+    private func updateOriginalFileIdentityAndPermissions(from url: URL) {
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+           let nsPerms = attrs[.posixPermissions] as? NSNumber {
+            permissions = mode_t(nsPerms.uint16Value)
+        }
+        updateOriginalFileIdentity(from: url)
+    }
+
     private func updateOriginalFileIdentity(from url: URL) {
         guard let values = try? url.resourceValues(forKeys: [.fileResourceIdentifierKey, .volumeIdentifierKey]),
               let file = values.fileResourceIdentifier,
@@ -686,7 +712,11 @@ final class EditorBuffer {
             discardSnapshot()
             return
         }
+        let oldRelativePath = relativePath
         relativePath = snap.relativePath
+        if oldRelativePath != snap.relativePath {
+            pendingRestoredPathChange = (oldRelativePath, snap.relativePath)
+        }
         language = lsp?.language(forFileExtension: (snap.relativePath as NSString).pathExtension)
         loading = true
         defer { loading = false }
@@ -695,7 +725,7 @@ final class EditorBuffer {
         originalMtime = snap.originalMtime
         lineEnding = snap.lineEnding
         readOnly = false
-        updateOriginalFileIdentity(from: worktreeRoot.appendingPathComponent(snap.relativePath))
+        updateOriginalFileIdentityAndPermissions(from: worktreeRoot.appendingPathComponent(snap.relativePath))
     }
 
     private func canRestoreSnapshotPath(_ path: String) -> Bool {
@@ -805,13 +835,7 @@ final class EditorBuffer {
         storage.setAttributedString(NSAttributedString(string: canonical))
         originalText = canonical
         lineEnding = detected
-        if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) {
-            originalMtime = (attrs[.modificationDate] as? Date) ?? .distantPast
-            if let nsPerms = attrs[.posixPermissions] as? NSNumber {
-                permissions = mode_t(nsPerms.uint16Value)
-            }
-        }
-        updateOriginalFileIdentity(from: url)
+        updateOriginalFileAttributes(from: url)
         // External buffers remain read-only even after a successful reload;
         // the isExternal flag is the authoritative source of read-only-ness.
         readOnly = isExternal ? true : false

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -682,6 +682,12 @@ final class EditorBuffer {
     // MARK: - Snapshot / restore (hot-exit)
 
     private func applySnapshot(_ snap: EditorBufferStore.Snapshot) {
+        guard canRestoreSnapshotPath(snap.relativePath) else {
+            discardSnapshot()
+            return
+        }
+        relativePath = snap.relativePath
+        language = lsp?.language(forFileExtension: (snap.relativePath as NSString).pathExtension)
         loading = true
         defer { loading = false }
         storage.setAttributedString(NSAttributedString(string: snap.content))
@@ -689,6 +695,17 @@ final class EditorBuffer {
         originalMtime = snap.originalMtime
         lineEnding = snap.lineEnding
         readOnly = false
+        updateOriginalFileIdentity(from: worktreeRoot.appendingPathComponent(snap.relativePath))
+    }
+
+    private func canRestoreSnapshotPath(_ path: String) -> Bool {
+        guard !path.isEmpty,
+              !path.contains("\0"),
+              !(path as NSString).isAbsolutePath else { return false }
+        let rootPath = worktreeRoot.standardizedFileURL.path
+        let targetPath = worktreeRoot.appendingPathComponent(path).standardizedFileURL.path
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        return targetPath.hasPrefix(prefix)
     }
 
     private func scheduleSnapshot() {

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -138,6 +138,30 @@ struct EditorBufferTests {
         #expect(try String(contentsOf: root.appendingPathComponent("b.txt"), encoding: .utf8) == "HELLO\n")
     }
 
+    @Test func restoreAfterDirtyMoveRefreshesTargetPermissions() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.sh", "#!/bin/sh\necho old\n", perms: 0o644)
+        let target = try writeFile(root, "b.sh", "#!/bin/sh\necho old\n", perms: 0o755)
+        let store = EditorBufferStore(rootOverride: tempWorktree())
+        let attrs = try FileManager.default.attributesOfItem(atPath: target.path)
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "b.sh",
+            content: "#!/bin/sh\necho new\n",
+            originalText: "#!/bin/sh\necho old\n",
+            originalMtime: (attrs[.modificationDate] as? Date) ?? Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: "t")
+
+        let restored = EditorBuffer(worktreeRoot: root, relativePath: "a.sh", store: store, worktreeId: "wt", tabId: "t")
+        try restored.save()
+
+        let savedAttrs = try FileManager.default.attributesOfItem(atPath: target.path)
+        let perms = (savedAttrs[.posixPermissions] as? NSNumber)?.intValue ?? 0
+        #expect(restored.relativePath == "b.sh")
+        #expect(perms == 0o755)
+    }
+
     @Test func moveToAllowsCaseOnlyRename() throws {
         let root = tempWorktree()
         _ = try writeFile(root, "case.txt", "hello\n")

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -122,6 +122,22 @@ struct EditorBufferTests {
         #expect(buffer.dirty == true)
     }
 
+    @Test func restoreAfterDirtyMoveUsesSnapshotPath() throws {
+        let root = tempWorktree()
+        _ = try writeFile(root, "a.txt", "hello\n")
+        let store = EditorBufferStore(rootOverride: tempWorktree())
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        buffer.storage.replaceCharacters(in: NSRange(location: 0, length: 5), with: "HELLO")
+
+        try buffer.moveTo(relativePath: "b.txt")
+
+        let restored = EditorBuffer(worktreeRoot: root, relativePath: "a.txt", store: store, worktreeId: "wt", tabId: "t")
+        #expect(restored.relativePath == "b.txt")
+        try restored.save()
+        #expect(!FileManager.default.fileExists(atPath: root.appendingPathComponent("a.txt").path))
+        #expect(try String(contentsOf: root.appendingPathComponent("b.txt"), encoding: .utf8) == "HELLO\n")
+    }
+
     @Test func moveToAllowsCaseOnlyRename() throws {
         let root = tempWorktree()
         _ = try writeFile(root, "case.txt", "hello\n")

--- a/AlasTests/TabsManagerBufferTests.swift
+++ b/AlasTests/TabsManagerBufferTests.swift
@@ -291,6 +291,124 @@ struct TabsManagerBufferTests {
         #expect(try String(contentsOf: root.appendingPathComponent("b.txt"), encoding: .utf8) == "y")
     }
 
+    @Test func bufferRestoredToSnapshotPathUpdatesTabAndCacheKey() throws {
+        let root = tempWorktree()
+        try "old\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "base\n".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let tab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let attrs = try FileManager.default.attributesOfItem(atPath: root.appendingPathComponent("b.txt").path)
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "b.txt",
+            content: "edited\n",
+            originalText: "base\n",
+            originalMtime: (attrs[.modificationDate] as? Date) ?? Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: tab.id)
+
+        let restored = manager.buffer(worktreeId: "wt", tabId: tab.id, worktreeRoot: root, relativePath: "a.txt")
+        let cachedByRestoredPath = manager.buffer(worktreeId: "wt", tabId: tab.id, worktreeRoot: root, relativePath: "b.txt")
+        let updatedTab = manager.tabs(forWorktree: "wt").first { $0.id == tab.id }
+
+        #expect(restored === cachedByRestoredPath)
+        #expect(restored.relativePath == "b.txt")
+        #expect(updatedTab?.title == "b.txt")
+        #expect(updatedTab?.relativeFilePath == "b.txt")
+    }
+
+    @Test func bufferRestoreToOpenTargetPathIsDiscarded() throws {
+        let root = tempWorktree()
+        try "old\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "base\n".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let sourceTab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let targetTab = manager.appendEditor(worktreeId: "wt", title: "b.txt", relativePath: "b.txt")
+        let target = manager.buffer(worktreeId: "wt", tabId: targetTab.id, worktreeRoot: root, relativePath: "b.txt")
+        target.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "target ")
+        let attrs = try FileManager.default.attributesOfItem(atPath: root.appendingPathComponent("b.txt").path)
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "b.txt",
+            content: "restored\n",
+            originalText: "base\n",
+            originalMtime: (attrs[.modificationDate] as? Date) ?? Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: sourceTab.id)
+
+        let restored = manager.buffer(worktreeId: "wt", tabId: sourceTab.id, worktreeRoot: root, relativePath: "a.txt")
+        let updatedTab = manager.tabs(forWorktree: "wt").first { $0.id == sourceTab.id }
+
+        #expect(restored !== target)
+        #expect(restored.relativePath == "a.txt")
+        #expect(target.storage.string == "target base\n")
+        #expect(manager.peekBuffer(tabId: targetTab.id) === target)
+        #expect(updatedTab?.relativeFilePath == "a.txt")
+        #expect(try store.read(worktreeId: "wt", tabId: sourceTab.id) == nil)
+    }
+
+    @Test func bufferRestoreToCleanUnloadedTargetPathIsDiscarded() throws {
+        let root = tempWorktree()
+        try "old\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "base\n".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let sourceTab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let targetTab = manager.appendEditor(worktreeId: "wt", title: "b.txt", relativePath: "b.txt")
+        let attrs = try FileManager.default.attributesOfItem(atPath: root.appendingPathComponent("b.txt").path)
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "b.txt",
+            content: "restored\n",
+            originalText: "base\n",
+            originalMtime: (attrs[.modificationDate] as? Date) ?? Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: sourceTab.id)
+
+        let restored = manager.buffer(worktreeId: "wt", tabId: sourceTab.id, worktreeRoot: root, relativePath: "a.txt")
+        let target = manager.buffer(worktreeId: "wt", tabId: targetTab.id, worktreeRoot: root, relativePath: "b.txt")
+        let updatedTab = manager.tabs(forWorktree: "wt").first { $0.id == sourceTab.id }
+
+        #expect(restored !== target)
+        #expect(restored.relativePath == "a.txt")
+        #expect(target.relativePath == "b.txt")
+        #expect(updatedTab?.relativeFilePath == "a.txt")
+        #expect(try store.read(worktreeId: "wt", tabId: sourceTab.id) == nil)
+    }
+
+    @Test func bufferRestoreAllowsTargetTabSnapshotThatMovesAway() throws {
+        let root = tempWorktree()
+        try "a\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "b\n".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        try "c\n".write(to: root.appendingPathComponent("c.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let first = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let second = manager.appendEditor(worktreeId: "wt", title: "b.txt", relativePath: "b.txt")
+        let bAttrs = try FileManager.default.attributesOfItem(atPath: root.appendingPathComponent("b.txt").path)
+        let cAttrs = try FileManager.default.attributesOfItem(atPath: root.appendingPathComponent("c.txt").path)
+        try store.write(EditorBufferStore.Snapshot(
+            relativePath: "b.txt",
+            content: "edited b\n",
+            originalText: "b\n",
+            originalMtime: (bAttrs[.modificationDate] as? Date) ?? Date(),
+            lineEnding: .lf
+        ), worktreeId: "wt", tabId: first.id)
+        try store.write(EditorBufferStore.Snapshot(
+            relativePath: "c.txt",
+            content: "edited c\n",
+            originalText: "c\n",
+            originalMtime: (cAttrs[.modificationDate] as? Date) ?? Date(),
+            lineEnding: .lf
+        ), worktreeId: "wt", tabId: second.id)
+
+        let firstBuffer = manager.buffer(worktreeId: "wt", tabId: first.id, worktreeRoot: root, relativePath: "a.txt")
+        let secondBuffer = manager.buffer(worktreeId: "wt", tabId: second.id, worktreeRoot: root, relativePath: "b.txt")
+
+        #expect(firstBuffer.relativePath == "b.txt")
+        #expect(secondBuffer.relativePath == "c.txt")
+        #expect(manager.tabs(forWorktree: "wt").first { $0.id == first.id }?.relativeFilePath == "b.txt")
+        #expect(manager.tabs(forWorktree: "wt").first { $0.id == second.id }?.relativeFilePath == "c.txt")
+    }
+
     @Test func saveAllSavesUnloadedDirtySnapshots() throws {
         let root = tempWorktree()
         try "x".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
@@ -311,6 +429,88 @@ struct TabsManagerBufferTests {
         #expect(manager.peekBuffer(tabId: tab.id) == nil)
         #expect(try store.read(worktreeId: "wt", tabId: tab.id) == nil)
         #expect(try String(contentsOf: root.appendingPathComponent("a.txt"), encoding: .utf8) == "edited\n")
+    }
+
+    @Test func saveAllUpdatesTabWhenUnloadedSnapshotRestoresMovedPath() throws {
+        let root = tempWorktree()
+        try "old\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "base\n".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let tab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let attrs = try FileManager.default.attributesOfItem(atPath: root.appendingPathComponent("b.txt").path)
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "b.txt",
+            content: "edited\n",
+            originalText: "base\n",
+            originalMtime: (attrs[.modificationDate] as? Date) ?? Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: tab.id)
+
+        let errors = manager.saveAll(worktreeRoots: ["wt": root])
+        let updatedTab = manager.tabs(forWorktree: "wt").first { $0.id == tab.id }
+
+        #expect(errors.isEmpty)
+        #expect(updatedTab?.title == "b.txt")
+        #expect(updatedTab?.relativeFilePath == "b.txt")
+        #expect(try store.read(worktreeId: "wt", tabId: tab.id) == nil)
+        #expect(try String(contentsOf: root.appendingPathComponent("b.txt"), encoding: .utf8) == "edited\n")
+    }
+
+    @Test func saveAllSkipsUnloadedSnapshotThatWouldReplaceLiveTargetBuffer() throws {
+        let root = tempWorktree()
+        try "old\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "base\n".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let sourceTab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let targetTab = manager.appendEditor(worktreeId: "wt", title: "b.txt", relativePath: "b.txt")
+        let target = manager.buffer(worktreeId: "wt", tabId: targetTab.id, worktreeRoot: root, relativePath: "b.txt")
+        target.storage.replaceCharacters(in: NSRange(location: 0, length: 0), with: "target ")
+        let attrs = try FileManager.default.attributesOfItem(atPath: root.appendingPathComponent("b.txt").path)
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "b.txt",
+            content: "restored\n",
+            originalText: "base\n",
+            originalMtime: (attrs[.modificationDate] as? Date) ?? Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: sourceTab.id)
+
+        let errors = manager.saveAll(worktreeRoots: ["wt": root])
+        let updatedTab = manager.tabs(forWorktree: "wt").first { $0.id == sourceTab.id }
+
+        #expect(errors.isEmpty)
+        #expect(updatedTab?.relativeFilePath == "a.txt")
+        #expect(target.storage.string == "target base\n")
+        #expect(manager.peekBuffer(tabId: targetTab.id) === target)
+        #expect(try String(contentsOf: root.appendingPathComponent("b.txt"), encoding: .utf8) == "target base\n")
+        #expect(try store.read(worktreeId: "wt", tabId: sourceTab.id) == nil)
+    }
+
+    @Test func saveAllUnsavedUpdatesTabWhenUnloadedSnapshotRestoresMovedPath() throws {
+        let root = tempWorktree()
+        try "old\n".write(to: root.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "base\n".write(to: root.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        let (manager, store, _) = makeManager()
+        let tab = manager.appendEditor(worktreeId: "wt", title: "a.txt", relativePath: "a.txt")
+        let attrs = try FileManager.default.attributesOfItem(atPath: root.appendingPathComponent("b.txt").path)
+        let snapshot = EditorBufferStore.Snapshot(
+            relativePath: "b.txt",
+            content: "edited\n",
+            originalText: "base\n",
+            originalMtime: (attrs[.modificationDate] as? Date) ?? Date(),
+            lineEnding: .lf
+        )
+        try store.write(snapshot, worktreeId: "wt", tabId: tab.id)
+
+        let errors = manager.saveAllUnsaved(forWorktree: "wt", root: root)
+        let updatedTab = manager.tabs(forWorktree: "wt").first { $0.id == tab.id }
+
+        #expect(errors.isEmpty)
+        #expect(updatedTab?.title == "b.txt")
+        #expect(updatedTab?.relativeFilePath == "b.txt")
+        #expect(try store.read(worktreeId: "wt", tabId: tab.id) == nil)
+        #expect(try String(contentsOf: root.appendingPathComponent("b.txt"), encoding: .utf8) == "edited\n")
     }
 
     @Test func saveAllPreservesUnloadedSnapshotWhenSaveFails() throws {


### PR DESCRIPTION
<!-- gg:managed:start -->
Ensure hot-exit restores follow the path recorded in the snapshot, while
rejecting invalid or escaping paths before applying persisted content.
<!-- gg:managed:end -->