### PR TITLE
fix(Search): report character columns for non-ASCII matches

### DIFF
--- a/Alas/Sources/Search/ContentSearcher.swift
+++ b/Alas/Sources/Search/ContentSearcher.swift
@@ -218,6 +218,7 @@ final class ContentSearcher: Sendable {
         let colByte = (first?["start"] as? Int) ?? 0
         let endColByte = (first?["end"] as? Int) ?? colByte
         let rawSnippet = lineBlob.trimmingCharacters(in: .newlines)
+        let column = charOffset(forByteOffset: colByte, in: rawSnippet).map { $0 + 1 } ?? (colByte + 1)
 
         // `--max-columns=400` doesn't apply in `--json` mode (per rg --help).
         // For a single very long line — minified JS, generated JSON, lockfiles —
@@ -235,7 +236,7 @@ final class ContentSearcher: Sendable {
             projectId: worktree.projectId,
             relativePath: pathBlob,
             line: lineNumber,
-            column: colByte + 1,
+            column: column,
             snippet: trimmedSnippet,
             matchCharRange: charRange
         )

--- a/AlasTests/ContentSearcherTests.swift
+++ b/AlasTests/ContentSearcherTests.swift
@@ -99,6 +99,30 @@ struct ContentSearcherTests {
         ) { hitsCS.append(h) }
         #expect(hitsCS.count == 1)
     }
+
+    @Test func columnsUseCharacterOffsetsForNonASCIIPrefixes() async throws {
+        try #require(rgAvailable())
+        let repo = try await makeRepo(files: [
+            ("a.txt", "éneedle\n"),
+        ])
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let cs = ContentSearcher()
+        var hits: [ContentSearchHit] = []
+        for try await h in cs.search(
+            query: "needle",
+            options: SearchContentOptions(),
+            worktrees: [SearchWorktree(
+                id: "w1", projectId: "p1", displayName: "w",
+                absolutePath: repo
+            )]
+        ) { hits.append(h) }
+
+        let hit = try #require(hits.first)
+        #expect(hit.column == 2)
+        #expect(hit.snippet == "éneedle")
+        #expect(hit.matchCharRange == 1..<7)
+    }
 }
 
 // `String * Int` operator for the cancellation test fixture.


### PR DESCRIPTION
<!-- gg:managed:start -->
rg JSON match offsets are byte-based, but search results expose columns and
ranges in characters for display. Convert the start column before building
hits so multibyte prefixes do not shift match locations.
<!-- gg:managed:end -->