### PR TITLE
fix(CommitTabView): clear stale details before loading commit

### DIFF
--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -100,6 +100,7 @@ struct CommitTabView: View {
         activeDetailsKey = requestedKey
         loadingDetails = true
         detailsError = nil
+        details = nil
         activeDiffKey = nil
         selectedPath = nil
         diff = ParsedDiff(hunks: [])


### PR DESCRIPTION
<!-- gg:managed:start -->
Part of stack `clawpatch`

Commit: 1cae24d
<!-- gg:managed:end -->