### PR TITLE
fix(AgentRunner): SIGKILL child after SIGTERM grace period

### DIFF
--- a/Alas/Sources/Agents/AgentRunner.swift
+++ b/Alas/Sources/Agents/AgentRunner.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 struct GeneratedMessage: Equatable {
@@ -123,7 +124,7 @@ enum AgentRunner {
             try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
             if !Task.isCancelled && process.isRunning {
                 timeoutState.markTimedOut()
-                process.terminate()
+                AgentRunnerProcessKiller.terminateThenKillIfNeeded(process)
             }
         }
 
@@ -137,7 +138,9 @@ enum AgentRunner {
             try? pipe.fileHandleForWriting.close()
             await exit.wait()
         } onCancel: {
-            if process.isRunning { process.terminate() }
+            if process.isRunning {
+                AgentRunnerProcessKiller.terminateThenKillIfNeeded(process)
+            }
         }
         watchdog.cancel()
 
@@ -223,6 +226,20 @@ private struct AgentPromptInvocation {
         let binaryName = (agent.resolvedBinary as NSString).lastPathComponent
         let subcommand = agent.promptModeArgs.first
         return binaryName == "codex" && (subcommand == "exec" || subcommand == "e")
+    }
+}
+
+private enum AgentRunnerProcessKiller {
+    static let sigtermGraceNanoseconds: UInt64 = 500_000_000
+
+    static func terminateThenKillIfNeeded(_ process: Process) {
+        process.terminate()
+        Task {
+            try? await Task.sleep(nanoseconds: sigtermGraceNanoseconds)
+            if process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+            }
+        }
     }
 }
 

--- a/AlasTests/AgentRunnerInvocationTests.swift
+++ b/AlasTests/AgentRunnerInvocationTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Darwin
 import Foundation
 @testable import Alas
 
@@ -154,5 +155,62 @@ struct AgentRunnerInvocationTests {
         } catch {
             Issue.record("wrong error: \(error)")
         }
+    }
+
+    @Test func timeoutCompletesWhenChildIgnoresSIGTERM() async throws {
+        let tmp = try makeTmp()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let pidFile = tmp.appendingPathComponent("ignore-term.pid")
+        let script = """
+        #!/bin/sh
+        echo $$ > "\(pidFile.path)"
+        trap '' TERM
+        while true; do sleep 1; done
+        """
+        let bin = tmp.appendingPathComponent("ignore-term")
+        try script.write(to: bin, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: bin.path
+        )
+
+        let start = Date()
+        let completed = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    _ = try await AgentRunner.runPrompt(
+                        agent: self.agent(id: "ignore-term", binary: "ignore-term", args: []),
+                        input: "",
+                        prompt: "",
+                        environment: ["PATH": "\(tmp.path):/usr/bin:/bin"],
+                        timeout: 0.1
+                    )
+                    Issue.record("expected timeout")
+                } catch AgentRunError.timedOut(let seconds) {
+                    #expect(seconds == 0.1)
+                    return true
+                } catch {
+                    Issue.record("wrong error: \(error)")
+                }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                if let pid = try? String(contentsOf: pidFile, encoding: .utf8)
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                   let processId = Int32(pid) {
+                    kill(processId, SIGKILL)
+                }
+                return false
+            }
+
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        #expect(completed)
+        #expect(elapsed < 1.5, "expected timeout to complete before test cleanup kill, took \(elapsed)s")
     }
 }


### PR DESCRIPTION
<!-- gg:managed:start -->
If a child agent ignores SIGTERM, `process.terminate()` alone leaves
the runner hanging until the process exits on its own. Follow up with
SIGKILL after a 500ms grace period so timeouts and cancellations
actually free the runner.
<!-- gg:managed:end -->