### PR TITLE
fix(ThemeStore): don't mutate state if theme load fails

### DIFF
--- a/Alas/Sources/Theme/ThemeStore.swift
+++ b/Alas/Sources/Theme/ThemeStore.swift
@@ -43,12 +43,12 @@ final class ThemeStore {
     }
 
     func activate(id: String) throws {
+        var next = try Theme.loadBundled(id: id)
+        next.accentOverrideHex = current.accentOverrideHex
         userPickedId = id
         // Manual selection turns off match-system implicitly so the user's
         // pick actually shows up.
         matchSystem = false
-        var next = try Theme.loadBundled(id: id)
-        next.accentOverrideHex = current.accentOverrideHex
         self.current = next
     }
 

--- a/AlasTests/ThemeStoreTests.swift
+++ b/AlasTests/ThemeStoreTests.swift
@@ -27,4 +27,17 @@ struct ThemeStoreTests {
         store.setMatchSystem(false)
         #expect(store.current.id == "light")
     }
+
+    @Test func failedActivationPreservesUserPick() throws {
+        let store = try ThemeStore()
+        try store.activate(id: "light")
+
+        #expect(throws: Error.self) {
+            try store.activate(id: "nope")
+        }
+
+        store.setMatchSystem(true)
+        store.setMatchSystem(false)
+        #expect(store.current.id == "light")
+    }
 }


### PR DESCRIPTION
<!-- gg:managed:start -->
Load the new theme before updating `userPickedId` and `matchSystem`,
so a failed activation leaves the previous pick intact instead of
silently switching the user off match-system with no theme change.
<!-- gg:managed:end -->