### PR TITLE
fix(codex): run AI commit in worktree and skip trust check

### DIFF
--- a/Alas/Sources/Agents/AgentRunner.swift
+++ b/Alas/Sources/Agents/AgentRunner.swift
@@ -36,6 +36,7 @@ enum AgentRunner {
         agent: AgentDefinition,
         input: String,
         prompt: String,
+        workingDirectory: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         timeout: TimeInterval = 120
     ) async throws -> GeneratedMessage {
@@ -53,6 +54,13 @@ enum AgentRunner {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [binary] + invocation.arguments
+        // Without an explicit cwd, the child inherits the app bundle's
+        // launch directory (typically `/`), which breaks CLIs whose first
+        // act is to inspect the surrounding git repo — codex refuses with
+        // "Not inside a trusted directory" before reading stdin.
+        if let workingDirectory {
+            process.currentDirectoryURL = URL(fileURLWithPath: workingDirectory)
+        }
         var env = environment
         env["PATH"] = AgentPath.augmented(base: env["PATH"])
         process.environment = env
@@ -201,8 +209,12 @@ private struct AgentPromptInvocation {
         prompt: String
     ) -> AgentPromptInvocation {
         if isCodexExec(agent) {
+            // `--skip-git-repo-check` is required because codex refuses to
+            // start in a directory it hasn't been told to trust (and there
+            // is no interactive prompt to satisfy in non-interactive exec).
+            // The trailing `-` makes codex read the prompt from stdin.
             return AgentPromptInvocation(
-                arguments: agent.promptModeArgs + ["-"],
+                arguments: agent.promptModeArgs + ["--skip-git-repo-check", "-"],
                 stdin: combinedPrompt(prompt: prompt, input: input)
             )
         }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -211,7 +211,8 @@ final class RightPaneState {
                 let message = try await AgentRunner.runPrompt(
                     agent: agent,
                     input: payload,
-                    prompt: promptOverride
+                    prompt: promptOverride,
+                    workingDirectory: wt.path
                 )
                 guard !Task.isCancelled else { return }
                 self.composer.subject = message.subject

--- a/AlasTests/AgentRunnerInvocationTests.swift
+++ b/AlasTests/AgentRunnerInvocationTests.swift
@@ -67,6 +67,7 @@ struct AgentRunnerInvocationTests {
         )
         let recorded = try String(contentsOf: record, encoding: .utf8)
         #expect(recorded.contains("exec\n"))
+        #expect(recorded.contains("--skip-git-repo-check\n"))
         #expect(recorded.contains("-\n"))
     }
 
@@ -82,6 +83,7 @@ struct AgentRunnerInvocationTests {
         )
         let recorded = try String(contentsOf: record, encoding: .utf8)
         #expect(recorded.contains("exec\n"))
+        #expect(recorded.contains("--skip-git-repo-check\n"))
         #expect(recorded.contains("-\n"))
         #expect(!recorded.contains("PROMPT\nstdin="))
         #expect(recorded.contains("stdin=\nPROMPT\n\nDIFF\n"))
@@ -99,6 +101,7 @@ struct AgentRunnerInvocationTests {
         )
         let recorded = try String(contentsOf: record, encoding: .utf8)
         #expect(recorded.contains("exec\n"))
+        #expect(recorded.contains("--skip-git-repo-check\n"))
         #expect(recorded.contains("-\n"))
         #expect(!recorded.contains("PROMPT\nstdin="))
         #expect(recorded.contains("stdin=\nPROMPT\n\nDIFF\n"))
@@ -116,9 +119,46 @@ struct AgentRunnerInvocationTests {
         )
         let recorded = try String(contentsOf: record, encoding: .utf8)
         #expect(recorded.contains("e\n"))
+        #expect(recorded.contains("--skip-git-repo-check\n"))
         #expect(recorded.contains("-\n"))
         #expect(!recorded.contains("PROMPT\nstdin="))
         #expect(recorded.contains("stdin=\nPROMPT\n\nDIFF\n"))
+    }
+
+    @Test func workingDirectorySetsCwdForChild() async throws {
+        let tmp = try makeTmp()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let cwdRecord = tmp.appendingPathComponent("cwd.record")
+        let script = """
+        #!/bin/sh
+        pwd > "\(cwdRecord.path)"
+        cat > /dev/null
+        printf 'subject\\n'
+        """
+        let bin = tmp.appendingPathComponent("claude")
+        try script.write(to: bin, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: bin.path
+        )
+        let workdir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cwd-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workdir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workdir) }
+
+        _ = try await AgentRunner.runPrompt(
+            agent: agent(id: "claude", binary: "claude", args: ["-p"]),
+            input: "x",
+            prompt: "y",
+            workingDirectory: workdir.path,
+            environment: ["PATH": "\(tmp.path):/usr/bin:/bin"]
+        )
+
+        let recorded = try String(contentsOf: cwdRecord, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // resolveSymlinksInPath handles /tmp → /private/tmp on macOS.
+        let expected = (workdir.resolvingSymlinksInPath().path)
+        let actual = URL(fileURLWithPath: recorded).resolvingSymlinksInPath().path
+        #expect(actual == expected)
     }
 
     @Test func opencodeUsesRunSubcommand() async throws {


### PR DESCRIPTION
## Summary
- Codex `exec` was failing with "Not inside a trusted directory and `--skip-git-repo-check` was not specified" when generating commit messages.
- Two compounding issues: the Alas .app launches with cwd `/` (so codex never saw the project repo), and codex won't trust a directory non-interactively.
- Fix: `AgentRunner` now takes a `workingDirectory` and sets `process.currentDirectoryURL` (benefits all agents), and codex exec invocations append `--skip-git-repo-check`.

## Test plan
- [x] `AgentRunnerInvocationTests` — 8/8 pass, including new `workingDirectorySetsCwdForChild` and updated codex assertions for the new flag.
- [ ] Manual: trigger AI commit generation with Codex selected in the commit composer and confirm it no longer surfaces the trust-check error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)