### PR TITLE
fix(terminal): shifted TUI input

### DIFF
--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -408,20 +408,16 @@ extension AlasGhostty {
             // Step A: forward the raw key event to Ghostty so it can match a
             // keybinding.
             //
-            // For Cmd/Ctrl-modified keys we attach the layout-translated text
-            // (alasGhosttyCharacters strips Ctrl and returns the unshifted
-            // character, e.g. Ctrl+L on Dvorak → "l") because Step B below
-            // returns before interpretKeyEvents — so this is Ghostty's only
-            // chance to see the layout character it needs to encode the
-            // control byte correctly on non-US layouts. For plain keys we
-            // leave text nil so the insertText callback can deliver it
-            // (avoids doubling).
+            // Attach translated printable text to the key event. If Ghostty
+            // consumes the key, this is the only payload the PTY/TUI receives;
+            // if it does not consume it, Step C still lets AppKit commit text
+            // through insertText so we avoid doubling.
             var keyEv = event.alasGhosttyKeyEvent(action, translationFlags: translationFlags)
 
             let cmdOrCtrl = event.modifierFlags.contains(.command)
                 || event.modifierFlags.contains(.control)
             let consumed: Bool
-            if cmdOrCtrl, let chars = translationEvent.alasGhosttyCharacters {
+            if let chars = translationEvent.alasGhosttyForwardedText {
                 consumed = chars.withCString { ptr -> Bool in
                     keyEv.text = ptr
                     return io.sendKey(keyEv)
@@ -686,6 +682,14 @@ extension NSEvent {
             }
         }
         return characters
+    }
+
+    /// Text payload to attach to the raw Ghostty key event before asking
+    /// Ghostty whether it consumes the key. Printable text is safe here
+    /// because unconsumed keys still fall through to AppKit's insertText path.
+    var alasGhosttyForwardedText: String? {
+        guard let text = alasGhosttyCharacters, !text.isEmpty else { return nil }
+        return text
     }
 }
 

--- a/AlasTests/SurfaceViewKeyboardTests.swift
+++ b/AlasTests/SurfaceViewKeyboardTests.swift
@@ -237,6 +237,44 @@ struct SurfaceViewKeyboardTests {
         #expect(keyEv.consumed_mods == GHOSTTY_MODS_SHIFT)
     }
 
+    @Test func shiftedPrintableCharacterIsForwardedAsGhosttyText() throws {
+        let event = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: .shift,
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "\"",
+                charactersIgnoringModifiers: "'",
+                isARepeat: false,
+                keyCode: 39
+            )
+        )
+
+        #expect(event.alasGhosttyForwardedText == "\"")
+    }
+
+    @Test func shiftedControlCharacterIsNotForwardedAsGhosttyText() throws {
+        let event = try #require(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: .shift,
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "\r",
+                charactersIgnoringModifiers: "\r",
+                isARepeat: false,
+                keyCode: 0x24
+            )
+        )
+
+        #expect(event.alasGhosttyForwardedText == nil)
+    }
+
     @Test @MainActor func fakeIOConformsToProtocol() {
         let io = FakeGhosttySurfaceIO()
         io.sendText("hi")


### PR DESCRIPTION
## Summary
- attach translated printable text to raw Ghostty key events before consumption checks
- keep control/function-key filtering for keys like Shift+Enter
- add keyboard regression coverage for shifted printable text

## Root cause
TUIs can consume Ghostty key events before AppKit insertText runs. The key event only carried text for Cmd/Ctrl paths, so shifted printable symbols such as double quotes and at signs could be swallowed as raw key events without their text payload.

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build\n- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test-without-building -only-testing:AlasTests/SurfaceViewKeyboardTests\n\nNote: full xcodebuild test and smoke-skipped full test both stalled locally without test output; AlasGhosttySmokeTests are documented as hang-prone in headless contexts.