### PR TITLE
fix(StatusParser): handle unmerged paths containing spaces

### DIFF
--- a/Alas/Sources/Git/StatusParser.swift
+++ b/Alas/Sources/Git/StatusParser.swift
@@ -36,9 +36,9 @@ enum StatusParser {
                 i += 1
             } else if line.hasPrefix("u ") {
                 // unmerged: surface as M for v1
-                let tokens = line.split(separator: " ", maxSplits: 11, omittingEmptySubsequences: true).map(String.init)
-                if tokens.count >= 12 {
-                    let path = tokens[11]
+                let tokens = line.split(separator: " ", maxSplits: 10, omittingEmptySubsequences: true).map(String.init)
+                if tokens.count >= 11 {
+                    let path = tokens[10]
                     result.append(ChangedFile(path: path, status: "M", stage: .unstaged, add: 0, del: 0, renameFrom: nil))
                 }
                 i += 1

--- a/Alas/Sources/Git/StatusParser.swift
+++ b/Alas/Sources/Git/StatusParser.swift
@@ -36,8 +36,9 @@ enum StatusParser {
                 i += 1
             } else if line.hasPrefix("u ") {
                 // unmerged: surface as M for v1
-                let tokens = line.split(separator: " ").map(String.init)
-                if let path = tokens.last {
+                let tokens = line.split(separator: " ", maxSplits: 11, omittingEmptySubsequences: true).map(String.init)
+                if tokens.count >= 12 {
+                    let path = tokens[11]
                     result.append(ChangedFile(path: path, status: "M", stage: .unstaged, add: 0, del: 0, renameFrom: nil))
                 }
                 i += 1

--- a/AlasTests/StatusParserTests.swift
+++ b/AlasTests/StatusParserTests.swift
@@ -80,4 +80,13 @@ struct StatusParserTests {
         #expect(entry.stage == .unstaged)
         #expect(entry.path == "scratch.txt")
     }
+
+    @Test func parsesUnmergedPathWithSpaces() throws {
+        let raw = "u UU N... 100644 100644 100644 100644 a b c d dir/a b.txt\u{0}"
+        let entries = try StatusParser.parse(raw)
+        let entry = try #require(entries.first)
+        #expect(entry.status == "M")
+        #expect(entry.stage == .unstaged)
+        #expect(entry.path == "dir/a b.txt")
+    }
 }

--- a/AlasTests/StatusParserTests.swift
+++ b/AlasTests/StatusParserTests.swift
@@ -82,7 +82,7 @@ struct StatusParserTests {
     }
 
     @Test func parsesUnmergedPathWithSpaces() throws {
-        let raw = "u UU N... 100644 100644 100644 100644 a b c d dir/a b.txt\u{0}"
+        let raw = "u UU N... 100644 100644 100644 100644 a b c dir/a b.txt\u{0}"
         let entries = try StatusParser.parse(raw)
         let entry = try #require(entries.first)
         #expect(entry.status == "M")


### PR DESCRIPTION
<!-- gg:managed:start -->
Porcelain v2 unmerged entries have a fixed 11-field prefix before the
path, so splitting on spaces and taking the last token dropped
everything after the first space in the filename. Cap the split at 11
and read the path from index 11 to preserve spaces.
<!-- gg:managed:end -->