### PR TITLE
Add reveal control for auto-hidden right sidebar

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
+		08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
 		0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
@@ -423,6 +424,7 @@
 		2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallProgressSheet.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
 		25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunch.swift; sourceTree = "<group>"; };
+		25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderViewTests.swift; sourceTree = "<group>"; };
 		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
 		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
@@ -868,6 +870,7 @@
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
+				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
@@ -1974,6 +1977,7 @@
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
+				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -9,6 +9,7 @@ struct RootView: View {
     @State private var showNewWorktree = false
     @State private var newWorktreePresetProjectId: String?
     @State private var collapsedProjects: Set<String> = []
+    @State private var rightPaneShown = false
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
@@ -47,7 +48,8 @@ struct RootView: View {
                                 onNewWorktree: { projectId in
                                     newWorktreePresetProjectId = projectId
                                     showNewWorktree = true
-                                }
+                                },
+                                rightSidebarHidden: !rightPaneShown
                             )
                         },
                         center: {
@@ -73,6 +75,9 @@ struct RootView: View {
                             }
                         }
                     )
+                    .onPreferenceChange(RightPaneVisiblePreferenceKey.self) { isVisible in
+                        rightPaneShown = isVisible
+                    }
                 }
             }
             FileSearchDialog(appState: state)

--- a/Alas/Sources/Layout/ThreePaneLayout.swift
+++ b/Alas/Sources/Layout/ThreePaneLayout.swift
@@ -61,6 +61,14 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                 }
             }
             .frame(width: proxy.size.width, height: proxy.size.height, alignment: .leading)
+            .preference(key: RightPaneVisiblePreferenceKey.self, value: sizing.rightVisible)
         }
+    }
+}
+
+struct RightPaneVisiblePreferenceKey: PreferenceKey {
+    static var defaultValue: Bool = false
+    static func reduce(value: inout Bool, nextValue: () -> Bool) {
+        value = nextValue()
     }
 }

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -4,12 +4,17 @@ struct SidebarHeaderView: View {
     let onSettings: () -> Void
     let onAddProject: () -> Void
     let onSearch: () -> Void
+    let onRevealRightSidebar: () -> Void
+    let rightSidebarHidden: Bool
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             TrafficLights()
             Spacer()
             HStack(alignment: .center, spacing: 2) {
+                if rightSidebarHidden {
+                    ToolbarBtn(icon: "sidebar.right", action: onRevealRightSidebar)
+                }
                 ToolbarBtn(icon: "search", action: onSearch)
                 ToolbarBtn(icon: "folder-plus", action: onAddProject)
                 ToolbarBtn(icon: "gear", action: onSettings)

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -9,6 +9,7 @@ struct SidebarView: View {
     let onEditProject: (_ projectId: String) -> Void
     let onRemoveProject: (_ projectId: String) -> Void
     let onNewWorktree: (_ projectId: String?) -> Void
+    let rightSidebarHidden: Bool
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -20,7 +21,12 @@ struct SidebarView: View {
                     onAddProject: onAddProject,
                     onSearch: {
                         NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
-                    }
+                    },
+                    onRevealRightSidebar: {
+                        state.config.rightPaneVisible = true
+                        state.saveConfig()
+                    },
+                    rightSidebarHidden: rightSidebarHidden
                 )
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {

--- a/AlasTests/SidebarHeaderViewTests.swift
+++ b/AlasTests/SidebarHeaderViewTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import Alas
+
+/// Smoke tests for SidebarHeaderView to guard against crashes when rendering
+/// with the right-sidebar reveal button visible and hidden.
+@Suite(.serialized)
+@MainActor
+struct SidebarHeaderViewTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test func headerWithHiddenRightSidebarRendersWithoutCrashing() {
+        let view = SidebarHeaderView(
+            onSettings: {},
+            onAddProject: {},
+            onSearch: {},
+            onRevealRightSidebar: {},
+            rightSidebarHidden: true
+        )
+        .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func headerWithVisibleRightSidebarRendersWithoutCrashing() {
+        let view = SidebarHeaderView(
+            onSettings: {},
+            onAddProject: {},
+            onSearch: {},
+            onRevealRightSidebar: {},
+            rightSidebarHidden: false
+        )
+        .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+}


### PR DESCRIPTION
Add reveal control for auto-hidden right sidebar
When the right sidebar is auto-hidden due to insufficient window width,
a new button appears in the left sidebar header to reveal it. The
button uses the existing ToolbarBtn style and posts the SF Symbol
sidebar.right icon. Clicking it sets rightPaneVisible=true and saves
config, which causes ThreePaneLayout to re-evaluate and show the right
pane.

Changes:
- ThreePaneLayout: emits RightPaneVisiblePreferenceKey so upstream views
  know whether the right pane is actually rendered (accounts for both
  manual hide and auto-hide due to width).
- RootView: reads the preference and passes !rightPaneShown as
  rightSidebarHidden down to SidebarView.
- SidebarView/SidebarHeaderView: accept rightSidebarHidden and render
  a reveal button when the right sidebar is not shown.
- SidebarHeaderViewTests: smoke tests for both visible/hidden states.