### PR TITLE
feat(right-pane): context-menu Ignore on untracked files and folders

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
 		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
 		B614CD7F894DD6908C903254 /* InstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */; };
+		B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */; };
 		B6C31E7AC3CE21AFEA371389 /* cool-slate.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DEB85132B767DB3B253620C /* cool-slate.json */; };
 		B76AD708A9FD54304F84366A /* ImageFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F942D660C7ABA8542C77D /* ImageFileType.swift */; };
 		B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */; };
@@ -302,6 +303,7 @@
 		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
 		D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */; };
+		D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */; };
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
 		D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */; };
@@ -531,6 +533,7 @@
 		6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagingTests.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
+		6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreServiceTests.swift; sourceTree = "<group>"; };
 		6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionView.swift; sourceTree = "<group>"; };
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
@@ -630,6 +633,7 @@
 		BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerHeadUpdatesTests.swift; sourceTree = "<group>"; };
 		BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfig.swift; sourceTree = "<group>"; };
 		BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletingWorktreeView.swift; sourceTree = "<group>"; };
+		BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreService.swift; sourceTree = "<group>"; };
 		BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcher.swift; sourceTree = "<group>"; };
 		BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManager.swift; sourceTree = "<group>"; };
 		BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelperTests.swift; sourceTree = "<group>"; };
@@ -829,6 +833,7 @@
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
 				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
+				6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */,
 				8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */,
 				38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
@@ -921,6 +926,7 @@
 				3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */,
 				E1703FC5CD7DF16F4450E274 /* DiffParser.swift */,
 				339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */,
+				BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */,
 				269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */,
 				B7CE7B4DAFDB65A79308FB63 /* GitService.swift */,
 				D2F90D03073708AA01531533 /* GitService+Staging.swift */,
@@ -1737,6 +1743,7 @@
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,
 				41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */,
 				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,
+				B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */,
 				175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */,
 				0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */,
 				12035048B950CE0197604F89 /* GitService.swift in Sources */,
@@ -1924,6 +1931,7 @@
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */,
 				D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */,
+				D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */,
 				513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */,
 				1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,

--- a/Alas/Sources/Git/GitIgnoreService.swift
+++ b/Alas/Sources/Git/GitIgnoreService.swift
@@ -141,23 +141,42 @@ enum GitIgnoreService {
 
     private static func escapeForGitignore(_ pattern: String) -> String {
         guard !pattern.isEmpty else { return pattern }
-        var out = pattern
 
-        // Escape leading '#', '!', or '[' so gitignore doesn't treat them
-        // as comment / negation / character-class markers.
-        if let first = out.first, first == "#" || first == "!" || first == "[" {
-            out = "\\" + out
+        // Escape gitignore glob metacharacters wherever they appear in the
+        // body so the pattern matches the literal path. '/' is the path
+        // separator and must stay unescaped. '\\' is itself the gitignore
+        // escape character, so a literal backslash in a filename is
+        // doubled. Without this, paths like `src/[draft].md` or
+        // `weird*name.log` get written verbatim and git interprets them
+        // as patterns, leaving the actual file untracked.
+        var body = ""
+        body.reserveCapacity(pattern.count)
+        for ch in pattern {
+            switch ch {
+            case "\\", "*", "?", "[":
+                body.append("\\")
+                body.append(ch)
+            default:
+                body.append(ch)
+            }
+        }
+
+        // Escape leading '#' or '!' so gitignore doesn't treat them as
+        // comment / negation markers. '[' is already escaped by the body
+        // loop above.
+        if let first = body.first, first == "#" || first == "!" {
+            body = "\\" + body
         }
 
         // Escape a single trailing space so gitignore doesn't strip it.
         // (Multiple trailing spaces are exceptionally rare in real paths;
         // escape just the last one — that's enough to preserve all of them
         // because gitignore strips unescaped trailing whitespace only.)
-        if out.hasSuffix(" ") {
-            out = String(out.dropLast()) + "\\ "
+        if body.hasSuffix(" ") {
+            body = String(body.dropLast()) + "\\ "
         }
 
-        return out
+        return body
     }
 
     private static func appendPatternIfMissing(_ pattern: String, to file: URL) throws {

--- a/Alas/Sources/Git/GitIgnoreService.swift
+++ b/Alas/Sources/Git/GitIgnoreService.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+enum IgnoreDestination {
+    case repoRoot
+    case nearest
+    case infoExclude
+}
+
+enum GitIgnoreService {
+    /// Append a gitignore pattern for `entryPath` to `destination`.
+    /// `entryPath` is repo-relative (POSIX `/` separators).
+    /// Returns the file written to. Idempotent: if the pattern already
+    /// exists in the destination, returns the URL without modifying it.
+    static func appendIgnore(
+        entryPath: String,
+        isDirectory: Bool,
+        destination: IgnoreDestination,
+        repoURL: URL
+    ) throws -> URL {
+        let target = try resolveTarget(
+            destination: destination,
+            repoURL: repoURL,
+            entryPath: entryPath
+        )
+        let pattern = computePattern(
+            entryPath: entryPath,
+            isDirectory: isDirectory,
+            targetFile: target,
+            repoURL: repoURL
+        )
+        try appendPatternIfMissing(pattern, to: target)
+        return target
+    }
+
+    // MARK: - Internals
+
+    private static func resolveTarget(
+        destination: IgnoreDestination,
+        repoURL: URL,
+        entryPath: String
+    ) throws -> URL {
+        switch destination {
+        case .repoRoot:
+            return repoURL.appendingPathComponent(".gitignore")
+        case .infoExclude:
+            return repoURL
+                .appendingPathComponent(".git")
+                .appendingPathComponent("info")
+                .appendingPathComponent("exclude")
+        case .nearest:
+            // Implemented in a later task.
+            return repoURL.appendingPathComponent(".gitignore")
+        }
+    }
+
+    private static func computePattern(
+        entryPath: String,
+        isDirectory: Bool,
+        targetFile: URL,
+        repoURL: URL
+    ) -> String {
+        // The pattern path is relative to the target file's directory.
+        // For repoRoot and infoExclude that's the repo root, so the entry
+        // path is already relative.
+        var path = entryPath
+        if isDirectory && !path.hasSuffix("/") {
+            path += "/"
+        }
+        return escapeForGitignore(path)
+    }
+
+    private static func escapeForGitignore(_ pattern: String) -> String {
+        // Will be implemented when escaping tests land. For now, identity.
+        return pattern
+    }
+
+    private static func appendPatternIfMissing(_ pattern: String, to file: URL) throws {
+        let fm = FileManager.default
+        let dir = file.deletingLastPathComponent()
+        if !fm.fileExists(atPath: dir.path) {
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+
+        let existing: String
+        if fm.fileExists(atPath: file.path) {
+            existing = (try? String(contentsOf: file, encoding: .utf8)) ?? ""
+        } else {
+            existing = ""
+        }
+
+        // Dedup: skip if any existing line (trimmed) equals the pattern.
+        let trimmedPattern = pattern.trimmingCharacters(in: .whitespaces)
+        for line in existing.split(separator: "\n", omittingEmptySubsequences: false) {
+            if line.trimmingCharacters(in: .whitespaces) == trimmedPattern {
+                return
+            }
+        }
+
+        var output = existing
+        if !output.isEmpty && !output.hasSuffix("\n") {
+            output += "\n"
+        }
+        output += pattern + "\n"
+
+        try output.write(to: file, atomically: true, encoding: .utf8)
+    }
+}

--- a/Alas/Sources/Git/GitIgnoreService.swift
+++ b/Alas/Sources/Git/GitIgnoreService.swift
@@ -127,8 +127,24 @@ enum GitIgnoreService {
     }
 
     private static func escapeForGitignore(_ pattern: String) -> String {
-        // Will be implemented when escaping tests land. For now, identity.
-        return pattern
+        guard !pattern.isEmpty else { return pattern }
+        var out = pattern
+
+        // Escape leading '#', '!', or '[' so gitignore doesn't treat them
+        // as comment / negation / character-class markers.
+        if let first = out.first, first == "#" || first == "!" || first == "[" {
+            out = "\\" + out
+        }
+
+        // Escape a single trailing space so gitignore doesn't strip it.
+        // (Multiple trailing spaces are exceptionally rare in real paths;
+        // escape just the last one — that's enough to preserve all of them
+        // because gitignore strips unescaped trailing whitespace only.)
+        if out.hasSuffix(" ") {
+            out = String(out.dropLast()) + "\\ "
+        }
+
+        return out
     }
 
     private static func appendPatternIfMissing(_ pattern: String, to file: URL) throws {

--- a/Alas/Sources/Git/GitIgnoreService.swift
+++ b/Alas/Sources/Git/GitIgnoreService.swift
@@ -11,16 +11,27 @@ enum GitIgnoreService {
     /// `entryPath` is repo-relative (POSIX `/` separators).
     /// Returns the file written to. Idempotent: if the pattern already
     /// exists in the destination, returns the URL without modifying it.
+    ///
+    /// `infoExcludeURL` overrides the destination URL when
+    /// `destination == .infoExclude`. Linked worktrees store
+    /// `info/exclude` outside the working tree (in the per-worktree git
+    /// dir under `.git/worktrees/<name>/info/exclude`), so callers
+    /// managing worktrees should resolve the path via
+    /// `git rev-parse --git-path info/exclude` and pass the result here.
+    /// When `nil`, the service falls back to `repoURL/.git/info/exclude`
+    /// — correct for primary worktrees only.
     static func appendIgnore(
         entryPath: String,
         isDirectory: Bool,
         destination: IgnoreDestination,
-        repoURL: URL
+        repoURL: URL,
+        infoExcludeURL: URL? = nil
     ) throws -> URL {
         let target = try resolveTarget(
             destination: destination,
             repoURL: repoURL,
-            entryPath: entryPath
+            entryPath: entryPath,
+            infoExcludeURL: infoExcludeURL
         )
         let pattern = computePattern(
             entryPath: entryPath,
@@ -37,13 +48,15 @@ enum GitIgnoreService {
     private static func resolveTarget(
         destination: IgnoreDestination,
         repoURL: URL,
-        entryPath: String
+        entryPath: String,
+        infoExcludeURL: URL?
     ) throws -> URL {
         let fm = FileManager.default
         switch destination {
         case .repoRoot:
             return repoURL.appendingPathComponent(".gitignore")
         case .infoExclude:
+            if let infoExcludeURL { return infoExcludeURL }
             return repoURL
                 .appendingPathComponent(".git")
                 .appendingPathComponent("info")

--- a/Alas/Sources/Git/GitIgnoreService.swift
+++ b/Alas/Sources/Git/GitIgnoreService.swift
@@ -39,6 +39,7 @@ enum GitIgnoreService {
         repoURL: URL,
         entryPath: String
     ) throws -> URL {
+        let fm = FileManager.default
         switch destination {
         case .repoRoot:
             return repoURL.appendingPathComponent(".gitignore")
@@ -48,8 +49,26 @@ enum GitIgnoreService {
                 .appendingPathComponent("info")
                 .appendingPathComponent("exclude")
         case .nearest:
-            // Implemented in a later task.
-            return repoURL.appendingPathComponent(".gitignore")
+            // Walk up from the entry's parent directory toward the repo root,
+            // using the first existing .gitignore. If none exist, fall back
+            // to creating one at the entry's own parent directory.
+            let entryParent = entryParentRelative(entryPath: entryPath)
+            var current = entryParent
+            while true {
+                let candidate = repoURL
+                    .appending(pathComponentsFromRepoRelative: current)
+                    .appendingPathComponent(".gitignore")
+                if fm.fileExists(atPath: candidate.path) {
+                    return candidate
+                }
+                if current.isEmpty { break }
+                current = parentRepoRelative(current)
+            }
+            // No existing .gitignore anywhere — create one at the entry's
+            // own parent directory (most-local scope).
+            return repoURL
+                .appending(pathComponentsFromRepoRelative: entryParent)
+                .appendingPathComponent(".gitignore")
         }
     }
 
@@ -59,14 +78,52 @@ enum GitIgnoreService {
         targetFile: URL,
         repoURL: URL
     ) -> String {
-        // The pattern path is relative to the target file's directory.
-        // For repoRoot and infoExclude that's the repo root, so the entry
-        // path is already relative.
-        var path = entryPath
+        // Path of the entry relative to the target file's directory.
+        let targetDirRepoRelative = repoRelativePath(
+            of: targetFile.deletingLastPathComponent(),
+            repoURL: repoURL
+        )
+        let relative = stripPathPrefix(entryPath, prefix: targetDirRepoRelative)
+        var path = relative
         if isDirectory && !path.hasSuffix("/") {
             path += "/"
         }
         return escapeForGitignore(path)
+    }
+
+    // MARK: - Path helpers (repo-relative, POSIX, '/' separators).
+
+    private static func entryParentRelative(entryPath: String) -> String {
+        if let slash = entryPath.lastIndex(of: "/") {
+            return String(entryPath[..<slash])
+        }
+        return ""
+    }
+
+    private static func parentRepoRelative(_ path: String) -> String {
+        if let slash = path.lastIndex(of: "/") {
+            return String(path[..<slash])
+        }
+        return ""
+    }
+
+    private static func repoRelativePath(of url: URL, repoURL: URL) -> String {
+        let repoPath = repoURL.standardizedFileURL.path
+        let p = url.standardizedFileURL.path
+        if p == repoPath { return "" }
+        if p.hasPrefix(repoPath + "/") {
+            return String(p.dropFirst(repoPath.count + 1))
+        }
+        return ""
+    }
+
+    private static func stripPathPrefix(_ path: String, prefix: String) -> String {
+        if prefix.isEmpty { return path }
+        if path == prefix { return "" }
+        if path.hasPrefix(prefix + "/") {
+            return String(path.dropFirst(prefix.count + 1))
+        }
+        return path
     }
 
     private static func escapeForGitignore(_ pattern: String) -> String {
@@ -103,5 +160,17 @@ enum GitIgnoreService {
         output += pattern + "\n"
 
         try output.write(to: file, atomically: true, encoding: .utf8)
+    }
+}
+
+private extension URL {
+    /// Append a repo-relative POSIX path (e.g. "src/foo") as path components.
+    func appending(pathComponentsFromRepoRelative relative: String) -> URL {
+        guard !relative.isEmpty else { return self }
+        var u = self
+        for part in relative.split(separator: "/") {
+            u = u.appendingPathComponent(String(part))
+        }
+        return u
     }
 }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -40,7 +40,10 @@ struct ChangesTabView: View {
                     onSelect: onSelect,
                     onToggleStage: { rps.toggleStage($0) },
                     onStageAll: { rps.stageAll($0) },
-                    onUnstageAll: { rps.unstageAll($0) }
+                    onUnstageAll: { rps.unstageAll($0) },
+                    onIgnore: { path, isDir, dest in
+                        rps.ignore(path: path, isDirectory: isDir, destination: dest)
+                    }
                 )
                 Divider().opacity(0.4)
                 CommitsSectionView(

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -150,6 +150,26 @@ final class RightPaneState {
         }
     }
 
+    /// Append a gitignore pattern for `path` to `destination` and refresh
+    /// the changes list. Idempotent at the service level — calling this for
+    /// a pattern that already exists in the destination is a no-op.
+    func ignore(path: String, isDirectory: Bool, destination: IgnoreDestination) {
+        let repoURL = worktree.path
+        Task { @MainActor in
+            do {
+                _ = try GitIgnoreService.appendIgnore(
+                    entryPath: path,
+                    isDirectory: isDirectory,
+                    destination: destination,
+                    repoURL: repoURL
+                )
+            } catch {
+                logger.error("ignore failed for \(path, privacy: .public) in worktree \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+            await self.refresh()
+        }
+    }
+
     // MARK: - Commit composer wiring
 
     /// Run an AI commit-message CLI with the staged diff + repo context as

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -153,21 +153,47 @@ final class RightPaneState {
     /// Append a gitignore pattern for `path` to `destination` and refresh
     /// the changes list. Idempotent at the service level — calling this for
     /// a pattern that already exists in the destination is a no-op.
+    ///
+    /// For `.infoExclude`, resolves the actual `info/exclude` path via
+    /// `git rev-parse --git-path` so linked worktrees write to the
+    /// per-worktree git dir (where `.git` is a gitfile, not a directory).
     func ignore(path: String, isDirectory: Bool, destination: IgnoreDestination) {
         let repoURL = worktree.path
         Task { @MainActor in
             do {
+                let infoExcludeURL: URL?
+                if destination == .infoExclude {
+                    infoExcludeURL = try await resolveInfoExcludeURL(worktreePath: repoURL)
+                } else {
+                    infoExcludeURL = nil
+                }
                 _ = try GitIgnoreService.appendIgnore(
                     entryPath: path,
                     isDirectory: isDirectory,
                     destination: destination,
-                    repoURL: repoURL
+                    repoURL: repoURL,
+                    infoExcludeURL: infoExcludeURL
                 )
             } catch {
                 logger.error("ignore failed for \(path, privacy: .public) in worktree \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
             await self.refresh()
         }
+    }
+
+    /// Resolve the absolute URL of `info/exclude` for this worktree via
+    /// `git rev-parse --git-path info/exclude`. Output is relative to the
+    /// worktree path unless git emits an absolute path.
+    private func resolveInfoExcludeURL(worktreePath: URL) async throws -> URL {
+        let result = try await Process.git(
+            ["rev-parse", "--git-path", "info/exclude"],
+            cwd: worktreePath
+        )
+        let raw = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        if raw.hasPrefix("/") {
+            return URL(fileURLWithPath: raw)
+        }
+        return URL(fileURLWithPath: raw, relativeTo: worktreePath).standardizedFileURL
     }
 
     // MARK: - Commit composer wiring

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -7,6 +7,7 @@ struct WorkingTreeSectionView: View {
     var onToggleStage: ((ChangedFile) -> Void)? = nil
     var onStageAll: (([ChangedFile]) -> Void)? = nil
     var onUnstageAll: (([ChangedFile]) -> Void)? = nil
+    var onIgnore: ((_ path: String, _ isDirectory: Bool, _ destination: IgnoreDestination) -> Void)? = nil
 
     @Environment(\.theme) private var theme
 
@@ -110,6 +111,41 @@ struct WorkingTreeSectionView: View {
         }
     }
 
+    /// A ChangedFile is "untracked" when status parser produced ("A",
+    /// .unstaged). Staged adds parse to ("A", .staged) so the stage check
+    /// is required.
+    private func isUntracked(_ file: ChangedFile) -> Bool {
+        file.status == "A" && file.stage == .unstaged
+    }
+
+    /// True when every ChangedFile reachable through `node` is untracked.
+    /// Folders that contain any tracked entry get no Ignore menu.
+    private func isUntrackedSubtree(
+        _ node: FileTreeNode,
+        filesByPath: [String: ChangedFile]
+    ) -> Bool {
+        if node.kind == .file {
+            return filesByPath[node.path].map(isUntracked) ?? false
+        }
+        guard let kids = node.children, !kids.isEmpty else { return false }
+        return kids.allSatisfy { isUntrackedSubtree($0, filesByPath: filesByPath) }
+    }
+
+    @ViewBuilder
+    private func ignoreMenu(path: String, isDirectory: Bool) -> some View {
+        Menu("Ignore") {
+            Button("Add to .gitignore (repo root)") {
+                onIgnore?(path, isDirectory, .repoRoot)
+            }
+            Button("Add to nearest .gitignore") {
+                onIgnore?(path, isDirectory, .nearest)
+            }
+            Button("Add to .git/info/exclude") {
+                onIgnore?(path, isDirectory, .infoExclude)
+            }
+        }
+    }
+
     private func renderNode(
         _ node: FileTreeNode,
         filesByPath: [String: ChangedFile],
@@ -119,6 +155,7 @@ struct WorkingTreeSectionView: View {
         if node.kind == .dir {
             let collapseKey = "\(collapseNamespace):\(node.path)"
             let open = !collapsedChangePaths.contains(collapseKey)
+            let folderUntracked = isUntrackedSubtree(node, filesByPath: filesByPath)
             return AnyView(
                 Group {
                     Button {
@@ -145,6 +182,11 @@ struct WorkingTreeSectionView: View {
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .contextMenu {
+                        if folderUntracked {
+                            ignoreMenu(path: node.path, isDirectory: true)
+                        }
+                    }
                     if open, let kids = node.children {
                         ForEach(kids) {
                             renderNode(
@@ -158,6 +200,7 @@ struct WorkingTreeSectionView: View {
                 }
             )
         } else if let file = filesByPath[node.path] {
+            let fileUntracked = isUntracked(file)
             return AnyView(
                 ChangedRow(
                     file: file,
@@ -165,6 +208,11 @@ struct WorkingTreeSectionView: View {
                     onSelect: { onSelect(file) },
                     onStage: onToggleStage.map { fn in { fn(file) } }
                 )
+                .contextMenu {
+                    if fileUntracked {
+                        ignoreMenu(path: file.path, isDirectory: false)
+                    }
+                }
             )
         } else {
             return AnyView(EmptyView())

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -48,4 +48,22 @@ struct GitIgnoreServiceTests {
 
         #expect(try read(gi) == "build/\n")
     }
+
+    @Test func dedupSkipsExistingPattern() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let gi = repo.appendingPathComponent(".gitignore")
+        try "src/foo/bar.log\nother.txt\n".write(to: gi, atomically: true, encoding: .utf8)
+        let before = try Data(contentsOf: gi)
+
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "src/foo/bar.log",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+
+        let after = try Data(contentsOf: gi)
+        #expect(before == after)
+    }
 }

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -193,6 +193,43 @@ struct GitIgnoreServiceTests {
         #expect(try read(written) == "dropped.local\n")
     }
 
+    /// Linked worktrees store `info/exclude` in the per-worktree git dir,
+    /// not under `<worktree>/.git/info/exclude`. The caller resolves the
+    /// real path via `git rev-parse --git-path info/exclude` and passes
+    /// it as `infoExcludeURL`. The pattern is still written relative to
+    /// the worktree root.
+    @Test func infoExcludeURLOverrideTargetsLinkedWorktreeGitDir() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        // Simulate a per-worktree git dir outside the working tree.
+        let externalGitDir = repo
+            .deletingLastPathComponent()
+            .appendingPathComponent("alas-ign-linked-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: externalGitDir) }
+        let override = externalGitDir
+            .appendingPathComponent("info")
+            .appendingPathComponent("exclude")
+
+        let written = try GitIgnoreService.appendIgnore(
+            entryPath: "src/foo/secret.local",
+            isDirectory: false,
+            destination: .infoExclude,
+            repoURL: repo,
+            infoExcludeURL: override
+        )
+
+        #expect(written == override)
+        #expect(try read(override) == "src/foo/secret.local\n")
+        // The default path under <repo>/.git/info/exclude must not have been
+        // written (overwriting `git init`'s seeded header would be a regression).
+        let defaultPath = repo
+            .appendingPathComponent(".git")
+            .appendingPathComponent("info")
+            .appendingPathComponent("exclude")
+        let defaultContents = (try? String(contentsOf: defaultPath, encoding: .utf8)) ?? ""
+        #expect(!defaultContents.contains("src/foo/secret.local"))
+    }
+
     @Test func escapesLeadingHashBangBracketAndTrailingSpaces() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -270,4 +270,48 @@ struct GitIgnoreServiceTests {
         """
         #expect(try read(gi) == expected)
     }
+
+    /// Interior glob metacharacters (`[`, `*`, `?`) must be escaped too,
+    /// otherwise git interprets the path as a pattern and the file stays
+    /// untracked. Backslashes in filenames must be escaped to themselves.
+    @Test func escapesInteriorGlobMetacharacters() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let gi = repo.appendingPathComponent(".gitignore")
+        try "".write(to: gi, atomically: true, encoding: .utf8)
+
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "src/[draft].md",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "logs/wild*name.log",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "data/who?.csv",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "weird\\name.txt",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+
+        let expected = """
+        src/\\[draft].md
+        logs/wild\\*name.log
+        data/who\\?.csv
+        weird\\\\name.txt
+
+        """
+        #expect(try read(gi) == expected)
+    }
 }

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -32,4 +32,20 @@ struct GitIgnoreServiceTests {
         #expect(written == gi)
         #expect(try read(gi) == "existing.log\nsrc/foo/bar.log\n")
     }
+
+    @Test func appendsFolderPatternWithTrailingSlash() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let gi = repo.appendingPathComponent(".gitignore")
+        try "".write(to: gi, atomically: true, encoding: .utf8)
+
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "build",
+            isDirectory: true,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+
+        #expect(try read(gi) == "build/\n")
+    }
 }

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -151,4 +151,45 @@ struct GitIgnoreServiceTests {
         #expect(written == repo.appendingPathComponent(".gitignore"))
         #expect(try read(written) == "top.log\n")
     }
+
+    @Test func appendsToInfoExclude() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let exclude = repo
+            .appendingPathComponent(".git")
+            .appendingPathComponent("info")
+            .appendingPathComponent("exclude")
+
+        // `git init` typically creates .git/info/exclude with a header comment;
+        // overwrite with empty so we can assert exact contents.
+        try "".write(to: exclude, atomically: true, encoding: .utf8)
+
+        let written = try GitIgnoreService.appendIgnore(
+            entryPath: "secret.local",
+            isDirectory: false,
+            destination: .infoExclude,
+            repoURL: repo
+        )
+
+        #expect(written == exclude)
+        #expect(try read(exclude) == "secret.local\n")
+    }
+
+    @Test func appendsToInfoExcludeCreatingDirectoryIfMissing() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let info = repo.appendingPathComponent(".git").appendingPathComponent("info")
+        try? FileManager.default.removeItem(at: info)
+        #expect(!FileManager.default.fileExists(atPath: info.path))
+
+        let written = try GitIgnoreService.appendIgnore(
+            entryPath: "dropped.local",
+            isDirectory: false,
+            destination: .infoExclude,
+            repoURL: repo
+        )
+
+        #expect(written == info.appendingPathComponent("exclude"))
+        #expect(try read(written) == "dropped.local\n")
+    }
 }

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -66,4 +66,36 @@ struct GitIgnoreServiceTests {
         let after = try Data(contentsOf: gi)
         #expect(before == after)
     }
+
+    @Test func createsGitignoreWhenAbsent() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let gi = repo.appendingPathComponent(".gitignore")
+        #expect(!FileManager.default.fileExists(atPath: gi.path))
+
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "fresh.log",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+
+        #expect(try read(gi) == "fresh.log\n")
+    }
+
+    @Test func addsMissingTrailingNewlineBeforeAppending() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let gi = repo.appendingPathComponent(".gitignore")
+        try "no-newline-at-end".write(to: gi, atomically: true, encoding: .utf8)
+
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "new.log",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+
+        #expect(try read(gi) == "no-newline-at-end\nnew.log\n")
+    }
 }

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -192,4 +192,45 @@ struct GitIgnoreServiceTests {
         #expect(written == info.appendingPathComponent("exclude"))
         #expect(try read(written) == "dropped.local\n")
     }
+
+    @Test func escapesLeadingHashBangBracketAndTrailingSpaces() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let gi = repo.appendingPathComponent(".gitignore")
+        try "".write(to: gi, atomically: true, encoding: .utf8)
+
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "#hash.txt",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "!bang.txt",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "[bracket].txt",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+        _ = try GitIgnoreService.appendIgnore(
+            entryPath: "trailing space ",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+
+        let expected = """
+        \\#hash.txt
+        \\!bang.txt
+        \\[bracket].txt
+        trailing space\\ 
+
+        """
+        #expect(try read(gi) == expected)
+    }
 }

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -98,4 +98,25 @@ struct GitIgnoreServiceTests {
 
         #expect(try read(gi) == "no-newline-at-end\nnew.log\n")
     }
+
+    @Test func nearestUsesExistingGitignoreInParentChain() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let src = repo.appendingPathComponent("src")
+        let foo = src.appendingPathComponent("foo")
+        try FileManager.default.createDirectory(at: foo, withIntermediateDirectories: true)
+        let srcGi = src.appendingPathComponent(".gitignore")
+        try "other\n".write(to: srcGi, atomically: true, encoding: .utf8)
+
+        let written = try GitIgnoreService.appendIgnore(
+            entryPath: "src/foo/bar.log",
+            isDirectory: false,
+            destination: .nearest,
+            repoURL: repo
+        )
+
+        #expect(written == srcGi)
+        // Pattern is relative to the .gitignore's directory (src/).
+        #expect(try read(srcGi) == "other\nfoo/bar.log\n")
+    }
 }

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -1,0 +1,35 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct GitIgnoreServiceTests {
+    private func makeRepo() async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ign-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        return dir
+    }
+
+    private func read(_ url: URL) throws -> String {
+        try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test func appendsFilePatternToRepoRootGitignore() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let gi = repo.appendingPathComponent(".gitignore")
+        try "existing.log\n".write(to: gi, atomically: true, encoding: .utf8)
+
+        let written = try GitIgnoreService.appendIgnore(
+            entryPath: "src/foo/bar.log",
+            isDirectory: false,
+            destination: .repoRoot,
+            repoURL: repo
+        )
+
+        #expect(written == gi)
+        #expect(try read(gi) == "existing.log\nsrc/foo/bar.log\n")
+    }
+}

--- a/AlasTests/GitIgnoreServiceTests.swift
+++ b/AlasTests/GitIgnoreServiceTests.swift
@@ -119,4 +119,36 @@ struct GitIgnoreServiceTests {
         // Pattern is relative to the .gitignore's directory (src/).
         #expect(try read(srcGi) == "other\nfoo/bar.log\n")
     }
+
+    @Test func nearestFallbackCreatesGitignoreAtEntryParent() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let foo = repo.appendingPathComponent("src").appendingPathComponent("foo")
+        try FileManager.default.createDirectory(at: foo, withIntermediateDirectories: true)
+
+        let written = try GitIgnoreService.appendIgnore(
+            entryPath: "src/foo/bar.log",
+            isDirectory: false,
+            destination: .nearest,
+            repoURL: repo
+        )
+
+        #expect(written == foo.appendingPathComponent(".gitignore"))
+        #expect(try read(written) == "bar.log\n")
+    }
+
+    @Test func nearestFallbackForTopLevelEntryUsesRepoRoot() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let written = try GitIgnoreService.appendIgnore(
+            entryPath: "top.log",
+            isDirectory: false,
+            destination: .nearest,
+            repoURL: repo
+        )
+
+        #expect(written == repo.appendingPathComponent(".gitignore"))
+        #expect(try read(written) == "top.log\n")
+    }
 }


### PR DESCRIPTION
## Summary

- Right-click on an untracked file or folder row in the Changes pane to reveal an **Ignore ▸** submenu with three destinations:
  - **Add to .gitignore (repo root)**
  - **Add to nearest .gitignore** — walks up from the entry's parent dir, picks the first existing `.gitignore`; creates one at the entry's own parent dir if none exists in the chain. Pattern is written relative to that `.gitignore`'s directory.
  - **Add to .git/info/exclude** — auto-creates `.git/info/` if absent.
- Patterns are repo-relative paths (trailing `/` for folders), gitignore-escaped (leading `#`/`!`/`[` and trailing space), deduped against existing lines, and appended with correct newline handling.
- Tracked entries (modified / staged-add / renamed / deleted) do NOT get the Ignore menu — `WorkingTreeSectionView.isUntracked` enforces `status == "A" && stage == .unstaged`. A folder row only gets the menu when every reachable leaf is untracked.
- Post-action is silent — the changes list refresh hides newly-ignored entries.

## Architecture

- **`Alas/Sources/Git/GitIgnoreService.swift`** (new, 192 lines) — pure `enum` namespace, no UI deps. Resolves destination → file URL, computes pattern (path relative to the destination dir, trailing `/` for folders), escapes, dedupes, appends.
- **`Alas/Sources/Right/RightPaneState.swift`** — adds `ignore(path:isDirectory:destination:)` orchestrator that calls the service then `await refresh()`s. Error path uses the existing `logger.error` channel (matches `loadOlder`).
- **`Alas/Sources/Right/WorkingTreeSectionView.swift`** — adds untracked-detection helpers, `@ViewBuilder ignoreMenu(...)`, and attaches `.contextMenu` to the folder Button and file ChangedRow.
- **`Alas/Sources/Right/ChangesTabView.swift`** — forwards the new `onIgnore` callback to `rps.ignore`.

## Test plan

- [x] 11 unit tests on `GitIgnoreService` covering all three destinations, dedup, file-creation, missing-newline patching, nearest walk-up + fallback, info/exclude auto-create, and escaping. All green.
- [x] Full project test pass — every other suite still green (pre-existing flakes in `AgentHookSocketServerTests` / `CodeTextViewMultiCursorTests` are unrelated to this branch).
- [x] Manual smoke covered: untracked root/nested file → Ignore submenu writes to the chosen destination and entry drops off the list; untracked folder → same with trailing `/`; modified tracked file → Ignore submenu absent; double-click → second is a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)