### PR TITLE
fix(Settings): trim whitespace when saving agent and language server configs

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */; };
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
+		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
 		3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6CCD7F7273667B5D67F821 /* SearchScope.swift */; };
@@ -576,6 +577,7 @@
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
 		932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFeature.swift; sourceTree = "<group>"; };
+		9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSaveNormalizationTests.swift; sourceTree = "<group>"; };
 		934BCC470703CF2DF2303357 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
 		93CDC9895F48619E97461875 /* CodePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePane.swift; sourceTree = "<group>"; };
 		93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltins.swift; sourceTree = "<group>"; };
@@ -869,6 +871,7 @@
 				B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
+				9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
 				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
@@ -1976,6 +1979,7 @@
 				FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
+				2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
 				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,

--- a/Alas/Sources/Settings/AgentEditView.swift
+++ b/Alas/Sources/Settings/AgentEditView.swift
@@ -168,9 +168,9 @@ struct AgentEditView: View {
             entry.binaryOverride = (trimmed?.isEmpty == false) ? trimmed : nil
             state.config.agents.builtinState[draft.id] = entry
         } else if isNew {
-            state.config.agents.custom.append(draft)
+            state.config.agents.custom.append(draft.normalizedForSettingsSave())
         } else if let idx = state.config.agents.custom.firstIndex(where: { $0.id == draft.id }) {
-            state.config.agents.custom[idx] = draft
+            state.config.agents.custom[idx] = draft.normalizedForSettingsSave()
         }
         state.saveConfig()
         state.rescanAgents()
@@ -190,5 +190,17 @@ struct AgentEditView: View {
         state.saveConfig()
         state.rescanAgents()
         onDismiss()
+    }
+}
+
+extension AgentDefinition {
+    func normalizedForSettingsSave() -> AgentDefinition {
+        var normalized = self
+        normalized.displayName = displayName.trimmingCharacters(in: .whitespaces)
+        normalized.binary = binary.trimmingCharacters(in: .whitespaces)
+        normalized.binaryOverride = nil
+        let trimmedBypass = bypassPermissionsFlag?.trimmingCharacters(in: .whitespaces)
+        normalized.bypassPermissionsFlag = (trimmedBypass?.isEmpty == false) ? trimmedBypass : nil
+        return normalized
     }
 }

--- a/Alas/Sources/Settings/CodeLanguageDetailView.swift
+++ b/Alas/Sources/Settings/CodeLanguageDetailView.swift
@@ -124,7 +124,11 @@ struct CodeLanguageDetailView: View {
             HStack(spacing: 8) {
                 Spacer()
                 AlasButton(title: "Cancel", style: .subtle, action: onCancel)
-                AlasButton(title: "Save", style: .primary, action: { onSave(entry, pendingRecipes) })
+                AlasButton(
+                    title: "Save",
+                    style: .primary,
+                    action: { onSave(entry.normalizedForSettingsSave(), pendingRecipes) }
+                )
                     .disabled(validationMessage != nil)
             }
             .padding(.top, 16)
@@ -162,5 +166,20 @@ struct CodeLanguageDetailView: View {
         entry.command = pkg.command
         entry.args = pkg.args
         pendingRecipes = pkg.recipes
+    }
+}
+
+extension LanguageServerConfig {
+    func normalizedForSettingsSave() -> LanguageServerConfig {
+        var normalized = self
+        normalized.language = language.trimmingCharacters(in: .whitespaces)
+        normalized.command = command.trimmingCharacters(in: .whitespaces)
+        normalized.args = args
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        normalized.rootMarkers = rootMarkers
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        return normalized
     }
 }

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -168,6 +168,7 @@ struct CodePane: View {
     }
 
     private func save(originalLanguage: String?, _ entry: LanguageServerConfig, recipes: [InstallRecipe]?) {
+        let entry = entry.normalizedForSettingsSave()
         var list = state.config.code.languageServers
         // Look up by the original language ID so renaming an entry replaces
         // it in place. Searching by the edited value (`entry.language`) would

--- a/AlasTests/SettingsSaveNormalizationTests.swift
+++ b/AlasTests/SettingsSaveNormalizationTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import Alas
+
+struct SettingsSaveNormalizationTests {
+    @Test func customAgentSaveTrimsPersistedCommandFields() {
+        let agent = AgentDefinition(
+            id: "custom",
+            displayName: "  Custom Agent  ",
+            binary: "  claude  ",
+            binaryOverride: "  ignored  ",
+            promptModeArgs: ["--print"],
+            bypassPermissionsFlag: " --dangerously-skip-permissions ",
+            isBuiltin: false,
+            isEnabled: true,
+            builtinLogoAssetName: nil
+        )
+
+        let normalized = agent.normalizedForSettingsSave()
+
+        #expect(normalized.displayName == "Custom Agent")
+        #expect(normalized.binary == "claude")
+        #expect(normalized.binaryOverride == nil)
+        #expect(normalized.bypassPermissionsFlag == "--dangerously-skip-permissions")
+    }
+
+    @Test func languageServerSaveTrimsPersistedCommandFields() {
+        let entry = LanguageServerConfig(
+            language: "  swift  ",
+            extensions: ["swift"],
+            command: "  sourcekit-lsp  ",
+            args: [" --stdio ", "", "  --log  "],
+            env: [:],
+            rootMarkers: [" Package.swift ", "", "  .git  "],
+            enabled: true
+        )
+
+        let normalized = entry.normalizedForSettingsSave()
+
+        #expect(normalized.language == "swift")
+        #expect(normalized.command == "sourcekit-lsp")
+        #expect(normalized.args == ["--stdio", "--log"])
+        #expect(normalized.rootMarkers == ["Package.swift", ".git"])
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
- Normalize custom agent and language server fields on save so stray
  spaces in display names, binaries, args, and root markers don't get
  persisted.
- Drop binaryOverride when saving custom agents to avoid carrying a
  stale override into settings.
- Add tests covering the normalization for both agent and language
  server saves.
<!-- gg:managed:end -->