### PR TITLE
fix(FileTreeBuilder): keep file and directory entries with same name

### DIFF
--- a/Alas/Sources/Git/FileTreeBuilder.swift
+++ b/Alas/Sources/Git/FileTreeBuilder.swift
@@ -34,17 +34,24 @@ enum FileTreeBuilder {
         guard let head = parts.first else { return }
         let isLeaf = parts.count == 1
         let nodePath = prefix.isEmpty ? head : "\(prefix)/\(head)"
-        let existing = map[head]
         if isLeaf {
+            let key = nodeKey(name: head, isDir: false)
+            let existing = map[key]
             let badge = badges[fullPath]
             if existing == nil {
-                map[head] = TreeBuildNode(name: head, path: nodePath, isDir: false, badge: badge)
+                map[key] = TreeBuildNode(name: head, path: nodePath, isDir: false, badge: badge)
             }
         } else {
+            let key = nodeKey(name: head, isDir: true)
+            let existing = map[key]
             let dir = existing ?? TreeBuildNode(name: head, path: nodePath, isDir: true, badge: nil)
-            map[head] = dir
+            map[key] = dir
             insert(parts: Array(parts.dropFirst()), into: &dir.children, fullPath: fullPath, badges: badges, prefix: nodePath)
         }
+    }
+
+    private static func nodeKey(name: String, isDir: Bool) -> String {
+        "\(isDir ? "dir" : "file"):\(name)"
     }
 
     private static func finalise(_ map: [String: TreeBuildNode]) -> [FileTreeNode] {

--- a/AlasTests/FileTreeBuilderTests.swift
+++ b/AlasTests/FileTreeBuilderTests.swift
@@ -14,4 +14,26 @@ struct FileTreeBuilderTests {
         let cFile = bDir.children!.first { $0.name == "c.rs" }!
         #expect(cFile.badge == "M")
     }
+
+    @Test func preservesFileAndDirectoryPathCollisions() {
+        assertPreservesFileAndDirectoryPathCollisions(["foo", "foo/bar.swift"])
+        assertPreservesFileAndDirectoryPathCollisions(["foo/bar.swift", "foo"])
+    }
+
+    private func assertPreservesFileAndDirectoryPathCollisions(_ paths: [String]) {
+        let tree = FileTreeBuilder.build(paths: paths, badges: ["foo": "D"])
+
+        #expect(tree.count == 2)
+        #expect(tree[0].name == "foo")
+        #expect(tree[0].path == "foo")
+        #expect(tree[0].kind == .dir)
+        #expect(tree[0].id == "dir:foo")
+        #expect(tree[0].children?.first?.name == "bar.swift")
+
+        #expect(tree[1].name == "foo")
+        #expect(tree[1].path == "foo")
+        #expect(tree[1].kind == .file)
+        #expect(tree[1].id == "file:foo")
+        #expect(tree[1].badge == "D")
+    }
 }


### PR DESCRIPTION
<!-- gg:managed:start -->
Previously the builder keyed nodes by name alone, so a deleted file and
a directory sharing the same path component would overwrite each other
in the tree. Key by kind+name so both entries survive.
<!-- gg:managed:end -->