### PR TITLE
feat: allow tab drag-and-drop without dragging the window

### DIFF
--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -52,7 +52,10 @@ struct CenterPaneView: View {
                 onRenameTerminal: { id in
                     state.renameTerminalTab(worktreeId: worktree.id, tabId: id)
                 },
-                onNewTerminal: openTerminal
+                onNewTerminal: openTerminal,
+                onMove: { draggedId, destinationId in
+                    state.tabs.moveTab(worktreeId: worktree.id, fromId: draggedId, toId: destinationId)
+                }
             )
             Group {
                 if tabs.isEmpty {

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -15,6 +15,7 @@ struct TabBarView: View {
     let onCopyRelativePath: (TabID) -> Void
     let onRenameTerminal: (TabID) -> Void
     let onNewTerminal: () -> Void
+    let onMove: (TabID, TabID) -> Void
     @Environment(\.theme) var theme
 
     private var isTerminalActive: Bool {
@@ -53,6 +54,12 @@ struct TabBarView: View {
                         Button("Copy Path") { onCopyPath(tab.id) }
                         Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
                     }
+                }
+                .draggable(tab.id)
+                .dropDestination(for: String.self) { ids, _ in
+                    guard let draggedId = ids.first, draggedId != tab.id else { return false }
+                    onMove(draggedId, tab.id)
+                    return true
                 }
             }
             Spacer()

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -63,6 +63,18 @@ final class TabsManager {
         return tabs(forWorktree: id).first(where: { $0.id == activeId })
     }
 
+    func moveTab(worktreeId: String, fromId: TabID, toId: TabID) {
+        guard fromId != toId else { return }
+        guard var file = byWorktree[worktreeId] else { return }
+        guard let fromIndex = file.tabs.firstIndex(where: { $0.id == fromId }) else { return }
+        guard let toIndex = file.tabs.firstIndex(where: { $0.id == toId }) else { return }
+        let tab = file.tabs.remove(at: fromIndex)
+        let insertionIndex = fromIndex < toIndex ? toIndex : toIndex
+        file.tabs.insert(tab, at: insertionIndex)
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+    }
+
     @discardableResult
     func activateTabNumber(_ number: Int, worktreeId: String) -> TabID? {
         guard number > 0 else { return nil }

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -322,6 +322,87 @@ struct TabsManagerTests {
             Issue.record("expected editor tab")
         }
     }
+
+    @Test func moveTabReordersTabs() {
+        let worktreeId = "tabs-manager-move-tab"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let a = mgr.appendTerminal(worktreeId: worktreeId, title: "a", sessionId: "s1")
+        let b = mgr.appendTerminal(worktreeId: worktreeId, title: "b", sessionId: "s2")
+        let c = mgr.appendTerminal(worktreeId: worktreeId, title: "c", sessionId: "s3")
+
+        mgr.moveTab(worktreeId: worktreeId, fromId: a.id, toId: c.id)
+
+        let ids = mgr.tabs(forWorktree: worktreeId).map(\.id)
+        #expect(ids == [b.id, c.id, a.id])
+    }
+
+    @Test func moveTabPreservesActiveTabId() {
+        let worktreeId = "tabs-manager-move-tab-active"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let a = mgr.appendTerminal(worktreeId: worktreeId, title: "a", sessionId: "s1")
+        let b = mgr.appendTerminal(worktreeId: worktreeId, title: "b", sessionId: "s2")
+        mgr.activate(worktreeId: worktreeId, tabId: a.id)
+
+        mgr.moveTab(worktreeId: worktreeId, fromId: a.id, toId: b.id)
+
+        #expect(mgr.activeTabId(forWorktree: worktreeId) == a.id)
+    }
+
+    @Test func moveTabMissingSourceIsNoOp() {
+        let worktreeId = "tabs-manager-move-tab-missing-source"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let a = mgr.appendTerminal(worktreeId: worktreeId, title: "a", sessionId: "s1")
+        let b = mgr.appendTerminal(worktreeId: worktreeId, title: "b", sessionId: "s2")
+
+        mgr.moveTab(worktreeId: worktreeId, fromId: "missing", toId: b.id)
+
+        let ids = mgr.tabs(forWorktree: worktreeId).map(\.id)
+        #expect(ids == [a.id, b.id])
+    }
+
+    @Test func moveTabMissingDestinationIsNoOp() {
+        let worktreeId = "tabs-manager-move-tab-missing-destination"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let a = mgr.appendTerminal(worktreeId: worktreeId, title: "a", sessionId: "s1")
+        let b = mgr.appendTerminal(worktreeId: worktreeId, title: "b", sessionId: "s2")
+
+        mgr.moveTab(worktreeId: worktreeId, fromId: a.id, toId: "missing")
+
+        let ids = mgr.tabs(forWorktree: worktreeId).map(\.id)
+        #expect(ids == [a.id, b.id])
+    }
+
+    @Test func moveTabSameIdIsNoOp() {
+        let worktreeId = "tabs-manager-move-tab-same"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let mgr = TabsManager()
+        let a = mgr.appendTerminal(worktreeId: worktreeId, title: "a", sessionId: "s1")
+        let b = mgr.appendTerminal(worktreeId: worktreeId, title: "b", sessionId: "s2")
+
+        mgr.moveTab(worktreeId: worktreeId, fromId: a.id, toId: a.id)
+
+        let ids = mgr.tabs(forWorktree: worktreeId).map(\.id)
+        #expect(ids == [a.id, b.id])
+    }
+
+    @Test func moveTabPersistsOrder() {
+        let worktreeId = "tabs-manager-move-tab-persist"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let firstMgr = TabsManager()
+        let a = firstMgr.appendTerminal(worktreeId: worktreeId, title: "a", sessionId: "s1")
+        let b = firstMgr.appendTerminal(worktreeId: worktreeId, title: "b", sessionId: "s2")
+        let c = firstMgr.appendTerminal(worktreeId: worktreeId, title: "c", sessionId: "s3")
+        firstMgr.moveTab(worktreeId: worktreeId, fromId: a.id, toId: c.id)
+
+        let secondMgr = TabsManager()
+        secondMgr.loadAll(worktreeIds: [worktreeId])
+        let ids = secondMgr.tabs(forWorktree: worktreeId).map(\.id)
+        #expect(ids == [b.id, c.id, a.id])
+    }
 }
 
 // MARK: - Pane tree mutations


### PR DESCRIPTION
## Summary

Tab drag-and-drop previously didn't work because dragging from the tab area fell through to the macOS hidden titlebar zone and moved the whole window instead. This PR makes tab buttons participate in SwiftUI drag/drop so tab drag gestures are captured before the window layer handles them.

## Changes

- **`TabsManager.swift`** — Added `moveTab(worktreeId:fromId:toId:)` method that reorders the worktree-local `tabs` array, preserves `activeTabId`, and persists to disk. Guards against same-id, missing source, and missing destination.
- **`TabBarView.swift`** — Added `onMove` callback and `.draggable(tab.id)` / `.dropDestination(for: String.self)` modifiers on each `TabButton`, matching the existing `RepoGroupView` sidebar reorder pattern.
- **`CenterPaneView.swift`** — Wired `onMove` to `state.tabs.moveTab(worktreeId:fromId:toId:)`.
- **`TabsManagerTests.swift`** — Six new tests covering: reorder, activeTabId preservation, missing source/destination no-ops, same-id no-op, and cross-session persistence.

## Key decisions

- Used `String` drag payloads (same as worktree reordering) — `TabID` is already `typealias TabID = String`
- No changes to `TitlelessWindow`, sidebar, or header chrome — window dragging continues to work from those areas
- Drag/drop scoped to `TabButton` only, not blank tab-bar space (which remains window chrome)

## Test plan

- [x] All 31 `TabsManagerTests` pass (6 new, 25 existing)
- [x] Full app build succeeds
- [ ] Dragging one tab onto another reorders tabs visually
- [ ] Dragging a tab does not move the window
- [ ] Dragging from sidebar/header areas still moves the window
- [ ] Tab context menus still open
- [ ] Clicking tabs still activates them
- [ ] Close buttons still close tabs

Closes #864