### PR TITLE
fix(tab): drag reordering

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		6A386E5CF4C958D9F90DF692 /* InstallSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */; };
 		6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */; };
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
+		6BDE0FB5E67AEFEB409E7AAF /* TabDragWindowShieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B334C5DE12CA2F082C9DC491 /* TabDragWindowShieldTests.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
 		6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */; };
@@ -244,6 +245,7 @@
 		A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
+		AA39E8B6257A8134101CE924 /* TabDragWindowShield.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137299B5614B9AC983A27803 /* TabDragWindowShield.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
 		AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */; };
 		AC905947E88C7A2BE39D9B00 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
@@ -403,6 +405,7 @@
 		12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewTabView.swift; sourceTree = "<group>"; };
 		12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
 		136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookEvent.swift; sourceTree = "<group>"; };
+		137299B5614B9AC983A27803 /* TabDragWindowShield.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDragWindowShield.swift; sourceTree = "<group>"; };
 		1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandleTests.swift; sourceTree = "<group>"; };
 		137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHookSettingsFile.swift; sourceTree = "<group>"; };
 		14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabView.swift; sourceTree = "<group>"; };
@@ -619,6 +622,7 @@
 		B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
+		B334C5DE12CA2F082C9DC491 /* TabDragWindowShieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDragWindowShieldTests.swift; sourceTree = "<group>"; };
 		B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateLoadOlderTests.swift; sourceTree = "<group>"; };
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
 		B4C486F9097A2B145D101E2C /* AlasButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasButton.swift; sourceTree = "<group>"; };
@@ -884,6 +888,7 @@
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
 				CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */,
 				D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */,
+				B334C5DE12CA2F082C9DC491 /* TabDragWindowShieldTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
 				71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */,
@@ -1114,6 +1119,7 @@
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
 				B27595490B7D883CF5D9FFD5 /* Tab.swift */,
 				BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */,
+				137299B5614B9AC983A27803 /* TabDragWindowShield.swift */,
 				A218B5125FC963339E40605E /* TabsManager.swift */,
 				14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */,
 				EA78AC4E93C2130046C92571 /* Commit */,
@@ -1847,6 +1853,7 @@
 				4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */,
 				D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */,
 				B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */,
+				AA39E8B6257A8134101CE924 /* TabDragWindowShield.swift in Sources */,
 				C51D65D3D40F801BC94ABBDD /* TabsManager.swift in Sources */,
 				17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */,
 				A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */,
@@ -1996,6 +2003,7 @@
 				3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */,
 				CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */,
 				B092D71B3D727B89EAF5D753 /* SymbolsFeatureTests.swift in Sources */,
+				6BDE0FB5E67AEFEB409E7AAF /* TabDragWindowShieldTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
 				42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */,

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -17,6 +17,10 @@ struct TabBarView: View {
     let onNewTerminal: () -> Void
     let onMove: (TabID, TabID) -> Void
     @Environment(\.theme) var theme
+    @State private var draggedTabId: TabID?
+    @State private var tabFrames: [TabID: CGRect] = [:]
+
+    private static let dragCoordinateSpace = "alas-tab-bar-drag"
 
     private var isTerminalActive: Bool {
         guard let activeId, let active = tabs.first(where: { $0.id == activeId }) else { return false }
@@ -36,6 +40,16 @@ struct TabBarView: View {
                     onActivate: { onActivate(tab.id) },
                     onClose: { onClose(tab.id) }
                 )
+                .opacity(draggedTabId == tab.id ? 0.75 : 1)
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: TabButtonFramePreferenceKey.self,
+                            value: [tab.id: proxy.frame(in: .named(Self.dragCoordinateSpace))]
+                        )
+                    }
+                )
+                .highPriorityGesture(tabDragGesture(for: tab.id))
                 .contextMenu {
                     if case .terminal = tab {
                         Button("Rename…") { onRenameTerminal(tab.id) }
@@ -55,12 +69,6 @@ struct TabBarView: View {
                         Button("Copy Relative Path") { onCopyRelativePath(tab.id) }
                     }
                 }
-                .draggable(tab.id)
-                .dropDestination(for: String.self) { ids, _ in
-                    guard let draggedId = ids.first, draggedId != tab.id else { return false }
-                    onMove(draggedId, tab.id)
-                    return true
-                }
             }
             Spacer()
             if isTerminalActive {
@@ -79,9 +87,40 @@ struct TabBarView: View {
             .help("New terminal")
             .padding(.horizontal, 8)
         }
+        .coordinateSpace(name: Self.dragCoordinateSpace)
         .frame(height: 34)
-        .background(theme.color("bg-2"))
+        .background {
+            theme.color("bg-2")
+            TabDragWindowShield()
+        }
         .overlay(Divider().opacity(0.5), alignment: .bottom)
+        .onPreferenceChange(TabButtonFramePreferenceKey.self) { frames in
+            tabFrames = frames
+        }
+    }
+
+    private func tabDragGesture(for tabId: TabID) -> some Gesture {
+        DragGesture(minimumDistance: 4, coordinateSpace: .named(Self.dragCoordinateSpace))
+            .onChanged { value in
+                if draggedTabId == nil {
+                    draggedTabId = tabId
+                }
+                guard draggedTabId == tabId,
+                      let targetId = tabFrames.first(where: { $0.value.contains(value.location) })?.key,
+                      targetId != tabId else { return }
+                onMove(tabId, targetId)
+            }
+            .onEnded { _ in
+                draggedTabId = nil
+            }
+    }
+}
+
+private struct TabButtonFramePreferenceKey: PreferenceKey {
+    static var defaultValue: [TabID: CGRect] = [:]
+
+    static func reduce(value: inout [TabID: CGRect], nextValue: () -> [TabID: CGRect]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
     }
 }
 

--- a/Alas/Sources/Center/TabDragWindowShield.swift
+++ b/Alas/Sources/Center/TabDragWindowShield.swift
@@ -1,0 +1,14 @@
+import AppKit
+import SwiftUI
+
+final class TabDragWindowShieldView: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
+}
+
+struct TabDragWindowShield: NSViewRepresentable {
+    func makeNSView(context: Context) -> TabDragWindowShieldView {
+        TabDragWindowShieldView()
+    }
+
+    func updateNSView(_ nsView: TabDragWindowShieldView, context: Context) {}
+}

--- a/AlasTests/TabDragWindowShieldTests.swift
+++ b/AlasTests/TabDragWindowShieldTests.swift
@@ -1,0 +1,12 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+struct TabDragWindowShieldTests {
+    @Test func shieldedTabDragViewDoesNotMoveWindowOnMouseDown() {
+        let view = TabDragWindowShieldView()
+
+        #expect(view.mouseDownCanMoveWindow == false)
+    }
+}


### PR DESCRIPTION
## Summary

- Replace native tab drag/drop handling with high-priority pointer dragging inside `TabBarView`.
- Keep rebased `TabsManager.moveTab(fromId:toId:)` as the tab-order model API.
- Add an AppKit shield view whose `mouseDownCanMoveWindow` is false for the tab bar region.
- Add regression coverage for the window-drag shield.

## Root cause

The app uses a titleless full-size content window. The tab bar sits in the invisible titlebar region, so tab drags that were not fully consumed by the tab UI could be interpreted by AppKit as window movement.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TabsManagerTests/moveTabReordersTabs -only-testing:AlasTests/TabsManagerTests/moveTabPreservesActiveTabId -only-testing:AlasTests/TabDragWindowShieldTests/shieldedTabDragViewDoesNotMoveWindowOnMouseDown test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full local suite note from the pre-rebase run: a timeout-enabled full `xcodebuild ... test` run executed 1064 tests and reported 4 failures in unrelated existing areas: `AgentRunnerInvocationTests.timeoutCompletesWhenChildIgnoresSIGTERM`, `SymbolsFeatureTests.ignoresStaleDocumentSymbolResponse`, `ProjectGitWatcherTests.headReadFailureEscalatesToTopology`, and `CodeTextViewMultiCursorTests.multiCursorNewlineReplacesNonEmptyRanges`.