### PR TITLE
fix(NewWorktreeDialog): hide branch error while only the prefix is typed

### DIFF
--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -60,7 +60,7 @@ struct NewWorktreeDialog: View {
                     Text("Open in new terminal pane").font(.system(size: 12))
                         .foregroundColor(theme.color("fg"))
                 }
-                if let validationMessage = branchValidationMessage {
+                if let validationMessage = branchValidationMessage, branch != state.config.worktrees.branchPrefix {
                     Text(validationMessage).font(.system(size: 11)).foregroundColor(.red)
                 }
                 if !state.agentRegistry.enabled().isEmpty {


### PR DESCRIPTION
## Summary
- When the New worktree dialog opens with a configured branch prefix (e.g. `nacho/`), the field is pre-filled with the prefix and the validation message "Name cannot start or end with '/'" was shown immediately.
- Suppress that error while the branch field still equals the configured prefix — the Create button is already disabled in that state, so the visible error was just noise.

## Test plan
- [ ] Configure a branch prefix ending in `/` in Worktrees settings
- [ ] Open New worktree → field shows the prefix, no red error text, Create disabled
- [ ] Type a name after the prefix → no error, Create enabled
- [ ] Type something invalid (e.g. trailing `/`) → error appears, Create disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)