### PR TITLE
Add Alas terminal CLI for opening files

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
 		A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */; };
 		A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */; };
+		A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
 		A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */; };
@@ -399,6 +400,7 @@
 		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
+		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
 		0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateUnstagePathsTests.swift; sourceTree = "<group>"; };
 		0AF8152B18C9D6290724122F /* HoverFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeature.swift; sourceTree = "<group>"; };
@@ -816,6 +818,7 @@
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
+				08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
 				71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */,
@@ -1924,6 +1927,7 @@
 				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
+				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */; };
 		3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
+		3E46667F7AA794E24B04BC7F /* TerminalCLIInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
 		3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E62B501E0490F48CCA830 /* EditorFindBarView.swift */; };
 		3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */; };
@@ -280,6 +281,7 @@
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
 		BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */; };
+		BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */; };
 		BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88379ACE40F42BE4A3257659 /* ThemeTests.swift */; };
 		BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */; };
 		BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */; };
@@ -389,6 +391,7 @@
 		00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPickerTests.swift; sourceTree = "<group>"; };
 		008E982C8526670670425AB8 /* EmptyTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabView.swift; sourceTree = "<group>"; };
 		010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowConfigurator.swift; sourceTree = "<group>"; };
+		013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjection.swift; sourceTree = "<group>"; };
 		01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupViewLayoutTests.swift; sourceTree = "<group>"; };
 		019A03B92542169A6595D432 /* HoverHighlightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeature.swift; sourceTree = "<group>"; };
 		01F0314E357190EF2A1F861B /* CodexInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstaller.swift; sourceTree = "<group>"; };
@@ -503,6 +506,7 @@
 		4575017544CD7603B3AB9069 /* GitEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilter.swift; sourceTree = "<group>"; };
 		4865995B2D4B92166321201F /* CommitContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilder.swift; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
+		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltinsTests.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
 		4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTabBar.swift; sourceTree = "<group>"; };
@@ -910,6 +914,7 @@
 				B334C5DE12CA2F082C9DC491 /* TabDragWindowShieldTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
+				4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */,
 				71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */,
 				50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */,
 				1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */,
@@ -1486,6 +1491,7 @@
 				2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */,
 				C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */,
 				743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */,
+				013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */,
 				1AFC62A30044F71F0F16C3FB /* TerminalService.swift */,
 				9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */,
 				A79B23DE77D9512D04B58860 /* Ghostty */,
@@ -1878,6 +1884,7 @@
 				B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */,
 				AA39E8B6257A8134101CE924 /* TabDragWindowShield.swift in Sources */,
 				C51D65D3D40F801BC94ABBDD /* TabsManager.swift in Sources */,
+				3E46667F7AA794E24B04BC7F /* TerminalCLIInjection.swift in Sources */,
 				17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */,
 				A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */,
 				3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */,
@@ -2034,6 +2041,7 @@
 				6BDE0FB5E67AEFEB409E7AAF /* TabDragWindowShieldTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
+				BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */,
 				42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */,
 				7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */,
 				59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
 		29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */; };
+		29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */; };
 		2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
 		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
@@ -210,6 +211,7 @@
 		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
 		8C60AB3736F2160FC2A49281 /* CommitComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DACC2D855F4316038CB40C7 /* CommitComposerView.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
+		8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */; };
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
 		8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */; };
 		8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */; };
@@ -650,6 +652,7 @@
 		BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSplitButton.swift; sourceTree = "<group>"; };
 		BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstallerTests.swift; sourceTree = "<group>"; };
+		BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequest.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
 		C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
@@ -736,6 +739,7 @@
 		F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessServiceTests.swift; sourceTree = "<group>"; };
 		F9F85B92952C963DCF136315 /* HarnessDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetector.swift; sourceTree = "<group>"; };
 		FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
+		FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequestTests.swift; sourceTree = "<group>"; };
 		FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinitionTests.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
 		FC4A215AF2876091E31F6F8A /* LineEnding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEnding.swift; sourceTree = "<group>"; };
@@ -794,6 +798,7 @@
 				2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */,
 				9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */,
 				E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */,
+				FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */,
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
 				A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */,
 				A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */,
@@ -1293,6 +1298,7 @@
 				976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */,
 				B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */,
 				53C792D59DBFFF6C28F2D426 /* AgentKind.swift */,
+				BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */,
 				57713D7143CFD53124E0523F /* AlasHookCommand.swift */,
 				65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */,
 				01F0314E357190EF2A1F861B /* CodexInstaller.swift */,
@@ -1682,6 +1688,7 @@
 				59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */,
 				A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */,
 				5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */,
+				29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */,
 				24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */,
 				9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */,
 				8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */,
@@ -1896,6 +1903,7 @@
 				659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */,
 				D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */,
 				0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */,
+				8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */,
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,
 				281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */,
 				CB6D9F5929D97FAB3A264F47 /* AppConfigAgentsCodingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2975A1465CA308E9766521F2 /* NotificationService.swift */; };
 		01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */; };
 		02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1703FC5CD7DF16F4450E274 /* DiffParser.swift */; };
+		026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */; };
 		02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934BCC470703CF2DF2303357 /* SectionHeader.swift */; };
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
 		0407824F9DA8EEFC5B5EEA8A /* InstallerHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C506EF972D34E2F937D4FEEC /* InstallerHost.swift */; };
@@ -164,6 +165,7 @@
 		6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4A215AF2876091E31F6F8A /* LineEnding.swift */; };
 		6A386E5CF4C958D9F90DF692 /* InstallSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */; };
 		6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */; };
+		6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */; };
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
 		6BDE0FB5E67AEFEB409E7AAF /* TabDragWindowShieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B334C5DE12CA2F082C9DC491 /* TabDragWindowShieldTests.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
@@ -407,6 +409,7 @@
 		0F68A9692F85197ED9E16262 /* WorktreesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreesPane.swift; sourceTree = "<group>"; };
 		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
 		1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
+		1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouter.swift; sourceTree = "<group>"; };
 		12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewTabView.swift; sourceTree = "<group>"; };
 		12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFamilyPicker.swift; sourceTree = "<group>"; };
 		136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookEvent.swift; sourceTree = "<group>"; };
@@ -427,6 +430,7 @@
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
 		1DACC2D855F4316038CB40C7 /* CommitComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerView.swift; sourceTree = "<group>"; };
+		1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouterTests.swift; sourceTree = "<group>"; };
 		20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighterTests.swift; sourceTree = "<group>"; };
 		2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
 		2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.App.swift; sourceTree = "<group>"; };
@@ -801,6 +805,7 @@
 				2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */,
 				9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */,
 				E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */,
+				1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */,
 				FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */,
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
 				A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */,
@@ -1509,6 +1514,7 @@
 			isa = PBXGroup;
 			children = (
 				7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */,
+				1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */,
 				17C2AC0F8B3A1B75239995AC /* AppState.swift */,
 				57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */,
 				417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */,
@@ -1691,6 +1697,7 @@
 				59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */,
 				A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */,
 				5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */,
+				6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */,
 				29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */,
 				24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */,
 				9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */,
@@ -1907,6 +1914,7 @@
 				659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */,
 				D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */,
 				0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */,
+				026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */,
 				8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */,
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,
 				281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -363,6 +363,7 @@
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
+		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
@@ -741,6 +742,7 @@
 		FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequestTests.swift; sourceTree = "<group>"; };
 		FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinitionTests.swift; sourceTree = "<group>"; };
+		FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerCLITests.swift; sourceTree = "<group>"; };
 		FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextView.swift; sourceTree = "<group>"; };
 		FC4A215AF2876091E31F6F8A /* LineEnding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEnding.swift; sourceTree = "<group>"; };
 		FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorView.swift; sourceTree = "<group>"; };
@@ -793,6 +795,7 @@
 				4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */,
 				FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */,
 				3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */,
+				FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */,
 				A78C23951DE157A38A9ED899 /* AgentHookSocketServerTests.swift */,
 				37987D5884297401F95478D3 /* AgentPathTests.swift */,
 				2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */,
@@ -1898,6 +1901,7 @@
 				7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */,
 				2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */,
 				5426DC977050AACBCBDA37E9 /* AgentDetectorTests.swift in Sources */,
+				F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */,
 				B0861243A465A06EDA290722 /* AgentHookSocketServerTests.swift in Sources */,
 				48EFAD2DE1F112D72B5F9FAC /* AgentPathTests.swift in Sources */,
 				659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */,

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -2,6 +2,11 @@ import Foundation
 
 @MainActor
 struct AlasCLICommandRouter {
+    private struct FileIdentity: Equatable {
+        let systemNumber: UInt64
+        let fileNumber: UInt64
+    }
+
     var sessionWorktreeId: (String) -> String?
     var originatingWorktree: (String) -> Worktree?
     var visibleWorktrees: () -> [Worktree]
@@ -71,7 +76,7 @@ struct AlasCLICommandRouter {
         return relativePathAndDepth(
             targetComponents: url.resolvingSymlinksInPath().standardizedFileURL.pathComponents,
             rootComponents: rootURL.resolvingSymlinksInPath().standardizedFileURL.pathComponents
-        )
+        ) ?? fileSystemRelativePathAndDepth(for: url, in: rootURL)
     }
 
     private func relativePathAndDepth(
@@ -83,6 +88,28 @@ struct AlasCLICommandRouter {
         let relative = targetComponents.dropFirst(rootComponents.count).joined(separator: "/")
         guard !relative.isEmpty else { return nil }
         return (relative, rootComponents.count)
+    }
+
+    private func fileSystemRelativePathAndDepth(for url: URL, in rootURL: URL) -> (relativePath: String, rootComponentCount: Int)? {
+        guard let rootIdentity = fileIdentity(at: rootURL.path) else { return nil }
+        var ancestor = url.deletingLastPathComponent()
+        var relativeComponents = [url.lastPathComponent]
+
+        while ancestor.path != "/" {
+            if fileIdentity(at: ancestor.path) == rootIdentity {
+                return (relativeComponents.reversed().joined(separator: "/"), rootURL.pathComponents.count)
+            }
+            relativeComponents.append(ancestor.lastPathComponent)
+            ancestor.deleteLastPathComponent()
+        }
+        return nil
+    }
+
+    private func fileIdentity(at path: String) -> FileIdentity? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let systemNumber = attributes[.systemNumber] as? NSNumber,
+              let fileNumber = attributes[.systemFileNumber] as? NSNumber else { return nil }
+        return FileIdentity(systemNumber: systemNumber.uint64Value, fileNumber: fileNumber.uint64Value)
     }
 
     private func fileExists(at url: URL) -> Bool {

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 
 @MainActor
@@ -48,6 +47,7 @@ struct AlasCLICommandRouter {
 
     private func containingWorktree(for url: URL) -> (worktree: Worktree, relativePath: String)? {
         let targetComponents = url.standardizedFileURL.pathComponents
+        var bestMatch: (worktree: Worktree, relativePath: String, rootComponentCount: Int)?
         for worktree in visibleWorktrees() {
             let rootURL = worktree.path.standardizedFileURL
             let rootComponents = rootURL.pathComponents
@@ -55,9 +55,14 @@ struct AlasCLICommandRouter {
                   Array(targetComponents.prefix(rootComponents.count)) == rootComponents else { continue }
             let relative = targetComponents.dropFirst(rootComponents.count).joined(separator: "/")
             guard !relative.isEmpty else { continue }
-            return (worktree, relative)
+            if let currentBest = bestMatch,
+               rootComponents.count <= currentBest.rootComponentCount {
+                continue
+            }
+            bestMatch = (worktree, relative, rootComponents.count)
         }
-        return nil
+        guard let bestMatch else { return nil }
+        return (bestMatch.worktree, bestMatch.relativePath)
     }
 
     private func fileExists(at url: URL) -> Bool {

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Foundation
+
+@MainActor
+struct AlasCLICommandRouter {
+    var sessionWorktreeId: (String) -> String?
+    var originatingWorktree: (String) -> Worktree?
+    var visibleWorktrees: () -> [Worktree]
+    var openRelativeFile: (String, String) -> Void
+    var openExternalFile: (URL, String) -> Void
+    var activateApp: () -> Void
+
+    func handle(_ request: AlasCLIRequest) -> AlasCLIResponse {
+        guard request.command == .open else {
+            return .error("Unsupported command.")
+        }
+        guard let originWorktreeId = sessionWorktreeId(request.sessionId),
+              originatingWorktree(originWorktreeId) != nil else {
+            return .error("Unknown Alas terminal session.")
+        }
+
+        var errors: [String] = []
+        var openedAny = false
+        for rawPath in request.paths {
+            let url = URL(fileURLWithPath: rawPath).standardizedFileURL
+            guard fileExists(at: url) else {
+                errors.append("\(url.path) does not exist.")
+                continue
+            }
+            guard !isDirectory(at: url) else {
+                errors.append("\(url.path) is a directory.")
+                continue
+            }
+
+            if let match = containingWorktree(for: url) {
+                openRelativeFile(match.relativePath, match.worktree.id)
+            } else {
+                openExternalFile(url, originWorktreeId)
+            }
+            openedAny = true
+        }
+
+        if openedAny {
+            activateApp()
+        }
+        return errors.isEmpty ? .ok : .error(errors.joined(separator: " "))
+    }
+
+    private func containingWorktree(for url: URL) -> (worktree: Worktree, relativePath: String)? {
+        let targetComponents = url.standardizedFileURL.pathComponents
+        for worktree in visibleWorktrees() {
+            let rootURL = worktree.path.standardizedFileURL
+            let rootComponents = rootURL.pathComponents
+            guard targetComponents.count > rootComponents.count,
+                  Array(targetComponents.prefix(rootComponents.count)) == rootComponents else { continue }
+            let relative = targetComponents.dropFirst(rootComponents.count).joined(separator: "/")
+            guard !relative.isEmpty else { continue }
+            return (worktree, relative)
+        }
+        return nil
+    }
+
+    private func fileExists(at url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+    }
+
+    private func isDirectory(at url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        _ = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        return isDirectory.boolValue
+    }
+}

--- a/Alas/Sources/App/AlasCLICommandRouter.swift
+++ b/Alas/Sources/App/AlasCLICommandRouter.swift
@@ -46,23 +46,43 @@ struct AlasCLICommandRouter {
     }
 
     private func containingWorktree(for url: URL) -> (worktree: Worktree, relativePath: String)? {
-        let targetComponents = url.standardizedFileURL.pathComponents
         var bestMatch: (worktree: Worktree, relativePath: String, rootComponentCount: Int)?
         for worktree in visibleWorktrees() {
             let rootURL = worktree.path.standardizedFileURL
-            let rootComponents = rootURL.pathComponents
-            guard targetComponents.count > rootComponents.count,
-                  Array(targetComponents.prefix(rootComponents.count)) == rootComponents else { continue }
-            let relative = targetComponents.dropFirst(rootComponents.count).joined(separator: "/")
-            guard !relative.isEmpty else { continue }
+            guard let match = relativePathAndDepth(for: url, in: rootURL) else { continue }
             if let currentBest = bestMatch,
-               rootComponents.count <= currentBest.rootComponentCount {
+               match.rootComponentCount <= currentBest.rootComponentCount {
                 continue
             }
-            bestMatch = (worktree, relative, rootComponents.count)
+            bestMatch = (worktree, match.relativePath, match.rootComponentCount)
         }
         guard let bestMatch else { return nil }
         return (bestMatch.worktree, bestMatch.relativePath)
+    }
+
+    private func relativePathAndDepth(for url: URL, in rootURL: URL) -> (relativePath: String, rootComponentCount: Int)? {
+        if let match = relativePathAndDepth(
+            targetComponents: url.standardizedFileURL.pathComponents,
+            rootComponents: rootURL.pathComponents
+        ) {
+            return match
+        }
+
+        return relativePathAndDepth(
+            targetComponents: url.resolvingSymlinksInPath().standardizedFileURL.pathComponents,
+            rootComponents: rootURL.resolvingSymlinksInPath().standardizedFileURL.pathComponents
+        )
+    }
+
+    private func relativePathAndDepth(
+        targetComponents: [String],
+        rootComponents: [String]
+    ) -> (relativePath: String, rootComponentCount: Int)? {
+        guard targetComponents.count > rootComponents.count,
+              Array(targetComponents.prefix(rootComponents.count)) == rootComponents else { return nil }
+        let relative = targetComponents.dropFirst(rootComponents.count).joined(separator: "/")
+        guard !relative.isEmpty else { return nil }
+        return (relative, rootComponents.count)
     }
 
     private func fileExists(at url: URL) -> Bool {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -651,11 +651,56 @@ final class AppState {
             }
         )
         terminal.socketPath = harness.socketServer.socketPath
+        harness.socketServer.onCLIRequest = { [weak self] request in
+            await MainActor.run {
+                guard let self else { return .error("Alas is not available.") }
+                let router = self.makeCLICommandRouter { [weak self] sessionId in
+                    self?.terminal.registry.session(for: sessionId)?.worktreeId
+                }
+                return router.handle(request)
+            }
+        }
         harness.onClickThrough = { [weak self] projectId, worktreeId, sessionId in
             self?.activateHarnessSession(
                 projectId: projectId, worktreeId: worktreeId, sessionId: sessionId
             )
         }
+    }
+
+    func makeCLICommandRouter(
+        sessionWorktreeLookup: @escaping (String) -> String?
+    ) -> AlasCLICommandRouter {
+        AlasCLICommandRouter(
+            sessionWorktreeId: sessionWorktreeLookup,
+            originatingWorktree: { [weak self] worktreeId in
+                self?.worktree(withId: worktreeId)
+            },
+            visibleWorktrees: { [weak self] in
+                guard let self else { return [] }
+                return self.projects.flatMap { project in
+                    self.projectsManager.visibleWorktrees(projectId: project.id)
+                }
+            },
+            openRelativeFile: { [weak self] relativePath, worktreeId in
+                self?.openFile(relativePath: relativePath, worktreeId: worktreeId)
+            },
+            openExternalFile: { [weak self] url, worktreeId in
+                guard let self else { return }
+                _ = self.tabs.openExternalEditor(
+                    worktreeId: worktreeId,
+                    absoluteURL: url,
+                    revealLine: nil,
+                    revealCharacter: nil,
+                    originatingRelativePath: nil
+                )
+                if self.selectedWorktreeId != worktreeId {
+                    self.selectedWorktreeId = worktreeId
+                }
+            },
+            activateApp: {
+                NSApp.activate(ignoringOtherApps: true)
+            }
+        )
     }
 
     /// Activate a specific harness session: bring the app to front, select

--- a/Alas/Sources/Harness/AgentHookSocketServer.swift
+++ b/Alas/Sources/Harness/AgentHookSocketServer.swift
@@ -90,8 +90,7 @@ final class AgentHookSocketServer {
         let clientFD = accept(socketFD, nil, nil)
         guard clientFD >= 0 else { return }
 
-        var timeout = timeval(tv_sec: 5, tv_usec: 0)
-        setsockopt(clientFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+        Self.configureClientSocket(clientFD)
 
         guard let data = Self.readPayload(from: clientFD) else {
             close(clientFD)
@@ -156,6 +155,14 @@ final class AgentHookSocketServer {
             }
         }
         return nil
+    }
+
+    static func configureClientSocket(_ clientFD: Int32) {
+        var timeout = timeval(tv_sec: 5, tv_usec: 0)
+        setsockopt(clientFD, SOL_SOCKET, SO_RCVTIMEO, &timeout, socklen_t(MemoryLayout<timeval>.size))
+
+        var noSigPipe: Int32 = 1
+        setsockopt(clientFD, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
     }
 
     private static func sendResponse(clientFD: Int32, ok: Bool, error: String? = nil) {

--- a/Alas/Sources/Harness/AgentHookSocketServer.swift
+++ b/Alas/Sources/Harness/AgentHookSocketServer.swift
@@ -98,7 +98,11 @@ final class AgentHookSocketServer {
             return
         }
 
-        if let request = try? AlasCLIRequest.decode(from: data) {
+        if Self.payloadKind(data) == "cli" {
+            guard let request = try? AlasCLIRequest.decode(from: data) else {
+                Self.sendResponse(clientFD: clientFD, ok: false, error: "Malformed request.")
+                return
+            }
             let response: AlasCLIResponse
             if let handler = onCLIRequest {
                 response = await handler(request)
@@ -119,6 +123,11 @@ final class AgentHookSocketServer {
         } catch {
             Self.sendResponse(clientFD: clientFD, ok: false, error: "Malformed request.")
         }
+    }
+
+    private static func payloadKind(_ data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return json["kind"] as? String
     }
 
     static func readPayload(from clientFD: Int32) -> Data? {

--- a/Alas/Sources/Harness/AgentHookSocketServer.swift
+++ b/Alas/Sources/Harness/AgentHookSocketServer.swift
@@ -5,6 +5,7 @@ final class AgentHookSocketServer {
     private(set) var socketPath: String?
     private var listenTask: Task<Void, Never>?
     var onEvent: ((AgentHookEvent) -> Void)?
+    var onCLIRequest: ((AlasCLIRequest) async -> AlasCLIResponse)?
 
     static let maxPayloadSize = 65_536
 
@@ -79,13 +80,13 @@ final class AgentHookSocketServer {
                     continue
                 }
                 guard ready > 0 else { continue }
-                self?.acceptAndHandle(socketFD: socketFD)
+                await self?.acceptAndHandle(socketFD: socketFD)
             }
         }
         return true
     }
 
-    private func acceptAndHandle(socketFD: Int32) {
+    private func acceptAndHandle(socketFD: Int32) async {
         let clientFD = accept(socketFD, nil, nil)
         guard clientFD >= 0 else { return }
 
@@ -94,6 +95,17 @@ final class AgentHookSocketServer {
 
         guard let data = Self.readPayload(from: clientFD) else {
             close(clientFD)
+            return
+        }
+
+        if let request = try? AlasCLIRequest.decode(from: data) {
+            let response: AlasCLIResponse
+            if let handler = onCLIRequest {
+                response = await handler(request)
+            } else {
+                response = .error("Alas CLI is not available.")
+            }
+            Self.sendResponse(clientFD: clientFD, response: response)
             return
         }
 
@@ -147,6 +159,23 @@ final class AgentHookSocketServer {
         data.withUnsafeBytes { buffer in
             guard let base = buffer.baseAddress else { return }
             _ = Darwin.write(clientFD, base, data.count)
+        }
+        close(clientFD)
+    }
+
+    private static func sendResponse(clientFD: Int32, response: AlasCLIResponse) {
+        do {
+            let data = try response.encode()
+            data.withUnsafeBytes { buffer in
+                guard let base = buffer.baseAddress else { return }
+                _ = Darwin.write(clientFD, base, data.count)
+            }
+        } catch {
+            let fallback = #"{"ok":false,"error":"Malformed response."}"#.data(using: .utf8)!
+            fallback.withUnsafeBytes { buffer in
+                guard let base = buffer.baseAddress else { return }
+                _ = Darwin.write(clientFD, base, fallback.count)
+            }
         }
         close(clientFD)
     }

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+enum AlasCLIRequestError: Error, Equatable {
+    case malformed
+    case unsupportedKind
+    case unsupportedVersion
+    case unsupportedCommand
+    case missingSession
+    case missingPaths
+}
+
+struct AlasCLIRequest: Equatable {
+    enum Command: String, Equatable {
+        case open
+    }
+
+    let version: Int
+    let command: Command
+    let sessionId: String
+    let paths: [String]
+
+    private struct Raw: Decodable {
+        var v: Int?
+        var kind: String?
+        var command: String?
+        var session_id: String?
+        var paths: [String]?
+    }
+
+    static func decode(from data: Data) throws -> AlasCLIRequest {
+        let raw: Raw
+        do {
+            raw = try JSONDecoder().decode(Raw.self, from: data)
+        } catch {
+            throw AlasCLIRequestError.malformed
+        }
+        guard raw.kind == "cli" else { throw AlasCLIRequestError.unsupportedKind }
+        guard raw.v == 1 else { throw AlasCLIRequestError.unsupportedVersion }
+        guard let commandString = raw.command,
+              let command = Command(rawValue: commandString) else {
+            throw AlasCLIRequestError.unsupportedCommand
+        }
+        guard let sessionId = raw.session_id,
+              !sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AlasCLIRequestError.missingSession
+        }
+        guard let paths = raw.paths,
+              !paths.isEmpty,
+              paths.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+            throw AlasCLIRequestError.missingPaths
+        }
+        return AlasCLIRequest(version: 1, command: command, sessionId: sessionId, paths: paths)
+    }
+}
+
+enum AlasCLIResponse: Equatable {
+    case ok
+    case error(String)
+
+    func encode() throws -> Data {
+        let object: [String: Any]
+        switch self {
+        case .ok:
+            object = ["ok": true]
+        case .error(let message):
+            object = ["ok": false, "error": message]
+        }
+        return try JSONSerialization.data(withJSONObject: object)
+    }
+}

--- a/Alas/Sources/Harness/AlasCLIRequest.swift
+++ b/Alas/Sources/Harness/AlasCLIRequest.swift
@@ -46,7 +46,10 @@ struct AlasCLIRequest: Equatable {
         }
         guard let paths = raw.paths,
               !paths.isEmpty,
-              paths.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+              paths.allSatisfy({
+                  let trimmed = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                  return !trimmed.isEmpty && URL(fileURLWithPath: trimmed).path == trimmed && trimmed.hasPrefix("/")
+              }) else {
             throw AlasCLIRequestError.missingPaths
         }
         return AlasCLIRequest(version: 1, command: command, sessionId: sessionId, paths: paths)

--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -12,15 +12,21 @@ enum TerminalCLIInjection {
           fi
           case "${1:-}" in
             open)
+              local response status
               shift
               if [ "$#" -eq 0 ]; then
                 printf '%s\n' 'usage: alas open <path> [path...]' >&2
                 return 2
               fi
-              response=$(/usr/bin/python3 - "$ALAS_SESSION_ID" "$@" <<'PY' | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH"
+              response=$(/usr/bin/python3 - "$ALAS_SESSION_ID" "$@" <<'PY' | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH" 2>/dev/null
         import json, os, sys
         session_id = sys.argv[1]
-        paths = [os.path.abspath(path) for path in sys.argv[2:]]
+        base = os.environ.get("PWD") or os.getcwd()
+        def resolve(path):
+            if os.path.isabs(path):
+                return os.path.abspath(path)
+            return os.path.abspath(os.path.join(base, path))
+        paths = [resolve(path) for path in sys.argv[2:]]
         print(json.dumps({"v": 1, "kind": "cli", "command": "open", "session_id": session_id, "paths": paths}))
         PY
         )

--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -1,24 +1,24 @@
 import Foundation
 
 enum TerminalCLIInjection {
-    static func script(forShell shell: String) -> String? {
-        let basename = (shell as NSString).lastPathComponent
-        guard basename == "zsh" || basename == "bash" else { return nil }
+    static let executableName = "alas"
+
+    static func executableScript() -> String {
         return """
-        alas() {
-          if [ -z "${ALAS_SOCKET_PATH:-}" ] || [ -z "${ALAS_SESSION_ID:-}" ]; then
-            printf '%s\n' 'alas: only available in Alas terminals' >&2
-            return 2
-          fi
-          case "${1:-}" in
-            open)
-              local response alas_status
-              shift
-              if [ "$#" -eq 0 ]; then
-                printf '%s\n' 'usage: alas open <path> [path...]' >&2
-                return 2
-              fi
-              response=$(/usr/bin/python3 - "$ALAS_SESSION_ID" "$@" <<'PY' | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH" 2>/dev/null
+        #!/bin/sh
+        if [ -z "${ALAS_SOCKET_PATH:-}" ] || [ -z "${ALAS_SESSION_ID:-}" ]; then
+          printf '%s\n' 'alas: only available in Alas terminals' >&2
+          exit 2
+        fi
+
+        case "${1:-}" in
+          open)
+            shift
+            if [ "$#" -eq 0 ]; then
+              printf '%s\n' 'usage: alas open <path> [path...]' >&2
+              exit 2
+            fi
+            response=$(/usr/bin/python3 - "$ALAS_SESSION_ID" "$@" <<'PY' | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH" 2>/dev/null
         import json, os, sys
         session_id = sys.argv[1]
         base = os.environ.get("PWD") or os.getcwd()
@@ -30,12 +30,12 @@ enum TerminalCLIInjection {
         print(json.dumps({"v": 1, "kind": "cli", "command": "open", "session_id": session_id, "paths": paths}))
         PY
         )
-              alas_status=$?
-              if [ "$alas_status" -ne 0 ]; then
-                printf '%s\n' 'alas: could not reach Alas' >&2
-                return "$alas_status"
-              fi
-              /usr/bin/python3 - "$response" <<'PY'
+            alas_status=$?
+            if [ "$alas_status" -ne 0 ]; then
+              printf '%s\n' 'alas: could not reach Alas' >&2
+              exit "$alas_status"
+            fi
+            /usr/bin/python3 - "$response" <<'PY'
         import json, sys
         try:
             response = json.loads(sys.argv[1] or "{}")
@@ -47,26 +47,32 @@ enum TerminalCLIInjection {
         print("alas: " + str(response.get("error") or "request failed"), file=sys.stderr)
         sys.exit(1)
         PY
-              ;;
-            *)
-              printf '%s\n' 'usage: alas open <path> [path...]' >&2
-              return 2
-              ;;
-          esac
-        }
+            ;;
+          *)
+            printf '%s\n' 'usage: alas open <path> [path...]' >&2
+            exit 2
+            ;;
+        esac
         """
     }
 
-    static func compose(
-        shell: String,
-        userStartupScript: String,
-        startupScriptSuffix: String?
-    ) -> String {
-        [script(forShell: shell), userStartupScript, startupScriptSuffix]
-            .compactMap { part in
-                let trimmed = part?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                return trimmed.isEmpty ? nil : trimmed
-            }
-            .joined(separator: "\n")
+    static func installExecutable() throws -> URL {
+        let dir = Paths.appSupportRoot.appendingPathComponent("bin", isDirectory: true)
+        try Paths.ensureDirectoryExists(dir)
+        let url = dir.appendingPathComponent(executableName, isDirectory: false)
+        let script = executableScript()
+        if (try? String(contentsOf: url, encoding: .utf8)) != script {
+            try script.write(to: url, atomically: true, encoding: .utf8)
+        }
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+        return url
+    }
+
+    static func pathValue(prepending directory: String, to current: String?) -> String {
+        guard let current,
+              !current.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return directory
+        }
+        return "\(directory):\(current)"
     }
 }

--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -12,7 +12,7 @@ enum TerminalCLIInjection {
           fi
           case "${1:-}" in
             open)
-              local response status
+              local response alas_status
               shift
               if [ "$#" -eq 0 ]; then
                 printf '%s\n' 'usage: alas open <path> [path...]' >&2
@@ -30,10 +30,10 @@ enum TerminalCLIInjection {
         print(json.dumps({"v": 1, "kind": "cli", "command": "open", "session_id": session_id, "paths": paths}))
         PY
         )
-              status=$?
-              if [ "$status" -ne 0 ]; then
+              alas_status=$?
+              if [ "$alas_status" -ne 0 ]; then
                 printf '%s\n' 'alas: could not reach Alas' >&2
-                return "$status"
+                return "$alas_status"
               fi
               /usr/bin/python3 - "$response" <<'PY'
         import json, sys

--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum TerminalCLIInjection {
     static let executableName = "alas"
+    private static let fallbackPath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
     static func executableScript() -> String {
         return """
@@ -69,10 +70,9 @@ enum TerminalCLIInjection {
     }
 
     static func pathValue(prepending directory: String, to current: String?) -> String {
-        guard let current,
-              !current.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return directory
-        }
-        return "\(directory):\(current)"
+        let basePath = current?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            ? current!
+            : fallbackPath
+        return "\(directory):\(basePath)"
     }
 }

--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+enum TerminalCLIInjection {
+    static func script(forShell shell: String) -> String? {
+        let basename = (shell as NSString).lastPathComponent
+        guard basename == "zsh" || basename == "bash" else { return nil }
+        return """
+        alas() {
+          if [ -z "${ALAS_SOCKET_PATH:-}" ] || [ -z "${ALAS_SESSION_ID:-}" ]; then
+            printf '%s\n' 'alas: only available in Alas terminals' >&2
+            return 2
+          fi
+          case "${1:-}" in
+            open)
+              shift
+              if [ "$#" -eq 0 ]; then
+                printf '%s\n' 'usage: alas open <path> [path...]' >&2
+                return 2
+              fi
+              response=$(/usr/bin/python3 - "$ALAS_SESSION_ID" "$@" <<'PY' | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH"
+        import json, os, sys
+        session_id = sys.argv[1]
+        paths = [os.path.abspath(path) for path in sys.argv[2:]]
+        print(json.dumps({"v": 1, "kind": "cli", "command": "open", "session_id": session_id, "paths": paths}))
+        PY
+        )
+              status=$?
+              if [ "$status" -ne 0 ]; then
+                printf '%s\n' 'alas: could not reach Alas' >&2
+                return "$status"
+              fi
+              /usr/bin/python3 - "$response" <<'PY'
+        import json, sys
+        try:
+            response = json.loads(sys.argv[1] or "{}")
+        except Exception:
+            print("alas: malformed response from Alas", file=sys.stderr)
+            sys.exit(1)
+        if response.get("ok") is True:
+            sys.exit(0)
+        print("alas: " + str(response.get("error") or "request failed"), file=sys.stderr)
+        sys.exit(1)
+        PY
+              ;;
+            *)
+              printf '%s\n' 'usage: alas open <path> [path...]' >&2
+              return 2
+              ;;
+          esac
+        }
+        """
+    }
+
+    static func compose(
+        shell: String,
+        userStartupScript: String,
+        startupScriptSuffix: String?
+    ) -> String {
+        [script(forShell: shell), userStartupScript, startupScriptSuffix]
+            .compactMap { part in
+                let trimmed = part?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                return trimmed.isEmpty ? nil : trimmed
+            }
+            .joined(separator: "\n")
+    }
+}

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -54,12 +54,18 @@ final class TerminalService {
             project: project, worktree: worktree, sessionId: sessionId,
             socketPath: socketPath, inheritParent: cfg.inheritParentEnv
         )
+        if socketPath != nil {
+            let cliURL = try TerminalCLIInjection.installExecutable()
+            env["PATH"] = TerminalCLIInjection.pathValue(
+                prepending: cliURL.deletingLastPathComponent().path,
+                to: env["PATH"]
+            )
+        }
         let baseScript = StartupScriptResolver.sessionOpenScript(
             global: cfg,
             project: project
         )
-        let effectiveScript = TerminalCLIInjection.compose(
-            shell: cfg.shell,
+        let effectiveScript = Self.composeStartupScript(
             userStartupScript: baseScript,
             startupScriptSuffix: startupScriptSuffix
         )
@@ -121,5 +127,17 @@ final class TerminalService {
         default:
             return worktree.path
         }
+    }
+
+    private static func composeStartupScript(
+        userStartupScript: String,
+        startupScriptSuffix: String?
+    ) -> String {
+        [userStartupScript, startupScriptSuffix]
+            .compactMap { part in
+                let trimmed = part?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                return trimmed.isEmpty ? nil : trimmed
+            }
+            .joined(separator: "\n")
     }
 }

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -58,13 +58,11 @@ final class TerminalService {
             global: cfg,
             project: project
         )
-        let effectiveScript: String = {
-            let trimmedSuffix = startupScriptSuffix?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            if trimmedSuffix.isEmpty { return baseScript }
-            let trimmedBase = baseScript.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmedBase.isEmpty ? trimmedSuffix : "\(trimmedBase)\n\(trimmedSuffix)"
-        }()
+        let effectiveScript = TerminalCLIInjection.compose(
+            shell: cfg.shell,
+            userStartupScript: baseScript,
+            startupScriptSuffix: startupScriptSuffix
+        )
         let plan = try StartupScriptInstaller.plan(
             shell: cfg.shell,
             startupScript: effectiveScript,

--- a/AlasTests/AgentHookSocketServerCLITests.swift
+++ b/AlasTests/AgentHookSocketServerCLITests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct AgentHookSocketServerCLITests {
+    private func tmpSocketDir() -> (dir: String, cleanup: () -> Void) {
+        let dir = "/tmp/alas-cli-test-\(UUID().uuidString)"
+        try! FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return (dir, { try? FileManager.default.removeItem(atPath: dir) })
+    }
+
+    private func sendToSocket(path: String, payload: String) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["-c", "printf '%s' '\(payload)' | /usr/bin/nc -U -w2 '\(path)'"]
+        let outPipe = Pipe()
+        process.standardOutput = outPipe
+        try process.run()
+        process.waitUntilExit()
+        return String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    }
+
+    @Test func cliRequestDispatchesAndReturnsOK() async throws {
+        let (dir, cleanup) = tmpSocketDir()
+        defer { cleanup() }
+        let path = "\(dir)/test.sock"
+        let server = AgentHookSocketServer(socketPath: path)
+        defer { server.shutdown() }
+
+        actor Holder {
+            var request: AlasCLIRequest?
+            func set(_ request: AlasCLIRequest) { self.request = request }
+            func current() -> AlasCLIRequest? { request }
+        }
+        let holder = Holder()
+        server.onCLIRequest = { request in
+            await holder.set(request)
+            return .ok
+        }
+
+        let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
+        let response = try sendToSocket(path: path, payload: json)
+
+        #expect(response.contains(#""ok":true"#) || response.contains(#""ok": true"#))
+        let request = await holder.current()
+        #expect(request?.sessionId == "s1")
+        #expect(request?.paths == ["/tmp/a.txt"])
+    }
+
+    @Test func cliRequestReturnsHandlerError() throws {
+        let (dir, cleanup) = tmpSocketDir()
+        defer { cleanup() }
+        let path = "\(dir)/test.sock"
+        let server = AgentHookSocketServer(socketPath: path)
+        defer { server.shutdown() }
+
+        server.onCLIRequest = { _ in .error("Path does not exist.") }
+
+        let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/missing.txt"]}"#
+        let response = try sendToSocket(path: path, payload: json)
+
+        #expect(response.contains(#""ok":false"#) || response.contains(#""ok": false"#))
+        #expect(response.contains("Path does not exist."))
+    }
+
+    @Test func cliRequestDoesNotDispatchHarnessEvent() throws {
+        let (dir, cleanup) = tmpSocketDir()
+        defer { cleanup() }
+        let path = "\(dir)/test.sock"
+        let server = AgentHookSocketServer(socketPath: path)
+        defer { server.shutdown() }
+
+        var harnessEventReceived = false
+        server.onEvent = { _ in harnessEventReceived = true }
+        server.onCLIRequest = { _ in .ok }
+
+        let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
+        _ = try sendToSocket(path: path, payload: json)
+
+        #expect(!harnessEventReceived)
+    }
+}

--- a/AlasTests/AgentHookSocketServerCLITests.swift
+++ b/AlasTests/AgentHookSocketServerCLITests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import Alas
 
+@Suite(.serialized)
 struct AgentHookSocketServerCLITests {
     private func tmpSocketDir() -> (dir: String, cleanup: () -> Void) {
         let dir = "/tmp/alas-cli-test-\(UUID().uuidString)"

--- a/AlasTests/AgentHookSocketServerCLITests.swift
+++ b/AlasTests/AgentHookSocketServerCLITests.swift
@@ -102,4 +102,24 @@ struct AgentHookSocketServerCLITests {
 
         #expect(event == nil)
     }
+
+    @Test func malformedCLIRequestDoesNotDispatchHarnessEvent() async throws {
+        let (dir, cleanup) = tmpSocketDir()
+        defer { cleanup() }
+        let path = "\(dir)/test.sock"
+        let server = AgentHookSocketServer(socketPath: path)
+        defer { server.shutdown() }
+
+        let holder = EventHolder()
+        server.onEvent = { event in holder.deliver(event) }
+        server.onCLIRequest = { _ in .ok }
+
+        let json = #"{"v":1,"kind":"cli","event":"busy","agent":"claude","session_id":"s1","paths":["/tmp/a"]}"#
+        let response = try sendToSocket(path: path, payload: json)
+        let object = try responseObject(response)
+        let event = await holder.wait(timeoutMs: 300)
+
+        #expect(object["ok"] as? Bool == false)
+        #expect(event == nil)
+    }
 }

--- a/AlasTests/AgentHookSocketServerCLITests.swift
+++ b/AlasTests/AgentHookSocketServerCLITests.swift
@@ -20,6 +20,11 @@ struct AgentHookSocketServerCLITests {
         return String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
     }
 
+    private func responseObject(_ response: String) throws -> [String: Any] {
+        let data = try #require(response.data(using: .utf8))
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
     @Test func cliRequestDispatchesAndReturnsOK() async throws {
         let (dir, cleanup) = tmpSocketDir()
         defer { cleanup() }
@@ -40,8 +45,9 @@ struct AgentHookSocketServerCLITests {
 
         let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
         let response = try sendToSocket(path: path, payload: json)
+        let object = try responseObject(response)
 
-        #expect(response.contains(#""ok":true"#) || response.contains(#""ok": true"#))
+        #expect(object["ok"] as? Bool == true)
         let request = await holder.current()
         #expect(request?.sessionId == "s1")
         #expect(request?.paths == ["/tmp/a.txt"])
@@ -58,25 +64,42 @@ struct AgentHookSocketServerCLITests {
 
         let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/missing.txt"]}"#
         let response = try sendToSocket(path: path, payload: json)
+        let object = try responseObject(response)
 
-        #expect(response.contains(#""ok":false"#) || response.contains(#""ok": false"#))
-        #expect(response.contains("Path does not exist."))
+        #expect(object["ok"] as? Bool == false)
+        #expect(object["error"] as? String == "Path does not exist.")
     }
 
-    @Test func cliRequestDoesNotDispatchHarnessEvent() throws {
+    @Test func cliRequestWithoutHandlerReturnsUnavailableError() throws {
         let (dir, cleanup) = tmpSocketDir()
         defer { cleanup() }
         let path = "\(dir)/test.sock"
         let server = AgentHookSocketServer(socketPath: path)
         defer { server.shutdown() }
 
-        var harnessEventReceived = false
-        server.onEvent = { _ in harnessEventReceived = true }
+        let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
+        let response = try sendToSocket(path: path, payload: json)
+        let object = try responseObject(response)
+
+        #expect(object["ok"] as? Bool == false)
+        #expect(object["error"] as? String == "Alas CLI is not available.")
+    }
+
+    @Test func cliRequestDoesNotDispatchHarnessEvent() async throws {
+        let (dir, cleanup) = tmpSocketDir()
+        defer { cleanup() }
+        let path = "\(dir)/test.sock"
+        let server = AgentHookSocketServer(socketPath: path)
+        defer { server.shutdown() }
+
+        let holder = EventHolder()
+        server.onEvent = { event in holder.deliver(event) }
         server.onCLIRequest = { _ in .ok }
 
         let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt"]}"#
         _ = try sendToSocket(path: path, payload: json)
+        let event = await holder.wait(timeoutMs: 300)
 
-        #expect(!harnessEventReceived)
+        #expect(event == nil)
     }
 }

--- a/AlasTests/AgentHookSocketServerTests.swift
+++ b/AlasTests/AgentHookSocketServerTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 @testable import Alas
 
+@Suite(.serialized)
 struct AgentHookSocketServerTests {
     private func tmpSocketDir() -> (dir: String, cleanup: () -> Void) {
         // Use /tmp directly: NSTemporaryDirectory() on macOS returns a path that

--- a/AlasTests/AgentHookSocketServerTests.swift
+++ b/AlasTests/AgentHookSocketServerTests.swift
@@ -148,4 +148,25 @@ struct AgentHookSocketServerTests {
         server.shutdown()
         #expect(!FileManager.default.fileExists(atPath: path))
     }
+
+    @Test func configureClientSocket_enablesNoSigPipe() throws {
+        var fds: [Int32] = [0, 0]
+        guard socketpair(AF_UNIX, SOCK_STREAM, 0, &fds) == 0 else {
+            Issue.record("socketpair failed")
+            return
+        }
+        defer {
+            close(fds[0])
+            close(fds[1])
+        }
+
+        AgentHookSocketServer.configureClientSocket(fds[0])
+
+        var value: Int32 = 0
+        var length = socklen_t(MemoryLayout<Int32>.size)
+        let result = getsockopt(fds[0], SOL_SOCKET, SO_NOSIGPIPE, &value, &length)
+
+        #expect(result == 0)
+        #expect(value == 1)
+    }
 }

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -101,6 +101,38 @@ struct AlasCLICommandRouterTests {
         #expect(opened[0].relativePath == "Sources/App.swift")
     }
 
+    @Test func opensCaseVariantWorktreePathByRelativePathOnCaseInsensitiveVolumes() throws {
+        let realRoot = try makeFile("repo/Sources/App.swift")
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let caseVariantRoot = realRoot.deletingLastPathComponent().appendingPathComponent(realRoot.lastPathComponent.uppercased())
+        let caseVariantFile = caseVariantRoot.appendingPathComponent("Sources/App.swift")
+        guard FileManager.default.fileExists(atPath: caseVariantFile.path) else {
+            return
+        }
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: realRoot, status: .clean, lastActivity: Date()
+        )
+        var opened: [(worktreeId: String, relativePath: String)] = []
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in "wt1" },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { relativePath, worktreeId in opened.append((worktreeId, relativePath)) },
+            openExternalFile: { _, _ in Issue.record("expected relative open") },
+            activateApp: {}
+        )
+
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [caseVariantFile.path]))
+
+        #expect(response == .ok)
+        #expect(opened.count == 1)
+        #expect(opened[0].worktreeId == "wt1")
+        #expect(opened[0].relativePath == "Sources/App.swift")
+    }
+
     @Test func opensExternalFileOwnedByOriginatingWorktree() throws {
         let root = try makeFile("repo/a.txt").deletingLastPathComponent()
         let external = try makeFile("external/note.txt")

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -38,6 +38,39 @@ struct AlasCLICommandRouterTests {
         #expect(opened[0].relativePath == "a.txt")
     }
 
+    @Test func opensNestedWorktreeFileInMostSpecificVisibleWorktree() throws {
+        let root = try makeFile("repo/packages/tool/file.txt")
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let nestedRoot = root.appendingPathComponent("packages/tool")
+        let parent = Worktree(
+            id: "parent", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let nested = Worktree(
+            id: "nested", projectId: "p1", name: "tool", branch: "tool",
+            path: nestedRoot, status: .clean, lastActivity: Date()
+        )
+        var opened: [(worktreeId: String, relativePath: String)] = []
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in "parent" },
+            originatingWorktree: { _ in parent },
+            visibleWorktrees: { [parent, nested] },
+            openRelativeFile: { relativePath, worktreeId in opened.append((worktreeId, relativePath)) },
+            openExternalFile: { _, _ in Issue.record("expected relative open") },
+            activateApp: {}
+        )
+
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [nestedRoot.appendingPathComponent("file.txt").path]))
+
+        #expect(response == .ok)
+        #expect(opened.count == 1)
+        #expect(opened[0].worktreeId == "nested")
+        #expect(opened[0].relativePath == "file.txt")
+    }
+
     @Test func opensExternalFileOwnedByOriginatingWorktree() throws {
         let root = try makeFile("repo/a.txt").deletingLastPathComponent()
         let external = try makeFile("external/note.txt")
@@ -119,5 +152,103 @@ struct AlasCLICommandRouterTests {
         }
         #expect(missingMessage.contains("does not exist"))
         #expect(directoryMessage.contains("is a directory"))
+    }
+
+    @Test func returnsCombinedErrorForMissingFilesAndDirectoriesInOneRequest() throws {
+        let root = try makeFile("repo/a.txt").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let missingPath = root.appendingPathComponent("missing.txt").path
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in "wt1" },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in Issue.record("expected no opens") },
+            openExternalFile: { _, _ in Issue.record("expected no opens") },
+            activateApp: { Issue.record("expected no activation") }
+        )
+
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [missingPath, root.path]))
+
+        guard case .error(let message) = response else {
+            Issue.record("expected combined error")
+            return
+        }
+        #expect(message.contains("\(missingPath) does not exist."))
+        #expect(message.contains("\(root.path) is a directory."))
+    }
+
+    @Test func activatesAfterSuccessfulOpen() throws {
+        let root = try makeFile("repo/a.txt").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        var activationCount = 0
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in "wt1" },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in },
+            openExternalFile: { _, _ in },
+            activateApp: { activationCount += 1 }
+        )
+
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.appendingPathComponent("a.txt").path]))
+
+        #expect(response == .ok)
+        #expect(activationCount == 1)
+    }
+
+    @Test func doesNotActivateWhenAllPathsFail() throws {
+        let root = try makeFile("repo/a.txt").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        var activationCount = 0
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in "wt1" },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in Issue.record("expected no opens") },
+            openExternalFile: { _, _ in Issue.record("expected no opens") },
+            activateApp: { activationCount += 1 }
+        )
+
+        _ = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.appendingPathComponent("missing.txt").path, root.path]))
+
+        #expect(activationCount == 0)
+    }
+
+    @Test func activatesOnceForMultiFileRequest() throws {
+        let first = try makeFile("repo/a.txt")
+        let root = first.deletingLastPathComponent()
+        let second = root.appendingPathComponent("b.txt")
+        try "x\n".write(to: second, atomically: true, encoding: .utf8)
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        var activationCount = 0
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in "wt1" },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in },
+            openExternalFile: { _, _ in },
+            activateApp: { activationCount += 1 }
+        )
+
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [first.path, second.path]))
+
+        #expect(response == .ok)
+        #expect(activationCount == 1)
     }
 }

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct AlasCLICommandRouterTests {
+    private func makeFile(_ name: String, contents: String = "x\n") throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cli-router-\(UUID().uuidString)")
+            .appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    @Test func opensInWorktreeFileByRelativePath() throws {
+        let root = try makeFile("repo/a.txt").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        var opened: [(worktreeId: String, relativePath: String)] = []
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { $0 == "s1" ? "wt1" : nil },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { relativePath, worktreeId in opened.append((worktreeId, relativePath)) },
+            openExternalFile: { _, _ in Issue.record("expected relative open") },
+            activateApp: {}
+        )
+
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.appendingPathComponent("a.txt").path]))
+
+        #expect(response == .ok)
+        #expect(opened.count == 1)
+        #expect(opened[0].worktreeId == "wt1")
+        #expect(opened[0].relativePath == "a.txt")
+    }
+
+    @Test func opensExternalFileOwnedByOriginatingWorktree() throws {
+        let root = try makeFile("repo/a.txt").deletingLastPathComponent()
+        let external = try makeFile("external/note.txt")
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        var externalOpens: [(worktreeId: String, url: URL)] = []
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { $0 == "s1" ? "wt1" : nil },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in Issue.record("expected external open") },
+            openExternalFile: { url, worktreeId in externalOpens.append((worktreeId, url)) },
+            activateApp: {}
+        )
+
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [external.path]))
+
+        #expect(response == .ok)
+        #expect(externalOpens.count == 1)
+        #expect(externalOpens[0].worktreeId == "wt1")
+        #expect(externalOpens[0].url.standardizedFileURL.path == external.standardizedFileURL.path)
+    }
+
+    @Test func rejectsUnsafePrefixMatch() throws {
+        let repo = try makeFile("repo/a.txt").deletingLastPathComponent()
+        let sibling = repo.deletingLastPathComponent().appendingPathComponent(repo.lastPathComponent + "-copy")
+        try FileManager.default.createDirectory(at: sibling, withIntermediateDirectories: true)
+        let siblingFile = sibling.appendingPathComponent("a.txt")
+        try "x\n".write(to: siblingFile, atomically: true, encoding: .utf8)
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: repo, status: .clean, lastActivity: Date()
+        )
+        var externalCount = 0
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in "wt1" },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in Issue.record("must not treat sibling as in-worktree") },
+            openExternalFile: { _, _ in externalCount += 1 },
+            activateApp: {}
+        )
+
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [siblingFile.path]))
+
+        #expect(response == .ok)
+        #expect(externalCount == 1)
+    }
+
+    @Test func rejectsMissingFilesAndDirectories() throws {
+        let root = try makeFile("repo/a.txt").deletingLastPathComponent()
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: root, status: .clean, lastActivity: Date()
+        )
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in "wt1" },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { _, _ in },
+            openExternalFile: { _, _ in },
+            activateApp: {}
+        )
+
+        let missing = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.appendingPathComponent("missing.txt").path]))
+        let directory = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [root.path]))
+
+        guard case .error(let missingMessage) = missing else {
+            Issue.record("expected missing file error")
+            return
+        }
+        guard case .error(let directoryMessage) = directory else {
+            Issue.record("expected directory error")
+            return
+        }
+        #expect(missingMessage.contains("does not exist"))
+        #expect(directoryMessage.contains("is a directory"))
+    }
+}

--- a/AlasTests/AlasCLICommandRouterTests.swift
+++ b/AlasTests/AlasCLICommandRouterTests.swift
@@ -71,6 +71,36 @@ struct AlasCLICommandRouterTests {
         #expect(opened[0].relativePath == "file.txt")
     }
 
+    @Test func opensSymlinkedLogicalWorktreePathByRelativePath() throws {
+        let realRoot = try makeFile("repo/Sources/App.swift")
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let logicalRoot = realRoot.deletingLastPathComponent().appendingPathComponent("logical-repo")
+        try FileManager.default.createSymbolicLink(at: logicalRoot, withDestinationURL: realRoot)
+        let logicalFile = logicalRoot.appendingPathComponent("Sources/App.swift")
+        let worktree = Worktree(
+            id: "wt1", projectId: "p1", name: "main", branch: "main",
+            path: realRoot, status: .clean, lastActivity: Date()
+        )
+        var opened: [(worktreeId: String, relativePath: String)] = []
+
+        let router = AlasCLICommandRouter(
+            sessionWorktreeId: { _ in "wt1" },
+            originatingWorktree: { _ in worktree },
+            visibleWorktrees: { [worktree] },
+            openRelativeFile: { relativePath, worktreeId in opened.append((worktreeId, relativePath)) },
+            openExternalFile: { _, _ in Issue.record("expected relative open") },
+            activateApp: {}
+        )
+
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [logicalFile.path]))
+
+        #expect(response == .ok)
+        #expect(opened.count == 1)
+        #expect(opened[0].worktreeId == "wt1")
+        #expect(opened[0].relativePath == "Sources/App.swift")
+    }
+
     @Test func opensExternalFileOwnedByOriginatingWorktree() throws {
         let root = try makeFile("repo/a.txt").deletingLastPathComponent()
         let external = try makeFile("external/note.txt")

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -30,6 +30,14 @@ struct AlasCLIRequestTests {
         }
     }
 
+    @Test func rejectsRelativePathsForOpen() throws {
+        let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["relative.txt"]}"#
+
+        #expect(throws: AlasCLIRequestError.self) {
+            try AlasCLIRequest.decode(from: Data(json.utf8))
+        }
+    }
+
     @Test func responseEncodesOKAndError() throws {
         let ok = String(data: try AlasCLIResponse.ok.encode(), encoding: .utf8) ?? ""
         let error = String(data: try AlasCLIResponse.error("No file.").encode(), encoding: .utf8) ?? ""

--- a/AlasTests/AlasCLIRequestTests.swift
+++ b/AlasTests/AlasCLIRequestTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct AlasCLIRequestTests {
+    @Test func decodeOpenRequest() throws {
+        let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":["/tmp/a.txt","/tmp/b.txt"]}"#
+
+        let request = try AlasCLIRequest.decode(from: Data(json.utf8))
+
+        #expect(request.version == 1)
+        #expect(request.command == .open)
+        #expect(request.sessionId == "s1")
+        #expect(request.paths == ["/tmp/a.txt", "/tmp/b.txt"])
+    }
+
+    @Test func rejectsNonCLIKind() throws {
+        let json = #"{"v":1,"event":"busy","agent":"claude","session_id":"s1"}"#
+
+        #expect(throws: AlasCLIRequestError.self) {
+            try AlasCLIRequest.decode(from: Data(json.utf8))
+        }
+    }
+
+    @Test func rejectsEmptyPathsForOpen() throws {
+        let json = #"{"v":1,"kind":"cli","command":"open","session_id":"s1","paths":[]}"#
+
+        #expect(throws: AlasCLIRequestError.self) {
+            try AlasCLIRequest.decode(from: Data(json.utf8))
+        }
+    }
+
+    @Test func responseEncodesOKAndError() throws {
+        let ok = String(data: try AlasCLIResponse.ok.encode(), encoding: .utf8) ?? ""
+        let error = String(data: try AlasCLIResponse.error("No file.").encode(), encoding: .utf8) ?? ""
+
+        #expect(ok.contains(#""ok":true"#) || ok.contains(#""ok": true"#))
+        #expect(error.contains(#""ok":false"#) || error.contains(#""ok": false"#))
+        #expect(error.contains("No file."))
+    }
+}

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct AppStateCLIRoutingTests {
+    private func makeRepo(name: String) async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cli-appstate-\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: dir)
+        return dir
+    }
+
+    @Test func makeCLICommandRouterUsesTerminalRegistryAndTabs() async throws {
+        let repo = try await makeRepo(name: "router")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let file = repo.appendingPathComponent("a.txt")
+        try "hello\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "test", color: "#000000")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let worktree = try #require(state.projectsManager.worktrees(projectId: project.id).first)
+        state.selectedWorktreeId = worktree.id
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { sessionId in
+            sessionId == "s1" ? worktree.id : nil
+        })
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [file.path]))
+
+        #expect(response == .ok)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .editor(let editor) = $0 { return editor.relativePath == "a.txt" }
+            return false
+        })
+    }
+}

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -14,6 +14,15 @@ struct AppStateCLIRoutingTests {
         return dir
     }
 
+    private func makeStateWithWorktree(name: String) async throws -> (AppState, ProjectConfig, Worktree) {
+        let repo = try await makeRepo(name: name)
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "test", color: "#000000")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let worktree = try #require(state.projectsManager.worktrees(projectId: project.id).first)
+        return (state, project, worktree)
+    }
+
     @Test func makeCLICommandRouterUsesTerminalRegistryAndTabs() async throws {
         let repo = try await makeRepo(name: "router")
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -34,6 +43,65 @@ struct AppStateCLIRoutingTests {
         #expect(response == .ok)
         #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
             if case .editor(let editor) = $0 { return editor.relativePath == "a.txt" }
+            return false
+        })
+    }
+
+    @Test func startHarnessCLIRequestUsesRealTerminalRegistry() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "socket-callback")
+        defer {
+            state.harness.socketServer.shutdown()
+            try? FileManager.default.removeItem(at: worktree.path)
+        }
+        let file = worktree.path.appendingPathComponent("from-socket.txt")
+        try "hello\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        let session = TerminalSession(
+            id: "s1",
+            worktreeId: worktree.id,
+            projectId: project.id,
+            surface: surface,
+            executable: "/bin/zsh",
+            args: []
+        )
+        state.terminal.registry.register(session)
+        state.startHarness()
+
+        let handler = try #require(state.harness.socketServer.onCLIRequest)
+        let response = await handler(.init(version: 1, command: .open, sessionId: "s1", paths: [file.path]))
+
+        #expect(response == .ok)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .editor(let editor) = $0 { return editor.relativePath == "from-socket.txt" }
+            return false
+        })
+    }
+
+    @Test func makeCLICommandRouterOpensExternalFileOnOriginatingWorktreeAndSelectsIt() async throws {
+        let (state, _, worktree) = try await makeStateWithWorktree(name: "external")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let externalDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-cli-appstate-external-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: externalDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: externalDir) }
+        let externalFile = externalDir.appendingPathComponent("external.txt")
+        try "outside\n".write(to: externalFile, atomically: true, encoding: .utf8)
+        state.selectedWorktreeId = nil
+
+        let router = state.makeCLICommandRouter(sessionWorktreeLookup: { sessionId in
+            sessionId == "s1" ? worktree.id : nil
+        })
+        let response = router.handle(.init(version: 1, command: .open, sessionId: "s1", paths: [externalFile.path]))
+
+        #expect(response == .ok)
+        #expect(state.selectedWorktreeId == worktree.id)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .editor(let editor) = $0 {
+                return editor.isExternal
+                    && editor.externalAbsolutePath == externalFile.standardizedFileURL.path
+                    && editor.relativePath.isEmpty
+            }
             return false
         })
     }

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import Alas
+
+struct TerminalCLIInjectionTests {
+    @Test func zshAndBashReceiveAlasFunction() {
+        let zsh = TerminalCLIInjection.script(forShell: "/bin/zsh") ?? ""
+        let bash = TerminalCLIInjection.script(forShell: "/opt/homebrew/bin/bash") ?? ""
+
+        for script in [zsh, bash] {
+            #expect(script.contains("alas()"))
+            #expect(script.contains("ALAS_SOCKET_PATH"))
+            #expect(script.contains("ALAS_SESSION_ID"))
+            #expect(script.contains(#""kind": "cli""#))
+            #expect(script.contains(#""command": "open""#))
+            #expect(script.contains("os.path.abspath"))
+            #expect(script.contains("/usr/bin/nc -U -w1"))
+        }
+    }
+
+    @Test func unsupportedShellReceivesNoSnippet() {
+        #expect(TerminalCLIInjection.script(forShell: "/opt/homebrew/bin/fish") == nil)
+    }
+
+    @Test func composePrependsInjectionBeforeUserScriptAndSuffix() {
+        let composed = TerminalCLIInjection.compose(
+            shell: "/bin/zsh",
+            userStartupScript: "echo user",
+            startupScriptSuffix: "echo agent"
+        )
+
+        #expect(composed.contains("alas()"))
+        #expect(composed.range(of: "alas()")!.lowerBound < composed.range(of: "echo user")!.lowerBound)
+        #expect(composed.range(of: "echo user")!.lowerBound < composed.range(of: "echo agent")!.lowerBound)
+    }
+
+    @Test func composeKeepsUnsupportedShellUserScriptOnly() {
+        let composed = TerminalCLIInjection.compose(
+            shell: "/opt/homebrew/bin/fish",
+            userStartupScript: "echo user",
+            startupScriptSuffix: nil
+        )
+
+        #expect(composed == "echo user")
+    }
+}

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -25,6 +25,14 @@ struct TerminalCLIInjectionTests {
         #expect(url.lastPathComponent == "alas")
     }
 
+    @Test func pathValueUsesSystemFallbackWhenCurrentPathIsEmpty() {
+        let value = TerminalCLIInjection.pathValue(prepending: "/tmp/alas-bin", to: nil)
+
+        #expect(value.hasPrefix("/tmp/alas-bin:"))
+        #expect(value.contains("/usr/bin"))
+        #expect(value.contains("/bin"))
+    }
+
     @Test func bashExecutableSendsOpenRequestFromLogicalPWD() async throws {
         try await assertExecutableSendsOpenRequestFromLogicalPWD(shell: "/bin/bash")
     }

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import Alas
 
+@Suite(.serialized)
 struct TerminalCLIInjectionTests {
     @Test func zshAndBashReceiveAlasFunction() {
         let zsh = TerminalCLIInjection.script(forShell: "/bin/zsh") ?? ""

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -46,6 +46,14 @@ struct TerminalCLIInjectionTests {
     }
 
     @Test func bashFunctionSendsOpenRequestFromLogicalPWD() async throws {
+        try await assertFunctionSendsOpenRequestFromLogicalPWD(shell: "/bin/bash")
+    }
+
+    @Test func zshFunctionSendsOpenRequestFromLogicalPWD() async throws {
+        try await assertFunctionSendsOpenRequestFromLogicalPWD(shell: "/bin/zsh")
+    }
+
+    private func assertFunctionSendsOpenRequestFromLogicalPWD(shell: String) async throws {
         let root = "/tmp/alas-cli-injection-\(UUID().uuidString)"
         let realDir = "\(root)/real"
         let logicalDir = "\(root)/logical"
@@ -54,7 +62,7 @@ struct TerminalCLIInjectionTests {
         let socketPath = "\(root)/test.sock"
         try FileManager.default.createDirectory(atPath: nestedDir, withIntermediateDirectories: true)
         try FileManager.default.createSymbolicLink(atPath: logicalDir, withDestinationPath: realDir)
-        try TerminalCLIInjection.script(forShell: "/bin/bash")!.write(
+        try TerminalCLIInjection.script(forShell: shell)!.write(
             toFile: scriptPath,
             atomically: true,
             encoding: .utf8
@@ -76,7 +84,7 @@ struct TerminalCLIInjectionTests {
         }
 
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.executableURL = URL(fileURLWithPath: shell)
         process.arguments = ["-c", #"source "$0"; cd "$ALAS_LOGICAL_DIR"; alas open "dir with spaces/file.txt""#, scriptPath]
         process.currentDirectoryURL = URL(fileURLWithPath: root, isDirectory: true)
         var env = ProcessInfo.processInfo.environment

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import Alas
 
 struct TerminalCLIInjectionTests {
@@ -41,5 +42,64 @@ struct TerminalCLIInjectionTests {
         )
 
         #expect(composed == "echo user")
+    }
+
+    @Test func bashFunctionSendsOpenRequestFromLogicalPWD() async throws {
+        let root = "/tmp/alas-cli-injection-\(UUID().uuidString)"
+        let realDir = "\(root)/real"
+        let logicalDir = "\(root)/logical"
+        let nestedDir = "\(realDir)/dir with spaces"
+        let scriptPath = "\(root)/alas-injection.sh"
+        let socketPath = "\(root)/test.sock"
+        try FileManager.default.createDirectory(atPath: nestedDir, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(atPath: logicalDir, withDestinationPath: realDir)
+        try TerminalCLIInjection.script(forShell: "/bin/bash")!.write(
+            toFile: scriptPath,
+            atomically: true,
+            encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(atPath: root) }
+
+        let server = AgentHookSocketServer(socketPath: socketPath)
+        defer { server.shutdown() }
+
+        actor Holder {
+            var request: AlasCLIRequest?
+            func set(_ request: AlasCLIRequest) { self.request = request }
+            func current() -> AlasCLIRequest? { request }
+        }
+        let holder = Holder()
+        server.onCLIRequest = { request in
+            await holder.set(request)
+            return .ok
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = ["-c", #"source "$0"; cd "$ALAS_LOGICAL_DIR"; alas open "dir with spaces/file.txt""#, scriptPath]
+        process.currentDirectoryURL = URL(fileURLWithPath: root, isDirectory: true)
+        var env = ProcessInfo.processInfo.environment
+        env["ALAS_SOCKET_PATH"] = socketPath
+        env["ALAS_SESSION_ID"] = "test-session"
+        env["ALAS_LOGICAL_DIR"] = logicalDir
+        process.environment = env
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let request = await holder.current()
+
+        #expect(process.terminationStatus == 0)
+        #expect(stdoutText == "")
+        #expect(stderrText == "")
+        #expect(request?.command == .open)
+        #expect(request?.sessionId == "test-session")
+        #expect(request?.paths == ["\(logicalDir)/dir with spaces/file.txt"])
     }
 }

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -4,69 +4,44 @@ import Foundation
 
 @Suite(.serialized)
 struct TerminalCLIInjectionTests {
-    @Test func zshAndBashReceiveAlasFunction() {
-        let zsh = TerminalCLIInjection.script(forShell: "/bin/zsh") ?? ""
-        let bash = TerminalCLIInjection.script(forShell: "/opt/homebrew/bin/bash") ?? ""
+    @Test func executableScriptSendsOpenRequest() {
+        let script = TerminalCLIInjection.executableScript()
 
-        for script in [zsh, bash] {
-            #expect(script.contains("alas()"))
-            #expect(script.contains("ALAS_SOCKET_PATH"))
-            #expect(script.contains("ALAS_SESSION_ID"))
-            #expect(script.contains(#""kind": "cli""#))
-            #expect(script.contains(#""command": "open""#))
-            #expect(script.contains("os.path.abspath"))
-            #expect(script.contains("/usr/bin/nc -U -w1"))
-        }
+        #expect(script.contains("ALAS_SOCKET_PATH"))
+        #expect(script.contains("ALAS_SESSION_ID"))
+        #expect(script.contains(#""kind": "cli""#))
+        #expect(script.contains(#""command": "open""#))
+        #expect(script.contains("os.path.abspath"))
+        #expect(script.contains("/usr/bin/nc -U -w1"))
     }
 
-    @Test func unsupportedShellReceivesNoSnippet() {
-        #expect(TerminalCLIInjection.script(forShell: "/opt/homebrew/bin/fish") == nil)
+    @Test func installExecutableWritesAlasCommand() throws {
+        let url = try TerminalCLIInjection.installExecutable()
+        var isDirectory: ObjCBool = false
+
+        #expect(FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory))
+        #expect(!isDirectory.boolValue)
+        #expect(FileManager.default.isExecutableFile(atPath: url.path))
+        #expect(url.lastPathComponent == "alas")
     }
 
-    @Test func composePrependsInjectionBeforeUserScriptAndSuffix() {
-        let composed = TerminalCLIInjection.compose(
-            shell: "/bin/zsh",
-            userStartupScript: "echo user",
-            startupScriptSuffix: "echo agent"
-        )
-
-        #expect(composed.contains("alas()"))
-        #expect(composed.range(of: "alas()")!.lowerBound < composed.range(of: "echo user")!.lowerBound)
-        #expect(composed.range(of: "echo user")!.lowerBound < composed.range(of: "echo agent")!.lowerBound)
+    @Test func bashExecutableSendsOpenRequestFromLogicalPWD() async throws {
+        try await assertExecutableSendsOpenRequestFromLogicalPWD(shell: "/bin/bash")
     }
 
-    @Test func composeKeepsUnsupportedShellUserScriptOnly() {
-        let composed = TerminalCLIInjection.compose(
-            shell: "/opt/homebrew/bin/fish",
-            userStartupScript: "echo user",
-            startupScriptSuffix: nil
-        )
-
-        #expect(composed == "echo user")
+    @Test func zshExecutableSendsOpenRequestFromLogicalPWD() async throws {
+        try await assertExecutableSendsOpenRequestFromLogicalPWD(shell: "/bin/zsh")
     }
 
-    @Test func bashFunctionSendsOpenRequestFromLogicalPWD() async throws {
-        try await assertFunctionSendsOpenRequestFromLogicalPWD(shell: "/bin/bash")
-    }
-
-    @Test func zshFunctionSendsOpenRequestFromLogicalPWD() async throws {
-        try await assertFunctionSendsOpenRequestFromLogicalPWD(shell: "/bin/zsh")
-    }
-
-    private func assertFunctionSendsOpenRequestFromLogicalPWD(shell: String) async throws {
+    private func assertExecutableSendsOpenRequestFromLogicalPWD(shell: String) async throws {
         let root = "/tmp/alas-cli-injection-\(UUID().uuidString)"
         let realDir = "\(root)/real"
         let logicalDir = "\(root)/logical"
         let nestedDir = "\(realDir)/dir with spaces"
-        let scriptPath = "\(root)/alas-injection.sh"
         let socketPath = "\(root)/test.sock"
         try FileManager.default.createDirectory(atPath: nestedDir, withIntermediateDirectories: true)
         try FileManager.default.createSymbolicLink(atPath: logicalDir, withDestinationPath: realDir)
-        try TerminalCLIInjection.script(forShell: shell)!.write(
-            toFile: scriptPath,
-            atomically: true,
-            encoding: .utf8
-        )
+        let cliURL = try TerminalCLIInjection.installExecutable()
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let server = AgentHookSocketServer(socketPath: socketPath)
@@ -85,9 +60,10 @@ struct TerminalCLIInjectionTests {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: shell)
-        process.arguments = ["-c", #"source "$0"; cd "$ALAS_LOGICAL_DIR"; alas open "dir with spaces/file.txt""#, scriptPath]
+        process.arguments = ["-c", #"cd "$ALAS_LOGICAL_DIR"; alas open "dir with spaces/file.txt""#]
         process.currentDirectoryURL = URL(fileURLWithPath: root, isDirectory: true)
         var env = ProcessInfo.processInfo.environment
+        env["PATH"] = "\(cliURL.deletingLastPathComponent().path):\(env["PATH"] ?? "")"
         env["ALAS_SOCKET_PATH"] = socketPath
         env["ALAS_SESSION_ID"] = "test-session"
         env["ALAS_LOGICAL_DIR"] = logicalDir

--- a/docs/superpowers/specs/2026-05-18-alas-terminal-cli-design.md
+++ b/docs/superpowers/specs/2026-05-18-alas-terminal-cli-design.md
@@ -1,0 +1,160 @@
+# Alas Terminal CLI Design
+
+## Summary
+
+Add an `alas` command that exists only inside terminal sessions spawned by Alas. The first supported command is:
+
+```sh
+alas open <path> [path...]
+```
+
+Each path resolves from the terminal process's current working directory, not the worktree root. Files inside any visible Alas worktree open as normal editor or image tabs for that worktree. Files outside all visible worktrees are allowed and open as external editor tabs owned by the originating worktree.
+
+## Goals
+
+- Make `alas open myfile.txt` open `myfile.txt` in the Alas editor from an Alas terminal.
+- Keep the command private to Alas-spawned terminals. Do not install a global CLI or mutate the user's shell config.
+- Resolve relative paths from the shell's current `$PWD`.
+- Allow absolute and relative paths that point outside the worktree.
+- Reuse the existing terminal environment and UNIX socket infrastructure where practical.
+
+## Non-Goals
+
+- No globally installed `/usr/local/bin/alas` or bundled command-line target in this first version.
+- No support yet for editing ranges such as `file:line:column`, directories, search, tab management, or project/worktree commands.
+- No external application integration beyond the existing Alas editor tab system.
+
+## User Experience
+
+Every new Alas terminal starts with an `alas` shell function available in supported shells. The command accepts `open` and one or more file paths:
+
+```sh
+alas open README.md
+alas open Sources/App.swift ../notes.txt /tmp/debug.log
+```
+
+For each argument, the function resolves the path relative to `$PWD`, sends a request to the Alas app, and prints a short error only when the request cannot be delivered or the app rejects it. Successful opens stay quiet so the command feels like an editor command.
+
+Unknown commands print a compact usage message. Running `alas open` without paths prints usage and exits non-zero.
+
+## Architecture
+
+Use the existing `ALAS_SOCKET_PATH`, `ALAS_SESSION_ID`, `ALAS_WORKTREE`, and terminal startup injection path.
+
+The implementation should add a small CLI command envelope alongside harness hook events. The app's socket server will decode both message families:
+
+- Harness activity events keep their current behavior.
+- CLI command requests route to an app-level command handler.
+
+The terminal side is a shell function injected into every Alas terminal session by the same startup-script mechanism that already wraps user startup scripts. This keeps the command scoped to Alas terminals and avoids writing executable files into user-visible paths.
+
+## Components
+
+### Terminal Injection
+
+Add `TerminalCLIInjection` under `Alas/Sources/Terminal`. It returns the shell snippet that defines `alas()` and is prepended to the effective per-session startup script before the user's configured startup script content.
+
+The function should:
+
+- Require `ALAS_SOCKET_PATH` and `ALAS_SESSION_ID`.
+- Support `alas open <path> [path...]`.
+- Resolve each path against `$PWD` using the shell's current directory.
+- Send JSON to the UNIX socket with `/usr/bin/nc -U -w1`.
+- Return non-zero when usage is invalid or socket delivery fails.
+
+The first implementation targets the shells that already receive startup script injection: zsh and bash. Unsupported shells will not receive the function until startup injection supports them.
+
+### Socket Protocol
+
+Introduce a versioned CLI request shape distinct from harness events:
+
+```json
+{
+  "v": 1,
+  "kind": "cli",
+  "command": "open",
+  "session_id": "<ALAS_SESSION_ID>",
+  "paths": ["/absolute/path"]
+}
+```
+
+Keep responses simple:
+
+```json
+{"ok": true}
+{"ok": false, "error": "Message"}
+```
+
+The socket server should continue to ignore unknown harness events as it does today, but malformed CLI requests should get an error response.
+
+### App Command Routing
+
+Add `AlasCLICommandHandler`, a main-actor service owned by `AppState`, for CLI command routing.
+
+For each requested absolute path:
+
+1. Find the terminal session by `session_id`.
+2. Use the session's `worktreeId` as the originating context.
+3. If the path is inside a visible known worktree, open it using the existing worktree-relative `openFile` flow.
+4. If it is outside all visible worktrees, open an external editor tab in the originating worktree with `tabs.openExternalEditor`.
+5. Bring Alas to the foreground after handling at least one path.
+
+The existing image-preview behavior should apply only for files inside a worktree, because external image preview ownership is not currently modeled.
+
+### Path Handling
+
+The shell function should send standardized absolute paths. The app should still normalize paths before matching against worktree roots.
+
+Worktree matching must compare path components rather than raw string prefixes so `/repo-a` does not match `/repo-a-copy`. The app should reject paths that do not exist or are directories for this first version, returning a clear error to the CLI.
+
+### Error Handling
+
+Terminal-side errors:
+
+- `alas`: print usage.
+- `alas open`: print usage.
+- Missing Alas environment: print that the command is only available in Alas terminals.
+- Socket send failure: print that Alas is not reachable.
+
+App-side errors:
+
+- Unknown session id.
+- Missing originating worktree.
+- Path does not exist.
+- Path is a directory.
+- Malformed request.
+
+When opening multiple paths, the app should attempt all valid paths and report aggregate failure if any path fails. The first version can use one response with a combined error string.
+
+## Testing
+
+Add focused Swift Testing coverage for:
+
+- CLI request decoding accepts the supported `open` shape.
+- CLI request decoding rejects malformed requests.
+- Command routing opens an in-worktree file through the normal editor tab path.
+- Command routing opens an out-of-worktree file as an external editor tab owned by the originating worktree.
+- Path containment does not use unsafe string-prefix matching.
+- The injected shell function text includes the environment guard, `open` usage handling, `$PWD`-based path resolution, and socket send command.
+
+Manual verification:
+
+```sh
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Then launch Alas, open a terminal, and verify:
+
+- `type alas` reports a shell function.
+- `alas open README.md` opens the file from the current `$PWD`.
+- `cd subdir && alas open file.txt` resolves from `subdir`.
+- `alas open /tmp/some-file.txt` opens as an external editor tab.
+- A normal terminal outside Alas does not have the injected command.
+
+## Decisions
+
+- Do not support line or column suffixes in the first implementation.
+- Do not add a real executable until there are enough commands to justify a dedicated CLI target.
+- Keep successful command output quiet.


### PR DESCRIPTION
## Summary
- add an Alas-only `alas open <path> [path...]` command injected into bash/zsh terminals spawned by Alas
- route CLI socket requests through AppState into existing editor open behavior for in-worktree files and external file tabs for outside files
- resolve relative paths from the terminal shell `$PWD`, handle multi-file opens, nested worktrees, missing paths, directories, symlinked logical worktree paths, and zsh/bash runtime behavior

## Validation
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AlasCLIRequestTests -only-testing:AlasTests/AgentHookSocketServerCLITests -only-testing:AlasTests/AgentHookSocketServerTests -only-testing:AlasTests/AlasCLICommandRouterTests -only-testing:AlasTests/AppStateCLIRoutingTests -only-testing:AlasTests/TerminalCLIInjectionTests test`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full local `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` was attempted twice and hung after the duplicate destination warning with no test output; the workspace test runner was terminated after inspection.