### PR TITLE
Changes / Working Tree UI improvements: safe discard, per-hunk actions, file context menu

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8B52175A7F6144B4C52010 /* EditorTabView.swift */; };
 		11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCEFADD952DB870B8BAB890 /* CommitRow.swift */; };
 		115C50272D2037FB24B8536F /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */; };
+		11B4AA1D032F054C666DD7F4 /* PendingDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */; };
 		11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */; };
 		1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */; };
 		12035048B950CE0197604F89 /* GitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7CE7B4DAFDB65A79308FB63 /* GitService.swift */; };
@@ -52,6 +53,7 @@
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
 		1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */; };
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
+		21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */; };
 		21D97FBF7356BC50400E0265 /* CommitContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */; };
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
 		23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */; };
@@ -69,6 +71,7 @@
 		29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */; };
 		2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
+		2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */; };
 		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
 		2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768D12909DD5233659AC4E03 /* RepoGroupView.swift */; };
 		2D313A7E99C93242DD35AA8E /* CursorInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */; };
@@ -117,6 +120,7 @@
 		42D8417781E790CA6AA49F7E /* CursorInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */; };
 		43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */; };
 		4421A9D1E7481B49701B3131 /* mason-lsps.json in Resources */ = {isa = PBXBuildFile; fileRef = F0D567F7F894902AD192D220 /* mason-lsps.json */; };
+		449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
 		45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC68B05B719B9235865027F /* ThreePaneSizing.swift */; };
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
@@ -200,6 +204,7 @@
 		7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */; };
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
+		8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */; };
 		8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
@@ -337,11 +342,13 @@
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
+		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
 		E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */; };
 		E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373D587E3153D902EB10208B /* MarkdownParserTests.swift */; };
 		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
 		E2A49F787B3DC3F45E92854D /* AgentEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */; };
+		E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */; };
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
 		E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA8FEE64D73BDEBAF74878 /* Kbd.swift */; };
 		E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */; };
@@ -359,6 +366,7 @@
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
+		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
@@ -492,6 +500,7 @@
 		3BF2F213480B30034B25B2B8 /* AgentRunError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunError.swift; sourceTree = "<group>"; };
 		3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfo.swift; sourceTree = "<group>"; };
 		3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPicker.swift; sourceTree = "<group>"; };
+		3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardTests.swift; sourceTree = "<group>"; };
 		3D105CB2C185958ED23164D1 /* IndentationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationMode.swift; sourceTree = "<group>"; };
 		3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
 		3DCEFADD952DB870B8BAB890 /* CommitRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRow.swift; sourceTree = "<group>"; };
@@ -507,6 +516,7 @@
 		4575017544CD7603B3AB9069 /* GitEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilter.swift; sourceTree = "<group>"; };
 		4865995B2D4B92166321201F /* CommitContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilder.swift; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
+		4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardPathsTests.swift; sourceTree = "<group>"; };
 		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltinsTests.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
@@ -585,6 +595,7 @@
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
+		856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscardTests.swift; sourceTree = "<group>"; };
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
 		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
@@ -595,6 +606,7 @@
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidatorTests.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
+		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
@@ -611,6 +623,8 @@
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
 		97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshotTests.swift; sourceTree = "<group>"; };
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
+		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
+		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunnerInvocationTests.swift; sourceTree = "<group>"; };
 		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
@@ -748,10 +762,12 @@
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
+		F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceDiscardTests.swift; sourceTree = "<group>"; };
 		F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchDialog.swift; sourceTree = "<group>"; };
 		F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessServiceTests.swift; sourceTree = "<group>"; };
 		F9F85B92952C963DCF136315 /* HarnessDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetector.swift; sourceTree = "<group>"; };
 		FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
+		FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilderTests.swift; sourceTree = "<group>"; };
 		FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequestTests.swift; sourceTree = "<group>"; };
 		FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinitionTests.swift; sourceTree = "<group>"; };
 		FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerCLITests.swift; sourceTree = "<group>"; };
@@ -867,6 +883,7 @@
 				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
 				6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */,
 				8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */,
+				F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */,
 				38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
 				039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */,
@@ -877,6 +894,7 @@
 				F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */,
 				2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */,
 				23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */,
+				FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */,
 				A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */,
 				BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */,
 				835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */,
@@ -892,6 +910,7 @@
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
 				16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */,
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
+				856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */,
 				7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */,
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
 				E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */,
@@ -902,6 +921,8 @@
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */,
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
+				4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */,
+				3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */,
 				5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */,
 				B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
@@ -967,9 +988,11 @@
 				BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */,
 				269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */,
 				B7CE7B4DAFDB65A79308FB63 /* GitService.swift */,
+				90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */,
 				D2F90D03073708AA01531533 /* GitService+Staging.swift */,
 				27A92711BC1D9A78D8A80561 /* GitTypes.swift */,
 				CB2EB554CB6AF797545DB95D /* HeadReader.swift */,
+				9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */,
 				C6CA79B71B4AA72697392702 /* NumstatParser.swift */,
 				79DDEA496740F5B0B5EE808B /* Process+Git.swift */,
 				91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */,
@@ -1059,6 +1082,7 @@
 				6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */,
 				BD4A3B9B1103346242438940 /* FilesTabView.swift */,
 				F721FB733081A583D4053DDA /* FileTypeIconView.swift */,
+				9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */,
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
 				795056B6AD803D2B555FC866 /* RightPaneStore.swift */,
 				4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */,
@@ -1789,6 +1813,7 @@
 				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,
 				B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */,
 				175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */,
+				DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */,
 				0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */,
 				12035048B950CE0197604F89 /* GitService.swift in Sources */,
 				676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */,
@@ -1802,6 +1827,7 @@
 				387EF12B6875648E422956F7 /* Highlighted.swift in Sources */,
 				AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */,
 				E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */,
+				EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */,
 				CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */,
 				B76AD708A9FD54304F84366A /* ImageFileType.swift in Sources */,
 				1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */,
@@ -1843,6 +1869,7 @@
 				74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */,
 				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
+				449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */,
 				671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */,
 				C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */,
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
@@ -1983,6 +2010,7 @@
 				D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */,
 				D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */,
 				513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */,
+				2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */,
 				1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,
 				E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */,
@@ -1994,6 +2022,7 @@
 				3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */,
 				D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */,
 				D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */,
+				E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */,
 				89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */,
 				CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */,
 				D675E5B1E5E95E7239F3A89F /* InstallRecipeTests.swift in Sources */,
@@ -2018,6 +2047,7 @@
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,
 				CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */,
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,
+				11B4AA1D032F054C666DD7F4 /* PendingDiscardTests.swift in Sources */,
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
 				636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */,
@@ -2029,6 +2059,8 @@
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
+				21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */,
+				8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */,
 				35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */,
 				FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -214,6 +214,7 @@ final class AppState {
         // happens async in RootView.task), so worktreesByProject is empty and
         // we'd resolve to a 0-element id list. RootView calls reloadTabs() after
         // refreshAll() returns.
+        rightPaneStore.appState = self
     }
 
     /// All worktree IDs currently known to the projects manager (including

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -95,13 +95,20 @@ struct CenterPaneView: View {
                         let openAvailable = DiffOpenFileAvailability.isAvailable(
                             worktreePath: worktree.path, relativePath: s.relativePath
                         )
+                        let rps = state.rightPaneStore.state(
+                            for: worktree,
+                            baseBranch: state.config.worktrees.baseBranch
+                        )
                         DiffTabView(
                             worktreePath: worktree.path,
                             relativePath: s.relativePath,
                             staged: s.staged,
                             onOpenFile: openAvailable
                                 ? { state.openFile(relativePath: s.relativePath, worktreeId: worktree.id) }
-                                : nil
+                                : nil,
+                            onRequestDiscardFile: {
+                                rps.requestDiscardFile(path: s.relativePath)
+                            }
                         )
                     case .commit(let s):
                         CommitTabView(

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -5,6 +5,7 @@ struct DiffTabView: View {
     let relativePath: String
     let staged: Bool
     let onOpenFile: (() -> Void)?
+    let onRequestDiscardFile: (() -> Void)?
     @Environment(\.theme) var theme
 
     @State private var diff: ParsedDiff = ParsedDiff(hunks: [])
@@ -13,12 +14,22 @@ struct DiffTabView: View {
     @State private var loaded = false
     @State private var error: String?
     @State private var activeLoadKey: String?
+    @State private var confirmingDiscardHunk: ParsedDiff.Hunk? = nil
+    @State private var isFileTracked: Bool = true
 
     private let git = GitService()
 
     var body: some View {
         VStack(spacing: 0) {
             header
+            if let error {
+                Text(error)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("del"))
+                    .padding(.horizontal, 14).padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(theme.color("bg-2"))
+            }
             ScrollView {
                 if !loaded {
                     ProgressView().padding()
@@ -27,7 +38,13 @@ struct DiffTabView: View {
                 } else {
                     VStack(alignment: .leading, spacing: 0) {
                         ForEach(Array(diff.hunks.enumerated()), id: \.offset) { (_, hunk) in
-                            HunkView(hunk: hunk, fileExtension: (relativePath as NSString).pathExtension)
+                            let actions = stagedHunkActions(hunk: hunk)
+                            HunkView(
+                                hunk: hunk,
+                                fileExtension: (relativePath as NSString).pathExtension,
+                                onStage: actions.stage,
+                                onDiscard: actions.discard
+                            )
                         }
                     }
                     .padding(.vertical, 8)
@@ -36,6 +53,25 @@ struct DiffTabView: View {
         }
         .background(theme.color("bg-1"))
         .task(id: loadKey) { await load() }
+        .alert(
+            "Discard this hunk in \u{201C}\((relativePath as NSString).lastPathComponent)\u{201D}?",
+            isPresented: Binding(
+                get: { confirmingDiscardHunk != nil },
+                set: { if !$0 { confirmingDiscardHunk = nil } }
+            ),
+            actions: {
+                Button("Discard", role: .destructive) {
+                    if let h = confirmingDiscardHunk {
+                        confirmingDiscardHunk = nil
+                        performDiscardHunk(h)
+                    }
+                }
+                Button("Cancel", role: .cancel) { confirmingDiscardHunk = nil }
+            },
+            message: {
+                Text("This permanently removes the selected hunk from your working copy. This cannot be undone.")
+            }
+        )
     }
 
     private var loadKey: String {
@@ -71,10 +107,9 @@ struct DiffTabView: View {
                 if let onOpenFile {
                     AlasButton(title: "Open File", style: .subtle, action: onOpenFile)
                 }
-                if !staged, let first = diff.hunks.first {
-                    AlasButton(title: "Stage hunk", style: .subtle, action: { stageHunk(first) })
+                if let onRequestDiscardFile {
+                    AlasButton(title: "Discard Changes...", style: .subtle, action: onRequestDiscardFile)
                 }
-                AlasButton(title: "Discard", style: .subtle, action: discard)
             }
         }
         .padding(.horizontal, 16).padding(.vertical, 10)
@@ -95,11 +130,16 @@ struct DiffTabView: View {
             let loadedDiff = try await git.diff(worktreePath: worktreePath, file: relativePath, staged: staged)
             let loadedTotalAdd = loadedDiff.hunks.flatMap(\.lines).filter { $0.kind == .add }.count
             let loadedTotalDel = loadedDiff.hunks.flatMap(\.lines).filter { $0.kind == .delete }.count
+            let tracked = (try? await Process.git(
+                ["ls-files", "--error-unmatch", "--", relativePath],
+                cwd: worktreePath
+            ))?.exitCode == 0
 
             guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
             diff = loadedDiff
             totalAdd = loadedTotalAdd
             totalDel = loadedTotalDel
+            isFileTracked = tracked
             loaded = true
         } catch {
             guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
@@ -131,30 +171,26 @@ struct DiffTabView: View {
         }
     }
 
-    private func discard() {
-        // `git checkout -- <path>` only restores a TRACKED file's worktree
-        // copy from the index. It silently no-ops for untracked files (still
-        // there) and doesn't unstage staged changes. Discard from the diff
-        // view is opened from `git status --porcelain=v2` entries which
-        // include both — handle each case explicitly:
-        //
-        //   tracked   → `git restore --staged --worktree --source=HEAD --` so
-        //               both the index and the worktree go back to HEAD,
-        //               covering staged-only, unstaged-only, and mixed states.
-        //   untracked → `rm -f` since git won't touch it.
+    private func stagedHunkActions(hunk: ParsedDiff.Hunk) -> (stage: (() -> Void)?, discard: (() -> Void)?) {
+        // Staged view: no per-hunk actions for now (out of scope).
+        if staged { return (nil, nil) }
+        // Unstaged tracked: stage + discard.
+        // Unstaged untracked: stage only (Discard hidden — whole file IS the hunk).
+        let stage: () -> Void = { stageHunk(hunk) }
+        let discard: (() -> Void)? = isFileTracked
+            ? { confirmingDiscardHunk = hunk }
+            : nil
+        return (stage, discard)
+    }
+
+    private func performDiscardHunk(_ hunk: ParsedDiff.Hunk) {
         Task {
-            let tracked = (try? await Process.git(
-                ["ls-files", "--error-unmatch", "--", relativePath],
-                cwd: worktreePath
-            ))?.exitCode == 0
-            if tracked {
-                _ = try? await Process.git(
-                    ["restore", "--staged", "--worktree", "--source=HEAD", "--", relativePath],
-                    cwd: worktreePath
-                )
-            } else {
-                let absolute = worktreePath.appendingPathComponent(relativePath)
-                try? FileManager.default.removeItem(at: absolute)
+            let patch = HunkPatchBuilder.patch(file: relativePath, hunk: hunk, tracked: true)
+            do {
+                let git = GitService()
+                try await git.applyPatchReverse(worktreePath: worktreePath, patch: patch)
+            } catch {
+                self.error = (error as NSError).localizedDescription
             }
             await load()
         }
@@ -164,17 +200,28 @@ struct DiffTabView: View {
 struct HunkView: View {
     let hunk: ParsedDiff.Hunk
     let fileExtension: String
+    var onStage:   (() -> Void)? = nil
+    var onDiscard: (() -> Void)? = nil
     @Environment(\.theme) var theme
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(hunk.header)
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(theme.color("fg-dim"))
-                .padding(.horizontal, 14).padding(.vertical, 4)
-                .background(theme.color("bg-2"))
-                .overlay(Divider().opacity(0.5), alignment: .top)
-                .overlay(Divider().opacity(0.5), alignment: .bottom)
+            HStack(spacing: 8) {
+                Text(hunk.header)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("fg-dim"))
+                Spacer(minLength: 8)
+                if onStage != nil {
+                    AlasButton(title: "Stage hunk", style: .subtle, action: { onStage?() })
+                }
+                if onDiscard != nil {
+                    AlasButton(title: "Discard hunk...", style: .subtle, action: { onDiscard?() })
+                }
+            }
+            .padding(.horizontal, 14).padding(.vertical, 4)
+            .background(theme.color("bg-2"))
+            .overlay(Divider().opacity(0.5), alignment: .top)
+            .overlay(Divider().opacity(0.5), alignment: .bottom)
             ForEach(Array(hunk.lines.enumerated()), id: \.offset) { (_, line) in
                 HStack(alignment: .top, spacing: 16) {
                     Text(lineMarker(line))

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -155,16 +155,22 @@ struct DiffTabView: View {
             let tmp = FileManager.default.temporaryDirectory
                 .appendingPathComponent("alas-stage-\(UUID().uuidString).patch")
             defer { try? FileManager.default.removeItem(at: tmp) }
+            var didFail = false
             do {
                 try patch.write(to: tmp, atomically: true, encoding: .utf8)
                 let result = try await Process.git(["apply", "--cached", tmp.path], cwd: worktreePath)
                 if result.exitCode != 0 {
                     self.error = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                    didFail = true
                 }
             } catch {
                 self.error = (error as NSError).localizedDescription
+                didFail = true
             }
-            await load()
+            // Only reload on success — load() resets `error` at its start, so
+            // calling it after a failure would erase the error we just set
+            // and make the action look like a silent no-op.
+            if !didFail { await load() }
         }
     }
 
@@ -183,12 +189,15 @@ struct DiffTabView: View {
     private func performDiscardHunk(_ hunk: ParsedDiff.Hunk) {
         Task {
             let patch = HunkPatchBuilder.patch(file: relativePath, hunk: hunk, tracked: true)
+            var didFail = false
             do {
                 try await git.applyPatchReverse(worktreePath: worktreePath, patch: patch)
             } catch {
                 self.error = (error as NSError).localizedDescription
+                didFail = true
             }
-            await load()
+            // See stageHunk: load() clears `error`, so only reload on success.
+            if !didFail { await load() }
         }
     }
 }

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -16,6 +16,7 @@ struct DiffTabView: View {
     @State private var activeLoadKey: String?
     @State private var confirmingDiscardHunk: ParsedDiff.Hunk? = nil
     @State private var isFileTracked: Bool = true
+    @State private var isFileDeleted: Bool = false
 
     private let git = GitService()
 
@@ -134,12 +135,20 @@ struct DiffTabView: View {
                 ["ls-files", "--error-unmatch", "--", relativePath],
                 cwd: worktreePath
             ))?.exitCode == 0
+            // A tracked file that's gone from disk is an unstaged deletion.
+            // The diff for it has `+++ /dev/null`, so reverse-applying a
+            // per-hunk patch (which uses `+++ b/<path>`) would fail — hide
+            // Discard hunk in that case and rely on file-level Discard.
+            let deleted = tracked && !FileManager.default.fileExists(
+                atPath: worktreePath.appendingPathComponent(relativePath).path
+            )
 
             guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
             diff = loadedDiff
             totalAdd = loadedTotalAdd
             totalDel = loadedTotalDel
             isFileTracked = tracked
+            isFileDeleted = deleted
             loaded = true
         } catch {
             guard !Task.isCancelled, activeLoadKey == requestedLoadKey else { return }
@@ -177,10 +186,13 @@ struct DiffTabView: View {
     private func stagedHunkActions(hunk: ParsedDiff.Hunk) -> (stage: (() -> Void)?, discard: (() -> Void)?) {
         // Staged view: no per-hunk actions for now (out of scope).
         if staged { return (nil, nil) }
-        // Unstaged tracked: stage + discard.
+        // Unstaged tracked, file exists: stage + discard.
         // Unstaged untracked: stage only (Discard hidden — whole file IS the hunk).
+        // Unstaged tracked, file deleted: stage only (Discard hidden — the
+        // generated patch would have `+++ b/<path>` but reverse-apply needs
+        // /dev/null; file-level Discard restores the whole file).
         let stage: () -> Void = { stageHunk(hunk) }
-        let discard: (() -> Void)? = isFileTracked
+        let discard: (() -> Void)? = (isFileTracked && !isFileDeleted)
             ? { confirmingDiscardHunk = hunk }
             : nil
         return (stage, discard)

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -150,16 +150,13 @@ struct DiffTabView: View {
 
     private func stageHunk(_ hunk: ParsedDiff.Hunk) {
         Task {
-            let tracked = (try? await Process.git(
-                ["ls-files", "--error-unmatch", "--", relativePath],
-                cwd: worktreePath
-            ))?.exitCode == 0
+            let tracked = isFileTracked
             let patch = HunkPatchBuilder.patch(file: relativePath, hunk: hunk, tracked: tracked)
             let tmp = FileManager.default.temporaryDirectory
                 .appendingPathComponent("alas-stage-\(UUID().uuidString).patch")
-            try? patch.write(to: tmp, atomically: true, encoding: .utf8)
             defer { try? FileManager.default.removeItem(at: tmp) }
             do {
+                try patch.write(to: tmp, atomically: true, encoding: .utf8)
                 let result = try await Process.git(["apply", "--cached", tmp.path], cwd: worktreePath)
                 if result.exitCode != 0 {
                     self.error = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -187,7 +184,6 @@ struct DiffTabView: View {
         Task {
             let patch = HunkPatchBuilder.patch(file: relativePath, hunk: hunk, tracked: true)
             do {
-                let git = GitService()
                 try await git.applyPatchReverse(worktreePath: worktreePath, patch: patch)
             } catch {
                 self.error = (error as NSError).localizedDescription

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -160,7 +160,16 @@ struct DiffTabView: View {
     private func stageHunk(_ hunk: ParsedDiff.Hunk) {
         Task {
             let tracked = isFileTracked
-            let patch = HunkPatchBuilder.patch(file: relativePath, hunk: hunk, tracked: tracked)
+            // For untracked files we need the real file mode so `git apply
+            // --cached` doesn't drop the +x bit or rewrite a symlink as a
+            // regular file. Tracked patches ignore this argument.
+            let untrackedMode = Self.fileMode(at: worktreePath.appendingPathComponent(relativePath))
+            let patch = HunkPatchBuilder.patch(
+                file: relativePath,
+                hunk: hunk,
+                tracked: tracked,
+                untrackedMode: untrackedMode
+            )
             let tmp = FileManager.default.temporaryDirectory
                 .appendingPathComponent("alas-stage-\(UUID().uuidString).patch")
             defer { try? FileManager.default.removeItem(at: tmp) }
@@ -211,6 +220,25 @@ struct DiffTabView: View {
             // See stageHunk: load() clears `error`, so only reload on success.
             if !didFail { await load() }
         }
+    }
+
+    /// Map a worktree file to the git mode string used in a `new file mode`
+    /// patch header. Symlinks → "120000", executable regular files → "100755",
+    /// everything else → "100644". Falls back to "100644" when the file isn't
+    /// readable (caller probably already errored out elsewhere).
+    static func fileMode(at url: URL) -> String {
+        do {
+            let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+            if let type = attrs[.type] as? FileAttributeType, type == .typeSymbolicLink {
+                return "120000"
+            }
+            if let perms = attrs[.posixPermissions] as? NSNumber, perms.uintValue & 0o111 != 0 {
+                return "100755"
+            }
+        } catch {
+            // Fall through to default.
+        }
+        return HunkPatchBuilder.defaultUntrackedMode
     }
 }
 

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -71,8 +71,8 @@ struct DiffTabView: View {
                 if let onOpenFile {
                     AlasButton(title: "Open File", style: .subtle, action: onOpenFile)
                 }
-                if !staged {
-                    AlasButton(title: "Stage hunk", style: .subtle, action: stageHunk)
+                if !staged, let first = diff.hunks.first {
+                    AlasButton(title: "Stage hunk", style: .subtle, action: { stageHunk(first) })
                 }
                 AlasButton(title: "Discard", style: .subtle, action: discard)
             }
@@ -108,47 +108,25 @@ struct DiffTabView: View {
         }
     }
 
-    private func stageHunk() {
+    private func stageHunk(_ hunk: ParsedDiff.Hunk) {
         Task {
-            guard let hunk = diff.hunks.first else { return }
-            let patchLines = hunk.lines.map { line -> String in
-                switch line.kind {
-                case .add:     return "+\(line.text)"
-                case .delete:  return "-\(line.text)"
-                case .context: return " \(line.text)"
-                }
-            }
-            // For untracked files the diff base is /dev/null; the patch header
-            // must reflect that or `git apply --cached` rejects it with
-            // "does not exist in index". For tracked files the conventional
-            // a/<path> b/<path> headers work.
             let tracked = (try? await Process.git(
                 ["ls-files", "--error-unmatch", "--", relativePath],
                 cwd: worktreePath
             ))?.exitCode == 0
-            let header: [String]
-            if tracked {
-                header = [
-                    "diff --git a/\(relativePath) b/\(relativePath)",
-                    "--- a/\(relativePath)",
-                    "+++ b/\(relativePath)",
-                    hunk.header,
-                ]
-            } else {
-                header = [
-                    "diff --git a/\(relativePath) b/\(relativePath)",
-                    "new file mode 100644",
-                    "--- /dev/null",
-                    "+++ b/\(relativePath)",
-                    hunk.header,
-                ]
-            }
-            let patch = header.joined(separator: "\n") + "\n"
-                + patchLines.joined(separator: "\n") + "\n"
-            let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("alas-stage-\(UUID().uuidString).patch")
+            let patch = HunkPatchBuilder.patch(file: relativePath, hunk: hunk, tracked: tracked)
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent("alas-stage-\(UUID().uuidString).patch")
             try? patch.write(to: tmp, atomically: true, encoding: .utf8)
-            _ = try? await Process.git(["apply", "--cached", tmp.path], cwd: worktreePath)
-            try? FileManager.default.removeItem(at: tmp)
+            defer { try? FileManager.default.removeItem(at: tmp) }
+            do {
+                let result = try await Process.git(["apply", "--cached", tmp.path], cwd: worktreePath)
+                if result.exitCode != 0 {
+                    self.error = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            } catch {
+                self.error = (error as NSError).localizedDescription
+            }
             await load()
         }
     }

--- a/Alas/Sources/Git/DiffParser.swift
+++ b/Alas/Sources/Git/DiffParser.swift
@@ -13,6 +13,11 @@ struct ParsedDiff: Equatable {
             let text: String        // without the leading + - or space
             let oldNumber: Int?
             let newNumber: Int?
+            /// True when the source diff carried a `\ No newline at end of file`
+            /// sentinel after this line. Patch builders must re-emit the
+            /// sentinel; otherwise `git apply` rejects the patch because the
+            /// content doesn't match the worktree.
+            var noTrailingNewline: Bool = false
         }
     }
 }
@@ -55,6 +60,14 @@ enum DiffParser {
                 current!.lines.append(.init(kind: .context, text: text, oldNumber: oldCounter, newNumber: newCounter))
                 oldCounter += 1
                 newCounter += 1
+            } else if line.hasPrefix("\\ No newline at end of file") {
+                // The sentinel follows whichever line (`+`, `-`, or ` `) lacks
+                // a trailing newline at EOF. Mark the previously-appended line
+                // so HunkPatchBuilder can re-emit the marker — without it,
+                // `git apply --reverse` rejects the patch.
+                if let lastIdx = current?.lines.indices.last {
+                    current!.lines[lastIdx].noTrailingNewline = true
+                }
             }
         }
         flush()

--- a/Alas/Sources/Git/GitService+Discard.swift
+++ b/Alas/Sources/Git/GitService+Discard.swift
@@ -89,6 +89,25 @@ extension GitService {
             try Self.assertSuccess(result, op: "discard")
         }
 
+        // `git restore --recurse-submodules` resets the submodule's commit
+        // and tracked content, but leaves nested untracked files behind. For
+        // any path in the discard set that IS a submodule, run `git clean`
+        // inside it so "Discard … (staged, unstaged, and untracked)" really
+        // does leave the worktree clean.
+        if head {
+            for path in indexTracked + headOnlyPaths {
+                guard try await isSubmodule(worktreePath: worktreePath, path: path) else {
+                    continue
+                }
+                let submoduleURL = worktreePath.appendingPathComponent(path)
+                let clean = try await Process.git(
+                    ["clean", "-fd"],
+                    cwd: submoduleURL
+                )
+                try Self.assertSuccess(clean, op: "discard")
+            }
+        }
+
         // Remove truly untracked files from disk.
         for path in trulyUntracked {
             let url = worktreePath.appendingPathComponent(path)
@@ -98,6 +117,26 @@ extension GitService {
                 continue
             }
         }
+    }
+
+    /// True iff `path` is a submodule registered in the index or HEAD.
+    /// Submodules are mode 160000 ("gitlink") in the tree object. We probe
+    /// the index first (the common case after a restore) and fall back to
+    /// HEAD for rename origins that aren't in the current index.
+    private func isSubmodule(worktreePath: URL, path: String) async throws -> Bool {
+        if let stage = try? await Process.git(
+            ["ls-files", "--stage", "--", path],
+            cwd: worktreePath
+        ), stage.exitCode == 0, stage.stdout.hasPrefix("160000") {
+            return true
+        }
+        if let tree = try? await Process.git(
+            ["ls-tree", "HEAD", "--", path],
+            cwd: worktreePath
+        ), tree.exitCode == 0, tree.stdout.hasPrefix("160000") {
+            return true
+        }
+        return false
     }
 
     /// Apply a unified-diff patch in reverse against the worktree. Used by

--- a/Alas/Sources/Git/GitService+Discard.swift
+++ b/Alas/Sources/Git/GitService+Discard.swift
@@ -1,19 +1,16 @@
 import Foundation
 
 extension GitService {
-    /// Discard worktree + index changes for the given paths. Splits paths
-    /// into tracked vs untracked: tracked paths go through
+    /// Discard worktree + index changes for the given paths. Splits paths into
+    /// three buckets: in-index (`indexTracked`), in-HEAD-only (`headOnlyPaths`,
+    /// e.g. staged-rename origins no longer in the index), and truly untracked.
+    /// In-index and HEAD-only paths route through
     /// `git restore --staged --worktree --source=HEAD --` (one batched call);
     /// untracked paths are removed via `FileManager`. On unborn HEAD where
-    /// `--source=HEAD` won't resolve, every tracked path is necessarily a
+    /// `--source=HEAD` won't resolve, every in-index path is necessarily a
     /// staged add, so we use `git rm -f --cached --` + `FileManager` removal.
     /// Empty `files` is a no-op. Missing untracked paths (ENOENT) are
     /// silently tolerated — the user already saw what they wanted gone.
-    ///
-    /// Staged renames are handled correctly: after `git mv a.txt b.txt` the
-    /// old path `a.txt` is no longer in the index but still exists in HEAD.
-    /// We detect such paths via `git cat-file -e HEAD:<path>` and include
-    /// them in the restore call so both halves of the rename are undone.
     func discardPaths(worktreePath: URL, files: [String]) async throws {
         guard !files.isEmpty else { return }
 
@@ -73,7 +70,12 @@ extension GitService {
                 try Self.assertSuccess(rm, op: "discard")
                 for path in indexTracked {
                     let url = worktreePath.appendingPathComponent(path)
-                    try? FileManager.default.removeItem(at: url)
+                    do {
+                        try FileManager.default.removeItem(at: url)
+                    } catch CocoaError.fileNoSuchFile {
+                        continue
+                    }
+                    // any other error propagates
                 }
             }
         } else if !headOnlyPaths.isEmpty {
@@ -90,8 +92,6 @@ extension GitService {
             let url = worktreePath.appendingPathComponent(path)
             do {
                 try FileManager.default.removeItem(at: url)
-            } catch let error as NSError where error.code == NSFileNoSuchFileError {
-                continue
             } catch CocoaError.fileNoSuchFile {
                 continue
             }

--- a/Alas/Sources/Git/GitService+Discard.swift
+++ b/Alas/Sources/Git/GitService+Discard.swift
@@ -97,4 +97,22 @@ extension GitService {
             }
         }
     }
+
+    /// Apply a unified-diff patch in reverse against the worktree. Used by
+    /// per-hunk "Discard hunk" for tracked files. Writes the patch to a
+    /// temp file (git apply needs a real path, not stdin) and removes it
+    /// on completion. Throws if `git apply --reverse` exits non-zero —
+    /// typically because the patch context no longer matches the working
+    /// copy (e.g. the user already discarded it elsewhere).
+    func applyPatchReverse(worktreePath: URL, patch: String) async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-discard-\(UUID().uuidString).patch")
+        try patch.write(to: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let result = try await Process.git(
+            ["apply", "--reverse", tmp.path],
+            cwd: worktreePath
+        )
+        try Self.assertSuccess(result, op: "applyPatchReverse")
+    }
 }

--- a/Alas/Sources/Git/GitService+Discard.swift
+++ b/Alas/Sources/Git/GitService+Discard.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+extension GitService {
+    /// Discard worktree + index changes for the given paths. Splits paths
+    /// into tracked vs untracked: tracked paths go through
+    /// `git restore --staged --worktree --source=HEAD --` (one batched call);
+    /// untracked paths are removed via `FileManager`. On unborn HEAD where
+    /// `--source=HEAD` won't resolve, every tracked path is necessarily a
+    /// staged add, so we use `git rm -f --cached --` + `FileManager` removal.
+    /// Empty `files` is a no-op. Missing untracked paths (ENOENT) are
+    /// silently tolerated — the user already saw what they wanted gone.
+    ///
+    /// Staged renames are handled correctly: after `git mv a.txt b.txt` the
+    /// old path `a.txt` is no longer in the index but still exists in HEAD.
+    /// We detect such paths via `git cat-file -e HEAD:<path>` and include
+    /// them in the restore call so both halves of the rename are undone.
+    func discardPaths(worktreePath: URL, files: [String]) async throws {
+        guard !files.isEmpty else { return }
+
+        let head = try await hasHead(worktreePath: worktreePath)
+
+        // Partition by index presence. ls-files --error-unmatch exits 0 iff
+        // the path is tracked in the index (includes staged adds and renames).
+        var indexTracked: [String] = []
+        var notInIndex: [String] = []
+        for path in files {
+            let result = try await Process.git(
+                ["ls-files", "--error-unmatch", "--", path],
+                cwd: worktreePath
+            )
+            if result.exitCode == 0 {
+                indexTracked.append(path)
+            } else {
+                notInIndex.append(path)
+            }
+        }
+
+        // Among paths not in the index, some may still exist in HEAD (e.g.
+        // the old name in a staged rename). Those need git restore too.
+        var headOnlyPaths: [String] = []
+        var trulyUntracked: [String] = []
+        if head {
+            for path in notInIndex {
+                let result = try await Process.git(
+                    ["cat-file", "-e", "HEAD:\(path)"],
+                    cwd: worktreePath
+                )
+                if result.exitCode == 0 {
+                    headOnlyPaths.append(path)
+                } else {
+                    trulyUntracked.append(path)
+                }
+            }
+        } else {
+            trulyUntracked = notInIndex
+        }
+
+        // Restore index-tracked paths (modifications, staged adds, renames).
+        if !indexTracked.isEmpty {
+            if head {
+                let result = try await Process.git(
+                    ["restore", "--staged", "--worktree", "--source=HEAD", "--"]
+                        + indexTracked + headOnlyPaths,
+                    cwd: worktreePath
+                )
+                try Self.assertSuccess(result, op: "discard")
+            } else {
+                // Unborn HEAD: every tracked path is a staged add.
+                let rm = try await Process.git(
+                    ["rm", "-f", "--cached", "--"] + indexTracked,
+                    cwd: worktreePath
+                )
+                try Self.assertSuccess(rm, op: "discard")
+                for path in indexTracked {
+                    let url = worktreePath.appendingPathComponent(path)
+                    try? FileManager.default.removeItem(at: url)
+                }
+            }
+        } else if !headOnlyPaths.isEmpty {
+            // No index-tracked paths but we have head-only paths (edge case).
+            let result = try await Process.git(
+                ["restore", "--staged", "--worktree", "--source=HEAD", "--"] + headOnlyPaths,
+                cwd: worktreePath
+            )
+            try Self.assertSuccess(result, op: "discard")
+        }
+
+        // Remove truly untracked files from disk.
+        for path in trulyUntracked {
+            let url = worktreePath.appendingPathComponent(path)
+            do {
+                try FileManager.default.removeItem(at: url)
+            } catch let error as NSError where error.code == NSFileNoSuchFileError {
+                continue
+            } catch CocoaError.fileNoSuchFile {
+                continue
+            }
+        }
+    }
+}

--- a/Alas/Sources/Git/GitService+Discard.swift
+++ b/Alas/Sources/Git/GitService+Discard.swift
@@ -53,10 +53,12 @@ extension GitService {
         }
 
         // Restore index-tracked paths (modifications, staged adds, renames).
+        // `--recurse-submodules` is required for dirty submodule worktrees;
+        // without it `git restore` leaves them at their current commit.
         if !indexTracked.isEmpty {
             if head {
                 let result = try await Process.git(
-                    ["restore", "--staged", "--worktree", "--source=HEAD", "--"]
+                    ["restore", "--staged", "--worktree", "--recurse-submodules", "--source=HEAD", "--"]
                         + indexTracked + headOnlyPaths,
                     cwd: worktreePath
                 )
@@ -81,7 +83,7 @@ extension GitService {
         } else if !headOnlyPaths.isEmpty {
             // No index-tracked paths but we have head-only paths (edge case).
             let result = try await Process.git(
-                ["restore", "--staged", "--worktree", "--source=HEAD", "--"] + headOnlyPaths,
+                ["restore", "--staged", "--worktree", "--recurse-submodules", "--source=HEAD", "--"] + headOnlyPaths,
                 cwd: worktreePath
             )
             try Self.assertSuccess(result, op: "discard")

--- a/Alas/Sources/Git/HunkPatchBuilder.swift
+++ b/Alas/Sources/Git/HunkPatchBuilder.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Builds a unified-diff patch for exactly one hunk. Pure — no I/O, no git.
+/// Output is suitable for `git apply --cached` (stage) or `git apply --reverse`
+/// (discard) when paired with the right `tracked` flag.
+enum HunkPatchBuilder {
+    static func patch(file: String, hunk: ParsedDiff.Hunk, tracked: Bool) -> String {
+        let bodyLines = hunk.lines.map { line -> String in
+            switch line.kind {
+            case .add:     return "+\(line.text)"
+            case .delete:  return "-\(line.text)"
+            case .context: return " \(line.text)"
+            }
+        }
+        let headerLines: [String]
+        if tracked {
+            headerLines = [
+                "diff --git a/\(file) b/\(file)",
+                "--- a/\(file)",
+                "+++ b/\(file)",
+                hunk.header,
+            ]
+        } else {
+            headerLines = [
+                "diff --git a/\(file) b/\(file)",
+                "new file mode 100644",
+                "--- /dev/null",
+                "+++ b/\(file)",
+                hunk.header,
+            ]
+        }
+        return (headerLines + bodyLines).joined(separator: "\n") + "\n"
+    }
+}

--- a/Alas/Sources/Git/HunkPatchBuilder.swift
+++ b/Alas/Sources/Git/HunkPatchBuilder.swift
@@ -4,7 +4,20 @@ import Foundation
 /// Output is suitable for `git apply --cached` (stage) or `git apply --reverse`
 /// (discard) when paired with the right `tracked` flag.
 enum HunkPatchBuilder {
-    static func patch(file: String, hunk: ParsedDiff.Hunk, tracked: Bool) -> String {
+    /// Git's mode string for a regular non-executable file. Used as the
+    /// default `untrackedMode` when the caller doesn't know the source
+    /// file's actual mode. Real callers staging from disk should probe
+    /// the file (executable bit / symlink) and pass the right value so
+    /// `git apply --cached` doesn't drop +x or turn a symlink into a regular
+    /// file.
+    static let defaultUntrackedMode = "100644"
+
+    static func patch(
+        file: String,
+        hunk: ParsedDiff.Hunk,
+        tracked: Bool,
+        untrackedMode: String = defaultUntrackedMode
+    ) -> String {
         var bodyLines: [String] = []
         for line in hunk.lines {
             let sigil: String
@@ -31,7 +44,7 @@ enum HunkPatchBuilder {
         } else {
             headerLines = [
                 "diff --git a/\(file) b/\(file)",
-                "new file mode 100644",
+                "new file mode \(untrackedMode)",
                 "--- /dev/null",
                 "+++ b/\(file)",
                 hunk.header,

--- a/Alas/Sources/Git/HunkPatchBuilder.swift
+++ b/Alas/Sources/Git/HunkPatchBuilder.swift
@@ -5,11 +5,19 @@ import Foundation
 /// (discard) when paired with the right `tracked` flag.
 enum HunkPatchBuilder {
     static func patch(file: String, hunk: ParsedDiff.Hunk, tracked: Bool) -> String {
-        let bodyLines = hunk.lines.map { line -> String in
+        var bodyLines: [String] = []
+        for line in hunk.lines {
+            let sigil: String
             switch line.kind {
-            case .add:     return "+\(line.text)"
-            case .delete:  return "-\(line.text)"
-            case .context: return " \(line.text)"
+            case .add:     sigil = "+"
+            case .delete:  sigil = "-"
+            case .context: sigil = " "
+            }
+            bodyLines.append("\(sigil)\(line.text)")
+            // EOF without trailing newline: re-emit the sentinel so
+            // `git apply` accepts the patch against the original worktree.
+            if line.noTrailingNewline {
+                bodyLines.append("\\ No newline at end of file")
             }
         }
         let headerLines: [String]

--- a/Alas/Sources/Git/HunkPatchBuilder.swift
+++ b/Alas/Sources/Git/HunkPatchBuilder.swift
@@ -33,23 +33,69 @@ enum HunkPatchBuilder {
                 bodyLines.append("\\ No newline at end of file")
             }
         }
+        // Quote a/<path> and b/<path> the way `git diff` does so paths with
+        // tabs, quotes, backslashes, or control characters round-trip through
+        // `git apply` correctly. Plain-ASCII paths come through unchanged.
+        let aPath = quotedHeaderPath(prefix: "a/", file: file)
+        let bPath = quotedHeaderPath(prefix: "b/", file: file)
         let headerLines: [String]
         if tracked {
             headerLines = [
-                "diff --git a/\(file) b/\(file)",
-                "--- a/\(file)",
-                "+++ b/\(file)",
+                "diff --git \(aPath) \(bPath)",
+                "--- \(aPath)",
+                "+++ \(bPath)",
                 hunk.header,
             ]
         } else {
             headerLines = [
-                "diff --git a/\(file) b/\(file)",
+                "diff --git \(aPath) \(bPath)",
                 "new file mode \(untrackedMode)",
                 "--- /dev/null",
-                "+++ b/\(file)",
+                "+++ \(bPath)",
                 hunk.header,
             ]
         }
         return (headerLines + bodyLines).joined(separator: "\n") + "\n"
+    }
+
+    /// Produce git's C-quoted path form for the patch header. Returns the raw
+    /// `prefix + file` when no quoting is needed (plain ASCII, no specials);
+    /// otherwise wraps the whole `prefix+file` string in double quotes and
+    /// escapes per git's `quote_c_style` rules. Mirrors `git diff` output so
+    /// `git apply` parses the path the same way it would parse a fresh diff.
+    static func quotedHeaderPath(prefix: String, file: String) -> String {
+        let combined = prefix + file
+        if !needsQuoting(combined) { return combined }
+        var out = "\""
+        for byte in combined.utf8 {
+            switch byte {
+            case 0x07: out += "\\a"
+            case 0x08: out += "\\b"
+            case 0x09: out += "\\t"
+            case 0x0a: out += "\\n"
+            case 0x0b: out += "\\v"
+            case 0x0c: out += "\\f"
+            case 0x0d: out += "\\r"
+            case 0x22: out += "\\\""
+            case 0x5c: out += "\\\\"
+            default:
+                if byte < 0x20 || byte == 0x7f || byte >= 0x80 {
+                    out += String(format: "\\%03o", byte)
+                } else {
+                    out.append(Character(UnicodeScalar(byte)))
+                }
+            }
+        }
+        out += "\""
+        return out
+    }
+
+    private static func needsQuoting(_ path: String) -> Bool {
+        for byte in path.utf8 {
+            if byte < 0x20 || byte == 0x7f { return true }
+            if byte == 0x22 || byte == 0x5c { return true } // " and \
+            if byte >= 0x80 { return true } // non-ASCII → git quotes by default
+        }
+        return false
     }
 }

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -5,6 +5,14 @@ struct ChangedRow: View {
     var depth: Int = 0
     let onSelect: () -> Void
     var onStage: (() -> Void)? = nil
+    var onOpenFile:       (() -> Void)? = nil
+    var onCopyRelative:   (() -> Void)? = nil
+    var onCopyFull:       (() -> Void)? = nil
+    var onRevealInFinder: (() -> Void)? = nil
+    var onCopyDiff:       (() -> Void)? = nil
+    var onDiscard:        (() -> Void)? = nil
+    var openFileEnabled:  Bool = true
+    var ignoreMenu:       AnyView? = nil
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -32,6 +40,24 @@ struct ChangedRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .contextMenu {
+            Button("Open File") { onOpenFile?() }
+                .disabled(!openFileEnabled || onOpenFile == nil)
+            Button("Copy Relative Path") { onCopyRelative?() }
+            Button("Copy Full Path") { onCopyFull?() }
+            Button("Reveal in Finder") { onRevealInFinder?() }
+            Divider()
+            Button("Copy Diff") { onCopyDiff?() }
+            Divider()
+            if onStage != nil {
+                Button(file.stage == .staged ? "Unstage" : "Stage") { onStage?() }
+            }
+            Button("Discard Changes...") { onDiscard?() }
+            if let ignoreMenu {
+                Divider()
+                ignoreMenu
+            }
+        }
     }
 }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -44,7 +44,8 @@ struct ChangesTabView: View {
                     onIgnore: { path, isDir, dest in
                         rps.ignore(path: path, isDirectory: isDir, destination: dest)
                     },
-                    onDiscardAll: { rps.requestDiscardAll() }
+                    onDiscardAll: { rps.requestDiscardAll() },
+                    onDiscardFolder: { path in rps.requestDiscardFolder(path: path) }
                 )
                 Divider().opacity(0.4)
                 CommitsSectionView(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -59,6 +59,25 @@ struct ChangesTabView: View {
                 )
             }
         }
+        .alert(
+            PendingDiscard.alertTitle(for: rps.pendingDiscard ?? .placeholder),
+            isPresented: Binding(
+                get: { rps.pendingDiscard != nil },
+                set: { if !$0 { rps.cancelDiscard() } }
+            ),
+            presenting: rps.pendingDiscard,
+            actions: { _ in
+                Button("Discard", role: .destructive) {
+                    Task { @MainActor in await rps.confirmDiscard() }
+                }
+                Button("Cancel", role: .cancel) {
+                    rps.cancelDiscard()
+                }
+            },
+            message: { p in
+                Text(PendingDiscard.alertMessage(for: p))
+            }
+        )
     }
 
     private var branchName: String? {

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -43,7 +43,8 @@ struct ChangesTabView: View {
                     onUnstageAll: { rps.unstageAll($0) },
                     onIgnore: { path, isDir, dest in
                         rps.ignore(path: path, isDirectory: isDir, destination: dest)
-                    }
+                    },
+                    onDiscardAll: { rps.requestDiscardAll() }
                 )
                 Divider().opacity(0.4)
                 CommitsSectionView(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -45,7 +45,33 @@ struct ChangesTabView: View {
                         rps.ignore(path: path, isDirectory: isDir, destination: dest)
                     },
                     onDiscardAll: { rps.requestDiscardAll() },
-                    onDiscardFolder: { path in rps.requestDiscardFolder(path: path) }
+                    onDiscardFolder: { path in rps.requestDiscardFolder(path: path) },
+                    onOpenFile: { file in
+                        appState.openFile(relativePath: file.path, worktreeId: rps.worktree.id)
+                    },
+                    onCopyRelative: { file in
+                        let pb = NSPasteboard.general
+                        pb.clearContents()
+                        pb.setString(file.path, forType: .string)
+                    },
+                    onCopyFull: { file in
+                        let absolute = rps.worktree.path.appendingPathComponent(file.path).path
+                        let pb = NSPasteboard.general
+                        pb.clearContents()
+                        pb.setString(absolute, forType: .string)
+                    },
+                    onRevealInFinder: { file in
+                        let url = rps.worktree.path.appendingPathComponent(file.path)
+                        NSWorkspace.shared.activateFileViewerSelecting([url])
+                    },
+                    onCopyDiff: { file in rps.copyDiff(for: file.path) },
+                    onDiscardFile: { file in rps.requestDiscardFile(path: file.path) },
+                    isOpenFileEnabled: { file in
+                        DiffOpenFileAvailability.isAvailable(
+                            worktreePath: rps.worktree.path,
+                            relativePath: file.path
+                        )
+                    }
                 )
                 Divider().opacity(0.4)
                 CommitsSectionView(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -64,7 +64,9 @@ struct ChangesTabView: View {
                         let url = rps.worktree.path.appendingPathComponent(file.path)
                         NSWorkspace.shared.activateFileViewerSelecting([url])
                     },
-                    onCopyDiff: { file in rps.copyDiff(for: file.path) },
+                    onCopyDiff: { file in
+                        rps.copyDiff(for: file.path, renameFrom: file.renameFrom)
+                    },
                     onDiscardFile: { file in rps.requestDiscardFile(path: file.path) },
                     isOpenFileEnabled: { file in
                         DiffOpenFileAvailability.isAvailable(

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -87,28 +87,6 @@ struct ChangesTabView: View {
                 )
             }
         }
-        .alert(
-            PendingDiscard.alertTitle(for: rps.pendingDiscard ?? .placeholder),
-            isPresented: Binding(
-                get: { rps.pendingDiscard != nil },
-                set: { if !$0 { rps.cancelDiscard() } }
-            ),
-            presenting: rps.pendingDiscard,
-            actions: { _ in
-                Button("Discard", role: .destructive) {
-                    if let pending = rps.pendingDiscard {
-                        rps.pendingDiscard = nil
-                        Task { @MainActor in await rps.confirmDiscard(pending) }
-                    }
-                }
-                Button("Cancel", role: .cancel) {
-                    rps.cancelDiscard()
-                }
-            },
-            message: { p in
-                Text(PendingDiscard.alertMessage(for: p))
-            }
-        )
     }
 
     private var branchName: String? {

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -96,7 +96,10 @@ struct ChangesTabView: View {
             presenting: rps.pendingDiscard,
             actions: { _ in
                 Button("Discard", role: .destructive) {
-                    Task { @MainActor in await rps.confirmDiscard() }
+                    if let pending = rps.pendingDiscard {
+                        rps.pendingDiscard = nil
+                        Task { @MainActor in await rps.confirmDiscard(pending) }
+                    }
                 }
                 Button("Cancel", role: .cancel) {
                     rps.cancelDiscard()

--- a/Alas/Sources/Right/PendingDiscard.swift
+++ b/Alas/Sources/Right/PendingDiscard.swift
@@ -39,3 +39,10 @@ struct PendingDiscard: Equatable {
         n == 1 ? "file" : "files"
     }
 }
+
+extension PendingDiscard {
+    /// Inert placeholder used as the `.alert` title fallback when there's
+    /// nothing pending. The alert is hidden in that state, so the title is
+    /// never visible — this is purely a type-system convenience.
+    static let placeholder = PendingDiscard(target: .all(fileCount: 0), paths: [])
+}

--- a/Alas/Sources/Right/PendingDiscard.swift
+++ b/Alas/Sources/Right/PendingDiscard.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Snapshot of a destructive discard request awaiting user confirmation.
+/// `paths` is computed at request time so the alert reflects what the user
+/// saw, even if the worktree watcher refreshes `changes` mid-prompt.
+struct PendingDiscard: Equatable {
+    enum Target: Equatable {
+        case file(path: String)
+        case folder(path: String, fileCount: Int)
+        case all(fileCount: Int)
+    }
+    let target: Target
+    let paths: [String]
+
+    static func alertTitle(for p: PendingDiscard) -> String {
+        switch p.target {
+        case .file(let path):
+            let basename = (path as NSString).lastPathComponent
+            return "Discard changes to \u{201C}\(basename)\u{201D}?"
+        case .folder(let path, _):
+            return "Discard changes under \u{201C}\(path)/\u{201D}?"
+        case .all:
+            return "Discard all working tree changes?"
+        }
+    }
+
+    static func alertMessage(for p: PendingDiscard) -> String {
+        switch p.target {
+        case .file:
+            return "This permanently removes your changes to this file. This cannot be undone."
+        case .folder(_, let n):
+            return "This permanently removes changes to \(n) \(plural(n)) under this folder. This cannot be undone."
+        case .all(let n):
+            return "This permanently removes changes to \(n) \(plural(n)) (staged, unstaged, and untracked). This cannot be undone."
+        }
+    }
+
+    private static func plural(_ n: Int) -> String {
+        n == 1 ? "file" : "files"
+    }
+}

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -410,10 +410,13 @@ final class RightPaneState {
 
     /// Run `git diff HEAD -- <file>` (or `--cached` on unborn HEAD, or
     /// `/dev/null` for untracked) and put the unified-diff output on the
-    /// general pasteboard. Best-effort: errors are surfaced via
-    /// `composer.error`. Single source of truth so the context menu and any
-    /// future "Copy Diff" affordances agree.
-    func copyDiff(for path: String) {
+    /// general pasteboard. `renameFrom` is the staged-rename origin path
+    /// (from `ChangedFile.renameFrom`); when present it's included in the
+    /// pathspec so `git diff` emits the rename-from/rename-to header
+    /// instead of an add-only patch. Best-effort: errors are surfaced via
+    /// `composer.error`. Single source of truth so the context menu and
+    /// any future "Copy Diff" affordances agree.
+    func copyDiff(for path: String, renameFrom: String? = nil) {
         let wt = worktree.path
         Task { @MainActor in
             do {
@@ -435,9 +438,18 @@ final class RightPaneState {
                 } else {
                     inHead = false
                 }
+                // For staged renames, `git diff HEAD -- <new>` strips the
+                // rename header (emits an add-only patch). Pass both paths
+                // in the pathspec so the rename-from/rename-to header is
+                // preserved. Only relevant when we're using a HEAD-based
+                // diff; the rename concept doesn't apply to untracked or
+                // unborn-HEAD cases.
+                let extraPath: String? = (renameFrom?.isEmpty == false) ? renameFrom : nil
                 let args: [String]
                 if head, inIndex || inHead {
-                    args = ["diff", "--no-color", "HEAD", "--", path]
+                    var a = ["diff", "--no-color", "HEAD", "--", path]
+                    if let extraPath { a.append(extraPath) }
+                    args = a
                 } else if !head, inIndex {
                     // Unborn HEAD: staged-add — diff index vs empty tree.
                     args = ["diff", "--no-color", "--cached", "--", path]

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -417,22 +417,30 @@ final class RightPaneState {
         let wt = worktree.path
         Task { @MainActor in
             do {
-                let tracked = (try? await Process.git(
+                // A staged deletion is *not* in the index (`ls-files` returns
+                // non-zero) but IS in HEAD — falling back to `--no-index` for
+                // that case yields an empty patch. Probe HEAD via `cat-file`
+                // so staged D entries still route through HEAD-based diff.
+                let inIndex = (try? await Process.git(
                     ["ls-files", "--error-unmatch", "--", path],
                     cwd: wt
                 ))?.exitCode == 0
+                let head = (try? await self.git.hasHead(worktreePath: wt)) ?? true
+                let inHead: Bool
+                if head {
+                    inHead = (try? await Process.git(
+                        ["cat-file", "-e", "HEAD:\(path)"],
+                        cwd: wt
+                    ))?.exitCode == 0
+                } else {
+                    inHead = false
+                }
                 let args: [String]
-                if tracked {
-                    // Unborn HEAD doesn't resolve, so `diff HEAD` errors with
-                    // "bad revision 'HEAD'". A staged-add in that state is still
-                    // ls-files-tracked — fall back to `--cached` (index vs empty
-                    // tree) so initial-commit workflows still produce a patch.
-                    let head = (try? await self.git.hasHead(worktreePath: wt)) ?? true
-                    if head {
-                        args = ["diff", "--no-color", "HEAD", "--", path]
-                    } else {
-                        args = ["diff", "--no-color", "--cached", "--", path]
-                    }
+                if head, inIndex || inHead {
+                    args = ["diff", "--no-color", "HEAD", "--", path]
+                } else if !head, inIndex {
+                    // Unborn HEAD: staged-add — diff index vs empty tree.
+                    args = ["diff", "--no-color", "--cached", "--", path]
                 } else {
                     args = ["diff", "--no-color", "--no-index", "--", "/dev/null", path]
                 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -42,6 +42,13 @@ final class RightPaneState {
     /// without throwing away the rest of the cached state.
     var baseBranch: String
 
+    var pendingDiscard: PendingDiscard? = nil
+
+    /// Injected by `RightPaneStore` after creation so `confirmDiscard` can
+    /// close any open diff tabs whose path was just discarded. Nil in tests
+    /// that construct `RightPaneState` directly.
+    var closeDiffTabs: (([String]) -> Void)? = nil
+
     private let git = GitService()
     private let watcher: WorktreeWatcher
     private let logger = Logger(subsystem: "io.nlopez.alas", category: "right-pane-state")
@@ -333,6 +340,54 @@ final class RightPaneState {
             catch { self.composer.error = (error as NSError).localizedDescription }
             await self.refresh()
         }
+    }
+
+    func requestDiscardFile(path: String) {
+        let paths = Self.discardPaths(forFileAt: path, in: changes)
+        guard !paths.isEmpty else { return }
+        pendingDiscard = PendingDiscard(target: .file(path: path), paths: paths)
+    }
+
+    func requestDiscardFolder(path: String) {
+        let paths = Self.discardPaths(forFolderAt: path, in: changes)
+        // Folder count = distinct ChangedFile entries under the prefix, not
+        // path count (a staged rename contributes two paths but one file).
+        let prefix = path.hasSuffix("/") ? path : path + "/"
+        let fileCount = changes.filter { $0.path.hasPrefix(prefix) }.count
+        guard fileCount > 0 else { return }
+        pendingDiscard = PendingDiscard(
+            target: .folder(path: path, fileCount: fileCount),
+            paths: paths
+        )
+    }
+
+    func requestDiscardAll() {
+        let paths = Self.discardPaths(forAllIn: changes)
+        guard !changes.isEmpty else { return }
+        pendingDiscard = PendingDiscard(
+            target: .all(fileCount: changes.count),
+            paths: paths
+        )
+    }
+
+    func cancelDiscard() {
+        pendingDiscard = nil
+    }
+
+    @MainActor
+    func confirmDiscard() async {
+        guard let pending = pendingDiscard else { return }
+        let paths = pending.paths
+        pendingDiscard = nil
+        composer.error = nil
+        do {
+            try await git.discardPaths(worktreePath: worktree.path, files: paths)
+        } catch {
+            composer.error = (error as NSError).localizedDescription
+            return
+        }
+        await refresh()
+        closeDiffTabs?(paths)
     }
 
     /// Append a gitignore pattern for `path` to `destination` and refresh

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -408,10 +408,11 @@ final class RightPaneState {
         closeDiffTabs?(paths)
     }
 
-    /// Run `git diff HEAD -- <file>` (or `/dev/null` for untracked) and put
-    /// the unified-diff output on the general pasteboard. Best-effort: errors
-    /// are surfaced via `composer.error`. Single source of truth so the
-    /// context menu and any future "Copy Diff" affordances agree.
+    /// Run `git diff HEAD -- <file>` (or `--cached` on unborn HEAD, or
+    /// `/dev/null` for untracked) and put the unified-diff output on the
+    /// general pasteboard. Best-effort: errors are surfaced via
+    /// `composer.error`. Single source of truth so the context menu and any
+    /// future "Copy Diff" affordances agree.
     func copyDiff(for path: String) {
         let wt = worktree.path
         Task { @MainActor in
@@ -422,7 +423,16 @@ final class RightPaneState {
                 ))?.exitCode == 0
                 let args: [String]
                 if tracked {
-                    args = ["diff", "--no-color", "HEAD", "--", path]
+                    // Unborn HEAD doesn't resolve, so `diff HEAD` errors with
+                    // "bad revision 'HEAD'". A staged-add in that state is still
+                    // ls-files-tracked — fall back to `--cached` (index vs empty
+                    // tree) so initial-commit workflows still produce a patch.
+                    let head = (try? await self.git.hasHead(worktreePath: wt)) ?? true
+                    if head {
+                        args = ["diff", "--no-color", "HEAD", "--", path]
+                    } else {
+                        args = ["diff", "--no-color", "--cached", "--", path]
+                    }
                 } else {
                     args = ["diff", "--no-color", "--no-index", "--", "/dev/null", path]
                 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -282,6 +282,39 @@ final class RightPaneState {
         }
     }
 
+    /// Paths to discard for the given file path. Expands staged renames into
+    /// both new and original paths so the deletion of the old side is also
+    /// restored. Returns `[]` if the path is not in `changes` (stale request).
+    static func discardPaths(forFileAt path: String, in changes: [ChangedFile]) -> [String] {
+        guard let file = changes.first(where: { $0.path == path }) else { return [] }
+        return unstagePaths(for: file)
+    }
+
+    /// Paths to discard for every change under a folder (recursive). Folders
+    /// in the Changes tree are virtual — built from changed paths only — so
+    /// a prefix match against `"<folder>/"` is exhaustive. Staged renames
+    /// under the folder include their original path even if the origin lives
+    /// outside the folder (rare but possible after a refactor).
+    static func discardPaths(forFolderAt folder: String, in changes: [ChangedFile]) -> [String] {
+        let prefix = folder.hasSuffix("/") ? folder : folder + "/"
+        let matching = changes.filter { $0.path.hasPrefix(prefix) }
+        return matching.flatMap(unstagePaths(for:))
+    }
+
+    /// Every changed path in the worktree (staged + unstaged + untracked),
+    /// with staged renames expanded.
+    static func discardPaths(forAllIn changes: [ChangedFile]) -> [String] {
+        // Deduplicate while preserving first-seen order.
+        var seen = Set<String>()
+        var out: [String] = []
+        for file in changes {
+            for p in unstagePaths(for: file) where seen.insert(p).inserted {
+                out.append(p)
+            }
+        }
+        return out
+    }
+
     func stageAll(_ files: [ChangedFile]) {
         let paths = files.map(\.path)
         composer.error = nil

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 import os
@@ -388,6 +389,41 @@ final class RightPaneState {
         }
         await refresh()
         closeDiffTabs?(paths)
+    }
+
+    /// Run `git diff HEAD -- <file>` (or `/dev/null` for untracked) and put
+    /// the unified-diff output on the general pasteboard. Best-effort: errors
+    /// are surfaced via `composer.error`. Single source of truth so the
+    /// context menu and any future "Copy Diff" affordances agree.
+    func copyDiff(for path: String) {
+        let wt = worktree.path
+        Task { @MainActor in
+            do {
+                let tracked = (try? await Process.git(
+                    ["ls-files", "--error-unmatch", "--", path],
+                    cwd: wt
+                ))?.exitCode == 0
+                let args: [String]
+                if tracked {
+                    args = ["diff", "--no-color", "HEAD", "--", path]
+                } else {
+                    args = ["diff", "--no-color", "--no-index", "--", "/dev/null", path]
+                }
+                let result = try await Process.git(args, cwd: wt)
+                // `--no-index` exits 1 when there ARE differences (the expected
+                // case for an untracked file).
+                if result.exitCode > 1 {
+                    self.composer.error = result.stderr
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    return
+                }
+                let pb = NSPasteboard.general
+                pb.clearContents()
+                pb.setString(result.stdout, forType: .string)
+            } catch {
+                self.composer.error = (error as NSError).localizedDescription
+            }
+        }
     }
 
     /// Append a gitignore pattern for `path` to `destination` and refresh

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -378,8 +378,25 @@ final class RightPaneState {
     @MainActor
     func confirmDiscard() async {
         guard let pending = pendingDiscard else { return }
-        let paths = pending.paths
         pendingDiscard = nil
+        await runDiscard(pending)
+    }
+
+    /// Run a previously-snapshotted discard. Used by view-layer callers that
+    /// need to capture and clear `pendingDiscard` synchronously in the alert
+    /// button action — the alert's `isPresented` binding fires its `set`
+    /// closure synchronously on dismissal, which would clear `pendingDiscard`
+    /// before the async `confirmDiscard()` could read it.
+    @MainActor
+    func confirmDiscard(_ pending: PendingDiscard) async {
+        // Defensive: if the caller didn't clear `pendingDiscard`, do it now.
+        if pendingDiscard == pending { pendingDiscard = nil }
+        await runDiscard(pending)
+    }
+
+    @MainActor
+    private func runDiscard(_ pending: PendingDiscard) async {
+        let paths = pending.paths
         composer.error = nil
         do {
             try await git.discardPaths(worktreePath: worktree.path, files: paths)

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -6,6 +6,11 @@ import Observation
 final class RightPaneStore {
     private var states: [String: RightPaneState] = [:]
 
+    /// Weak back-reference used to close diff tabs after a successful discard.
+    /// Set by `AppState` after both objects exist. Weak so the store doesn't
+    /// retain the app.
+    weak var appState: AppState?
+
     func state(for worktree: Worktree, baseBranch: String) -> RightPaneState {
         if let existing = states[worktree.id] {
             // Keep the cached state in sync with the currently-configured
@@ -21,14 +26,22 @@ final class RightPaneStore {
             return existing
         }
         let new = RightPaneState(worktree: worktree, baseBranch: baseBranch)
+        let worktreeId = worktree.id
+        new.closeDiffTabs = { [weak self] paths in
+            guard let app = self?.appState else { return }
+            let pathSet = Set(paths)
+            for tab in app.tabs.tabs(forWorktree: worktreeId) {
+                if case .diff(let s) = tab, pathSet.contains(s.relativePath) {
+                    app.closeTab(worktreeId: worktreeId, tabId: s.id)
+                }
+            }
+        }
         states[worktree.id] = new
         new.start()
         return new
     }
 
     func releaseUnselected(keep id: String) {
-        // No-op for v1; states are cheap to keep.
-        // Stop watchers for backgrounded worktrees if memory becomes an issue.
         _ = id
     }
 }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -52,5 +52,31 @@ struct RightPaneView: View {
         .task(id: worktree.id) {
             await rps.refresh()
         }
+        // Host the discard confirmation here (not on ChangesTabView) so
+        // diff-tab Discard actions still present the alert when the right
+        // pane is on the Files tab — `requestDiscardFile` sets pending state
+        // regardless of which child view is mounted.
+        .alert(
+            PendingDiscard.alertTitle(for: rps.pendingDiscard ?? .placeholder),
+            isPresented: Binding(
+                get: { rps.pendingDiscard != nil },
+                set: { if !$0 { rps.cancelDiscard() } }
+            ),
+            presenting: rps.pendingDiscard,
+            actions: { _ in
+                Button("Discard", role: .destructive) {
+                    if let pending = rps.pendingDiscard {
+                        rps.pendingDiscard = nil
+                        Task { @MainActor in await rps.confirmDiscard(pending) }
+                    }
+                }
+                Button("Cancel", role: .cancel) {
+                    rps.cancelDiscard()
+                }
+            },
+            message: { p in
+                Text(PendingDiscard.alertMessage(for: p))
+            }
+        )
     }
 }

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -8,6 +8,7 @@ struct WorkingTreeSectionView: View {
     var onStageAll: (([ChangedFile]) -> Void)? = nil
     var onUnstageAll: (([ChangedFile]) -> Void)? = nil
     var onIgnore: ((_ path: String, _ isDirectory: Bool, _ destination: IgnoreDestination) -> Void)? = nil
+    var onDiscardAll: (() -> Void)? = nil
 
     @Environment(\.theme) private var theme
 
@@ -40,6 +41,12 @@ struct WorkingTreeSectionView: View {
                         AlasButton(title: "Stage all", style: .subtle, action: { onStageAll?(unstaged) })
                     }
                 }
+            }
+            .contextMenu {
+                Button("Discard all working tree changes...") {
+                    onDiscardAll?()
+                }
+                .disabled(changes.isEmpty)
             }
 
             if expanded {

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -9,6 +9,7 @@ struct WorkingTreeSectionView: View {
     var onUnstageAll: (([ChangedFile]) -> Void)? = nil
     var onIgnore: ((_ path: String, _ isDirectory: Bool, _ destination: IgnoreDestination) -> Void)? = nil
     var onDiscardAll: (() -> Void)? = nil
+    var onDiscardFolder: ((String) -> Void)? = nil
 
     @Environment(\.theme) private var theme
 
@@ -190,6 +191,9 @@ struct WorkingTreeSectionView: View {
                     }
                     .buttonStyle(.plain)
                     .contextMenu {
+                        Button("Discard Changes...") {
+                            onDiscardFolder?(node.path)
+                        }
                         if folderUntracked {
                             ignoreMenu(path: node.path, isDirectory: true)
                         }

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -10,6 +10,13 @@ struct WorkingTreeSectionView: View {
     var onIgnore: ((_ path: String, _ isDirectory: Bool, _ destination: IgnoreDestination) -> Void)? = nil
     var onDiscardAll: (() -> Void)? = nil
     var onDiscardFolder: ((String) -> Void)? = nil
+    var onOpenFile:        ((ChangedFile) -> Void)? = nil
+    var onCopyRelative:    ((ChangedFile) -> Void)? = nil
+    var onCopyFull:        ((ChangedFile) -> Void)? = nil
+    var onRevealInFinder:  ((ChangedFile) -> Void)? = nil
+    var onCopyDiff:        ((ChangedFile) -> Void)? = nil
+    var onDiscardFile:     ((ChangedFile) -> Void)? = nil
+    var isOpenFileEnabled: ((ChangedFile) -> Bool)? = nil
 
     @Environment(\.theme) private var theme
 
@@ -212,18 +219,24 @@ struct WorkingTreeSectionView: View {
             )
         } else if let file = filesByPath[node.path] {
             let fileUntracked = isUntracked(file)
+            let ignore: AnyView? = fileUntracked
+                ? AnyView(ignoreMenu(path: file.path, isDirectory: false))
+                : nil
             return AnyView(
                 ChangedRow(
                     file: file,
                     depth: depth,
                     onSelect: { onSelect(file) },
-                    onStage: onToggleStage.map { fn in { fn(file) } }
+                    onStage: onToggleStage.map { fn in { fn(file) } },
+                    onOpenFile: onOpenFile.map { fn in { fn(file) } },
+                    onCopyRelative: onCopyRelative.map { fn in { fn(file) } },
+                    onCopyFull: onCopyFull.map { fn in { fn(file) } },
+                    onRevealInFinder: onRevealInFinder.map { fn in { fn(file) } },
+                    onCopyDiff: onCopyDiff.map { fn in { fn(file) } },
+                    onDiscard: onDiscardFile.map { fn in { fn(file) } },
+                    openFileEnabled: isOpenFileEnabled?(file) ?? true,
+                    ignoreMenu: ignore
                 )
-                .contextMenu {
-                    if fileUntracked {
-                        ignoreMenu(path: file.path, isDirectory: false)
-                    }
-                }
             )
         } else {
             return AnyView(EmptyView())

--- a/AlasTests/DiffParserTests.swift
+++ b/AlasTests/DiffParserTests.swift
@@ -27,4 +27,26 @@ struct DiffParserTests {
         let diff = DiffParser.parse("")
         #expect(diff.hunks.isEmpty)
     }
+
+    @Test func capturesNoTrailingNewlineOnDeleteAndAddSides() {
+        // git diff shape for a one-line modification at EOF where both the
+        // pre- and post-image lack a trailing newline. The `\ No newline...`
+        // sentinel follows each side's content line.
+        let raw = """
+        diff --git a/a.txt b/a.txt
+        --- a/a.txt
+        +++ b/a.txt
+        @@ -1,1 +1,1 @@
+        -old
+        \\ No newline at end of file
+        +new
+        \\ No newline at end of file
+        """
+        let diff = DiffParser.parse(raw)
+        #expect(diff.hunks.count == 1)
+        let lines = diff.hunks[0].lines
+        #expect(lines.count == 2)
+        #expect(lines[0].kind == .delete && lines[0].noTrailingNewline)
+        #expect(lines[1].kind == .add && lines[1].noTrailingNewline)
+    }
 }

--- a/AlasTests/GitServiceDiscardTests.swift
+++ b/AlasTests/GitServiceDiscardTests.swift
@@ -1,0 +1,161 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct GitServiceDiscardTests {
+    private func makeRepo() async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-disc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: dir)
+        return dir
+    }
+
+    private func writeFile(_ repo: URL, _ name: String, _ contents: String) throws {
+        try contents.write(
+            to: repo.appendingPathComponent(name),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private func exists(_ repo: URL, _ name: String) -> Bool {
+        FileManager.default.fileExists(atPath: repo.appendingPathComponent(name).path)
+    }
+
+    @Test func emptyFilesIsNoOp() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let svc = GitService()
+        try await svc.discardPaths(worktreePath: repo, files: [])
+    }
+
+    @Test func discardsTrackedModifiedFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeFile(repo, "a.txt", "original\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try writeFile(repo, "a.txt", "modified\n")
+
+        let svc = GitService()
+        try await svc.discardPaths(worktreePath: repo, files: ["a.txt"])
+        let contents = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(contents == "original\n")
+        let status = try await svc.status(worktreePath: repo)
+        #expect(status.isEmpty)
+    }
+
+    @Test func discardsStagedModification() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeFile(repo, "a.txt", "original\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try writeFile(repo, "a.txt", "staged\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+
+        let svc = GitService()
+        try await svc.discardPaths(worktreePath: repo, files: ["a.txt"])
+        let contents = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(contents == "original\n")
+        let status = try await svc.status(worktreePath: repo)
+        #expect(status.isEmpty)
+    }
+
+    @Test func discardsUntrackedFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeFile(repo, "seed.txt", "x\n")
+        _ = try await Process.git(["add", "seed.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try writeFile(repo, "u.txt", "untracked\n")
+
+        let svc = GitService()
+        try await svc.discardPaths(worktreePath: repo, files: ["u.txt"])
+        #expect(!exists(repo, "u.txt"))
+    }
+
+    @Test func discardsStagedAdd() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeFile(repo, "seed.txt", "x\n")
+        _ = try await Process.git(["add", "seed.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try writeFile(repo, "added.txt", "new\n")
+        _ = try await Process.git(["add", "added.txt"], cwd: repo)
+
+        let svc = GitService()
+        try await svc.discardPaths(worktreePath: repo, files: ["added.txt"])
+        #expect(!exists(repo, "added.txt"))
+        let status = try await svc.status(worktreePath: repo)
+        #expect(status.allSatisfy { $0.path != "added.txt" })
+    }
+
+    @Test func discardsMixedTrackedAndUntracked() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeFile(repo, "a.txt", "v1\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try writeFile(repo, "a.txt", "v2\n")
+        try writeFile(repo, "u.txt", "untracked\n")
+
+        let svc = GitService()
+        try await svc.discardPaths(worktreePath: repo, files: ["a.txt", "u.txt"])
+        let contents = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(contents == "v1\n")
+        #expect(!exists(repo, "u.txt"))
+    }
+
+    @Test func discardsStagedRenameBothPaths() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeFile(repo, "a.txt", "content\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        _ = try await Process.git(["mv", "a.txt", "b.txt"], cwd: repo)
+
+        let svc = GitService()
+        try await svc.discardPaths(worktreePath: repo, files: ["b.txt", "a.txt"])
+        #expect(exists(repo, "a.txt"))
+        #expect(!exists(repo, "b.txt"))
+        let status = try await svc.status(worktreePath: repo)
+        #expect(status.isEmpty)
+    }
+
+    @Test func discardsStagedAddOnUnbornHead() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-unborn-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: repo)
+        try "hello\n".write(
+            to: repo.appendingPathComponent("a.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+
+        let svc = GitService()
+        try await svc.discardPaths(worktreePath: repo, files: ["a.txt"])
+        #expect(!FileManager.default.fileExists(atPath: repo.appendingPathComponent("a.txt").path))
+    }
+
+    @Test func tolerantOfMissingUntrackedPath() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeFile(repo, "seed.txt", "x\n")
+        _ = try await Process.git(["add", "seed.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+
+        // Path was never created — discardPaths should swallow ENOENT.
+        let svc = GitService()
+        try await svc.discardPaths(worktreePath: repo, files: ["ghost.txt"])
+    }
+}

--- a/AlasTests/GitServiceDiscardTests.swift
+++ b/AlasTests/GitServiceDiscardTests.swift
@@ -182,6 +182,31 @@ struct GitServiceDiscardTests {
         #expect(contents == "1\n2\n3\n4\n5\n6\n7\n8\n9\nE\n")
     }
 
+    @Test func applyPatchReverseHandlesEofWithoutTrailingNewline() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        // Seed a file WITHOUT trailing newline.
+        try writeFile(repo, "a.txt", "old")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        // Modify the EOF-without-newline content.
+        try writeFile(repo, "a.txt", "new")
+
+        let svc = GitService()
+        let parsed = try await svc.diff(worktreePath: repo, file: "a.txt")
+        #expect(parsed.hunks.count == 1)
+        // Both pre- and post-image lines should carry the no-newline flag.
+        let lines = parsed.hunks[0].lines
+        #expect(lines.contains { $0.kind == .delete && $0.noTrailingNewline })
+        #expect(lines.contains { $0.kind == .add && $0.noTrailingNewline })
+
+        let patch = HunkPatchBuilder.patch(file: "a.txt", hunk: parsed.hunks[0], tracked: true)
+        try await svc.applyPatchReverse(worktreePath: repo, patch: patch)
+
+        let contents = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(contents == "old")
+    }
+
     @Test func applyPatchReverseThrowsWhenAlreadyApplied() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceDiscardTests.swift
+++ b/AlasTests/GitServiceDiscardTests.swift
@@ -158,4 +158,48 @@ struct GitServiceDiscardTests {
         let svc = GitService()
         try await svc.discardPaths(worktreePath: repo, files: ["ghost.txt"])
     }
+
+    @Test func applyPatchReverseRemovesOneHunk() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        // 10 lines so changes to line 1 and line 10 produce two separate hunks
+        // (git's 3-line context windows do not overlap).
+        try writeFile(repo, "a.txt", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        // Two distinct hunks: change line 1 → A, change line 10 → E.
+        try writeFile(repo, "a.txt", "A\n2\n3\n4\n5\n6\n7\n8\n9\nE\n")
+
+        let svc = GitService()
+        let parsed = try await svc.diff(worktreePath: repo, file: "a.txt")
+        #expect(parsed.hunks.count == 2)
+        let firstHunk = parsed.hunks[0]
+        let patch = HunkPatchBuilder.patch(file: "a.txt", hunk: firstHunk, tracked: true)
+        try await svc.applyPatchReverse(worktreePath: repo, patch: patch)
+
+        let contents = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        // First hunk discarded → line 1 back to "1", line 10 still "E".
+        #expect(contents == "1\n2\n3\n4\n5\n6\n7\n8\n9\nE\n")
+    }
+
+    @Test func applyPatchReverseThrowsWhenAlreadyApplied() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeFile(repo, "a.txt", "1\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        // Build a patch that doesn't match current state.
+        let bogus = """
+        diff --git a/a.txt b/a.txt
+        --- a/a.txt
+        +++ b/a.txt
+        @@ -1,1 +1,1 @@
+        -nope
+        +never
+        """ + "\n"
+        let svc = GitService()
+        await #expect(throws: (any Error).self) {
+            try await svc.applyPatchReverse(worktreePath: repo, patch: bogus)
+        }
+    }
 }

--- a/AlasTests/HunkPatchBuilderTests.swift
+++ b/AlasTests/HunkPatchBuilderTests.swift
@@ -51,6 +51,17 @@ struct HunkPatchBuilderTests {
         #expect(patch.contains("b/café/π.swift"))
     }
 
+    @Test func untrackedFilePatchUsesProvidedMode() {
+        // Stage hunk on a new executable script must emit `new file mode 100755`
+        // so `git apply --cached` doesn't drop the +x bit.
+        let h = hunk("@@ -0,0 +1,1 @@", [add("#!/bin/sh")])
+        let patch = HunkPatchBuilder.patch(
+            file: "run.sh", hunk: h, tracked: false, untrackedMode: "100755"
+        )
+        #expect(patch.contains("new file mode 100755"))
+        #expect(!patch.contains("new file mode 100644"))
+    }
+
     @Test func emitsNoTrailingNewlineSentinelAfterAffectedLines() {
         // Mark both the delete and add as missing their trailing newline.
         // The builder must re-emit the `\ No newline at end of file` marker

--- a/AlasTests/HunkPatchBuilderTests.swift
+++ b/AlasTests/HunkPatchBuilderTests.swift
@@ -1,0 +1,52 @@
+import Testing
+@testable import Alas
+
+struct HunkPatchBuilderTests {
+    private func hunk(_ header: String, _ lines: [ParsedDiff.Hunk.Line]) -> ParsedDiff.Hunk {
+        ParsedDiff.Hunk(header: header, oldStart: 1, newStart: 1, lines: lines)
+    }
+
+    private func ctx(_ s: String) -> ParsedDiff.Hunk.Line {
+        .init(kind: .context, text: s, oldNumber: 1, newNumber: 1)
+    }
+    private func add(_ s: String) -> ParsedDiff.Hunk.Line {
+        .init(kind: .add, text: s, oldNumber: nil, newNumber: 1)
+    }
+    private func del(_ s: String) -> ParsedDiff.Hunk.Line {
+        .init(kind: .delete, text: s, oldNumber: 1, newNumber: nil)
+    }
+
+    @Test func trackedFilePatchHasStandardHeader() {
+        let h = hunk("@@ -10,3 +10,4 @@", [ctx("a"), add("b"), del("c")])
+        let patch = HunkPatchBuilder.patch(file: "src/a.swift", hunk: h, tracked: true)
+        let lines = patch.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[0] == "diff --git a/src/a.swift b/src/a.swift")
+        #expect(lines[1] == "--- a/src/a.swift")
+        #expect(lines[2] == "+++ b/src/a.swift")
+        #expect(lines[3] == "@@ -10,3 +10,4 @@")
+        #expect(lines[4] == " a")
+        #expect(lines[5] == "+b")
+        #expect(lines[6] == "-c")
+        // Trailing newline → final element empty
+        #expect(patch.hasSuffix("\n"))
+    }
+
+    @Test func untrackedFilePatchHasNewFileHeader() {
+        let h = hunk("@@ -0,0 +1,1 @@", [add("hello")])
+        let patch = HunkPatchBuilder.patch(file: "new.txt", hunk: h, tracked: false)
+        let lines = patch.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        #expect(lines[0] == "diff --git a/new.txt b/new.txt")
+        #expect(lines[1] == "new file mode 100644")
+        #expect(lines[2] == "--- /dev/null")
+        #expect(lines[3] == "+++ b/new.txt")
+        #expect(lines[4] == "@@ -0,0 +1,1 @@")
+        #expect(lines[5] == "+hello")
+    }
+
+    @Test func nonAsciiPathPassesThroughUnescaped() {
+        let h = hunk("@@ -1,1 +1,1 @@", [add("x")])
+        let patch = HunkPatchBuilder.patch(file: "café/π.swift", hunk: h, tracked: true)
+        #expect(patch.contains("a/café/π.swift"))
+        #expect(patch.contains("b/café/π.swift"))
+    }
+}

--- a/AlasTests/HunkPatchBuilderTests.swift
+++ b/AlasTests/HunkPatchBuilderTests.swift
@@ -50,4 +50,27 @@ struct HunkPatchBuilderTests {
         #expect(patch.contains("a/café/π.swift"))
         #expect(patch.contains("b/café/π.swift"))
     }
+
+    @Test func emitsNoTrailingNewlineSentinelAfterAffectedLines() {
+        // Mark both the delete and add as missing their trailing newline.
+        // The builder must re-emit the `\ No newline at end of file` marker
+        // immediately after each affected line; without it `git apply`
+        // rejects the patch for EOF-without-newline files.
+        let delLine = ParsedDiff.Hunk.Line(
+            kind: .delete, text: "old", oldNumber: 1, newNumber: nil,
+            noTrailingNewline: true
+        )
+        let addLine = ParsedDiff.Hunk.Line(
+            kind: .add, text: "new", oldNumber: nil, newNumber: 1,
+            noTrailingNewline: true
+        )
+        let h = hunk("@@ -1,1 +1,1 @@", [delLine, addLine])
+        let patch = HunkPatchBuilder.patch(file: "a.txt", hunk: h, tracked: true)
+        let lines = patch.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        // Header (4) + delete + sentinel + add + sentinel + trailing empty.
+        #expect(lines[4] == "-old")
+        #expect(lines[5] == "\\ No newline at end of file")
+        #expect(lines[6] == "+new")
+        #expect(lines[7] == "\\ No newline at end of file")
+    }
 }

--- a/AlasTests/HunkPatchBuilderTests.swift
+++ b/AlasTests/HunkPatchBuilderTests.swift
@@ -41,6 +41,7 @@ struct HunkPatchBuilderTests {
         #expect(lines[3] == "+++ b/new.txt")
         #expect(lines[4] == "@@ -0,0 +1,1 @@")
         #expect(lines[5] == "+hello")
+        #expect(patch.hasSuffix("\n"))
     }
 
     @Test func nonAsciiPathPassesThroughUnescaped() {

--- a/AlasTests/HunkPatchBuilderTests.swift
+++ b/AlasTests/HunkPatchBuilderTests.swift
@@ -44,11 +44,34 @@ struct HunkPatchBuilderTests {
         #expect(patch.hasSuffix("\n"))
     }
 
-    @Test func nonAsciiPathPassesThroughUnescaped() {
+    @Test func nonAsciiPathIsOctalEscapedAndQuoted() {
+        // Matches `git diff` default behavior (core.quotePath=true): non-ASCII
+        // bytes in the header path are wrapped in C-quotes and emitted as
+        // octal escapes. UTF-8 of "é" is C3 A9 → "\303\251".
         let h = hunk("@@ -1,1 +1,1 @@", [add("x")])
-        let patch = HunkPatchBuilder.patch(file: "café/π.swift", hunk: h, tracked: true)
-        #expect(patch.contains("a/café/π.swift"))
-        #expect(patch.contains("b/café/π.swift"))
+        let patch = HunkPatchBuilder.patch(file: "café.swift", hunk: h, tracked: true)
+        #expect(patch.contains("\"a/caf\\303\\251.swift\""))
+        #expect(patch.contains("\"b/caf\\303\\251.swift\""))
+    }
+
+    @Test func tabbedPathIsQuotedAndEscaped() {
+        let h = hunk("@@ -1,1 +1,1 @@", [add("x")])
+        let patch = HunkPatchBuilder.patch(file: "weird\tname.txt", hunk: h, tracked: true)
+        #expect(patch.contains("\"a/weird\\tname.txt\""))
+        #expect(patch.contains("\"b/weird\\tname.txt\""))
+        #expect(patch.contains("--- \"a/weird\\tname.txt\""))
+        #expect(patch.contains("+++ \"b/weird\\tname.txt\""))
+    }
+
+    @Test func plainAsciiPathStaysUnquoted() {
+        // Common case must produce the simpler header form, not gratuitous
+        // quotes — matches `git diff` for plain paths.
+        let h = hunk("@@ -1,1 +1,1 @@", [add("x")])
+        let patch = HunkPatchBuilder.patch(file: "src/foo.swift", hunk: h, tracked: true)
+        #expect(patch.contains("diff --git a/src/foo.swift b/src/foo.swift"))
+        #expect(patch.contains("--- a/src/foo.swift"))
+        #expect(patch.contains("+++ b/src/foo.swift"))
+        #expect(!patch.contains("\""))
     }
 
     @Test func untrackedFilePatchUsesProvidedMode() {

--- a/AlasTests/PendingDiscardTests.swift
+++ b/AlasTests/PendingDiscardTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import Alas
+
+struct PendingDiscardTests {
+    @Test func fileTitleAndMessage() {
+        let p = PendingDiscard(target: .file(path: "src/foo/bar.swift"), paths: ["src/foo/bar.swift"])
+        #expect(PendingDiscard.alertTitle(for: p) == "Discard changes to \u{201C}bar.swift\u{201D}?")
+        #expect(PendingDiscard.alertMessage(for: p)
+            == "This permanently removes your changes to this file. This cannot be undone.")
+    }
+
+    @Test func folderTitleAndMessageSingular() {
+        let p = PendingDiscard(target: .folder(path: "src/foo", fileCount: 1), paths: ["src/foo/a.swift"])
+        #expect(PendingDiscard.alertTitle(for: p) == "Discard changes under \u{201C}src/foo/\u{201D}?")
+        #expect(PendingDiscard.alertMessage(for: p)
+            == "This permanently removes changes to 1 file under this folder. This cannot be undone.")
+    }
+
+    @Test func folderTitleAndMessagePlural() {
+        let p = PendingDiscard(target: .folder(path: "src", fileCount: 7), paths: [])
+        #expect(PendingDiscard.alertMessage(for: p)
+            == "This permanently removes changes to 7 files under this folder. This cannot be undone.")
+    }
+
+    @Test func allTitleAndMessage() {
+        let p = PendingDiscard(target: .all(fileCount: 3), paths: [])
+        #expect(PendingDiscard.alertTitle(for: p) == "Discard all working tree changes?")
+        #expect(PendingDiscard.alertMessage(for: p)
+            == "This permanently removes changes to 3 files (staged, unstaged, and untracked). This cannot be undone.")
+    }
+
+    @Test func allTitleAndMessageSingular() {
+        let p = PendingDiscard(target: .all(fileCount: 1), paths: [])
+        #expect(PendingDiscard.alertMessage(for: p)
+            == "This permanently removes changes to 1 file (staged, unstaged, and untracked). This cannot be undone.")
+    }
+}

--- a/AlasTests/RightPaneStateDiscardPathsTests.swift
+++ b/AlasTests/RightPaneStateDiscardPathsTests.swift
@@ -46,6 +46,17 @@ struct RightPaneStateDiscardPathsTests {
         #expect(paths.sorted() == ["src/new.txt", "src/old.txt"])
     }
 
+    @Test func discardPathsForFolderIncludesCrossFolderRenameOrigin() {
+        // Staged rename whose origin lives OUTSIDE the folder being discarded.
+        // The folder discard must still expand to both new and origin paths so
+        // the deletion of the cross-folder origin is also restored.
+        let changes = [
+            cf("src/new.txt", stage: .staged, status: "R", renameFrom: "docs/old.txt"),
+        ]
+        let paths = RightPaneState.discardPaths(forFolderAt: "src", in: changes)
+        #expect(paths.sorted() == ["docs/old.txt", "src/new.txt"])
+    }
+
     @Test func discardPathsForAllExpandsRenamesAndDeduplicates() {
         let changes = [
             cf("a.txt"),

--- a/AlasTests/RightPaneStateDiscardPathsTests.swift
+++ b/AlasTests/RightPaneStateDiscardPathsTests.swift
@@ -1,0 +1,58 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct RightPaneStateDiscardPathsTests {
+    private func cf(
+        _ path: String,
+        stage: ChangeStage = .unstaged,
+        status: String = "M",
+        renameFrom: String? = nil
+    ) -> ChangedFile {
+        ChangedFile(path: path, status: status, stage: stage, add: 0, del: 0, renameFrom: renameFrom)
+    }
+
+    @Test func discardPathsForFileReturnsSinglePath() {
+        let changes = [cf("a.txt"), cf("b.txt")]
+        #expect(RightPaneState.discardPaths(forFileAt: "a.txt", in: changes) == ["a.txt"])
+    }
+
+    @Test func discardPathsForStagedRenameIncludesOldAndNewPath() {
+        let changes = [cf("b.txt", stage: .staged, status: "R", renameFrom: "a.txt")]
+        #expect(RightPaneState.discardPaths(forFileAt: "b.txt", in: changes) == ["b.txt", "a.txt"])
+    }
+
+    @Test func discardPathsForFileMissingFromChangesReturnsEmpty() {
+        let changes = [cf("a.txt")]
+        #expect(RightPaneState.discardPaths(forFileAt: "missing.txt", in: changes).isEmpty)
+    }
+
+    @Test func discardPathsForFolderMatchesPrefix() {
+        let changes = [
+            cf("src/a.txt"),
+            cf("src/sub/b.txt"),
+            cf("docs/c.txt"),
+            cf("srcfoo.txt"), // not under src/
+        ]
+        let paths = RightPaneState.discardPaths(forFolderAt: "src", in: changes)
+        #expect(paths.sorted() == ["src/a.txt", "src/sub/b.txt"])
+    }
+
+    @Test func discardPathsForFolderIncludesRenameOrigins() {
+        let changes = [
+            cf("src/new.txt", stage: .staged, status: "R", renameFrom: "src/old.txt"),
+        ]
+        let paths = RightPaneState.discardPaths(forFolderAt: "src", in: changes)
+        #expect(paths.sorted() == ["src/new.txt", "src/old.txt"])
+    }
+
+    @Test func discardPathsForAllExpandsRenamesAndDeduplicates() {
+        let changes = [
+            cf("a.txt"),
+            cf("b.txt", stage: .staged, status: "R", renameFrom: "old.txt"),
+            cf("c.txt"),
+        ]
+        let paths = RightPaneState.discardPaths(forAllIn: changes)
+        #expect(Set(paths) == Set(["a.txt", "b.txt", "old.txt", "c.txt"]))
+    }
+}

--- a/AlasTests/RightPaneStateDiscardTests.swift
+++ b/AlasTests/RightPaneStateDiscardTests.swift
@@ -1,0 +1,155 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct RightPaneStateDiscardTests {
+    private func makeRepo() async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-rpsd-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: dir)
+        return dir
+    }
+
+    private func write(_ repo: URL, _ name: String, _ contents: String) throws {
+        try contents.write(
+            to: repo.appendingPathComponent(name),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private func makeState(at path: URL) -> RightPaneState {
+        let wt = Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: "p",
+            name: "test",
+            branch: "main",
+            path: path,
+            status: .clean,
+            lastActivity: Date()
+        )
+        return RightPaneState(worktree: wt, baseBranch: "main")
+    }
+
+    private func porcelain(at repo: URL) async throws -> String {
+        let r = try await Process.git(["status", "--porcelain"], cwd: repo)
+        return r.stdout
+    }
+
+    @Test func requestDiscardFileSetsPendingFromChanges() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try write(repo, "a.txt", "v1\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try write(repo, "a.txt", "v2\n")
+
+        let rps = makeState(at: repo)
+        await rps.refresh()
+        rps.requestDiscardFile(path: "a.txt")
+        #expect(rps.pendingDiscard?.target == .file(path: "a.txt"))
+        #expect(rps.pendingDiscard?.paths == ["a.txt"])
+    }
+
+    @Test func requestDiscardFileForUnknownPathIsNoOp() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try write(repo, "a.txt", "v1\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+
+        let rps = makeState(at: repo)
+        await rps.refresh()
+        rps.requestDiscardFile(path: "missing.txt")
+        #expect(rps.pendingDiscard == nil)
+    }
+
+    @Test func cancelDiscardClearsStateAndLeavesRepoUntouched() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try write(repo, "a.txt", "v1\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try write(repo, "a.txt", "v2\n")
+
+        let rps = makeState(at: repo)
+        await rps.refresh()
+        rps.requestDiscardFile(path: "a.txt")
+        let before = try await porcelain(at: repo)
+        rps.cancelDiscard()
+        let after = try await porcelain(at: repo)
+        #expect(rps.pendingDiscard == nil)
+        #expect(before == after)
+    }
+
+    @Test func confirmDiscardFileRunsGitAndClearsPending() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try write(repo, "a.txt", "v1\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try write(repo, "a.txt", "v2\n")
+
+        let rps = makeState(at: repo)
+        await rps.refresh()
+        rps.requestDiscardFile(path: "a.txt")
+
+        var closedPaths: [String] = []
+        rps.closeDiffTabs = { closedPaths.append(contentsOf: $0) }
+        await rps.confirmDiscard()
+
+        let contents = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(contents == "v1\n")
+        #expect(rps.pendingDiscard == nil)
+        #expect(closedPaths == ["a.txt"])
+    }
+
+    @Test func confirmDiscardFolderHonoursPrefix() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try FileManager.default.createDirectory(
+            at: repo.appendingPathComponent("src"),
+            withIntermediateDirectories: true
+        )
+        try write(repo, "src/a.txt", "v1\n")
+        try write(repo, "outside.txt", "v1\n")
+        _ = try await Process.git(["add", "."], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try write(repo, "src/a.txt", "v2\n")
+        try write(repo, "outside.txt", "v2\n")
+
+        let rps = makeState(at: repo)
+        await rps.refresh()
+        rps.requestDiscardFolder(path: "src")
+        await rps.confirmDiscard()
+
+        let inside = try String(contentsOf: repo.appendingPathComponent("src/a.txt"), encoding: .utf8)
+        let outside = try String(contentsOf: repo.appendingPathComponent("outside.txt"), encoding: .utf8)
+        #expect(inside == "v1\n")
+        #expect(outside == "v2\n")
+    }
+
+    @Test func confirmDiscardAllClearsWorktree() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try write(repo, "a.txt", "v1\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+        try write(repo, "a.txt", "v2\n")
+        try write(repo, "u.txt", "new\n")
+
+        let rps = makeState(at: repo)
+        await rps.refresh()
+        rps.requestDiscardAll()
+        await rps.confirmDiscard()
+
+        let contents = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(contents == "v1\n")
+        #expect(!FileManager.default.fileExists(atPath: repo.appendingPathComponent("u.txt").path))
+    }
+}


### PR DESCRIPTION
## Summary

- **Destructive discard with confirmation** at file / folder / working-tree-header / hunk scopes — single `.alert` on `ChangesTabView` for file/folder/all, local confirmation in `DiffTabView` for per-hunk. Untracked deletions are unrecoverable; alert copy says so explicitly.
- **Per-hunk Stage hunk / Discard hunk** in the diff tab — fixes the bug where "Stage hunk" always operated on the first hunk regardless of which one you clicked. Per-hunk buttons live in each hunk header. Discard hunk is hidden for untracked files (the whole file IS the hunk; file-level Discard already covers it).
- **Full file context menu** on `ChangedRow`: Open File / Copy Relative Path / Copy Full Path / Reveal in Finder / divider / Copy Diff / divider / Stage|Unstage / Discard Changes... — with the existing Ignore submenu merged at the bottom for fully-untracked files.

## Architecture

- New pure helpers: `HunkPatchBuilder.patch(file:hunk:tracked:)`, `PendingDiscard` + alert copy, three static `RightPaneState.discardPaths(...)` derivations (file/folder/all with rename-origin expansion).
- New `GitService` extension: `discardPaths(worktreePath:files:)` and `applyPatchReverse(worktreePath:patch:)`. `discardPaths` handles index-tracked, HEAD-only (staged-rename origins), and truly-untracked paths separately; falls back to `git rm --cached` on unborn HEAD.
- `RightPaneState` owns the `pendingDiscard` state plus `requestDiscardFile/Folder/All`, `confirmDiscard`, and `cancelDiscard`. After a successful discard, a `closeDiffTabs` closure (injected by `RightPaneStore`, weak `AppState` back-ref) closes any open diff tabs whose path was just cleaned.
- `confirmDiscard` snapshots the pending value synchronously in the alert action and passes it into the async path — avoids a SwiftUI race where the `isPresented` binding setter would clear `pendingDiscard` before the dispatched Task ran.

## Test plan

Automated (60 tests across 9 suites, all green locally):

- [x] `HunkPatchBuilderTests` — tracked vs untracked headers, trailing newline, non-ASCII paths.
- [x] `PendingDiscardTests` — title/message + singular/plural for file/folder/all targets.
- [x] `RightPaneStateDiscardPathsTests` — file (with rename), folder prefix, cross-folder rename origin, all-with-dedup.
- [x] `GitServiceDiscardTests` — tracked-modified, staged-modification, untracked, staged-add, mixed, staged-rename, unborn-HEAD, missing-untracked, plus `applyPatchReverse` removing one of two hunks and throwing on bogus patch.
- [x] `RightPaneStateDiscardTests` — request/confirm/cancel (with porcelain byte-equality on cancel), folder-prefix correctness, discard-all clears worktree.
- [x] Regression suites still green: `GitServiceStagingTests`, `GitIgnoreServiceTests`, `RightPaneStateUnstagePathsTests`, `DiffParserTests`.

Manual smoke (passes locally):

- [x] File row context menu shows all items in spec order.
- [x] Folder row Discard Changes... + Ignore submenu (when untracked).
- [x] Working Tree header Discard all (disabled when empty).
- [x] File / folder / all Discard alerts name the target and discard scope; cancel leaves the worktree untouched; confirm refreshes Changes and auto-closes affected diff tabs.
- [x] Per-hunk Stage hunk operates on the clicked hunk; Discard hunk confirmation works; both hidden appropriately for untracked / staged views.
- [x] Top-bar Discard Changes... routes through the same Changes-pane confirmation.
- [x] Failing apply/discard surfaces inline (red strip in diff tab; composer error in Changes pane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)