### PR TITLE
Show ignored files in Files tab

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */; };
 		3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36992F601C8EB6C3D45B584F /* SearchKbd.swift */; };
 		3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */; };
+		35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */; };
 		363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */; };
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
 		3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */; };
@@ -528,6 +529,7 @@
 		57713D7143CFD53124E0523F /* AlasHookCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommand.swift; sourceTree = "<group>"; };
 		57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledFontRegistrar.swift; sourceTree = "<group>"; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
+		5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateFileTreeTests.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPane.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */,
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
+				5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */,
 				B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
@@ -2026,6 +2029,7 @@
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
+				35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */,
 				FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,

--- a/Alas/Sources/Git/FileTreeBuilder.swift
+++ b/Alas/Sources/Git/FileTreeBuilder.swift
@@ -1,11 +1,28 @@
 import Foundation
 
 enum FileTreeBuilder {
-    static func build(paths: [String], badges: [String: String]) -> [FileTreeNode] {
+    static func build(
+        paths: [String],
+        badges: [String: String],
+        visibility: [String: FileVisibility] = [:],
+        directories: Set<String> = [],
+        lazyDirectories: Set<String> = []
+    ) -> [FileTreeNode] {
         var roots: [String: TreeBuildNode] = [:]
+        let nestedDirectories = nestedDirectoryPaths(paths)
         for path in paths {
             let parts = path.split(separator: "/").map(String.init)
-            insert(parts: parts, into: &roots, fullPath: path, badges: badges, prefix: "")
+            insert(
+                parts: parts,
+                into: &roots,
+                fullPath: path,
+                badges: badges,
+                visibility: visibility,
+                directories: directories,
+                lazyDirectories: lazyDirectories,
+                nestedDirectories: nestedDirectories,
+                prefix: ""
+            )
         }
         return finalise(roots).sorted(by: nodeOrder)
     }
@@ -15,12 +32,23 @@ enum FileTreeBuilder {
         let path: String
         let isDir: Bool
         var badge: String?
+        var visibility: FileVisibility
+        var childrenState: DirectoryChildrenState
         var children: [String: TreeBuildNode] = [:]
-        init(name: String, path: String, isDir: Bool, badge: String?) {
+        init(
+            name: String,
+            path: String,
+            isDir: Bool,
+            badge: String?,
+            visibility: FileVisibility,
+            childrenState: DirectoryChildrenState
+        ) {
             self.name = name
             self.path = path
             self.isDir = isDir
             self.badge = badge
+            self.visibility = visibility
+            self.childrenState = childrenState
         }
     }
 
@@ -29,25 +57,129 @@ enum FileTreeBuilder {
         into map: inout [String: TreeBuildNode],
         fullPath: String,
         badges: [String: String],
+        visibility: [String: FileVisibility],
+        directories: Set<String>,
+        lazyDirectories: Set<String>,
+        nestedDirectories: Set<String>,
         prefix: String
     ) {
         guard let head = parts.first else { return }
         let isLeaf = parts.count == 1
         let nodePath = prefix.isEmpty ? head : "\(prefix)/\(head)"
+        let hasDirectoryMetadata = isDirectoryPath(
+            fullPath,
+            directories: directories,
+            lazyDirectories: lazyDirectories
+        )
+        let hasNestedChildren = nestedDirectories.contains(nodePath)
+        let explicitDirectory = hasDirectoryMetadata && !hasNestedChildren
+        let isDir = !isLeaf || explicitDirectory
         if isLeaf {
-            let key = nodeKey(name: head, isDir: false)
+            if hasDirectoryMetadata && hasNestedChildren {
+                upsertDirectory(
+                    name: head,
+                    path: nodePath,
+                    into: &map,
+                    visibility: visibility,
+                    lazyDirectories: lazyDirectories
+                )
+            }
+            let key = nodeKey(name: head, isDir: isDir)
             let existing = map[key]
             let badge = badges[fullPath]
             if existing == nil {
-                map[key] = TreeBuildNode(name: head, path: nodePath, isDir: false, badge: badge)
+                map[key] = TreeBuildNode(
+                    name: head,
+                    path: nodePath,
+                    isDir: isDir,
+                    badge: badge,
+                    visibility: nodeVisibility(nodePath, visibility: visibility),
+                    childrenState: childrenState(path: nodePath, isDir: isDir, lazyDirectories: lazyDirectories)
+                )
+            } else {
+                existing?.badge = badge
+                existing?.visibility = nodeVisibility(nodePath, visibility: visibility)
+                existing?.childrenState = childrenState(path: nodePath, isDir: isDir, lazyDirectories: lazyDirectories)
             }
         } else {
             let key = nodeKey(name: head, isDir: true)
             let existing = map[key]
-            let dir = existing ?? TreeBuildNode(name: head, path: nodePath, isDir: true, badge: nil)
+            let dir = existing ?? TreeBuildNode(
+                name: head,
+                path: nodePath,
+                isDir: true,
+                badge: nil,
+                visibility: nodeVisibility(nodePath, visibility: visibility),
+                childrenState: childrenState(path: nodePath, isDir: true, lazyDirectories: lazyDirectories)
+            )
+            dir.visibility = nodeVisibility(nodePath, visibility: visibility)
+            dir.childrenState = childrenState(path: nodePath, isDir: true, lazyDirectories: lazyDirectories)
             map[key] = dir
-            insert(parts: Array(parts.dropFirst()), into: &dir.children, fullPath: fullPath, badges: badges, prefix: nodePath)
+            insert(
+                parts: Array(parts.dropFirst()),
+                into: &dir.children,
+                fullPath: fullPath,
+                badges: badges,
+                visibility: visibility,
+                directories: directories,
+                lazyDirectories: lazyDirectories,
+                nestedDirectories: nestedDirectories,
+                prefix: nodePath
+            )
         }
+    }
+
+    private static func upsertDirectory(
+        name: String,
+        path: String,
+        into map: inout [String: TreeBuildNode],
+        visibility: [String: FileVisibility],
+        lazyDirectories: Set<String>
+    ) {
+        let key = nodeKey(name: name, isDir: true)
+        let dir = map[key] ?? TreeBuildNode(
+            name: name,
+            path: path,
+            isDir: true,
+            badge: nil,
+            visibility: nodeVisibility(path, visibility: visibility),
+            childrenState: childrenState(path: path, isDir: true, lazyDirectories: lazyDirectories)
+        )
+        dir.visibility = nodeVisibility(path, visibility: visibility)
+        dir.childrenState = childrenState(path: path, isDir: true, lazyDirectories: lazyDirectories)
+        map[key] = dir
+    }
+
+    private static func nestedDirectoryPaths(_ paths: [String]) -> Set<String> {
+        var directories: Set<String> = []
+        for path in paths {
+            let parts = path.split(separator: "/").map(String.init)
+            guard parts.count > 1 else { continue }
+            for index in 1..<parts.count {
+                directories.insert(parts.prefix(index).joined(separator: "/"))
+            }
+        }
+        return directories
+    }
+
+    private static func isDirectoryPath(
+        _ path: String,
+        directories: Set<String>,
+        lazyDirectories: Set<String>
+    ) -> Bool {
+        directories.contains(path) || lazyDirectories.contains(path)
+    }
+
+    private static func nodeVisibility(_ path: String, visibility: [String: FileVisibility]) -> FileVisibility {
+        visibility[path] ?? .tracked
+    }
+
+    private static func childrenState(
+        path: String,
+        isDir: Bool,
+        lazyDirectories: Set<String>
+    ) -> DirectoryChildrenState {
+        isDir && lazyDirectories.contains(path) ? .notLoaded : .loaded
     }
 
     private static func nodeKey(name: String, isDir: Bool) -> String {
@@ -56,13 +188,17 @@ enum FileTreeBuilder {
 
     private static func finalise(_ map: [String: TreeBuildNode]) -> [FileTreeNode] {
         map.values.map { node -> FileTreeNode in
-            let kids = node.isDir ? finalise(node.children).sorted(by: nodeOrder) : nil
+            let kids = node.isDir && node.childrenState != .notLoaded
+                ? finalise(node.children).sorted(by: nodeOrder)
+                : nil
             return FileTreeNode(
                 name: node.name,
                 path: node.path,
                 kind: node.isDir ? .dir : .file,
                 children: kids,
-                badge: node.badge
+                badge: node.badge,
+                visibility: node.visibility,
+                childrenState: node.childrenState
             )
         }
     }

--- a/Alas/Sources/Git/FileTreeBuilder.swift
+++ b/Alas/Sources/Git/FileTreeBuilder.swift
@@ -75,6 +75,7 @@ enum FileTreeBuilder {
         let explicitDirectory = hasDirectoryMetadata && !hasNestedChildren
         let isDir = !isLeaf || explicitDirectory
         if isLeaf {
+            let badge = badges[fullPath]
             if hasDirectoryMetadata && hasNestedChildren {
                 upsertDirectory(
                     name: head,
@@ -83,10 +84,10 @@ enum FileTreeBuilder {
                     visibility: visibility,
                     lazyDirectories: lazyDirectories
                 )
+                if badge == nil { return }
             }
             let key = nodeKey(name: head, isDir: isDir)
             let existing = map[key]
-            let badge = badges[fullPath]
             if existing == nil {
                 map[key] = TreeBuildNode(
                     name: head,

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -427,6 +427,7 @@ extension GitService {
         var visibility: [String: FileVisibility] = [:]
         for entry in checkIgnoreMatches(result.stdout) {
             guard let root = queriedPathToRoot[entry.path] else { continue }
+            guard !entry.pattern.hasPrefix("!") else { continue }
             let source = normalizedPath(entry.source, relativeTo: worktreePath)
             visibility[root] = excludedSourcePaths.contains(source) ? .excluded : .ignored
         }
@@ -435,6 +436,7 @@ extension GitService {
 
     private struct CheckIgnoreMatch {
         let source: String
+        let pattern: String
         let path: String
     }
 
@@ -443,7 +445,7 @@ extension GitService {
         var matches: [CheckIgnoreMatch] = []
         var index = 0
         while index + 3 < fields.count {
-            matches.append(CheckIgnoreMatch(source: fields[index], path: fields[index + 3]))
+            matches.append(CheckIgnoreMatch(source: fields[index], pattern: fields[index + 2], path: fields[index + 3]))
             index += 4
         }
         return matches

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -342,7 +342,7 @@ extension GitService {
         let visiblePaths = Set(try await gitVisibleFilePaths(worktreePath: worktreePath))
         var visibility: [String: FileVisibility] = [:]
         let ignoredCandidates = candidates.filter { candidate in
-            if visiblePaths.contains(candidate.path) || hasVisibleDescendant(of: candidate.path, in: visiblePaths) {
+            if visiblePaths.contains(candidate.path) {
                 visibility[candidate.path] = .tracked
                 return false
             }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -252,17 +252,186 @@ extension GitService {
     }
 
     func fileTree(worktreePath: URL, statusEntries: [ChangedFile]) async throws -> [FileTreeNode] {
+        let visiblePaths = try await gitVisibleFilePaths(worktreePath: worktreePath)
+        var paths = Set(visiblePaths)
+        var badges: [String: String] = [:]
+        var visibility: [String: FileVisibility] = [:]
+        var directories = Set<String>()
+        var lazyDirectories = Set<String>()
+
+        for entry in statusEntries {
+            badges[entry.path] = entry.status
+            if entry.status == "A" {
+                visibility[entry.path] = .untracked
+            }
+        }
+
+        let rootEntries = try FileManager.default.contentsOfDirectory(
+            at: worktreePath,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
+            options: []
+        )
+        let excludedSources = try await excludedSourcePaths(worktreePath: worktreePath)
+        let candidateRootEntries = rootEntries.compactMap { url -> RootIgnoreCandidate? in
+            let rel = url.lastPathComponent
+            guard rel != ".git", !paths.contains(rel) else { return nil }
+            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            return RootIgnoreCandidate(path: rel, isDirectory: isDirectory)
+        }
+        let rootVisibility = try await ignoredOrExcludedVisibility(
+            candidates: candidateRootEntries,
+            worktreePath: worktreePath,
+            excludedSourcePaths: excludedSources
+        )
+
+        for candidate in candidateRootEntries {
+            let rel = candidate.path
+            guard let kind = rootVisibility[rel] else { continue }
+            visibility[rel] = kind
+            if candidate.isDirectory {
+                directories.insert(rel)
+                guard !hasVisibleDescendant(of: rel, in: paths) else { continue }
+                lazyDirectories.insert(rel)
+            }
+            paths.insert(rel)
+        }
+
+        return FileTreeBuilder.build(
+            paths: Array(paths),
+            badges: badges,
+            visibility: visibility,
+            directories: directories,
+            lazyDirectories: lazyDirectories
+        )
+    }
+
+    private func gitVisibleFilePaths(worktreePath: URL) async throws -> [String] {
         let result = try await Process.git(
             ["ls-files", "--cached", "--others", "--exclude-standard"],
             cwd: worktreePath
         )
-        let paths = result.stdout
+        return result.stdout
             .split(separator: "\n")
             .map(String.init)
             .filter { !$0.isEmpty }
-        var badges: [String: String] = [:]
-        for entry in statusEntries { badges[entry.path] = entry.status }
-        return FileTreeBuilder.build(paths: paths, badges: badges)
+    }
+
+    private struct RootIgnoreCandidate {
+        let path: String
+        let isDirectory: Bool
+    }
+
+    private func ignoredOrExcludedVisibility(
+        candidates: [RootIgnoreCandidate],
+        worktreePath: URL,
+        excludedSourcePaths: Set<String>
+    ) async throws -> [String: FileVisibility] {
+        guard !candidates.isEmpty else { return [:] }
+
+        var queriedPathToRoot: [String: String] = [:]
+        var inputPaths: [String] = []
+        for candidate in candidates {
+            inputPaths.append(candidate.path)
+            queriedPathToRoot[candidate.path] = candidate.path
+            if candidate.isDirectory {
+                let directoryPath = "\(candidate.path)/"
+                inputPaths.append(directoryPath)
+                queriedPathToRoot[directoryPath] = candidate.path
+            }
+        }
+
+        let result = try await Process.git(
+            ["check-ignore", "--stdin", "--no-index", "-v", "-z"],
+            cwd: worktreePath,
+            stdin: inputPaths.joined(separator: "\0") + "\0"
+        )
+        guard result.exitCode == 0 else { return [:] }
+
+        var visibility: [String: FileVisibility] = [:]
+        for entry in checkIgnoreMatches(result.stdout) {
+            guard let root = queriedPathToRoot[entry.path] else { continue }
+            let source = normalizedPath(entry.source, relativeTo: worktreePath)
+            visibility[root] = excludedSourcePaths.contains(source) ? .excluded : .ignored
+        }
+        return visibility
+    }
+
+    private struct CheckIgnoreMatch {
+        let source: String
+        let path: String
+    }
+
+    private func checkIgnoreMatches(_ output: String) -> [CheckIgnoreMatch] {
+        let fields = output.split(separator: "\0", omittingEmptySubsequences: true).map(String.init)
+        var matches: [CheckIgnoreMatch] = []
+        var index = 0
+        while index + 3 < fields.count {
+            matches.append(CheckIgnoreMatch(source: fields[index], path: fields[index + 3]))
+            index += 4
+        }
+        return matches
+    }
+
+    private func hasVisibleDescendant(of root: String, in paths: Set<String>) -> Bool {
+        let prefix = "\(root)/"
+        return paths.contains { $0.hasPrefix(prefix) }
+    }
+
+    private func excludedSourcePaths(worktreePath: URL) async throws -> Set<String> {
+        var paths: Set<String> = []
+
+        let infoExclude = try await Process.git(
+            ["rev-parse", "--git-path", "info/exclude"],
+            cwd: worktreePath
+        )
+        if infoExclude.exitCode == 0 {
+            let path = infoExclude.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !path.isEmpty {
+                paths.insert(normalizedPath(path, relativeTo: worktreePath))
+            }
+        }
+
+        let result = try await Process.git(
+            ["config", "--path", "--get", "core.excludesfile"],
+            cwd: worktreePath
+        )
+        if result.exitCode == 0 {
+            let path = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !path.isEmpty {
+                paths.insert(normalizedPath(path, relativeTo: worktreePath))
+            }
+        }
+        if let defaultGlobalExcludes = defaultGlobalExcludesPath() {
+            paths.insert(normalizedPath(defaultGlobalExcludes, relativeTo: worktreePath))
+        }
+
+        return paths
+    }
+
+    private func defaultGlobalExcludesPath() -> String? {
+        if let xdgConfigHome = getenv("XDG_CONFIG_HOME").flatMap({ String(validatingUTF8: $0) }),
+           !xdgConfigHome.isEmpty {
+            return URL(fileURLWithPath: xdgConfigHome)
+                .appendingPathComponent("git")
+                .appendingPathComponent("ignore")
+                .path
+        }
+        guard let home = getenv("HOME").flatMap({ String(validatingUTF8: $0) }),
+              !home.isEmpty else {
+            return nil
+        }
+        return URL(fileURLWithPath: home)
+            .appendingPathComponent(".config")
+            .appendingPathComponent("git")
+            .appendingPathComponent("ignore")
+            .path
+    }
+
+    private func normalizedPath(_ path: String, relativeTo base: URL) -> String {
+        let url = path.hasPrefix("/")
+            ? URL(fileURLWithPath: path)
+            : base.appendingPathComponent(path)
+        return url.standardizedFileURL.path
     }
 }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1,6 +1,9 @@
 import Foundation
+import os
 
 struct GitService {
+    private static let logger = Logger(subsystem: "io.nlopez.alas", category: "git-service")
+
     func isGitRepository(_ path: URL) async throws -> Bool {
         let result = try await Process.git(["rev-parse", "--is-inside-work-tree"], cwd: path)
         return result.exitCode == 0 &&
@@ -266,34 +269,40 @@ extension GitService {
             }
         }
 
-        let rootEntries = try FileManager.default.contentsOfDirectory(
-            at: worktreePath,
-            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
-            options: []
-        )
-        let excludedSources = try await excludedSourcePaths(worktreePath: worktreePath)
-        let candidateRootEntries = rootEntries.compactMap { url -> RootIgnoreCandidate? in
-            let rel = url.lastPathComponent
-            guard rel != ".git", !paths.contains(rel) else { return nil }
-            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
-            return RootIgnoreCandidate(path: rel, isDirectory: isDirectory)
-        }
-        let rootVisibility = try await ignoredOrExcludedVisibility(
-            candidates: candidateRootEntries,
-            worktreePath: worktreePath,
-            excludedSourcePaths: excludedSources
-        )
-
-        for candidate in candidateRootEntries {
-            let rel = candidate.path
-            guard let kind = rootVisibility[rel] else { continue }
-            visibility[rel] = kind
-            if candidate.isDirectory {
-                directories.insert(rel)
-                guard !hasVisibleDescendant(of: rel, in: paths) else { continue }
-                lazyDirectories.insert(rel)
+        do {
+            let rootEntries = try FileManager.default.contentsOfDirectory(
+                at: worktreePath,
+                includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
+                options: []
+            )
+            let excludedSources = try await excludedSourcePaths(worktreePath: worktreePath)
+            let candidateRootEntries = rootEntries.compactMap { url -> RootIgnoreCandidate? in
+                let rel = url.lastPathComponent
+                guard rel != ".git", !paths.contains(rel) else { return nil }
+                let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+                return RootIgnoreCandidate(path: rel, isDirectory: isDirectory)
             }
-            paths.insert(rel)
+            let rootVisibility = try await ignoredOrExcludedVisibility(
+                candidates: candidateRootEntries,
+                worktreePath: worktreePath,
+                excludedSourcePaths: excludedSources
+            )
+
+            for candidate in candidateRootEntries {
+                let rel = candidate.path
+                guard let kind = rootVisibility[rel] else { continue }
+                visibility[rel] = kind
+                if candidate.isDirectory {
+                    directories.insert(rel)
+                    guard !hasVisibleDescendant(of: rel, in: paths) else { continue }
+                    lazyDirectories.insert(rel)
+                }
+                paths.insert(rel)
+            }
+        } catch {
+            // Git-visible paths are still useful if the best-effort all-files
+            // root scan or ignore classification fails.
+            Self.logger.error("file tree root scan failed for \(worktreePath.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
 
         return FileTreeBuilder.build(
@@ -330,11 +339,21 @@ extension GitService {
         }
 
         let excludedSources = try await excludedSourcePaths(worktreePath: worktreePath)
-        var visibility = try await ignoredOrExcludedVisibility(
-            candidates: candidates,
+        let visiblePaths = Set(try await gitVisibleFilePaths(worktreePath: worktreePath))
+        var visibility: [String: FileVisibility] = [:]
+        let ignoredCandidates = candidates.filter { candidate in
+            if visiblePaths.contains(candidate.path) || hasVisibleDescendant(of: candidate.path, in: visiblePaths) {
+                visibility[candidate.path] = .tracked
+                return false
+            }
+            return true
+        }
+        let ignoredVisibility = try await ignoredOrExcludedVisibility(
+            candidates: ignoredCandidates,
             worktreePath: worktreePath,
             excludedSourcePaths: excludedSources
         )
+        visibility.merge(ignoredVisibility) { current, _ in current }
         for path in childPaths where visibility[path] == nil {
             visibility[path] = .tracked
         }
@@ -346,12 +365,21 @@ extension GitService {
             directories: directories,
             lazyDirectories: lazyDirectories
         )
-        return built.flatMap { node in
-            if node.path == path, let children = node.children {
-                return children
+        guard !path.isEmpty else { return built }
+        return findFileTreeNode(path: path, in: built)?.children ?? []
+    }
+
+    private func findFileTreeNode(path: String, in nodes: [FileTreeNode]) -> FileTreeNode? {
+        for node in nodes {
+            if node.path == path {
+                return node
             }
-            return [node]
+            if let children = node.children,
+               let found = findFileTreeNode(path: path, in: children) {
+                return found
+            }
         }
+        return nil
     }
 
     private func gitVisibleFilePaths(worktreePath: URL) async throws -> [String] {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -305,6 +305,55 @@ extension GitService {
         )
     }
 
+    func fileTreeChildren(worktreePath: URL, path: String) async throws -> [FileTreeNode] {
+        let directory = worktreePath.appendingPathComponent(path)
+        let urls = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
+            options: []
+        )
+
+        var childPaths: [String] = []
+        var directories = Set<String>()
+        var lazyDirectories = Set<String>()
+        var candidates: [RootIgnoreCandidate] = []
+
+        for url in urls where url.lastPathComponent != ".git" {
+            let rel = path.isEmpty ? url.lastPathComponent : "\(path)/\(url.lastPathComponent)"
+            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            childPaths.append(rel)
+            candidates.append(RootIgnoreCandidate(path: rel, isDirectory: isDirectory))
+            if isDirectory {
+                directories.insert(rel)
+                lazyDirectories.insert(rel)
+            }
+        }
+
+        let excludedSources = try await excludedSourcePaths(worktreePath: worktreePath)
+        var visibility = try await ignoredOrExcludedVisibility(
+            candidates: candidates,
+            worktreePath: worktreePath,
+            excludedSourcePaths: excludedSources
+        )
+        for path in childPaths where visibility[path] == nil {
+            visibility[path] = .tracked
+        }
+
+        let built = FileTreeBuilder.build(
+            paths: childPaths,
+            badges: [:],
+            visibility: visibility,
+            directories: directories,
+            lazyDirectories: lazyDirectories
+        )
+        return built.flatMap { node in
+            if node.path == path, let children = node.children {
+                return children
+            }
+            return [node]
+        }
+    }
+
     private func gitVisibleFilePaths(worktreePath: URL) async throws -> [String] {
         let result = try await Process.git(
             ["ls-files", "--cached", "--others", "--exclude-standard"],

--- a/Alas/Sources/Git/GitTypes.swift
+++ b/Alas/Sources/Git/GitTypes.swift
@@ -35,6 +35,20 @@ enum ChangeStage: String, Codable {
     case unstaged
 }
 
+enum FileVisibility: String, Equatable, Codable {
+    case tracked
+    case untracked
+    case ignored
+    case excluded
+}
+
+enum DirectoryChildrenState: String, Equatable, Codable {
+    case loaded
+    case notLoaded
+    case loading
+    case failed
+}
+
 struct FileTreeNode: Identifiable, Equatable, Codable {
     var id: String { "\(kind.rawValue):\(path)" }
     let name: String
@@ -42,6 +56,8 @@ struct FileTreeNode: Identifiable, Equatable, Codable {
     let kind: Kind
     var children: [FileTreeNode]?
     var badge: String?        // "A"|"M"|"D"|"R" if status non-empty
+    var visibility: FileVisibility = .tracked
+    var childrenState: DirectoryChildrenState = .loaded
 
     enum Kind: String, Codable { case dir, file }
 }

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -25,6 +25,7 @@ extension Process {
         args: [String],
         cwd: URL? = nil,
         env: [String: String]? = nil,
+        stdin: String? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResult {
         let process = Process()
@@ -33,8 +34,11 @@ extension Process {
         if let cwd { process.currentDirectoryURL = cwd }
         if let env { process.environment = env }
 
+        let stdinWriter = stdin.map(StdinPipeWriter.init)
+        let inputPipe = stdinWriter.map { _ in Pipe() }
         let outPipe = Pipe()
         let errPipe = Pipe()
+        if let inputPipe { process.standardInput = inputPipe }
         process.standardOutput = outPipe
         process.standardError = errPipe
 
@@ -94,12 +98,17 @@ extension Process {
             if Task.isCancelled { return }
             if process.isRunning {
                 timeoutState.markTimedOut()
+                stdinWriter?.close()
                 fputs(
                     "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
                     stderr
                 )
                 process.terminate()
             }
+        }
+
+        if let inputPipe {
+            stdinWriter?.start(pipe: inputPipe)
         }
 
         // SIGTERM the child if the awaiting Task is cancelled. The
@@ -110,9 +119,11 @@ extension Process {
         await withTaskCancellationHandler {
             await exit.wait()
         } onCancel: {
+            stdinWriter?.close()
             if process.isRunning { process.terminate() }
         }
         watchdog.cancel()
+        stdinWriter?.close()
 
         // Wait for both pipes to actually report EOF before we drop the
         // readability handlers — a fixed grace period would truncate
@@ -164,6 +175,7 @@ extension Process {
     static func git(
         _ args: [String],
         cwd: URL? = nil,
+        stdin: String? = nil,
         timeout: TimeInterval = Process.defaultTimeout
     ) async throws -> ProcessResult {
         try await run(
@@ -171,6 +183,7 @@ extension Process {
             args: ["git"] + args,
             cwd: cwd,
             env: gitEnv(),
+            stdin: stdin,
             timeout: timeout
         )
     }
@@ -190,6 +203,87 @@ private final class TimeoutState: @unchecked Sendable {
         lock.lock()
         timedOut = true
         lock.unlock()
+    }
+}
+
+private final class StdinPipeWriter: @unchecked Sendable {
+    private let lock = NSLock()
+    private let data: Data
+    private var offset = 0
+    private var closed = false
+    private weak var handle: FileHandle?
+    private let chunkSize = 16 * 1024
+
+    init(_ stdin: String) {
+        self.data = Data(stdin.utf8)
+    }
+
+    func start(pipe: Pipe) {
+        let writeHandle = pipe.fileHandleForWriting
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            try? writeHandle.close()
+            return
+        }
+        handle = writeHandle
+        if data.isEmpty {
+            closed = true
+            handle = nil
+            lock.unlock()
+            try? writeHandle.close()
+            return
+        }
+        lock.unlock()
+
+        writeHandle.writeabilityHandler = { [weak self] handle in
+            self?.writeAvailable(handle)
+        }
+    }
+
+    func close() {
+        lock.lock()
+        guard !closed else {
+            lock.unlock()
+            return
+        }
+        closed = true
+        let writeHandle = handle
+        handle = nil
+        lock.unlock()
+
+        writeHandle?.writeabilityHandler = nil
+        try? writeHandle?.close()
+    }
+
+    private func writeAvailable(_ writeHandle: FileHandle) {
+        let chunk: Data?
+        lock.lock()
+        if closed || offset >= data.count {
+            closed = true
+            handle = nil
+            lock.unlock()
+            writeHandle.writeabilityHandler = nil
+            try? writeHandle.close()
+            return
+        }
+        let end = min(offset + chunkSize, data.count)
+        chunk = data[offset..<end]
+        offset = end
+        let didFinish = offset >= data.count
+        if didFinish {
+            closed = true
+            handle = nil
+        }
+        lock.unlock()
+
+        if let chunk {
+            writeHandle.write(chunk)
+        }
+        if didFinish {
+            writeHandle.writeabilityHandler = nil
+            try? writeHandle.close()
+        }
     }
 }
 

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -4,6 +4,7 @@ struct FilesTabView: View {
     let nodes: [FileTreeNode]
     @Binding var openPaths: Set<String>
     let onSelectFile: (FileTreeNode) -> Void
+    let onLoadChildren: (String) -> Void
 
     @Environment(\.theme) private var theme
 
@@ -24,25 +25,57 @@ struct FilesTabView: View {
             return AnyView(
                 Group {
                     Button {
-                        if open { openPaths.remove(node.path) } else { openPaths.insert(node.path) }
+                        if open {
+                            openPaths.remove(node.path)
+                        } else {
+                            openPaths.insert(node.path)
+                            onLoadChildren(node.path)
+                        }
                     } label: {
                         HStack(spacing: 6) {
                             Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
-                            Icon(name: "folder", size: 11, color: open ? theme.color("accent") : theme.color("fg-dim"))
+                            Icon(name: "folder", size: 11, color: folderColor(for: node, open: open))
                             Text(node.name)
                                 .font(.system(size: 11.5, design: .monospaced))
-                                .foregroundColor(theme.color("fg"))
+                                .foregroundColor(rowForeground(for: node))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
                             Spacer()
+                            if isOffGit(node) {
+                                visibilityPill(node)
+                            }
                         }
                         .padding(.leading, CGFloat(12 + depth * 14))
                         .padding(.trailing, 12)
                         .padding(.vertical, 4)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .opacity(isOffGit(node) ? 0.72 : 1.0)
+                        .overlay(alignment: .leading) {
+                            if isOffGit(node) {
+                                ghostRail(depth: depth)
+                            }
+                        }
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    if open, let kids = node.children {
-                        ForEach(kids) { renderNode($0, depth: depth + 1) }
+                    if open {
+                        switch node.childrenState {
+                        case .loading:
+                            treeMessage("Loading...", depth: depth + 1)
+                            renderChildren(of: node, depth: depth + 1)
+                        case .failed:
+                            treeMessage("Could not load children", depth: depth + 1)
+                            renderChildren(of: node, depth: depth + 1)
+                        case .loaded:
+                            renderChildren(of: node, depth: depth + 1)
+                        case .notLoaded:
+                            EmptyView()
+                        }
+                    }
+                }
+                .task(id: loadTaskID(for: node, open: open)) {
+                    if shouldAutoLoadChildren(for: node, open: open) {
+                        onLoadChildren(node.path)
                     }
                 }
             )
@@ -53,8 +86,13 @@ struct FilesTabView: View {
                         FileTypeIconView(filename: node.name, size: 18)
                         Text(node.name)
                             .font(.system(size: 11.5, design: .monospaced))
-                            .foregroundColor(theme.color("fg"))
+                            .foregroundColor(rowForeground(for: node))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
                         Spacer()
+                        if isOffGit(node) {
+                            visibilityPill(node)
+                        }
                         if let badge = node.badge {
                             StatusBadge(status: badge)
                         }
@@ -63,10 +101,75 @@ struct FilesTabView: View {
                     .padding(.trailing, 12)
                     .padding(.vertical, 4)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .opacity(isOffGit(node) ? 0.72 : 1.0)
+                    .overlay(alignment: .leading) {
+                        if isOffGit(node) {
+                            ghostRail(depth: depth)
+                        }
+                    }
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
             )
         }
+    }
+
+    private func loadTaskID(for node: FileTreeNode, open: Bool) -> String {
+        "\(node.path):\(open):\(node.childrenState.rawValue)"
+    }
+
+    private func shouldAutoLoadChildren(for node: FileTreeNode, open: Bool) -> Bool {
+        open && node.childrenState == .notLoaded
+    }
+
+    private func renderChildren(of node: FileTreeNode, depth: Int) -> some View {
+        Group {
+            if let kids = node.children {
+                ForEach(kids) { renderNode($0, depth: depth) }
+            }
+        }
+    }
+
+    private func isOffGit(_ node: FileTreeNode) -> Bool {
+        node.visibility == .ignored || node.visibility == .excluded
+    }
+
+    private func rowForeground(for node: FileTreeNode) -> Color {
+        isOffGit(node) ? theme.color("fg-dim") : theme.color("fg")
+    }
+
+    private func folderColor(for node: FileTreeNode, open: Bool) -> Color {
+        if isOffGit(node) {
+            return theme.color("fg-dim")
+        }
+        return open ? theme.color("accent") : theme.color("fg-dim")
+    }
+
+    private func visibilityPill(_ node: FileTreeNode) -> some View {
+        Text(node.visibility.rawValue)
+            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+            .foregroundColor(theme.color("fg-dim"))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(theme.color("bg-4").opacity(0.75))
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+
+    private func ghostRail(depth: Int) -> some View {
+        Rectangle()
+            .fill(theme.color("fg-faint").opacity(0.55))
+            .frame(width: 2)
+            .padding(.leading, CGFloat(8 + depth * 14))
+            .padding(.vertical, 4)
+    }
+
+    private func treeMessage(_ text: String, depth: Int) -> some View {
+        Text(text)
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundColor(theme.color("fg-faint"))
+            .padding(.leading, CGFloat(12 + depth * 14 + 14))
+            .padding(.trailing, 12)
+            .padding(.vertical, 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -2,8 +2,10 @@ import SwiftUI
 
 struct FilesTabView: View {
     let nodes: [FileTreeNode]
+    let fileTreeGeneration: Int
     @Binding var openPaths: Set<String>
     let onSelectFile: (FileTreeNode) -> Void
+    let shouldAutoLoadChildren: (String, DirectoryChildrenState) -> Bool
     let onLoadChildren: (String) -> Void
 
     @Environment(\.theme) private var theme
@@ -115,11 +117,11 @@ struct FilesTabView: View {
     }
 
     private func loadTaskID(for node: FileTreeNode, open: Bool) -> String {
-        "\(node.path):\(open):\(node.childrenState.rawValue)"
+        "\(fileTreeGeneration):\(node.path):\(open):\(node.childrenState.rawValue)"
     }
 
     private func shouldAutoLoadChildren(for node: FileTreeNode, open: Bool) -> Bool {
-        open && node.childrenState == .notLoaded
+        open && shouldAutoLoadChildren(node.path, node.childrenState)
     }
 
     private func renderChildren(of node: FileTreeNode, depth: Int) -> some View {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -15,6 +15,7 @@ final class RightPaneState {
     var openPaths: Set<String> = []   // expanded directories in the tree
     private(set) var loadedFileTreeChildPaths: Set<String> = [""]
     private(set) var loadingFileTreeChildPaths: Set<String> = []
+    private(set) var failedFileTreeChildPaths: Set<String> = []
     private(set) var fileTreeGeneration: Int = 0
 
     // New in right-sidebar-refactor:
@@ -112,6 +113,7 @@ final class RightPaneState {
         fileTreeGeneration += 1
         loadedFileTreeChildPaths = [""]
         loadingFileTreeChildPaths = []
+        failedFileTreeChildPaths = []
         fileTree = Self.resetLoadingFileTreeChildren(in: fileTree)
     }
 
@@ -160,7 +162,7 @@ final class RightPaneState {
                     if let existing = merged[child.id] {
                         var refreshed = existing
                         refreshed.badge = child.badge ?? existing.badge
-                        refreshed.visibility = child.visibility
+                        refreshed.visibility = mergedVisibility(existing: existing.visibility, incoming: child.visibility)
                         refreshed.childrenState = child.childrenState
                         if refreshed.children == nil {
                             refreshed.children = child.children
@@ -187,6 +189,16 @@ final class RightPaneState {
         return (updatedNodes, didMerge)
     }
 
+    nonisolated private static func mergedVisibility(
+        existing: FileVisibility,
+        incoming: FileVisibility
+    ) -> FileVisibility {
+        if incoming == .tracked, existing != .tracked {
+            return existing
+        }
+        return incoming
+    }
+
     nonisolated static func resetLoadingFileTreeChildren(in nodes: [FileTreeNode]) -> [FileTreeNode] {
         nodes.map { node in
             var updated = node
@@ -199,6 +211,29 @@ final class RightPaneState {
             }
             return updated
         }
+    }
+
+    nonisolated static func shouldAutoLoadFileTreeChildren(
+        path: String,
+        childrenState: DirectoryChildrenState,
+        loadedPaths: Set<String>,
+        loadingPaths: Set<String>,
+        failedPaths: Set<String>
+    ) -> Bool {
+        guard !loadedPaths.contains(path),
+              !loadingPaths.contains(path),
+              !failedPaths.contains(path) else { return false }
+        return childrenState == .notLoaded || childrenState == .loaded
+    }
+
+    func shouldAutoLoadFileTreeChildren(path: String, childrenState: DirectoryChildrenState) -> Bool {
+        Self.shouldAutoLoadFileTreeChildren(
+            path: path,
+            childrenState: childrenState,
+            loadedPaths: loadedFileTreeChildPaths,
+            loadingPaths: loadingFileTreeChildPaths,
+            failedPaths: failedFileTreeChildPaths
+        )
     }
 
     func loadFileTreeChildren(path: String) {
@@ -224,11 +259,13 @@ final class RightPaneState {
                 let result = Self.mergingChildren(in: self.fileTree, for: path, with: children, state: .loaded)
                 guard result.didMerge else { return }
                 self.loadedFileTreeChildPaths.insert(path)
+                self.failedFileTreeChildPaths.remove(path)
                 self.fileTree = result.nodes
             } catch {
                 guard self.fileTreeGeneration == generation else { return }
                 let result = Self.mergingChildren(in: self.fileTree, for: path, with: [], state: .failed)
                 guard result.didMerge else { return }
+                self.failedFileTreeChildPaths.insert(path)
                 self.fileTree = result.nodes
                 logger.error("file tree child load failed for \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -163,7 +163,7 @@ final class RightPaneState {
                         var refreshed = existing
                         refreshed.badge = child.badge ?? existing.badge
                         refreshed.visibility = mergedVisibility(existing: existing.visibility, incoming: child.visibility)
-                        refreshed.childrenState = child.childrenState
+                        refreshed.childrenState = mergedChildrenState(existing: existing.childrenState, incoming: child.childrenState)
                         if refreshed.children == nil {
                             refreshed.children = child.children
                         }
@@ -194,6 +194,16 @@ final class RightPaneState {
         incoming: FileVisibility
     ) -> FileVisibility {
         if incoming == .tracked, existing != .tracked {
+            return existing
+        }
+        return incoming
+    }
+
+    nonisolated private static func mergedChildrenState(
+        existing: DirectoryChildrenState,
+        incoming: DirectoryChildrenState
+    ) -> DirectoryChildrenState {
+        if incoming == .notLoaded, existing != .notLoaded {
             return existing
         }
         return incoming

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -13,6 +13,9 @@ final class RightPaneState {
     var fileTree: [FileTreeNode] = []
     var loading: Bool = false
     var openPaths: Set<String> = []   // expanded directories in the tree
+    private(set) var loadedFileTreeChildPaths: Set<String> = [""]
+    private(set) var loadingFileTreeChildPaths: Set<String> = []
+    private(set) var fileTreeGeneration: Int = 0
 
     // New in right-sidebar-refactor:
     var activeTab: RightPaneTab = .changes
@@ -62,6 +65,7 @@ final class RightPaneState {
     func refresh() async {
         loading = true
         defer { loading = false }
+        invalidateFileTreeChildLoadsForRefresh()
         do {
             // Any refresh re-anchors the older-history cursor; drop the
             // accumulated pages so we don't accidentally splice an old
@@ -104,6 +108,13 @@ final class RightPaneState {
         }
     }
 
+    func invalidateFileTreeChildLoadsForRefresh() {
+        fileTreeGeneration += 1
+        loadedFileTreeChildPaths = [""]
+        loadingFileTreeChildPaths = []
+        fileTree = Self.resetLoadingFileTreeChildren(in: fileTree)
+    }
+
     func toggleStage(_ file: ChangedFile) {
         composer.error = nil
         Task { @MainActor in
@@ -128,6 +139,89 @@ final class RightPaneState {
             return [file.path, from]
         }
         return [file.path]
+    }
+
+    nonisolated static func mergingChildren(
+        in nodes: [FileTreeNode],
+        for path: String,
+        with children: [FileTreeNode],
+        state: DirectoryChildrenState
+    ) -> (nodes: [FileTreeNode], didMerge: Bool) {
+        var didMerge = false
+        let updatedNodes = nodes.map { node in
+            if node.path == path {
+                didMerge = true
+                var updated = node
+                var merged: [String: FileTreeNode] = [:]
+                for child in node.children ?? [] {
+                    merged[child.id] = child
+                }
+                for child in children where merged[child.id] == nil {
+                    merged[child.id] = child
+                }
+                updated.children = merged.values.sorted { lhs, rhs in
+                    if lhs.kind != rhs.kind { return lhs.kind == .dir }
+                    return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+                }
+                updated.childrenState = state
+                return updated
+            }
+            guard let existing = node.children else { return node }
+            var updated = node
+            let result = mergingChildren(in: existing, for: path, with: children, state: state)
+            didMerge = didMerge || result.didMerge
+            updated.children = result.nodes
+            return updated
+        }
+        return (updatedNodes, didMerge)
+    }
+
+    nonisolated static func resetLoadingFileTreeChildren(in nodes: [FileTreeNode]) -> [FileTreeNode] {
+        nodes.map { node in
+            var updated = node
+            if let children = node.children {
+                updated.children = resetLoadingFileTreeChildren(in: children)
+            }
+            if node.kind == .dir, node.childrenState == .loading {
+                updated.children = nil
+                updated.childrenState = .notLoaded
+            }
+            return updated
+        }
+    }
+
+    func loadFileTreeChildren(path: String) {
+        guard !loadedFileTreeChildPaths.contains(path),
+              !loadingFileTreeChildPaths.contains(path) else { return }
+        loadingFileTreeChildPaths.insert(path)
+        let loadingMerge = Self.mergingChildren(in: fileTree, for: path, with: [], state: .loading)
+        guard loadingMerge.didMerge else {
+            loadingFileTreeChildPaths.remove(path)
+            return
+        }
+        fileTree = loadingMerge.nodes
+        let generation = fileTreeGeneration
+        Task { @MainActor in
+            defer {
+                if self.fileTreeGeneration == generation {
+                    self.loadingFileTreeChildPaths.remove(path)
+                }
+            }
+            do {
+                let children = try await git.fileTreeChildren(worktreePath: worktree.path, path: path)
+                guard self.fileTreeGeneration == generation else { return }
+                let result = Self.mergingChildren(in: self.fileTree, for: path, with: children, state: .loaded)
+                guard result.didMerge else { return }
+                self.loadedFileTreeChildPaths.insert(path)
+                self.fileTree = result.nodes
+            } catch {
+                guard self.fileTreeGeneration == generation else { return }
+                let result = Self.mergingChildren(in: self.fileTree, for: path, with: [], state: .failed)
+                guard result.didMerge else { return }
+                self.fileTree = result.nodes
+                logger.error("file tree child load failed for \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
+        }
     }
 
     func stageAll(_ files: [ChangedFile]) {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -156,8 +156,19 @@ final class RightPaneState {
                 for child in node.children ?? [] {
                     merged[child.id] = child
                 }
-                for child in children where merged[child.id] == nil {
-                    merged[child.id] = child
+                for child in children {
+                    if let existing = merged[child.id] {
+                        var refreshed = existing
+                        refreshed.badge = child.badge ?? existing.badge
+                        refreshed.visibility = child.visibility
+                        refreshed.childrenState = child.childrenState
+                        if refreshed.children == nil {
+                            refreshed.children = child.children
+                        }
+                        merged[child.id] = refreshed
+                    } else {
+                        merged[child.id] = child
+                    }
                 }
                 updated.children = merged.values.sorted { lhs, rhs in
                     if lhs.kind != rhs.kind { return lhs.kind == .dir }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -30,11 +30,15 @@ struct RightPaneView: View {
                 case .files:
                     FilesTabView(
                         nodes: rps.fileTree,
+                        fileTreeGeneration: rps.fileTreeGeneration,
                         openPaths: Binding(
                             get: { rps.openPaths },
                             set: { rps.openPaths = $0 }
                         ),
                         onSelectFile: onSelectTreeFile,
+                        shouldAutoLoadChildren: { path, childrenState in
+                            rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
+                        },
                         onLoadChildren: { rps.loadFileTreeChildren(path: $0) }
                     )
                 }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -34,7 +34,8 @@ struct RightPaneView: View {
                             get: { rps.openPaths },
                             set: { rps.openPaths = $0 }
                         ),
-                        onSelectFile: onSelectTreeFile
+                        onSelectFile: onSelectTreeFile,
+                        onLoadChildren: { rps.loadFileTreeChildren(path: $0) }
                     )
                 }
             }

--- a/AlasTests/FileTreeBuilderTests.swift
+++ b/AlasTests/FileTreeBuilderTests.swift
@@ -20,15 +20,96 @@ struct FileTreeBuilderTests {
         assertPreservesFileAndDirectoryPathCollisions(["foo/bar.swift", "foo"])
     }
 
-    private func assertPreservesFileAndDirectoryPathCollisions(_ paths: [String]) {
-        let tree = FileTreeBuilder.build(paths: paths, badges: ["foo": "D"])
+    @Test func preservesFileAndDirectoryPathCollisionsWithExplicitDirectories() {
+        assertPreservesFileAndDirectoryPathCollisions(["foo", "foo/bar.swift"], directories: ["foo"])
+        assertPreservesFileAndDirectoryPathCollisions(["foo/bar.swift", "foo"], directories: ["foo"])
+    }
+
+    @Test func preservesFileAndDirectoryPathCollisionsWithLazyDirectories() {
+        assertPreservesFileAndDirectoryPathCollisions(
+            ["foo", "foo/bar.swift"],
+            lazyDirectories: ["foo"],
+            expectLazyDirectory: true
+        )
+        assertPreservesFileAndDirectoryPathCollisions(
+            ["foo/bar.swift", "foo"],
+            lazyDirectories: ["foo"],
+            expectLazyDirectory: true
+        )
+    }
+
+    @Test func assignsVisibilityAndLazyDirectoryState() {
+        let tree = FileTreeBuilder.build(
+            paths: ["Sources/App.swift", ".build"],
+            badges: [:],
+            visibility: [".build": .ignored],
+            directories: [".build"],
+            lazyDirectories: [".build"]
+        )
+
+        let buildDir = tree.first { $0.path == ".build" }!
+        #expect(buildDir.kind == .dir)
+        #expect(buildDir.visibility == .ignored)
+        #expect(buildDir.childrenState == .notLoaded)
+        #expect(buildDir.children == nil)
+
+        let sources = tree.first { $0.path == "Sources" }!
+        #expect(sources.visibility == .tracked)
+        #expect(sources.childrenState == .loaded)
+    }
+
+    @Test func treatsLazyDirectoryPathAsUnloadedDirectory() {
+        let tree = FileTreeBuilder.build(
+            paths: [".build"],
+            badges: [:],
+            lazyDirectories: [".build"]
+        )
+
+        let buildDir = tree.first { $0.path == ".build" }!
+        #expect(buildDir.kind == .dir)
+        #expect(buildDir.childrenState == .notLoaded)
+        #expect(buildDir.children == nil)
+    }
+
+    @Test func preservesUntrackedStatusBadgeSeparatelyFromVisibility() {
+        let tree = FileTreeBuilder.build(
+            paths: ["new.txt"],
+            badges: ["new.txt": "A"],
+            visibility: ["new.txt": .untracked]
+        )
+
+        let file = tree.first { $0.path == "new.txt" }!
+        #expect(file.kind == .file)
+        #expect(file.badge == "A")
+        #expect(file.visibility == .untracked)
+        #expect(file.childrenState == .loaded)
+    }
+
+    private func assertPreservesFileAndDirectoryPathCollisions(
+        _ paths: [String],
+        directories: Set<String> = [],
+        lazyDirectories: Set<String> = [],
+        expectLazyDirectory: Bool = false
+    ) {
+        let tree = FileTreeBuilder.build(
+            paths: paths,
+            badges: ["foo": "D"],
+            directories: directories,
+            lazyDirectories: lazyDirectories
+        )
 
         #expect(tree.count == 2)
         #expect(tree[0].name == "foo")
         #expect(tree[0].path == "foo")
         #expect(tree[0].kind == .dir)
         #expect(tree[0].id == "dir:foo")
-        #expect(tree[0].children?.first?.name == "bar.swift")
+        #expect(tree[0].badge == nil)
+        #expect(tree[0].childrenState == (expectLazyDirectory ? .notLoaded : .loaded))
+        if expectLazyDirectory {
+            #expect(tree[0].children == nil)
+        } else {
+            #expect(tree[0].children?.first?.name == "bar.swift")
+        }
 
         #expect(tree[1].name == "foo")
         #expect(tree[1].path == "foo")

--- a/AlasTests/FileTreeBuilderTests.swift
+++ b/AlasTests/FileTreeBuilderTests.swift
@@ -58,6 +58,25 @@ struct FileTreeBuilderTests {
         #expect(sources.childrenState == .loaded)
     }
 
+    @Test func explicitDirectoryMetadataDoesNotCreateDuplicateFileLeafForLoadedChildren() {
+        let tree = FileTreeBuilder.build(
+            paths: ["generated", "generated/keep.txt"],
+            badges: [:],
+            visibility: ["generated": .ignored],
+            directories: ["generated"]
+        )
+
+        let generatedNodes = tree.filter { $0.path == "generated" }
+        #expect(generatedNodes.count == 1)
+        let generated = generatedNodes.first
+        #expect(generated?.id == "dir:generated")
+        #expect(generated?.kind == .dir)
+        #expect(generated?.visibility == .ignored)
+        #expect(generated?.childrenState == .loaded)
+        #expect(generated?.children?.contains { $0.path == "generated/keep.txt" } == true)
+        #expect(!tree.contains { $0.id == "file:generated" })
+    }
+
     @Test func treatsLazyDirectoryPathAsUnloadedDirectory() {
         let tree = FileTreeBuilder.build(
             paths: [".build"],

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -176,6 +176,27 @@ struct GitServiceTests {
         #expect(excluded.children == nil)
     }
 
+    @Test func fileTreeDoesNotMarkNegatedIgnoredRootDirectoryAsIgnored() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "ignored-root/\n!ignored-root/\n".write(
+            to: repo.appendingPathComponent(".gitignore"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.createDirectory(at: repo.appendingPathComponent("ignored-root"), withIntermediateDirectories: true)
+        try "tracked\n".write(to: repo.appendingPathComponent("ignored-root/keep.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        let tree = try await GitService().fileTree(worktreePath: repo, statusEntries: [])
+
+        let root = try #require(tree.first { $0.path == "ignored-root" })
+        #expect(root.visibility == .tracked)
+        #expect(root.children?.contains { $0.path == "ignored-root/keep.txt" } == true)
+    }
+
     @Test func fileTreeKeepsTrackedChildrenLoadedInIgnoredRootDirectory() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -248,6 +248,40 @@ struct GitServiceTests {
         #expect(nestedNode.children == nil)
     }
 
+    @Test func fileTreeChildrenLoadsNestedIgnoredDirectoryChildren() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "ignored-root/\n".write(to: repo.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        let nested = repo.appendingPathComponent("ignored-root/nested")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "two\n".write(to: nested.appendingPathComponent("two.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        let children = try await GitService().fileTreeChildren(worktreePath: repo, path: "ignored-root/nested")
+
+        #expect(children.map(\.path) == ["ignored-root/nested/two.txt"])
+        #expect(children.first?.visibility == .ignored)
+    }
+
+    @Test func fileTreeChildrenKeepsForceTrackedChildTrackedInsideIgnoredDirectory() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "generated/\n".write(to: repo.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: repo.appendingPathComponent("generated"), withIntermediateDirectories: true)
+        try "tracked\n".write(to: repo.appendingPathComponent("generated/keep.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore"], cwd: repo)
+        _ = try await Process.git(["add", "-f", "generated/keep.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        let children = try await GitService().fileTreeChildren(worktreePath: repo, path: "generated")
+
+        let keep = try #require(children.first { $0.path == "generated/keep.txt" })
+        #expect(keep.visibility == .tracked)
+    }
+
     @Test func fileTreeChildrenRevealsIgnoredChildInsideTrackedDirectory() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -225,4 +225,26 @@ struct GitServiceTests {
         #expect(generated.childrenState == .loaded)
         #expect(generated.children?.contains { $0.path == "local-generated/keep.txt" } == true)
     }
+
+    @Test func loadFileTreeChildrenLoadsOnlyImmediateIgnoredChildren() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "ignored-root/\n".write(to: repo.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        let nested = repo.appendingPathComponent("ignored-root/nested")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "one\n".write(to: repo.appendingPathComponent("ignored-root/one.txt"), atomically: true, encoding: .utf8)
+        try "two\n".write(to: nested.appendingPathComponent("two.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        let children = try await GitService().fileTreeChildren(worktreePath: repo, path: "ignored-root")
+
+        #expect(children.map(\.path).sorted() == ["ignored-root/nested", "ignored-root/one.txt"])
+        #expect(children.first { $0.path == "ignored-root/one.txt" }?.visibility == .ignored)
+        let nestedNode = children.first { $0.path == "ignored-root/nested" }!
+        #expect(nestedNode.kind == .dir)
+        #expect(nestedNode.childrenState == .notLoaded)
+        #expect(nestedNode.children == nil)
+    }
 }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -247,4 +247,21 @@ struct GitServiceTests {
         #expect(nestedNode.childrenState == .notLoaded)
         #expect(nestedNode.children == nil)
     }
+
+    @Test func fileTreeChildrenRevealsIgnoredChildInsideTrackedDirectory() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "Sources/cache.log\n".write(to: repo.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: repo.appendingPathComponent("Sources"), withIntermediateDirectories: true)
+        try "tracked\n".write(to: repo.appendingPathComponent("Sources/App.swift"), atomically: true, encoding: .utf8)
+        try "ignored\n".write(to: repo.appendingPathComponent("Sources/cache.log"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore", "Sources/App.swift"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        let children = try await GitService().fileTreeChildren(worktreePath: repo, path: "Sources")
+
+        #expect(children.contains { $0.path == "Sources/App.swift" && $0.visibility == .tracked })
+        #expect(children.contains { $0.path == "Sources/cache.log" && $0.visibility == .ignored })
+    }
 }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -282,6 +282,27 @@ struct GitServiceTests {
         #expect(keep.visibility == .tracked)
     }
 
+    @Test func fileTreeChildrenKeepsIgnoredDirectoryAffordanceWhenItHasTrackedDescendants() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "generated/\n".write(to: repo.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: repo.appendingPathComponent("generated/nested"), withIntermediateDirectories: true)
+        try "tracked\n".write(to: repo.appendingPathComponent("generated/nested/keep.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore"], cwd: repo)
+        _ = try await Process.git(["add", "-f", "generated/nested/keep.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        let generatedChildren = try await GitService().fileTreeChildren(worktreePath: repo, path: "generated")
+        let nested = try #require(generatedChildren.first { $0.path == "generated/nested" })
+        #expect(nested.visibility == .ignored)
+        #expect(nested.childrenState == .notLoaded)
+
+        let nestedChildren = try await GitService().fileTreeChildren(worktreePath: repo, path: "generated/nested")
+        let keep = try #require(nestedChildren.first { $0.path == "generated/nested/keep.txt" })
+        #expect(keep.visibility == .tracked)
+    }
+
     @Test func fileTreeChildrenRevealsIgnoredChildInsideTrackedDirectory() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -89,4 +89,140 @@ struct GitServiceTests {
         #expect(branches.contains("origin/release/remote-only"))
         #expect(branches.firstIndex(of: "develop")! < branches.firstIndex(of: "origin/main")!)
     }
+
+    @Test func fileTreeIncludesIgnoredAndExcludedRootEntries() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "ignored-root/\n".write(
+            to: repo.appendingPathComponent(".gitignore"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.createDirectory(at: repo.appendingPathComponent("ignored-root"), withIntermediateDirectories: true)
+        try "cache\n".write(to: repo.appendingPathComponent("ignored-root/cache.txt"), atomically: true, encoding: .utf8)
+
+        let exclude = repo.appendingPathComponent(".git/info/exclude")
+        try "excluded-root/\n".write(to: exclude, atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: repo.appendingPathComponent("excluded-root"), withIntermediateDirectories: true)
+        try "local\n".write(to: repo.appendingPathComponent("excluded-root/local.txt"), atomically: true, encoding: .utf8)
+
+        try "tracked\n".write(to: repo.appendingPathComponent("tracked.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore", "tracked.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        let tree = try await GitService().fileTree(worktreePath: repo, statusEntries: [])
+
+        let ignored = try #require(tree.first { $0.path == "ignored-root" })
+        #expect(ignored.visibility == .ignored)
+        #expect(ignored.childrenState == .notLoaded)
+        #expect(ignored.children == nil)
+
+        let excluded = try #require(tree.first { $0.path == "excluded-root" })
+        #expect(excluded.visibility == .excluded)
+        #expect(excluded.childrenState == .notLoaded)
+
+        let tracked = try #require(tree.first { $0.path == "tracked.txt" })
+        #expect(tracked.visibility == .tracked)
+    }
+
+    @Test func fileTreeClassifiesGlobalExcludesAsExcludedRootEntries() async throws {
+        let repo = try await makeRepo()
+        let globalExcludes = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-global-excludes-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: globalExcludes)
+        }
+
+        try "global-cache/\n".write(to: globalExcludes, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["config", "core.excludesfile", globalExcludes.path], cwd: repo)
+        try FileManager.default.createDirectory(at: repo.appendingPathComponent("global-cache"), withIntermediateDirectories: true)
+        try "cache\n".write(to: repo.appendingPathComponent("global-cache/cache.txt"), atomically: true, encoding: .utf8)
+
+        let tree = try await GitService().fileTree(worktreePath: repo, statusEntries: [])
+
+        let excluded = try #require(tree.first { $0.path == "global-cache" })
+        #expect(excluded.visibility == .excluded)
+        #expect(excluded.childrenState == .notLoaded)
+        #expect(excluded.children == nil)
+    }
+
+    @Test func fileTreeClassifiesLinkedWorktreeInfoExcludeAsExcluded() async throws {
+        let repo = try await makeRepo()
+        let linked = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-linked-worktree-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: linked)
+            try? FileManager.default.removeItem(at: repo)
+        }
+
+        _ = try await Process.git(["worktree", "add", "-q", "-b", "linked-test", linked.path], cwd: repo)
+        let excludeResult = try await Process.git(["rev-parse", "--git-path", "info/exclude"], cwd: linked)
+        let excludePath = excludeResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let exclude = excludePath.hasPrefix("/")
+            ? URL(fileURLWithPath: excludePath)
+            : linked.appendingPathComponent(excludePath)
+
+        try "linked-excluded/\n".write(to: exclude, atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: linked.appendingPathComponent("linked-excluded"), withIntermediateDirectories: true)
+        try "local\n".write(to: linked.appendingPathComponent("linked-excluded/local.txt"), atomically: true, encoding: .utf8)
+
+        let tree = try await GitService().fileTree(worktreePath: linked, statusEntries: [])
+
+        let excluded = try #require(tree.first { $0.path == "linked-excluded" })
+        #expect(excluded.visibility == .excluded)
+        #expect(excluded.childrenState == .notLoaded)
+        #expect(excluded.children == nil)
+    }
+
+    @Test func fileTreeKeepsTrackedChildrenLoadedInIgnoredRootDirectory() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try "generated/\n".write(
+            to: repo.appendingPathComponent(".gitignore"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.createDirectory(at: repo.appendingPathComponent("generated"), withIntermediateDirectories: true)
+        try "tracked\n".write(to: repo.appendingPathComponent("generated/keep.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", ".gitignore"], cwd: repo)
+        _ = try await Process.git(["add", "-f", "generated/keep.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        let tree = try await GitService().fileTree(worktreePath: repo, statusEntries: [])
+
+        let generatedNodes = tree.filter { $0.path == "generated" }
+        #expect(generatedNodes.count == 1)
+        #expect(!tree.contains { $0.id == "file:generated" })
+        let generated = try #require(generatedNodes.first)
+        #expect(generated.kind == .dir)
+        #expect(generated.visibility == .ignored)
+        #expect(generated.childrenState == .loaded)
+        #expect(generated.children?.contains { $0.path == "generated/keep.txt" } == true)
+    }
+
+    @Test func fileTreeKeepsTrackedChildrenLoadedInInfoExcludedRootDirectory() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let exclude = repo.appendingPathComponent(".git/info/exclude")
+        try "local-generated/\n".write(to: exclude, atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: repo.appendingPathComponent("local-generated"), withIntermediateDirectories: true)
+        try "tracked\n".write(to: repo.appendingPathComponent("local-generated/keep.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "-f", "local-generated/keep.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "seed"], cwd: repo)
+
+        let tree = try await GitService().fileTree(worktreePath: repo, statusEntries: [])
+
+        let generatedNodes = tree.filter { $0.path == "local-generated" }
+        #expect(generatedNodes.count == 1)
+        #expect(!tree.contains { $0.id == "file:local-generated" })
+        let generated = try #require(generatedNodes.first)
+        #expect(generated.kind == .dir)
+        #expect(generated.visibility == .excluded)
+        #expect(generated.childrenState == .loaded)
+        #expect(generated.children?.contains { $0.path == "local-generated/keep.txt" } == true)
+    }
 }

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -30,6 +30,33 @@ struct ProcessGitTests {
         #expect(result.stdout.count >= 200000)
     }
 
+    @Test func runWritesStdinToReader() async throws {
+        let result = try await Process.run(
+            "/usr/bin/wc",
+            args: ["-c"],
+            stdin: "hello stdin\n"
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == "12")
+    }
+
+    @Test func runTimeoutStillAppliesWhenProcessDoesNotReadLargeStdin() async throws {
+        let largeInput = String(repeating: "x", count: 2_000_000)
+        let start = Date()
+        do {
+            _ = try await Process.run("/bin/sleep", args: ["5"], stdin: largeInput, timeout: 0.1)
+            Issue.record("expected timeout")
+        } catch ProcessError.timedOut(let executable, _, let seconds) {
+            let elapsed = Date().timeIntervalSince(start)
+            #expect(executable == "/bin/sleep")
+            #expect(seconds == 0.1)
+            #expect(elapsed < 3.0, "expected stdin timeout to return quickly, took \(elapsed)s")
+        } catch {
+            Issue.record("wrong error: \(error)")
+        }
+    }
+
     @Test func signaledExitIsNotReportedAsTimeout() async throws {
         let result = try await Process.run("/bin/sh", args: ["-c", "kill -TERM $$"], timeout: 5)
         #expect(result.exitCode == 15)

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -100,7 +100,7 @@ struct RightPaneStateFileTreeTests {
         #expect(generated?.path == "Sources/Generated")
         #expect(generated?.kind == .dir)
         #expect(generated?.visibility == .ignored)
-        #expect(generated?.childrenState == .notLoaded)
+        #expect(generated?.childrenState == .loaded)
         #expect(keep?.path == "Sources/Generated/keep.txt")
         #expect(keep?.badge == "A")
     }

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct RightPaneStateFileTreeTests {
+    @Test func mergingChildrenMarksDirectoryLoadedAndPreservesExistingBadges() {
+        let tree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "App.swift",
+                        path: "Sources/App.swift",
+                        kind: .file,
+                        children: nil,
+                        badge: "M",
+                        visibility: .tracked,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+        let children = [
+            FileTreeNode(
+                name: "cache.log",
+                path: "Sources/cache.log",
+                kind: .file,
+                children: nil,
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .loaded
+            )
+        ]
+
+        let result = RightPaneState.mergingChildren(in: tree, for: "Sources", with: children, state: .loaded)
+        let updated = result.nodes
+        let root = updated.first!
+        #expect(result.didMerge)
+        #expect(root.childrenState == .loaded)
+        #expect(root.children?.contains { $0.path == "Sources/App.swift" && $0.badge == "M" } == true)
+        #expect(root.children?.contains { $0.path == "Sources/cache.log" && $0.visibility == .ignored } == true)
+    }
+
+    @Test func mergingChildrenReportsMissingTargetWithoutMutatingTree() {
+        let tree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: nil,
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .notLoaded
+            )
+        ]
+        let children = [
+            FileTreeNode(
+                name: "cache.log",
+                path: "Missing/cache.log",
+                kind: .file,
+                children: nil,
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .loaded
+            )
+        ]
+
+        let result = RightPaneState.mergingChildren(in: tree, for: "Missing", with: children, state: .loaded)
+
+        #expect(result.didMerge == false)
+        #expect(result.nodes == tree)
+    }
+
+    @Test func invalidatingFileTreeChildLoadsStartsNewGenerationAndClearsTracking() {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-filetree-generation-\(UUID().uuidString)")
+        let state = RightPaneState(
+            worktree: Worktree(
+                id: Worktree.makeId(path: path),
+                projectId: "test-project",
+                name: "main",
+                branch: "main",
+                path: path,
+                status: .clean,
+                lastActivity: Date()
+            ),
+            baseBranch: "main"
+        )
+        let generation = state.fileTreeGeneration
+
+        state.invalidateFileTreeChildLoadsForRefresh()
+
+        #expect(state.fileTreeGeneration == generation + 1)
+        #expect(state.loadedFileTreeChildPaths == [""])
+        #expect(state.loadingFileTreeChildPaths.isEmpty)
+    }
+
+    @Test func invalidatingFileTreeChildLoadsResetsLoadingDirectoriesInRetainedTree() {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-filetree-loading-reset-\(UUID().uuidString)")
+        let state = RightPaneState(
+            worktree: Worktree(
+                id: Worktree.makeId(path: path),
+                projectId: "test-project",
+                name: "main",
+                branch: "main",
+                path: path,
+                status: .clean,
+                lastActivity: Date()
+            ),
+            baseBranch: "main"
+        )
+        state.fileTree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "Generated",
+                        path: "Sources/Generated",
+                        kind: .dir,
+                        children: [],
+                        badge: nil,
+                        visibility: .ignored,
+                        childrenState: .loading
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+
+        state.invalidateFileTreeChildLoadsForRefresh()
+
+        let sources = state.fileTree.first
+        let generated = sources?.children?.first
+        #expect(sources?.childrenState == .loaded)
+        #expect(generated?.childrenState == .notLoaded)
+        #expect(generated?.children == nil)
+    }
+
+    @Test func resetLoadingFileTreeChildrenRecursivelyMarksLoadingDirectoriesNotLoaded() {
+        let tree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "Generated",
+                        path: "Sources/Generated",
+                        kind: .dir,
+                        children: [
+                            FileTreeNode(
+                                name: "cache.log",
+                                path: "Sources/Generated/cache.log",
+                                kind: .file,
+                                children: nil,
+                                badge: nil,
+                                visibility: .ignored,
+                                childrenState: .loaded
+                            )
+                        ],
+                        badge: nil,
+                        visibility: .ignored,
+                        childrenState: .loading
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+
+        let reset = RightPaneState.resetLoadingFileTreeChildren(in: tree)
+        let sources = reset.first
+        let generated = sources?.children?.first
+
+        #expect(sources?.childrenState == .loaded)
+        #expect(generated?.childrenState == .notLoaded)
+        #expect(generated?.children == nil)
+    }
+}

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -47,6 +47,64 @@ struct RightPaneStateFileTreeTests {
         #expect(root.children?.contains { $0.path == "Sources/cache.log" && $0.visibility == .ignored } == true)
     }
 
+    @Test func mergingChildrenRefreshesExistingChildMetadataAndPreservesDescendants() {
+        let tree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "Generated",
+                        path: "Sources/Generated",
+                        kind: .dir,
+                        children: [
+                            FileTreeNode(
+                                name: "keep.txt",
+                                path: "Sources/Generated/keep.txt",
+                                kind: .file,
+                                children: nil,
+                                badge: "A",
+                                visibility: .tracked,
+                                childrenState: .loaded
+                            )
+                        ],
+                        badge: nil,
+                        visibility: .tracked,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+        let children = [
+            FileTreeNode(
+                name: "Generated",
+                path: "Sources/Generated",
+                kind: .dir,
+                children: nil,
+                badge: nil,
+                visibility: .ignored,
+                childrenState: .notLoaded
+            )
+        ]
+
+        let result = RightPaneState.mergingChildren(in: tree, for: "Sources", with: children, state: .loaded)
+        let generated = result.nodes.first?.children?.first
+        let keep = generated?.children?.first
+
+        #expect(result.didMerge)
+        #expect(generated?.name == "Generated")
+        #expect(generated?.path == "Sources/Generated")
+        #expect(generated?.kind == .dir)
+        #expect(generated?.visibility == .ignored)
+        #expect(generated?.childrenState == .notLoaded)
+        #expect(keep?.path == "Sources/Generated/keep.txt")
+        #expect(keep?.badge == "A")
+    }
+
     @Test func mergingChildrenReportsMissingTargetWithoutMutatingTree() {
         let tree = [
             FileTreeNode(

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -105,6 +105,48 @@ struct RightPaneStateFileTreeTests {
         #expect(keep?.badge == "A")
     }
 
+    @Test func mergingChildrenPreservesSpecificExistingVisibilityWhenReturnedVisibilityIsDefaultTracked() {
+        let tree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "New.swift",
+                        path: "Sources/New.swift",
+                        kind: .file,
+                        children: nil,
+                        badge: "A",
+                        visibility: .untracked,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+        let children = [
+            FileTreeNode(
+                name: "New.swift",
+                path: "Sources/New.swift",
+                kind: .file,
+                children: nil,
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+
+        let result = RightPaneState.mergingChildren(in: tree, for: "Sources", with: children, state: .loaded)
+        let file = result.nodes.first?.children?.first
+
+        #expect(result.didMerge)
+        #expect(file?.badge == "A")
+        #expect(file?.visibility == .untracked)
+    }
+
     @Test func mergingChildrenReportsMissingTargetWithoutMutatingTree() {
         let tree = [
             FileTreeNode(
@@ -157,6 +199,7 @@ struct RightPaneStateFileTreeTests {
         #expect(state.fileTreeGeneration == generation + 1)
         #expect(state.loadedFileTreeChildPaths == [""])
         #expect(state.loadingFileTreeChildPaths.isEmpty)
+        #expect(state.failedFileTreeChildPaths.isEmpty)
     }
 
     @Test func invalidatingFileTreeChildLoadsResetsLoadingDirectoriesInRetainedTree() {
@@ -245,5 +288,50 @@ struct RightPaneStateFileTreeTests {
         #expect(sources?.childrenState == .loaded)
         #expect(generated?.childrenState == .notLoaded)
         #expect(generated?.children == nil)
+    }
+
+    @Test func shouldAutoLoadFileTreeChildrenReconcilesOpenLoadedDirectoriesOnce() {
+        #expect(RightPaneState.shouldAutoLoadFileTreeChildren(
+            path: "Sources",
+            childrenState: .loaded,
+            loadedPaths: [""],
+            loadingPaths: [],
+            failedPaths: []
+        ))
+        #expect(RightPaneState.shouldAutoLoadFileTreeChildren(
+            path: "Sources",
+            childrenState: .notLoaded,
+            loadedPaths: [""],
+            loadingPaths: [],
+            failedPaths: []
+        ))
+        #expect(!RightPaneState.shouldAutoLoadFileTreeChildren(
+            path: "Sources",
+            childrenState: .loaded,
+            loadedPaths: ["", "Sources"],
+            loadingPaths: [],
+            failedPaths: []
+        ))
+        #expect(!RightPaneState.shouldAutoLoadFileTreeChildren(
+            path: "Sources",
+            childrenState: .loaded,
+            loadedPaths: [""],
+            loadingPaths: ["Sources"],
+            failedPaths: []
+        ))
+        #expect(!RightPaneState.shouldAutoLoadFileTreeChildren(
+            path: "Sources",
+            childrenState: .loaded,
+            loadedPaths: [""],
+            loadingPaths: [],
+            failedPaths: ["Sources"]
+        ))
+        #expect(!RightPaneState.shouldAutoLoadFileTreeChildren(
+            path: "Sources",
+            childrenState: .failed,
+            loadedPaths: [""],
+            loadingPaths: [],
+            failedPaths: []
+        ))
     }
 }

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -143,6 +143,10 @@
 3. Confirm the Files section shows worktree files and supports directory expand/collapse.
 4. Confirm file loading errors remain scoped to the Files section and do not break terminal input.
 5. Confirm Git status loading errors remain scoped to the Changed section and do not break terminal input.
+6. Create an ignored root directory such as `.build/` and confirm it appears in the Files section with a dimmed ghost-rail row and an `ignored` pill.
+7. Expand the ignored root directory and confirm only the first level appears at first; deeper directories load only when expanded.
+8. Add a path to `.git/info/exclude`, create the matching file or folder, and confirm it appears with an `excluded` pill.
+9. Create a normal untracked file and confirm it still uses the existing `A` badge instead of the ignored/excluded affordance.
 
 ## ACP Agent Chat
 

--- a/docs/superpowers/specs/2026-05-18-files-tab-show-all-design.md
+++ b/docs/superpowers/specs/2026-05-18-files-tab-show-all-design.md
@@ -1,0 +1,101 @@
+# Files Tab Show All Files Design
+
+## Context
+
+The right pane Files tab currently builds its tree from `git ls-files --cached --others --exclude-standard`. That shows tracked files and normal untracked files, but omits ignored files and entries excluded by Git. The goal is to make the Files tab capable of surfacing those non-Git entries without making large generated directories expensive to browse.
+
+Untracked files are already represented in the app as normal files with the existing `A` status badge. This design preserves that behavior. The new visual treatment applies only to ignored or excluded entries.
+
+## User Experience
+
+The Files tab shows tracked, untracked, ignored, and excluded paths in one tree.
+
+Tracked and untracked rows keep their current density, icon treatment, and status badges. Modified, added, deleted, and renamed status badges continue to use the existing `badge` behavior.
+
+Ignored and excluded rows use the selected "ghost rail" affordance:
+
+- dimmed file or folder icon and filename,
+- a subtle left rail for ignored or excluded subtrees,
+- a trailing pill that says `ignored` or `excluded`,
+- regular tree placement so paths remain where users expect them.
+
+The design does not introduce a separate "Not on git" group. Keeping ignored/excluded entries in place is more useful for navigation and avoids breaking the mental model of a filesystem tree.
+
+## Lazy Enumeration
+
+Initial Files tab refresh must not recursively walk ignored or excluded directories. Large directories such as `.build/`, `DerivedData/`, `node_modules/`, and `.swiftpm/` should be visible if present, but their children should be unknown until the user expands the directory.
+
+The initial tree should include:
+
+- the current Git-visible files from `git ls-files --cached --others --exclude-standard`,
+- status badges from the existing status refresh,
+- top-level ignored and excluded entries that are direct children of the worktree root.
+
+When the user expands any directory, Alas may reconcile that directory's immediate filesystem children with the Git-visible tree. This is how ignored or excluded files nested under otherwise normal tracked directories become visible. Child directories remain lazy and enumerate one level at a time when expanded. This keeps expensive generated trees browseable without front-loading their full cost.
+
+Normal tracked or untracked files can keep the existing eager tree behavior because Git already returns those paths cheaply. Directory expansion adds only missing ignored or excluded entries.
+
+## Data Model
+
+`FileTreeNode` should grow explicit metadata instead of overloading `badge`.
+
+Proposed additions:
+
+- `visibility`: `tracked`, `untracked`, `ignored`, or `excluded`.
+- `childrenState`: `loaded`, `notLoaded`, or `loading`, only meaningful for directories.
+
+`badge` remains the source for Git status badges such as `A`, `M`, `D`, and `R`. A plain untracked file continues to have `visibility == untracked` and `badge == "A"`.
+
+Ignored/excluded files normally have no Git status badge. Their non-Git state is represented by `visibility` and rendered by the Files tab row. Classification should use Git's own ignore/exclude rules so the tree matches command-line behavior. Paths matched by repository `.gitignore` files are `ignored`; paths matched by `.git/info/exclude` or the user's global excludes file are `excluded`.
+
+## Data Flow
+
+`RightPaneState.refresh()` continues to fetch Git status and commits as it does today. Its file-tree call changes from "Git-visible files only" to "Git-visible files plus lazy filesystem entries."
+
+The initial file tree service should:
+
+1. Run the existing Git-visible listing for tracked and untracked files.
+2. Merge status badges into those paths.
+3. Enumerate only the worktree root's immediate filesystem children.
+4. Use Git ignore/exclude classification for root children not present in the Git-visible set.
+5. Add ignored/excluded root children as lazy directory nodes or leaf file nodes.
+
+When a user expands a directory with `childrenState == notLoaded`, `FilesTabView` asks `RightPaneState` to load that path. `RightPaneState` delegates to `GitService`, which enumerates the immediate children and classifies missing non-Git entries as ignored or excluded before merging them into the existing tree.
+
+## Rendering
+
+`FilesTabView` remains responsible for recursive row rendering and expand/collapse state. It should add a row style branch for `visibility == ignored || visibility == excluded`.
+
+For ignored/excluded rows:
+
+- keep the same row height and monospace filename as normal rows,
+- dim the icon and name using existing theme colors,
+- draw a subtle vertical rail for ignored/excluded subtree rows,
+- show a compact trailing pill with the visibility reason,
+- show a loading affordance only while a lazy directory expansion is in flight.
+
+The selected design should avoid a separate group header, because grouping would move paths away from their filesystem location.
+
+## Errors
+
+If lazy expansion fails for one ignored/excluded directory, the failure should stay local to that directory. The rest of the Files tab should remain usable. A small inline row under the directory can indicate that children could not be loaded.
+
+If the initial ignored/excluded root scan fails, the app should still show the current Git-visible tree. The failure should be logged, matching the current right-pane refresh behavior.
+
+## Tests
+
+Add focused Swift Testing coverage for:
+
+- tree building keeps current tracked and untracked status badge behavior,
+- ignored and excluded nodes are represented distinctly from untracked `A` nodes,
+- ignored/excluded directories can be present with children not loaded,
+- loading one lazy directory adds only its immediate children,
+- expanding a tracked directory can reveal an ignored/excluded child that was absent from the initial Git-visible tree,
+- file and directory path collisions remain preserved with the expanded metadata.
+
+Manual verification should include:
+
+- ignored root directories such as `.build/` appear in the Files tab,
+- expanding an ignored directory loads its first-level children without recursively walking the full tree,
+- untracked files still render with the existing `A` badge,
+- ignored/excluded rows use the ghost-rail affordance.


### PR DESCRIPTION
## Summary
- Include ignored and excluded root entries in the Files tab while preserving existing untracked status affordances.
- Render ignored/excluded rows with the selected ghost-rail affordance and lazy-load directory children on expansion.
- Reconcile open directories after refresh and preserve tracked/untracked metadata during lazy child scans.

## Validation
- `rtk xcodegen`
- `rtk git merge-tree --write-tree HEAD origin/main`
- `rtk git diff --check`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ProcessGitTests -only-testing:AlasTests/FileTreeBuilderTests -only-testing:AlasTests/GitServiceTests -only-testing:AlasTests/RightPaneStateFileTreeTests test`

Note: the full local `xcodebuild ... test` command repeatedly hangs after launching the debug app test host; focused suites for the touched behavior pass.