### PR TITLE
Fix right-pane reveal icon visibility; hide button on right pane

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -9,7 +9,6 @@ struct RootView: View {
     @State private var showNewWorktree = false
     @State private var newWorktreePresetProjectId: String?
     @State private var collapsedProjects: Set<String> = []
-    @State private var rightPaneShown = false
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
@@ -48,8 +47,7 @@ struct RootView: View {
                                 onNewWorktree: { projectId in
                                     newWorktreePresetProjectId = projectId
                                     showNewWorktree = true
-                                },
-                                rightSidebarHidden: !rightPaneShown
+                                }
                             )
                         },
                         center: {
@@ -75,9 +73,6 @@ struct RootView: View {
                             }
                         }
                     )
-                    .onPreferenceChange(RightPaneVisiblePreferenceKey.self) { isVisible in
-                        rightPaneShown = isVisible
-                    }
                 }
             }
             FileSearchDialog(appState: state)

--- a/Alas/Sources/Layout/ThreePaneLayout.swift
+++ b/Alas/Sources/Layout/ThreePaneLayout.swift
@@ -61,14 +61,6 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                 }
             }
             .frame(width: proxy.size.width, height: proxy.size.height, alignment: .leading)
-            .preference(key: RightPaneVisiblePreferenceKey.self, value: sizing.rightVisible)
         }
-    }
-}
-
-struct RightPaneVisiblePreferenceKey: PreferenceKey {
-    static var defaultValue: Bool = false
-    static func reduce(value: inout Bool, nextValue: () -> Bool) {
-        value = nextValue()
     }
 }

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -5,16 +5,17 @@ struct RightPaneTabBar: View {
     let changesCount: Int
     let totalAdd: Int
     let totalDel: Int
-    let onOpenFileSearch: () -> Void
+    let onHidePane: () -> Void
 
     @Environment(\.theme) private var theme
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 6) {
             segment(.changes, icon: "diff", label: "Changes", count: changesCount)
             segment(.files,   icon: "folder", label: "Files",  count: nil)
             Spacer(minLength: 8)
             trailing
+            ToolbarBtn(icon: "sidebar.right", action: onHidePane)
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
         .overlay(Divider().opacity(0.5), alignment: .bottom)
@@ -60,12 +61,7 @@ struct RightPaneTabBar: View {
                 .padding(.trailing, 4)
             }
         case .files:
-            Button(action: onOpenFileSearch) {
-                Icon(name: "search", size: 11)
-            }
-            .buttonStyle(.plain)
-            .opacity(0.7)
-            .padding(.trailing, 4)
+            EmptyView()
         }
     }
 }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -21,7 +21,10 @@ struct RightPaneView: View {
                     changesCount: rps.changes.count,
                     totalAdd: rps.changes.reduce(0) { $0 + $1.add },
                     totalDel: rps.changes.reduce(0) { $0 + $1.del },
-                    onOpenFileSearch: { state.isSearchOpen = true }
+                    onHidePane: {
+                        state.config.rightPaneVisible = false
+                        state.saveConfig()
+                    }
                 )
 
                 switch rps.activeTab {

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -9,7 +9,6 @@ struct SidebarView: View {
     let onEditProject: (_ projectId: String) -> Void
     let onRemoveProject: (_ projectId: String) -> Void
     let onNewWorktree: (_ projectId: String?) -> Void
-    let rightSidebarHidden: Bool
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -26,7 +25,7 @@ struct SidebarView: View {
                         state.config.rightPaneVisible = true
                         state.saveConfig()
                     },
-                    rightSidebarHidden: rightSidebarHidden
+                    rightSidebarHidden: !state.config.rightPaneVisible
                 )
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
## Summary
- The `sidebar.right` reveal icon in the left sidebar header used to appear whenever the right pane wasn't being rendered. On small windows the layout auto-collapses the pane, so the icon would show but clicking it did nothing visible (`rightPaneVisible` was already `true`). Drive the icon from the user preference instead of the rendered state — it now only appears when the user has explicitly hidden the pane.
- Add a `sidebar.right` hide button on the right pane's tab bar so the pane can be collapsed from the right on wide windows.
- Remove the duplicate search icon from the right pane tab bar (the Files-tab one). Search is already in the left sidebar header.

## Test plan
- [ ] Resize the window narrow enough that the right pane auto-collapses: no reveal icon appears in the left sidebar header.
- [ ] On a wide window, click the new hide button on the right pane's tab bar: the right pane collapses and the reveal icon appears in the left sidebar header.
- [ ] Click the reveal icon: the right pane reappears.
- [ ] Switch to the Files tab in the right pane: no search icon present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)