### PR TITLE
Add ao shortcut for alas open

### DIFF
--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -70,16 +70,25 @@ enum TerminalCLIInjection {
         """
     }
 
-    static func installExecutable() throws -> URL {
+    /// Writes the `alas` and `ao` scripts into Alas's per-user bin dir and
+    /// returns that directory. Callers prepend the returned path to the
+    /// session PATH so both commands are visible to the spawned shell.
+    /// Both scripts are written atomically, with `0o700` permissions, and
+    /// only rewritten when their content differs from the desired script.
+    static func installExecutables() throws -> URL {
         let dir = Paths.appSupportRoot.appendingPathComponent("bin", isDirectory: true)
         try Paths.ensureDirectoryExists(dir)
-        let url = dir.appendingPathComponent(executableName, isDirectory: false)
-        let script = executableScript()
+        try writeScript(executableScript(), named: executableName, into: dir)
+        try writeScript(aoExecutableScript(), named: aoExecutableName, into: dir)
+        return dir
+    }
+
+    private static func writeScript(_ script: String, named name: String, into dir: URL) throws {
+        let url = dir.appendingPathComponent(name, isDirectory: false)
         if (try? String(contentsOf: url, encoding: .utf8)) != script {
             try script.write(to: url, atomically: true, encoding: .utf8)
         }
         try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
-        return url
     }
 
     static func pathValue(prepending directory: String, to current: String?) -> String {

--- a/Alas/Sources/Terminal/TerminalCLIInjection.swift
+++ b/Alas/Sources/Terminal/TerminalCLIInjection.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum TerminalCLIInjection {
     static let executableName = "alas"
+    static let aoExecutableName = "ao"
     private static let fallbackPath = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
     static func executableScript() -> String {
@@ -54,6 +55,18 @@ enum TerminalCLIInjection {
             exit 2
             ;;
         esac
+        """
+    }
+
+    /// One-line wrapper that delegates to `alas open`. Lives next to `alas` in
+    /// the same bin dir that's prepended to the session PATH, so the inner
+    /// `alas` lookup is guaranteed to hit Alas's own script. `exec` replaces
+    /// the wrapper process so exit codes and signals propagate verbatim from
+    /// `alas open`.
+    static func aoExecutableScript() -> String {
+        return """
+        #!/bin/sh
+        exec alas open "$@"
         """
     }
 

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -55,9 +55,9 @@ final class TerminalService {
             socketPath: socketPath, inheritParent: cfg.inheritParentEnv
         )
         if socketPath != nil {
-            let cliURL = try TerminalCLIInjection.installExecutable()
+            let binDir = try TerminalCLIInjection.installExecutables()
             env["PATH"] = TerminalCLIInjection.pathValue(
-                prepending: cliURL.deletingLastPathComponent().path,
+                prepending: binDir.path,
                 to: env["PATH"]
             )
         }

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -22,14 +22,38 @@ struct TerminalCLIInjectionTests {
         #expect(script.contains(#"exec alas open "$@""#))
     }
 
-    @Test func installExecutableWritesAlasCommand() throws {
-        let url = try TerminalCLIInjection.installExecutable()
+    @Test func installExecutablesWritesAlasAndAoCommands() throws {
+        let dir = try TerminalCLIInjection.installExecutables()
         var isDirectory: ObjCBool = false
 
-        #expect(FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory))
-        #expect(!isDirectory.boolValue)
-        #expect(FileManager.default.isExecutableFile(atPath: url.path))
-        #expect(url.lastPathComponent == "alas")
+        #expect(FileManager.default.fileExists(atPath: dir.path, isDirectory: &isDirectory))
+        #expect(isDirectory.boolValue)
+
+        let alasURL = dir.appendingPathComponent("alas")
+        var alasIsDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: alasURL.path, isDirectory: &alasIsDir))
+        #expect(!alasIsDir.boolValue)
+        #expect(FileManager.default.isExecutableFile(atPath: alasURL.path))
+
+        let aoURL = dir.appendingPathComponent("ao")
+        var aoIsDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: aoURL.path, isDirectory: &aoIsDir))
+        #expect(!aoIsDir.boolValue)
+        #expect(FileManager.default.isExecutableFile(atPath: aoURL.path))
+    }
+
+    @Test func installExecutablesIsIdempotent() throws {
+        let dir1 = try TerminalCLIInjection.installExecutables()
+        let alasBefore = try String(contentsOf: dir1.appendingPathComponent("alas"), encoding: .utf8)
+        let aoBefore = try String(contentsOf: dir1.appendingPathComponent("ao"), encoding: .utf8)
+
+        let dir2 = try TerminalCLIInjection.installExecutables()
+
+        #expect(dir1.path == dir2.path)
+        let alasAfter = try String(contentsOf: dir2.appendingPathComponent("alas"), encoding: .utf8)
+        let aoAfter = try String(contentsOf: dir2.appendingPathComponent("ao"), encoding: .utf8)
+        #expect(alasAfter == alasBefore)
+        #expect(aoAfter == aoBefore)
     }
 
     @Test func pathValueUsesSystemFallbackWhenCurrentPathIsEmpty() {
@@ -56,7 +80,7 @@ struct TerminalCLIInjectionTests {
         let socketPath = "\(root)/test.sock"
         try FileManager.default.createDirectory(atPath: nestedDir, withIntermediateDirectories: true)
         try FileManager.default.createSymbolicLink(atPath: logicalDir, withDestinationPath: realDir)
-        let cliURL = try TerminalCLIInjection.installExecutable()
+        let binDir = try TerminalCLIInjection.installExecutables()
         defer { try? FileManager.default.removeItem(atPath: root) }
 
         let server = AgentHookSocketServer(socketPath: socketPath)
@@ -78,7 +102,7 @@ struct TerminalCLIInjectionTests {
         process.arguments = ["-c", #"cd "$ALAS_LOGICAL_DIR"; alas open "dir with spaces/file.txt""#]
         process.currentDirectoryURL = URL(fileURLWithPath: root, isDirectory: true)
         var env = ProcessInfo.processInfo.environment
-        env["PATH"] = "\(cliURL.deletingLastPathComponent().path):\(env["PATH"] ?? "")"
+        env["PATH"] = "\(binDir.path):\(env["PATH"] ?? "")"
         env["ALAS_SOCKET_PATH"] = socketPath
         env["ALAS_SESSION_ID"] = "test-session"
         env["ALAS_LOGICAL_DIR"] = logicalDir

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -34,12 +34,14 @@ struct TerminalCLIInjectionTests {
         #expect(FileManager.default.fileExists(atPath: alasURL.path, isDirectory: &alasIsDir))
         #expect(!alasIsDir.boolValue)
         #expect(FileManager.default.isExecutableFile(atPath: alasURL.path))
+        #expect(try String(contentsOf: alasURL, encoding: .utf8) == TerminalCLIInjection.executableScript())
 
         let aoURL = dir.appendingPathComponent("ao")
         var aoIsDir: ObjCBool = false
         #expect(FileManager.default.fileExists(atPath: aoURL.path, isDirectory: &aoIsDir))
         #expect(!aoIsDir.boolValue)
         #expect(FileManager.default.isExecutableFile(atPath: aoURL.path))
+        #expect(try String(contentsOf: aoURL, encoding: .utf8) == TerminalCLIInjection.aoExecutableScript())
     }
 
     @Test func installExecutablesIsIdempotent() throws {

--- a/AlasTests/TerminalCLIInjectionTests.swift
+++ b/AlasTests/TerminalCLIInjectionTests.swift
@@ -15,6 +15,13 @@ struct TerminalCLIInjectionTests {
         #expect(script.contains("/usr/bin/nc -U -w1"))
     }
 
+    @Test func aoExecutableScriptExecsAlasOpen() {
+        let script = TerminalCLIInjection.aoExecutableScript()
+
+        #expect(script.hasPrefix("#!/bin/sh"))
+        #expect(script.contains(#"exec alas open "$@""#))
+    }
+
     @Test func installExecutableWritesAlasCommand() throws {
         let url = try TerminalCLIInjection.installExecutable()
         var isDirectory: ObjCBool = false

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -210,3 +210,12 @@ Run from a real worktree with at least one Swift file and one CRLF text file.
 - **Permissions preservation.** `chmod 755` a script file, open it, edit, ⌘S. `ls -l` still shows `-rwxr-xr-x`.
 - **Big file responsiveness.** Open a 5 k-line file, type rapidly. No visible flicker. Diagnostics catch up within ~1 s of pause.
 - **Save failure.** `chmod 555` the parent directory, edit, ⌘S. The conflict-banner area shows "Couldn't save: …". Restore perms, ⌘S succeeds.
+
+## `ao` alias
+
+Inside an Alas-spawned terminal:
+
+- `type ao` reports the script path under Alas's per-user bin dir (same directory as `alas`).
+- `ao README.md` opens the file in the editor (identical behavior to `alas open README.md`).
+- `ao` with no arguments prints `usage: alas open <path> [path...]` and exits with a non-zero status.
+- Launching a terminal **outside** Alas, `type ao` reports `ao: not found` (or the shell's equivalent).


### PR DESCRIPTION
## Summary

- Add an `ao` shell script wrapper that does `exec alas open "$@"`, installed alongside `alas` in the Alas-managed bin dir so it's available exactly where `alas` is (only inside Alas-spawned terminals, all shells).
- Refactor `TerminalCLIInjection.installExecutable() -> URL` to `installExecutables() -> URL`, returning the bin directory and writing both scripts via a small private `writeScript(_:named:into:)` helper that preserves the existing atomic-write + content-diff-skip + 0o700 pattern.
- Add `docs/manual-test.md` coverage for the new alias.

`ao` is locked to the `open` subcommand — it is **not** a general short form of `alas`. Future `alas` subcommands stay on `alas` only.

## Test plan

- [x] `xcodebuild test -only-testing:AlasTests/TerminalCLIInjectionTests` passes (7 tests: existing 5 + `aoExecutableScriptExecsAlasOpen`, `installExecutablesWritesAlasAndAoCommands`, `installExecutablesIsIdempotent`; existing bash + zsh end-to-end tests still cover the full PATH-injection + socket flow)
- [x] `xcodebuild build` succeeds
- [x] Manual: launched a fresh Debug build, opened a terminal pane, ran `ao README.md` — file opens identically to `alas open README.md`
- [ ] CI green