### PR TITLE
Cmd-K "Switch Repository" dialog

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D105CB2C185958ED23164D1 /* IndentationMode.swift */; };
 		70FCC2B12AE446728EE7CF8D /* LSPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38499AFE31188908546EE222 /* LSPTransport.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
+		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
 		7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */; };
 		74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 77EF95AD63DDA8DB0504087B /* TreeSitterSwift */; };
 		74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A34259DE8E978943E8BE16 /* OKLCH.swift */; };
@@ -337,6 +338,7 @@
 		D675E5B1E5E95E7239F3A89F /* InstallRecipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */; };
 		D6A8D3925ACCB69DAC380B95 /* AgentPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58DD85A6E01972B39F2D8AD /* AgentPath.swift */; };
 		D6B39CE8878BB196FF2277B6 /* AgentDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */; };
+		D7A0A35396E440B31711F9D9 /* RepoSelectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
 		D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */; };
 		DAD02DC484C697D856B0CD6A /* CommitComposerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D733701E36E13A7A23748A37 /* CommitComposerState.swift */; };
@@ -456,6 +458,7 @@
 		2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
 		2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.App.swift; sourceTree = "<group>"; };
 		215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyHost.swift; sourceTree = "<group>"; };
+		220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModelTests.swift; sourceTree = "<group>"; };
 		23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCommandShellTests.swift; sourceTree = "<group>"; };
 		2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallProgressSheet.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
@@ -602,6 +605,7 @@
 		7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshot.swift; sourceTree = "<group>"; };
 		7FFC9539E615699AC90A7412 /* ProjectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManager.swift; sourceTree = "<group>"; };
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
+		822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModel.swift; sourceTree = "<group>"; };
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
 		856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscardTests.swift; sourceTree = "<group>"; };
@@ -935,6 +939,7 @@
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */,
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
+				220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */,
 				784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */,
 				4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */,
 				3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */,
@@ -1434,6 +1439,7 @@
 			isa = PBXGroup;
 			children = (
 				37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */,
+				822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */,
 				9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */,
 				DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */,
 			);
@@ -1907,6 +1913,7 @@
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
 				E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */,
+				D7A0A35396E440B31711F9D9 /* RepoSelectorModel.swift in Sources */,
 				E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */,
 				2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
@@ -2090,6 +2097,7 @@
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
+				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,
 				21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */,
 				8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -361,6 +361,7 @@
 		E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */; };
 		E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
+		E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */; };
 		E6CB573877637461E11CACAF /* InstallRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */; };
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
 		E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A03B92542169A6595D432 /* HoverHighlightFeature.swift */; };
@@ -496,6 +497,7 @@
 		3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerWorktreeOrderingTests.swift; sourceTree = "<group>"; };
 		373D587E3153D902EB10208B /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
 		37987D5884297401F95478D3 /* AgentPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPathTests.swift; sourceTree = "<group>"; };
+		37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorEnvironment.swift; sourceTree = "<group>"; };
 		38499AFE31188908546EE222 /* LSPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransport.swift; sourceTree = "<group>"; };
 		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
 		38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceHeadMessageTests.swift; sourceTree = "<group>"; };
@@ -1431,6 +1433,7 @@
 		C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */ = {
 			isa = PBXGroup;
 			children = (
+				37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */,
 				9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */,
 				DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */,
 			);
@@ -1903,6 +1906,7 @@
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
+				E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */,
 				E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */,
 				2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */; };
 		3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36992F601C8EB6C3D45B584F /* SearchKbd.swift */; };
 		3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */; };
+		35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */; };
 		35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */; };
 		363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */; };
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
@@ -351,6 +352,7 @@
 		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
 		E2A49F787B3DC3F45E92854D /* AgentEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */; };
 		E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */; };
+		E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */; };
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
 		E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA8FEE64D73BDEBAF74878 /* Kbd.swift */; };
 		E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */; };
@@ -583,6 +585,7 @@
 		76F2498E56CBAF84CB67166C /* HarnessKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessKind.swift; sourceTree = "<group>"; };
 		781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionPicker.swift; sourceTree = "<group>"; };
 		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = .build/ghostty/GhosttyKit.xcframework; sourceTree = "<group>"; };
+		784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecentsTests.swift; sourceTree = "<group>"; };
 		7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstaller.swift; sourceTree = "<group>"; };
 		795056B6AD803D2B555FC866 /* RightPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStore.swift; sourceTree = "<group>"; };
 		79DDEA496740F5B0B5EE808B /* Process+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Process+Git.swift"; sourceTree = "<group>"; };
@@ -629,6 +632,7 @@
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
 		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
+		9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecents.swift; sourceTree = "<group>"; };
 		9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunnerInvocationTests.swift; sourceTree = "<group>"; };
 		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
 		9DCC5576ACD7C49EB6915992 /* CommitComposerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerStateTests.swift; sourceTree = "<group>"; };
@@ -927,6 +931,7 @@
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */,
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
+				784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */,
 				4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */,
 				3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */,
 				5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */,
@@ -969,6 +974,7 @@
 				EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */,
 				711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */,
 				3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */,
+				C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */,
 			);
 			path = Dialogs;
 			sourceTree = "<group>";
@@ -1418,6 +1424,14 @@
 				0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */ = {
+			isa = PBXGroup;
+			children = (
+				9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */,
+			);
+			path = RepoSelector;
 			sourceTree = "<group>";
 		};
 		C86FE0D59F990939C552C7E2 /* Products */ = {
@@ -1886,6 +1900,7 @@
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
+				E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
 				BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */,
@@ -2067,6 +2082,7 @@
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
+				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,
 				21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */,
 				8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */,
 				35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
 		A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */; };
 		A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */; };
+		A2B0E4C1D80EB12F7BECE7FC /* RepoSelectorDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */; };
 		A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
@@ -545,6 +546,7 @@
 		524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibility.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
+		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
 		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
@@ -1440,6 +1442,7 @@
 		C2E05FF3EC7EAB497BA0FFE0 /* RepoSelector */ = {
 			isa = PBXGroup;
 			children = (
+				541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */,
 				37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */,
 				822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */,
 				9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */,
@@ -1915,6 +1918,7 @@
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
+				A2B0E4C1D80EB12F7BECE7FC /* RepoSelectorDialog.swift in Sources */,
 				E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */,
 				D7A0A35396E440B31711F9D9 /* RepoSelectorModel.swift in Sources */,
 				E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		2D313A7E99C93242DD35AA8E /* CursorInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */; };
 		2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */; };
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
+		2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */; };
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
 		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
@@ -729,6 +730,7 @@
 		D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
 		D97EF761C70A3AF83C00879A /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		D9E6D61B213F3378243B4A26 /* AlasField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasField.swift; sourceTree = "<group>"; };
+		DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRow.swift; sourceTree = "<group>"; };
 		DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetailsTests.swift; sourceTree = "<group>"; };
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
 		DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewModeTests.swift; sourceTree = "<group>"; };
@@ -1430,6 +1432,7 @@
 			isa = PBXGroup;
 			children = (
 				9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */,
+				DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */,
 			);
 			path = RepoSelector;
 			sourceTree = "<group>";
@@ -1901,6 +1904,7 @@
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
 				E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */,
+				2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
 				BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
 		1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */; };
+		1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
 		1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */; };
@@ -777,6 +778,7 @@
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
+		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
 		F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceDiscardTests.swift; sourceTree = "<group>"; };
 		F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchDialog.swift; sourceTree = "<group>"; };
@@ -1442,6 +1444,7 @@
 				822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */,
 				9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */,
 				DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */,
+				F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */,
 			);
 			path = RepoSelector;
 			sourceTree = "<group>";
@@ -1916,6 +1919,7 @@
 				D7A0A35396E440B31711F9D9 /* RepoSelectorModel.swift in Sources */,
 				E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */,
 				2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */,
+				1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
 				BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -134,6 +134,10 @@ struct AlasApp: App {
                 }
                 .keyboardShortcut("n", modifiers: [.command, .option])
                 .disabled(state.projects.isEmpty)
+                Button("Switch Repository…") {
+                    NotificationCenter.default.post(name: .alasOpenRepoSelector, object: nil)
+                }
+                .keyboardShortcut("k", modifiers: .command)
                 Divider()
                 Button("Refresh Worktrees") {
                     NotificationCenter.default.post(name: .alasRefreshWorktrees, object: nil)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -261,7 +261,14 @@ final class AppState {
         RepoSelectorEnvironment(
             projects: { [weak self] in self?.projects ?? [] },
             visibleWorktrees: { [weak self] projectId in
-                self?.projectsManager.visibleWorktrees(projectId: projectId) ?? []
+                guard let self else { return [] }
+                // Hide worktrees that are mid-create/delete or in a failed
+                // operation state — the main pane refuses to render them
+                // and the sidebar deliberately ignores taps on those rows,
+                // so the selector must not focus them either.
+                return self.projectsManager.visibleWorktrees(projectId: projectId).filter {
+                    self.projectsManager.operationState(for: $0.id) == nil
+                }
             },
             readRecents: { [weak self] in
                 guard let self else { return RepoSelectorRecents() }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -262,12 +262,17 @@ final class AppState {
             projects: { [weak self] in self?.projects ?? [] },
             visibleWorktrees: { [weak self] projectId in
                 guard let self else { return [] }
-                // Hide worktrees that are mid-create/delete or in a failed
-                // operation state — the main pane refuses to render them
-                // and the sidebar deliberately ignores taps on those rows,
-                // so the selector must not focus them either.
+                // Match `RootView.selectedWorktree()`: hide creating /
+                // deleting / createFailed rows (the main pane returns nil
+                // for them) but keep deleteFailed selectable so the user
+                // can recover via keyboard nav, mirroring the sidebar.
                 return self.projectsManager.visibleWorktrees(projectId: projectId).filter {
-                    self.projectsManager.operationState(for: $0.id) == nil
+                    switch self.projectsManager.operationState(for: $0.id) {
+                    case .creating, .deleting, .createFailed:
+                        return false
+                    case nil, .deleteFailed:
+                        return true
+                    }
                 }
             },
             readRecents: { [weak self] in

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -24,6 +24,8 @@ final class AppState {
     private var lspManager: WorkspaceLSPManager?
 
     var isSearchOpen: Bool = false
+    var isRepoSelectorOpen: Bool = false
+    let repoSelector = RepoSelectorModel()
 
     /// Computed each time `config.agents` changes or detection re-runs.
     /// `RootView.task` calls `rescanAgents()` once at launch; the Settings
@@ -249,6 +251,38 @@ final class AppState {
     }
 
     var projects: [ProjectConfig] { projectsManager.projects }
+
+    /// Build a `RepoSelectorEnvironment` that captures `self`. Used by
+    /// `RepoSelectorDialog` to bind the model to the live app state.
+    func repoSelectorEnvironment(
+        openNewProject: @escaping () -> Void,
+        openNewWorktree: @escaping (String) -> Void
+    ) -> RepoSelectorEnvironment {
+        RepoSelectorEnvironment(
+            projects: { [weak self] in self?.projects ?? [] },
+            visibleWorktrees: { [weak self] projectId in
+                self?.projectsManager.visibleWorktrees(projectId: projectId) ?? []
+            },
+            readRecents: { [weak self] in
+                guard let self else { return RepoSelectorRecents() }
+                return RepoSelectorRecents(
+                    projectIds: self.config.recentProjectIds,
+                    worktreeIdsByProject: self.config.recentWorktreeIdsByProject
+                )
+            },
+            writeRecents: { [weak self] r in
+                guard let self else { return }
+                self.config.recentProjectIds = r.projectIds
+                self.config.recentWorktreeIdsByProject = r.worktreeIdsByProject
+                _ = self.saveConfig()
+            },
+            focusWorktree: { [weak self] id in
+                self?.selectedWorktreeId = id
+            },
+            openNewProject: openNewProject,
+            openNewWorktree: openNewWorktree
+        )
+    }
 
     @discardableResult
     func saveConfig() -> Bool {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -372,6 +372,7 @@ private struct RootBaseHandlers: ViewModifier {
                 // Close the repo selector so the two overlays never overlap;
                 // RepoSelectorDialog is mounted after FileSearchDialog and
                 // would otherwise keep capturing keys.
+                state.repoSelector.close()
                 state.isRepoSelectorOpen = false
                 state.search.open()
                 state.isSearchOpen = true
@@ -379,10 +380,14 @@ private struct RootBaseHandlers: ViewModifier {
         let o = n
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenRepoSelector)) { _ in
                 // Toggle: closing if already open, opening (and closing the
-                // file searcher) if not.
+                // file searcher) if not. We also call `search.close()` so an
+                // in-flight content search task is cancelled rather than
+                // continuing in the background under the new overlay.
                 if state.isRepoSelectorOpen {
+                    state.repoSelector.close()
                     state.isRepoSelectorOpen = false
                 } else {
+                    state.search.close()
                     state.isSearchOpen = false
                     state.isRepoSelectorOpen = true
                 }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -367,6 +367,17 @@ private struct RootBaseHandlers: ViewModifier {
                 state.isSearchOpen = true
             }
         let o = n
+            .onReceive(NotificationCenter.default.publisher(for: .alasOpenRepoSelector)) { _ in
+                // Toggle: closing if already open, opening (and closing the
+                // file searcher) if not.
+                if state.isRepoSelectorOpen {
+                    state.isRepoSelectorOpen = false
+                } else {
+                    state.isSearchOpen = false
+                    state.isRepoSelectorOpen = true
+                }
+            }
+        let p = o
             .onReceive(NotificationCenter.default.publisher(for: .alasRefreshWorktrees)) { _ in
                 let beforeIds = state.allWorktreeIds()
                 Task {
@@ -377,7 +388,7 @@ private struct RootBaseHandlers: ViewModifier {
                     state.cleanupMissingWorktrees(beforeIds: beforeIds)
                 }
             }
-        return o
+        return p
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                 state.stopAllProjectGitWatchers()
                 state.tabs.snapshotDirtyBuffersForQuit()
@@ -434,6 +445,7 @@ extension Notification.Name {
     static let alasActivateTabByNumber = Notification.Name("AlasActivateTabByNumber")
     static let alasOpenSettings    = Notification.Name("AlasOpenSettings")
     static let alasOpenSearch      = Notification.Name("AlasOpenSearch")
+    static let alasOpenRepoSelector = Notification.Name("AlasOpenRepoSelector")
     static let alasSaveActiveTab   = Notification.Name("AlasSaveActiveTab")
     static let alasSaveActiveTabAs = Notification.Name("AlasSaveActiveTabAs")
     static let alasSaveAllTabs     = Notification.Name("AlasSaveAllTabs")

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -76,6 +76,7 @@ struct RootView: View {
                 }
             }
             FileSearchDialog(appState: state)
+            RepoSelectorDialog(appState: state)
         }
         .environment(\.theme, state.themeStore.current)
         .onChange(of: state.themeStore.current.id) { _, _ in

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -369,6 +369,10 @@ private struct RootBaseHandlers: ViewModifier {
             }
         let n = m
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenSearch)) { _ in
+                // Close the repo selector so the two overlays never overlap;
+                // RepoSelectorDialog is mounted after FileSearchDialog and
+                // would otherwise keep capturing keys.
+                state.isRepoSelectorOpen = false
                 state.search.open()
                 state.isSearchOpen = true
             }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -88,6 +88,7 @@ struct RootView: View {
         .modifier(RootCommandHandlers(
             state: state,
             showNewWorktree: $showNewWorktree,
+            newWorktreePresetProjectId: $newWorktreePresetProjectId,
             showNewProject: $showNewProject,
             selectedWorktree: selectedWorktree,
             openSettings: openSettingsWindow
@@ -267,6 +268,7 @@ struct RootView: View {
 private struct RootCommandHandlers: ViewModifier {
     @Bindable var state: AppState
     @Binding var showNewWorktree: Bool
+    @Binding var newWorktreePresetProjectId: String?
     @Binding var showNewProject: Bool
     let selectedWorktree: () -> Worktree?
     let openSettings: () -> Void
@@ -276,6 +278,7 @@ private struct RootCommandHandlers: ViewModifier {
             .modifier(RootBaseHandlers(
                 state: state,
                 showNewWorktree: $showNewWorktree,
+                newWorktreePresetProjectId: $newWorktreePresetProjectId,
                 showNewProject: $showNewProject,
                 selectedWorktree: selectedWorktree,
                 openSettings: openSettings
@@ -290,6 +293,7 @@ private struct RootCommandHandlers: ViewModifier {
 private struct RootBaseHandlers: ViewModifier {
     @Bindable var state: AppState
     @Binding var showNewWorktree: Bool
+    @Binding var newWorktreePresetProjectId: String?
     @Binding var showNewProject: Bool
     let selectedWorktree: () -> Worktree?
     let openSettings: () -> Void
@@ -305,7 +309,8 @@ private struct RootBaseHandlers: ViewModifier {
                 showNewProject = true
             }
         let c = b
-            .onReceive(NotificationCenter.default.publisher(for: .alasNewWorktree)) { _ in
+            .onReceive(NotificationCenter.default.publisher(for: .alasNewWorktree)) { notification in
+                newWorktreePresetProjectId = notification.object as? String
                 showNewWorktree = true
             }
         let d = c

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -202,6 +202,15 @@ struct RepoSelectorDialog: View {
         case .return:
             activate(rows: rows)
             return .handled
+        case .tab:
+            // The no-projects empty hint advertises "Press ⇥ to add one".
+            // Honor that here; everywhere else Tab is left alone.
+            let safeIndex = max(0, min(rows.count - 1, model.selectedIndex))
+            if rows.indices.contains(safeIndex), case .emptyHint = rows[safeIndex] {
+                activate(rows: rows)
+                return .handled
+            }
+            return .ignored
         default:
             return .ignored
         }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -90,27 +90,37 @@ struct RepoSelectorDialog: View {
         let env = environment()
         let rows = appState.repoSelector.rows(environment: env)
         let projectsById = Dictionary(uniqueKeysWithValues: appState.projects.map { ($0.id, $0) })
-        return ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(Array(rows.enumerated()), id: \.offset) { idx, row in
-                    RepoSelectorRowView(
-                        row: row,
-                        isSelected: idx == appState.repoSelector.selectedIndex,
-                        projectsById: projectsById,
-                        onTap: {
-                            // Snap selection to the clicked row before
-                            // activating so a tap without a preceding hover
-                            // can't fire the stale keyboard selection.
-                            appState.repoSelector.setSelectedIndex(idx, in: rows)
-                            activate(rows: rows)
-                        },
-                        onHover: { appState.repoSelector.setSelectedIndex(idx, in: rows) }
-                    )
+        return ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(rows.enumerated()), id: \.offset) { idx, row in
+                        RepoSelectorRowView(
+                            row: row,
+                            isSelected: idx == appState.repoSelector.selectedIndex,
+                            projectsById: projectsById,
+                            onTap: {
+                                // Snap selection to the clicked row before
+                                // activating so a tap without a preceding hover
+                                // can't fire the stale keyboard selection.
+                                appState.repoSelector.setSelectedIndex(idx, in: rows)
+                                activate(rows: rows)
+                            },
+                            onHover: { appState.repoSelector.setSelectedIndex(idx, in: rows) }
+                        )
+                        .id(idx)
+                    }
                 }
+                .padding(.vertical, 4)
             }
-            .padding(.vertical, 4)
+            .frame(minHeight: 200, maxHeight: 420)
+            // Scroll to the selected row when the keyboard moves selection.
+            // We watch `scrollToSelectionTick` (bumped by ↑/↓) instead of
+            // `selectedIndex` itself so hover-driven selection doesn't fight
+            // the user's scroll input.
+            .onChange(of: appState.repoSelector.scrollToSelectionTick) { _, _ in
+                proxy.scrollTo(appState.repoSelector.selectedIndex, anchor: .center)
+            }
         }
-        .frame(minHeight: 200, maxHeight: 420)
     }
 
     private var footer: some View {

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -155,7 +155,7 @@ struct RepoSelectorDialog: View {
         switch result {
         case .focused, .openedNewWorktree, .openedNewProject:
             appState.isRepoSelectorOpen = false
-        case .pushed, .showEmptyHint:
+        case .pushed:
             inputFocused = true
         case .noop:
             break

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -97,7 +97,13 @@ struct RepoSelectorDialog: View {
                         row: row,
                         isSelected: idx == appState.repoSelector.selectedIndex,
                         projectsById: projectsById,
-                        onTap: { activate(rows: rows) },
+                        onTap: {
+                            // Snap selection to the clicked row before
+                            // activating so a tap without a preceding hover
+                            // can't fire the stale keyboard selection.
+                            appState.repoSelector.setSelectedIndex(idx, in: rows)
+                            activate(rows: rows)
+                        },
                         onHover: { appState.repoSelector.setSelectedIndex(idx, in: rows) }
                     )
                 }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+
+struct RepoSelectorDialog: View {
+    @Bindable var appState: AppState
+    @Environment(\.theme) private var theme
+    @FocusState private var inputFocused: Bool
+
+    var body: some View {
+        if appState.isRepoSelectorOpen {
+            ZStack {
+                Color.black.opacity(0.42)
+                    .ignoresSafeArea()
+                    .onTapGesture { close() }
+
+                VStack(spacing: 0) {
+                    if case .worktrees(let projectId) = appState.repoSelector.step {
+                        breadcrumb(projectId: projectId)
+                    }
+                    inputRow
+                    Divider().background(theme.color("line"))
+                    rowList
+                    footer
+                }
+                .frame(width: 480)
+                .frame(maxHeight: 520)
+                .background(theme.color("bg-1").opacity(0.92))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                )
+                .shadow(color: .black.opacity(0.5), radius: 30, x: 0, y: 20)
+                .padding(.top, 70)
+                .frame(maxHeight: .infinity, alignment: .top)
+                .onTapGesture { /* swallow */ }
+                .onKeyPress { press in handleKey(press) }
+            }
+            .transition(.opacity.combined(with: .offset(y: -6)))
+            .onAppear {
+                appState.repoSelector.open()
+                inputFocused = true
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var inputRow: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg-faint"))
+            TextField(placeholder, text: Bindable(appState.repoSelector).query)
+                .textFieldStyle(.plain)
+                .focused($inputFocused)
+                .font(.system(size: 14))
+                .foregroundColor(theme.color("fg"))
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+    }
+
+    private var placeholder: String {
+        switch appState.repoSelector.step {
+        case .repos:
+            return "Switch repository…"
+        case .worktrees(let projectId):
+            let name = appState.projects.first(where: { $0.id == projectId })?.name ?? ""
+            return "Switch worktree in \(name)…"
+        }
+    }
+
+    private func breadcrumb(projectId: String) -> some View {
+        let name = appState.projects.first(where: { $0.id == projectId })?.name ?? ""
+        return HStack(spacing: 6) {
+            Image(systemName: "chevron.left")
+                .font(.system(size: 10, weight: .semibold))
+            Text(name)
+                .font(.system(size: 12, weight: .medium))
+        }
+        .foregroundColor(theme.color("fg-dim"))
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .onTapGesture { popToRepos() }
+    }
+
+    private var rowList: some View {
+        let env = environment()
+        let rows = appState.repoSelector.rows(environment: env)
+        let projectsById = Dictionary(uniqueKeysWithValues: appState.projects.map { ($0.id, $0) })
+        return ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { idx, row in
+                    RepoSelectorRowView(
+                        row: row,
+                        isSelected: idx == appState.repoSelector.selectedIndex,
+                        projectsById: projectsById,
+                        onTap: { activate(rows: rows) },
+                        onHover: { appState.repoSelector.setSelectedIndex(idx, in: rows) }
+                    )
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .frame(minHeight: 200, maxHeight: 420)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            label("↑↓ navigate")
+            label("↵ open")
+            label("esc \(escLabel)")
+            Spacer()
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-2").opacity(0.5))
+        .overlay(
+            Rectangle().fill(theme.color("line-soft")).frame(height: 0.5),
+            alignment: .top
+        )
+    }
+
+    private func label(_ s: String) -> some View {
+        Text(s)
+            .font(.system(size: 11))
+            .foregroundColor(theme.color("fg-faint"))
+    }
+
+    private var escLabel: String {
+        switch appState.repoSelector.step {
+        case .repos: return "close"
+        case .worktrees: return "back"
+        }
+    }
+
+    // MARK: - Actions
+
+    private func environment() -> RepoSelectorEnvironment {
+        appState.repoSelectorEnvironment(
+            openNewProject: {
+                NotificationCenter.default.post(name: .alasCreateProject, object: nil)
+            },
+            openNewWorktree: { projectId in
+                NotificationCenter.default.post(name: .alasNewWorktree, object: projectId)
+            }
+        )
+    }
+
+    private func activate(rows: [RepoSelectorRow]) {
+        let env = environment()
+        let result = appState.repoSelector.activate(rows: rows, environment: env)
+        switch result {
+        case .focused, .openedNewWorktree, .openedNewProject:
+            appState.isRepoSelectorOpen = false
+        case .pushed, .showEmptyHint:
+            inputFocused = true
+        case .noop:
+            break
+        }
+    }
+
+    private func popToRepos() {
+        appState.repoSelector.popToRepos()
+        inputFocused = true
+    }
+
+    private func close() {
+        appState.repoSelector.close()
+        appState.isRepoSelectorOpen = false
+    }
+
+    // MARK: - Keys
+
+    private func handleKey(_ press: KeyPress) -> KeyPress.Result {
+        let model = appState.repoSelector
+        let env = environment()
+        let rows = model.rows(environment: env)
+        switch press.key {
+        case .escape:
+            switch model.step {
+            case .repos:
+                close()
+            case .worktrees:
+                popToRepos()
+            }
+            return .handled
+        case .upArrow:
+            model.moveSelectionUp(in: rows)
+            return .handled
+        case .downArrow:
+            model.moveSelectionDown(in: rows)
+            return .handled
+        case .return:
+            activate(rows: rows)
+            return .handled
+        default:
+            return .ignored
+        }
+    }
+}

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorEnvironment.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorEnvironment.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// All inputs `RepoSelectorModel` needs from the rest of the app, isolated
+/// for testing. Closures capture `AppState` in production wiring.
+@MainActor
+struct RepoSelectorEnvironment {
+    /// Configured projects in sidebar order (`AppState.projects`).
+    var projects: () -> [ProjectConfig]
+    /// Visible worktrees for a given project, in sidebar order
+    /// (`ProjectsManager.visibleWorktrees(projectId:)`).
+    var visibleWorktrees: (String) -> [Worktree]
+    /// Read the current recents value (from `AppConfig`).
+    var readRecents: () -> RepoSelectorRecents
+    /// Write a mutated recents value back to `AppConfig` and persist.
+    var writeRecents: (RepoSelectorRecents) -> Void
+    /// Focus a worktree by id (sets `AppState.selectedWorktreeId`).
+    var focusWorktree: (_ worktreeId: String) -> Void
+    /// Open `NewProjectDialog` (post `.alasCreateProject`).
+    var openNewProject: () -> Void
+    /// Open `NewWorktreeDialog` for the given project.
+    var openNewWorktree: (_ projectId: String) -> Void
+}

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -98,13 +98,80 @@ final class RepoSelectorModel {
             .map { .repo($0.project, indices: $0.result.indices) }
     }
 
-    // MARK: - Step 2 rows (stub for Task 7 — keep compiling)
+    // MARK: - Step transitions
+
+    func pushRepo(projectId: String) {
+        savedReposQuery = query
+        savedReposSelectedIndex = selectedIndex
+        step = .worktrees(projectId: projectId)
+        query = ""
+        selectedIndex = 0
+    }
+
+    func popToRepos() {
+        step = .repos
+        query = savedReposQuery
+        selectedIndex = savedReposSelectedIndex
+    }
+
+    // MARK: - Step 2 rows
 
     private func worktreeRows(
         projectId: String,
         environment env: RepoSelectorEnvironment
     ) -> [RepoSelectorRow] {
-        return []
+        let worktrees = env.visibleWorktrees(projectId)
+
+        let listed: [RepoSelectorRow]
+        if query.isEmpty {
+            listed = emptyQueryWorktreeRows(
+                projectId: projectId,
+                worktrees: worktrees,
+                environment: env
+            )
+        } else {
+            listed = filteredWorktreeRows(worktrees: worktrees)
+        }
+
+        var rows = listed
+        rows.append(.divider(label: ""))
+        rows.append(.action(.newWorktreeForRepo(projectId: projectId)))
+        return rows
+    }
+
+    private func emptyQueryWorktreeRows(
+        projectId: String,
+        worktrees: [Worktree],
+        environment env: RepoSelectorEnvironment
+    ) -> [RepoSelectorRow] {
+        let validIds = Set(worktrees.map(\.id))
+        let recentIds = env.readRecents().liveWorktreeIds(in: projectId, validWorktreeIds: validIds)
+        let byId = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0) })
+        let recentRows: [RepoSelectorRow] = recentIds.compactMap {
+            byId[$0].map { .worktree($0, indices: []) }
+        }
+        let recentSet = Set(recentIds)
+        let rest = worktrees
+            .filter { !recentSet.contains($0.id) }
+            .map { RepoSelectorRow.worktree($0, indices: []) }
+        return recentRows + rest
+    }
+
+    private func filteredWorktreeRows(worktrees: [Worktree]) -> [RepoSelectorRow] {
+        struct Scored {
+            let worktree: Worktree
+            let result: FuzzyMatch.Result
+        }
+        let scored: [Scored] = worktrees.compactMap { w in
+            guard let r = FuzzyMatch.score(query: query, target: w.branch) else { return nil }
+            return Scored(worktree: w, result: r)
+        }
+        return scored
+            .sorted { a, b in
+                if a.result.score != b.result.score { return a.result.score > b.result.score }
+                return a.worktree.branch.localizedCaseInsensitiveCompare(b.worktree.branch) == .orderedAscending
+            }
+            .map { .worktree($0.worktree, indices: $0.result.indices) }
     }
 
     // MARK: - Selection

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -14,7 +14,13 @@ final class RepoSelectorModel {
 
     var isOpen: Bool = false
     private(set) var step: Step = .repos
-    var query: String = ""
+    var query: String = "" {
+        didSet {
+            // Reset selection so a shrinking filter never strands the cursor
+            // on a stale row (especially the trailing `+ New worktree…`).
+            if query != oldValue { selectedIndex = 0 }
+        }
+    }
     private(set) var selectedIndex: Int = 0
 
     // Snapshot of step-1 state preserved across a push so popToRepos can
@@ -179,7 +185,6 @@ final class RepoSelectorModel {
     enum Activation: Equatable {
         case pushed(projectId: String)
         case focused(worktreeId: String)
-        case showEmptyHint(projectId: String)
         case openedNewWorktree(projectId: String)
         case openedNewProject
         case noop
@@ -213,11 +218,6 @@ final class RepoSelectorModel {
             close()
             return .openedNewProject
 
-        case .emptyHint(.noVisibleWorktrees(let projectId)):
-            env.openNewWorktree(projectId)
-            close()
-            return .openedNewWorktree(projectId: projectId)
-
         case .divider:
             return .noop
         }
@@ -230,7 +230,11 @@ final class RepoSelectorModel {
         let wts = env.visibleWorktrees(project.id)
         switch wts.count {
         case 0:
-            return .showEmptyHint(projectId: project.id)
+            // Activation on a repo with no open worktrees has nowhere to
+            // navigate, so jump straight to creating one.
+            env.openNewWorktree(project.id)
+            close()
+            return .openedNewWorktree(projectId: project.id)
         case 1:
             return focus(worktree: wts[0], environment: env)
         default:

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -140,7 +140,12 @@ final class RepoSelectorModel {
         }
 
         var rows = listed
-        rows.append(.divider(label: ""))
+        // Only separate the worktree list from the action with a divider
+        // when there's something above it. Otherwise the divider would land
+        // at row 0 and swallow the default selection.
+        if !listed.isEmpty {
+            rows.append(.divider(label: ""))
+        }
         rows.append(.action(.newWorktreeForRepo(projectId: projectId)))
         return rows
     }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -18,7 +18,13 @@ final class RepoSelectorModel {
         didSet {
             // Reset selection so a shrinking filter never strands the cursor
             // on a stale row (especially the trailing `+ New worktree…`).
-            if query != oldValue { selectedIndex = 0 }
+            // Also bump the scroll tick — the list may have been scrolled
+            // down via keyboard nav before the filter changed, and we need
+            // the view to snap back to the new top.
+            if query != oldValue {
+                selectedIndex = 0
+                scrollToSelectionTick &+= 1
+            }
         }
     }
     private(set) var selectedIndex: Int = 0

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -267,7 +267,10 @@ final class RepoSelectorModel {
     /// Set selection directly, snapping forward (then backward) to the
     /// nearest selectable row if the target is a divider. Used on hover.
     func setSelectedIndex(_ index: Int, in rows: [RepoSelectorRow]) {
-        guard !rows.isEmpty else { selectedIndex = 0; return }
+        guard !rows.isEmpty else {
+            selectedIndex = 0
+            return
+        }
         let clamped = max(0, min(rows.count - 1, index))
         if rows[clamped].isSelectable {
             selectedIndex = clamped

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -22,6 +22,10 @@ final class RepoSelectorModel {
         }
     }
     private(set) var selectedIndex: Int = 0
+    /// Bumped by keyboard navigation (Up/Down). The view scrolls the
+    /// selected row into view on changes to this — not on `selectedIndex`
+    /// itself — so hover-driven selection doesn't fight the user's scroll.
+    private(set) var scrollToSelectionTick: Int = 0
 
     // Snapshot of step-1 state preserved across a push so popToRepos can
     // restore both the query and (where possible) the selection.
@@ -265,12 +269,18 @@ final class RepoSelectorModel {
 
     func moveSelectionDown(in rows: [RepoSelectorRow]) {
         let next = nextSelectable(from: selectedIndex, step: 1, in: rows)
-        if let next { selectedIndex = next }
+        if let next {
+            selectedIndex = next
+            scrollToSelectionTick &+= 1
+        }
     }
 
     func moveSelectionUp(in rows: [RepoSelectorRow]) {
         let prev = nextSelectable(from: selectedIndex, step: -1, in: rows)
-        if let prev { selectedIndex = prev }
+        if let prev {
+            selectedIndex = prev
+            scrollToSelectionTick &+= 1
+        }
     }
 
     /// Set selection directly, snapping forward (then backward) to the

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -122,12 +122,16 @@ final class RepoSelectorModel {
         step = .worktrees(projectId: projectId)
         query = ""
         selectedIndex = 0
+        // Reset the scroll position too — without this, the freshly-pushed
+        // worktree list could remain scrolled to wherever the repo list was.
+        scrollToSelectionTick &+= 1
     }
 
     func popToRepos() {
         step = .repos
         query = savedReposQuery
         selectedIndex = savedReposSelectedIndex
+        scrollToSelectionTick &+= 1
     }
 
     // MARK: - Step 2 rows

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Observation
+
+/// State + logic for the repo-selector dialog. View-agnostic; takes a
+/// `RepoSelectorEnvironment` for all external reads/writes so the model is
+/// unit-testable.
+@Observable
+@MainActor
+final class RepoSelectorModel {
+    enum Step: Equatable {
+        case repos
+        case worktrees(projectId: String)
+    }
+
+    var isOpen: Bool = false
+    private(set) var step: Step = .repos
+    var query: String = ""
+    private(set) var selectedIndex: Int = 0
+
+    // Snapshot of step-1 state preserved across a push so popToRepos can
+    // restore both the query and (where possible) the selection.
+    private var savedReposQuery: String = ""
+    private var savedReposSelectedIndex: Int = 0
+
+    func open() {
+        step = .repos
+        query = ""
+        selectedIndex = 0
+        savedReposQuery = ""
+        savedReposSelectedIndex = 0
+        isOpen = true
+    }
+
+    func close() {
+        isOpen = false
+    }
+
+    /// Compute the rows for the current step. Pure — does not mutate `self`.
+    /// Callers re-invoke whenever inputs (query, step, projects, recents)
+    /// change.
+    func rows(environment env: RepoSelectorEnvironment) -> [RepoSelectorRow] {
+        switch step {
+        case .repos:
+            return repoRows(environment: env)
+        case .worktrees(let projectId):
+            return worktreeRows(projectId: projectId, environment: env)
+        }
+    }
+
+    // MARK: - Step 1 rows
+
+    private func repoRows(environment env: RepoSelectorEnvironment) -> [RepoSelectorRow] {
+        let projects = env.projects()
+        guard !projects.isEmpty else { return [.emptyHint(.noProjects)] }
+
+        if query.isEmpty {
+            return emptyQueryRepoRows(projects: projects, environment: env)
+        } else {
+            return filteredRepoRows(projects: projects)
+        }
+    }
+
+    private func emptyQueryRepoRows(
+        projects: [ProjectConfig],
+        environment env: RepoSelectorEnvironment
+    ) -> [RepoSelectorRow] {
+        let validIds = Set(projects.map(\.id))
+        let recentIds = env.readRecents().liveProjectIds(validProjectIds: validIds)
+        let projectsById = Dictionary(uniqueKeysWithValues: projects.map { ($0.id, $0) })
+
+        let recentRows: [RepoSelectorRow] = recentIds.compactMap { id in
+            projectsById[id].map { .repo($0, indices: []) }
+        }
+        let recentSet = Set(recentIds)
+        let rest = projects
+            .filter { !recentSet.contains($0.id) }
+            .map { RepoSelectorRow.repo($0, indices: []) }
+
+        if recentRows.isEmpty { return rest }
+        if rest.isEmpty { return recentRows }
+        return recentRows + [.divider(label: "All repositories")] + rest
+    }
+
+    private func filteredRepoRows(projects: [ProjectConfig]) -> [RepoSelectorRow] {
+        struct Scored {
+            let project: ProjectConfig
+            let result: FuzzyMatch.Result
+        }
+        let scored: [Scored] = projects.compactMap { p in
+            guard let r = FuzzyMatch.score(query: query, target: p.name) else { return nil }
+            return Scored(project: p, result: r)
+        }
+        return scored
+            .sorted { a, b in
+                if a.result.score != b.result.score { return a.result.score > b.result.score }
+                return a.project.name.localizedCaseInsensitiveCompare(b.project.name) == .orderedAscending
+            }
+            .map { .repo($0.project, indices: $0.result.indices) }
+    }
+
+    // MARK: - Step 2 rows (stub for Task 7 — keep compiling)
+
+    private func worktreeRows(
+        projectId: String,
+        environment env: RepoSelectorEnvironment
+    ) -> [RepoSelectorRow] {
+        return []
+    }
+}

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -106,4 +106,61 @@ final class RepoSelectorModel {
     ) -> [RepoSelectorRow] {
         return []
     }
+
+    // MARK: - Selection
+
+    func moveSelectionDown(in rows: [RepoSelectorRow]) {
+        let next = nextSelectable(from: selectedIndex, step: 1, in: rows)
+        if let next { selectedIndex = next }
+    }
+
+    func moveSelectionUp(in rows: [RepoSelectorRow]) {
+        let prev = nextSelectable(from: selectedIndex, step: -1, in: rows)
+        if let prev { selectedIndex = prev }
+    }
+
+    /// Set selection directly, snapping forward (then backward) to the
+    /// nearest selectable row if the target is a divider. Used on hover.
+    func setSelectedIndex(_ index: Int, in rows: [RepoSelectorRow]) {
+        guard !rows.isEmpty else { selectedIndex = 0; return }
+        let clamped = max(0, min(rows.count - 1, index))
+        if rows[clamped].isSelectable {
+            selectedIndex = clamped
+            return
+        }
+        // Try forward first, then backward.
+        if let fwd = scan(from: clamped, step: 1, in: rows) {
+            selectedIndex = fwd
+        } else if let back = scan(from: clamped, step: -1, in: rows) {
+            selectedIndex = back
+        } else {
+            selectedIndex = clamped
+        }
+    }
+
+    /// Resets selection to the first selectable row. Called after recomputes.
+    func resetSelectionToFirstSelectable(in rows: [RepoSelectorRow]) {
+        if let idx = scan(from: -1, step: 1, in: rows) {
+            selectedIndex = idx
+        } else {
+            selectedIndex = 0
+        }
+    }
+
+    private func nextSelectable(
+        from index: Int,
+        step: Int,
+        in rows: [RepoSelectorRow]
+    ) -> Int? {
+        scan(from: index, step: step, in: rows)
+    }
+
+    private func scan(from index: Int, step: Int, in rows: [RepoSelectorRow]) -> Int? {
+        var i = index + step
+        while i >= 0 && i < rows.count {
+            if rows[i].isSelectable { return i }
+            i += step
+        }
+        return nil
+    }
 }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -174,6 +174,84 @@ final class RepoSelectorModel {
             .map { .worktree($0.worktree, indices: $0.result.indices) }
     }
 
+    // MARK: - Activation
+
+    enum Activation: Equatable {
+        case pushed(projectId: String)
+        case focused(worktreeId: String)
+        case showEmptyHint(projectId: String)
+        case openedNewWorktree(projectId: String)
+        case openedNewProject
+        case noop
+    }
+
+    @discardableResult
+    func activate(rows: [RepoSelectorRow], environment env: RepoSelectorEnvironment) -> Activation {
+        guard !rows.isEmpty else { return .noop }
+        let safeIndex = max(0, min(rows.count - 1, selectedIndex))
+        let row = rows[safeIndex]
+
+        switch row {
+        case .repo(let project, _):
+            return activateRepo(project, environment: env)
+
+        case .worktree(let worktree, _):
+            return focus(worktree: worktree, environment: env)
+
+        case .action(.newWorktreeForRepo(let projectId)):
+            env.openNewWorktree(projectId)
+            close()
+            return .openedNewWorktree(projectId: projectId)
+
+        case .action(.newProject):
+            env.openNewProject()
+            close()
+            return .openedNewProject
+
+        case .emptyHint(.noProjects):
+            env.openNewProject()
+            close()
+            return .openedNewProject
+
+        case .emptyHint(.noVisibleWorktrees(let projectId)):
+            env.openNewWorktree(projectId)
+            close()
+            return .openedNewWorktree(projectId: projectId)
+
+        case .divider:
+            return .noop
+        }
+    }
+
+    private func activateRepo(
+        _ project: ProjectConfig,
+        environment env: RepoSelectorEnvironment
+    ) -> Activation {
+        let wts = env.visibleWorktrees(project.id)
+        switch wts.count {
+        case 0:
+            return .showEmptyHint(projectId: project.id)
+        case 1:
+            return focus(worktree: wts[0], environment: env)
+        default:
+            pushRepo(projectId: project.id)
+            return .pushed(projectId: project.id)
+        }
+    }
+
+    private func focus(
+        worktree: Worktree,
+        environment env: RepoSelectorEnvironment
+    ) -> Activation {
+        env.focusWorktree(worktree.id)
+        var r = env.readRecents()
+        r.bumpProject(worktree.projectId)
+        r.bumpWorktree(worktree.id, in: worktree.projectId)
+        env.writeRecents(r)
+        close()
+        return .focused(worktreeId: worktree.id)
+    }
+
     // MARK: - Selection
 
     func moveSelectionDown(in rows: [RepoSelectorRow]) {

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRecents.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRecents.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Mutable, value-typed recents store used by the repo selector. Lives on
+/// `AppConfig` as two plain fields; this struct is the in-memory shape +
+/// mutation helpers so the persistence layer doesn't carry behavior.
+struct RepoSelectorRecents: Equatable {
+    static let projectCap = 5
+    static let worktreeCapPerProject = 5
+
+    var projectIds: [String] = []
+    var worktreeIdsByProject: [String: [String]] = [:]
+
+    init(
+        projectIds: [String] = [],
+        worktreeIdsByProject: [String: [String]] = [:]
+    ) {
+        self.projectIds = projectIds
+        self.worktreeIdsByProject = worktreeIdsByProject
+    }
+
+    mutating func bumpProject(_ id: String) {
+        projectIds.removeAll { $0 == id }
+        projectIds.insert(id, at: 0)
+        if projectIds.count > Self.projectCap {
+            projectIds.removeLast(projectIds.count - Self.projectCap)
+        }
+    }
+
+    mutating func bumpWorktree(_ id: String, in projectId: String) {
+        var list = worktreeIdsByProject[projectId] ?? []
+        list.removeAll { $0 == id }
+        list.insert(id, at: 0)
+        if list.count > Self.worktreeCapPerProject {
+            list.removeLast(list.count - Self.worktreeCapPerProject)
+        }
+        worktreeIdsByProject[projectId] = list
+    }
+
+    /// Returns projectIds filtered to those still present in the supplied
+    /// set, preserving recency order.
+    func liveProjectIds(validProjectIds: Set<String>) -> [String] {
+        projectIds.filter { validProjectIds.contains($0) }
+    }
+
+    /// Returns the recents for a project filtered to ids still present.
+    func liveWorktreeIds(in projectId: String, validWorktreeIds: Set<String>) -> [String] {
+        (worktreeIdsByProject[projectId] ?? []).filter { validWorktreeIds.contains($0) }
+    }
+}

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRow.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRow.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// All row variants the repo selector can emit. `indices` carries
+/// fuzzy-match positions (matching `FuzzyMatch.Result.indices`) for
+/// highlighting; empty when no query is active.
+enum RepoSelectorRow: Equatable {
+    case repo(ProjectConfig, indices: [Int])
+    case worktree(Worktree, indices: [Int])
+    case action(Action)
+    case emptyHint(EmptyHint)
+    case divider(label: String)
+
+    enum Action: Equatable {
+        case newProject
+        case newWorktreeForRepo(projectId: String)
+    }
+
+    enum EmptyHint: Equatable {
+        /// Step 1 hit Return on a project that has no visible worktrees.
+        case noVisibleWorktrees(projectId: String)
+        /// Step 1 with zero configured projects at all.
+        case noProjects
+    }
+
+    /// True when keyboard navigation should be able to land on this row.
+    var isSelectable: Bool {
+        switch self {
+        case .divider: return false
+        default: return true
+        }
+    }
+}

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRow.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRow.swift
@@ -16,8 +16,6 @@ enum RepoSelectorRow: Equatable {
     }
 
     enum EmptyHint: Equatable {
-        /// Step 1 hit Return on a project that has no visible worktrees.
-        case noVisibleWorktrees(projectId: String)
         /// Step 1 with zero configured projects at all.
         case noProjects
     }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift
@@ -90,13 +90,6 @@ struct RepoSelectorRowView: View {
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.vertical, 16)
 
-        case .emptyHint(.noVisibleWorktrees):
-            Text("No open worktrees. Press ⇥ to create one.")
-                .font(.system(size: 12))
-                .foregroundColor(theme.color("fg-dim"))
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.vertical, 16)
-
         case .divider(let label):
             HStack(spacing: 6) {
                 Text(label.uppercased())

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+struct RepoSelectorRowView: View {
+    let row: RepoSelectorRow
+    let isSelected: Bool
+    let projectsById: [String: ProjectConfig]
+    let onTap: () -> Void
+    let onHover: () -> Void
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            if isSelected, row.isSelectable {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(theme.color("bg-4"))
+                    .padding(.horizontal, 4)
+            }
+            content
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if row.isSelectable { onTap() }
+        }
+        .onHover { hovering in
+            if hovering, row.isSelectable { onHover() }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch row {
+        case .repo(let project, let indices):
+            HStack(spacing: 8) {
+                RepoDot(color: project.color, letter: String(project.name.prefix(1)).uppercased())
+                Highlighted(text: project.name, indices: indices)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 0)
+            }
+
+        case .worktree(let worktree, let indices):
+            HStack(spacing: 8) {
+                if let project = projectsById[worktree.projectId] {
+                    Circle()
+                        .fill(Color(hex: project.color))
+                        .frame(width: 8, height: 8)
+                }
+                Highlighted(text: worktree.branch, indices: indices)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 0)
+                statusText(for: worktree)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-faint"))
+            }
+
+        case .action(.newWorktreeForRepo):
+            HStack(spacing: 8) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(theme.color("fg-faint"))
+                Text("New worktree…")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg"))
+                Spacer(minLength: 0)
+            }
+
+        case .action(.newProject):
+            HStack(spacing: 8) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(theme.color("fg-faint"))
+                Text("Add project…")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg"))
+                Spacer(minLength: 0)
+            }
+
+        case .emptyHint(.noProjects):
+            Text("No repositories. Press ⇥ to add one.")
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg-dim"))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 16)
+
+        case .emptyHint(.noVisibleWorktrees):
+            Text("No open worktrees. Press ⇥ to create one.")
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg-dim"))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 16)
+
+        case .divider(let label):
+            HStack(spacing: 6) {
+                Text(label.uppercased())
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.color("fg-faint"))
+                Rectangle()
+                    .fill(theme.color("line-soft"))
+                    .frame(height: 0.5)
+            }
+            .padding(.top, 6)
+            .padding(.bottom, 2)
+        }
+    }
+
+    @ViewBuilder
+    private func statusText(for w: Worktree) -> some View {
+        if w.addedLines == 0, w.deletedLines == 0 {
+            Text("clean")
+        } else {
+            HStack(spacing: 4) {
+                if w.addedLines > 0 { Text("+\(w.addedLines)").foregroundColor(theme.color("add")) }
+                if w.deletedLines > 0 { Text("−\(w.deletedLines)").foregroundColor(theme.color("del")) }
+            }
+        }
+    }
+}

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -19,6 +19,8 @@ struct AppConfig: Codable, Equatable {
     var changes: Changes
     var agents: Agents
     var files: Files
+    var recentProjectIds: [String] = []
+    var recentWorktreeIdsByProject: [String: [String]] = [:]
 
     struct General: Codable, Equatable {
         var launchAtLogin: Bool
@@ -191,7 +193,9 @@ struct AppConfig: Codable, Equatable {
                 useBypassPermissions: false
             )
         ),
-        files: Files(showIgnored: true)
+        files: Files(showIgnored: true),
+        recentProjectIds: [],
+        recentWorktreeIdsByProject: [:]
     )
 }
 
@@ -224,7 +228,8 @@ extension AppConfig {
              commitDetailSplitRatio,
              general, worktrees, terminal, harness, code, markdown, changes,
              agents,
-             files
+             files,
+             recentProjectIds, recentWorktreeIdsByProject
     }
 
     // Custom decode tolerates older config files that predate `code`.
@@ -322,5 +327,8 @@ extension AppConfig {
         } else {
             files = Files(showIgnored: true)
         }
+        recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
+        recentWorktreeIdsByProject =
+            (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]
     }
 }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -497,6 +497,9 @@ extension AlasGhostty {
 
             // ⌘T — reserved for the app's New Terminal Tab.
             if flags == .command && chars == "t" { return true }
+            // ⌘P — Search Files. ⌘K — Switch Repository. Without these the
+            // terminal swallows the keystroke before the menu fires.
+            if flags == .command && (chars == "p" || chars == "k") { return true }
             // ⌘1..⌘9 — reserved for app tab switching.
             if flags == .command && ("1"..."9").contains(chars) { return true }
             // ⌘D / ⇧⌘D — Split Right / Split Down.

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -196,4 +196,53 @@ struct AppConfigTests {
         let decoded2 = try JSONDecoder().decode(AppConfig.self, from: data2)
         #expect(decoded2.themeId == "cool-slate")
     }
+
+    @Test func decodeOldConfigDefaultsRepoSelectorRecentsEmpty() throws {
+        // A config blob that predates the repo-selector recents fields must
+        // still decode, with both recents collections defaulting to empty.
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "density": "comfortable",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/code/.worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.recentProjectIds == [])
+        #expect(cfg.recentWorktreeIdsByProject == [:])
+    }
+
+    @Test func repoSelectorRecentsRoundTrip() throws {
+        var cfg = AppConfig.defaults
+        cfg.recentProjectIds = ["proj-a", "proj-b"]
+        cfg.recentWorktreeIdsByProject = ["proj-a": ["wt-1", "wt-2"]]
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.recentProjectIds == ["proj-a", "proj-b"])
+        #expect(decoded.recentWorktreeIdsByProject == ["proj-a": ["wt-1", "wt-2"]])
+    }
 }

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -129,4 +129,61 @@ struct RepoSelectorModelTests {
         }
         #expect(indices == [0, 1])
     }
+
+    // MARK: - Selection movement
+
+    @Test func moveSelectionDownSkipsDivider() {
+        let model = RepoSelectorModel()
+        let rows: [RepoSelectorRow] = [
+            .repo(project("a"), indices: []),
+            .divider(label: "All repositories"),
+            .repo(project("b"), indices: []),
+        ]
+        model.moveSelectionDown(in: rows)  // 0 -> 2 (skip divider at 1)
+        #expect(model.selectedIndex == 2)
+    }
+
+    @Test func moveSelectionUpSkipsDivider() {
+        let model = RepoSelectorModel()
+        let rows: [RepoSelectorRow] = [
+            .repo(project("a"), indices: []),
+            .divider(label: "All repositories"),
+            .repo(project("b"), indices: []),
+        ]
+        model.setSelectedIndex(2, in: rows)
+        model.moveSelectionUp(in: rows)
+        #expect(model.selectedIndex == 0)
+    }
+
+    @Test func moveSelectionDownClampsAtBottom() {
+        let model = RepoSelectorModel()
+        let rows: [RepoSelectorRow] = [
+            .repo(project("a"), indices: []),
+            .repo(project("b"), indices: []),
+        ]
+        model.setSelectedIndex(1, in: rows)
+        model.moveSelectionDown(in: rows)
+        #expect(model.selectedIndex == 1)
+    }
+
+    @Test func moveSelectionUpClampsAtTop() {
+        let model = RepoSelectorModel()
+        let rows: [RepoSelectorRow] = [
+            .repo(project("a"), indices: []),
+            .repo(project("b"), indices: []),
+        ]
+        model.moveSelectionUp(in: rows)
+        #expect(model.selectedIndex == 0)
+    }
+
+    @Test func setSelectedIndexSnapsAwayFromDivider() {
+        let model = RepoSelectorModel()
+        let rows: [RepoSelectorRow] = [
+            .repo(project("a"), indices: []),
+            .divider(label: "All repositories"),
+            .repo(project("b"), indices: []),
+        ]
+        model.setSelectedIndex(1, in: rows)  // divider; snap to next selectable
+        #expect(model.selectedIndex == 2)
+    }
 }

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -187,6 +187,21 @@ struct RepoSelectorModelTests {
         #expect(model.selectedIndex == 2)
     }
 
+    @Test func changingQueryResetsSelectionToZero() {
+        // Without this reset, a user could move selection down then type a
+        // filter that shrinks the list and inadvertently activate the
+        // trailing "+ New worktree…" action.
+        let model = RepoSelectorModel()
+        let rows: [RepoSelectorRow] = [
+            .repo(project("a"), indices: []),
+            .repo(project("b"), indices: []),
+        ]
+        model.setSelectedIndex(1, in: rows)
+        #expect(model.selectedIndex == 1)
+        model.query = "a"
+        #expect(model.selectedIndex == 0)
+    }
+
     // MARK: - Push / pop
 
     @Test func pushRepoSwitchesStepAndResetsQuery() {
@@ -305,20 +320,24 @@ struct RepoSelectorModelTests {
         #expect(writtenRecents?.worktreeIdsByProject["p1"] == ["w1"])
     }
 
-    @Test func activateProjectWithZeroWorktreesEmitsEmptyHintWithoutFocus() {
+    @Test func activateProjectWithZeroWorktreesOpensNewWorktreeFlow() {
         let model = RepoSelectorModel()
+        model.isOpen = true
         var focused: String? = nil
         var writtenRecents: RepoSelectorRecents? = nil
+        var openedFor: String? = nil
         var e = env(projects: [project("p1")], worktrees: ["p1": []])
         e.focusWorktree = { focused = $0 }
         e.writeRecents = { writtenRecents = $0 }
+        e.openNewWorktree = { openedFor = $0 }
 
         let rows = model.rows(environment: e)
         model.setSelectedIndex(0, in: rows)
         let result = model.activate(rows: rows, environment: e)
 
-        #expect(result == .showEmptyHint(projectId: "p1"))
-        #expect(model.step == .repos)
+        #expect(result == .openedNewWorktree(projectId: "p1"))
+        #expect(openedFor == "p1")
+        #expect(model.isOpen == false)
         #expect(focused == nil)
         #expect(writtenRecents == nil)
     }

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -275,6 +275,20 @@ struct RepoSelectorModelTests {
         #expect(rows.last == .action(.newWorktreeForRepo(projectId: "p1")))
     }
 
+    @Test func step2NoMatchesOmitsDividerSoActionRowIsTheDefault() {
+        // When the filter excludes every worktree, the divider would otherwise
+        // land at row 0 (because the leading list is empty) and swallow the
+        // default selection. The action row must remain the only thing in the
+        // list so Return on selectedIndex == 0 still creates a new worktree.
+        let model = RepoSelectorModel()
+        let wts = [worktree("w1", projectId: "p1", branch: "main")]
+        let e = env(projects: [project("p1")], worktrees: ["p1": wts])
+        model.pushRepo(projectId: "p1")
+        model.query = "nope"
+        let rows = model.rows(environment: e)
+        #expect(rows == [.action(.newWorktreeForRepo(projectId: "p1"))])
+    }
+
     // MARK: - Activation
 
     @Test func activateProjectWithMultipleWorktreesPushesNoFocusNoRecents() {

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -186,4 +186,77 @@ struct RepoSelectorModelTests {
         model.setSelectedIndex(1, in: rows)  // divider; snap to next selectable
         #expect(model.selectedIndex == 2)
     }
+
+    // MARK: - Push / pop
+
+    @Test func pushRepoSwitchesStepAndResetsQuery() {
+        let model = RepoSelectorModel()
+        model.query = "ala"
+        model.pushRepo(projectId: "p1")
+        #expect(model.step == .worktrees(projectId: "p1"))
+        #expect(model.query == "")
+        #expect(model.selectedIndex == 0)
+    }
+
+    @Test func popToReposRestoresQueryAndStep() {
+        let model = RepoSelectorModel()
+        model.query = "ala"
+        let e = env(projects: [project("p1", name: "alas"), project("p2", name: "other")])
+        _ = model.rows(environment: e)
+        model.setSelectedIndex(0, in: model.rows(environment: e))
+        model.pushRepo(projectId: "p1")
+        model.popToRepos()
+        #expect(model.step == .repos)
+        #expect(model.query == "ala")
+        #expect(model.selectedIndex == 0)
+    }
+
+    // MARK: - Step 2 rows
+
+    @Test func step2EmptyQueryListsRecentsThenRestThenAction() {
+        let model = RepoSelectorModel()
+        var r = RepoSelectorRecents()
+        r.bumpWorktree("w3", in: "p1")
+        r.bumpWorktree("w1", in: "p1")  // most recent
+        let wts = [
+            worktree("w1", projectId: "p1"),
+            worktree("w2", projectId: "p1"),
+            worktree("w3", projectId: "p1"),
+        ]
+        let e = env(
+            projects: [project("p1")],
+            worktrees: ["p1": wts],
+            recents: r
+        )
+        model.pushRepo(projectId: "p1")
+        let rows = model.rows(environment: e)
+        #expect(rows == [
+            .worktree(wts[0], indices: []),                                    // w1 (most recent)
+            .worktree(wts[2], indices: []),                                    // w3 (next recent)
+            .worktree(wts[1], indices: []),                                    // w2 (rest, sidebar order)
+            .divider(label: ""),
+            .action(.newWorktreeForRepo(projectId: "p1")),
+        ])
+    }
+
+    @Test func step2NonEmptyQueryFiltersAndKeepsActionRow() {
+        let model = RepoSelectorModel()
+        let wts = [
+            worktree("w1", projectId: "p1", branch: "main"),
+            worktree("w2", projectId: "p1", branch: "feature/login"),
+            worktree("w3", projectId: "p1", branch: "feature/repo-selector"),
+        ]
+        let e = env(projects: [project("p1")], worktrees: ["p1": wts])
+        model.pushRepo(projectId: "p1")
+        model.query = "feat"
+        let rows = model.rows(environment: e)
+        let branches: [String] = rows.compactMap {
+            if case .worktree(let w, _) = $0 { return w.branch } else { return nil }
+        }
+        #expect(branches.contains("feature/login"))
+        #expect(branches.contains("feature/repo-selector"))
+        #expect(!branches.contains("main"))
+        // The action row remains at the bottom regardless of query.
+        #expect(rows.last == .action(.newWorktreeForRepo(projectId: "p1")))
+    }
 }

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -259,4 +259,124 @@ struct RepoSelectorModelTests {
         // The action row remains at the bottom regardless of query.
         #expect(rows.last == .action(.newWorktreeForRepo(projectId: "p1")))
     }
+
+    // MARK: - Activation
+
+    @Test func activateProjectWithMultipleWorktreesPushesNoFocusNoRecents() {
+        let model = RepoSelectorModel()
+        var focused: String? = nil
+        var writtenRecents: RepoSelectorRecents? = nil
+        let wts = [
+            worktree("w1", projectId: "p1"),
+            worktree("w2", projectId: "p1"),
+        ]
+        var e = env(projects: [project("p1")], worktrees: ["p1": wts])
+        e.focusWorktree = { focused = $0 }
+        e.writeRecents = { writtenRecents = $0 }
+
+        let rows = model.rows(environment: e)
+        model.setSelectedIndex(0, in: rows)
+        let result = model.activate(rows: rows, environment: e)
+
+        #expect(result == .pushed(projectId: "p1"))
+        #expect(model.step == .worktrees(projectId: "p1"))
+        #expect(focused == nil)
+        #expect(writtenRecents == nil)
+    }
+
+    @Test func activateProjectWithOneWorktreeFocusesClosesAndBumpsRecents() {
+        let model = RepoSelectorModel()
+        model.isOpen = true
+        var focused: String? = nil
+        var writtenRecents: RepoSelectorRecents? = nil
+        let wts = [worktree("w1", projectId: "p1")]
+        var e = env(projects: [project("p1")], worktrees: ["p1": wts])
+        e.focusWorktree = { focused = $0 }
+        e.writeRecents = { writtenRecents = $0 }
+
+        let rows = model.rows(environment: e)
+        model.setSelectedIndex(0, in: rows)
+        let result = model.activate(rows: rows, environment: e)
+
+        #expect(result == .focused(worktreeId: "w1"))
+        #expect(focused == "w1")
+        #expect(model.isOpen == false)
+        #expect(writtenRecents?.projectIds == ["p1"])
+        #expect(writtenRecents?.worktreeIdsByProject["p1"] == ["w1"])
+    }
+
+    @Test func activateProjectWithZeroWorktreesEmitsEmptyHintWithoutFocus() {
+        let model = RepoSelectorModel()
+        var focused: String? = nil
+        var writtenRecents: RepoSelectorRecents? = nil
+        var e = env(projects: [project("p1")], worktrees: ["p1": []])
+        e.focusWorktree = { focused = $0 }
+        e.writeRecents = { writtenRecents = $0 }
+
+        let rows = model.rows(environment: e)
+        model.setSelectedIndex(0, in: rows)
+        let result = model.activate(rows: rows, environment: e)
+
+        #expect(result == .showEmptyHint(projectId: "p1"))
+        #expect(model.step == .repos)
+        #expect(focused == nil)
+        #expect(writtenRecents == nil)
+    }
+
+    @Test func activateWorktreeRowFocusesAndBumpsBothRecents() {
+        let model = RepoSelectorModel()
+        model.isOpen = true
+        var focused: String? = nil
+        var writtenRecents: RepoSelectorRecents? = nil
+        let wts = [worktree("w1", projectId: "p1"), worktree("w2", projectId: "p1")]
+        var e = env(projects: [project("p1")], worktrees: ["p1": wts])
+        e.focusWorktree = { focused = $0 }
+        e.writeRecents = { writtenRecents = $0 }
+
+        model.pushRepo(projectId: "p1")
+        let rows = model.rows(environment: e)
+        // index 1 is w2 in this list (w1 first since no recents)
+        model.setSelectedIndex(1, in: rows)
+        let result = model.activate(rows: rows, environment: e)
+
+        #expect(result == .focused(worktreeId: "w2"))
+        #expect(focused == "w2")
+        #expect(model.isOpen == false)
+        #expect(writtenRecents?.projectIds == ["p1"])
+        #expect(writtenRecents?.worktreeIdsByProject["p1"] == ["w2"])
+    }
+
+    @Test func activateNewWorktreeActionDelegatesAndCloses() {
+        let model = RepoSelectorModel()
+        model.isOpen = true
+        var openedFor: String? = nil
+        var e = env(projects: [project("p1")], worktrees: ["p1": [worktree("w1", projectId: "p1"), worktree("w2", projectId: "p1")]])
+        e.openNewWorktree = { openedFor = $0 }
+
+        model.pushRepo(projectId: "p1")
+        let rows = model.rows(environment: e)
+        // last row is the action
+        model.setSelectedIndex(rows.count - 1, in: rows)
+        let result = model.activate(rows: rows, environment: e)
+
+        #expect(result == .openedNewWorktree(projectId: "p1"))
+        #expect(openedFor == "p1")
+        #expect(model.isOpen == false)
+    }
+
+    @Test func activateNoProjectsHintDelegatesToNewProject() {
+        let model = RepoSelectorModel()
+        model.isOpen = true
+        var openedNewProject = false
+        var e = env(projects: [])
+        e.openNewProject = { openedNewProject = true }
+
+        let rows = model.rows(environment: e)
+        model.setSelectedIndex(0, in: rows)
+        let result = model.activate(rows: rows, environment: e)
+
+        #expect(result == .openedNewProject)
+        #expect(openedNewProject)
+        #expect(model.isOpen == false)
+    }
 }

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -1,0 +1,132 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+struct RepoSelectorModelTests {
+    // MARK: - Helpers
+
+    private func project(_ id: String, name: String? = nil) -> ProjectConfig {
+        ProjectConfig(
+            id: id,
+            name: name ?? id,
+            path: "/tmp/\(id)",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0)
+        )
+    }
+
+    private func worktree(_ id: String, projectId: String, branch: String? = nil) -> Worktree {
+        Worktree(
+            id: id,
+            projectId: projectId,
+            name: branch ?? id,
+            branch: branch ?? id,
+            path: URL(fileURLWithPath: "/tmp/\(projectId)/\(id)"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0),
+            addedLines: 0,
+            deletedLines: 0
+        )
+    }
+
+    private func env(
+        projects: [ProjectConfig] = [],
+        worktrees: [String: [Worktree]] = [:],
+        recents: RepoSelectorRecents = RepoSelectorRecents()
+    ) -> RepoSelectorEnvironment {
+        var recentsBox = recents
+        return RepoSelectorEnvironment(
+            projects: { projects },
+            visibleWorktrees: { worktrees[$0] ?? [] },
+            readRecents: { recentsBox },
+            writeRecents: { recentsBox = $0 },
+            focusWorktree: { _ in },
+            openNewProject: { },
+            openNewWorktree: { _ in }
+        )
+    }
+
+    // MARK: - Empty query
+
+    @Test func emptyQueryNoRecentsListsProjectsInOrder() {
+        let model = RepoSelectorModel()
+        let e = env(projects: [project("a"), project("b"), project("c")])
+        let rows = model.rows(environment: e)
+        #expect(rows == [
+            .repo(project("a"), indices: []),
+            .repo(project("b"), indices: []),
+            .repo(project("c"), indices: []),
+        ])
+    }
+
+    @Test func emptyQueryWithRecentsPutsRecentsFirstWithDivider() {
+        let model = RepoSelectorModel()
+        var r = RepoSelectorRecents()
+        r.bumpProject("b")
+        r.bumpProject("c")  // most recent: c, then b
+        let e = env(
+            projects: [project("a"), project("b"), project("c")],
+            recents: r
+        )
+        let rows = model.rows(environment: e)
+        #expect(rows == [
+            .repo(project("c"), indices: []),
+            .repo(project("b"), indices: []),
+            .divider(label: "All repositories"),
+            .repo(project("a"), indices: []),
+        ])
+    }
+
+    @Test func emptyQueryDropsDanglingRecents() {
+        let model = RepoSelectorModel()
+        var r = RepoSelectorRecents()
+        r.bumpProject("missing")
+        r.bumpProject("a")
+        let e = env(projects: [project("a")], recents: r)
+        let rows = model.rows(environment: e)
+        #expect(rows == [.repo(project("a"), indices: [])])
+    }
+
+    @Test func emptyQueryEmptyProjectsShowsNoProjectsHint() {
+        let model = RepoSelectorModel()
+        let e = env(projects: [])
+        let rows = model.rows(environment: e)
+        #expect(rows == [.emptyHint(.noProjects)])
+    }
+
+    // MARK: - Non-empty query
+
+    @Test func nonEmptyQueryFiltersAndRanks() {
+        let model = RepoSelectorModel()
+        model.query = "ala"
+        let e = env(projects: [
+            project("p1", name: "alas"),
+            project("p2", name: "other"),
+            project("p3", name: "alacrity"),
+        ])
+        let rows = model.rows(environment: e)
+        // Both "alas" and "alacrity" match; ordering relies on FuzzyMatch
+        // (shorter target ranks higher because the span penalty is smaller).
+        // We only assert containment + that "other" was dropped.
+        let names: [String] = rows.compactMap {
+            if case .repo(let p, _) = $0 { return p.name } else { return nil }
+        }
+        #expect(names.contains("alas"))
+        #expect(names.contains("alacrity"))
+        #expect(!names.contains("other"))
+        #expect(!rows.contains { if case .divider = $0 { return true } else { return false } })
+    }
+
+    @Test func nonEmptyQueryIncludesFuzzyIndices() {
+        let model = RepoSelectorModel()
+        model.query = "al"
+        let e = env(projects: [project("p1", name: "alas")])
+        let rows = model.rows(environment: e)
+        guard case .repo(_, let indices) = rows.first else {
+            Issue.record("expected first row to be a repo")
+            return
+        }
+        #expect(indices == [0, 1])
+    }
+}

--- a/AlasTests/RepoSelectorRecentsTests.swift
+++ b/AlasTests/RepoSelectorRecentsTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct RepoSelectorRecentsTests {
+    @Test func bumpProjectPrependsAndDedupes() {
+        var r = RepoSelectorRecents()
+        r.bumpProject("p1")
+        r.bumpProject("p2")
+        r.bumpProject("p1")  // moves to front
+        #expect(r.projectIds == ["p1", "p2"])
+    }
+
+    @Test func bumpProjectCapsAtFive() {
+        var r = RepoSelectorRecents()
+        for id in ["p1", "p2", "p3", "p4", "p5", "p6"] { r.bumpProject(id) }
+        #expect(r.projectIds == ["p6", "p5", "p4", "p3", "p2"])
+    }
+
+    @Test func bumpWorktreePrependsPerProjectAndCaps() {
+        var r = RepoSelectorRecents()
+        for id in ["w1", "w2", "w3", "w4", "w5", "w6"] {
+            r.bumpWorktree(id, in: "proj")
+        }
+        r.bumpWorktree("w2", in: "proj")
+        #expect(r.worktreeIdsByProject["proj"] == ["w2", "w6", "w5", "w4", "w3"])
+    }
+
+    @Test func bumpWorktreeKeepsProjectsIndependent() {
+        var r = RepoSelectorRecents()
+        r.bumpWorktree("w1", in: "a")
+        r.bumpWorktree("w1", in: "b")
+        #expect(r.worktreeIdsByProject["a"] == ["w1"])
+        #expect(r.worktreeIdsByProject["b"] == ["w1"])
+    }
+
+    @Test func liveProjectsFiltersDangling() {
+        var r = RepoSelectorRecents()
+        r.projectIds = ["p1", "p2", "p3"]
+        let live = r.liveProjectIds(validProjectIds: ["p1", "p3"])
+        #expect(live == ["p1", "p3"])
+    }
+
+    @Test func liveWorktreesFiltersDangling() {
+        var r = RepoSelectorRecents()
+        r.worktreeIdsByProject = ["p1": ["w1", "w2", "w3"]]
+        let live = r.liveWorktreeIds(in: "p1", validWorktreeIds: ["w1", "w3"])
+        #expect(live == ["w1", "w3"])
+    }
+
+    @Test func liveWorktreesReturnsEmptyForUnknownProject() {
+        let r = RepoSelectorRecents()
+        #expect(r.liveWorktreeIds(in: "missing", validWorktreeIds: ["w1"]) == [])
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `Cmd-K` overlay (sibling to the file searcher) that fuzzy-matches configured projects and, when a repo has multiple open worktrees, pushes to a second step to pick which worktree to focus.
- Recents (last-focused project and per-project worktree) are persisted in `AppConfig` and float to the top of each list.
- Bonus: also fixes `Cmd-P` (Search Files) being swallowed by the Ghostty terminal when it has focus. Both shortcuts are now reserved app globals.

Built TDD-style: 42 new tests across `RepoSelectorModelTests`, `RepoSelectorRecentsTests`, and `AppConfigTests`.

Design spec: `docs/superpowers/specs/2026-05-19-repo-selector-design.md`.

## Test plan
- [ ] Cmd-K with 0 configured projects → "No repositories. Press ⇥ to add one." Tab opens the Add Project dialog.
- [ ] Cmd-K with multiple projects → type a fragment, ↵: focuses immediately when the repo has 1 worktree, pushes to step 2 when it has 2+.
- [ ] On step 2, Esc returns to step 1 with the previous query preserved.
- [ ] Last row on step 2 is `+ New worktree…`; ↵ on it opens NewWorktreeDialog scoped to that repo.
- [ ] Quit and relaunch → recents appear at the top of step 1 and (per project) step 2.
- [ ] Cmd-P still works (file searcher); Cmd-K and Cmd-P can't be open at the same time.
- [ ] From a focused terminal pane, Cmd-K and Cmd-P both open the corresponding dialog (no longer swallowed by Ghostty).