### PR TITLE
Files tab: context menu to show/hide ignored files

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */; };
 		CB6D9F5929D97FAB3A264F47 /* AppConfigAgentsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */; };
 		CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */; };
+		CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */; };
 		CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */; };
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
 		CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */; };
@@ -749,6 +750,7 @@
 		EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPane.swift; sourceTree = "<group>"; };
 		EB52B59655B85764D85CFB7F /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
 		EBBBF87CC508451B2C0F3A66 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigFilesTests.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
 		ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewIndentationTests.swift; sourceTree = "<group>"; };
 		EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParserTests.swift; sourceTree = "<group>"; };
@@ -836,6 +838,7 @@
 				A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */,
 				333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */,
 				D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */,
+				EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */,
 				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
@@ -1961,6 +1964,7 @@
 				CB6D9F5929D97FAB3A264F47 /* AppConfigAgentsCodingTests.swift in Sources */,
 				1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */,
 				D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */,
+				CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */,
 				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
 		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
+		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
 		A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */; };
 		A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */; };
@@ -441,6 +442,7 @@
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		1841997CCBDB9611576B930C /* AlasToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasToggle.swift; sourceTree = "<group>"; };
 		1874031C788ADB4398151FF1 /* StageChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageChip.swift; sourceTree = "<group>"; };
+		1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabFilterTests.swift; sourceTree = "<group>"; };
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
@@ -877,6 +879,7 @@
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
 				25493E3B18A1AB94EA6985C3 /* EventHolder.swift */,
 				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
+				1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */,
 				3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */,
 				2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */,
 				A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */,
@@ -2007,6 +2010,7 @@
 				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
 				6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */,
+				A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */,
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -106,14 +106,6 @@ struct AppConfig: Codable, Equatable {
         }
     }
 
-    struct Files: Codable, Equatable {
-        var showIgnored: Bool
-
-        enum CodingKeys: String, CodingKey {
-            case showIgnored
-        }
-    }
-
     struct Agents: Codable, Equatable {
         var builtinState: [String: BuiltinAgentState]
         var custom: [AgentDefinition]
@@ -121,6 +113,14 @@ struct AppConfig: Codable, Equatable {
 
         enum CodingKeys: String, CodingKey {
             case builtinState, custom, worktreeAutoLaunch
+        }
+    }
+
+    struct Files: Codable, Equatable {
+        var showIgnored: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case showIgnored
         }
     }
 

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -18,6 +18,7 @@ struct AppConfig: Codable, Equatable {
     var markdown: Markdown
     var changes: Changes
     var agents: Agents
+    var files: Files
 
     struct General: Codable, Equatable {
         var launchAtLogin: Bool
@@ -105,6 +106,14 @@ struct AppConfig: Codable, Equatable {
         }
     }
 
+    struct Files: Codable, Equatable {
+        var showIgnored: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case showIgnored
+        }
+    }
+
     struct Agents: Codable, Equatable {
         var builtinState: [String: BuiltinAgentState]
         var custom: [AgentDefinition]
@@ -181,7 +190,8 @@ struct AppConfig: Codable, Equatable {
                 agentId: nil,
                 useBypassPermissions: false
             )
-        )
+        ),
+        files: Files(showIgnored: true)
     )
 }
 
@@ -213,7 +223,8 @@ extension AppConfig {
              sidebarMaterial, sidebarWidth, rightPaneWidth, rightPaneVisible,
              commitDetailSplitRatio,
              general, worktrees, terminal, harness, code, markdown, changes,
-             agents
+             agents,
+             files
     }
 
     // Custom decode tolerates older config files that predate `code`.
@@ -302,6 +313,14 @@ extension AppConfig {
                     agentId: nil, useBypassPermissions: false
                 )
             )
+        }
+        if let filesContainer = try? c.nestedContainer(
+            keyedBy: AppConfig.Files.CodingKeys.self, forKey: .files
+        ) {
+            let showIgnored = (try? filesContainer.decode(Bool.self, forKey: .showIgnored)) ?? true
+            files = Files(showIgnored: showIgnored)
+        } else {
+            files = Files(showIgnored: true)
         }
     }
 }

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -141,12 +141,20 @@ struct FilesTabView: View {
     ) -> [FileTreeNode] {
         guard !showIgnored else { return nodes }
         return nodes.compactMap { node in
-            if node.visibility == .ignored || node.visibility == .excluded {
-                return nil
+            let offGit = node.visibility == .ignored || node.visibility == .excluded
+            // Files: drop if ignored/excluded.
+            if node.kind == .file {
+                return offGit ? nil : node
             }
+            // Directories: filter children first. An ignored directory may
+            // still contain tracked descendants (gitignore rules don't
+            // un-track a path that's already in the index), so we only drop
+            // the directory if it has no visible children left.
             var copy = node
-            if let kids = node.children {
-                copy.children = filteredNodes(kids, showIgnored: showIgnored)
+            let visibleChildren = filteredNodes(node.children ?? [], showIgnored: showIgnored)
+            copy.children = visibleChildren
+            if offGit && visibleChildren.isEmpty {
+                return nil
             }
             return copy
         }

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -7,13 +7,14 @@ struct FilesTabView: View {
     let onSelectFile: (FileTreeNode) -> Void
     let shouldAutoLoadChildren: (String, DirectoryChildrenState) -> Bool
     let onLoadChildren: (String) -> Void
+    let showIgnored: Bool
 
     @Environment(\.theme) private var theme
 
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(nodes) { node in
+                ForEach(Self.filteredNodes(nodes, showIgnored: showIgnored)) { node in
                     renderNode(node, depth: 0)
                 }
             }
@@ -127,7 +128,9 @@ struct FilesTabView: View {
     private func renderChildren(of node: FileTreeNode, depth: Int) -> some View {
         Group {
             if let kids = node.children {
-                ForEach(kids) { renderNode($0, depth: depth) }
+                ForEach(Self.filteredNodes(kids, showIgnored: showIgnored)) {
+                    renderNode($0, depth: depth)
+                }
             }
         }
     }

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -146,7 +146,7 @@ struct FilesTabView: View {
             }
             var copy = node
             if let kids = node.children {
-                copy.children = filteredNodes(kids, showIgnored: false)
+                copy.children = filteredNodes(kids, showIgnored: showIgnored)
             }
             return copy
         }

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -132,6 +132,23 @@ struct FilesTabView: View {
         }
     }
 
+    nonisolated static func filteredNodes(
+        _ nodes: [FileTreeNode],
+        showIgnored: Bool
+    ) -> [FileTreeNode] {
+        guard !showIgnored else { return nodes }
+        return nodes.compactMap { node in
+            if node.visibility == .ignored || node.visibility == .excluded {
+                return nil
+            }
+            var copy = node
+            if let kids = node.children {
+                copy.children = filteredNodes(kids, showIgnored: false)
+            }
+            return copy
+        }
+    }
+
     private func isOffGit(_ node: FileTreeNode) -> Bool {
         node.visibility == .ignored || node.visibility == .excluded
     }

--- a/Alas/Sources/Right/RightPaneTabBar.swift
+++ b/Alas/Sources/Right/RightPaneTabBar.swift
@@ -6,6 +6,8 @@ struct RightPaneTabBar: View {
     let totalAdd: Int
     let totalDel: Int
     let onHidePane: () -> Void
+    let showIgnored: Bool
+    let onToggleShowIgnored: () -> Void
 
     @Environment(\.theme) private var theme
 
@@ -13,6 +15,12 @@ struct RightPaneTabBar: View {
         HStack(spacing: 6) {
             segment(.changes, icon: "diff", label: "Changes", count: changesCount)
             segment(.files,   icon: "folder", label: "Files",  count: nil)
+                .contextMenu {
+                    Toggle("Show ignored or excluded files", isOn: Binding(
+                        get: { showIgnored },
+                        set: { _ in onToggleShowIgnored() }
+                    ))
+                }
             Spacer(minLength: 8)
             trailing
             ToolbarBtn(icon: "sidebar.right", action: onHidePane)

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -24,6 +24,11 @@ struct RightPaneView: View {
                     onHidePane: {
                         state.config.rightPaneVisible = false
                         state.saveConfig()
+                    },
+                    showIgnored: state.config.files.showIgnored,
+                    onToggleShowIgnored: {
+                        state.config.files.showIgnored.toggle()
+                        state.saveConfig()
                     }
                 )
 
@@ -42,7 +47,8 @@ struct RightPaneView: View {
                         shouldAutoLoadChildren: { path, childrenState in
                             rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
                         },
-                        onLoadChildren: { rps.loadFileTreeChildren(path: $0) }
+                        onLoadChildren: { rps.loadFileTreeChildren(path: $0) },
+                        showIgnored: state.config.files.showIgnored
                     )
                 }
             }

--- a/AlasTests/AppConfigFilesTests.swift
+++ b/AlasTests/AppConfigFilesTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct AppConfigFilesTests {
+    @Test func defaultsHaveShowIgnoredOn() {
+        #expect(AppConfig.defaults.files.showIgnored == true)
+    }
+
+    @Test func decodesLegacyConfigWithoutFilesKey() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "density": "comfortable",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/code/.worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.files.showIgnored == true)
+    }
+
+    @Test func roundTripsFilesShowIgnored() throws {
+        for value in [true, false] {
+            var cfg = AppConfig.defaults
+            cfg.files.showIgnored = value
+            let data = try JSONEncoder().encode(cfg)
+            let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+            #expect(decoded.files.showIgnored == value)
+        }
+    }
+}

--- a/AlasTests/FilesTabFilterTests.swift
+++ b/AlasTests/FilesTabFilterTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct FilesTabFilterTests {
+    private func node(
+        name: String,
+        path: String,
+        kind: FileTreeNode.Kind,
+        visibility: FileVisibility,
+        children: [FileTreeNode]? = nil
+    ) -> FileTreeNode {
+        FileTreeNode(
+            name: name,
+            path: path,
+            kind: kind,
+            children: children,
+            badge: nil,
+            visibility: visibility,
+            childrenState: .loaded
+        )
+    }
+
+    @Test func showIgnoredTrueReturnsInputUnchanged() {
+        let tree = [
+            node(name: "Sources", path: "Sources", kind: .dir, visibility: .tracked, children: [
+                node(name: "App.swift", path: "Sources/App.swift", kind: .file, visibility: .tracked),
+                node(name: "cache.log", path: "Sources/cache.log", kind: .file, visibility: .ignored)
+            ]),
+            node(name: ".build", path: ".build", kind: .dir, visibility: .ignored)
+        ]
+        let result = FilesTabView.filteredNodes(tree, showIgnored: true)
+        #expect(result == tree)
+    }
+
+    @Test func showIgnoredFalseDropsTopLevelIgnoredAndExcluded() {
+        let tree = [
+            node(name: "Sources", path: "Sources", kind: .dir, visibility: .tracked),
+            node(name: ".build", path: ".build", kind: .dir, visibility: .ignored),
+            node(name: "DerivedData", path: "DerivedData", kind: .dir, visibility: .excluded),
+            node(name: "README.md", path: "README.md", kind: .file, visibility: .tracked)
+        ]
+        let result = FilesTabView.filteredNodes(tree, showIgnored: false)
+        #expect(result.map(\.path) == ["Sources", "README.md"])
+    }
+
+    @Test func showIgnoredFalseDropsNestedIgnoredChildren() {
+        let tree = [
+            node(name: "Sources", path: "Sources", kind: .dir, visibility: .tracked, children: [
+                node(name: "App.swift", path: "Sources/App.swift", kind: .file, visibility: .tracked),
+                node(name: "cache.log", path: "Sources/cache.log", kind: .file, visibility: .ignored),
+                node(name: "secrets.env", path: "Sources/secrets.env", kind: .file, visibility: .excluded)
+            ])
+        ]
+        let result = FilesTabView.filteredNodes(tree, showIgnored: false)
+        let sources = result.first
+        #expect(sources?.path == "Sources")
+        #expect(sources?.children?.map(\.path) == ["Sources/App.swift"])
+    }
+
+    @Test func showIgnoredFalsePreservesTrackedDirectoryWithOnlyIgnoredChildren() {
+        let tree = [
+            node(name: "Sources", path: "Sources", kind: .dir, visibility: .tracked, children: [
+                node(name: "cache.log", path: "Sources/cache.log", kind: .file, visibility: .ignored)
+            ])
+        ]
+        let result = FilesTabView.filteredNodes(tree, showIgnored: false)
+        #expect(result.map(\.path) == ["Sources"])
+        #expect(result.first?.children?.isEmpty == true)
+    }
+}

--- a/AlasTests/FilesTabFilterTests.swift
+++ b/AlasTests/FilesTabFilterTests.swift
@@ -58,6 +58,47 @@ struct FilesTabFilterTests {
         #expect(sources?.children?.map(\.path) == ["Sources/App.swift"])
     }
 
+    @Test func showIgnoredFalsePreservesIgnoredDirectoryWithTrackedDescendant() {
+        // GitService can build a tree where a top-level directory is marked
+        // ignored but still contains tracked descendants (e.g., a file inside
+        // an ignored dir that was committed before the gitignore rule). The
+        // filter must not drop such a directory or the tracked descendant
+        // becomes unreachable.
+        let tree = [
+            node(name: ".build", path: ".build", kind: .dir, visibility: .ignored, children: [
+                node(name: "out.swift", path: ".build/out.swift", kind: .file, visibility: .tracked),
+                node(name: "cache.log", path: ".build/cache.log", kind: .file, visibility: .ignored)
+            ])
+        ]
+        let result = FilesTabView.filteredNodes(tree, showIgnored: false)
+        #expect(result.map(\.path) == [".build"])
+        #expect(result.first?.children?.map(\.path) == [".build/out.swift"])
+    }
+
+    @Test func showIgnoredFalseDropsIgnoredDirectoryWithOnlyIgnoredChildren() {
+        let tree = [
+            node(name: ".build", path: ".build", kind: .dir, visibility: .ignored, children: [
+                node(name: "cache.log", path: ".build/cache.log", kind: .file, visibility: .ignored)
+            ])
+        ]
+        let result = FilesTabView.filteredNodes(tree, showIgnored: false)
+        #expect(result.isEmpty)
+    }
+
+    @Test func showIgnoredFalsePreservesIgnoredDirectoryWithTrackedNestedDescendant() {
+        let tree = [
+            node(name: ".build", path: ".build", kind: .dir, visibility: .ignored, children: [
+                node(name: "gen", path: ".build/gen", kind: .dir, visibility: .ignored, children: [
+                    node(name: "kept.swift", path: ".build/gen/kept.swift", kind: .file, visibility: .tracked)
+                ])
+            ])
+        ]
+        let result = FilesTabView.filteredNodes(tree, showIgnored: false)
+        #expect(result.map(\.path) == [".build"])
+        #expect(result.first?.children?.map(\.path) == [".build/gen"])
+        #expect(result.first?.children?.first?.children?.map(\.path) == [".build/gen/kept.swift"])
+    }
+
     @Test func showIgnoredFalsePreservesTrackedDirectoryWithOnlyIgnoredChildren() {
         let tree = [
             node(name: "Sources", path: "Sources", kind: .dir, visibility: .tracked, children: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### ✨ Features
+
+- add a Files tab context menu (right-click the Files segment) to toggle showing ignored and excluded entries, default on, persisted globally.
+
 ## [0.3.6] - 2026-05-19
 
 ### ✨ Features


### PR DESCRIPTION
## Summary

- Add a global "Show ignored or excluded files" toggle to the Files tab via a context menu on the Files segment in the right-pane tab bar.
- Default is on, so existing behavior (ignored entries visible with ghost-rail treatment) is preserved.
- Preference persists in `AppConfig` as a new nested `Files` struct, with tolerant decode for older configs.
- Filtering happens at render time in `FilesTabView` via a pure `filteredNodes` helper — no data-layer changes, no refetch, instant toggle.

## Test plan

- [x] `AppConfigFilesTests` (3 tests) — default value, legacy decode, round-trip.
- [x] `FilesTabFilterTests` (4 tests) — pure filter helper covers show-on, top-level hide, nested hide, and tracked-dir-with-only-ignored-children preservation.
- [ ] Manual: right-click Files segment shows the menu with a checkmark; toggling hides/shows ignored rows immediately; preference survives worktree switch and app relaunch.