### PR TITLE
Settings: customizable keyboard shortcuts

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */; };
 		1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
+		1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
 		1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */; };
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
@@ -533,6 +534,7 @@
 		4261E417947C1A21E77C1587 /* GitStatusCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCache.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
+		45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigShortcutsCodingTests.swift; sourceTree = "<group>"; };
 		4575017544CD7603B3AB9069 /* GitEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilter.swift; sourceTree = "<group>"; };
 		4865995B2D4B92166321201F /* CommitContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilder.swift; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
@@ -866,6 +868,7 @@
 				D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */,
 				EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */,
 				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
+				45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
@@ -2029,6 +2032,7 @@
 				D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */,
 				CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */,
 				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
+				1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1874031C788ADB4398151FF1 /* StageChip.swift */; };
 		629B98E07ED9A159A695707D /* JetBrainsMonoNerdFont-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */; };
 		636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */; };
+		64402D666DBDAA9B98D641F6 /* ShortcutRecorderValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */; };
 		64ADA6AFE69C52F121A163E1 /* FileTypeIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F721FB733081A583D4053DDA /* FileTypeIconView.swift */; };
 		659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */; };
 		66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */; };
@@ -245,6 +246,7 @@
 		9782C5866410EFE13E670AFF /* FilesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A3B9B1103346242438940 /* FilesTabView.swift */; };
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
 		98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */; };
+		98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */; };
 		9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
@@ -428,6 +430,7 @@
 		0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSplitButton.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
 		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
+		05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
@@ -573,6 +576,7 @@
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstallerTests.swift; sourceTree = "<group>"; };
 		6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindControllerTests.swift; sourceTree = "<group>"; };
+		60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderValidationTests.swift; sourceTree = "<group>"; };
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
@@ -970,6 +974,7 @@
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
 				00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */,
 				2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */,
+				60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */,
 				6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */,
 				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
@@ -1508,6 +1513,7 @@
 			children = (
 				9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */,
 				2B9E3F080F847EF069137844 /* ShortcutBinding.swift */,
+				05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */,
 				4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */,
 			);
 			path = Shortcuts;
@@ -1977,6 +1983,7 @@
 				D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */,
 				90BB0EFFD7E0EF8DE64296E6 /* ShortcutAction.swift in Sources */,
 				2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */,
+				98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */,
 				5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */,
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,
 				115C50272D2037FB24B8536F /* SidebarView.swift in Sources */,
@@ -2150,6 +2157,7 @@
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
 				01F51F05BA5DD24D4FBC4B4B /* ShortcutActionTests.swift in Sources */,
 				B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */,
+				64402D666DBDAA9B98D641F6 /* ShortcutRecorderValidationTests.swift in Sources */,
 				CF2AD9C6F30BC02C040902A8 /* ShortcutResolverTests.swift in Sources */,
 				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */; };
 		29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */; };
 		2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */; };
+		2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9E3F080F847EF069137844 /* ShortcutBinding.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
 		2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */; };
 		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
@@ -286,6 +287,7 @@
 		B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */; };
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
+		B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */; };
 		B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */; };
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
@@ -463,6 +465,7 @@
 		220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModelTests.swift; sourceTree = "<group>"; };
 		23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCommandShellTests.swift; sourceTree = "<group>"; };
 		2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallProgressSheet.swift; sourceTree = "<group>"; };
+		2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBindingTests.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
 		25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunch.swift; sourceTree = "<group>"; };
 		25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderViewTests.swift; sourceTree = "<group>"; };
@@ -475,6 +478,7 @@
 		295319DB8544C170DDD6328D /* PathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsTests.swift; sourceTree = "<group>"; };
 		2975A1465CA308E9766521F2 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRegistry.swift; sourceTree = "<group>"; };
+		2B9E3F080F847EF069137844 /* ShortcutBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBinding.swift; sourceTree = "<group>"; };
 		2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailabilityTests.swift; sourceTree = "<group>"; };
 		2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchPicker.swift; sourceTree = "<group>"; };
 		2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryTests.swift; sourceTree = "<group>"; };
@@ -953,6 +957,7 @@
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
+				2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */,
 				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */,
@@ -1079,6 +1084,7 @@
 				413E432DDAAAE618029482C3 /* Right */,
 				986CC94FDFD6411BCED67A48 /* Search */,
 				59E804284C70FCAD77A09774 /* Settings */,
+				DA23E862C6C2D386B4C76E10 /* Shortcuts */,
 				697AACFEA2DCEBE4CEB2CD4E /* Sidebar */,
 				F556D34B5B6FE20EA80F892A /* Terminal */,
 				7592B5DE2FBCFC47DB6F481D /* Theme */,
@@ -1482,6 +1488,14 @@
 				99DCC0EF4B5701083CB34167 /* ghostty */,
 			);
 			path = ThirdParty;
+			sourceTree = "<group>";
+		};
+		DA23E862C6C2D386B4C76E10 /* Shortcuts */ = {
+			isa = PBXGroup;
+			children = (
+				2B9E3F080F847EF069137844 /* ShortcutBinding.swift */,
+			);
+			path = Shortcuts;
 			sourceTree = "<group>";
 		};
 		E25BFA956432F729835EA7E3 /* Commit */ = {
@@ -1946,6 +1960,7 @@
 				730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */,
 				8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */,
 				D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */,
+				2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */,
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,
 				115C50272D2037FB24B8536F /* SidebarView.swift in Sources */,
 				6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */,
@@ -2115,6 +2130,7 @@
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
+				B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */,
 				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
 		3E46667F7AA794E24B04BC7F /* TerminalCLIInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */; };
+		3E4C896D74C96DE0BFCAE2A5 /* ShortcutReservationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
 		3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E62B501E0490F48CCA830 /* EditorFindBarView.swift */; };
 		3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */; };
@@ -219,6 +220,7 @@
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
 		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
+		873535DE3342024BD7AA057E /* ShortcutReservations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */; };
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
 		87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */; };
@@ -467,6 +469,7 @@
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
+		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
 		1DACC2D855F4316038CB40C7 /* CommitComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerView.swift; sourceTree = "<group>"; };
 		1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouterTests.swift; sourceTree = "<group>"; };
 		20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighterTests.swift; sourceTree = "<group>"; };
@@ -636,6 +639,7 @@
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
 		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
+		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
@@ -979,6 +983,7 @@
 				00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */,
 				2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */,
 				60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */,
+				1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */,
 				6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */,
 				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
@@ -1520,6 +1525,7 @@
 				9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */,
 				2B9E3F080F847EF069137844 /* ShortcutBinding.swift */,
 				05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */,
+				8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */,
 				4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */,
 			);
 			path = Shortcuts;
@@ -1991,6 +1997,7 @@
 				2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */,
 				724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */,
 				98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */,
+				873535DE3342024BD7AA057E /* ShortcutReservations.swift in Sources */,
 				5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */,
 				F4B9A51A40365909B7644561 /* ShortcutsPane.swift in Sources */,
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,
@@ -2166,6 +2173,7 @@
 				01F51F05BA5DD24D4FBC4B4B /* ShortcutActionTests.swift in Sources */,
 				B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */,
 				64402D666DBDAA9B98D641F6 /* ShortcutRecorderValidationTests.swift in Sources */,
+				3E4C896D74C96DE0BFCAE2A5 /* ShortcutReservationsTests.swift in Sources */,
 				CF2AD9C6F30BC02C040902A8 /* ShortcutResolverTests.swift in Sources */,
 				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */; };
+		F4B9A51A40365909B7644561 /* ShortcutsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6821B71680094791995C4975 /* ShortcutsPane.swift */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
 		F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */; };
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
@@ -587,6 +588,7 @@
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherFilterTests.swift; sourceTree = "<group>"; };
 		679E62B501E0490F48CCA830 /* EditorFindBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindBarView.swift; sourceTree = "<group>"; };
+		6821B71680094791995C4975 /* ShortcutsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsPane.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
 		6A190D4B29B35C457AA9829F /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
@@ -1202,6 +1204,7 @@
 				EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */,
 				FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */,
 				410A42B1C46E68965FD36793 /* ShortcutChip.swift */,
+				6821B71680094791995C4975 /* ShortcutsPane.swift */,
 				FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */,
 				0F68A9692F85197ED9E16262 /* WorktreesPane.swift */,
 			);
@@ -1989,6 +1992,7 @@
 				724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */,
 				98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */,
 				5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */,
+				F4B9A51A40365909B7644561 /* ShortcutsPane.swift in Sources */,
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,
 				115C50272D2037FB24B8536F /* SidebarView.swift in Sources */,
 				6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2975A1465CA308E9766521F2 /* NotificationService.swift */; };
 		01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */; };
+		01F51F05BA5DD24D4FBC4B4B /* ShortcutActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */; };
 		02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1703FC5CD7DF16F4450E274 /* DiffParser.swift */; };
 		026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */; };
 		02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934BCC470703CF2DF2303357 /* SectionHeader.swift */; };
@@ -232,6 +233,7 @@
 		8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2AC0F8B3A1B75239995AC /* AppState.swift */; };
 		90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */; };
 		90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */; };
+		90BB0EFFD7E0EF8DE64296E6 /* ShortcutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */; };
 		91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C69060B922A729DD807920 /* LSPURI.swift */; };
 		92EEAFAEFB3E637FB72174A8 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
 		93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D759586280250330A9A04 /* FontSizeCommands.swift */; };
@@ -409,6 +411,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutActionTests.swift; sourceTree = "<group>"; };
 		00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPickerTests.swift; sourceTree = "<group>"; };
 		008E982C8526670670425AB8 /* EmptyTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabView.swift; sourceTree = "<group>"; };
 		010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowConfigurator.swift; sourceTree = "<group>"; };
@@ -638,6 +641,7 @@
 		93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltins.swift; sourceTree = "<group>"; };
 		9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfoTests.swift; sourceTree = "<group>"; };
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
+		9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAction.swift; sourceTree = "<group>"; };
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
 		97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroupViewTests.swift; sourceTree = "<group>"; };
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
@@ -957,6 +961,7 @@
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
+				00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */,
 				2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */,
 				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
@@ -1493,6 +1498,7 @@
 		DA23E862C6C2D386B4C76E10 /* Shortcuts */ = {
 			isa = PBXGroup;
 			children = (
+				9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */,
 				2B9E3F080F847EF069137844 /* ShortcutBinding.swift */,
 			);
 			path = Shortcuts;
@@ -1960,6 +1966,7 @@
 				730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */,
 				8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */,
 				D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */,
+				90BB0EFFD7E0EF8DE64296E6 /* ShortcutAction.swift in Sources */,
 				2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */,
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,
 				115C50272D2037FB24B8536F /* SidebarView.swift in Sources */,
@@ -2130,6 +2137,7 @@
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
+				01F51F05BA5DD24D4FBC4B4B /* ShortcutActionTests.swift in Sources */,
 				B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */,
 				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
 		59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */; };
 		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
+		5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */; };
 		5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */; };
 		5D2A45DB652AD797E2276A7A /* AgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7544FD20BC61E587CAFAC099 /* AgentRegistry.swift */; };
 		5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C486F9097A2B145D101E2C /* AlasButton.swift */; };
@@ -328,6 +329,7 @@
 		CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */; };
 		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
 		CF12433D8F30CEA05088FFB0 /* CodeTextViewIndentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */; };
+		CF2AD9C6F30BC02C040902A8 /* ShortcutResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */; };
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
@@ -527,6 +529,7 @@
 		3DCEFADD952DB870B8BAB890 /* CommitRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRow.swift; sourceTree = "<group>"; };
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
 		3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
+		4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolver.swift; sourceTree = "<group>"; };
 		412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsRangeTests.swift; sourceTree = "<group>"; };
 		413CE0B0BBC96D412D048B1D /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionState.swift; sourceTree = "<group>"; };
@@ -589,6 +592,7 @@
 		6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagingTests.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
+		6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolverTests.swift; sourceTree = "<group>"; };
 		6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreServiceTests.swift; sourceTree = "<group>"; };
 		6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionView.swift; sourceTree = "<group>"; };
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
@@ -966,6 +970,7 @@
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
 				00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */,
 				2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */,
+				6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */,
 				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */,
@@ -1503,6 +1508,7 @@
 			children = (
 				9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */,
 				2B9E3F080F847EF069137844 /* ShortcutBinding.swift */,
+				4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */,
 			);
 			path = Shortcuts;
 			sourceTree = "<group>";
@@ -1971,6 +1977,7 @@
 				D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */,
 				90BB0EFFD7E0EF8DE64296E6 /* ShortcutAction.swift in Sources */,
 				2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */,
+				5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */,
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,
 				115C50272D2037FB24B8536F /* SidebarView.swift in Sources */,
 				6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */,
@@ -2143,6 +2150,7 @@
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
 				01F51F05BA5DD24D4FBC4B4B /* ShortcutActionTests.swift in Sources */,
 				B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */,
+				CF2AD9C6F30BC02C040902A8 /* ShortcutResolverTests.swift in Sources */,
 				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
 		709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D105CB2C185958ED23164D1 /* IndentationMode.swift */; };
 		70FCC2B12AE446728EE7CF8D /* LSPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38499AFE31188908546EE222 /* LSPTransport.swift */; };
+		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
 		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
 		7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */; };
@@ -533,6 +534,7 @@
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
 		3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
 		4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolver.swift; sourceTree = "<group>"; };
+		410A42B1C46E68965FD36793 /* ShortcutChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutChip.swift; sourceTree = "<group>"; };
 		412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsRangeTests.swift; sourceTree = "<group>"; };
 		413CE0B0BBC96D412D048B1D /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionState.swift; sourceTree = "<group>"; };
@@ -1199,6 +1201,7 @@
 				515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */,
 				EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */,
 				FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */,
+				410A42B1C46E68965FD36793 /* ShortcutChip.swift */,
 				FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */,
 				0F68A9692F85197ED9E16262 /* WorktreesPane.swift */,
 			);
@@ -1983,6 +1986,7 @@
 				D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */,
 				90BB0EFFD7E0EF8DE64296E6 /* ShortcutAction.swift in Sources */,
 				2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */,
+				724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */,
 				98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */,
 				5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */,
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -59,29 +59,29 @@ struct AlasApp: App {
                 Button("Search Files…") {
                     NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
                 }
-                .keyboardShortcut("p", modifiers: .command)
+                .keyboardShortcut(state.shortcut(for: .searchFiles))
                 Divider()
                 Button("Split Selection into Lines") {
                     NSApp.sendAction(#selector(CodeTextView.splitSelectionIntoLines(_:)), to: nil, from: nil)
                 }
-                .keyboardShortcut("l", modifiers: [.command, .shift])
+                .keyboardShortcut(state.shortcut(for: .splitSelectionIntoLines))
                 .disabled(!state.hasActiveCodeEditorTab)
                 Divider()
                 Button("Find and Replace") {
                     NotificationCenter.default.post(name: .alasShowFindReplace, object: nil)
                 }
-                .keyboardShortcut("f", modifiers: [.command, .option])
+                .keyboardShortcut(state.shortcut(for: .findAndReplace))
                 .disabled(!state.hasActiveCodeEditorTab)
             }
             CommandGroup(after: .toolbar) {
                 Button("Toggle Right Pane") {
                     NotificationCenter.default.post(name: .alasToggleRightPane, object: nil)
                 }
-                .keyboardShortcut(.return, modifiers: [.command, .option])
+                .keyboardShortcut(state.shortcut(for: .toggleRightPane))
                 Button("New Terminal Tab") {
                     NotificationCenter.default.post(name: .alasNewTerminalTab, object: nil)
                 }
-                .keyboardShortcut("t", modifiers: .command)
+                .keyboardShortcut(state.shortcut(for: .newTerminalTab))
                 Button("Close Tab") {
                     NotificationCenter.default.post(name: .alasCloseTab, object: nil)
                 }
@@ -128,16 +128,16 @@ struct AlasApp: App {
                 Button("Create Project…") {
                     NotificationCenter.default.post(name: .alasCreateProject, object: nil)
                 }
-                .keyboardShortcut("n", modifiers: [.command, .shift])
+                .keyboardShortcut(state.shortcut(for: .createProject))
                 Button("New Worktree…") {
                     NotificationCenter.default.post(name: .alasNewWorktree, object: nil)
                 }
-                .keyboardShortcut("n", modifiers: [.command, .option])
+                .keyboardShortcut(state.shortcut(for: .newWorktree))
                 .disabled(state.projects.isEmpty)
                 Button("Switch Repository…") {
                     NotificationCenter.default.post(name: .alasOpenRepoSelector, object: nil)
                 }
-                .keyboardShortcut("k", modifiers: .command)
+                .keyboardShortcut(state.shortcut(for: .switchRepository))
                 Divider()
                 Button("Refresh Worktrees") {
                     NotificationCenter.default.post(name: .alasRefreshWorktrees, object: nil)
@@ -148,11 +148,11 @@ struct AlasApp: App {
                 Button("Split Right") {
                     NotificationCenter.default.post(name: .alasSplitRight, object: nil)
                 }
-                .keyboardShortcut("d", modifiers: .command)
+                .keyboardShortcut(state.shortcut(for: .splitTerminalRight))
                 Button("Split Down") {
                     NotificationCenter.default.post(name: .alasSplitDown, object: nil)
                 }
-                .keyboardShortcut("d", modifiers: [.command, .shift])
+                .keyboardShortcut(state.shortcut(for: .splitTerminalDown))
                 Button("Close Pane") {
                     NotificationCenter.default.post(name: .alasCloseTab, object: nil)
                 }
@@ -160,51 +160,51 @@ struct AlasApp: App {
                 Button("Focus Pane Left") {
                     NotificationCenter.default.post(name: .alasFocusPaneLeft, object: nil)
                 }
-                .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+                .keyboardShortcut(state.shortcut(for: .focusPaneLeft))
                 Button("Focus Pane Right") {
                     NotificationCenter.default.post(name: .alasFocusPaneRight, object: nil)
                 }
-                .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+                .keyboardShortcut(state.shortcut(for: .focusPaneRight))
                 Button("Focus Pane Up") {
                     NotificationCenter.default.post(name: .alasFocusPaneUp, object: nil)
                 }
-                .keyboardShortcut(.upArrow, modifiers: [.command, .option])
+                .keyboardShortcut(state.shortcut(for: .focusPaneUp))
                 Button("Focus Pane Down") {
                     NotificationCenter.default.post(name: .alasFocusPaneDown, object: nil)
                 }
-                .keyboardShortcut(.downArrow, modifiers: [.command, .option])
+                .keyboardShortcut(state.shortcut(for: .focusPaneDown))
                 Divider()
                 Button("Resize Pane Left") {
                     NotificationCenter.default.post(name: .alasResizePaneLeft, object: nil)
                 }
-                .keyboardShortcut(.leftArrow, modifiers: [.command, .control])
+                .keyboardShortcut(state.shortcut(for: .resizePaneLeft))
                 Button("Resize Pane Right") {
                     NotificationCenter.default.post(name: .alasResizePaneRight, object: nil)
                 }
-                .keyboardShortcut(.rightArrow, modifiers: [.command, .control])
+                .keyboardShortcut(state.shortcut(for: .resizePaneRight))
                 Button("Resize Pane Up") {
                     NotificationCenter.default.post(name: .alasResizePaneUp, object: nil)
                 }
-                .keyboardShortcut(.upArrow, modifiers: [.command, .control])
+                .keyboardShortcut(state.shortcut(for: .resizePaneUp))
                 Button("Resize Pane Down") {
                     NotificationCenter.default.post(name: .alasResizePaneDown, object: nil)
                 }
-                .keyboardShortcut(.downArrow, modifiers: [.command, .control])
+                .keyboardShortcut(state.shortcut(for: .resizePaneDown))
             }
             CommandGroup(after: .toolbar) {
                 Divider()
                 Button("Increase Font Size") {
                     NSApp.sendAction(#selector(FontSizeResponder.increaseFontSize(_:)), to: nil, from: nil)
                 }
-                .keyboardShortcut("=", modifiers: .command)
+                .keyboardShortcut(state.shortcut(for: .increaseFontSize))
                 Button("Decrease Font Size") {
                     NSApp.sendAction(#selector(FontSizeResponder.decreaseFontSize(_:)), to: nil, from: nil)
                 }
-                .keyboardShortcut("-", modifiers: .command)
+                .keyboardShortcut(state.shortcut(for: .decreaseFontSize))
                 Button("Reset Font Size") {
                     NSApp.sendAction(#selector(FontSizeResponder.resetFontSize(_:)), to: nil, from: nil)
                 }
-                .keyboardShortcut("0", modifiers: .command)
+                .keyboardShortcut(state.shortcut(for: .resetFontSize))
             }
         }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -199,6 +199,9 @@ final class AppState {
         let config = (try? store.readIfExists(AppConfig.self, from: Paths.appConfigFile)) ?? AppConfig.defaults
         let projectsFile = (try? store.readIfExists(ProjectsFile.self, from: Paths.projectsFile)) ?? ProjectsFile(projects: [])
         self.config = config
+        // Publish the effective shortcut reservations so the terminal pane
+        // can honor user overrides from the very first keystroke.
+        ShortcutReservations.update(from: config)
         self.projectsManager = ProjectsManager(persistedProjects: projectsFile.projects)
         let themeStore = (try? ThemeStore(initialId: config.themeId)) ?? (try! ThemeStore())
         // Apply the persisted accent override so the picker's selection

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -69,7 +69,7 @@ struct MarkdownTabView: View {
             // scoped to markdown tabs without explicit isEnabled gating.
             Button(action: cycleMode) { Color.clear }
                 .frame(width: 0, height: 0)
-                .keyboardShortcut("m", modifiers: [.command, .shift])
+                .keyboardShortcut(appState.shortcut(for: .toggleMarkdownPreview))
                 .opacity(0)
                 .accessibilityHidden(true)
         }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -21,6 +21,7 @@ struct AppConfig: Codable, Equatable {
     var files: Files
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
+    var shortcutOverrides: [String: ShortcutBinding?] = [:]
 
     struct General: Codable, Equatable {
         var launchAtLogin: Bool
@@ -195,7 +196,8 @@ struct AppConfig: Codable, Equatable {
         ),
         files: Files(showIgnored: true),
         recentProjectIds: [],
-        recentWorktreeIdsByProject: [:]
+        recentWorktreeIdsByProject: [:],
+        shortcutOverrides: [:]
     )
 }
 
@@ -229,7 +231,8 @@ extension AppConfig {
              general, worktrees, terminal, harness, code, markdown, changes,
              agents,
              files,
-             recentProjectIds, recentWorktreeIdsByProject
+             recentProjectIds, recentWorktreeIdsByProject,
+             shortcutOverrides
     }
 
     // Custom decode tolerates older config files that predate `code`.
@@ -330,5 +333,7 @@ extension AppConfig {
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]
+        shortcutOverrides =
+            (try? c.decode([String: ShortcutBinding?].self, forKey: .shortcutOverrides)) ?? [:]
     }
 }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -23,6 +23,7 @@ struct ChangesTabView: View {
                 if stagedCount > 0 {
                     CommitComposerView(
                         state: rps.composer,
+                        appState: appState,
                         stagedCount: stagedCount,
                         stagedAdd: stagedAdd,
                         stagedDel: stagedDel,

--- a/Alas/Sources/Right/Commit/CommitComposerView.swift
+++ b/Alas/Sources/Right/Commit/CommitComposerView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CommitComposerView: View {
     @Bindable var state: CommitComposerState
+    let appState: AppState
     let stagedCount: Int
     let stagedAdd: Int
     let stagedDel: Int
@@ -153,7 +154,7 @@ struct CommitComposerView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(!state.canCommit(stagedCount: stagedCount))
-                .keyboardShortcut(.return, modifiers: .command)
+                .keyboardShortcut(appState.shortcut(for: .commitInComposer))
             }
             .padding(.horizontal, 12)
 

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum SettingsSection: String, CaseIterable, Identifiable {
-    case agents, appearance, changes, code, terminal, worktrees
+    case agents, appearance, changes, code, shortcuts, terminal, worktrees
     var id: String { rawValue }
     var label: String {
         switch self {
@@ -9,6 +9,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .appearance: return "Appearance"
         case .changes:    return "Changes"
         case .code:       return "Code"
+        case .shortcuts:  return "Shortcuts"
         case .terminal:   return "Terminal"
         case .worktrees:  return "Worktrees"
         }
@@ -19,6 +20,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .appearance: return "palette"
         case .changes:    return "diff"
         case .code:       return "code"
+        case .shortcuts:  return "keyboard"
         case .terminal:   return "terminal"
         case .worktrees:  return "branch"
         }

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -33,6 +33,7 @@ struct SettingsWindow: View {
                     case .appearance: AppearancePane(state: state)
                     case .changes:    ChangesPane(state: state)
                     case .code:       CodePane(state: state)
+                    case .shortcuts:  ShortcutsPane(state: state)
                     case .terminal:   TerminalPane(state: state)
                     case .worktrees:  WorktreesPane(state: state)
                     }

--- a/Alas/Sources/Settings/ShortcutChip.swift
+++ b/Alas/Sources/Settings/ShortcutChip.swift
@@ -12,9 +12,9 @@ struct ShortcutChip: View {
     @State private var isHovering = false
 
     var body: some View {
-        HStack(spacing: 3) {
+        HStack(spacing: 4) {
             Text(label)
-                .font(.system(size: 11.5, design: .monospaced))
+                .font(.custom("JetBrainsMonoNF-Regular", size: 12))
                 .foregroundColor(textColor)
             if showClear {
                 Button(action: onClear) {
@@ -26,7 +26,7 @@ struct ShortcutChip: View {
                 .padding(.leading, 2)
             }
         }
-        .padding(.horizontal, 8).padding(.vertical, 3)
+        .padding(.horizontal, 10).padding(.vertical, 5)
         .background(background)
         .clipShape(RoundedRectangle(cornerRadius: 5))
         .overlay(border)
@@ -40,7 +40,7 @@ struct ShortcutChip: View {
             if liveModifiers.isEmpty { return "Press keys…" }
             let order: [ShortcutBinding.Modifier] = [.control, .option, .shift, .command]
             return order.filter { liveModifiers.contains($0) }
-                .map { symbol(for: $0) }.joined()
+                .map { symbol(for: $0) }.joined(separator: " ")
         }
         if let binding { return binding.displayString }
         return "Not set"

--- a/Alas/Sources/Settings/ShortcutChip.swift
+++ b/Alas/Sources/Settings/ShortcutChip.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct ShortcutChip: View {
+    let binding: ShortcutBinding?     // nil = unbound
+    let isRecording: Bool
+    let justModified: Bool
+    let liveModifiers: [ShortcutBinding.Modifier]   // shown during recording
+    var onClick: () -> Void
+    var onClear: () -> Void
+
+    @Environment(\.theme) var theme
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(.system(size: 11.5, design: .monospaced))
+                .foregroundColor(textColor)
+            if showClear {
+                Button(action: onClear) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(theme.color("fg-faint"))
+                }
+                .buttonStyle(.plain)
+                .padding(.leading, 2)
+            }
+        }
+        .padding(.horizontal, 8).padding(.vertical, 3)
+        .background(background)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+        .overlay(border)
+        .onHover { isHovering = $0 }
+        .contentShape(Rectangle())
+        .onTapGesture { onClick() }
+    }
+
+    private var label: String {
+        if isRecording {
+            if liveModifiers.isEmpty { return "Press keys…" }
+            let order: [ShortcutBinding.Modifier] = [.control, .option, .shift, .command]
+            return order.filter { liveModifiers.contains($0) }
+                .map { symbol(for: $0) }.joined()
+        }
+        if let binding { return binding.displayString }
+        return "Not set"
+    }
+
+    private func symbol(for m: ShortcutBinding.Modifier) -> String {
+        switch m {
+        case .control: return "⌃"
+        case .option:  return "⌥"
+        case .shift:   return "⇧"
+        case .command: return "⌘"
+        }
+    }
+
+    private var textColor: Color {
+        if isRecording { return Color.black }
+        if binding == nil { return theme.color("fg-faint") }
+        return theme.color("fg")
+    }
+
+    private var background: Color {
+        if isRecording { return theme.color("accent") }
+        return theme.color("bg-3")
+    }
+
+    @ViewBuilder
+    private var border: some View {
+        RoundedRectangle(cornerRadius: 5)
+            .strokeBorder(
+                justModified ? theme.color("accent") : Color.black.opacity(0.25),
+                lineWidth: justModified ? 1.5 : 0.5
+            )
+    }
+
+    private var showClear: Bool {
+        isHovering && binding != nil && !isRecording
+    }
+}

--- a/Alas/Sources/Settings/ShortcutsPane.swift
+++ b/Alas/Sources/Settings/ShortcutsPane.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+
+struct ShortcutsPane: View {
+    @Bindable var state: AppState
+    @Environment(\.theme) var theme
+    @State private var searchText = ""
+    @State private var recordingAction: ShortcutAction?
+    @State private var liveModifiers: [ShortcutBinding.Modifier] = []
+    @State private var justModifiedAction: ShortcutAction?
+    @State private var pendingConflict: PendingConflict?
+    @State private var showResetAllConfirm = false
+    @State private var recorder: ShortcutRecorderSession?
+
+    private struct PendingConflict: Equatable {
+        let action: ShortcutAction
+        let conflictingWith: ShortcutAction
+        let candidate: ShortcutBinding
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Shortcuts").font(.system(size: 18, weight: .semibold))
+                Text("Customize keyboard shortcuts. Click a chip and press a new combo.")
+                    .font(.system(size: 12.5))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding(.bottom, 12)
+
+                searchField
+
+                ForEach(ShortcutGroup.allCases, id: \.self) { group in
+                    let actions = visibleActions(in: group)
+                    if !actions.isEmpty {
+                        SettingsGroup(title: group.label) {
+                            ForEach(actions, id: \.self) { action in
+                                row(for: action)
+                            }
+                        }
+                    }
+                }
+
+                HStack {
+                    Spacer()
+                    Button("Reset all to defaults") { showResetAllConfirm = true }
+                        .buttonStyle(.borderless)
+                        .foregroundColor(theme.color("fg-muted"))
+                }
+                .padding(.top, 16)
+            }
+            .padding(.horizontal, 32).padding(.vertical, 24)
+        }
+        .onDisappear { stopRecorder() }
+        .confirmationDialog(
+            "Reset all \(ShortcutAction.allCases.count) shortcuts to their defaults? This will clear your overrides.",
+            isPresented: $showResetAllConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Reset all", role: .destructive) { state.resetAllShortcuts() }
+            Button("Cancel", role: .cancel) { }
+        }
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-faint"))
+            TextField("Search…", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12.5))
+        }
+        .padding(.horizontal, 10).padding(.vertical, 6)
+        .background(theme.color("bg-3"))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .padding(.bottom, 12)
+    }
+
+    @ViewBuilder
+    private func row(for action: ShortcutAction) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            SettingsRow(name: action.label, desc: action.description) {
+                ShortcutChip(
+                    binding: state.binding(for: action),
+                    isRecording: recordingAction == action,
+                    justModified: justModifiedAction == action,
+                    liveModifiers: recordingAction == action ? liveModifiers : [],
+                    onClick: { startRecording(for: action) },
+                    onClear: { state.setShortcut(nil, for: action) }
+                )
+            }
+            .contextMenu {
+                Button("Reset to default") { state.resetShortcut(for: action) }
+            }
+            if let pending = pendingConflict, pending.action == action {
+                conflictBanner(pending: pending)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func conflictBanner(pending: PendingConflict) -> some View {
+        HStack(spacing: 10) {
+            (Text("\(pending.candidate.displayString) is already bound to ")
+                .foregroundColor(theme.color("fg-muted"))
+             + Text(pending.conflictingWith.label).bold().foregroundColor(theme.color("fg")))
+            Spacer()
+            Button("Reassign") {
+                state.setShortcut(nil, for: pending.conflictingWith)
+                state.setShortcut(pending.candidate, for: pending.action)
+                flashJustModified(pending.action)
+                pendingConflict = nil
+            }
+            .buttonStyle(.borderedProminent)
+            Button("Cancel") { pendingConflict = nil }
+                .buttonStyle(.borderless)
+        }
+        .font(.system(size: 11.5))
+        .padding(.horizontal, 10).padding(.vertical, 6)
+        // "danger-soft" is not a theme token; use del at low opacity (same
+        // pattern as InlineErrorStrip).
+        .background(theme.color("del").opacity(0.10))
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    // MARK: - Filtering
+
+    private func visibleActions(in group: ShortcutGroup) -> [ShortcutAction] {
+        let inGroup = ShortcutAction.allCases.filter { $0.group == group }
+        guard !searchText.isEmpty else { return inGroup }
+        let q = searchText.lowercased()
+        return inGroup.filter { action in
+            if action.label.lowercased().contains(q) { return true }
+            if group.label.lowercased().contains(q) { return true }
+            if let b = state.binding(for: action),
+               b.displayString.lowercased().contains(q) { return true }
+            return false
+        }
+    }
+
+    // MARK: - Recording
+
+    private func startRecording(for action: ShortcutAction) {
+        pendingConflict = nil
+        recordingAction = action
+        liveModifiers = []
+        recorder?.stop()
+        let session = ShortcutRecorderSession(
+            onCapture: { binding in
+                handleCapture(binding, for: action)
+            },
+            onCancel: {
+                cancelRecording()
+            }
+        )
+        session.start()
+        recorder = session
+    }
+
+    private func handleCapture(_ binding: ShortcutBinding, for action: ShortcutAction) {
+        switch ShortcutRecorder.validate(binding) {
+        case .needsModifier, .reserved:
+            // Stay in recording state; the user can try again or press Esc.
+            return
+        case .ok:
+            stopRecorder()
+            if let conflict = state.conflict(for: binding, excluding: action) {
+                pendingConflict = PendingConflict(
+                    action: action,
+                    conflictingWith: conflict,
+                    candidate: binding
+                )
+            } else {
+                state.setShortcut(binding, for: action)
+                flashJustModified(action)
+            }
+            recordingAction = nil
+            liveModifiers = []
+        }
+    }
+
+    private func cancelRecording() {
+        stopRecorder()
+        recordingAction = nil
+        liveModifiers = []
+    }
+
+    private func stopRecorder() {
+        recorder?.stop()
+        recorder = nil
+    }
+
+    private func flashJustModified(_ action: ShortcutAction) {
+        justModifiedAction = action
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            if justModifiedAction == action { justModifiedAction = nil }
+        }
+    }
+}

--- a/Alas/Sources/Settings/ShortcutsPane.swift
+++ b/Alas/Sources/Settings/ShortcutsPane.swift
@@ -145,12 +145,9 @@ struct ShortcutsPane: View {
         liveModifiers = []
         recorder?.stop()
         let session = ShortcutRecorderSession(
-            onCapture: { binding in
-                handleCapture(binding, for: action)
-            },
-            onCancel: {
-                cancelRecording()
-            }
+            onCapture: { binding in handleCapture(binding, for: action) },
+            onCancel: { cancelRecording() },
+            onFlagsChanged: { mods in liveModifiers = mods }
         )
         session.start()
         recorder = session

--- a/Alas/Sources/Settings/ShortcutsPane.swift
+++ b/Alas/Sources/Settings/ShortcutsPane.swift
@@ -128,11 +128,18 @@ struct ShortcutsPane: View {
         let inGroup = ShortcutAction.allCases.filter { $0.group == group }
         guard !searchText.isEmpty else { return inGroup }
         let q = searchText.lowercased()
+        // Normalize spaces so typing "⌘P" matches the displayed "⌘ P".
+        let qStripped = q.replacingOccurrences(of: " ", with: "")
         return inGroup.filter { action in
             if action.label.lowercased().contains(q) { return true }
             if group.label.lowercased().contains(q) { return true }
-            if let b = state.binding(for: action),
-               b.displayString.lowercased().contains(q) { return true }
+            if let b = state.binding(for: action) {
+                let display = b.displayString.lowercased()
+                if display.contains(q) { return true }
+                if display.replacingOccurrences(of: " ", with: "").contains(qStripped) {
+                    return true
+                }
+            }
             return false
         }
     }

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+enum ShortcutGroup: String, CaseIterable, Sendable {
+    case global, codeEditor, terminal
+    var label: String {
+        switch self {
+        case .global:     return "Global"
+        case .codeEditor: return "Code editor"
+        case .terminal:   return "Terminal"
+        }
+    }
+}
+
+enum ShortcutAction: String, CaseIterable, Codable, Sendable {
+    // Global
+    case searchFiles, switchRepository, findAndReplace, toggleRightPane,
+         createProject, newWorktree, newTerminalTab,
+         increaseFontSize, decreaseFontSize, resetFontSize
+    // Code editor
+    case splitSelectionIntoLines, toggleMarkdownPreview, commitInComposer
+    // Terminal
+    case splitTerminalRight, splitTerminalDown,
+         focusPaneLeft, focusPaneRight, focusPaneUp, focusPaneDown,
+         resizePaneLeft, resizePaneRight, resizePaneUp, resizePaneDown
+
+    var group: ShortcutGroup {
+        switch self {
+        case .searchFiles, .switchRepository, .findAndReplace, .toggleRightPane,
+             .createProject, .newWorktree, .newTerminalTab,
+             .increaseFontSize, .decreaseFontSize, .resetFontSize:
+            return .global
+        case .splitSelectionIntoLines, .toggleMarkdownPreview, .commitInComposer:
+            return .codeEditor
+        case .splitTerminalRight, .splitTerminalDown,
+             .focusPaneLeft, .focusPaneRight, .focusPaneUp, .focusPaneDown,
+             .resizePaneLeft, .resizePaneRight, .resizePaneUp, .resizePaneDown:
+            return .terminal
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .searchFiles:              return "Search Files"
+        case .switchRepository:         return "Switch Repository"
+        case .findAndReplace:           return "Find and Replace"
+        case .toggleRightPane:          return "Toggle Right Pane"
+        case .createProject:            return "Create Project"
+        case .newWorktree:              return "New Worktree"
+        case .newTerminalTab:           return "New Terminal Tab"
+        case .increaseFontSize:         return "Increase Font Size"
+        case .decreaseFontSize:         return "Decrease Font Size"
+        case .resetFontSize:            return "Reset Font Size"
+        case .splitSelectionIntoLines:  return "Split Selection into Lines"
+        case .toggleMarkdownPreview:    return "Toggle Markdown Preview"
+        case .commitInComposer:         return "Commit (in composer)"
+        case .splitTerminalRight:       return "Split Right"
+        case .splitTerminalDown:        return "Split Down"
+        case .focusPaneLeft:            return "Focus Pane Left"
+        case .focusPaneRight:           return "Focus Pane Right"
+        case .focusPaneUp:              return "Focus Pane Up"
+        case .focusPaneDown:            return "Focus Pane Down"
+        case .resizePaneLeft:           return "Resize Pane Left"
+        case .resizePaneRight:          return "Resize Pane Right"
+        case .resizePaneUp:             return "Resize Pane Up"
+        case .resizePaneDown:           return "Resize Pane Down"
+        }
+    }
+
+    var description: String? {
+        switch self {
+        case .searchFiles:        return "Open the file search"
+        case .switchRepository:   return "Open the repository picker"
+        case .commitInComposer:   return "In the commit composer"
+        default:                  return nil
+        }
+    }
+
+    var defaultBinding: ShortcutBinding {
+        switch self {
+        case .searchFiles:              return .init(key: "p",          modifiers: [.command])
+        case .switchRepository:         return .init(key: "k",          modifiers: [.command])
+        case .findAndReplace:           return .init(key: "f",          modifiers: [.command, .option])
+        case .toggleRightPane:          return .init(key: "return",     modifiers: [.command, .option])
+        case .createProject:            return .init(key: "n",          modifiers: [.command, .shift])
+        case .newWorktree:              return .init(key: "n",          modifiers: [.command, .option])
+        case .newTerminalTab:           return .init(key: "t",          modifiers: [.command])
+        case .increaseFontSize:         return .init(key: "=",          modifiers: [.command])
+        case .decreaseFontSize:         return .init(key: "-",          modifiers: [.command])
+        case .resetFontSize:            return .init(key: "0",          modifiers: [.command])
+        case .splitSelectionIntoLines:  return .init(key: "l",          modifiers: [.command, .shift])
+        case .toggleMarkdownPreview:    return .init(key: "m",          modifiers: [.command, .shift])
+        case .commitInComposer:         return .init(key: "return",     modifiers: [.command])
+        case .splitTerminalRight:       return .init(key: "d",          modifiers: [.command])
+        case .splitTerminalDown:        return .init(key: "d",          modifiers: [.command, .shift])
+        case .focusPaneLeft:            return .init(key: "leftArrow",  modifiers: [.command, .option])
+        case .focusPaneRight:           return .init(key: "rightArrow", modifiers: [.command, .option])
+        case .focusPaneUp:              return .init(key: "upArrow",    modifiers: [.command, .option])
+        case .focusPaneDown:            return .init(key: "downArrow",  modifiers: [.command, .option])
+        case .resizePaneLeft:           return .init(key: "leftArrow",  modifiers: [.command, .control])
+        case .resizePaneRight:          return .init(key: "rightArrow", modifiers: [.command, .control])
+        case .resizePaneUp:             return .init(key: "upArrow",    modifiers: [.command, .control])
+        case .resizePaneDown:           return .init(key: "downArrow",  modifiers: [.command, .control])
+        }
+    }
+
+    /// Bindings owned by non-rebindable actions (macOS standards + tab switchers
+    /// + New File). Rejected by the recorder when the user tries to assign one
+    /// of these to a rebindable action.
+    static let reservedBindings: [ShortcutBinding] = [
+        .init(key: "q", modifiers: [.command]),
+        .init(key: "w", modifiers: [.command]),
+        .init(key: "s", modifiers: [.command]),
+        .init(key: "s", modifiers: [.command, .shift]),
+        .init(key: "s", modifiers: [.command, .option]),
+        .init(key: ",", modifiers: [.command]),
+        .init(key: "n", modifiers: [.command]),
+        .init(key: "1", modifiers: [.command]),
+        .init(key: "2", modifiers: [.command]),
+        .init(key: "3", modifiers: [.command]),
+        .init(key: "4", modifiers: [.command]),
+        .init(key: "5", modifiers: [.command]),
+        .init(key: "6", modifiers: [.command]),
+        .init(key: "7", modifiers: [.command]),
+        .init(key: "8", modifiers: [.command]),
+        .init(key: "9", modifiers: [.command]),
+    ]
+}

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -75,6 +75,20 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         }
     }
 
+    /// Whether the action should be reserved away from a focused terminal
+    /// surface. `false` for code-editor- or composer-scoped actions: those
+    /// have no responder when the terminal is focused, so reserving them
+    /// would swallow the keystroke instead of letting the shell receive it.
+    var appliesInTerminal: Bool {
+        switch self {
+        case .splitSelectionIntoLines, .toggleMarkdownPreview,
+             .commitInComposer, .findAndReplace:
+            return false
+        default:
+            return true
+        }
+    }
+
     var defaultBinding: ShortcutBinding {
         switch self {
         case .searchFiles:              return .init(key: "p",          modifiers: [.command])

--- a/Alas/Sources/Shortcuts/ShortcutBinding.swift
+++ b/Alas/Sources/Shortcuts/ShortcutBinding.swift
@@ -11,9 +11,10 @@ struct ShortcutBinding: Codable, Equatable, Hashable, Sendable {
 
     var displayString: String {
         // Order: control, option, shift, command — Apple HIG.
+        // Symbols are space-separated so chips read clearly: "⌘ P", "⇧ ⌘ L".
         let order: [Modifier] = [.control, .option, .shift, .command]
-        let mods = order.filter { modifiers.contains($0) }.map(symbol(for:)).joined()
-        return mods + keySymbol
+        let symbols = order.filter { modifiers.contains($0) }.map(symbol(for:))
+        return (symbols + [keySymbol]).joined(separator: " ")
     }
 
     private func symbol(for m: Modifier) -> String {

--- a/Alas/Sources/Shortcuts/ShortcutBinding.swift
+++ b/Alas/Sources/Shortcuts/ShortcutBinding.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftUI
+
+struct ShortcutBinding: Codable, Equatable, Hashable, Sendable {
+    var key: String          // "p", "return", "leftArrow", "="
+    var modifiers: [Modifier]
+
+    enum Modifier: String, Codable, CaseIterable, Sendable {
+        case control, option, shift, command
+    }
+
+    var displayString: String {
+        // Order: control, option, shift, command — Apple HIG.
+        let order: [Modifier] = [.control, .option, .shift, .command]
+        let mods = order.filter { modifiers.contains($0) }.map(symbol(for:)).joined()
+        return mods + keySymbol
+    }
+
+    private func symbol(for m: Modifier) -> String {
+        switch m {
+        case .control: return "⌃"
+        case .option:  return "⌥"
+        case .shift:   return "⇧"
+        case .command: return "⌘"
+        }
+    }
+
+    private var keySymbol: String {
+        switch key {
+        case "return":     return "↩"
+        case "leftArrow":  return "←"
+        case "rightArrow": return "→"
+        case "upArrow":    return "↑"
+        case "downArrow":  return "↓"
+        case "delete":     return "⌫"
+        case "escape":     return "⎋"
+        case "tab":        return "⇥"
+        case "space":      return "␣"
+        default:           return key.uppercased()
+        }
+    }
+
+    func asKeyboardShortcut() -> KeyboardShortcut {
+        KeyboardShortcut(keyEquivalent, modifiers: eventModifiers)
+    }
+
+    private var keyEquivalent: KeyEquivalent {
+        switch key {
+        case "return":     return .return
+        case "leftArrow":  return .leftArrow
+        case "rightArrow": return .rightArrow
+        case "upArrow":    return .upArrow
+        case "downArrow":  return .downArrow
+        case "delete":     return .delete
+        case "escape":     return .escape
+        case "tab":        return .tab
+        case "space":      return .space
+        default:
+            return key.count == 1 ? KeyEquivalent(key.first!) : KeyEquivalent(" ")
+        }
+    }
+
+    private var eventModifiers: EventModifiers {
+        var m: EventModifiers = []
+        if modifiers.contains(.command) { m.insert(.command) }
+        if modifiers.contains(.shift)   { m.insert(.shift) }
+        if modifiers.contains(.option)  { m.insert(.option) }
+        if modifiers.contains(.control) { m.insert(.control) }
+        return m
+    }
+}

--- a/Alas/Sources/Shortcuts/ShortcutRecorder.swift
+++ b/Alas/Sources/Shortcuts/ShortcutRecorder.swift
@@ -23,3 +23,85 @@ enum ShortcutRecorder {
         return .ok
     }
 }
+
+/// Live key-capture session. Install one while a chip is in recording state,
+/// uninstall on commit/cancel. The callback is invoked on the main queue for
+/// each captured key-down event (after validation in the UI layer).
+@MainActor
+final class ShortcutRecorderSession {
+    typealias Callback = (ShortcutBinding) -> Void
+    typealias CancelCallback = () -> Void
+
+    // `monitor` holds an opaque token from `NSEvent.addLocalMonitorForEvents`.
+    // Marked `nonisolated(unsafe)` so the (nonisolated) `deinit` can call
+    // `NSEvent.removeMonitor` on it; all live accesses go through MainActor-
+    // isolated methods, so concurrent reads/writes are not possible in practice.
+    nonisolated(unsafe) private var monitor: Any?
+    private let onCapture: Callback
+    private let onCancel: CancelCallback
+
+    init(onCapture: @escaping Callback, onCancel: @escaping CancelCallback) {
+        self.onCapture = onCapture
+        self.onCancel = onCancel
+    }
+
+    func start() {
+        guard monitor == nil else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            if event.keyCode == 53 {  // Escape
+                self.onCancel()
+                return nil
+            }
+            if let binding = Self.binding(from: event) {
+                self.onCapture(binding)
+                return nil  // swallow — don't propagate to the app
+            }
+            return event
+        }
+    }
+
+    func stop() {
+        teardownMonitor()
+    }
+
+    deinit {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+    }
+
+    private func teardownMonitor() {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+    }
+
+    /// Translate an NSEvent.keyDown into a ShortcutBinding, or nil if the
+    /// event isn't recordable (e.g. modifier-only).
+    static func binding(from event: NSEvent) -> ShortcutBinding? {
+        let flags = event.modifierFlags
+        var mods: [ShortcutBinding.Modifier] = []
+        if flags.contains(.command) { mods.append(.command) }
+        if flags.contains(.option)  { mods.append(.option) }
+        if flags.contains(.control) { mods.append(.control) }
+        if flags.contains(.shift)   { mods.append(.shift) }
+
+        let key: String
+        switch event.keyCode {
+        case 36:  key = "return"
+        case 48:  key = "tab"
+        case 49:  key = "space"
+        case 51:  key = "delete"
+        case 53:  key = "escape"
+        case 123: key = "leftArrow"
+        case 124: key = "rightArrow"
+        case 125: key = "downArrow"
+        case 126: key = "upArrow"
+        default:
+            let raw = (event.charactersIgnoringModifiers ?? "").lowercased()
+            guard !raw.isEmpty, raw.first?.isLetter == true || "0123456789-=,.;'/[]\\`".contains(raw) else {
+                return nil
+            }
+            key = raw
+        }
+        return ShortcutBinding(key: key, modifiers: mods)
+    }
+}

--- a/Alas/Sources/Shortcuts/ShortcutRecorder.swift
+++ b/Alas/Sources/Shortcuts/ShortcutRecorder.swift
@@ -1,0 +1,25 @@
+import AppKit
+import SwiftUI
+
+enum ShortcutRecorderValidation: Equatable, Sendable {
+    case ok
+    case needsModifier
+    case reserved
+}
+
+enum ShortcutRecorder {
+    /// Pure validation against rules in the spec:
+    /// - must include at least one of ⌘ ⌥ ⌃
+    /// - shift alone with a letter is not enough (would shadow typing)
+    /// - reserved bindings are rejected outright
+    static func validate(_ binding: ShortcutBinding) -> ShortcutRecorderValidation {
+        if ShortcutAction.reservedBindings.contains(binding) {
+            return .reserved
+        }
+        let hasStrongModifier = binding.modifiers.contains(.command)
+            || binding.modifiers.contains(.option)
+            || binding.modifiers.contains(.control)
+        guard hasStrongModifier else { return .needsModifier }
+        return .ok
+    }
+}

--- a/Alas/Sources/Shortcuts/ShortcutRecorder.swift
+++ b/Alas/Sources/Shortcuts/ShortcutRecorder.swift
@@ -31,23 +31,32 @@ enum ShortcutRecorder {
 final class ShortcutRecorderSession {
     typealias Callback = (ShortcutBinding) -> Void
     typealias CancelCallback = () -> Void
+    typealias FlagsCallback = ([ShortcutBinding.Modifier]) -> Void
 
-    // `monitor` holds an opaque token from `NSEvent.addLocalMonitorForEvents`.
-    // Marked `nonisolated(unsafe)` so the (nonisolated) `deinit` can call
-    // `NSEvent.removeMonitor` on it; all live accesses go through MainActor-
-    // isolated methods, so concurrent reads/writes are not possible in practice.
-    nonisolated(unsafe) private var monitor: Any?
+    // `keyMonitor` and `flagsMonitor` hold opaque tokens from
+    // `NSEvent.addLocalMonitorForEvents`. Marked `nonisolated(unsafe)` so the
+    // (nonisolated) `deinit` can call `NSEvent.removeMonitor` on them; all live
+    // accesses go through MainActor-isolated methods, so concurrent reads/writes
+    // are not possible in practice.
+    nonisolated(unsafe) private var keyMonitor: Any?
+    nonisolated(unsafe) private var flagsMonitor: Any?
     private let onCapture: Callback
     private let onCancel: CancelCallback
+    private let onFlagsChanged: FlagsCallback
 
-    init(onCapture: @escaping Callback, onCancel: @escaping CancelCallback) {
+    init(
+        onCapture: @escaping Callback,
+        onCancel: @escaping CancelCallback,
+        onFlagsChanged: @escaping FlagsCallback = { _ in }
+    ) {
         self.onCapture = onCapture
         self.onCancel = onCancel
+        self.onFlagsChanged = onFlagsChanged
     }
 
     func start() {
-        guard monitor == nil else { return }
-        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+        guard keyMonitor == nil else { return }
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
             if event.keyCode == 53 {  // Escape
                 self.onCancel()
@@ -59,19 +68,36 @@ final class ShortcutRecorderSession {
             }
             return event
         }
+        flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            guard let self else { return event }
+            self.onFlagsChanged(Self.modifiers(from: event.modifierFlags))
+            return event
+        }
     }
 
     func stop() {
-        teardownMonitor()
+        teardownMonitors()
     }
 
     deinit {
-        if let monitor { NSEvent.removeMonitor(monitor) }
+        if let keyMonitor { NSEvent.removeMonitor(keyMonitor) }
+        if let flagsMonitor { NSEvent.removeMonitor(flagsMonitor) }
     }
 
-    private func teardownMonitor() {
-        if let monitor { NSEvent.removeMonitor(monitor) }
-        monitor = nil
+    private func teardownMonitors() {
+        if let keyMonitor { NSEvent.removeMonitor(keyMonitor) }
+        if let flagsMonitor { NSEvent.removeMonitor(flagsMonitor) }
+        keyMonitor = nil
+        flagsMonitor = nil
+    }
+
+    static func modifiers(from flags: NSEvent.ModifierFlags) -> [ShortcutBinding.Modifier] {
+        var mods: [ShortcutBinding.Modifier] = []
+        if flags.contains(.control) { mods.append(.control) }
+        if flags.contains(.option)  { mods.append(.option) }
+        if flags.contains(.shift)   { mods.append(.shift) }
+        if flags.contains(.command) { mods.append(.command) }
+        return mods
     }
 
     /// Translate an NSEvent.keyDown into a ShortcutBinding, or nil if the

--- a/Alas/Sources/Shortcuts/ShortcutReservations.swift
+++ b/Alas/Sources/Shortcuts/ShortcutReservations.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Process-global set of key-combos the app reserves from the terminal pane.
+/// The Ghostty surface consults this on every keystroke to decide whether to
+/// forward the event to libghostty or let it bubble up to the app's menus.
+///
+/// `AppState` writes the current effective bindings whenever shortcut
+/// overrides change so customizations take effect immediately. All access
+/// happens on the main thread (terminal key handling and AppState writes are
+/// both main-actor-isolated), which justifies `nonisolated(unsafe)`.
+enum ShortcutReservations {
+    nonisolated(unsafe) private static var _current: Set<ShortcutBinding>?
+
+    /// The currently effective reserved set. Falls back to `defaultReserved`
+    /// when nothing has been published yet (e.g. in tests that exercise the
+    /// terminal directly without spinning up an AppState).
+    static var current: Set<ShortcutBinding> {
+        _current ?? defaultReserved
+    }
+
+    /// Reservations derived from the action defaults — used as the seed
+    /// before any AppState publishes its effective state.
+    static let defaultReserved: Set<ShortcutBinding> = {
+        var set = Set<ShortcutBinding>(ShortcutAction.reservedBindings)
+        for action in ShortcutAction.allCases {
+            set.insert(action.defaultBinding)
+        }
+        return set
+    }()
+
+    /// Pure: compute the effective reserved set for a given config snapshot.
+    /// An explicit `nil` override drops the action from the set so the
+    /// terminal can receive that combo.
+    static func snapshot(from config: AppConfig) -> Set<ShortcutBinding> {
+        var set = Set<ShortcutBinding>(ShortcutAction.reservedBindings)
+        for action in ShortcutAction.allCases {
+            if let override = config.shortcutOverrides[action.rawValue] {
+                if let binding = override { set.insert(binding) }
+            } else {
+                set.insert(action.defaultBinding)
+            }
+        }
+        return set
+    }
+
+    /// Recompute the effective reservations from `config` and publish them.
+    static func update(from config: AppConfig) {
+        _current = snapshot(from: config)
+    }
+
+    /// Reset the published state back to defaults — used by tests that need
+    /// a clean baseline regardless of test execution order.
+    static func resetToDefaults() {
+        _current = nil
+    }
+}

--- a/Alas/Sources/Shortcuts/ShortcutReservations.swift
+++ b/Alas/Sources/Shortcuts/ShortcutReservations.swift
@@ -19,10 +19,12 @@ enum ShortcutReservations {
     }
 
     /// Reservations derived from the action defaults — used as the seed
-    /// before any AppState publishes its effective state.
+    /// before any AppState publishes its effective state. Code-editor and
+    /// composer-scoped actions are skipped: they have no responder when the
+    /// terminal is focused, so reserving them would just swallow the key.
     static let defaultReserved: Set<ShortcutBinding> = {
         var set = Set<ShortcutBinding>(ShortcutAction.reservedBindings)
-        for action in ShortcutAction.allCases {
+        for action in ShortcutAction.allCases where action.appliesInTerminal {
             set.insert(action.defaultBinding)
         }
         return set
@@ -30,10 +32,11 @@ enum ShortcutReservations {
 
     /// Pure: compute the effective reserved set for a given config snapshot.
     /// An explicit `nil` override drops the action from the set so the
-    /// terminal can receive that combo.
+    /// terminal can receive that combo. Code-editor- and composer-scoped
+    /// actions are never reserved regardless of override.
     static func snapshot(from config: AppConfig) -> Set<ShortcutBinding> {
         var set = Set<ShortcutBinding>(ShortcutAction.reservedBindings)
-        for action in ShortcutAction.allCases {
+        for action in ShortcutAction.allCases where action.appliesInTerminal {
             if let override = config.shortcutOverrides[action.rawValue] {
                 if let binding = override { set.insert(binding) }
             } else {

--- a/Alas/Sources/Shortcuts/ShortcutResolver.swift
+++ b/Alas/Sources/Shortcuts/ShortcutResolver.swift
@@ -1,0 +1,49 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+extension AppState {
+    /// Effective binding for an action: override if present (including explicit
+    /// nil = unbound), else the default. Nil = no shortcut.
+    func binding(for action: ShortcutAction) -> ShortcutBinding? {
+        let key = action.rawValue
+        if let override = config.shortcutOverrides[key] {
+            return override  // may be nil = explicit unbind
+        }
+        return action.defaultBinding
+    }
+
+    /// SwiftUI-ready form. Pass directly into `.keyboardShortcut(_:)`.
+    func shortcut(for action: ShortcutAction) -> KeyboardShortcut? {
+        binding(for: action)?.asKeyboardShortcut()
+    }
+
+    /// Assign a binding (nil = explicit unbind, removes default too).
+    func setShortcut(_ binding: ShortcutBinding?, for action: ShortcutAction) {
+        config.shortcutOverrides[action.rawValue] = .some(binding)
+        _ = saveConfig()
+    }
+
+    /// Remove the override entirely, returning the action to its default.
+    func resetShortcut(for action: ShortcutAction) {
+        config.shortcutOverrides.removeValue(forKey: action.rawValue)
+        _ = saveConfig()
+    }
+
+    /// Drop every override.
+    func resetAllShortcuts() {
+        config.shortcutOverrides.removeAll()
+        _ = saveConfig()
+    }
+
+    /// Find the first other action that currently has `candidate` as its
+    /// effective binding. Returns nil when no conflict.
+    func conflict(for candidate: ShortcutBinding, excluding action: ShortcutAction) -> ShortcutAction? {
+        for a in ShortcutAction.allCases where a != action {
+            if binding(for: a) == candidate {
+                return a
+            }
+        }
+        return nil
+    }
+}

--- a/Alas/Sources/Shortcuts/ShortcutResolver.swift
+++ b/Alas/Sources/Shortcuts/ShortcutResolver.swift
@@ -18,7 +18,12 @@ extension AppState {
         binding(for: action)?.asKeyboardShortcut()
     }
 
-    /// Assign a binding (nil = explicit unbind, removes default too).
+    /// Assign or unbind a shortcut.
+    ///
+    /// - Pass a non-nil binding to override the default.
+    /// - Pass `nil` to *explicitly unbind* the action (suppresses the default —
+    ///   the action will have no shortcut).
+    /// - Use `resetShortcut(for:)` instead if you want the default restored.
     func setShortcut(_ binding: ShortcutBinding?, for action: ShortcutAction) {
         config.shortcutOverrides[action.rawValue] = .some(binding)
         _ = saveConfig()

--- a/Alas/Sources/Shortcuts/ShortcutResolver.swift
+++ b/Alas/Sources/Shortcuts/ShortcutResolver.swift
@@ -27,18 +27,21 @@ extension AppState {
     func setShortcut(_ binding: ShortcutBinding?, for action: ShortcutAction) {
         config.shortcutOverrides[action.rawValue] = .some(binding)
         _ = saveConfig()
+        ShortcutReservations.update(from: config)
     }
 
     /// Remove the override entirely, returning the action to its default.
     func resetShortcut(for action: ShortcutAction) {
         config.shortcutOverrides.removeValue(forKey: action.rawValue)
         _ = saveConfig()
+        ShortcutReservations.update(from: config)
     }
 
     /// Drop every override.
     func resetAllShortcuts() {
         config.shortcutOverrides.removeAll()
         _ = saveConfig()
+        ShortcutReservations.update(from: config)
     }
 
     /// Find the first other action that currently has `candidate` as its

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -488,32 +488,18 @@ extension AlasGhostty {
         }
 
         static func isReservedAppKeyEquivalent(_ event: NSEvent) -> Bool {
+            isReservedAppKeyEquivalent(event, in: ShortcutReservations.current)
+        }
+
+        /// Test seam: same logic against an explicit reservation set so unit
+        /// tests don't depend on the global registry state.
+        static func isReservedAppKeyEquivalent(
+            _ event: NSEvent,
+            in reservations: Set<ShortcutBinding>
+        ) -> Bool {
             guard event.type == .keyDown else { return false }
-
-            let flags = event.modifierFlags
-                .intersection(.deviceIndependentFlagsMask)
-                .subtracting(.capsLock)
-            let chars = event.charactersIgnoringModifiers?.lowercased() ?? ""
-
-            // ⌘T — reserved for the app's New Terminal Tab.
-            if flags == .command && chars == "t" { return true }
-            // ⌘P — Search Files. ⌘K — Switch Repository. Without these the
-            // terminal swallows the keystroke before the menu fires.
-            if flags == .command && (chars == "p" || chars == "k") { return true }
-            // ⌘1..⌘9 — reserved for app tab switching.
-            if flags == .command && ("1"..."9").contains(chars) { return true }
-            // ⌘D / ⇧⌘D — Split Right / Split Down.
-            if flags == .command && chars == "d" { return true }
-            if flags == [.command, .shift] && chars == "d" { return true }
-            // ⌘W — Close Pane / Close Tab (AppState decides).
-            if flags == .command && chars == "w" { return true }
-            // Arrow shortcuts: focus (⌥⌘) and resize (⌃⌘).
-            let arrows: Set<UInt16> = [123, 124, 125, 126]  // left, right, down, up
-            if (flags == [.command, .option] || flags == [.command, .control])
-                && arrows.contains(event.keyCode) {
-                return true
-            }
-            return false
+            guard let binding = ShortcutRecorderSession.binding(from: event) else { return false }
+            return reservations.contains(binding)
         }
 
         // MARK: - NSTextInputClient doCommand

--- a/AlasTests/AppConfigShortcutsCodingTests.swift
+++ b/AlasTests/AppConfigShortcutsCodingTests.swift
@@ -1,0 +1,40 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct AppConfigShortcutsCodingTests {
+    @Test func defaultsHaveEmptyOverrides() {
+        #expect(AppConfig.defaults.shortcutOverrides.isEmpty)
+    }
+
+    @Test func oldConfigWithoutOverridesDecodesToEmpty() throws {
+        let original = AppConfig.defaults
+        var dict = try JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(original)
+        ) as! [String: Any]
+        dict.removeValue(forKey: "shortcutOverrides")
+        let data = try JSONSerialization.data(withJSONObject: dict)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.shortcutOverrides.isEmpty)
+    }
+
+    @Test func roundTripWithOverrides() throws {
+        var cfg = AppConfig.defaults
+        cfg.shortcutOverrides = [
+            ShortcutAction.searchFiles.rawValue: ShortcutBinding(key: "o", modifiers: [.command]),
+            ShortcutAction.switchRepository.rawValue: nil,
+        ]
+        let data = try JSONEncoder().encode(cfg)
+        // Verify the explicit-nil reaches JSON as `null` (not stripped).
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let overrides = json["shortcutOverrides"] as! [String: Any]
+        #expect(overrides["switchRepository"] is NSNull,
+                "explicit-nil override must serialize as JSON null, not be dropped")
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.shortcutOverrides[ShortcutAction.searchFiles.rawValue] ==
+                .some(ShortcutBinding(key: "o", modifiers: [.command])))
+        // explicit-nil round-trips as Optional<Binding>.none stored under the key
+        #expect(decoded.shortcutOverrides.keys.contains(ShortcutAction.switchRepository.rawValue))
+        #expect(decoded.shortcutOverrides[ShortcutAction.switchRepository.rawValue] == .some(nil))
+    }
+}

--- a/AlasTests/AppStatePersistenceTests.swift
+++ b/AlasTests/AppStatePersistenceTests.swift
@@ -5,6 +5,11 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct AppStatePersistenceTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
     private struct FailingStore: PersistenceStoreProtocol {
         let error = NSError(
             domain: "AppStatePersistenceTests",
@@ -45,5 +50,17 @@ struct AppStatePersistenceTests {
         #expect(saved == false)
         #expect(reports.map(\.title) == ["Projects Save Failed"])
         #expect(reports.first?.message == "write rejected")
+    }
+
+    @Test func shortcutOverridesPersistThroughSaveAndReload() throws {
+        let state = AppState(store: MemoryStore())
+        state.setShortcut(ShortcutBinding(key: "o", modifiers: [.command]), for: .searchFiles)
+        state.setShortcut(nil, for: .switchRepository)
+        // Reload by encoding/decoding via AppConfig (mirrors what disk does).
+        let data = try JSONEncoder().encode(state.config)
+        let reloaded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(reloaded.shortcutOverrides[ShortcutAction.searchFiles.rawValue] ==
+                .some(ShortcutBinding(key: "o", modifiers: [.command])))
+        #expect(reloaded.shortcutOverrides[ShortcutAction.switchRepository.rawValue] == .some(nil))
     }
 }

--- a/AlasTests/ShortcutActionTests.swift
+++ b/AlasTests/ShortcutActionTests.swift
@@ -1,0 +1,88 @@
+import Testing
+@testable import Alas
+
+struct ShortcutActionTests {
+    @Test func allCasesHaveDefaultBinding() {
+        for action in ShortcutAction.allCases {
+            _ = action.defaultBinding
+            #expect(!action.label.isEmpty)
+        }
+    }
+
+    @Test func noDuplicateDefaultBindings() {
+        var seen: [ShortcutBinding: ShortcutAction] = [:]
+        for action in ShortcutAction.allCases {
+            let b = action.defaultBinding
+            #expect(seen[b] == nil, "Duplicate default \(b.displayString): \(action) and \(seen[b]!)")
+            seen[b] = action
+        }
+    }
+
+    @Test func defaultsMatchAlasAppValues() {
+        let expected: [(ShortcutAction, String, [ShortcutBinding.Modifier])] = [
+            (.searchFiles,          "p",          [.command]),
+            (.switchRepository,     "k",          [.command]),
+            (.findAndReplace,       "f",          [.command, .option]),
+            (.toggleRightPane,      "return",     [.command, .option]),
+            (.createProject,        "n",          [.command, .shift]),
+            (.newWorktree,          "n",          [.command, .option]),
+            (.newTerminalTab,       "t",          [.command]),
+            (.increaseFontSize,     "=",          [.command]),
+            (.decreaseFontSize,     "-",          [.command]),
+            (.resetFontSize,        "0",          [.command]),
+            (.splitSelectionIntoLines, "l",       [.command, .shift]),
+            (.toggleMarkdownPreview, "m",         [.command, .shift]),
+            (.commitInComposer,     "return",     [.command]),
+            (.splitTerminalRight,   "d",          [.command]),
+            (.splitTerminalDown,    "d",          [.command, .shift]),
+            (.focusPaneLeft,        "leftArrow",  [.command, .option]),
+            (.focusPaneRight,       "rightArrow", [.command, .option]),
+            (.focusPaneUp,          "upArrow",    [.command, .option]),
+            (.focusPaneDown,        "downArrow",  [.command, .option]),
+            (.resizePaneLeft,       "leftArrow",  [.command, .control]),
+            (.resizePaneRight,      "rightArrow", [.command, .control]),
+            (.resizePaneUp,         "upArrow",    [.command, .control]),
+            (.resizePaneDown,       "downArrow",  [.command, .control]),
+        ]
+        #expect(expected.count == ShortcutAction.allCases.count)
+        for (action, key, mods) in expected {
+            #expect(action.defaultBinding == ShortcutBinding(key: key, modifiers: mods),
+                    "default mismatch for \(action)")
+        }
+    }
+
+    @Test func groupAssignmentsMatchSpec() {
+        let global: Set<ShortcutAction> = [
+            .searchFiles, .switchRepository, .findAndReplace, .toggleRightPane,
+            .createProject, .newWorktree, .newTerminalTab,
+            .increaseFontSize, .decreaseFontSize, .resetFontSize,
+        ]
+        let codeEditor: Set<ShortcutAction> = [
+            .splitSelectionIntoLines, .toggleMarkdownPreview, .commitInComposer,
+        ]
+        let terminal: Set<ShortcutAction> = [
+            .splitTerminalRight, .splitTerminalDown,
+            .focusPaneLeft, .focusPaneRight, .focusPaneUp, .focusPaneDown,
+            .resizePaneLeft, .resizePaneRight, .resizePaneUp, .resizePaneDown,
+        ]
+        for a in ShortcutAction.allCases {
+            switch a.group {
+            case .global:     #expect(global.contains(a), "\(a) miscategorized")
+            case .codeEditor: #expect(codeEditor.contains(a), "\(a) miscategorized")
+            case .terminal:   #expect(terminal.contains(a), "\(a) miscategorized")
+            }
+        }
+    }
+
+    @Test func reservedBindingsContainsStandards() {
+        let reserved = ShortcutAction.reservedBindings
+        #expect(reserved.contains(ShortcutBinding(key: "q", modifiers: [.command])))
+        #expect(reserved.contains(ShortcutBinding(key: "w", modifiers: [.command])))
+        #expect(reserved.contains(ShortcutBinding(key: "s", modifiers: [.command])))
+        #expect(reserved.contains(ShortcutBinding(key: ",", modifiers: [.command])))
+        #expect(reserved.contains(ShortcutBinding(key: "n", modifiers: [.command])))
+        for n in 1...9 {
+            #expect(reserved.contains(ShortcutBinding(key: String(n), modifiers: [.command])))
+        }
+    }
+}

--- a/AlasTests/ShortcutBindingTests.swift
+++ b/AlasTests/ShortcutBindingTests.swift
@@ -19,24 +19,25 @@ struct ShortcutBindingTests {
     }
 
     @Test func displayStringForCommandP() {
-        #expect(ShortcutBinding(key: "p", modifiers: [.command]).displayString == "⌘P")
+        #expect(ShortcutBinding(key: "p", modifiers: [.command]).displayString == "⌘ P")
     }
 
     @Test func displayStringForCommandShiftL() {
         // Apple HIG order: control, option, shift, command — command is last.
-        #expect(ShortcutBinding(key: "l", modifiers: [.command, .shift]).displayString == "⇧⌘L")
+        // Symbols are space-separated so chips read clearly.
+        #expect(ShortcutBinding(key: "l", modifiers: [.command, .shift]).displayString == "⇧ ⌘ L")
     }
 
     @Test func displayStringSpecialKeys() {
-        #expect(ShortcutBinding(key: "return", modifiers: [.command]).displayString == "⌘↩")
-        #expect(ShortcutBinding(key: "leftArrow", modifiers: [.command, .option]).displayString == "⌥⌘←")
-        #expect(ShortcutBinding(key: "=", modifiers: [.command]).displayString == "⌘=")
+        #expect(ShortcutBinding(key: "return", modifiers: [.command]).displayString == "⌘ ↩")
+        #expect(ShortcutBinding(key: "leftArrow", modifiers: [.command, .option]).displayString == "⌥ ⌘ ←")
+        #expect(ShortcutBinding(key: "=", modifiers: [.command]).displayString == "⌘ =")
     }
 
     @Test func displayStringModifierOrderIsStable() {
         // Order: control, option, shift, command (matches Apple HIG).
         let b = ShortcutBinding(key: "k", modifiers: [.shift, .command, .control])
-        #expect(b.displayString == "⌃⇧⌘K")
+        #expect(b.displayString == "⌃ ⇧ ⌘ K")
     }
 
     @Test func asKeyboardShortcutLetter() {

--- a/AlasTests/ShortcutBindingTests.swift
+++ b/AlasTests/ShortcutBindingTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import Foundation
+import SwiftUI
+@testable import Alas
+
+struct ShortcutBindingTests {
+    @Test func codableRoundTripCommandP() throws {
+        let original = ShortcutBinding(key: "p", modifiers: [.command])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ShortcutBinding.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func codableRoundTripCommandShiftL() throws {
+        let original = ShortcutBinding(key: "l", modifiers: [.command, .shift])
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ShortcutBinding.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func displayStringForCommandP() {
+        #expect(ShortcutBinding(key: "p", modifiers: [.command]).displayString == "⌘P")
+    }
+
+    @Test func displayStringForCommandShiftL() {
+        // Apple HIG order: control, option, shift, command — command is last.
+        #expect(ShortcutBinding(key: "l", modifiers: [.command, .shift]).displayString == "⇧⌘L")
+    }
+
+    @Test func displayStringSpecialKeys() {
+        #expect(ShortcutBinding(key: "return", modifiers: [.command]).displayString == "⌘↩")
+        #expect(ShortcutBinding(key: "leftArrow", modifiers: [.command, .option]).displayString == "⌥⌘←")
+        #expect(ShortcutBinding(key: "=", modifiers: [.command]).displayString == "⌘=")
+    }
+
+    @Test func displayStringModifierOrderIsStable() {
+        // Order: control, option, shift, command (matches Apple HIG).
+        let b = ShortcutBinding(key: "k", modifiers: [.shift, .command, .control])
+        #expect(b.displayString == "⌃⇧⌘K")
+    }
+
+    @Test func asKeyboardShortcutLetter() {
+        let b = ShortcutBinding(key: "p", modifiers: [.command])
+        let ks = b.asKeyboardShortcut()
+        #expect(ks.key == KeyEquivalent("p"))
+        #expect(ks.modifiers == .command)
+    }
+
+    @Test func asKeyboardShortcutReturn() {
+        let b = ShortcutBinding(key: "return", modifiers: [.command])
+        let ks = b.asKeyboardShortcut()
+        #expect(ks.key == .return)
+    }
+}

--- a/AlasTests/ShortcutRecorderValidationTests.swift
+++ b/AlasTests/ShortcutRecorderValidationTests.swift
@@ -1,0 +1,39 @@
+import Testing
+@testable import Alas
+
+struct ShortcutRecorderValidationTests {
+    @Test func rejectsBareLetter() {
+        let b = ShortcutBinding(key: "p", modifiers: [])
+        #expect(ShortcutRecorder.validate(b) == .needsModifier)
+    }
+
+    @Test func rejectsShiftOnlyLetter() {
+        let b = ShortcutBinding(key: "p", modifiers: [.shift])
+        #expect(ShortcutRecorder.validate(b) == .needsModifier)
+    }
+
+    @Test func acceptsShiftPlusCommand() {
+        let b = ShortcutBinding(key: "p", modifiers: [.command, .shift])
+        #expect(ShortcutRecorder.validate(b) == .ok)
+    }
+
+    @Test func acceptsControlOnlyArrow() {
+        let b = ShortcutBinding(key: "leftArrow", modifiers: [.control])
+        #expect(ShortcutRecorder.validate(b) == .ok)
+    }
+
+    @Test func rejectsReservedCommandQ() {
+        let b = ShortcutBinding(key: "q", modifiers: [.command])
+        #expect(ShortcutRecorder.validate(b) == .reserved)
+    }
+
+    @Test func rejectsReservedCommand1() {
+        let b = ShortcutBinding(key: "1", modifiers: [.command])
+        #expect(ShortcutRecorder.validate(b) == .reserved)
+    }
+
+    @Test func acceptsCommandLetter() {
+        let b = ShortcutBinding(key: "j", modifiers: [.command])
+        #expect(ShortcutRecorder.validate(b) == .ok)
+    }
+}

--- a/AlasTests/ShortcutReservationsTests.swift
+++ b/AlasTests/ShortcutReservationsTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+struct ShortcutReservationsTests {
+    // Tests use `snapshot(from:)` (pure) so they don't depend on or pollute
+    // the global registry — Swift Testing runs suites in parallel and the
+    // production `update(from:)` path is shared with other suites.
+
+    @Test func defaultsIncludeActionDefaults() {
+        let reserved = ShortcutReservations.defaultReserved
+        #expect(reserved.contains(ShortcutAction.searchFiles.defaultBinding))
+        #expect(reserved.contains(ShortcutAction.newTerminalTab.defaultBinding))
+        #expect(reserved.contains(ShortcutAction.resetFontSize.defaultBinding))
+    }
+
+    @Test func defaultsIncludeStandardsAndTabSwitchers() {
+        let reserved = ShortcutReservations.defaultReserved
+        // ⌘W (Close Tab) and ⌘1..⌘9 stay reserved regardless of rebinds.
+        #expect(reserved.contains(ShortcutBinding(key: "w", modifiers: [.command])))
+        #expect(reserved.contains(ShortcutBinding(key: "1", modifiers: [.command])))
+        #expect(reserved.contains(ShortcutBinding(key: "9", modifiers: [.command])))
+    }
+
+    @Test func snapshotMovesReservationWhenOverridden() {
+        // Rebind Search Files: ⌘P → ⌘O. The terminal should reserve ⌘O and
+        // free ⌘P.
+        var config = AppConfig.defaults
+        config.shortcutOverrides[ShortcutAction.searchFiles.rawValue] =
+            .some(ShortcutBinding(key: "o", modifiers: [.command]))
+
+        let reserved = ShortcutReservations.snapshot(from: config)
+        #expect(reserved.contains(ShortcutBinding(key: "o", modifiers: [.command])))
+        #expect(!reserved.contains(ShortcutBinding(key: "p", modifiers: [.command])))
+    }
+
+    @Test func snapshotDropsExplicitUnbinds() {
+        // Explicit unbind: ⌘P no longer reserved.
+        var config = AppConfig.defaults
+        config.shortcutOverrides[ShortcutAction.searchFiles.rawValue] = .some(nil)
+
+        let reserved = ShortcutReservations.snapshot(from: config)
+        #expect(!reserved.contains(ShortcutBinding(key: "p", modifiers: [.command])))
+        // Other defaults still reserved.
+        #expect(reserved.contains(ShortcutAction.newTerminalTab.defaultBinding))
+    }
+
+    @Test func surfaceViewHonorsDynamicReservation() throws {
+        // The explicit-set overload lets us prove integration without
+        // touching the global registry.
+        var config = AppConfig.defaults
+        config.shortcutOverrides[ShortcutAction.searchFiles.rawValue] =
+            .some(ShortcutBinding(key: "o", modifiers: [.command]))
+        let reserved = ShortcutReservations.snapshot(from: config)
+
+        let cmdO = try keyEvent(characters: "o", ignoringModifiers: "o",
+                                modifiers: .command, keyCode: 31)
+        let cmdP = try keyEvent(characters: "p", ignoringModifiers: "p",
+                                modifiers: .command, keyCode: 35)
+
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(cmdO, in: reserved))
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(cmdP, in: reserved))
+    }
+
+    private func keyEvent(
+        type: NSEvent.EventType = .keyDown,
+        characters: String,
+        ignoringModifiers: String,
+        modifiers: NSEvent.ModifierFlags,
+        keyCode: UInt16
+    ) throws -> NSEvent {
+        let event = NSEvent.keyEvent(
+            with: type,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: ignoringModifiers,
+            isARepeat: false,
+            keyCode: keyCode
+        )
+        return try #require(event)
+    }
+}

--- a/AlasTests/ShortcutReservationsTests.swift
+++ b/AlasTests/ShortcutReservationsTests.swift
@@ -23,6 +23,28 @@ struct ShortcutReservationsTests {
         #expect(reserved.contains(ShortcutBinding(key: "9", modifiers: [.command])))
     }
 
+    @Test func defaultsExcludeCodeEditorAndComposerScopedActions() {
+        // These actions have no responder when the terminal is focused, so
+        // reserving them would swallow the keystroke. Pass through to the
+        // shell instead.
+        let reserved = ShortcutReservations.defaultReserved
+        #expect(!reserved.contains(ShortcutAction.splitSelectionIntoLines.defaultBinding))
+        #expect(!reserved.contains(ShortcutAction.toggleMarkdownPreview.defaultBinding))
+        #expect(!reserved.contains(ShortcutAction.commitInComposer.defaultBinding))
+        #expect(!reserved.contains(ShortcutAction.findAndReplace.defaultBinding))
+    }
+
+    @Test func snapshotKeepsScopedActionsOutEvenWhenOverridden() {
+        // Rebinding a code-editor-scoped action to a new combo must NOT add
+        // that combo to the reserved set — the terminal still wants it.
+        var config = AppConfig.defaults
+        config.shortcutOverrides[ShortcutAction.toggleMarkdownPreview.rawValue] =
+            .some(ShortcutBinding(key: "j", modifiers: [.command, .shift]))
+
+        let reserved = ShortcutReservations.snapshot(from: config)
+        #expect(!reserved.contains(ShortcutBinding(key: "j", modifiers: [.command, .shift])))
+    }
+
     @Test func snapshotMovesReservationWhenOverridden() {
         // Rebind Search Files: ⌘P → ⌘O. The terminal should reserve ⌘O and
         // free ⌘P.

--- a/AlasTests/ShortcutResolverTests.swift
+++ b/AlasTests/ShortcutResolverTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import SwiftUI
+@testable import Alas
+
+@MainActor
+struct ShortcutResolverTests {
+    /// An in-memory store that never touches disk, so tests don't
+    /// clobber the user's real config file.
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    private func makeState() -> AppState {
+        AppState(store: MemoryStore())
+    }
+
+    @Test func returnsDefaultWhenNoOverride() async {
+        let state = makeState()
+        let binding = state.binding(for: .searchFiles)
+        #expect(binding == ShortcutAction.searchFiles.defaultBinding)
+    }
+
+    @Test func returnsOverrideWhenSet() async {
+        let state = makeState()
+        let custom = ShortcutBinding(key: "o", modifiers: [.command])
+        state.setShortcut(custom, for: .searchFiles)
+        #expect(state.binding(for: .searchFiles) == custom)
+    }
+
+    @Test func returnsNilForExplicitUnbind() async {
+        let state = makeState()
+        state.setShortcut(nil, for: .searchFiles)
+        #expect(state.binding(for: .searchFiles) == nil)
+        #expect(state.shortcut(for: .searchFiles) == nil)
+    }
+
+    @Test func resetSingleClearsOverride() async {
+        let state = makeState()
+        state.setShortcut(ShortcutBinding(key: "o", modifiers: [.command]), for: .searchFiles)
+        state.resetShortcut(for: .searchFiles)
+        #expect(state.binding(for: .searchFiles) == ShortcutAction.searchFiles.defaultBinding)
+        #expect(!state.config.shortcutOverrides.keys.contains(ShortcutAction.searchFiles.rawValue))
+    }
+
+    @Test func resetAllClearsEverything() async {
+        let state = makeState()
+        state.setShortcut(ShortcutBinding(key: "o", modifiers: [.command]), for: .searchFiles)
+        state.setShortcut(nil, for: .switchRepository)
+        state.resetAllShortcuts()
+        #expect(state.config.shortcutOverrides.isEmpty)
+    }
+
+    @Test func conflictDetectsExistingDefaultBinding() async {
+        let state = makeState()
+        let cmdP = ShortcutBinding(key: "p", modifiers: [.command])
+        let conflict = state.conflict(for: cmdP, excluding: .switchRepository)
+        #expect(conflict == .searchFiles)
+    }
+
+    @Test func conflictExcludesSelf() async {
+        let state = makeState()
+        let cmdP = ShortcutBinding(key: "p", modifiers: [.command])
+        let conflict = state.conflict(for: cmdP, excluding: .searchFiles)
+        #expect(conflict == nil)
+    }
+
+    @Test func conflictNilWhenNoneFound() async {
+        let state = makeState()
+        let weird = ShortcutBinding(key: "j", modifiers: [.command, .control, .shift])
+        #expect(state.conflict(for: weird, excluding: .searchFiles) == nil)
+    }
+
+    @Test func conflictDetectsExistingOverride() async {
+        let state = makeState()
+        // searchFiles' default is ⌘P. Override switchRepository to ⌘P.
+        // A new candidate of ⌘P from another action should now find switchRepository,
+        // not searchFiles, because the search short-circuits at the first hit (and
+        // the loop ordering is allCases). Either match is acceptable per the spec —
+        // we just want to prove that an override participates in conflict detection.
+        let cmdP = ShortcutBinding(key: "p", modifiers: [.command])
+        state.setShortcut(cmdP, for: .switchRepository)
+        // Asking about a third action: must report either .searchFiles OR .switchRepository
+        let conflict = state.conflict(for: cmdP, excluding: .findAndReplace)
+        #expect(conflict == .searchFiles || conflict == .switchRepository,
+                "expected override to participate in conflict detection")
+    }
+}

--- a/AlasTests/SurfaceViewShortcutTests.swift
+++ b/AlasTests/SurfaceViewShortcutTests.swift
@@ -4,6 +4,10 @@ import Testing
 
 @MainActor
 struct SurfaceViewShortcutTests {
+    // Tests pass `ShortcutReservations.defaultReserved` explicitly so they
+    // don't depend on the global registry (other suites mutate it under
+    // parallel test execution).
+
     @Test func commandTIsReservedForAppCommand() throws {
         let event = try keyEvent(
             characters: "t",
@@ -12,7 +16,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 17
         )
 
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandTAllowsCapsLock() throws {
@@ -23,7 +27,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 17
         )
 
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func modifiedCommandTIsNotReserved() throws {
@@ -34,7 +38,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 17
         )
 
-        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandDigitOneIsReservedForAppCommand() throws {
@@ -45,7 +49,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 18
         )
 
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandDigitNineIsReservedForAppCommand() throws {
@@ -56,7 +60,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 25
         )
 
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandDigitAllowsCapsLock() throws {
@@ -67,7 +71,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 18
         )
 
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func modifiedCommandDigitIsNotReserved() throws {
@@ -78,10 +82,13 @@ struct SurfaceViewShortcutTests {
             keyCode: 18
         )
 
-        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
-    @Test func commandZeroIsNotReserved() throws {
+    @Test func commandZeroIsReservedForFontReset() throws {
+        // ⌘0 is the default binding for Reset Font Size — when the terminal
+        // pane is focused, the menu's action handler routes through the
+        // FontSizeResponder chain and resets the surface's font size.
         let event = try keyEvent(
             characters: "0",
             ignoringModifiers: "0",
@@ -89,7 +96,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 29
         )
 
-        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func otherCommandKeysAreNotReserved() throws {
@@ -101,7 +108,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 14
         )
 
-        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func controlTIsNotReserved() throws {
@@ -112,7 +119,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 17
         )
 
-        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func keyUpIsNotReserved() throws {
@@ -124,7 +131,7 @@ struct SurfaceViewShortcutTests {
             keyCode: 17
         )
 
-        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandDIsReserved() throws {
@@ -132,7 +139,7 @@ struct SurfaceViewShortcutTests {
             characters: "d", ignoringModifiers: "d",
             modifiers: .command, keyCode: 2
         )
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandShiftDIsReserved() throws {
@@ -140,7 +147,7 @@ struct SurfaceViewShortcutTests {
             characters: "D", ignoringModifiers: "d",
             modifiers: [.command, .shift], keyCode: 2
         )
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandWIsReserved() throws {
@@ -148,7 +155,7 @@ struct SurfaceViewShortcutTests {
             characters: "w", ignoringModifiers: "w",
             modifiers: .command, keyCode: 13
         )
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandOptionLeftArrowIsReserved() throws {
@@ -156,7 +163,7 @@ struct SurfaceViewShortcutTests {
             characters: "\u{F702}", ignoringModifiers: "\u{F702}",
             modifiers: [.command, .option], keyCode: 123
         )
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func commandCtrlRightArrowIsReserved() throws {
@@ -164,7 +171,7 @@ struct SurfaceViewShortcutTests {
             characters: "\u{F703}", ignoringModifiers: "\u{F703}",
             modifiers: [.command, .control], keyCode: 124
         )
-        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     @Test func plainArrowIsNotReserved() throws {
@@ -172,7 +179,7 @@ struct SurfaceViewShortcutTests {
             characters: "\u{F702}", ignoringModifiers: "\u{F702}",
             modifiers: [], keyCode: 123
         )
-        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event))
+        #expect(!AlasGhostty.SurfaceView.isReservedAppKeyEquivalent(event, in: ShortcutReservations.defaultReserved))
     }
 
     private func keyEvent(


### PR DESCRIPTION
## Summary
- Adds a Settings → Shortcuts pane that lets users rebind 23 keyboard shortcuts across Global, Code editor, and Terminal groups.
- Existing `.keyboardShortcut(...)` callsites in `AlasApp.swift`, `CommitComposerView`, and `MarkdownTabView` now resolve through a central `ShortcutAction` registry; per-action overrides persist in `AppConfig`.
- Inline recording on each chip with live modifier preview, conflict detection (with Reassign), per-row context-menu reset, and "Reset all to defaults" footer with confirm sheet.
- Reserved combos (macOS standards + ⌘1..⌘9 tab switchers + ⌘N New File) cannot be assigned to rebindable actions.

## Architecture
- `Alas/Sources/Shortcuts/` — `ShortcutBinding` (Codable model), `ShortcutAction` (23 stable IDs + defaults + reserved list), `ShortcutResolver` (extension on AppState with `binding(for:)`, `setShortcut`, `resetShortcut`, `resetAllShortcuts`, `conflict(for:excluding:)`), `ShortcutRecorder` (validator + NSEvent monitor session with `.keyDown` + `.flagsChanged` for live modifier preview).
- `Alas/Sources/Settings/` — `ShortcutChip` (5-state trailing chip), `ShortcutsPane` (groups + search + recording + conflict banner + reset).
- `AppConfig.shortcutOverrides: [String: ShortcutBinding?]` — tri-state: missing key → default, present non-nil → override, present nil → explicit unbind. Backward-compatible decode for older configs.

## Test plan
- [x] Unit tests: model round-trip, default-vs-AlasApp parity snapshot, no-duplicate-defaults invariant, conflict matrix (self-exclude + override participation + no-match), reserved validation, AppConfig backward-compat + JSON-null preservation, AppState persistence integration. ~30 tests across 5 new files.
- [x] Build clean under strict concurrency (Swift 5.9, `SWIFT_STRICT_CONCURRENCY: complete`).
- [x] Manual: rebind ⌘P → another combo, observe new shortcut works without restart.
- [x] Manual: conflict banner triggers correctly; Reassign unbinds the other action.
- [x] Manual: `×` clears to "Not set"; right-click → Reset to default; footer Reset all to defaults with confirm sheet.
- [x] Manual: search filters across action label, group label, and rendered shortcut (space-normalized).

Spec: `docs/superpowers/specs/2026-05-19-settings-shortcuts-design.md`
Plan: `docs/superpowers/plans/2026-05-19-settings-shortcuts.md`