### PR TITLE
Cmd+D add next occurrence and Option+Shift+drag column selection

### DIFF
--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -32,6 +32,14 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     var resetFontSizeHandler: (() -> Void)?
 
     private var multiCursorSelectedRanges: [NSValue]?
+    private var possibleColumnSelectionDrag: ColumnSelectionDrag?
+
+    private struct ColumnSelectionDrag {
+        let startPoint: NSPoint
+        var hasExceededThreshold: Bool
+    }
+
+    private static let columnSelectionDragThreshold: CGFloat = 4
 
     @objc func increaseFontSize(_ sender: Any?) { increaseFontSizeHandler?() }
     @objc func decreaseFontSize(_ sender: Any?) { decreaseFontSizeHandler?() }
@@ -314,9 +322,15 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
         let ranges = normalizedSelectedRanges()
 
-        // If any range has non-zero length, let AppKit handle it natively
         if ranges.contains(where: { $0.length > 0 }) {
-            super.insertNewline(sender)
+            let edits = ranges.map {
+                MultiCursorEdit(
+                    originalRange: $0,
+                    replacement: "\n",
+                    resultingSelection: NSRange(location: $0.location + 1, length: 0)
+                )
+            }
+            applyMultiCursorEdits(edits)
             return
         }
 
@@ -410,6 +424,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
         if isOption, isShift {
             let p = convert(event.locationInWindow, from: nil)
+            possibleColumnSelectionDrag = ColumnSelectionDrag(startPoint: p, hasExceededThreshold: false)
             let charIndex = indexAtPoint(p)
             if charIndex != NSNotFound {
                 let current = normalizedSelectedRanges()
@@ -447,6 +462,32 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         super.mouseDown(with: event)
     }
 
+    override func mouseDragged(with event: NSEvent) {
+        guard var drag = possibleColumnSelectionDrag else {
+            super.mouseDragged(with: event)
+            return
+        }
+
+        let p = convert(event.locationInWindow, from: nil)
+        if !drag.hasExceededThreshold {
+            let distance = hypot(p.x - drag.startPoint.x, p.y - drag.startPoint.y)
+            guard distance >= Self.columnSelectionDragThreshold else { return }
+            drag.hasExceededThreshold = true
+            possibleColumnSelectionDrag = drag
+        }
+
+        let ranges = columnSelectionRanges(from: drag.startPoint, to: p)
+        guard !ranges.isEmpty else { return }
+        setNormalizedSelectedRanges(ranges)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        let handledColumnDrag = possibleColumnSelectionDrag?.hasExceededThreshold == true
+        possibleColumnSelectionDrag = nil
+        if handledColumnDrag { return }
+        super.mouseUp(with: event)
+    }
+
     override func flagsChanged(with event: NSEvent) {
         super.flagsChanged(with: event)
         flagsChangedHandler?(event)
@@ -455,6 +496,20 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
         mouseExitedHandler?()
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let isCommandOnly = modifiers.contains(.command)
+            && !modifiers.contains(.shift)
+            && !modifiers.contains(.option)
+            && !modifiers.contains(.control)
+        let isD = event.charactersIgnoringModifiers?.lowercased() == "d"
+        if isCommandOnly, isD {
+            addNextOccurrence()
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
     }
 
     override func updateTrackingAreas() {
@@ -466,6 +521,158 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             owner: self, userInfo: nil
         )
         addTrackingArea(area)
+    }
+
+    // MARK: - Selection helpers
+
+    private func addNextOccurrence() {
+        let ranges = normalizedSelectedRanges()
+        guard !string.isEmpty else { return }
+
+        let ns = string as NSString
+        let activeRange: NSRange
+        if let last = ranges.last, last.length > 0 {
+            activeRange = last
+        } else {
+            let cursor = ranges.last?.location ?? selectedRange().location
+            guard let word = wordRange(at: cursor) else { return }
+            var updated = ranges
+            if updated.isEmpty {
+                updated = [word]
+            } else {
+                updated[updated.count - 1] = word
+            }
+            setNormalizedSelectedRanges(updated)
+            scrollRangeToVisible(word)
+            return
+        }
+
+        let needle = ns.substring(with: activeRange)
+        guard !needle.isEmpty else { return }
+        let searchStart = NSMaxRange(activeRange)
+        guard let next = nextUnselectedOccurrence(of: needle, after: searchStart, selected: ranges) else { return }
+        appendSelection(next)
+        scrollRangeToVisible(next)
+    }
+
+    private func nextUnselectedOccurrence(of needle: String, after location: Int, selected: [NSRange]) -> NSRange? {
+        let ns = string as NSString
+        let length = ns.length
+        guard location <= length else { return nil }
+
+        var searchLocation = location
+        var hasWrapped = false
+        while true {
+            let range = NSRange(location: searchLocation, length: length - searchLocation)
+            let found = ns.range(of: needle, options: [], range: range)
+            if found.location == NSNotFound {
+                if !hasWrapped, location > 0 {
+                    searchLocation = 0
+                    hasWrapped = true
+                    continue
+                }
+                return nil
+            }
+            if hasWrapped, found.location >= location { return nil }
+            if !selected.contains(where: { NSEqualRanges($0, found) }) {
+                return found
+            }
+            searchLocation = found.location + found.length
+            if searchLocation > length { return nil }
+        }
+    }
+
+    private func columnSelectionRanges(from startPoint: NSPoint, to endPoint: NSPoint) -> [NSRange] {
+        guard let layoutManager, let textContainer else { return [] }
+        let nsLength = (string as NSString).length
+        guard nsLength > 0 else { return [] }
+
+        layoutManager.ensureLayout(for: textContainer)
+
+        let origin = textContainerOrigin
+        let start = NSPoint(x: startPoint.x - origin.x, y: startPoint.y - origin.y)
+        let end = NSPoint(x: endPoint.x - origin.x, y: endPoint.y - origin.y)
+        let minX = min(start.x, end.x)
+        let maxX = max(start.x, end.x)
+        let minY = min(start.y, end.y)
+        let maxY = max(start.y, end.y)
+        let selectionRect = NSRect(x: minX, y: minY, width: max(maxX - minX, 1), height: max(maxY - minY, 1))
+
+        let glyphRange = layoutManager.glyphRange(for: textContainer)
+        var ranges: [NSRange] = []
+        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { lineRect, _, _, lineGlyphRange, _ in
+            guard lineRect.intersects(selectionRect) || selectionRect.contains(NSPoint(x: minX, y: lineRect.midY)) else { return }
+
+            let glyphCharRange = layoutManager.characterRange(forGlyphRange: lineGlyphRange, actualGlyphRange: nil)
+            let lineCharRange = self.textContentRange(forLineCharacterRange: glyphCharRange)
+            guard lineCharRange.location != NSNotFound, lineCharRange.location <= nsLength else { return }
+
+            let y = lineRect.midY
+            let startLocation = self.characterIndex(atContainerPoint: NSPoint(x: minX, y: y), constrainedTo: lineCharRange)
+            let endLocation = self.characterIndex(atContainerPoint: NSPoint(x: maxX, y: y), constrainedTo: lineCharRange)
+            let lower = min(startLocation, endLocation)
+            let upper = max(startLocation, endLocation)
+            ranges.append(NSRange(location: lower, length: upper - lower))
+        }
+
+        return ranges
+    }
+
+    private func characterIndex(atContainerPoint point: NSPoint, constrainedTo lineCharRange: NSRange) -> Int {
+        guard let layoutManager, let textContainer else { return lineCharRange.location }
+        let nsLength = (string as NSString).length
+        let lineStart = min(max(lineCharRange.location, 0), nsLength)
+        let lineEnd = min(max(NSMaxRange(lineCharRange), lineStart), nsLength)
+        var fraction: CGFloat = 0
+        let index = layoutManager.characterIndex(
+            for: point,
+            in: textContainer,
+            fractionOfDistanceBetweenInsertionPoints: &fraction
+        )
+        return min(max(index, lineStart), lineEnd)
+    }
+
+    private func textContentRange(forLineCharacterRange lineCharRange: NSRange) -> NSRange {
+        let nsString = string as NSString
+        let nsLength = nsString.length
+        let lineStart = min(max(lineCharRange.location, 0), nsLength)
+        var lineEnd = min(max(NSMaxRange(lineCharRange), lineStart), nsLength)
+        while lineEnd > lineStart {
+            let trailing = nsString.substring(with: NSRange(location: lineEnd - 1, length: 1))
+            guard trailing == "\n" || trailing == "\r" else { break }
+            lineEnd -= 1
+        }
+        return NSRange(location: lineStart, length: lineEnd - lineStart)
+    }
+
+    private func wordRange(at location: Int) -> NSRange? {
+        let ns = string as NSString
+        guard location >= 0, location <= ns.length else { return nil }
+        if ns.length == 0 { return nil }
+        let clamped = min(location, ns.length - 1)
+        let char = ns.substring(with: NSRange(location: clamped, length: 1))
+        guard char.rangeOfCharacter(from: .alphanumerics) != nil || char == "_" else { return nil }
+        var start = clamped
+        while start > 0 {
+            let prev = ns.substring(with: NSRange(location: start - 1, length: 1))
+            if prev.rangeOfCharacter(from: .alphanumerics) != nil || prev == "_" {
+                start -= 1
+            } else {
+                break
+            }
+        }
+        var end = clamped
+        while end < ns.length - 1 {
+            let next = ns.substring(with: NSRange(location: end + 1, length: 1))
+            if next.rangeOfCharacter(from: .alphanumerics) != nil || next == "_" {
+                end += 1
+            } else {
+                break
+            }
+        }
+        let length = end - start + 1
+        guard length > 0 else { return nil }
+        return NSRange(location: start, length: length)
     }
 
     // MARK: - Private helpers

--- a/AlasTests/CodeTextViewMultiCursorTests.swift
+++ b/AlasTests/CodeTextViewMultiCursorTests.swift
@@ -203,4 +203,263 @@ struct CodeTextViewMultiCursorTests {
 
         #expect(textView.selectedRanges.count == 1)
     }
+
+    // MARK: - Add next occurrence
+
+    @Test func cmdDSelectsWordAtCursorWhenSelectionIsEmpty() {
+        let textView = makeTextView("foo bar foo")
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        let handled = textView.performKeyEquivalent(with: commandD())
+
+        #expect(handled == true)
+        #expect(selectedRanges(in: textView) == [NSRange(location: 0, length: 3)])
+    }
+
+    @Test func repeatedCmdDAddsNextOccurrence() {
+        let textView = makeTextView("foo bar foo")
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        _ = textView.performKeyEquivalent(with: commandD())
+        _ = textView.performKeyEquivalent(with: commandD())
+
+        #expect(selectedRanges(in: textView) == [
+            NSRange(location: 0, length: 3),
+            NSRange(location: 8, length: 3)
+        ])
+    }
+
+    @Test func cmdDWrapsAroundFromLastOccurrence() {
+        let textView = makeTextView("foo bar foo")
+        textView.setSelectedRange(NSRange(location: 8, length: 3))
+
+        _ = textView.performKeyEquivalent(with: commandD())
+
+        #expect(selectedRanges(in: textView) == [
+            NSRange(location: 0, length: 3),
+            NSRange(location: 8, length: 3)
+        ])
+    }
+
+    @Test func cmdDSkipsAlreadySelectedOccurrences() {
+        let textView = makeTextView("foo foo foo")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 3)),
+            NSValue(range: NSRange(location: 4, length: 3))
+        ], affinity: .downstream, stillSelecting: false)
+
+        _ = textView.performKeyEquivalent(with: commandD())
+
+        #expect(selectedRanges(in: textView) == [
+            NSRange(location: 0, length: 3),
+            NSRange(location: 4, length: 3),
+            NSRange(location: 8, length: 3)
+        ])
+    }
+
+    @Test func cmdDDoesNotDuplicateWhenAllOccurrencesAreSelected() {
+        let textView = makeTextView("foo foo")
+        textView.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 3)),
+            NSValue(range: NSRange(location: 4, length: 3))
+        ], affinity: .downstream, stillSelecting: false)
+
+        _ = textView.performKeyEquivalent(with: commandD())
+
+        #expect(selectedRanges(in: textView) == [
+            NSRange(location: 0, length: 3),
+            NSRange(location: 4, length: 3)
+        ])
+    }
+
+    @Test func cmdDIsCaseSensitive() {
+        let textView = makeTextView("Foo foo Foo")
+        textView.setSelectedRange(NSRange(location: 0, length: 3))
+
+        _ = textView.performKeyEquivalent(with: commandD())
+
+        #expect(selectedRanges(in: textView) == [
+            NSRange(location: 0, length: 3),
+            NSRange(location: 8, length: 3)
+        ])
+    }
+
+    @Test func nonCommandDIsNotHandledAsKeyEquivalent() {
+        let textView = makeTextView("foo")
+
+        let handled = textView.performKeyEquivalent(with: keyDWithoutCommand())
+
+        #expect(handled == false)
+    }
+
+    // MARK: - Column selection
+
+    @Test func columnSelectionCreatesRangeForEachVisualLine() throws {
+        let textView = makeGeometryTextView("abcde\nfghij\nklmno")
+        let start = try pointForCharacter(at: 1, in: textView)
+        let end = try pointForCharacter(at: 15, in: textView)
+
+        performColumnDrag(in: textView, from: start, to: end)
+
+        #expect(selectedRanges(in: textView) == [
+            NSRange(location: 1, length: 2),
+            NSRange(location: 7, length: 2),
+            NSRange(location: 13, length: 2)
+        ])
+    }
+
+    @Test func columnSelectionReverseDragProducesSameRanges() throws {
+        let textView = makeGeometryTextView("abcde\nfghij\nklmno")
+        let start = try pointForCharacter(at: 15, in: textView)
+        let end = try pointForCharacter(at: 1, in: textView)
+
+        performColumnDrag(in: textView, from: start, to: end)
+
+        #expect(selectedRanges(in: textView) == [
+            NSRange(location: 1, length: 2),
+            NSRange(location: 7, length: 2),
+            NSRange(location: 13, length: 2)
+        ])
+    }
+
+    @Test func columnSelectionUsesWrappedVisualLines() throws {
+        let textView = makeGeometryTextView("abcdef ghijkl", width: 48)
+        guard let container = textView.textContainer, let layoutManager = textView.layoutManager else {
+            Issue.record("Missing TextKit components")
+            return
+        }
+        layoutManager.ensureLayout(for: container)
+
+        let glyphRange = layoutManager.glyphRange(for: container)
+        var lineCount = 0
+        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { _, _, _, _, _ in
+            lineCount += 1
+        }
+        #expect(lineCount > 1)
+
+        let start = try pointForCharacter(at: 1, in: textView)
+        let end = try pointForCharacter(at: 9, in: textView)
+        performColumnDrag(in: textView, from: start, to: end)
+
+        #expect(selectedRanges(in: textView).count > 1)
+    }
+
+    @Test func optionShiftDragBelowThresholdPreservesClickExtension() throws {
+        let textView = makeGeometryTextView("abcde")
+        textView.setSelectedRange(NSRange(location: 1, length: 0))
+        let start = try pointForCharacter(at: 4, in: textView)
+
+        let end = NSPoint(x: start.x + 2, y: start.y + 1)
+        textView.mouseDown(with: mouseEvent(.leftMouseDown, in: textView, at: start, modifiers: [.option, .shift]))
+        textView.mouseDragged(with: mouseEvent(.leftMouseDragged, in: textView, at: end, modifiers: [.option, .shift]))
+        textView.mouseUp(with: mouseEvent(.leftMouseUp, in: textView, at: end, modifiers: [.option, .shift]))
+
+        #expect(selectedRanges(in: textView) == [NSRange(location: 1, length: 3)])
+    }
+
+    private func makeGeometryTextView(_ text: String, width: CGFloat = 800) -> CodeTextView {
+        let storage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: width, height: 600))
+        container.lineFragmentPadding = 0
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: width, height: 600), textContainer: container)
+        textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        textView.textContainerInset = .zero
+        textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        layoutManager.ensureLayout(for: container)
+        return textView
+    }
+
+    private func selectedRanges(in textView: CodeTextView) -> [NSRange] {
+        textView.selectedRanges.map(\.rangeValue)
+    }
+
+    private func commandD() -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "d",
+            charactersIgnoringModifiers: "d",
+            isARepeat: false,
+            keyCode: 2
+        )!
+    }
+
+    private func keyDWithoutCommand() -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "d",
+            charactersIgnoringModifiers: "d",
+            isARepeat: false,
+            keyCode: 2
+        )!
+    }
+
+    private func mouseEvent(_ type: NSEvent.EventType, in textView: CodeTextView, at point: NSPoint, modifiers: NSEvent.ModifierFlags) -> NSEvent {
+        NSEvent.mouseEvent(
+            with: type,
+            location: textView.convert(point, to: nil),
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+    }
+
+    private func performColumnDrag(in textView: CodeTextView, from start: NSPoint, to end: NSPoint) {
+        textView.mouseDown(with: mouseEvent(.leftMouseDown, in: textView, at: start, modifiers: [.option, .shift]))
+        textView.mouseDragged(with: mouseEvent(.leftMouseDragged, in: textView, at: end, modifiers: [.option, .shift]))
+        textView.mouseUp(with: mouseEvent(.leftMouseUp, in: textView, at: end, modifiers: [.option, .shift]))
+    }
+
+    private func pointForCharacter(at location: Int, in textView: CodeTextView) throws -> NSPoint {
+        guard let layoutManager = textView.layoutManager, let container = textView.textContainer else {
+            Issue.record("Missing TextKit components")
+            return .zero
+        }
+
+        layoutManager.ensureLayout(for: container)
+        let nsLength = (textView.string as NSString).length
+        let clamped = min(max(location, 0), nsLength)
+        let glyphRange = layoutManager.glyphRange(for: container)
+        var point: NSPoint?
+
+        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { _, usedRect, _, lineGlyphRange, stop in
+            let charRange = layoutManager.characterRange(forGlyphRange: lineGlyphRange, actualGlyphRange: nil)
+            guard clamped >= charRange.location, clamped <= NSMaxRange(charRange) else { return }
+
+            let x: CGFloat
+            if clamped == NSMaxRange(charRange) {
+                x = usedRect.maxX
+            } else {
+                let glyphIndex = layoutManager.glyphIndexForCharacter(at: clamped)
+                x = layoutManager.location(forGlyphAt: glyphIndex).x
+            }
+            point = NSPoint(
+                x: textView.textContainerOrigin.x + x,
+                y: textView.textContainerOrigin.y + usedRect.midY
+            )
+            stop.pointee = true
+        }
+
+        guard let point else {
+            Issue.record("Could not resolve point for character \(location)")
+            return .zero
+        }
+        return point
+    }
 }


### PR DESCRIPTION
## Summary
- **Cmd+D** selects the word at cursor when no selection exists, then repeatedly adds the next matching occurrence (literal, case-sensitive, UTF-16) with wrap-around and duplicate skipping
- **Option+Shift+drag** column/box selection uses a 4pt movement threshold to preserve existing Option+Shift+Click extend-selection behavior, mapping the drag rectangle to per-visual-line ranges through TextKit 1 line fragment enumeration
- Fixes multi-cursor newline with non-empty selections to use `applyMultiCursorEdits` instead of `super.insertNewline` for consistent behavior in headless/test contexts

## Test plan
- [x] 23 multi-cursor tests pass (12 new: 7 Cmd+D, 4 column selection, 1 threshold)
- [x] Build succeeds
- [ ] Manual: Cmd+D expands word at cursor, repeated press adds next occurrence, wraps around
- [ ] Manual: Option+Shift+drag creates rectangular multi-cursor selection across lines
- [ ] Manual: Option+Shift+click (no drag) still extends selection as before
- [ ] Manual: Existing undo/redo, IME, and scroll behavior unaffected