### PR TITLE
Fix half-dark first-launch appearance in light mode

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -79,7 +79,12 @@ struct RootView: View {
             RepoSelectorDialog(appState: state)
         }
         .environment(\.theme, state.themeStore.current)
-        .onChange(of: state.themeStore.current.id) { _, _ in
+        .onChange(of: state.themeStore.current.id, initial: true) { _, _ in
+            // `initial: true` is load-bearing: AppState.init() calls
+            // WindowAppearance.apply too, but that runs before the SwiftUI
+            // Window's NSWindow exists, so the per-window appearance never
+            // gets set. Without firing on first appearance, light-mode
+            // launches render half-dark until the user toggles the theme.
             WindowAppearance.apply(darkMode: state.themeStore.current.darkMode)
         }
         .background(WindowConfigurator())


### PR DESCRIPTION
## Summary
- `AppState.init()` calls `WindowAppearance.apply` before the SwiftUI Window's `NSWindow` exists, so the per-window appearance never lands.
- `RootView`'s `.onChange(of: themeStore.current.id)` didn't fire on initial mount, so first launch in light mode rendered half-dark (light sidebars, dark center) until the user toggled the material/theme.
- Pass `initial: true` so the appearance is applied as soon as the view first appears (and on subsequent theme changes, as before).

## Test plan
- [ ] Quit Alas, ensure light theme is the persisted current theme
- [ ] Launch — main window renders fully light (center pane, sidebars, title bar all consistent) without any toggling
- [ ] Switch to a dark theme — flips correctly
- [ ] Switch back to light — flips correctly