### PR TITLE
Add Archive action to failed worktree delete state

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -663,6 +663,7 @@ final class AppState {
         let wasSelected = selectedWorktreeId == worktree.id
 
         cleanupWorktreeState(worktreeId: worktree.id)
+        projectsManager.setOperationState(id: worktree.id, state: nil)
         projectsManager.setWorktreeHidden(
             projectId: worktree.projectId,
             path: worktree.path,

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -193,6 +193,7 @@ struct RootView: View {
                 worktree: wt,
                 message: message,
                 onRetry: { state.deleteWorktree(wt) },
+                onArchive: { state.archiveWorktree(wt) },
                 onCopyError: {
                     let pb = NSPasteboard.general
                     pb.clearContents()

--- a/Alas/Sources/Center/DeleteFailedWorktreeView.swift
+++ b/Alas/Sources/Center/DeleteFailedWorktreeView.swift
@@ -4,6 +4,7 @@ struct DeleteFailedWorktreeView: View {
     let worktree: Worktree
     let message: String
     let onRetry: () -> Void
+    let onArchive: () -> Void
     let onCopyError: () -> Void
     @Environment(\.theme) var theme
 
@@ -33,6 +34,7 @@ struct DeleteFailedWorktreeView: View {
                 .padding(.horizontal, 24)
             HStack(spacing: 10) {
                 AlasButton(title: "Copy Error", icon: "doc.on.doc", style: .normal, action: onCopyError)
+                AlasButton(title: "Archive", icon: "archivebox", style: .normal, action: onArchive)
                 AlasButton(title: "Retry Delete", icon: "arrow.clockwise", style: .primary, action: onRetry)
             }
         }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -124,6 +124,7 @@ struct WorktreeRowView: View {
                 Button("Copy Path", action: onCopyPath)
             } else if case .deleteFailed = operationState {
                 Button("Retry Delete", action: onRetryDelete)
+                Button("Archive", action: onArchive)
                 Divider()
                 if let errorMessage {
                     Button("Copy Error") { onCopyError(errorMessage) }

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -471,6 +471,59 @@ struct AppStateCleanupTests {
         #expect(state.projects.contains(where: { $0.id == project.id }) == false)
     }
 
+    // MARK: - Archive from delete-failed state
+
+    @Test func archiveWorktreeFromDeleteFailedStateHidesWorktree() async throws {
+        let repo = try await makeRepo(name: "archive-from-failed")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "archive", color: "#5fb7c4")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        #expect(trees.count == 1)
+        let wt = trees[0]
+
+        // Simulate a failed delete.
+        state.projectsManager.setOperationState(id: wt.id, state: .deleteFailed(message: "permission denied"))
+        state.selectedWorktreeId = wt.id
+
+        // Archive should succeed and hide the worktree.
+        state.archiveWorktree(wt)
+
+        #expect(state.projectsManager.isWorktreeHidden(projectId: project.id, path: wt.path))
+        #expect(state.projectsManager.archivedWorktrees(projectId: project.id).count == 1)
+        #expect(state.projectsManager.visibleWorktrees(projectId: project.id).isEmpty)
+        // Operation state should be cleared.
+        #expect(state.projectsManager.operationState(for: wt.id) == nil)
+        // Selection should move away because the worktree is no longer visible.
+        #expect(state.selectedWorktreeId != wt.id)
+    }
+
+    @Test func archiveWorktreeFromDeleteFailedStateClosesTabs() async throws {
+        let repo = try await makeRepo(name: "archive-from-failed-tabs")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "archive-tabs", color: "#5fb7c4")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+
+        let wt = state.projectsManager.worktrees(projectId: project.id)[0]
+        state.tabs.appendTerminal(worktreeId: wt.id, title: "term", sessionId: "s1")
+        #expect(state.tabs.tabs(forWorktree: wt.id).count == 1)
+
+        state.projectsManager.setOperationState(id: wt.id, state: .deleteFailed(message: "permission denied"))
+        state.selectedWorktreeId = wt.id
+
+        state.archiveWorktree(wt)
+
+        // Tabs should be closed.
+        #expect(state.tabs.tabs(forWorktree: wt.id).isEmpty)
+        // And selection updated.
+        #expect(state.selectedWorktreeId != wt.id)
+    }
+
     @Test func createWorktreeAfterProjectRemovalDoesNotMutateState() async throws {
         let repo = try await makeRepo(name: "create-after-remove")
         defer { try? FileManager.default.removeItem(at: repo) }


### PR DESCRIPTION
## Summary

- When deleting a worktree fails, users previously could only retry. This adds an **Archive** button alongside Retry so they can move on without a successful delete.
- Reuses the existing `archiveWorktree` flow — no new state logic. The only addition is clearing the delete-failed operation state during archive so the row stops rendering as errored.
- Archive appears in both the center `DeleteFailedWorktreeView` and the sidebar context menu for consistency.

### What changed

| File | Change |
|------|--------|
| `DeleteFailedWorktreeView.swift` | Added `onArchive` closure and Archive button next to Retry Delete |
| `WorktreeRowView.swift` | Added Archive to sidebar context menu for `deleteFailed` rows |
| `RootView.swift` | Wired `onArchive` to `state.archiveWorktree(wt)` |
| `AppState.swift` | `archiveWorktree` now clears the operation state before hiding |
| `AppStateCleanupTests.swift` | Two focused tests: worktree hidden + operation cleared, tabs closed + selection updated |