### PR TITLE
Route Ghostty cmd-click on workspace files to the alas editor

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1322,6 +1322,48 @@ final class AppState {
         openFile(relativePath: relativePath, worktreeId: worktreeId)
     }
 
+    /// Route a cmd-clicked URL from a Ghostty terminal surface. Mirrors `alas
+    /// open` for files inside the session's worktree (resolving relatives
+    /// against the shell cwd), and returns false for anything else so the
+    /// caller can fall back to `NSWorkspace.shared.open`.
+    func routeTerminalOpenURL(rawURL: String, sessionId: String) -> Bool {
+        guard let session = terminal.registry.session(for: sessionId),
+              let worktree = worktree(withId: session.worktreeId) else { return false }
+
+        let path: String
+        if let parsed = URL(string: rawURL), parsed.isFileURL {
+            path = parsed.path
+        } else {
+            path = rawURL
+        }
+        guard !path.isEmpty else { return false }
+
+        let absoluteURL: URL
+        if (path as NSString).isAbsolutePath {
+            absoluteURL = URL(fileURLWithPath: path).standardizedFileURL
+        } else {
+            let base = session.surface.currentWorkingDirectory ?? worktree.path
+            absoluteURL = base.appendingPathComponent(path).standardizedFileURL
+        }
+
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: absoluteURL.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue else { return false }
+
+        let rootComponents = worktree.path.standardizedFileURL.pathComponents
+        let targetComponents = absoluteURL.pathComponents
+        guard targetComponents.count > rootComponents.count,
+              Array(targetComponents.prefix(rootComponents.count)) == rootComponents else {
+            return false
+        }
+        let relativePath = targetComponents.dropFirst(rootComponents.count).joined(separator: "/")
+        guard !relativePath.isEmpty else { return false }
+
+        openFile(relativePath: relativePath, worktreeId: worktree.id)
+        NSApp.activate(ignoringOtherApps: true)
+        return true
+    }
+
     private func relativePath(for url: URL, in worktreeRoot: URL) throws -> String {
         let root = worktreeRoot.standardizedFileURL.path
         let target = url.standardizedFileURL.path

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1350,8 +1350,13 @@ final class AppState {
         guard FileManager.default.fileExists(atPath: absoluteURL.path, isDirectory: &isDirectory),
               !isDirectory.boolValue else { return false }
 
-        let rootComponents = worktree.path.standardizedFileURL.pathComponents
-        let targetComponents = absoluteURL.pathComponents
+        // Resolve symlinks on both sides before the containment check so that
+        // an in-tree symlink pointing outside the worktree (e.g.
+        // `worktree/escape -> /elsewhere`) doesn't get routed to the editor.
+        let resolvedTarget = absoluteURL.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedRoot = worktree.path.resolvingSymlinksInPath().standardizedFileURL
+        let rootComponents = resolvedRoot.pathComponents
+        let targetComponents = resolvedTarget.pathComponents
         guard targetComponents.count > rootComponents.count,
               Array(targetComponents.prefix(rootComponents.count)) == rootComponents else {
             return false

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -87,7 +87,10 @@ private struct PaneLeafView: View {
         Group {
             if let session = state.terminal.registry.session(for: leaf.sessionId) {
                 GhosttyHost(session: session, isFocused: isFocused)
-                    .onAppear { wireCwdHandler(session: session) }
+                    .onAppear {
+                        wireCwdHandler(session: session)
+                        wireOpenURLHandler(session: session)
+                    }
             } else {
                 Color.clear
             }
@@ -118,6 +121,13 @@ private struct PaneLeafView: View {
             _ = state.tabs.setLeafCwd(
                 worktreeId: worktreeId, tabId: tabId, leafId: leafId, cwd: url.path
             )
+        }
+    }
+
+    private func wireOpenURLHandler(session: TerminalSession) {
+        session.surface.openURLHandler = { [weak state, sessionId = session.id] rawURL in
+            guard let state else { return false }
+            return state.routeTerminalOpenURL(rawURL: rawURL, sessionId: sessionId)
         }
     }
 }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
@@ -238,8 +238,11 @@ private func alasGhosttyAction(
         guard let ptr = v.url, v.len > 0 else { return false }
         let data = Data(bytes: ptr, count: Int(v.len))
         let s = String(data: data, encoding: .utf8) ?? ""
-        guard let url = URL(string: s) else { return false }
-        DispatchQueue.main.async { NSWorkspace.shared.open(url) }
+        DispatchQueue.main.async {
+            if let handler = surfaceView?.openURLHandler, handler(s) { return }
+            guard let url = URL(string: s) else { return }
+            NSWorkspace.shared.open(url)
+        }
         return true
 
     case GHOSTTY_ACTION_SHOW_CHILD_EXITED:

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -87,6 +87,11 @@ extension AlasGhostty {
         /// Fired on the main queue when the shell reports a new working directory.
         var cwdHandler: ((URL) -> Void)?
 
+        /// Invoked on the main queue when Ghostty emits a cmd-click URL.
+        /// Return `true` to swallow the event; `false` lets the caller fall
+        /// back to `NSWorkspace.shared.open` for default macOS handling.
+        var openURLHandler: ((String) -> Bool)?
+
         func setCurrentWorkingDirectory(_ url: URL) {
             currentWorkingDirectory = url
             cwdHandler?(url)

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -189,6 +189,35 @@ struct AppStateCLIRoutingTests {
         #expect(handled == false)
     }
 
+    @Test func routeTerminalOpenURLReturnsFalseForInWorktreeSymlinkPointingOutside() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-symlink-out")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let externalDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ghostty-symlink-target-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: externalDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: externalDir) }
+        let externalFile = externalDir.appendingPathComponent("escaped.txt")
+        try "x\n".write(to: externalFile, atomically: true, encoding: .utf8)
+        let linkURL = worktree.path.appendingPathComponent("escape.txt")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: externalFile)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        surface.setCurrentWorkingDirectory(worktree.path)
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: "escape.txt", sessionId: "s1")
+
+        #expect(handled == false)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).allSatisfy { tab in
+            if case .editor = tab { return false }
+            return true
+        })
+    }
+
     @Test func routeTerminalOpenURLReturnsFalseForUnknownSession() async throws {
         let state = AppState()
         let handled = state.routeTerminalOpenURL(rawURL: "anything", sessionId: "missing")

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -78,6 +78,142 @@ struct AppStateCLIRoutingTests {
         })
     }
 
+    @Test func routeTerminalOpenURLResolvesRelativePathAgainstShellCwd() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-relative")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let subdir = worktree.path.appendingPathComponent("notes")
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+        let file = subdir.appendingPathComponent("plan.md")
+        try "x\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        surface.setCurrentWorkingDirectory(subdir)
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: "plan.md", sessionId: "s1")
+
+        #expect(handled == true)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .editor(let s) = $0 { return s.relativePath == "notes/plan.md" && !s.isExternal }
+            return false
+        })
+    }
+
+    @Test func routeTerminalOpenURLAcceptsAbsolutePathInsideWorkspace() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-absolute")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let file = worktree.path.appendingPathComponent("README.md")
+        try "x\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: file.path, sessionId: "s1")
+
+        #expect(handled == true)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .editor(let s) = $0 { return s.relativePath == "README.md" && !s.isExternal }
+            return false
+        })
+    }
+
+    @Test func routeTerminalOpenURLAcceptsFileURLInsideWorkspace() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-fileurl")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let file = worktree.path.appendingPathComponent("README.md")
+        try "x\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: file.absoluteURL.absoluteString, sessionId: "s1")
+
+        #expect(handled == true)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .editor(let s) = $0 { return s.relativePath == "README.md" }
+            return false
+        })
+    }
+
+    @Test func routeTerminalOpenURLReturnsFalseForPathOutsideWorkspace() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-outside")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let externalDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-ghostty-outside-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: externalDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: externalDir) }
+        let externalFile = externalDir.appendingPathComponent("out.txt")
+        try "x\n".write(to: externalFile, atomically: true, encoding: .utf8)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: externalFile.path, sessionId: "s1")
+
+        #expect(handled == false)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).allSatisfy { tab in
+            if case .editor = tab { return false }
+            return true
+        })
+    }
+
+    @Test func routeTerminalOpenURLReturnsFalseForMissingFile() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-missing")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        surface.setCurrentWorkingDirectory(worktree.path)
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: "does-not-exist.md", sessionId: "s1")
+
+        #expect(handled == false)
+    }
+
+    @Test func routeTerminalOpenURLReturnsFalseForUnknownSession() async throws {
+        let state = AppState()
+        let handled = state.routeTerminalOpenURL(rawURL: "anything", sessionId: "missing")
+        #expect(handled == false)
+    }
+
+    @Test func routeTerminalOpenURLReturnsFalseForDirectory() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-dir")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let subdir = worktree.path.appendingPathComponent("subdir")
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        surface.setCurrentWorkingDirectory(worktree.path)
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: "subdir", sessionId: "s1")
+
+        #expect(handled == false)
+    }
+
     @Test func makeCLICommandRouterOpensExternalFileOnOriginatingWorktreeAndSelectsIt() async throws {
         let (state, _, worktree) = try await makeStateWithWorktree(name: "external")
         defer { try? FileManager.default.removeItem(at: worktree.path) }


### PR DESCRIPTION
## Summary
- Cmd-clicking a relative path that Ghostty highlights now opens the file as an editor tab when it resolves inside the active worktree, instead of bouncing with the Finder "-50" dialog.
- Relative paths are resolved against the surface's shell cwd (`GHOSTTY_ACTION_PWD` via OSC 7), with the worktree root as fallback. Same flow as `alas open <path>`.
- Anything outside the worktree (or unresolvable, missing, a directory) still falls through to `NSWorkspace.shared.open` so URLs / external files behave as before.

## Implementation
- `AlasGhostty.SurfaceView` gains `openURLHandler: ((String) -> Bool)?` alongside the existing `cwdHandler`.
- `GHOSTTY_ACTION_OPEN_URL` in `AlasGhostty.App` consults the handler first; falls back to `NSWorkspace` only when there's no handler or it returns false.
- `AppState.routeTerminalOpenURL(rawURL:sessionId:)` resolves the path, checks containment in the session's worktree, and delegates to the existing `openFile`.
- `TerminalTabView` wires the handler in `onAppear`, next to `wireCwdHandler`.

## Test plan
- [x] `AlasTests/AppStateCLIRoutingTests` — 7 new tests cover relative-vs-cwd, absolute, `file://`, outside-workspace, missing file, unknown session, directory.
- [ ] Manual: cmd-click `README.md`, `docs/superpowers/plans/2026-05-19-sidebar-contrast-sliders.md`, and an absolute in-workspace path — all open as editor tabs.
- [ ] Manual: cmd-click an `https://` URL — still opens in browser (NSWorkspace fallback).
- [ ] Manual: cmd-click a path that exists but lives outside the worktree — falls through to NSWorkspace as before.