### PR TITLE
Add ~15% inter-line spacing to central-panel text surfaces

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		D7A0A35396E440B31711F9D9 /* RepoSelectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
 		D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */; };
+		D8ACECF849D38029FB56C303 /* CenterTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0307CFD55404D01F14A5B602 /* CenterTypography.swift */; };
 		DAD02DC484C697D856B0CD6A /* CommitComposerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D733701E36E13A7A23748A37 /* CommitComposerState.swift */; };
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
@@ -430,6 +431,7 @@
 		01F0314E357190EF2A1F861B /* CodexInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstaller.swift; sourceTree = "<group>"; };
 		028348C468E45161F567110A /* LSPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallerTests.swift; sourceTree = "<group>"; };
 		02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.SurfaceView.swift; sourceTree = "<group>"; };
+		0307CFD55404D01F14A5B602 /* CenterTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterTypography.swift; sourceTree = "<group>"; };
 		0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCache.swift; sourceTree = "<group>"; };
 		0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSplitButton.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
@@ -1220,6 +1222,7 @@
 			isa = PBXGroup;
 			children = (
 				F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */,
+				0307CFD55404D01F14A5B602 /* CenterTypography.swift */,
 				E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */,
 				BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */,
 				D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */,
@@ -1835,6 +1838,7 @@
 				7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */,
 				139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */,
 				FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */,
+				D8ACECF849D38029FB56C303 /* CenterTypography.swift in Sources */,
 				40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */,
 				8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */,
 				8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */,

--- a/Alas/Sources/Center/CenterTypography.swift
+++ b/Alas/Sources/Center/CenterTypography.swift
@@ -1,0 +1,31 @@
+import AppKit
+import SwiftUI
+
+/// Typography helpers for text-dense surfaces in the central panel.
+/// `lineHeightMultiple` is the single source of truth; the SwiftUI row
+/// padding and `Text` lineSpacing values are derived so the visual
+/// rhythm matches across `NSTextView` and SwiftUI surfaces.
+enum CenterTypography {
+    static let lineHeightMultiple: CGFloat = 1.15
+
+    static func paragraphStyle() -> NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.lineHeightMultiple = lineHeightMultiple
+        return style
+    }
+
+    static let rowVerticalPadding: CGFloat = 1
+
+    /// SwiftUI `Text` doesn't expose `lineHeightMultiple`, so we convert
+    /// `lineHeightMultiple` to an absolute `.lineSpacing` value. The 1.2
+    /// factor approximates SF's default line-height-to-point-size ratio.
+    static func textLineSpacing(forFontSize size: CGFloat) -> CGFloat {
+        (lineHeightMultiple - 1) * size * 1.2
+    }
+}
+
+extension View {
+    func centerPanelRowSpacing() -> some View {
+        padding(.vertical, CenterTypography.rowVerticalPadding)
+    }
+}

--- a/Alas/Sources/Center/Commit/CommitFilesListView.swift
+++ b/Alas/Sources/Center/Commit/CommitFilesListView.swift
@@ -47,6 +47,7 @@ struct CommitFilesListView: View {
             }
             .font(.system(size: 10.5, design: .monospaced))
             .padding(.horizontal, 12).padding(.vertical, 4)
+            .centerPanelRowSpacing()
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(isSelected ? theme.color("accent").opacity(0.2) : Color.clear)
             .contentShape(Rectangle())

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -67,6 +67,7 @@ struct CommitHeaderView: View {
             if !details.body.isEmpty {
                 Text(details.body)
                     .font(.system(size: 12))
+                    .lineSpacing(CenterTypography.textLineSpacing(forFontSize: 12))
                     .foregroundColor(theme.color("fg-dim"))
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -277,6 +277,7 @@ struct HunkView: View {
                 }
                 .font(.system(size: 12.5, design: .monospaced))
                 .padding(.horizontal, 14)
+                .centerPanelRowSpacing()
                 .background(rowBg(line))
             }
         }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -103,6 +103,9 @@ final class CodeEditorCoordinator {
         self.currentFontFamily = family
         self.currentFontSize = size
         textView.font = Self.resolveFont(family: family, size: size)
+        let codeParagraphStyle = CenterTypography.paragraphStyle()
+        textView.defaultParagraphStyle = codeParagraphStyle
+        textView.typingAttributes[.paragraphStyle] = codeParagraphStyle
         textView.increaseFontSizeHandler = { [weak self] in self?.adjustFontSize(by: 1) }
         textView.decreaseFontSizeHandler = { [weak self] in self?.adjustFontSize(by: -1) }
         textView.resetFontSizeHandler = { [weak self] in self?.resetFontSize() }
@@ -507,7 +510,8 @@ final class CodeEditorCoordinator {
         textView.font = font
         let baseAttrs: [NSAttributedString.Key: Any] = [
             .font: font,
-            .foregroundColor: editorTheme.defaultFG
+            .foregroundColor: editorTheme.defaultFG,
+            .paragraphStyle: CenterTypography.paragraphStyle()
         ]
         let storage = buffer.storage
         storage.beginEditing()

--- a/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownPreviewController.swift
@@ -41,6 +41,7 @@ final class MarkdownPreviewController: NSObject {
 
         let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600),
                                   textContainer: textContainer)
+        textView.defaultParagraphStyle = CenterTypography.paragraphStyle()
         textView.isEditable = false
         textView.isSelectable = true
         textView.drawsBackground = true

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -400,6 +400,7 @@ final class MarkdownRenderer {
         paragraph.paragraphSpacing = 0
         paragraph.paragraphSpacingBefore = 0
         paragraph.lineBreakMode = .byWordWrapping
+        paragraph.lineHeightMultiple = CenterTypography.lineHeightMultiple
         return paragraph
     }
 


### PR DESCRIPTION
## Summary
- Adds a `CenterTypography` helper with a single `lineHeightMultiple = 1.15` constant. NSTextView surfaces use the matching `NSParagraphStyle`; SwiftUI rows use a derived 1pt vertical padding modifier; SwiftUI multi-line `Text` uses a derived `.lineSpacing` value.
- Applies it to the file editor, Markdown preview (body + table cells), diff hunk lines (used by both the working-tree diff panel and the commit diff view), the commit file list, and the expanded commit message body.
- Baked in, not user-configurable. Single magic number to tune later.

## Test plan
- [x] Build clean: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`
- [x] Tests pass (three failures are pre-existing flakes unrelated to this branch: `timeoutCompletesWhenChildIgnoresSIGTERM`, `cliRequestDispatchesAndReturnsOK`, `multiCursorNewlineReplacesNonEmptyRanges` — the last exercises `CodeTextView` directly via `makeTextView`, bypassing the `CodeEditorCoordinator` path this change touches).
- [x] Visual check — editor (incl. ⌘+/⌘- font-size changes), diff panel, commit file list, commit diff hunks, expanded commit body, Markdown preview body + tables.