### PR TITLE
Sidebar contrast sliders

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
 		8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */; };
 		8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */; };
+		8FD71F989EFA5BF22B92B4CD /* SidebarMaterialChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */; };
 		8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2AC0F8B3A1B75239995AC /* AppState.swift */; };
 		90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */; };
 		90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */; };
@@ -779,6 +780,7 @@
 		F12340A649892955245BECB7 /* DefinitionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionFeature.swift; sourceTree = "<group>"; };
 		F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffTabView.swift; sourceTree = "<group>"; };
 		F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetectorTests.swift; sourceTree = "<group>"; };
+		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
@@ -957,6 +959,7 @@
 				9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
 				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
+				F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
@@ -2120,6 +2123,7 @@
 				2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
 				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
+				8FD71F989EFA5BF22B92B4CD /* SidebarMaterialChoiceTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */; };
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
 		21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */; };
+		214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98D0A96093087BF4C284053 /* AlasSlider.swift */; };
 		21D97FBF7356BC50400E0265 /* CommitContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */; };
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
 		23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */; };
@@ -668,6 +669,7 @@
 		A78C23951DE157A38A9ED899 /* AgentHookSocketServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerTests.swift; sourceTree = "<group>"; };
 		A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailabilityTests.swift; sourceTree = "<group>"; };
 		A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunner.swift; sourceTree = "<group>"; };
+		A98D0A96093087BF4C284053 /* AlasSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasSlider.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
@@ -1064,6 +1066,7 @@
 				CA554728676F9D3B5E2C05FA /* .gitkeep */,
 				B4C486F9097A2B145D101E2C /* AlasButton.swift */,
 				D9E6D61B213F3378243B4A26 /* AlasField.swift */,
+				A98D0A96093087BF4C284053 /* AlasSlider.swift */,
 				1841997CCBDB9611576B930C /* AlasToggle.swift */,
 				524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
@@ -1792,6 +1795,7 @@
 				6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */,
 				2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */,
 				B06544FDB162DD8CDCD9EAF2 /* AlasHookCommand.swift in Sources */,
+				214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */,
 				F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */,
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
 				8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620C4A708CD1013DE2736A00 /* AppIconTests.swift */; };
 		C1EBF68A32C7C1D61ECC89AC /* LSPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */; };
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
+		C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */; };
 		C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */; };
 		C487C3AD43E7B5BBB45490DB /* CodexInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F0314E357190EF2A1F861B /* CodexInstaller.swift */; };
 		C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */; };
@@ -374,7 +375,6 @@
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
-		5688008C3D7140A78F0E3BF3 /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E852248C11C04318B9148B2D /* AppConfigSidebarChromeOverridesTests.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
 		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
@@ -584,6 +584,7 @@
 		6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreServiceTests.swift; sourceTree = "<group>"; };
 		6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionView.swift; sourceTree = "<group>"; };
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
+		705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigSidebarChromeOverridesTests.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
 		71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionStateResolverTests.swift; sourceTree = "<group>"; };
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
@@ -640,7 +641,6 @@
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
 		97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshotTests.swift; sourceTree = "<group>"; };
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
-		E852248C11C04318B9148B2D /* AppConfigSidebarChromeOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigSidebarChromeOverridesTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
 		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
@@ -860,7 +860,7 @@
 				D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */,
 				EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */,
 				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
-				E852248C11C04318B9148B2D /* AppConfigSidebarChromeOverridesTests.swift */,
+				705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
@@ -2010,7 +2010,7 @@
 				D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */,
 				CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */,
 				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
-				5688008C3D7140A78F0E3BF3 /* AppConfigSidebarChromeOverridesTests.swift in Sources */,
+				C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -374,6 +374,7 @@
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
+		5688008C3D7140A78F0E3BF3 /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E852248C11C04318B9148B2D /* AppConfigSidebarChromeOverridesTests.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
 		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
@@ -639,6 +640,7 @@
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
 		97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshotTests.swift; sourceTree = "<group>"; };
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
+		E852248C11C04318B9148B2D /* AppConfigSidebarChromeOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigSidebarChromeOverridesTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
 		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
@@ -858,6 +860,7 @@
 				D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */,
 				EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */,
 				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
+				E852248C11C04318B9148B2D /* AppConfigSidebarChromeOverridesTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
@@ -2007,6 +2010,7 @@
 				D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */,
 				CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */,
 				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
+				5688008C3D7140A78F0E3BF3 /* AppConfigSidebarChromeOverridesTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@
 		E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */; };
 		E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66950F2226F1182DCDD39A /* RightPaneView.swift */; };
 		E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */; };
+		E51AC728D0735EEC53825C68 /* SidebarChromeTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02161104BA524379A359CB2D /* SidebarChromeTheme.swift */; };
 		E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
 		E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */; };
@@ -417,6 +418,7 @@
 		01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupViewLayoutTests.swift; sourceTree = "<group>"; };
 		019A03B92542169A6595D432 /* HoverHighlightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeature.swift; sourceTree = "<group>"; };
 		01F0314E357190EF2A1F861B /* CodexInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstaller.swift; sourceTree = "<group>"; };
+		02161104BA524379A359CB2D /* SidebarChromeTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarChromeTheme.swift; sourceTree = "<group>"; };
 		028348C468E45161F567110A /* LSPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallerTests.swift; sourceTree = "<group>"; };
 		02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.SurfaceView.swift; sourceTree = "<group>"; };
 		0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCache.swift; sourceTree = "<group>"; };
@@ -1229,6 +1231,7 @@
 			isa = PBXGroup;
 			children = (
 				73A34259DE8E978943E8BE16 /* OKLCH.swift */,
+				02161104BA524379A359CB2D /* SidebarChromeTheme.swift */,
 				E6CA3930F30444A51FB2393D /* Theme.swift */,
 				7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */,
 				05EE713DD3CACF29F206553C /* ThemeStore.swift */,
@@ -1955,6 +1958,7 @@
 				730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */,
 				8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */,
 				D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */,
+				E51AC728D0735EEC53825C68 /* SidebarChromeTheme.swift in Sources */,
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,
 				115C50272D2037FB24B8536F /* SidebarView.swift in Sources */,
 				6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
+		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
 		BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */; };
@@ -681,6 +682,7 @@
 		B58DD85A6E01972B39F2D8AD /* AgentPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPath.swift; sourceTree = "<group>"; };
 		B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatOnSaveTests.swift; sourceTree = "<group>"; };
 		B65018D176CD2E52A3999CF0 /* AlasTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlasTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSidebarContrastTests.swift; sourceTree = "<group>"; };
 		B77927262BEAF31E39CE6698 /* RecommendedLanguageCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedLanguageCatalogTests.swift; sourceTree = "<group>"; };
 		B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTests.swift; sourceTree = "<group>"; };
 		B7CE7B4DAFDB65A79308FB63 /* GitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitService.swift; sourceTree = "<group>"; };
@@ -971,6 +973,7 @@
 				4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */,
 				71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */,
 				50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */,
+				B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */,
 				1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */,
 				88379ACE40F42BE4A3257659 /* ThemeTests.swift */,
 				C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */,
@@ -2136,6 +2139,7 @@
 				BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */,
 				42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */,
 				7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */,
+				BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */,
 				59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */,
 				BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */,
 				422B560D70571FF42F0E78E6 /* ThreePaneSizingTests.swift in Sources */,

--- a/Alas/Sources/App/WindowChrome/VisualEffectView.swift
+++ b/Alas/Sources/App/WindowChrome/VisualEffectView.swift
@@ -124,14 +124,31 @@ struct VisualEffectView: NSViewRepresentable {
 
 struct SidebarMaterialBackground: View {
     let choice: SidebarMaterialChoice
+    /// 0…1 alpha for a theme-colored overlay painted on top of the
+    /// material. Ignored when `choice == .none` (the rectangle below is
+    /// already opaque). 0 = pure material (today's look).
+    var backgroundOpacity: Double = 0
+    @Environment(\.theme) var theme
 
     var body: some View {
-        if let material = choice.appKitMaterial {
-            VisualEffectView(material: material, blendingMode: .behindWindow)
-        } else if let material = choice.swiftUIMaterial {
-            Rectangle()
-                .fill(.clear)
-                .background(material)
+        ZStack {
+            if choice == .none {
+                Rectangle().fill(theme.color("bg-0"))
+            } else if let material = choice.appKitMaterial {
+                VisualEffectView(material: material, blendingMode: .behindWindow)
+                Rectangle()
+                    .fill(theme.color("bg-0"))
+                    .opacity(clamp01(backgroundOpacity))
+                    .allowsHitTesting(false)
+            } else if let material = choice.swiftUIMaterial {
+                Rectangle().fill(.clear).background(material)
+                Rectangle()
+                    .fill(theme.color("bg-0"))
+                    .opacity(clamp01(backgroundOpacity))
+                    .allowsHitTesting(false)
+            }
         }
     }
+
+    private func clamp01(_ x: Double) -> Double { max(0, min(1, x)) }
 }

--- a/Alas/Sources/App/WindowChrome/VisualEffectView.swift
+++ b/Alas/Sources/App/WindowChrome/VisualEffectView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import AppKit
 
 enum SidebarMaterialChoice: String, CaseIterable, Codable, Equatable {
+    case none
     case appKitAppearanceBased
     case appKitLight
     case appKitDark
@@ -29,6 +30,7 @@ enum SidebarMaterialChoice: String, CaseIterable, Codable, Equatable {
 
     var displayName: String {
         switch self {
+        case .none: return "None — solid theme color"
         case .appKitAppearanceBased: return "AppKit: Appearance Based"
         case .appKitLight: return "AppKit: Light"
         case .appKitDark: return "AppKit: Dark"
@@ -77,6 +79,8 @@ enum SidebarMaterialChoice: String, CaseIterable, Codable, Equatable {
         case .appKitContentBackground: return .contentBackground
         case .appKitUnderWindowBackground: return .underWindowBackground
         case .appKitUnderPageBackground: return .underPageBackground
+        case .none:
+            return nil
         case .swiftUIUltraThin, .swiftUIThin, .swiftUIRegular, .swiftUIThick, .swiftUIUltraThick:
             return nil
         }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+struct SidebarChromeOverride: Codable, Equatable {
+    var backgroundOpacity: Double  // 0...1
+    var textContrast: Double       // 0...1
+
+    static let bundledDefaults: [String: SidebarChromeOverride] = [
+        "cool-slate": SidebarChromeOverride(backgroundOpacity: 0.25, textContrast: 0.15),
+        "light":      SidebarChromeOverride(backgroundOpacity: 0.25, textContrast: 0.15),
+    ]
+
+    static let zero = SidebarChromeOverride(backgroundOpacity: 0, textContrast: 0)
+}
+
 struct AppConfig: Codable, Equatable {
     var themeId: String
     var accent: String
@@ -21,6 +33,7 @@ struct AppConfig: Codable, Equatable {
     var files: Files
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
+    var sidebarChromeOverrides: [String: SidebarChromeOverride] = [:]
 
     struct General: Codable, Equatable {
         var launchAtLogin: Bool
@@ -195,7 +208,8 @@ struct AppConfig: Codable, Equatable {
         ),
         files: Files(showIgnored: true),
         recentProjectIds: [],
-        recentWorktreeIdsByProject: [:]
+        recentWorktreeIdsByProject: [:],
+        sidebarChromeOverrides: SidebarChromeOverride.bundledDefaults
     )
 }
 
@@ -229,7 +243,8 @@ extension AppConfig {
              general, worktrees, terminal, harness, code, markdown, changes,
              agents,
              files,
-             recentProjectIds, recentWorktreeIdsByProject
+             recentProjectIds, recentWorktreeIdsByProject,
+             sidebarChromeOverrides
     }
 
     // Custom decode tolerates older config files that predate `code`.
@@ -330,5 +345,14 @@ extension AppConfig {
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]
+        sidebarChromeOverrides =
+            (try? c.decode([String: SidebarChromeOverride].self, forKey: .sidebarChromeOverrides)) ?? [:]
+    }
+}
+
+extension AppConfig {
+    func sidebarChromeOverride(forThemeId themeId: String) -> SidebarChromeOverride {
+        if let saved = sidebarChromeOverrides[themeId] { return saved }
+        return SidebarChromeOverride.bundledDefaults[themeId] ?? .zero
     }
 }

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -10,7 +10,7 @@ struct RightPaneView: View {
 
     var body: some View {
         let rps = state.rightPaneStore.state(for: worktree, baseBranch: state.config.worktrees.baseBranch)
-        let override = state.config.sidebarChromeOverride(forThemeId: state.config.themeId)
+        let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
         ZStack {
             SidebarMaterialBackground(
                 choice: state.config.sidebarMaterial,

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -10,8 +10,12 @@ struct RightPaneView: View {
 
     var body: some View {
         let rps = state.rightPaneStore.state(for: worktree, baseBranch: state.config.worktrees.baseBranch)
+        let override = state.config.sidebarChromeOverride(forThemeId: state.config.themeId)
         ZStack {
-            SidebarMaterialBackground(choice: state.config.sidebarMaterial)
+            SidebarMaterialBackground(
+                choice: state.config.sidebarMaterial,
+                backgroundOpacity: override.backgroundOpacity
+            )
             VStack(spacing: 0) {
                 RightPaneTabBar(
                     activeTab: Binding(
@@ -52,6 +56,7 @@ struct RightPaneView: View {
                     )
                 }
             }
+            .sidebarChromeTheme(textContrast: override.textContrast)
         }
         // Force a refresh whenever the user (re-)selects this worktree. The
         // FSEvent watcher is the primary update path, but if it ever misses

--- a/Alas/Sources/Settings/AppearancePane.swift
+++ b/Alas/Sources/Settings/AppearancePane.swift
@@ -185,10 +185,10 @@ struct AppearancePane: View {
     private func chromeBinding<T>(_ kp: WritableKeyPath<SidebarChromeOverride, T>) -> Binding<T> {
         Binding(
             get: {
-                state.config.sidebarChromeOverride(forThemeId: state.config.themeId)[keyPath: kp]
+                state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)[keyPath: kp]
             },
             set: { newValue in
-                let themeId = state.config.themeId
+                let themeId = state.themeStore.current.id
                 var current = state.config.sidebarChromeOverride(forThemeId: themeId)
                 current[keyPath: kp] = newValue
                 state.config.sidebarChromeOverrides[themeId] = current

--- a/Alas/Sources/Settings/AppearancePane.swift
+++ b/Alas/Sources/Settings/AppearancePane.swift
@@ -129,6 +129,20 @@ struct AppearancePane: View {
                             .help("Next material")
                         }
                     }
+                    SettingsRow(name: "Background opacity",
+                                desc: "How much theme color to layer over the material.") {
+                        AlasSlider(value: chromeBinding(\.backgroundOpacity), range: 0...1, step: 0.05)
+                    }
+                    .opacity(state.config.sidebarMaterial == .none ? 0.5 : 1.0)
+                    .disabled(state.config.sidebarMaterial == .none)
+                    .help(state.config.sidebarMaterial == .none
+                          ? "Applies only when a material is selected."
+                          : "")
+
+                    SettingsRow(name: "Text contrast",
+                                desc: "Pulls sidebar text toward maximum contrast.") {
+                        AlasSlider(value: chromeBinding(\.textContrast), range: 0...1, step: 0.05)
+                    }
                 }
                 SettingsGroup(title: "Layout") {
                     SettingsRow(name: "Density") {
@@ -165,6 +179,21 @@ struct AppearancePane: View {
             get: { state.config[keyPath: kp] },
             set: { state.config[keyPath: kp] = $0
             state.saveConfig() }
+        )
+    }
+
+    private func chromeBinding<T>(_ kp: WritableKeyPath<SidebarChromeOverride, T>) -> Binding<T> {
+        Binding(
+            get: {
+                state.config.sidebarChromeOverride(forThemeId: state.config.themeId)[keyPath: kp]
+            },
+            set: { newValue in
+                let themeId = state.config.themeId
+                var current = state.config.sidebarChromeOverride(forThemeId: themeId)
+                current[keyPath: kp] = newValue
+                state.config.sidebarChromeOverrides[themeId] = current
+                state.saveConfig()
+            }
         )
     }
 

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -12,7 +12,7 @@ struct SidebarView: View {
     @Environment(\.theme) var theme
 
     var body: some View {
-        let override = state.config.sidebarChromeOverride(forThemeId: state.config.themeId)
+        let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
         ZStack {
             SidebarMaterialBackground(
                 choice: state.config.sidebarMaterial,

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -12,8 +12,12 @@ struct SidebarView: View {
     @Environment(\.theme) var theme
 
     var body: some View {
+        let override = state.config.sidebarChromeOverride(forThemeId: state.config.themeId)
         ZStack {
-            SidebarMaterialBackground(choice: state.config.sidebarMaterial)
+            SidebarMaterialBackground(
+                choice: state.config.sidebarMaterial,
+                backgroundOpacity: override.backgroundOpacity
+            )
             VStack(spacing: 0) {
                 SidebarHeaderView(
                     onSettings: onSettings,
@@ -126,6 +130,7 @@ struct SidebarView: View {
                     .padding(.top, 8)
                 }
             }
+            .sidebarChromeTheme(textContrast: override.textContrast)
         }
     }
 }

--- a/Alas/Sources/Theme/SidebarChromeTheme.swift
+++ b/Alas/Sources/Theme/SidebarChromeTheme.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Wraps sidebar content with a theme where the foreground tokens have
+/// been blended toward maximum contrast by the active per-theme
+/// `textContrast` override. Has no effect when the override is zero.
+struct SidebarChromeTheme: ViewModifier {
+    @Environment(\.theme) private var baseTheme
+    let textContrast: Double
+
+    func body(content: Content) -> some View {
+        let derived = baseTheme.applyingSidebarTextContrast(textContrast)
+        return content.environment(\.theme, derived)
+    }
+}
+
+extension View {
+    /// Apply the sidebar text-contrast derivation to a subtree. Pass the
+    /// resolved `textContrast` (already looked up from `AppConfig`).
+    func sidebarChromeTheme(textContrast: Double) -> some View {
+        modifier(SidebarChromeTheme(textContrast: textContrast))
+    }
+}

--- a/Alas/Sources/Theme/Theme.swift
+++ b/Alas/Sources/Theme/Theme.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 
@@ -11,6 +12,13 @@ struct Theme: Codable, Equatable {
     /// SwiftUI Color via the Color(hex:) extension so we can also derive a
     /// muted variant if needed in future.
     var accentOverrideHex: String? = nil
+
+    /// Token-name → precomputed `Color` overrides that win over the raw
+    /// OKLCH lookup. Populated by `applyingSidebarTextContrast(_:)` when
+    /// a non-zero contrast is requested. Excluded from `Codable` (see
+    /// `CodingKeys`) because `Color` is not directly Codable and these
+    /// are purely runtime-derived.
+    var resolvedColorOverrides: [String: Color] = [:]
 
     enum CodingKeys: String, CodingKey { case id, name, tokens }
 
@@ -42,8 +50,9 @@ struct Theme: Codable, Equatable {
     }
 
     func color(_ token: String) -> Color {
-        // Accent override wins over the theme JSON when set (so the
-        // settings-pane picker actually changes the chrome).
+        if let override = resolvedColorOverrides[token] {
+            return override
+        }
         if let hex = accentOverrideHex {
             if token == "accent" {
                 return Color(hex: hex)
@@ -57,5 +66,44 @@ struct Theme: Codable, Equatable {
             return .pink   // sentinel, easy to spot
         }
         return parsed.toColor()
+    }
+}
+
+extension Theme {
+    static let sidebarTextContrastTokens: [String] = [
+        "fg", "fg-muted", "fg-dim", "fg-faint",
+    ]
+
+    /// Returns a copy of this theme where the sidebar fg tokens have been
+    /// blended `value` (clamped to 0…1) of the way toward maximum contrast.
+    /// Maximum contrast = white for dark themes, black for light themes.
+    /// `value == 0` returns the receiver unchanged.
+    func applyingSidebarTextContrast(_ value: Double) -> Theme {
+        let t = max(0, min(1, value))
+        if t == 0 { return self }
+        let target: Color = darkMode ? .white : .black
+        var copy = self
+        var overrides = resolvedColorOverrides
+        for token in Theme.sidebarTextContrastTokens {
+            let base = self.color(token)
+            overrides[token] = Color.blend(base, target, t: t)
+        }
+        copy.resolvedColorOverrides = overrides
+        return copy
+    }
+}
+
+extension Color {
+    /// Linear blend in sRGB. `t == 0` → `a`, `t == 1` → `b`.
+    static func blend(_ a: Color, _ b: Color, t: Double) -> Color {
+        if t <= 0 { return a }
+        if t >= 1 { return b }
+        let aN = NSColor(a).usingColorSpace(.sRGB) ?? NSColor(a)
+        let bN = NSColor(b).usingColorSpace(.sRGB) ?? NSColor(b)
+        let r  = aN.redComponent   + (bN.redComponent   - aN.redComponent)   * CGFloat(t)
+        let g  = aN.greenComponent + (bN.greenComponent - aN.greenComponent) * CGFloat(t)
+        let bl = aN.blueComponent  + (bN.blueComponent  - aN.blueComponent)  * CGFloat(t)
+        let al = aN.alphaComponent + (bN.alphaComponent - aN.alphaComponent) * CGFloat(t)
+        return Color(.sRGB, red: r, green: g, blue: bl, opacity: al)
     }
 }

--- a/Alas/Sources/UI/AlasSlider.swift
+++ b/Alas/Sources/UI/AlasSlider.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Thin styled wrapper around SwiftUI's `Slider`. Keeps the look in line
+/// with `AlasToggle` / `Seg` so the settings rows feel consistent.
+struct AlasSlider: View {
+    @Binding var value: Double
+    var range: ClosedRange<Double> = 0...1
+    var step: Double? = nil
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if let step {
+                Slider(value: $value, in: range, step: step)
+            } else {
+                Slider(value: $value, in: range)
+            }
+            Text(percentLabel)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(theme.color("fg-muted"))
+                .frame(width: 36, alignment: .trailing)
+        }
+        .frame(width: 240)
+    }
+
+    private var percentLabel: String {
+        let lo = range.lowerBound
+        let hi = range.upperBound
+        let normalized = (value - lo) / max(hi - lo, .leastNonzeroMagnitude)
+        return "\(Int((normalized * 100).rounded()))%"
+    }
+}

--- a/AlasTests/AppConfigSidebarChromeOverridesTests.swift
+++ b/AlasTests/AppConfigSidebarChromeOverridesTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct AppConfigSidebarChromeOverridesTests {
+    @Test func defaultsContainsBothBundledThemes() {
+        let defaults = SidebarChromeOverride.bundledDefaults
+        #expect(defaults["cool-slate"]?.backgroundOpacity == 0.25)
+        #expect(defaults["cool-slate"]?.textContrast == 0.15)
+        #expect(defaults["light"]?.backgroundOpacity == 0.25)
+        #expect(defaults["light"]?.textContrast == 0.15)
+    }
+
+    @Test func resolveFallsBackToBundledDefaults() {
+        let cfg = AppConfig.defaults
+        let resolved = cfg.sidebarChromeOverride(forThemeId: "cool-slate")
+        #expect(resolved.backgroundOpacity == 0.25)
+        #expect(resolved.textContrast == 0.15)
+    }
+
+    @Test func resolveUnknownThemeFallsBackToZeroSafeValue() {
+        let cfg = AppConfig.defaults
+        let resolved = cfg.sidebarChromeOverride(forThemeId: "no-such-theme")
+        #expect(resolved.backgroundOpacity == 0.0)
+        #expect(resolved.textContrast == 0.0)
+    }
+
+    @Test func codableRoundTripPreservesOverrides() throws {
+        var cfg = AppConfig.defaults
+        cfg.sidebarChromeOverrides["cool-slate"] = SidebarChromeOverride(
+            backgroundOpacity: 0.7, textContrast: 0.5
+        )
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.sidebarChromeOverrides["cool-slate"]?.backgroundOpacity == 0.7)
+        #expect(decoded.sidebarChromeOverrides["cool-slate"]?.textContrast == 0.5)
+    }
+
+    @Test func decodingOlderConfigWithoutOverridesProducesEmptyDict() throws {
+        let json = """
+        {
+            "themeId": "cool-slate",
+            "accent": "teal",
+            "density": "comfortable",
+            "matchSystemTheme": false,
+            "sidebarMaterial": "appKitSidebar",
+            "sidebarWidth": 244,
+            "rightPaneWidth": 320,
+            "rightPaneVisible": true,
+            "commitDetailSplitRatio": 0.32,
+            "general": {"launchAtLogin":false,"closeToTray":true,"confirmQuit":true,"autoUpdate":true,"updateChannel":"Stable","crashReports":false,"usageAnalytics":false},
+            "worktrees": {"rootPath":"~/x","pathTemplate":"{worktreeRoot}/{repo}/{branch}","branchPrefix":"f/","baseBranch":"main","trackUpstream":true,"deleteBranchOnRemove":true,"autoFetch":true,"fetchIntervalMinutes":5,"pruneStale":false},
+            "terminal": {"shell":"/bin/zsh","workingDirectory":"worktreeRoot","startupScript":"","worktreeCreateScript":"","inheritParentEnv":true,"fontFamily":"JetBrains Mono","fontSize":13,"cursorStyle":"beam","cursorBlink":true,"scrollbackLines":10000,"bell":"visual"},
+            "harness": {"notifyOnFinish":true,"notifyOnAwaiting":true},
+            "code": {"fontFamily":"SF Mono","fontSize":13,"formatOnSave":true,"languageServers":[],"dismissedInstallNudges":[],"userDefinedRecipes":{}},
+            "markdown": {"defaultViewMode":"editor"},
+            "changes": {"aiToolId":"none","prompt":""},
+            "agents": {"builtinState":{},"custom":[],"worktreeAutoLaunch":{"agentId":null,"useBypassPermissions":false}},
+            "files": {"showIgnored":true}
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: json)
+        #expect(decoded.sidebarChromeOverrides.isEmpty)
+    }
+}

--- a/AlasTests/SidebarMaterialChoiceTests.swift
+++ b/AlasTests/SidebarMaterialChoiceTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct SidebarMaterialChoiceTests {
+    @Test func noneIsACase() {
+        #expect(SidebarMaterialChoice.allCases.contains(.none))
+    }
+
+    @Test func noneIsFirstCase() {
+        // `.none` reads as the lowest-translucency option, so we want it
+        // at the top of the picker.
+        #expect(SidebarMaterialChoice.allCases.first == SidebarMaterialChoice.none)
+    }
+
+    @Test func noneHasReadableDisplayName() {
+        #expect(SidebarMaterialChoice.none.displayName == "None — solid theme color")
+    }
+
+    @Test func noneReturnsNilForBothMaterials() {
+        #expect(SidebarMaterialChoice.none.appKitMaterial == nil)
+        #expect(SidebarMaterialChoice.none.swiftUIMaterial == nil)
+    }
+
+    @Test func codableRoundTripIncludesNone() throws {
+        let data = try JSONEncoder().encode(SidebarMaterialChoice.none)
+        let decoded = try JSONDecoder().decode(SidebarMaterialChoice.self, from: data)
+        #expect(decoded == .none)
+    }
+
+    @Test func unknownRawValueDecodeFailsCleanly() {
+        let json = "\"some-unknown-material\"".data(using: .utf8)!
+        #expect(throws: (any Error).self) {
+            _ = try JSONDecoder().decode(SidebarMaterialChoice.self, from: json)
+        }
+    }
+}

--- a/AlasTests/ThemeSidebarContrastTests.swift
+++ b/AlasTests/ThemeSidebarContrastTests.swift
@@ -1,0 +1,53 @@
+import Testing
+import SwiftUI
+@testable import Alas
+
+struct ThemeSidebarContrastTests {
+    @Test func zeroContrastReturnsUnchangedTheme() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let derived = theme.applyingSidebarTextContrast(0)
+        #expect(derived.resolvedColorOverrides.isEmpty)
+    }
+
+    @Test func nonZeroContrastPopulatesOverridesForFgFamily() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let derived = theme.applyingSidebarTextContrast(0.5)
+        #expect(derived.resolvedColorOverrides["fg"] != nil)
+        #expect(derived.resolvedColorOverrides["fg-muted"] != nil)
+        #expect(derived.resolvedColorOverrides["fg-dim"] != nil)
+        #expect(derived.resolvedColorOverrides["fg-faint"] != nil)
+        #expect(derived.resolvedColorOverrides["bg-0"] == nil)
+        #expect(derived.resolvedColorOverrides["accent"] == nil)
+    }
+
+    @Test func fullContrastReturnsTargetForDarkTheme() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let derived = theme.applyingSidebarTextContrast(1)
+        #expect(derived.resolvedColorOverrides["fg"] == Color.white)
+    }
+
+    @Test func fullContrastReturnsTargetForLightTheme() throws {
+        let theme = try Theme.loadBundled(id: "light")
+        let derived = theme.applyingSidebarTextContrast(1)
+        #expect(derived.resolvedColorOverrides["fg"] == Color.black)
+    }
+
+    @Test func colorLookupUsesOverrideWhenPresent() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let derived = theme.applyingSidebarTextContrast(1)
+        #expect(derived.color("fg") == Color.white)
+    }
+
+    @Test func colorLookupFallsThroughForUnsetTokens() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let derived = theme.applyingSidebarTextContrast(1)
+        #expect(derived.color("bg-0") == theme.color("bg-0"))
+    }
+
+    @Test func clampsValuesOutsideZeroOne() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        #expect(theme.applyingSidebarTextContrast(-1).resolvedColorOverrides.isEmpty)
+        let high = theme.applyingSidebarTextContrast(2)
+        #expect(high.resolvedColorOverrides["fg"] == Color.white)
+    }
+}


### PR DESCRIPTION
## Summary
- Two per-theme sliders in Settings → Appearance: **Background opacity** (paints the theme's `bg-0` over the chosen `NSVisualEffectView` material) and **Text contrast** (blends sidebar foreground tokens toward white on dark themes / black on light themes).
- New `None — solid theme color` option in the Sidebar material picker for a fully opaque sidebar; the background-opacity row is disabled (with tooltip) when this is selected.
- Per-theme defaults seed at `0.25` / `0.15` for both bundled themes, so existing installs get a small contrast bump on first launch after upgrade.

## Test plan
- [ ] Settings → Appearance shows "None — solid theme color" as the first picker entry.
- [ ] On a translucent material, both sliders drag live: background opacity progressively replaces the material with `bg-0`; text contrast brightens (dark theme) / darkens (light theme) sidebar text.
- [ ] Selecting `None` dims the Background opacity row to ~50% with tooltip "Applies only when a material is selected."
- [ ] Switching between cool-slate and light themes preserves each theme's own slider values.
- [ ] Quitting and relaunching persists slider positions.
- [ ] On a busy desktop wallpaper, bumping both sliders genuinely improves readability.