### PR TITLE
Enlarge small touch targets

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
+		9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
 		9D6FE5A4589D73A7480CE2B2 /* IndentationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */; };
 		9E302329243407946D47DC91 /* BranchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */; };
@@ -585,6 +586,7 @@
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
 		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
+		56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTargetSmokeTests.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
 		57713D7143CFD53124E0523F /* AlasHookCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommand.swift; sourceTree = "<group>"; };
 		57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledFontRegistrar.swift; sourceTree = "<group>"; };
@@ -1026,6 +1028,7 @@
 				88379ACE40F42BE4A3257659 /* ThemeTests.swift */,
 				C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
+				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
 				321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */,
@@ -2232,6 +2235,7 @@
 				BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */,
 				422B560D70571FF42F0E78E6 /* ThreePaneSizingTests.swift in Sources */,
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
+				9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
 				E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */,

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -82,6 +82,7 @@ struct TabBarView: View {
             Button(action: onNewTerminal) {
                 Icon(name: "plus", size: 13)
                     .frame(width: 26, height: 22)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .help("New terminal")
@@ -167,8 +168,11 @@ private struct TabButton: View {
                         }
                     }
                     .frame(width: 14, height: 14)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .frame(width: 20, height: 20)
+                .contentShape(Rectangle())
                 .onHover { hoveringClose = $0 }
                 .help(dirty ? "Unsaved changes — click to close" : "Close")
             }
@@ -206,6 +210,7 @@ private struct ToolbarIconButton: View {
             Icon(name: iconName, size: 13,
                  color: hovering ? theme.color("fg") : theme.color("fg-faint"))
                 .frame(width: 26, height: 22)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .onHover { hovering = $0 }

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -156,23 +156,24 @@ private struct TabButton: View {
             if showClose {
                 Button(action: onClose) {
                     ZStack {
-                        if dirty && !hoveringClose {
-                            Circle()
-                                .fill(theme.color("fg"))
-                                .frame(width: 7, height: 7)
-                        } else {
-                            Icon(name: "x", size: 9,
-                                 color: hoveringClose ? theme.color("fg") : theme.color("fg-faint"))
-                                .background(hoveringClose ? theme.color("bg-4") : .clear)
-                                .clipShape(RoundedRectangle(cornerRadius: 3))
+                        ZStack {
+                            if dirty && !hoveringClose {
+                                Circle()
+                                    .fill(theme.color("fg"))
+                                    .frame(width: 7, height: 7)
+                            } else {
+                                Icon(name: "x", size: 9,
+                                     color: hoveringClose ? theme.color("fg") : theme.color("fg-faint"))
+                                    .background(hoveringClose ? theme.color("bg-4") : .clear)
+                                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                            }
                         }
+                        .frame(width: 14, height: 14)
                     }
-                    .frame(width: 14, height: 14)
+                    .frame(width: 20, height: 20)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .frame(width: 20, height: 20)
-                .contentShape(Rectangle())
                 .onHover { hoveringClose = $0 }
                 .help(dirty ? "Unsaved changes — click to close" : "Close")
             }

--- a/Alas/Sources/Right/Commit/StageChip.swift
+++ b/Alas/Sources/Right/Commit/StageChip.swift
@@ -18,6 +18,8 @@ struct StageChip: View {
                     .frame(width: 14, height: 14)
                 Icon(name: glyph, size: 9, color: glyphColor)
             }
+            .frame(width: 20, height: 20)
+            .contentShape(Rectangle())
             .opacity(staged || hovering ? 1.0 : 0.55)
         }
         .buttonStyle(.plain)

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -34,6 +34,7 @@ struct ToolbarBtn: View {
         Button(action: action) {
             Icon(name: icon, size: 13, color: hovering ? theme.color("fg") : theme.color("fg-muted"))
                 .frame(width: 26, height: 22)
+                .contentShape(Rectangle())
                 .background(hovering ? theme.color("bg-3") : .clear)
                 .clipShape(RoundedRectangle(cornerRadius: 5))
         }

--- a/Alas/Sources/UI/Seg.swift
+++ b/Alas/Sources/UI/Seg.swift
@@ -21,7 +21,7 @@ struct Seg<Value: Hashable>: View {
     }
 
     var body: some View {
-        HStack(spacing: 1) {
+        HStack(spacing: 0) {
             ForEach(options, id: \.0) { item in
                 Button {
                     value = item.0
@@ -29,6 +29,7 @@ struct Seg<Value: Hashable>: View {
                     label(for: item.1)
                         .font(.system(size: 12))
                         .padding(.horizontal, 12).padding(.vertical, 5)
+                        .contentShape(Rectangle())
                         .background(value == item.0 ? theme.color("bg-3") : .clear)
                         .foregroundColor(value == item.0 ? theme.color("fg") : theme.color("fg-muted"))
                         .clipShape(RoundedRectangle(cornerRadius: 4))

--- a/AlasTests/TouchTargetSmokeTests.swift
+++ b/AlasTests/TouchTargetSmokeTests.swift
@@ -1,0 +1,108 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import Alas
+
+/// Smoke tests for touch-target sized controls to guard against frame or
+/// label crashes when rendered in an NSHostingController.
+@Suite(.serialized)
+@MainActor
+struct TouchTargetSmokeTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test func segmentedControlRendersWithoutCrashing() {
+        let view = Seg(value: .constant(MarkdownViewMode.editor),
+                       options: [(.editor, "Editor"), (.preview, "Preview")])
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func segmentedControlWithSystemImageRendersWithoutCrashing() {
+        let view = Seg(value: .constant(MarkdownViewMode.editor),
+                       systemImageOptions: [(.editor, "pencil"), (.preview, "eye")])
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func tabBarViewRendersWithoutCrashing() {
+        let tab = Tab.editor(EditorTabState(
+            id: "t1",
+            title: "hello.swift",
+            relativePath: "hello.swift",
+            revealLine: nil,
+            revealCharacter: nil,
+            externalAbsolutePath: nil,
+            originatingRelativePath: nil,
+            markdownViewMode: nil,
+            markdownSplitFraction: nil
+        ))
+        let view = TabBarView(
+            tabs: [tab],
+            activeId: tab.id,
+            harnessLookup: { _ in nil },
+            dirtyLookup: { _ in false },
+            onActivate: { _ in },
+            onClose: { _ in },
+            onCloseOthers: { _ in },
+            onCloseAll: { },
+            onCloseToLeft: { _ in },
+            onCloseToRight: { _ in },
+            onCopyPath: { _ in },
+            onCopyRelativePath: { _ in },
+            onRenameTerminal: { _ in },
+            onNewTerminal: { },
+            onMove: { _, _ in }
+        )
+        .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func tabBarViewWithDirtyAndHarnessRendersWithoutCrashing() {
+        let tab = Tab.terminal(TerminalTabState(id: "term1", title: "bash", sessionId: "s1"))
+        let view = TabBarView(
+            tabs: [tab],
+            activeId: tab.id,
+            harnessLookup: { _ in (agent: .codex, state: .busy) },
+            dirtyLookup: { _ in true },
+            onActivate: { _ in },
+            onClose: { _ in },
+            onCloseOthers: { _ in },
+            onCloseAll: { },
+            onCloseToLeft: { _ in },
+            onCloseToRight: { _ in },
+            onCopyPath: { _ in },
+            onCopyRelativePath: { _ in },
+            onRenameTerminal: { _ in },
+            onNewTerminal: { },
+            onMove: { _, _ in }
+        )
+        .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func stageChipRendersWithoutCrashing() {
+        let view = StageChip(staged: false, action: { })
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func stageChipStagedRendersWithoutCrashing() {
+        let view = StageChip(staged: true, action: { })
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Enlarged close-tab and stage-chip hit areas from 14×14 to 20×20pt (visual chrome stays 14×14) using `.contentShape(Rectangle())` + larger frames
- Added explicit `.contentShape(Rectangle())` to segmented control segments, new-tab plus button, tab toolbar buttons, and sidebar toolbar buttons
- Removed 1pt dead gap between segmented control segments (`spacing: 1` → `0`)

## Details

Several icon-only controls had hit areas that were too small for comfortable clicking. The worst offenders (close-tab button, stage/unstage chip) were 14×14pt — well below macOS's recommended ~20pt minimum.

For genuinely tiny controls, the visual frame was enlarged to 20×20pt while keeping the icon/chrome at its original size. For borderline controls (26×22pt toolbar buttons), `.contentShape(Rectangle())` ensures the full padded area is hit-testable — consistent with 33+ existing uses of this pattern in the codebase.

## Test plan

- [x] `xcodebuild build` passes
- [x] New `TouchTargetSmokeTests` (6 tests) pass
- [ ] Manual verification: each control responds to clicks anywhere within its visual bounds
- [ ] No overlap between adjacent controls (close button vs tab title, stage chip vs filename)
- [ ] Hover states activate on the full enlarged area
- [ ] Seg segments have no dead zones between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)