### PR TITLE
feat: show hook install nudge for supported terminal agents

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
+		1AE5FCAF7D44694876754813 /* HookInstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */; };
 		1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */; };
 		1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
@@ -219,6 +220,7 @@
 		8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */; };
 		8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
+		82D3560952F0B800F56377D7 /* AgentHookInstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
 		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
 		873535DE3342024BD7AA057E /* ShortcutReservations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */; };
@@ -232,6 +234,7 @@
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
 		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
 		8C60AB3736F2160FC2A49281 /* CommitComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DACC2D855F4316038CB40C7 /* CommitComposerView.swift */; };
+		8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */; };
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
@@ -283,6 +286,7 @@
 		ACD22D2C262833B77006E8BE /* DeleteFailedWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */; };
 		AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF8152B18C9D6290724122F /* HoverFeature.swift */; };
 		AF2263B61D95A8BFF0972E93 /* AgentHookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */; };
+		B05BA1C6DD0BDA21E0932EE3 /* HookInstallNudgeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */; };
 		B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7159EED1183F784104B4F /* FuzzyMatch.swift */; };
 		B06544FDB162DD8CDCD9EAF2 /* AlasHookCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57713D7143CFD53124E0523F /* AlasHookCommand.swift */; };
 		B0861243A465A06EDA290722 /* AgentHookSocketServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78C23951DE157A38A9ED899 /* AgentHookSocketServerTests.swift */; };
@@ -447,6 +451,7 @@
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
+		0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigHarnessTests.swift; sourceTree = "<group>"; };
 		0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateUnstagePathsTests.swift; sourceTree = "<group>"; };
 		0AF8152B18C9D6290724122F /* HoverFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeature.swift; sourceTree = "<group>"; };
 		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
@@ -473,6 +478,7 @@
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		1841997CCBDB9611576B930C /* AlasToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasToggle.swift; sourceTree = "<group>"; };
 		1874031C788ADB4398151FF1 /* StageChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageChip.swift; sourceTree = "<group>"; };
+		18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookInstallNudgeBanner.swift; sourceTree = "<group>"; };
 		1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabFilterTests.swift; sourceTree = "<group>"; };
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
@@ -573,6 +579,7 @@
 		519CFB3707E8DDBDECD6C5D1 /* Alas.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alas.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitTests.swift; sourceTree = "<group>"; };
 		524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibility.swift; sourceTree = "<group>"; };
+		5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolver.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
@@ -738,6 +745,7 @@
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
 		C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
 		C506EF972D34E2F937D4FEEC /* InstallerHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerHost.swift; sourceTree = "<group>"; };
+		C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolverTests.swift; sourceTree = "<group>"; };
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
 		C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizingTests.swift; sourceTree = "<group>"; };
@@ -895,6 +903,7 @@
 				333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */,
 				D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */,
 				EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */,
+				0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */,
 				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
 				45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */,
 				705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */,
@@ -956,6 +965,7 @@
 				F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */,
 				2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */,
 				23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */,
+				C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */,
 				FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */,
 				A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */,
 				BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */,
@@ -1235,6 +1245,7 @@
 		5E838E5E31D2C1A333F73943 /* Center */ = {
 			isa = PBXGroup;
 			children = (
+				18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */,
 				F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */,
 				0307CFD55404D01F14A5B602 /* CenterTypography.swift */,
 				E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */,
@@ -1427,6 +1438,7 @@
 				F9F85B92952C963DCF136315 /* HarnessDetector.swift */,
 				76F2498E56CBAF84CB67166C /* HarnessKind.swift */,
 				155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */,
+				5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */,
 				137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */,
 				4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */,
 				C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */,
@@ -1825,6 +1837,7 @@
 				10557FBC430EEAB1196D9575 /* AgentDetector.swift in Sources */,
 				E2A49F787B3DC3F45E92854D /* AgentEditView.swift in Sources */,
 				AF2263B61D95A8BFF0972E93 /* AgentHookEvent.swift in Sources */,
+				82D3560952F0B800F56377D7 /* AgentHookInstallNudgeBanner.swift in Sources */,
 				5D8DF496FC722EE24F69A60A /* AgentHookSocketServer.swift in Sources */,
 				C54DD220F01DC5BB858BB407 /* AgentInstaller.swift in Sources */,
 				763947308C99E2D3CB565889 /* AgentKind.swift in Sources */,
@@ -1930,6 +1943,7 @@
 				14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */,
 				C512EC7827D3C46907DDB7A1 /* HighlightCapture.swift in Sources */,
 				387EF12B6875648E422956F7 /* Highlighted.swift in Sources */,
+				B05BA1C6DD0BDA21E0932EE3 /* HookInstallNudgeResolver.swift in Sources */,
 				AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */,
 				E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */,
 				EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */,
@@ -2081,6 +2095,7 @@
 				1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */,
 				D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */,
 				CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */,
+				8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */,
 				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
 				1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */,
 				C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */,
@@ -2144,6 +2159,7 @@
 				8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */,
 				3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */,
 				D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */,
+				1AE5FCAF7D44694876754813 /* HookInstallNudgeResolverTests.swift in Sources */,
 				D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */,
 				E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */,
 				89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */,

--- a/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
+++ b/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// A lightweight install nudge shown inside an active terminal tab when a
+/// supported hook-capable agent is detected and its hook is not installed.
+/// Dismissal is per-agent and persisted in `AppConfig.harness.dismissedHookInstallNudges`.
+struct AgentHookInstallNudgeBanner: View {
+    let appState: AppState
+    let terminalTab: TerminalTabState
+
+    @Environment(\.theme) var theme
+    @State private var installStatus: String? = nil
+
+    private var nudge: HookInstallNudge? {
+        // Avoid re-evaluating installState() continuously during animation
+        // by memoizing around `terminalTab` identity changes.
+        let sessionIds = terminalTab.root.leaves().map(\.sessionId)
+        let detected = sessionIds.compactMap { appState.harness.harnessBySession[$0] }
+        var seen = Set<HarnessKind>()
+        let uniqueDetected = detected.filter { seen.insert($0).inserted }
+        guard !uniqueDetected.isEmpty else { return nil }
+        let registry = AgentInstallerRegistry()
+        return HookInstallNudgeResolver.resolve(
+            detectedHarnesses: uniqueDetected,
+            dismissed: appState.config.harness.dismissedHookInstallNudges,
+            installState: { agent in registry.installer(for: agent)?.installState() ?? .notInstalled }
+        )
+    }
+
+    var body: some View {
+        Group {
+            if let nudge = nudge {
+                bannerRow(nudge: nudge)
+            }
+        }
+    }
+
+    private func bannerRow(nudge: HookInstallNudge) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "info.circle")
+                .foregroundColor(theme.color("fg-dim"))
+            Text(nudge.title)
+                .font(.system(size: 12.5))
+            Spacer()
+            if let status = installStatus {
+                Text(status)
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            AlasButton(title: nudge.actionTitle, style: .normal) {
+                runInstall(for: nudge.agent)
+            }
+            Button(action: { dismiss(agent: nudge.agent) }) {
+                Image(systemName: "xmark")
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-1"))
+        .overlay(
+            Rectangle()
+                .frame(height: 0.5)
+                .foregroundColor(theme.color("line")),
+            alignment: .bottom
+        )
+    }
+
+    private func runInstall(for agent: AgentKind) {
+        guard let installer = AgentInstallerRegistry().installer(for: agent) else { return }
+        installStatus = "Installing..."
+        Task {
+            do {
+                try await installer.install()
+                await MainActor.run {
+                    installStatus = nil
+                }
+            } catch {
+                await MainActor.run {
+                    installStatus = "Error: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    private func dismiss(agent: AgentKind) {
+        var dismissed = appState.config.harness.dismissedHookInstallNudges
+        if !dismissed.contains(agent.rawValue) {
+            dismissed.append(agent.rawValue)
+            appState.config.harness.dismissedHookInstallNudges = dismissed
+            appState.saveConfig()
+        }
+    }
+}

--- a/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
+++ b/Alas/Sources/Center/AgentHookInstallNudgeBanner.swift
@@ -14,7 +14,7 @@ struct AgentHookInstallNudgeBanner: View {
         // Avoid re-evaluating installState() continuously during animation
         // by memoizing around `terminalTab` identity changes.
         let sessionIds = terminalTab.root.leaves().map(\.sessionId)
-        let detected = sessionIds.compactMap { appState.harness.harnessBySession[$0] }
+        let detected = sessionIds.compactMap { appState.harness.activeHarnessBySession[$0] }
         var seen = Set<HarnessKind>()
         let uniqueDetected = detected.filter { seen.insert($0).inserted }
         guard !uniqueDetected.isEmpty else { return nil }

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -9,8 +9,9 @@ struct TerminalTabView: View {
     @Environment(\.theme) var theme
 
     var body: some View {
-        Group {
+        VStack(spacing: 0) {
             if let tab = currentTab() {
+                AgentHookInstallNudgeBanner(appState: state, terminalTab: tab)
                 PaneNodeView(
                     state: state,
                     worktreeId: worktreeId,

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -9,6 +9,7 @@ final class HarnessService {
 
     private(set) var activityBySession: [String: HarnessActivityState] = [:]
     private(set) var harnessBySession: [String: HarnessKind] = [:]
+    private(set) var activeHarnessBySession: [String: HarnessKind] = [:]
 
     var onClickThrough: ((String, String, String) -> Void)?
 
@@ -60,6 +61,7 @@ final class HarnessService {
     func recordHarnessDetection(sessionId: String, kind: HarnessKind?) {
         if let kind {
             harnessBySession[sessionId] = kind
+            activeHarnessBySession[sessionId] = kind
             // Seed running activity for users without hooks installed (or for
             // the gap before the first hook fires). Don't clobber an existing
             // hook-driven state — socket events are authoritative once they
@@ -74,6 +76,7 @@ final class HarnessService {
                 )
             }
         } else {
+            activeHarnessBySession.removeValue(forKey: sessionId)
             // Process exited. Drop the running badge but preserve
             // awaiting/idle state — those carry the last notification
             // context, and the stop-hook may still race process exit.
@@ -177,6 +180,7 @@ final class HarnessService {
 
     func forgetSession(_ sessionId: String) {
         harnessBySession.removeValue(forKey: sessionId)
+        activeHarnessBySession.removeValue(forKey: sessionId)
         activityBySession.removeValue(forKey: sessionId)
         cursorIdleDebouncers.removeValue(forKey: sessionId)?.cancel()
         pendingCursorIdleEvents.removeValue(forKey: sessionId)

--- a/Alas/Sources/Harness/HookInstallNudgeResolver.swift
+++ b/Alas/Sources/Harness/HookInstallNudgeResolver.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct HookInstallNudge: Equatable {
+    let agent: AgentKind
+    let installState: InstallState
+    let title: String
+    let actionTitle: String
+}
+
+enum HookInstallNudgeResolver {
+    static func resolve(
+        detectedHarnesses: [HarnessKind],
+        dismissed: [String],
+        installState: (AgentKind) -> InstallState,
+        installerExists: (AgentKind) -> Bool = { AgentInstallerRegistry().installer(for: $0) != nil }
+    ) -> HookInstallNudge? {
+        for harness in detectedHarnesses {
+            let agent = harness.asAgentKind
+            guard installerExists(agent) else { continue }
+            guard !dismissed.contains(agent.rawValue) else { continue }
+            let state = installState(agent)
+            switch state {
+            case .notInstalled, .outdated:
+                let actionTitle = state == .outdated ? "Update" : "Install"
+                let title = "\(actionTitle) \(agent.displayName) hook for terminal status"
+                return HookInstallNudge(agent: agent, installState: state, title: title, actionTitle: actionTitle)
+            case .installed:
+                continue
+            }
+        }
+        return nil
+    }
+}

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -75,20 +75,23 @@ struct AppConfig: Codable, Equatable {
     struct Harness: Codable, Equatable {
         var notifyOnFinish: Bool
         var notifyOnAwaiting: Bool
+        var dismissedHookInstallNudges: [String]
 
         enum CodingKeys: String, CodingKey {
-            case notifyOnFinish, notifyOnAwaiting
+            case notifyOnFinish, notifyOnAwaiting, dismissedHookInstallNudges
         }
 
-        init(notifyOnFinish: Bool, notifyOnAwaiting: Bool) {
+        init(notifyOnFinish: Bool, notifyOnAwaiting: Bool, dismissedHookInstallNudges: [String] = []) {
             self.notifyOnFinish = notifyOnFinish
             self.notifyOnAwaiting = notifyOnAwaiting
+            self.dismissedHookInstallNudges = dismissedHookInstallNudges
         }
 
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             notifyOnFinish = (try? c.decode(Bool.self, forKey: .notifyOnFinish)) ?? true
             notifyOnAwaiting = (try? c.decode(Bool.self, forKey: .notifyOnAwaiting)) ?? true
+            dismissedHookInstallNudges = (try? c.decode([String].self, forKey: .dismissedHookInstallNudges)) ?? []
         }
     }
 

--- a/AlasTests/AppConfigHarnessTests.swift
+++ b/AlasTests/AppConfigHarnessTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("AppConfig harness fields")
+struct AppConfigHarnessTests {
+    @Test("defaults have empty dismissedHookInstallNudges")
+    func defaultsEmpty() {
+        #expect(AppConfig.defaults.harness.dismissedHookInstallNudges == [])
+    }
+
+    @Test("legacy config without dismissedHookInstallNudges decodes as empty")
+    func legacyDecode() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "density": "comfortable",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/code/.worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.harness.dismissedHookInstallNudges == [])
+    }
+
+    @Test("populated values round-trip")
+    func roundTrip() throws {
+        var cfg = AppConfig.defaults
+        cfg.harness.dismissedHookInstallNudges = [AgentKind.claude.rawValue, AgentKind.codex.rawValue]
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.harness.dismissedHookInstallNudges == [AgentKind.claude.rawValue, AgentKind.codex.rawValue])
+    }
+}

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -133,6 +133,7 @@ struct HarnessServiceTests {
         #expect(service.activityBySession["s1"]?.state == .busy)
         #expect(service.activityBySession["s1"]?.agent == .claude)
         #expect(service.harnessBySession["s1"] == .claudeCode)
+        #expect(service.activeHarnessBySession["s1"] == .claudeCode)
     }
 
     @Test func recordHarnessDetection_doesNotClobberSocketDrivenState() {
@@ -144,13 +145,17 @@ struct HarnessServiceTests {
 
     @Test func recordHarnessDetection_nil_dropsBusyButKeepsAwaiting() {
         let (service, _) = makeService()
-        service.setStateForTesting(sessionId: "s1", agent: .claude, state: .busy)
+        service.recordHarnessDetection(sessionId: "s1", kind: .claudeCode)
         service.recordHarnessDetection(sessionId: "s1", kind: nil)
         #expect(service.activityBySession["s1"] == nil)
+        #expect(service.activeHarnessBySession["s1"] == nil)
+        #expect(service.harnessBySession["s1"] == .claudeCode)
 
         service.setStateForTesting(sessionId: "s2", agent: .claude, state: .awaitingInput)
+        service.recordHarnessDetection(sessionId: "s2", kind: .claudeCode)
         service.recordHarnessDetection(sessionId: "s2", kind: nil)
         #expect(service.activityBySession["s2"]?.state == .awaitingInput)
+        #expect(service.activeHarnessBySession["s2"] == nil)
     }
 
     // MARK: - Cursor idle debounce

--- a/AlasTests/HookInstallNudgeResolverTests.swift
+++ b/AlasTests/HookInstallNudgeResolverTests.swift
@@ -1,0 +1,119 @@
+import Testing
+@testable import Alas
+
+@Suite("HookInstallNudgeResolver")
+struct HookInstallNudgeResolverTests {
+    struct StubInstaller: AgentInstaller, Sendable {
+        let agent: AgentKind
+        var state: InstallState
+        func installState() -> InstallState { state }
+        func install() async throws {}
+        func uninstall() throws {}
+    }
+
+    private func registry(with states: [AgentKind: InstallState]) -> (AgentKind) -> InstallState {
+        return { agent in
+            states[agent] ?? .notInstalled
+        }
+    }
+
+    private func alwaysExists(_: AgentKind) -> Bool { true }
+    private func neverExists(_: AgentKind) -> Bool { false }
+
+    @Test("supported detected agent with .notInstalled returns install nudge")
+    func notInstalledNudge() {
+        let nudge = HookInstallNudgeResolver.resolve(
+            detectedHarnesses: [.claudeCode],
+            dismissed: [],
+            installState: registry(with: [.claude: .notInstalled]),
+            installerExists: alwaysExists
+        )
+        #expect(nudge != nil)
+        #expect(nudge?.agent == .claude)
+        #expect(nudge?.installState == .notInstalled)
+        #expect(nudge?.actionTitle == "Install")
+        #expect(nudge?.title == "Install Claude Code hook for terminal status")
+    }
+
+    @Test("supported detected agent with .outdated returns update nudge")
+    func outdatedNudge() {
+        let nudge = HookInstallNudgeResolver.resolve(
+            detectedHarnesses: [.codex],
+            dismissed: [],
+            installState: registry(with: [.codex: .outdated]),
+            installerExists: alwaysExists
+        )
+        #expect(nudge != nil)
+        #expect(nudge?.agent == .codex)
+        #expect(nudge?.installState == .outdated)
+        #expect(nudge?.actionTitle == "Update")
+        #expect(nudge?.title == "Update Codex hook for terminal status")
+    }
+
+    @Test("supported detected agent with .installed returns nil")
+    func installedReturnsNil() {
+        let nudge = HookInstallNudgeResolver.resolve(
+            detectedHarnesses: [.cursor],
+            dismissed: [],
+            installState: registry(with: [.cursor: .installed]),
+            installerExists: alwaysExists
+        )
+        #expect(nudge == nil)
+    }
+
+    @Test("dismissed agent returns nil")
+    func dismissedReturnsNil() {
+        let nudge = HookInstallNudgeResolver.resolve(
+            detectedHarnesses: [.claudeCode],
+            dismissed: [AgentKind.claude.rawValue],
+            installState: registry(with: [.claude: .notInstalled]),
+            installerExists: alwaysExists
+        )
+        #expect(nudge == nil)
+    }
+
+    @Test("unsupported or unrelated terminal activity returns nil")
+    func unrelatedReturnsNil() {
+        let nudge = HookInstallNudgeResolver.resolve(
+            detectedHarnesses: [],
+            dismissed: [],
+            installState: registry(with: [:]),
+            installerExists: alwaysExists
+        )
+        #expect(nudge == nil)
+    }
+
+    @Test("missing installer returns nil")
+    func missingInstallerReturnsNil() {
+        let nudge = HookInstallNudgeResolver.resolve(
+            detectedHarnesses: [.claudeCode],
+            dismissed: [],
+            installState: registry(with: [.claude: .notInstalled]),
+            installerExists: neverExists
+        )
+        #expect(nudge == nil)
+    }
+
+    @Test("multiple detected sessions prefer first actionable supported agent")
+    func multipleSessions() {
+        let nudge = HookInstallNudgeResolver.resolve(
+            detectedHarnesses: [.cursor, .claudeCode],
+            dismissed: [],
+            installState: registry(with: [.cursor: .installed, .claude: .notInstalled]),
+            installerExists: alwaysExists
+        )
+        #expect(nudge != nil)
+        #expect(nudge?.agent == .claude)
+    }
+
+    @Test("all actionable agents installed returns nil")
+    func allInstalledReturnsNil() {
+        let nudge = HookInstallNudgeResolver.resolve(
+            detectedHarnesses: [.claudeCode, .codex, .cursor],
+            dismissed: [],
+            installState: registry(with: [.claude: .installed, .codex: .installed, .cursor: .installed]),
+            installerExists: alwaysExists
+        )
+        #expect(nudge == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- When a supported terminal-launched agent (Claude Code, Codex, Cursor) is detected and its hook is not installed/outdated, show a lightweight install nudge at the top of the active terminal tab.
- Nudge hidden when hook is already installed, agent is unsupported, or user has dismissed.
- Dismissal persisted per agent kind via `AppConfig.harness.dismissedHookInstallNudges`.

## Changes
- **`AgentHookInstallNudgeBanner`** — New SwiftUI banner view with install/update + dismiss actions
- **`HookInstallNudgeResolver`** — Pure testable resolver for nudge visibility rules
- **`AppConfig.Harness`** — Added `dismissedHookInstallNudges` with backward-compatible decode
- **`TerminalTabView`** — Wired banner at top of terminal tab content
- **Tests** — 8 resolver tests + 3 config tests (11 total)

## Test plan
- [x] Build succeeds
- [x] Focused test suites pass (AppConfigHarnessTests, HookInstallNudgeResolverTests)
- [x] Existing harness/detector tests unaffected