### PR TITLE
Add Harness entry point from Agents settings

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 		C54DD220F01DC5BB858BB407 /* AgentInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */; };
 		C55B79DC0AAE96CFA14BE76F /* CommitFilesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */; };
 		C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDEA496740F5B0B5EE808B /* Process+Git.swift */; };
+		C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */; };
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
 		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
@@ -764,6 +765,7 @@
 		CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroup.swift; sourceTree = "<group>"; };
 		CB020862232495EC1C5ECBEA /* WindowAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearance.swift; sourceTree = "<group>"; };
 		CB2EB554CB6AF797545DB95D /* HeadReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReader.swift; sourceTree = "<group>"; };
+		CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPaneTests.swift; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
@@ -897,6 +899,7 @@
 				2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */,
 				9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */,
 				E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */,
+				CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */,
 				1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */,
 				FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */,
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
@@ -2090,6 +2093,7 @@
 				659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */,
 				D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */,
 				0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */,
+				C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */,
 				026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */,
 				8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */,
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct AgentsPane: View {
     @Bindable var state: AppState
     @Environment(\.theme) var theme
+    var onNavigate: (SettingsSection) -> Void = { _ in }
 
     @State private var editing: EditTarget?
 
@@ -59,6 +60,30 @@ struct AgentsPane: View {
                     cardGrid
                 }
                 .padding(.vertical, 18)
+
+                SettingsGroup(title: "Harness") {
+                    HStack(alignment: .top, spacing: 16) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Terminal / Harness")
+                                .font(.system(size: 12.5, weight: .medium))
+                                .foregroundColor(theme.color("fg"))
+                            Text("Configure harness notifications and install hooks.")
+                                .font(.system(size: 11.5))
+                                .foregroundColor(theme.color("fg-dim"))
+                                .lineLimit(2)
+                        }
+                        .frame(width: 240, alignment: .leading)
+                        .padding(.top, 4)
+                        VStack(alignment: .leading, spacing: 6) {
+                            AlasButton(title: "Open Terminal Settings", style: .subtle) {
+                                onNavigate(.terminal)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(.vertical, 10)
+                    .overlay(Divider().opacity(0.5), alignment: .top)
+                }
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
         }

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -29,7 +29,7 @@ struct SettingsWindow: View {
                 SettingsNavView(selection: $section)
                 Group {
                     switch section {
-                    case .agents:     AgentsPane(state: state)
+                    case .agents:     AgentsPane(state: state) { section = $0 }
                     case .appearance: AppearancePane(state: state)
                     case .changes:    ChangesPane(state: state)
                     case .code:       CodePane(state: state)

--- a/AlasTests/AgentsPaneTests.swift
+++ b/AlasTests/AgentsPaneTests.swift
@@ -1,0 +1,35 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import Alas
+
+/// Smoke and navigation tests for AgentsPane.
+@Suite(.serialized)
+@MainActor
+struct AgentsPaneTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test func agentsPaneRendersWithoutCrashing() {
+        let view = AgentsPane(state: AppState(), onNavigate: { _ in })
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(!controller.view.subviews.isEmpty)
+    }
+
+    @Test func harnessEntryNavigatesToTerminal() {
+        var navigated: SettingsSection?
+        let pane = AgentsPane(state: AppState()) { section in
+            navigated = section
+        }
+        let view = pane.environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(navigated == nil)
+        // Invoke the closure directly as a proxy for wiring correctness.
+        pane.onNavigate(.terminal)
+        #expect(navigated == .terminal)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Harness subsection to Settings > Agents with a link that navigates directly to the Terminal / Harness settings section
- Gives users a discoverable path from Agents settings to Harness configuration
- Uses existing `SettingsGroup` / navigation patterns

## Changes
- **`AgentsPane.swift`** — New `onNavigate` closure parameter; renders a `SettingsGroup(title: "Harness")` row with a button wired to `onNavigate(.terminal)`
- **`SettingsWindow.swift`** — Passes a `navigate` closure to `AgentsPane` that sets the active section
- **`AgentsPaneTests.swift`** — Smoke render test + navigation callback test

## Test plan
- [x] Build succeeds
- [x] `AgentsPaneTests` pass (2/2)
- [x] `SettingsSectionTests` still pass
- [ ] Manual: open Settings > Agents, verify Harness row appears, click navigates to Terminal pane