### PR TITLE
Clarify Mason LSP search field

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2975A1465CA308E9766521F2 /* NotificationService.swift */; };
+		01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */; };
 		01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */; };
 		01F51F05BA5DD24D4FBC4B4B /* ShortcutActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */; };
 		02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1703FC5CD7DF16F4450E274 /* DiffParser.swift */; };
@@ -410,6 +411,7 @@
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
 		F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */; };
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
+		F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169FC38D03727F34855EB521 /* AlasFieldTests.swift */; };
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
@@ -474,6 +476,7 @@
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
 		1688AB1B49758FAB5BF0AF2F /* light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = light.json; sourceTree = "<group>"; };
+		169FC38D03727F34855EB521 /* AlasFieldTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasFieldTests.swift; sourceTree = "<group>"; };
 		16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeTests.swift; sourceTree = "<group>"; };
 		16CA8FEE64D73BDEBAF74878 /* Kbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kbd.swift; sourceTree = "<group>"; };
 		179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimerTests.swift; sourceTree = "<group>"; };
@@ -811,6 +814,7 @@
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilderTests.swift; sourceTree = "<group>"; };
 		E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClientTests.swift; sourceTree = "<group>"; };
+		E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailViewTests.swift; sourceTree = "<group>"; };
 		E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionTests.swift; sourceTree = "<group>"; };
 		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
 		EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPane.swift; sourceTree = "<group>"; };
@@ -902,6 +906,7 @@
 				CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */,
 				1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */,
 				FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */,
+				169FC38D03727F34855EB521 /* AlasFieldTests.swift */,
 				69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */,
 				A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */,
 				A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */,
@@ -922,6 +927,7 @@
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
+				E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */,
 				7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */,
 				ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */,
 				A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */,
@@ -2096,6 +2102,7 @@
 				C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */,
 				026C8FB815E41D31C8E9421B /* AlasCLICommandRouterTests.swift in Sources */,
 				8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */,
+				F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */,
 				B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */,
 				281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */,
 				CB6D9F5929D97FAB3A264F47 /* AppConfigAgentsCodingTests.swift in Sources */,
@@ -2116,6 +2123,7 @@
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,
+				01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */,
 				1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */,
 				CF12433D8F30CEA05088FFB0 /* CodeTextViewIndentationTests.swift in Sources */,
 				C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */,

--- a/Alas/Sources/Settings/CodeLanguageDetailView.swift
+++ b/Alas/Sources/Settings/CodeLanguageDetailView.swift
@@ -32,8 +32,13 @@ struct CodeLanguageDetailView: View {
                     .foregroundColor(theme.color("fg-dim"))
                     .padding(.bottom, 6)
 
-                AlasField(text: $prefillQuery, monospaced: false)
-                    .padding(.bottom, 6)
+                AlasField(
+                    text: $prefillQuery,
+                    placeholder: "Search LSP packages…",
+                    monospaced: false,
+                    leadingIcon: "magnifyingglass"
+                )
+                .padding(.bottom, 6)
 
                 let results = MasonSnapshot.shared.search(prefillQuery)
                 if !results.isEmpty {

--- a/Alas/Sources/UI/AlasField.swift
+++ b/Alas/Sources/UI/AlasField.swift
@@ -7,6 +7,7 @@ struct AlasField: View {
     var monospaced: Bool = false
     var focusOnAppear: Bool = false
     var onSubmit: (() -> Void)? = nil
+    var leadingIcon: String? = nil
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -20,19 +21,38 @@ struct AlasField: View {
             )
             .frame(height: 28)
         } else {
-            TextField(placeholder, text: $text)
+            let field = TextField(placeholder, text: $text)
                 .textFieldStyle(.plain)
                 .font(.system(size: 12, design: monospaced ? .monospaced : .default))
-                .padding(.horizontal, 10)
-                .frame(height: 28)
-                .background(theme.color("bg-1"))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
-                )
                 .foregroundColor(theme.color("fg"))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            if let leadingIcon = leadingIcon {
+                HStack(spacing: 6) {
+                    Image(systemName: leadingIcon)
+                        .font(.system(size: 12, weight: .regular))
+                        .foregroundColor(theme.color("fg-dim"))
+                        .accessibilityHidden(true)
+                    field
+                }
+                .fieldChrome(theme: theme)
+            } else {
+                field
+                    .fieldChrome(theme: theme)
+            }
         }
+    }
+}
+
+private extension View {
+    func fieldChrome(theme: Theme) -> some View {
+        padding(.horizontal, 10)
+            .frame(height: 28)
+            .background(theme.color("bg-1"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 }
 

--- a/AlasTests/AlasFieldTests.swift
+++ b/AlasTests/AlasFieldTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct AlasFieldTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test func fieldWithLeadingIconRendersWithoutCrashing() {
+        let view = AlasField(
+            text: .constant("test"),
+            placeholder: "Placeholder",
+            leadingIcon: "magnifyingglass"
+        )
+        .environment(\.theme, currentTheme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(!controller.view.subviews.isEmpty)
+    }
+
+    @Test func fieldWithoutLeadingIconRendersWithoutCrashing() {
+        let view = AlasField(text: .constant("test"))
+            .environment(\.theme, currentTheme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(!controller.view.subviews.isEmpty)
+    }
+}

--- a/AlasTests/CodeLanguageDetailViewTests.swift
+++ b/AlasTests/CodeLanguageDetailViewTests.swift
@@ -1,0 +1,58 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct CodeLanguageDetailViewTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test func newLanguageViewRendersWithoutCrashing() {
+        let config = LanguageServerConfig(
+            language: "",
+            extensions: [],
+            command: "",
+            args: [],
+            env: [:],
+            rootMarkers: [],
+            enabled: true
+        )
+        let view = CodeLanguageDetailView(
+            initial: config,
+            isNew: true,
+            onSave: { _, _ in },
+            onCancel: {}
+        )
+        .environment(\.theme, currentTheme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(!controller.view.subviews.isEmpty)
+    }
+
+    @Test func existingLanguageViewRendersWithoutCrashing() {
+        let config = LanguageServerConfig(
+            language: "swift",
+            extensions: ["swift"],
+            command: "sourcekit-lsp",
+            args: [],
+            env: [:],
+            rootMarkers: [],
+            enabled: true
+        )
+        let view = CodeLanguageDetailView(
+            initial: config,
+            isNew: false,
+            onSave: { _, _ in },
+            onCancel: {}
+        )
+        .environment(\.theme, currentTheme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(!controller.view.subviews.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- add a decorative magnifying-glass icon to the Mason LSP search field
- update the placeholder to make the search purpose explicit
- add SwiftUI smoke coverage for the field and language detail view

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- focused SwiftUI smoke tests passed