### PR TITLE
Reduce cursor-agent hook overhead and clean up harness on quit

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -407,6 +407,13 @@ private struct RootBaseHandlers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                 state.stopAllProjectGitWatchers()
                 state.tabs.snapshotDirtyBuffersForQuit()
+                // Cancel the hook socket accept loop and any pending cursor
+                // idle debouncers before the process tears down. Otherwise
+                // in-flight hook subprocesses (cursor-agent fires a 1s `nc -U`
+                // per event) keep delivering events to a half-torn-down
+                // HarnessService, which is one of the candidates for the
+                // permission-prompt avalanche reported on quit.
+                state.harness.stop()
             }
     }
 }

--- a/Alas/Sources/Harness/AlasHookCommand.swift
+++ b/Alas/Sources/Harness/AlasHookCommand.swift
@@ -53,11 +53,20 @@ enum AlasHookCommand {
     }
 
     private static func bodyEnvelopePipeline(event: ActivityEvent, agent: AgentKind) -> String {
-        let bodyExtract = #"body=$(printf '%s' "$payload" | /usr/bin/python3 -c 'import json,sys; d=json.loads(sys.stdin.read() or "{}"); print((d.get("message") or d.get("last_assistant_message") or d.get("assistant_response") or "")[:500])' 2>/dev/null)"#
-        let jsonBody = #"$(printf '%s' "$body" | /usr/bin/python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"#
-        let envelope =
-            #"{"v":1,"event":"\#(event.rawValue)","agent":"\#(agent.rawValue)","session_id":"%s","pid":%s,"body":%s}"#
-        let printfCmd = #"printf '\#(envelope)\n' "$ALAS_SESSION_ID" "$PPID" "\#(jsonBody)" | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH""#
-        return "\(bodyExtract); \(printfCmd)"
+        // One python3 invocation: parse stdin JSON, extract a message body,
+        // and emit the full envelope. The previous implementation used TWO
+        // python3 invocations per event (one to extract the body, one to
+        // JSON-encode it), which doubled interpreter startup cost. cursor-agent
+        // flaps these hooks fast enough that the duplicate cost contributed
+        // to runaway system load. $PPID is passed as argv because python's
+        // os.getppid() returns the surrounding shell, not the harness.
+        let script = """
+            import json,os,sys
+            try: d=json.loads(sys.stdin.read() or "{}")
+            except Exception: d={}
+            b=(d.get("message") or d.get("last_assistant_message") or d.get("assistant_response") or "")[:500] if isinstance(d, dict) else ""
+            print(json.dumps({"v":1,"event":"\(event.rawValue)","agent":"\(agent.rawValue)","session_id":os.environ.get("ALAS_SESSION_ID",""),"pid":int(sys.argv[1] or "0"),"body":b}))
+            """
+        return #"printf '%s' "$payload" | /usr/bin/python3 -c '\#(script)' "$PPID" 2>/dev/null | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH""#
     }
 }

--- a/Alas/Sources/Harness/AlasHookCommand.swift
+++ b/Alas/Sources/Harness/AlasHookCommand.swift
@@ -52,6 +52,30 @@ enum AlasHookCommand {
         return #"printf '\#(envelope)\n' "$ALAS_SESSION_ID" "$PPID" | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH""#
     }
 
+    /// Python script that `bodyEnvelopePipeline` invokes. Reads the cursor
+    /// hook payload from stdin, extracts a string body from the first
+    /// matching key, and emits the full envelope on stdout. Defensive against
+    /// malformed JSON, non-dict roots, and non-string body fields so the
+    /// pipeline always delivers an envelope to `nc` — the previous two-python
+    /// implementation degraded to empty body on any extraction failure and
+    /// we preserve that contract here. Exposed at `internal` scope so tests
+    /// can drive it without rebuilding the surrounding shell composition.
+    static func bodyEnvelopePythonScript(event: ActivityEvent, agent: AgentKind) -> String {
+        """
+        import json,os,sys
+        try: d=json.loads(sys.stdin.read() or "{}")
+        except Exception: d={}
+        b=""
+        if isinstance(d, dict):
+            for k in ("message","last_assistant_message","assistant_response"):
+                v=d.get(k)
+                if isinstance(v,str) and v:
+                    b=v[:500]
+                    break
+        print(json.dumps({"v":1,"event":"\(event.rawValue)","agent":"\(agent.rawValue)","session_id":os.environ.get("ALAS_SESSION_ID",""),"pid":int(sys.argv[1] or "0"),"body":b}))
+        """
+    }
+
     private static func bodyEnvelopePipeline(event: ActivityEvent, agent: AgentKind) -> String {
         // One python3 invocation: parse stdin JSON, extract a message body,
         // and emit the full envelope. The previous implementation used TWO
@@ -60,13 +84,7 @@ enum AlasHookCommand {
         // flaps these hooks fast enough that the duplicate cost contributed
         // to runaway system load. $PPID is passed as argv because python's
         // os.getppid() returns the surrounding shell, not the harness.
-        let script = """
-            import json,os,sys
-            try: d=json.loads(sys.stdin.read() or "{}")
-            except Exception: d={}
-            b=(d.get("message") or d.get("last_assistant_message") or d.get("assistant_response") or "")[:500] if isinstance(d, dict) else ""
-            print(json.dumps({"v":1,"event":"\(event.rawValue)","agent":"\(agent.rawValue)","session_id":os.environ.get("ALAS_SESSION_ID",""),"pid":int(sys.argv[1] or "0"),"body":b}))
-            """
+        let script = bodyEnvelopePythonScript(event: event, agent: agent)
         return #"printf '%s' "$payload" | /usr/bin/python3 -c '\#(script)' "$PPID" 2>/dev/null | /usr/bin/nc -U -w1 "$ALAS_SOCKET_PATH""#
     }
 }

--- a/AlasTests/AlasHookCommandTests.swift
+++ b/AlasTests/AlasHookCommandTests.swift
@@ -1,8 +1,44 @@
 import Testing
+import Foundation
 @testable import Alas
 
 struct AlasHookCommandTests {
     static let sentinel = "# alas-managed-hook"
+
+    /// Run `bodyEnvelopePythonScript` end-to-end so we can assert behavior of
+    /// the embedded python script (graceful degradation, body extraction)
+    /// rather than just its source-string shape.
+    private func runBodyEnvelope(
+        stdin payload: String,
+        event: ActivityEvent = .idle,
+        agent: AgentKind = .cursor
+    ) throws -> [String: Any] {
+        let script = AlasHookCommand.bodyEnvelopePythonScript(event: event, agent: agent)
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        proc.arguments = ["-c", script, "99"]
+        var env = ProcessInfo.processInfo.environment
+        env["ALAS_SESSION_ID"] = "test-session"
+        proc.environment = env
+        let inPipe = Pipe()
+        let outPipe = Pipe()
+        proc.standardInput = inPipe
+        proc.standardOutput = outPipe
+        proc.standardError = Pipe()
+        try proc.run()
+        try inPipe.fileHandleForWriting.write(contentsOf: Data(payload.utf8))
+        try inPipe.fileHandleForWriting.close()
+        proc.waitUntilExit()
+        let data = (try? outPipe.fileHandleForReading.readToEnd()) ?? Data()
+        guard let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(
+                domain: "AlasHookCommandTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "script produced no JSON: \(String(data: data, encoding: .utf8) ?? "<nil>")"]
+            )
+        }
+        return obj
+    }
 
     @Test func busyWithoutBody_producesSimpleCommand() {
         let cmd = AlasHookCommand.compositeCommand(
@@ -64,5 +100,50 @@ struct AlasHookCommandTests {
         )
         let count = cmd.components(separatedBy: "/usr/bin/python3").count - 1
         #expect(count == 1)
+    }
+
+    @Test func bodyEnvelope_extractsStringMessage() throws {
+        let env = try runBodyEnvelope(stdin: #"{"message":"hello from cursor"}"#)
+        #expect(env["event"] as? String == "idle")
+        #expect(env["agent"] as? String == "cursor")
+        #expect(env["body"] as? String == "hello from cursor")
+    }
+
+    @Test func bodyEnvelope_fallsBackToLastAssistantMessage() throws {
+        let env = try runBodyEnvelope(stdin: #"{"last_assistant_message":"fallback"}"#)
+        #expect(env["body"] as? String == "fallback")
+    }
+
+    @Test func bodyEnvelope_truncatesBodyAt500Chars() throws {
+        let long = String(repeating: "x", count: 1000)
+        let env = try runBodyEnvelope(stdin: #"{"message":"\#(long)"}"#)
+        #expect((env["body"] as? String)?.count == 500)
+    }
+
+    /// Codex review on #211: a non-string `message` (e.g. `{"message":123}`)
+    /// previously raised `TypeError` and silently dropped the hook event.
+    /// The original two-python implementation degraded to an empty body in
+    /// that case; preserve that contract here.
+    @Test func bodyEnvelope_emitsEmptyBodyForNonStringMessage() throws {
+        let env = try runBodyEnvelope(stdin: #"{"message":123}"#)
+        #expect(env["event"] as? String == "idle")
+        #expect(env["agent"] as? String == "cursor")
+        #expect(env["body"] as? String == "")
+    }
+
+    @Test func bodyEnvelope_emitsEmptyBodyForObjectMessage() throws {
+        let env = try runBodyEnvelope(stdin: #"{"message":{"nested":"obj"}}"#)
+        #expect(env["body"] as? String == "")
+    }
+
+    @Test func bodyEnvelope_emitsEmptyBodyForMalformedJSON() throws {
+        let env = try runBodyEnvelope(stdin: "not json")
+        #expect(env["body"] as? String == "")
+        #expect(env["event"] as? String == "idle")
+    }
+
+    @Test func bodyEnvelope_emitsEmptyBodyForJSONArray() throws {
+        let env = try runBodyEnvelope(stdin: "[]")
+        #expect(env["body"] as? String == "")
     }
 }

--- a/AlasTests/AlasHookCommandTests.swift
+++ b/AlasTests/AlasHookCommandTests.swift
@@ -53,4 +53,16 @@ struct AlasHookCommandTests {
         #expect(AlasHookCommand.isManagedCommand(cmd))
         #expect(!AlasHookCommand.isManagedCommand("echo hello"))
     }
+
+    /// Each cursor hook event fires this command, so the subprocess cost
+    /// matters: a body-bearing event with two python3 invocations doubles
+    /// interpreter startup per event and contributes to the runaway load
+    /// we saw with cursor-agent. Keep the body path to a single python3.
+    @Test func bodyEnvelopePipeline_usesSinglePython3Invocation() {
+        let cmd = AlasHookCommand.compositeCommand(
+            events: [.idle], agent: .cursor, forwardStdinAsBody: true
+        )
+        let count = cmd.components(separatedBy: "/usr/bin/python3").count - 1
+        #expect(count == 1)
+    }
 }


### PR DESCRIPTION
## Summary
- Collapse `bodyEnvelopePipeline` from two `/usr/bin/python3` invocations per cursor-agent event to one, halving interpreter-startup cost per hook fire.
- Wire `HarnessService.stop()` into `willTerminate` so the hook socket accept loop and pending cursor idle debouncers are cancelled before the process tears down, instead of dispatching in-flight events during shutdown.

## Context
Reported symptom: heavy cursor-agent use degrades the whole machine (memory growth, stutter), and on quit Alas asks for a flood of "access data from other apps" permission prompts. These are defensive changes targeting two of the most plausible amplifiers — they don't yet prove root cause, but they substantially reduce the per-event subprocess pressure and tear-down state that could be feeding the avalanche. We still want the affected machine's `log stream` from tccd to confirm.

## Test plan
- [x] New TDD test `bodyEnvelopePipeline_usesSinglePython3Invocation` (RED → GREEN)
- [x] `AlasHookCommandTests` 7/7 pass
- [x] `HarnessServiceTests` pass (unchanged)
- [x] Full `xcodebuild test` — pre-existing flakes only (`multiCursorNewlineReplacesNonEmptyRanges`, timing-bound `timeoutCompletesWhenChildIgnoresSIGTERM`); confirmed both fail/flake on baseline without these changes
- [x] `xcodebuild build` — BUILD SUCCEEDED
- [x] Generated python script verified end-to-end against: valid JSON, fallback keys, malformed JSON, empty stdin, non-dict JSON, 1000-char body truncating to 500
- [ ] Manual reproduction on the affected machine — confirm cursor-agent runs no longer balloon memory and quit no longer triggers the prompt avalanche