### PR TITLE
Allow text selection in diff panes

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		0F560F9B2458B94C807E96A1 /* CodeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */; };
 		10557FBC430EEAB1196D9575 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */; };
 		1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8B52175A7F6144B4C52010 /* EditorTabView.swift */; };
+		10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */; };
 		11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCEFADD952DB870B8BAB890 /* CommitRow.swift */; };
 		115C50272D2037FB24B8536F /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */; };
 		11B4AA1D032F054C666DD7F4 /* PendingDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */; };
@@ -750,6 +751,7 @@
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
 		C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
+		C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextTests.swift; sourceTree = "<group>"; };
 		C506EF972D34E2F937D4FEEC /* InstallerHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerHost.swift; sourceTree = "<group>"; };
 		C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolverTests.swift; sourceTree = "<group>"; };
 		C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstaller.swift; sourceTree = "<group>"; };
@@ -947,6 +949,7 @@
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
 				EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */,
+				C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */,
 				1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */,
 				35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */,
 				C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */,
@@ -2145,6 +2148,7 @@
 				BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */,
 				9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */,
 				0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */,
+				10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */,
 				A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */,
 				3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */,
 				C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */,

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -281,6 +281,7 @@ struct HunkView: View {
                 .background(rowBg(line))
             }
         }
+        .textSelection(.enabled)
     }
 
     /// Compose a single `AttributedString` for `line` with per-token

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -1,0 +1,116 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import Alas
+
+/// Smoke tests for the shared diff hunk renderer used by working-tree and
+/// commit diff panes. Text selection is exercised at runtime via
+/// `.textSelection(.enabled)` and is not inspectable in an `NSHostingController`;
+/// these tests guard rendering crashes with varied hunk shapes.
+@Suite(.serialized)
+@MainActor
+struct DiffSelectableTextTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    private func sampleHunk() -> ParsedDiff.Hunk {
+        ParsedDiff.Hunk(
+            header: "@@ -10,3 +10,4 @@",
+            oldStart: 10,
+            newStart: 10,
+            lines: [
+                .init(kind: .context, text: "struct Foo {", oldNumber: 10, newNumber: 10),
+                .init(kind: .delete, text: "    let bar: Int", oldNumber: 11, newNumber: nil),
+                .init(kind: .add, text: "    let bar: String", oldNumber: nil, newNumber: 11),
+                .init(kind: .context, text: "}", oldNumber: 12, newNumber: 12),
+            ]
+        )
+    }
+
+    // MARK: HunkView standalone
+
+    @Test func hunkViewRendersWithoutCrashing() {
+        let view = HunkView(hunk: sampleHunk(), fileExtension: "swift")
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func hunkViewWithActionsRendersWithoutCrashing() {
+        let view = HunkView(
+            hunk: sampleHunk(),
+            fileExtension: "swift",
+            onStage: {},
+            onDiscard: {}
+        )
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func hunkViewWithEmptyLinesRendersWithoutCrashing() {
+        let emptyHunk = ParsedDiff.Hunk(
+            header: "@@ -1,0 +1,0 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: []
+        )
+        let view = HunkView(hunk: emptyHunk, fileExtension: "md")
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    // MARK: CommitDiffView integration
+
+    @Test func commitDiffViewWithHunksRendersWithoutCrashing() {
+        let diff = ParsedDiff(hunks: [sampleHunk()])
+        let view = CommitDiffView(
+            path: "Sources/App.swift",
+            diff: diff,
+            loading: false,
+            error: nil,
+            onOpenFile: nil
+        )
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func commitDiffViewEmptyHunksRendersWithoutCrashing() {
+        let view = CommitDiffView(
+            path: "a.txt",
+            diff: ParsedDiff(hunks: []),
+            loading: false,
+            error: nil,
+            onOpenFile: nil
+        )
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func hunkViewWithPlainTextExtensionRendersWithoutCrashing() {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -1,3 +1,3 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: [
+                .init(kind: .context, text: "hello", oldNumber: 1, newNumber: 1),
+                .init(kind: .delete, text: "world", oldNumber: 2, newNumber: nil),
+                .init(kind: .add, text: "there", oldNumber: nil, newNumber: 2),
+            ]
+        )
+        let view = HunkView(hunk: hunk, fileExtension: "txt")
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Enable text selection for shared diff hunk rendering
- Add focused smoke coverage for diff selectable text surfaces

## Testing
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/DiffSelectableTextTests

Full scheme test was attempted but timed out during test-session finalization without a reported test failure.