### PR TITLE
Decouple agent bypass setting

### DIFF
--- a/Alas/Sources/Agents/AgentAutoLaunch.swift
+++ b/Alas/Sources/Agents/AgentAutoLaunch.swift
@@ -31,14 +31,41 @@ enum AgentAutoLaunch {
             agentId = projectAgentId
             useBypass = projectUseBypass
         }
-        guard let id = agentId,
-              let agent = registry.enabled().first(where: { $0.id == id }) else {
+        guard let id = agentId else {
             return nil
         }
+        guard let resolved = resolveExplicit(
+            agentId: id,
+            registry: registry,
+            useBypass: useBypass
+        ) else {
+            return nil
+        }
+        return resolved
+    }
+
+    /// Resolve an explicit per-creation agent launch (e.g. chosen in the
+    /// NewWorktreeDialog). Unlike `resolve`, this does not require a default
+    /// agent to be configured.
+    static func resolveExplicit(
+        agentId: String,
+        registry: AgentRegistry,
+        useBypass: Bool
+    ) -> Resolved? {
+        guard let agent = registry.enabled().first(where: { $0.id == agentId }) else {
+            return nil
+        }
+        return Resolved(
+            argv: buildCommand(agent: agent, useBypass: useBypass),
+            agentId: agent.id
+        )
+    }
+
+    static func buildCommand(agent: AgentDefinition, useBypass: Bool) -> [String] {
         var argv: [String] = [agent.resolvedBinary]
         if useBypass, let flag = agent.bypassPermissionsFlag {
             argv.append(flag)
         }
-        return Resolved(argv: argv, agentId: agent.id)
+        return argv
     }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -397,9 +397,7 @@ final class AppState {
                 // interactive CLI (claude, codex, gemini) would just exit
                 // immediately on the EOF from its missing stdin.
                 let launchAgentCommand: String? = {
-                    guard let id = launchAgentId,
-                          let agent = self.agentRegistry.enabled().first(where: { $0.id == id })
-                    else { return nil }
+                    guard let id = launchAgentId else { return nil }
                     let useBypass: Bool = {
                         switch project.startupScripts.worktreeAgentMode {
                         case .disabled: return false
@@ -409,11 +407,12 @@ final class AppState {
                             return project.startupScripts.worktreeAgentUseBypassPermissions
                         }
                     }()
-                    var argv = [agent.resolvedBinary]
-                    if useBypass, let flag = agent.bypassPermissionsFlag {
-                        argv.append(flag)
-                    }
-                    return argv.map { Self.shellQuote($0) }.joined(separator: " ")
+                    guard let resolved = AgentAutoLaunch.resolveExplicit(
+                        agentId: id,
+                        registry: self.agentRegistry,
+                        useBypass: useBypass
+                    ) else { return nil }
+                    return resolved.argv.map { Self.shellQuote($0) }.joined(separator: " ")
                 }()
 
                 do {

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -37,11 +37,9 @@ struct AgentsPane: View {
                     }
                     SettingsRow(
                         name: "Bypass permissions",
-                        desc: "Append the agent's --bypass-permissions flag when auto-launching."
+                        desc: "Append the agent's --bypass-permissions flag when auto-launching. Only applied when the selected agent supports it."
                     ) {
                         AlasToggle(on: state.bind(\.agents.worktreeAutoLaunch.useBypassPermissions))
-                            .disabled(!autoLaunchSupportsBypass)
-                            .opacity(autoLaunchSupportsBypass ? 1 : 0.4)
                     }
                 }
 
@@ -112,12 +110,6 @@ struct AgentsPane: View {
         }
         .pickerStyle(.menu)
         .frame(width: 240)
-    }
-
-    private var autoLaunchSupportsBypass: Bool {
-        guard let id = state.config.agents.worktreeAutoLaunch.agentId,
-              let agent = state.agent(id: id) else { return false }
-        return agent.bypassPermissionsFlag != nil
     }
 
     private var cardGrid: some View {

--- a/AlasTests/AgentAutoLaunchTests.swift
+++ b/AlasTests/AgentAutoLaunchTests.swift
@@ -106,4 +106,84 @@ struct AgentAutoLaunchTests {
         )!
         #expect(resolved.argv == ["codex"])
     }
+
+    @Test func resolveExplicitReturnsNilForUnknownAgent() {
+        let r = registry([], installed: [])
+        let resolved = AgentAutoLaunch.resolveExplicit(
+            agentId: "missing",
+            registry: r,
+            useBypass: true
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test func resolveExplicitAppendsBypassFlagWhenSupported() {
+        let agent = mkAgent(id: "test-claude", binary: "claude", bypass: "--dangerously-skip-permissions")
+        let r = registry([agent], installed: ["test-claude"])
+        let resolved = AgentAutoLaunch.resolveExplicit(
+            agentId: "test-claude",
+            registry: r,
+            useBypass: true
+        )!
+        #expect(resolved.argv == ["claude", "--dangerously-skip-permissions"])
+    }
+
+    @Test func resolveExplicitOmitsBypassFlagWhenNotSupported() {
+        let agent = mkAgent(id: "test-pi", binary: "pi", bypass: nil)
+        let r = registry([agent], installed: ["test-pi"])
+        let resolved = AgentAutoLaunch.resolveExplicit(
+            agentId: "test-pi",
+            registry: r,
+            useBypass: true
+        )!
+        #expect(resolved.argv == ["pi"])
+    }
+
+    @Test func resolvedGlobalReturnsNilWhenNoAgentIdButBypassEnabled() {
+        // Bypass permissions is stored independently of the default agent.
+        // When no default agent is set, auto-launch should return nil
+        // regardless of the bypass toggle.
+        let r = registry([], installed: [])
+        let resolved = AgentAutoLaunch.resolve(
+            registry: r,
+            globalAgentId: nil,
+            globalUseBypass: true,
+            projectMode: .useGlobal,
+            projectAgentId: nil,
+            projectUseBypass: false
+        )
+        #expect(resolved == nil)
+    }
+
+    @Test func resolveExplicitOmitsBypassWhenUseBypassIsFalse() {
+        let agent = mkAgent(id: "test-claude", binary: "claude", bypass: "--dangerously-skip-permissions")
+        let r = registry([agent], installed: ["test-claude"])
+        let resolved = AgentAutoLaunch.resolveExplicit(
+            agentId: "test-claude",
+            registry: r,
+            useBypass: false
+        )!
+        #expect(resolved.argv == ["claude"])
+    }
+
+    @Test func explicitSelectionUsesBypassWithoutDefaultAgent() {
+        let agent = mkAgent(id: "test-claude", binary: "claude", bypass: "--dangerously-skip-permissions")
+        let r = registry([agent], installed: ["test-claude"])
+        let defaultResolved = AgentAutoLaunch.resolve(
+            registry: r,
+            globalAgentId: nil,
+            globalUseBypass: true,
+            projectMode: .useGlobal,
+            projectAgentId: nil,
+            projectUseBypass: false
+        )
+        let explicitResolved = AgentAutoLaunch.resolveExplicit(
+            agentId: "test-claude",
+            registry: r,
+            useBypass: true
+        )
+
+        #expect(defaultResolved == nil)
+        #expect(explicitResolved?.argv == ["claude", "--dangerously-skip-permissions"])
+    }
 }


### PR DESCRIPTION
## Summary
- Keep bypass permissions configurable when Default Agent is None
- Route explicit New Worktree agent launches through the shared AgentAutoLaunch resolver
- Add focused coverage for explicit Claude Code selection with bypass enabled

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- Focused AgentAutoLaunchTests passed