### PR TITLE
Show copy feedback for git references

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
+		0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */; };
 		0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB91379591DA21D216A894 /* RelativeTime.swift */; };
 		0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */; };
 		0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */; };
@@ -357,6 +358,7 @@
 		CF2AD9C6F30BC02C040902A8 /* ShortcutResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */; };
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
+		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
 		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
 		D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */; };
@@ -470,6 +472,7 @@
 		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
 		0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewController.swift; sourceTree = "<group>"; };
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
+		0E6600436B01C75D85C01FFA /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
 		0F68A9692F85197ED9E16262 /* WorktreesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreesPane.swift; sourceTree = "<group>"; };
 		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
@@ -612,6 +615,7 @@
 		5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateFileTreeTests.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
 		5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPane.swift; sourceTree = "<group>"; };
+		5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackState.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
@@ -1147,6 +1151,8 @@
 				A98D0A96093087BF4C284053 /* AlasSlider.swift */,
 				1841997CCBDB9611576B930C /* AlasToggle.swift */,
 				524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */,
+				0E6600436B01C75D85C01FFA /* Clipboard.swift */,
+				5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
 				EECB91379591DA21D216A894 /* RelativeTime.swift */,
 				489C9B383554D7DAB170C2F8 /* Seg.swift */,
@@ -1915,6 +1921,7 @@
 				23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */,
 				D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */,
 				87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */,
+				D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */,
 				EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */,
 				41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */,
 				A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */,
@@ -1935,6 +1942,7 @@
 				CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */,
 				A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */,
 				A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */,
+				0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */,
 				2D313A7E99C93242DD35AA8E /* CursorInstaller.swift in Sources */,
 				49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */,
 				5711B2BE2D70220A4BED5B2B /* DefinitionFeature.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
 		1AE5FCAF7D44694876754813 /* HookInstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */; };
 		1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */; };
+		1B1A33B610D29116A1D08A74 /* PointingHandCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */; };
 		1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
 		1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */; };
@@ -667,6 +668,7 @@
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewAutoPairTests.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
+		7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointingHandCursor.swift; sourceTree = "<group>"; };
 		7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCacheTests.swift; sourceTree = "<group>"; };
 		7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApp.swift; sourceTree = "<group>"; };
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
@@ -1154,6 +1156,7 @@
 				0E6600436B01C75D85C01FFA /* Clipboard.swift */,
 				5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */,
 				16CA8FEE64D73BDEBAF74878 /* Kbd.swift */,
+				7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */,
 				EECB91379591DA21D216A894 /* RelativeTime.swift */,
 				489C9B383554D7DAB170C2F8 /* Seg.swift */,
 				2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */,
@@ -2041,6 +2044,7 @@
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
 				449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */,
 				671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */,
+				1B1A33B610D29116A1D08A74 /* PointingHandCursor.swift in Sources */,
 				C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */,
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
 				F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */,

--- a/Alas/Sources/Center/Commit/CommitDiffView.swift
+++ b/Alas/Sources/Center/Commit/CommitDiffView.swift
@@ -8,6 +8,8 @@ struct CommitDiffView: View {
     let onOpenFile: (() -> Void)?
 
     @Environment(\.theme) private var theme
+    @StateObject private var copyFeedback = CopyFeedbackState()
+    @State private var titleHovering = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -19,13 +21,23 @@ struct CommitDiffView: View {
 
     private var header: some View {
         HStack(spacing: 6) {
-            Text((path as NSString).lastPathComponent)
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(theme.color("fg"))
-            Text("·").foregroundColor(theme.color("fg-faint"))
-            Text((path as NSString).deletingLastPathComponent)
-                .font(.system(size: 11))
-                .foregroundColor(theme.color("fg-dim"))
+            HStack(spacing: 6) {
+                Text((path as NSString).lastPathComponent)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(titleHovering ? theme.color("accent") : theme.color("fg"))
+                Text("·").foregroundColor(theme.color("fg-faint"))
+                Text((path as NSString).deletingLastPathComponent)
+                    .font(.system(size: 11))
+                    .foregroundColor(titleHovering ? theme.color("accent") : theme.color("fg-dim"))
+            }
+            .contentShape(Rectangle())
+            .onTapGesture { copyTitle() }
+            .onHover { hovering in
+                titleHovering = hovering
+                if hovering { NSCursor.pointingHand.push() }
+                else { NSCursor.pop() }
+            }
+            .help("Click to copy diff title")
             Spacer()
             if let onOpenFile {
                 AlasButton(title: "Open File", style: .subtle, action: onOpenFile)
@@ -34,6 +46,7 @@ struct CommitDiffView: View {
         .padding(.horizontal, 16).padding(.vertical, 8)
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.4), alignment: .bottom)
+        .copyFeedbackOverlay(message: copyFeedback.message)
     }
 
     @ViewBuilder
@@ -59,5 +72,10 @@ struct CommitDiffView: View {
                 .padding(.vertical, 8)
             }
         }
+    }
+
+    private func copyTitle() {
+        Clipboard.copy(path)
+        copyFeedback.show("Copied title")
     }
 }

--- a/Alas/Sources/Center/Commit/CommitDiffView.swift
+++ b/Alas/Sources/Center/Commit/CommitDiffView.swift
@@ -34,9 +34,8 @@ struct CommitDiffView: View {
             .onTapGesture { copyTitle() }
             .onHover { hovering in
                 titleHovering = hovering
-                if hovering { NSCursor.pointingHand.push() }
-                else { NSCursor.pop() }
             }
+            .pointingHandCursor()
             .help("Click to copy diff title")
             Spacer()
             if let onOpenFile {

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -5,6 +5,7 @@ struct CommitHeaderView: View {
     @Binding var expanded: Bool
 
     @Environment(\.theme) private var theme
+    @StateObject private var copyFeedback = CopyFeedbackState()
     @State private var shaHovering = false
 
     var body: some View {
@@ -15,6 +16,7 @@ struct CommitHeaderView: View {
         .padding(.horizontal, 16).padding(.vertical, 10)
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
+        .copyFeedbackOverlay(message: copyFeedback.message)
     }
 
     private var compactRow: some View {
@@ -35,8 +37,7 @@ struct CommitHeaderView: View {
                 .font(.system(size: 11, design: .monospaced))
                 .foregroundColor(shaHovering ? theme.color("accent") : theme.color("fg-faint"))
                 .onTapGesture {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(details.info.sha, forType: .string)
+                    copyToPasteboard(details.info.sha, feedback: "Copied SHA")
                 }
                 .onHover { hovering in
                     shaHovering = hovering
@@ -84,8 +85,7 @@ struct CommitHeaderView: View {
                         ForEach(Array(details.parents.enumerated()), id: \.offset) { index, parent in
                             Text(parent)
                                 .onTapGesture {
-                                    NSPasteboard.general.clearContents()
-                                    NSPasteboard.general.setString(parent, forType: .string)
+                                    copyToPasteboard(parent, feedback: "Copied SHA")
                                 }
                                 .onHover { hovering in
                                     if hovering { NSCursor.pointingHand.push() }
@@ -113,5 +113,10 @@ struct CommitHeaderView: View {
         let fmt = DateFormatter()
         fmt.dateFormat = "yyyy-MM-dd HH:mm"
         return fmt.string(from: date)
+    }
+
+    private func copyToPasteboard(_ text: String, feedback: String) {
+        Clipboard.copy(text)
+        copyFeedback.show(feedback)
     }
 }

--- a/Alas/Sources/Center/Commit/CommitHeaderView.swift
+++ b/Alas/Sources/Center/Commit/CommitHeaderView.swift
@@ -41,9 +41,8 @@ struct CommitHeaderView: View {
                 }
                 .onHover { hovering in
                     shaHovering = hovering
-                    if hovering { NSCursor.pointingHand.push() }
-                    else { NSCursor.pop() }
                 }
+                .pointingHandCursor()
                 .help("Click to copy SHA")
             Text("·").foregroundColor(theme.color("fg-faint"))
             Text(details.info.author)
@@ -87,10 +86,7 @@ struct CommitHeaderView: View {
                                 .onTapGesture {
                                     copyToPasteboard(parent, feedback: "Copied SHA")
                                 }
-                                .onHover { hovering in
-                                    if hovering { NSCursor.pointingHand.push() }
-                                    else { NSCursor.pop() }
-                                }
+                                .pointingHandCursor()
                                 .help("Click to copy SHA")
                             if index < details.parents.count - 1 {
                                 Text(" ")

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -51,15 +51,11 @@ struct ChangesTabView: View {
                         appState.openFile(relativePath: file.path, worktreeId: rps.worktree.id)
                     },
                     onCopyRelative: { file in
-                        let pb = NSPasteboard.general
-                        pb.clearContents()
-                        pb.setString(file.path, forType: .string)
+                        Clipboard.copy(file.path)
                     },
                     onCopyFull: { file in
                         let absolute = rps.worktree.path.appendingPathComponent(file.path).path
-                        let pb = NSPasteboard.general
-                        pb.clearContents()
-                        pb.setString(absolute, forType: .string)
+                        Clipboard.copy(absolute)
                     },
                     onRevealInFinder: { file in
                         let url = rps.worktree.path.appendingPathComponent(file.path)
@@ -110,8 +106,6 @@ struct ChangesTabView: View {
     }
 
     private func copyCommitSHA(_ commit: CommitInfo) {
-        let pb = NSPasteboard.general
-        pb.clearContents()
-        pb.setString(commit.sha, forType: .string)
+        Clipboard.copy(commit.sha)
     }
 }

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -8,6 +8,8 @@ struct CommitRow: View {
     let onCopySHA: () -> Void
 
     @Environment(\.theme) private var theme
+    @StateObject private var copyFeedback = CopyFeedbackState()
+    @State private var shaHovering = false
 
     var body: some View {
         Button(action: onSelect) {
@@ -25,8 +27,9 @@ struct CommitRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .copyFeedbackOverlay(message: copyFeedback.message)
         .contextMenu {
-            Button("Copy Commit SHA") { onCopySHA() }
+            Button("Copy Commit SHA") { copySHA() }
         }
     }
 
@@ -71,7 +74,14 @@ struct CommitRow: View {
         HStack(spacing: 6) {
             Text(commit.shortSha)
                 .font(.system(size: 10.5, design: .monospaced))
-                .foregroundColor(theme.color("fg-faint"))
+                .foregroundColor(shaHovering ? theme.color("accent") : theme.color("fg-faint"))
+                .onTapGesture { copySHA() }
+                .onHover { hovering in
+                    shaHovering = hovering
+                    if hovering { NSCursor.pointingHand.push() }
+                    else { NSCursor.pop() }
+                }
+                .help("Click to copy SHA")
             avatar
             Text(relativeTime(commit.date))
                 .font(.system(size: 10.5))
@@ -120,5 +130,10 @@ struct CommitRow: View {
             hash = ((hash &<< 5) &+ hash) &+ UInt64(byte)
         }
         return Color(hex: palette[Int(hash % UInt64(palette.count))])
+    }
+
+    private func copySHA() {
+        onCopySHA()
+        copyFeedback.show("Copied SHA")
     }
 }

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -78,9 +78,8 @@ struct CommitRow: View {
                 .onTapGesture { copySHA() }
                 .onHover { hovering in
                     shaHovering = hovering
-                    if hovering { NSCursor.pointingHand.push() }
-                    else { NSCursor.pop() }
                 }
+                .pointingHandCursor()
                 .help("Click to copy SHA")
             avatar
             Text(relativeTime(commit.date))

--- a/Alas/Sources/UI/Clipboard.swift
+++ b/Alas/Sources/UI/Clipboard.swift
@@ -1,0 +1,8 @@
+import AppKit
+
+enum Clipboard {
+    static func copy(_ text: String, to pasteboard: NSPasteboard = .general) {
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+}

--- a/Alas/Sources/UI/CopyFeedbackState.swift
+++ b/Alas/Sources/UI/CopyFeedbackState.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+@MainActor
+final class CopyFeedbackState: ObservableObject {
+    @Published private(set) var message: String?
+
+    private let displayNanoseconds: UInt64
+    private var token = UUID()
+    private var dismissTask: Task<Void, Never>?
+
+    init(displayNanoseconds: UInt64 = 5_000_000_000) {
+        self.displayNanoseconds = displayNanoseconds
+    }
+
+    deinit {
+        dismissTask?.cancel()
+    }
+
+    func show(_ message: String) {
+        dismissTask?.cancel()
+
+        let nextToken = UUID()
+        token = nextToken
+        self.message = message
+
+        let delay = displayNanoseconds
+        dismissTask = Task { [weak self, nextToken] in
+            try? await Task.sleep(nanoseconds: delay)
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                guard self?.token == nextToken else { return }
+                self?.message = nil
+            }
+        }
+    }
+}
+
+struct CopyFeedbackChip: View {
+    let message: String
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 9, weight: .semibold))
+            Text(message)
+                .font(.system(size: 11, weight: .medium))
+        }
+        .foregroundColor(theme.color("fg"))
+        .padding(.horizontal, 8)
+        .frame(height: 22)
+        .background(theme.color("bg-3"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 5)
+                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+        .shadow(color: .black.opacity(0.18), radius: 8, y: 3)
+        .allowsHitTesting(false)
+        .accessibilityLabel(message)
+    }
+}
+
+struct CopyFeedbackOverlay: ViewModifier {
+    let message: String?
+
+    func body(content: Content) -> some View {
+        content.overlay(alignment: .topTrailing) {
+            if let message {
+                CopyFeedbackChip(message: message)
+                    .padding(.top, 5)
+                    .padding(.trailing, 8)
+                    .transition(.opacity.combined(with: .scale(scale: 0.96, anchor: .topTrailing)))
+            }
+        }
+        .animation(.easeOut(duration: 0.16), value: message)
+    }
+}
+
+extension View {
+    func copyFeedbackOverlay(message: String?) -> some View {
+        modifier(CopyFeedbackOverlay(message: message))
+    }
+}

--- a/Alas/Sources/UI/PointingHandCursor.swift
+++ b/Alas/Sources/UI/PointingHandCursor.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct PointingHandCursorModifier: ViewModifier {
+    @State private var cursorPushed = false
+
+    func body(content: Content) -> some View {
+        content
+            .onHover { hovering in
+                if hovering {
+                    pushCursor()
+                } else {
+                    popCursor()
+                }
+            }
+            .onDisappear {
+                popCursor()
+            }
+    }
+
+    private func pushCursor() {
+        guard !cursorPushed else { return }
+        NSCursor.pointingHand.push()
+        cursorPushed = true
+    }
+
+    private func popCursor() {
+        guard cursorPushed else { return }
+        NSCursor.pop()
+        cursorPushed = false
+    }
+}
+
+extension View {
+    func pointingHandCursor() -> some View {
+        modifier(PointingHandCursorModifier())
+    }
+}

--- a/AlasTests/CommitRowTests.swift
+++ b/AlasTests/CommitRowTests.swift
@@ -20,16 +20,20 @@ struct CommitRowTests {
         let pasteboard = NSPasteboard(name: .init("io.nlopez.alas.test-commit-copy"))
         pasteboard.clearContents()
 
-        func copySHA(_ commit: CommitInfo) {
-            let pb = NSPasteboard(name: .init("io.nlopez.alas.test-commit-copy"))
-            pb.clearContents()
-            pb.setString(commit.sha, forType: .string)
-        }
-
-        copySHA(commit)
+        Clipboard.copy(commit.sha, to: pasteboard)
 
         let copied = pasteboard.string(forType: .string)
         #expect(copied == "deadbeef1234567890abcdef1234567890abcdef")
+    }
+
+    @Test func copiesCommitDiffTitle() {
+        let pasteboard = NSPasteboard(name: .init("io.nlopez.alas.test-commit-diff-title-copy"))
+        pasteboard.clearContents()
+
+        Clipboard.copy("Sources/Center/Commit/CommitDiffView.swift", to: pasteboard)
+
+        let copied = pasteboard.string(forType: .string)
+        #expect(copied == "Sources/Center/Commit/CommitDiffView.swift")
     }
 
     @Test func commitInfoIdUsesSHA() {
@@ -47,5 +51,30 @@ struct CommitRowTests {
         )
 
         #expect(commit.id == "aabbccdd11223344556677889900aabbccdd1122")
+    }
+
+    @MainActor
+    @Test func copyFeedbackShowsThenDismisses() async throws {
+        let feedback = CopyFeedbackState(displayNanoseconds: 10_000_000)
+
+        feedback.show("Copied SHA")
+
+        #expect(feedback.message == "Copied SHA")
+        try await Task.sleep(nanoseconds: 30_000_000)
+        #expect(feedback.message == nil)
+    }
+
+    @MainActor
+    @Test func copyFeedbackRefreshKeepsLatestMessageVisible() async throws {
+        let feedback = CopyFeedbackState(displayNanoseconds: 50_000_000)
+
+        feedback.show("Copied SHA")
+        try await Task.sleep(nanoseconds: 20_000_000)
+        feedback.show("Copied title")
+        try await Task.sleep(nanoseconds: 35_000_000)
+
+        #expect(feedback.message == "Copied title")
+        try await Task.sleep(nanoseconds: 30_000_000)
+        #expect(feedback.message == nil)
     }
 }


### PR DESCRIPTION
## Summary
- show lightweight copy feedback after copying git SHAs
- make commit diff titles tappable to copy their text
- add focused clipboard and feedback timing coverage

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CommitRowTests test

Full suite was attempted previously but stalled in the test host process.