### PR TITLE
Fix initial focus for command overlays

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
 		AA39E8B6257A8134101CE924 /* TabDragWindowShield.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137299B5614B9AC983A27803 /* TabDragWindowShield.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
+		ABB5595A9A39C8AF203B5873 /* AppStateOverlayFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */; };
 		AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */; };
 		AC905947E88C7A2BE39D9B00 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		ACD22D2C262833B77006E8BE /* DeleteFailedWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */; };
@@ -623,6 +624,7 @@
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
 		65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstaller.swift; sourceTree = "<group>"; };
+		6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateOverlayFocusTests.swift; sourceTree = "<group>"; };
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherFilterTests.swift; sourceTree = "<group>"; };
 		679E62B501E0490F48CCA830 /* EditorFindBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindBarView.swift; sourceTree = "<group>"; };
@@ -941,6 +943,7 @@
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
 				08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */,
+				6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */,
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
@@ -2150,6 +2153,7 @@
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,
+				ABB5595A9A39C8AF203B5873 /* AppStateOverlayFocusTests.swift in Sources */,
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -36,7 +36,10 @@ struct AgentLauncherDialog: View {
             .transition(.opacity.combined(with: .offset(y: -6)))
             .onAppear {
                 appState.agentLauncher.reset()
-                inputFocused = true
+                requestInputFocus()
+            }
+            .onChange(of: appState.isAgentLauncherOpen) { _, isOpen in
+                if isOpen { requestInputFocus() }
             }
         }
     }
@@ -149,6 +152,16 @@ struct AgentLauncherDialog: View {
     private func close() {
         appState.agentLauncher.reset()
         appState.isAgentLauncherOpen = false
+    }
+
+    private func requestInputFocus() {
+        inputFocused = false
+        DispatchQueue.main.async {
+            inputFocused = true
+            DispatchQueue.main.async {
+                inputFocused = true
+            }
+        }
     }
 }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -42,6 +42,9 @@ final class AppState {
     var isSearchOpen: Bool = false
     var isRepoSelectorOpen: Bool = false
     var isAgentLauncherOpen: Bool = false
+    var isKeyboardOverlayOpen: Bool {
+        isSearchOpen || isRepoSelectorOpen || isAgentLauncherOpen
+    }
     let repoSelector = RepoSelectorModel()
     let agentLauncher = AgentLauncherModel()
 

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -186,7 +186,11 @@ struct RootView: View {
         )
         switch resolver.resolve() {
         case .worktree(let wt):
-            CenterPaneView(state: state, worktree: wt)
+            CenterPaneView(
+                state: state,
+                worktree: wt,
+                allowsPaneFocus: !state.isKeyboardOverlayOpen
+            )
         case .deleting(let wt):
             DeletingWorktreeView(worktree: wt)
         case .deleteFailed(let wt, let message):

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct CenterPaneView: View {
     @Bindable var state: AppState
     let worktree: Worktree
+    var allowsPaneFocus: Bool = true
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -70,7 +71,8 @@ struct CenterPaneView: View {
                     case .terminal:
                         TerminalTabView(state: state,
                                         worktreeId: worktree.id,
-                                        tabId: tab.id)
+                                        tabId: tab.id,
+                                        allowsPaneFocus: allowsPaneFocus)
                     case .editor(let s):
                         if MarkdownFileType.isMarkdown(relativePath: s.isExternal
                                                         ? (s.externalAbsolutePath ?? "")

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -5,6 +5,7 @@ struct TerminalTabView: View {
     @Bindable var state: AppState
     let worktreeId: String
     let tabId: TabID
+    var allowsPaneFocus: Bool = true
 
     @Environment(\.theme) var theme
 
@@ -18,6 +19,7 @@ struct TerminalTabView: View {
                     tabId: tabId,
                     node: tab.root,
                     focusedLeafId: tab.focusedLeafId,
+                    allowsPaneFocus: allowsPaneFocus,
                     inSplit: false
                 )
             } else {
@@ -49,6 +51,7 @@ private struct PaneNodeView: View {
     let tabId: TabID
     let node: PaneNode
     let focusedLeafId: String
+    let allowsPaneFocus: Bool
     let inSplit: Bool
 
     var body: some View {
@@ -59,7 +62,7 @@ private struct PaneNodeView: View {
                 worktreeId: worktreeId,
                 tabId: tabId,
                 leaf: leaf,
-                isFocused: leaf.id == focusedLeafId,
+                isFocused: leaf.id == focusedLeafId && allowsPaneFocus,
                 showFocusBorder: inSplit
             )
         case .split(let split):
@@ -68,7 +71,8 @@ private struct PaneNodeView: View {
                 worktreeId: worktreeId,
                 tabId: tabId,
                 split: split,
-                focusedLeafId: focusedLeafId
+                focusedLeafId: focusedLeafId,
+                allowsPaneFocus: allowsPaneFocus
             )
         }
     }
@@ -139,6 +143,7 @@ private struct SplitContainer: View {
     let tabId: TabID
     let split: PaneSplit
     let focusedLeafId: String
+    let allowsPaneFocus: Bool
 
     @Environment(\.theme) var theme
 
@@ -162,24 +167,28 @@ private struct SplitContainer: View {
         if split.axis == .vertical {
             HStack(spacing: 0) {
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
-                             node: split.children[0], focusedLeafId: focusedLeafId, inSplit: true)
+                             node: split.children[0], focusedLeafId: focusedLeafId,
+                             allowsPaneFocus: allowsPaneFocus, inSplit: true)
                     .frame(width: firstSize)
                     .clipped()
                 dividerView(totalForFraction: totalForFraction)
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
-                             node: split.children[1], focusedLeafId: focusedLeafId, inSplit: true)
+                             node: split.children[1], focusedLeafId: focusedLeafId,
+                             allowsPaneFocus: allowsPaneFocus, inSplit: true)
                     .frame(width: secondSize)
                     .clipped()
             }
         } else {
             VStack(spacing: 0) {
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
-                             node: split.children[0], focusedLeafId: focusedLeafId, inSplit: true)
+                             node: split.children[0], focusedLeafId: focusedLeafId,
+                             allowsPaneFocus: allowsPaneFocus, inSplit: true)
                     .frame(height: firstSize)
                     .clipped()
                 dividerView(totalForFraction: totalForFraction)
                 PaneNodeView(state: state, worktreeId: worktreeId, tabId: tabId,
-                             node: split.children[1], focusedLeafId: focusedLeafId, inSplit: true)
+                             node: split.children[1], focusedLeafId: focusedLeafId,
+                             allowsPaneFocus: allowsPaneFocus, inSplit: true)
                     .frame(height: secondSize)
                     .clipped()
             }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -38,7 +38,10 @@ struct RepoSelectorDialog: View {
             .transition(.opacity.combined(with: .offset(y: -6)))
             .onAppear {
                 appState.repoSelector.open()
-                inputFocused = true
+                requestInputFocus()
+            }
+            .onChange(of: appState.isRepoSelectorOpen) { _, isOpen in
+                if isOpen { requestInputFocus() }
             }
         }
     }
@@ -172,7 +175,7 @@ struct RepoSelectorDialog: View {
         case .focused, .openedNewWorktree, .openedNewProject:
             appState.isRepoSelectorOpen = false
         case .pushed:
-            inputFocused = true
+            requestInputFocus()
         case .noop:
             break
         }
@@ -180,12 +183,22 @@ struct RepoSelectorDialog: View {
 
     private func popToRepos() {
         appState.repoSelector.popToRepos()
-        inputFocused = true
+        requestInputFocus()
     }
 
     private func close() {
         appState.repoSelector.close()
         appState.isRepoSelectorOpen = false
+    }
+
+    private func requestInputFocus() {
+        inputFocused = false
+        DispatchQueue.main.async {
+            inputFocused = true
+            DispatchQueue.main.async {
+                inputFocused = true
+            }
+        }
     }
 
     // MARK: - Keys

--- a/Alas/Sources/Search/Views/FileSearchDialog.swift
+++ b/Alas/Sources/Search/Views/FileSearchDialog.swift
@@ -42,7 +42,10 @@ struct FileSearchDialog: View {
                 .onKeyPress { press in handleKey(press) }
             }
             .transition(.opacity.combined(with: .offset(y: -6)))
-            .onAppear { inputFocused = true }
+            .onAppear { requestInputFocus() }
+            .onChange(of: appState.isSearchOpen) { _, isOpen in
+                if isOpen { requestInputFocus() }
+            }
         }
     }
 
@@ -169,6 +172,16 @@ struct FileSearchDialog: View {
     private func close() {
         appState.search.close()
         appState.isSearchOpen = false
+    }
+
+    private func requestInputFocus() {
+        inputFocused = false
+        DispatchQueue.main.async {
+            inputFocused = true
+            DispatchQueue.main.async {
+                inputFocused = true
+            }
+        }
     }
 }
 

--- a/AlasTests/AppStateOverlayFocusTests.swift
+++ b/AlasTests/AppStateOverlayFocusTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct AppStateOverlayFocusTests {
+    @Test func keyboardOverlayFlagTracksSearchAndRepoSelector() {
+        let state = AppState()
+
+        #expect(!state.isKeyboardOverlayOpen)
+
+        state.openSearchOverlay()
+        #expect(state.isSearchOpen)
+        #expect(!state.isRepoSelectorOpen)
+        #expect(!state.isAgentLauncherOpen)
+        #expect(state.isKeyboardOverlayOpen)
+
+        state.toggleRepoSelectorOverlay()
+        #expect(!state.isSearchOpen)
+        #expect(state.isRepoSelectorOpen)
+        #expect(!state.isAgentLauncherOpen)
+        #expect(state.isKeyboardOverlayOpen)
+
+        state.toggleRepoSelectorOverlay()
+        #expect(!state.isSearchOpen)
+        #expect(!state.isRepoSelectorOpen)
+        #expect(!state.isAgentLauncherOpen)
+        #expect(!state.isKeyboardOverlayOpen)
+    }
+
+    @Test func agentLauncherOverlayAlsoBlocksPaneFocus() {
+        let state = AppState()
+
+        state.openSearchOverlay()
+        state.toggleAgentLauncherOverlay(canOpen: true)
+
+        #expect(!state.isSearchOpen)
+        #expect(!state.isRepoSelectorOpen)
+        #expect(state.isAgentLauncherOpen)
+        #expect(state.isKeyboardOverlayOpen)
+
+        state.toggleAgentLauncherOverlay(canOpen: true)
+
+        #expect(!state.isSearchOpen)
+        #expect(!state.isRepoSelectorOpen)
+        #expect(!state.isAgentLauncherOpen)
+        #expect(!state.isKeyboardOverlayOpen)
+    }
+}


### PR DESCRIPTION
## Summary
- defer initial overlay input focus for Cmd-K/Cmd-P keyboard overlays
- gate pane focus while keyboard overlays are open so typing reaches the overlay
- add state coverage for overlay focus gating

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/AppStateOverlayFocusTests

Full test suite hung twice with only the test host app running; focused overlay state tests pass.