### PR TITLE
Make commit errors expandable

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
 		2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */; };
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
+		2ED636DD3A179B95C061A9E6 /* InlineErrorStripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */; };
 		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
@@ -719,6 +720,7 @@
 		9DCC5576ACD7C49EB6915992 /* CommitComposerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerStateTests.swift; sourceTree = "<group>"; };
 		9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipe.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
+		A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStripTests.swift; sourceTree = "<group>"; };
 		A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTree.swift; sourceTree = "<group>"; };
 		A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabStateTests.swift; sourceTree = "<group>"; };
 		A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileTypeTests.swift; sourceTree = "<group>"; };
@@ -1011,6 +1013,7 @@
 				FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */,
 				A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */,
 				BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */,
+				A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */,
 				835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */,
 				EB52B59655B85764D85CFB7F /* LineEndingTests.swift */,
 				19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */,
@@ -2230,6 +2233,7 @@
 				E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */,
 				89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */,
 				CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */,
+				2ED636DD3A179B95C061A9E6 /* InlineErrorStripTests.swift in Sources */,
 				7A816022DD913BC76F5EBA7F /* InstallNudgeResolverTests.swift in Sources */,
 				D675E5B1E5E95E7239F3A89F /* InstallRecipeTests.swift in Sources */,
 				32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */,

--- a/Alas/Sources/Right/Commit/InlineErrorStrip.swift
+++ b/Alas/Sources/Right/Commit/InlineErrorStrip.swift
@@ -3,20 +3,25 @@ import SwiftUI
 struct InlineErrorStrip: View {
     let message: String
     let onDismiss: () -> Void
+    @State private var expanded: Bool
     @Environment(\.theme) var theme
 
+    init(message: String, onDismiss: @escaping () -> Void, initiallyExpanded: Bool = false) {
+        self.message = message
+        self.onDismiss = onDismiss
+        _expanded = State(initialValue: initiallyExpanded)
+    }
+
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(alignment: .top, spacing: 8) {
             Icon(name: "alert", size: 11, color: theme.color("del"))
-            Text(message)
-                .font(.system(size: 11.5, design: .monospaced))
-                .foregroundColor(theme.color("fg"))
-                .lineLimit(2)
-            Spacer()
+                .padding(.top, 2)
+            messageView
             Button(action: onDismiss) {
                 Icon(name: "x", size: 10, color: theme.color("fg-faint"))
             }
             .buttonStyle(.plain)
+            .help("Dismiss error")
         }
         .padding(.horizontal, 10).padding(.vertical, 6)
         .background(theme.color("del").opacity(0.10))
@@ -24,6 +29,34 @@ struct InlineErrorStrip: View {
             RoundedRectangle(cornerRadius: 4)
                 .stroke(theme.color("del").opacity(0.30), lineWidth: 0.5)
         )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            expanded = true
+        }
+        .help(expanded ? "Select and copy error text" : "Click to expand error")
         .padding(.horizontal, 12)
+    }
+
+    @ViewBuilder
+    private var messageView: some View {
+        if expanded {
+            ScrollView(.vertical) {
+                messageText
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.trailing, 2)
+            }
+            .frame(maxWidth: .infinity, maxHeight: 180, alignment: .leading)
+        } else {
+            messageText
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var messageText: some View {
+        Text(message)
+            .font(.system(size: 11.5, design: .monospaced))
+            .foregroundColor(theme.color("fg"))
+            .textSelection(.enabled)
     }
 }

--- a/AlasTests/InlineErrorStripTests.swift
+++ b/AlasTests/InlineErrorStripTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct InlineErrorStripTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test func compactErrorStripRendersLongMessageWithoutCrashing() {
+        let view = InlineErrorStrip(message: longErrorMessage, onDismiss: {})
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 420, height: 80)
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(controller.view != nil)
+    }
+
+    @Test func expandedErrorStripAllowsMoreVerticalSpaceForLongMessage() {
+        let compact = hostingHeight(for: InlineErrorStrip(
+            message: longErrorMessage,
+            onDismiss: {},
+            initiallyExpanded: false
+        ))
+        let expanded = hostingHeight(for: InlineErrorStrip(
+            message: longErrorMessage,
+            onDismiss: {},
+            initiallyExpanded: true
+        ))
+
+        #expect(expanded > compact)
+    }
+
+    private func hostingHeight(for view: InlineErrorStrip) -> CGFloat {
+        let themedView = view.environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: themedView)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 420, height: 400)
+        controller.view.layoutSubtreeIfNeeded()
+        return controller.view.fittingSize.height
+    }
+
+    private var longErrorMessage: String {
+        """
+        fatal: unable to create commit
+        error: gpg failed to sign the data
+        hint: run `git config --global user.signingkey` and verify the key is available
+        stderr: signing failed after the pinentry helper exited before returning a passphrase
+        """
+    }
+}


### PR DESCRIPTION
## Summary
- make commit/amend inline errors expandable on click
- make expanded error text selectable and scrollable
- add rendering coverage for the shared error strip

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- targeted InlineErrorStripTests and CommitComposerStateTests passed

Note: full xcodebuild test was attempted twice locally but hung in the test host with no progress output.