### PR TITLE
Add drag-and-drop reordering for sidebar projects

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
+		9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
 		9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
@@ -793,6 +794,7 @@
 		CA554728676F9D3B5E2C05FA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroup.swift; sourceTree = "<group>"; };
 		CB020862232495EC1C5ECBEA /* WindowAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearance.swift; sourceTree = "<group>"; };
+		CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerProjectOrderingTests.swift; sourceTree = "<group>"; };
 		CB2EB554CB6AF797545DB95D /* HeadReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReader.swift; sourceTree = "<group>"; };
 		CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPaneTests.swift; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -1035,6 +1037,7 @@
 				8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */,
 				00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */,
 				BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */,
+				CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */,
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
@@ -2265,6 +2268,7 @@
 				2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */,
 				4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */,
 				BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */,
+				9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -59,6 +59,25 @@ final class ProjectsManager {
         projects[idx].startupScripts = update.startupScripts
     }
 
+    func reorderProject(fromIndex: Int, toIndex: Int) {
+        guard projects.indices.contains(fromIndex),
+              projects.indices.contains(toIndex),
+              fromIndex != toIndex
+        else { return }
+
+        let moving = projects.remove(at: fromIndex)
+        let clampedDestination = min(toIndex, projects.count)
+        projects.insert(moving, at: clampedDestination)
+    }
+
+    func reorderProject(movingId: String, destinationId: String) {
+        guard let fromIndex = projects.firstIndex(where: { $0.id == movingId }),
+              let toIndex = projects.firstIndex(where: { $0.id == destinationId }),
+              fromIndex != toIndex
+        else { return }
+        reorderProject(fromIndex: fromIndex, toIndex: toIndex)
+    }
+
     func worktrees(projectId: String) -> [Worktree] {
         worktreesByProject[projectId] ?? []
     }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -1,4 +1,12 @@
 import SwiftUI
+import UniformTypeIdentifiers
+
+struct ProjectDragId: Codable, Transferable {
+    let id: String
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .json)
+    }
+}
 
 struct RepoGroupView: View {
     let project: ProjectConfig
@@ -23,6 +31,7 @@ struct RepoGroupView: View {
     let onRetryDelete: (Worktree) -> Void
     let onRemoveFailed: (Worktree) -> Void
     let onDropWorktree: (_ draggedId: String, _ destinationId: String) -> Void
+    let onDropProject: (_ draggedId: String, _ destinationId: String) -> Void
     @Environment(\.theme) var theme
     @State private var hovering = false
     @State private var plusHovering = false
@@ -89,6 +98,12 @@ struct RepoGroupView: View {
                 .padding(.trailing, 12)
             }
             .onHover { hovering = $0 }
+            .draggable(ProjectDragId(id: project.id))
+            .dropDestination(for: ProjectDragId.self) { items, _ in
+                guard let draggedId = items.first?.id, draggedId != project.id else { return false }
+                onDropProject(draggedId, project.id)
+                return true
+            }
             if !collapsed {
                 VStack(spacing: 1) {
                     ForEach(worktrees) { wt in

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -123,6 +123,13 @@ struct SidebarView: View {
                                         destinationId: destinationId
                                     )
                                     state.saveProjects()
+                                },
+                                onDropProject: { draggedId, destinationId in
+                                    state.projectsManager.reorderProject(
+                                        movingId: draggedId,
+                                        destinationId: destinationId
+                                    )
+                                    state.saveProjects()
                                 }
                             )
                         }

--- a/AlasTests/ProjectsManagerProjectOrderingTests.swift
+++ b/AlasTests/ProjectsManagerProjectOrderingTests.swift
@@ -1,0 +1,125 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct ProjectsManagerProjectOrderingTests {
+    private func makeProjects(_ names: [String]) -> [ProjectConfig] {
+        names.enumerated().map { index, name in
+            ProjectConfig(
+                id: name,
+                name: name,
+                path: "/repos/\(name)",
+                color: "blue",
+                addedAt: Date(timeIntervalSince1970: Double(index))
+            )
+        }
+    }
+
+    // MARK: - reorderProject(fromIndex:toIndex:)
+
+    @Test func reorderMovesProjectToNewPosition() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C"]))
+
+        mgr.reorderProject(fromIndex: 0, toIndex: 2)
+
+        #expect(mgr.projects.map(\.id) == ["B", "C", "A"])
+    }
+
+    @Test func reorderMovesProjectForward() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C", "D"]))
+
+        mgr.reorderProject(fromIndex: 3, toIndex: 1)
+
+        #expect(mgr.projects.map(\.id) == ["A", "D", "B", "C"])
+    }
+
+    @Test func reorderSameIndexIsNoOp() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C"]))
+
+        mgr.reorderProject(fromIndex: 1, toIndex: 1)
+
+        #expect(mgr.projects.map(\.id) == ["A", "B", "C"])
+    }
+
+    @Test func reorderOutOfBoundsFromIndexIsNoOp() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B"]))
+
+        mgr.reorderProject(fromIndex: 5, toIndex: 0)
+
+        #expect(mgr.projects.map(\.id) == ["A", "B"])
+    }
+
+    @Test func reorderOutOfBoundsToIndexIsNoOp() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B"]))
+
+        mgr.reorderProject(fromIndex: 0, toIndex: 5)
+
+        #expect(mgr.projects.map(\.id) == ["A", "B"])
+    }
+
+    @Test func reorderSwapsAdjacentProjects() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C"]))
+
+        mgr.reorderProject(fromIndex: 0, toIndex: 1)
+
+        #expect(mgr.projects.map(\.id) == ["B", "A", "C"])
+    }
+
+    // MARK: - reorderProject(movingId:destinationId:)
+
+    @Test func reorderByIdMovesToDestination() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C"]))
+
+        mgr.reorderProject(movingId: "C", destinationId: "A")
+
+        #expect(mgr.projects.map(\.id) == ["C", "A", "B"])
+    }
+
+    @Test func reorderByIdSameIdIsNoOp() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C"]))
+
+        mgr.reorderProject(movingId: "B", destinationId: "B")
+
+        #expect(mgr.projects.map(\.id) == ["A", "B", "C"])
+    }
+
+    @Test func reorderByIdUnknownIdIsNoOp() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B"]))
+
+        mgr.reorderProject(movingId: "Z", destinationId: "A")
+
+        #expect(mgr.projects.map(\.id) == ["A", "B"])
+    }
+
+    @Test func reorderByIdMovesLastToFirst() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C", "D"]))
+
+        mgr.reorderProject(movingId: "D", destinationId: "A")
+
+        #expect(mgr.projects.map(\.id) == ["D", "A", "B", "C"])
+    }
+
+    @Test func reorderByIdMovesFirstToLast() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C", "D"]))
+
+        mgr.reorderProject(movingId: "A", destinationId: "D")
+
+        #expect(mgr.projects.map(\.id) == ["B", "C", "D", "A"])
+    }
+
+    // MARK: - persistence roundtrip
+
+    @Test func projectOrderIsDeterminedByArrayPosition() {
+        let projects = makeProjects(["X", "Y", "Z"])
+        let file = ProjectsFile(projects: projects)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try! encoder.encode(file)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try! decoder.decode(ProjectsFile.self, from: data)
+        #expect(decoded.projects.map(\.id) == ["X", "Y", "Z"])
+    }
+}

--- a/AlasTests/RepoGroupViewLayoutTests.swift
+++ b/AlasTests/RepoGroupViewLayoutTests.swift
@@ -56,7 +56,8 @@ struct RepoGroupViewLayoutTests {
             onRetryCreate: { _ in },
             onRetryDelete: { _ in },
             onRemoveFailed: { _ in },
-            onDropWorktree: { _, _ in }
+            onDropWorktree: { _, _ in },
+            onDropProject: { _, _ in }
         )
         .environment(\.theme, try ThemeStore().current)
 


### PR DESCRIPTION
## Summary
- add project-level drag-and-drop reordering in the sidebar
- persist project order through the existing projects save path
- add focused project ordering and persistence tests

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test