### PR TITLE
Expand agent hook lifecycle support

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934BCC470703CF2DF2303357 /* SectionHeader.swift */; };
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
 		0407824F9DA8EEFC5B5EEA8A /* InstallerHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C506EF972D34E2F937D4FEEC /* InstallerHost.swift */; };
+		04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */; };
 		0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
@@ -175,6 +176,7 @@
 		5D2A45DB652AD797E2276A7A /* AgentRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7544FD20BC61E587CAFAC099 /* AgentRegistry.swift */; };
 		5D3E7C2D040B58D0C9D1C0E8 /* AlasButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C486F9097A2B145D101E2C /* AlasButton.swift */; };
 		5D8DF496FC722EE24F69A60A /* AgentHookSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */; };
+		5E687CE659E83EF3B71CA86F /* PiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */; };
 		5EA1AA5C8D9DE003BACE8291 /* AlasGhostty.Surface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */; };
 		5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE58EF9CF8EC461667D9430 /* AppConfig.swift */; };
 		5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */; };
@@ -595,6 +597,7 @@
 		45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigShortcutsCodingTests.swift; sourceTree = "<group>"; };
 		4575017544CD7603B3AB9069 /* GitEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilter.swift; sourceTree = "<group>"; };
 		45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModelTests.swift; sourceTree = "<group>"; };
+		4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstallerTests.swift; sourceTree = "<group>"; };
 		4865995B2D4B92166321201F /* CommitContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilder.swift; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
 		4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardPathsTests.swift; sourceTree = "<group>"; };
@@ -708,6 +711,7 @@
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
+		932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstaller.swift; sourceTree = "<group>"; };
 		932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsFeature.swift; sourceTree = "<group>"; };
 		9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSaveNormalizationTests.swift; sourceTree = "<group>"; };
 		934BCC470703CF2DF2303357 /* SectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeader.swift; sourceTree = "<group>"; };
@@ -1044,6 +1048,7 @@
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
 				856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */,
 				7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */,
+				4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */,
 				5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */,
 				E1FD24B10ED0B3D4280F15E8 /* ProjectConfigAgentOverrideTests.swift */,
 				5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */,
@@ -1511,6 +1516,7 @@
 				C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */,
 				2975A1465CA308E9766521F2 /* NotificationService.swift */,
 				CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */,
+				932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */,
 			);
 			path = Harness;
 			sourceTree = "<group>";
@@ -2071,6 +2077,7 @@
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
 				449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */,
 				671F28D6A18DD75EB912596B /* PersistenceStore.swift in Sources */,
+				5E687CE659E83EF3B71CA86F /* PiInstaller.swift in Sources */,
 				1B1A33B610D29116A1D08A74 /* PointingHandCursor.swift in Sources */,
 				C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */,
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
@@ -2283,6 +2290,7 @@
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,
 				11B4AA1D032F054C666DD7F4 /* PendingDiscardTests.swift in Sources */,
 				EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */,
+				04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
 				636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */,
 				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE8B45ECF898B83A616586D /* SubHeader.swift */; };
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
 		5426DC977050AACBCBDA37E9 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */; };
+		55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */; };
 		55C7881F382ACCEBCDB7D157 /* AgentsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */; };
 		5632CE3BB7220370D87A987B /* AgentLauncherModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */; };
 		5685074AFE30889AAC69EB8D /* ThreePaneLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */; };
@@ -240,6 +241,7 @@
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
 		87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
+		8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */; };
 		8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */; };
 		899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */; };
 		89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */; };
@@ -538,6 +540,7 @@
 		2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconTests.swift; sourceTree = "<group>"; };
 		2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficLights.swift; sourceTree = "<group>"; };
 		2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDiffView.swift; sourceTree = "<group>"; };
+		2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstallerTests.swift; sourceTree = "<group>"; };
 		2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstallerTests.swift; sourceTree = "<group>"; };
 		2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReaderTests.swift; sourceTree = "<group>"; };
 		30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorCoordinator.swift; sourceTree = "<group>"; };
@@ -880,6 +883,7 @@
 		FBFB85AF60C0E4520ED0DA8E /* AgentLauncherDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherDialog.swift; sourceTree = "<group>"; };
 		FC4A215AF2876091E31F6F8A /* LineEnding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEnding.swift; sourceTree = "<group>"; };
 		FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorView.swift; sourceTree = "<group>"; };
+		FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstaller.swift; sourceTree = "<group>"; };
 		FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipeTests.swift; sourceTree = "<group>"; };
 		FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceUpstreamTests.swift; sourceTree = "<group>"; };
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
@@ -999,6 +1003,7 @@
 				A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */,
 				B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */,
 				E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */,
+				2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */,
 				3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */,
 				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
 				6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */,
@@ -1491,6 +1496,7 @@
 				65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */,
 				01F0314E357190EF2A1F861B /* CodexInstaller.swift */,
 				7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */,
+				FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */,
 				F9F85B92952C963DCF136315 /* HarnessDetector.swift */,
 				76F2498E56CBAF84CB67166C /* HarnessKind.swift */,
 				155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */,
@@ -1991,6 +1997,7 @@
 				AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */,
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
+				55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,
 				41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */,
 				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,
@@ -2221,6 +2228,7 @@
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
+				8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */,
 				01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */,
 				D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */,
 				D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
 		3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E62B501E0490F48CCA830 /* EditorFindBarView.swift */; };
 		3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */; };
+		3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64C0B7363363C77718B446C /* CopilotInstaller.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
@@ -317,6 +318,7 @@
 		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
 		B614CD7F894DD6908C903254 /* InstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */; };
 		B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */; };
+		B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */; };
 		B6C31E7AC3CE21AFEA371389 /* cool-slate.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DEB85132B767DB3B253620C /* cool-slate.json */; };
 		B76AD708A9FD54304F84366A /* ImageFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3F942D660C7ABA8542C77D /* ImageFileType.swift */; };
 		B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */; };
@@ -750,6 +752,7 @@
 		A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailabilityTests.swift; sourceTree = "<group>"; };
 		A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunner.swift; sourceTree = "<group>"; };
 		A98D0A96093087BF4C284053 /* AlasSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasSlider.swift; sourceTree = "<group>"; };
+		AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstallerTests.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
@@ -825,6 +828,7 @@
 		D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilterTests.swift; sourceTree = "<group>"; };
 		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		D64C0B7363363C77718B446C /* CopilotInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstaller.swift; sourceTree = "<group>"; };
 		D6A9977C979705A40595FD5E /* TabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerTests.swift; sourceTree = "<group>"; };
 		D733701E36E13A7A23748A37 /* CommitComposerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerState.swift; sourceTree = "<group>"; };
 		D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailability.swift; sourceTree = "<group>"; };
@@ -992,6 +996,7 @@
 				A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */,
 				97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */,
 				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
+				AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */,
 				BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */,
 				179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */,
 				2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */,
@@ -1505,6 +1510,7 @@
 				57713D7143CFD53124E0523F /* AlasHookCommand.swift */,
 				65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */,
 				01F0314E357190EF2A1F861B /* CodexInstaller.swift */,
+				D64C0B7363363C77718B446C /* CopilotInstaller.swift */,
 				7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */,
 				FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */,
 				F9F85B92952C963DCF136315 /* HarnessDetector.swift */,
@@ -1976,6 +1982,7 @@
 				CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */,
 				A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */,
 				A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */,
+				3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */,
 				0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */,
 				2D313A7E99C93242DD35AA8E /* CursorInstaller.swift in Sources */,
 				49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */,
@@ -2221,6 +2228,7 @@
 				4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */,
 				5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
+				B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */,
 				42D8417781E790CA6AA49F7E /* CursorInstallerTests.swift in Sources */,
 				25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */,
 				7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */; };
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
 		1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */; };
+		1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */; };
 		1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */; };
 		21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */; };
 		214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98D0A96093087BF4C284053 /* AlasSlider.swift */; };
@@ -191,6 +192,7 @@
 		676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4261E417947C1A21E77C1587 /* GitStatusCache.swift */; };
 		67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */; };
 		6866301B0A6F1F7488819B98 /* LineEnding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4A215AF2876091E31F6F8A /* LineEnding.swift */; };
+		6A10E9DF8A052DBDFF477863 /* OpenCodeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */; };
 		6A386E5CF4C958D9F90DF692 /* InstallSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */; };
 		6A5B87FF631136E5246D0F38 /* AgentLauncherModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */; };
 		6A5D19016FE0100CD54D24B2 /* MarkdownImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */; };
@@ -529,6 +531,7 @@
 		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
 		27A92711BC1D9A78D8A80561 /* GitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypes.swift; sourceTree = "<group>"; };
 		27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitFilesListView.swift; sourceTree = "<group>"; };
+		292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstallerTests.swift; sourceTree = "<group>"; };
 		29313DDC46A0CCA2FA42CDE9 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
 		295319DB8544C170DDD6328D /* PathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsTests.swift; sourceTree = "<group>"; };
 		2975A1465CA308E9766521F2 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -806,6 +809,7 @@
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
+		CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstaller.swift; sourceTree = "<group>"; };
 		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
@@ -1035,6 +1039,7 @@
 				C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
 				0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */,
+				292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */,
 				16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */,
 				295319DB8544C170DDD6328D /* PathsTests.swift */,
 				856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */,
@@ -1505,6 +1510,7 @@
 				4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */,
 				C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */,
 				2975A1465CA308E9766521F2 /* NotificationService.swift */,
+				CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */,
 			);
 			path = Harness;
 			sourceTree = "<group>";
@@ -2060,6 +2066,7 @@
 				004A8BA5B9353F67AAA3AE83 /* NotificationService.swift in Sources */,
 				7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */,
 				74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */,
+				6A10E9DF8A052DBDFF477863 /* OpenCodeInstaller.swift in Sources */,
 				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
 				449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */,
@@ -2271,6 +2278,7 @@
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,
 				43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */,
+				1ECA2C8485DB484C5C687F3D /* OpenCodeInstallerTests.swift in Sources */,
 				CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */,
 				497D21A67A062CE6282008CD /* PathsTests.swift in Sources */,
 				11B4AA1D032F054C666DD7F4 /* PendingDiscardTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		C55B79DC0AAE96CFA14BE76F /* CommitFilesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */; };
 		C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDEA496740F5B0B5EE808B /* Process+Git.swift */; };
 		C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */; };
+		C7AACF777FF0DAD9ACA426F3 /* AgentLifecycleEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */; };
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
 		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
@@ -414,6 +415,7 @@
 		EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
+		EE02460865C6A4ED1046B13F /* AgentLifecycleEventMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */; };
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
 		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
@@ -499,6 +501,7 @@
 		17C2AC0F8B3A1B75239995AC /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		1841997CCBDB9611576B930C /* AlasToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasToggle.swift; sourceTree = "<group>"; };
 		1874031C788ADB4398151FF1 /* StageChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageChip.swift; sourceTree = "<group>"; };
+		18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapperTests.swift; sourceTree = "<group>"; };
 		18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookInstallNudgeBanner.swift; sourceTree = "<group>"; };
 		1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabFilterTests.swift; sourceTree = "<group>"; };
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
@@ -656,6 +659,7 @@
 		71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionStateResolverTests.swift; sourceTree = "<group>"; };
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
+		73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapper.swift; sourceTree = "<group>"; };
 		743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolver.swift; sourceTree = "<group>"; };
 		74D394D40BC9060833DD640A /* LSPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstaller.swift; sourceTree = "<group>"; };
 		7544FD20BC61E587CAFAC099 /* AgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistry.swift; sourceTree = "<group>"; };
@@ -928,6 +932,7 @@
 				FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */,
 				A78C23951DE157A38A9ED899 /* AgentHookSocketServerTests.swift */,
 				45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */,
+				18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */,
 				37987D5884297401F95478D3 /* AgentPathTests.swift */,
 				2C2381497E73D74C8C314928 /* AgentRegistryTests.swift */,
 				9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */,
@@ -1480,6 +1485,7 @@
 				976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */,
 				B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */,
 				53C792D59DBFFF6C28F2D426 /* AgentKind.swift */,
+				73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */,
 				BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */,
 				57713D7143CFD53124E0523F /* AlasHookCommand.swift */,
 				65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */,
@@ -1897,6 +1903,7 @@
 				763947308C99E2D3CB565889 /* AgentKind.swift in Sources */,
 				65095BDBA1E160D7DF4F2A65 /* AgentLauncherDialog.swift in Sources */,
 				6A5B87FF631136E5246D0F38 /* AgentLauncherModel.swift in Sources */,
+				C7AACF777FF0DAD9ACA426F3 /* AgentLifecycleEventMapper.swift in Sources */,
 				D6A8D3925ACCB69DAC380B95 /* AgentPath.swift in Sources */,
 				5D2A45DB652AD797E2276A7A /* AgentRegistry.swift in Sources */,
 				2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */,
@@ -2145,6 +2152,7 @@
 				F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */,
 				B0861243A465A06EDA290722 /* AgentHookSocketServerTests.swift in Sources */,
 				5632CE3BB7220370D87A987B /* AgentLauncherModelTests.swift in Sources */,
+				EE02460865C6A4ED1046B13F /* AgentLifecycleEventMapperTests.swift in Sources */,
 				48EFAD2DE1F112D72B5F9FAC /* AgentPathTests.swift in Sources */,
 				659B9DBE590DCF6C395C64B3 /* AgentRegistryTests.swift in Sources */,
 				D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */,

--- a/Alas/Sources/Agents/AgentBuiltins.swift
+++ b/Alas/Sources/Agents/AgentBuiltins.swift
@@ -95,6 +95,19 @@ enum AgentBuiltins {
             isEnabled: true,
             builtinLogoAssetName: "agent-gemini"
         ),
+        // Recorded from the Task 5 built-in catalog requirements (2026-05-20).
+        // -i is the prompt-mode arg; --allow-tool=write scopes write access.
+        AgentDefinition(
+            id: "copilot",
+            displayName: "Copilot",
+            binary: "copilot",
+            binaryOverride: nil,
+            promptModeArgs: ["-i"],
+            bypassPermissionsFlag: "--allow-tool=write",
+            isBuiltin: true,
+            isEnabled: true,
+            builtinLogoAssetName: "agent-copilot"
+        ),
     ]
 
     /// Look up a catalog entry by id; nil for unknown ids.

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -241,6 +241,8 @@ final class AppState {
     private let store: any PersistenceStoreProtocol
     @ObservationIgnored
     private let persistenceErrorHandler: (String, String) -> Void
+    @ObservationIgnored
+    private let fileActionErrorHandler: (String, String) -> Void
 
     /// One FSEvents watcher per project, watching `<repo>/.git` to auto-refresh
     /// the sidebar when branches flip or worktrees appear/disappear externally.
@@ -250,10 +252,14 @@ final class AppState {
     init(
         store: any PersistenceStoreProtocol = PersistenceStore(),
         persistenceErrorHandler: ((String, String) -> Void)? = nil,
+        fileActionErrorHandler: ((String, String) -> Void)? = nil,
         terminalSessionOpener: TerminalSessionOpener? = nil
     ) {
         self.store = store
         self.persistenceErrorHandler = persistenceErrorHandler ?? { title, message in
+            AppState.showWarningAlert(title: title, message: message)
+        }
+        self.fileActionErrorHandler = fileActionErrorHandler ?? { title, message in
             AppState.showWarningAlert(title: title, message: message)
         }
         self.terminalSessionOpener = terminalSessionOpener
@@ -537,6 +543,9 @@ final class AppState {
             throw AgentTerminalLaunchError.agentUnavailable
         }
         do {
+            if agent.id == AgentKind.copilot.rawValue {
+                try CopilotInstaller(projectRootURL: worktree.path).install()
+            }
             return try openTerminalTab(
                 for: worktree,
                 startupScriptSuffix: agentStartupCommand(for: agent, project: project)
@@ -1510,7 +1519,7 @@ final class AppState {
     }
 
     private func showFileActionError(title: String, message: String) {
-        Self.showWarningAlert(title: title, message: message)
+        fileActionErrorHandler(title, message)
     }
 
     private static func showWarningAlert(title: String, message: String) {

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -164,6 +164,7 @@ private struct TabButton: View {
         switch s {
         case .busy:          return theme.color("add")
         case .awaitingInput: return theme.color("mod")
+        case .permissionRequest: return theme.color("mod")
         case .idle:          return theme.color("fg-faint")
         }
     }

--- a/Alas/Sources/Harness/AgentHookEvent.swift
+++ b/Alas/Sources/Harness/AgentHookEvent.swift
@@ -4,12 +4,16 @@ import Foundation
 enum ActivityEvent: String, Sendable {
     case busy
     case awaitingInput = "awaiting_input"
+    case permissionRequest = "permission_request"
     case idle
+    case attached
+    case detached
 }
 
 enum ActivityState: String, Sendable, Equatable {
     case busy
     case awaitingInput = "awaiting_input"
+    case permissionRequest = "permission_request"
     case idle
 }
 
@@ -35,7 +39,7 @@ extension AgentHookEvent {
         guard let eventStr = json["event"] as? String else {
             throw AgentHookEventError.malformed("Missing 'event'")
         }
-        guard let event = ActivityEvent(rawValue: eventStr) else {
+        guard let event = AgentLifecycleEventMapper.map(eventStr) else {
             throw AgentHookEventError.unknownEvent(eventStr)
         }
         guard let agentStr = json["agent"] as? String else {

--- a/Alas/Sources/Harness/AgentHookSocketServer.swift
+++ b/Alas/Sources/Harness/AgentHookSocketServer.swift
@@ -258,7 +258,7 @@ extension AgentHookEvent {
     static func isUnknownEvent(_ data: Data) throws -> Bool {
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let eventStr = json["event"] as? String,
-              ActivityEvent(rawValue: eventStr) == nil else { return false }
+              AgentLifecycleEventMapper.map(eventStr) == nil else { return false }
         return true
     }
 }

--- a/Alas/Sources/Harness/AgentInstaller.swift
+++ b/Alas/Sources/Harness/AgentInstaller.swift
@@ -21,6 +21,7 @@ struct AgentInstallerRegistry: Sendable {
             ClaudeInstaller(),
             CodexInstaller(),
             CursorInstaller(),
+            GeminiInstaller(),
         ]
     }
 

--- a/Alas/Sources/Harness/AgentInstaller.swift
+++ b/Alas/Sources/Harness/AgentInstaller.swift
@@ -28,6 +28,10 @@ struct AgentInstallerRegistry: Sendable {
         self.installers = installers
     }
 
+    var supportedAgents: [AgentKind] {
+        installers.map(\.agent)
+    }
+
     func installer(for agent: AgentKind) -> (any AgentInstaller)? {
         installers.first { $0.agent == agent }
     }

--- a/Alas/Sources/Harness/AgentInstaller.swift
+++ b/Alas/Sources/Harness/AgentInstaller.swift
@@ -23,6 +23,7 @@ struct AgentInstallerRegistry: Sendable {
             CursorInstaller(),
             GeminiInstaller(),
             OpenCodeInstaller(),
+            PiInstaller(),
         ]
     }
 

--- a/Alas/Sources/Harness/AgentInstaller.swift
+++ b/Alas/Sources/Harness/AgentInstaller.swift
@@ -22,6 +22,7 @@ struct AgentInstallerRegistry: Sendable {
             CodexInstaller(),
             CursorInstaller(),
             GeminiInstaller(),
+            OpenCodeInstaller(),
         ]
     }
 

--- a/Alas/Sources/Harness/AgentKind.swift
+++ b/Alas/Sources/Harness/AgentKind.swift
@@ -5,6 +5,10 @@ enum AgentKind: String, CaseIterable, Sendable, Codable, Identifiable {
     case claude
     case codex
     case cursor
+    case gemini
+    case opencode
+    case pi
+    case copilot
 
     var id: String { rawValue }
 
@@ -13,6 +17,10 @@ enum AgentKind: String, CaseIterable, Sendable, Codable, Identifiable {
         case .claude: return "Claude Code"
         case .codex:  return "Codex"
         case .cursor: return "Cursor"
+        case .gemini: return "Gemini CLI"
+        case .opencode: return "opencode"
+        case .pi: return "Pi"
+        case .copilot: return "Copilot"
         }
     }
 }

--- a/Alas/Sources/Harness/AgentLifecycleEventMapper.swift
+++ b/Alas/Sources/Harness/AgentLifecycleEventMapper.swift
@@ -18,11 +18,12 @@ enum AgentLifecycleEventMapper {
              "AfterTool",
              "userPromptSubmitted",
              "postToolUse",
+             "preToolUse",
              "task_started":
             return .busy
         case "PermissionRequest",
+             "permissionRequest",
              "PreToolUse",
-             "preToolUse",
              "exec_approval_request",
              "apply_patch_approval_request",
              "request_user_input":

--- a/Alas/Sources/Harness/AgentLifecycleEventMapper.swift
+++ b/Alas/Sources/Harness/AgentLifecycleEventMapper.swift
@@ -18,6 +18,7 @@ enum AgentLifecycleEventMapper {
              "AfterTool",
              "userPromptSubmitted",
              "postToolUse",
+             "postToolUseFailure",
              "preToolUse",
              "task_started":
             return .busy

--- a/Alas/Sources/Harness/AgentLifecycleEventMapper.swift
+++ b/Alas/Sources/Harness/AgentLifecycleEventMapper.swift
@@ -30,6 +30,8 @@ enum AgentLifecycleEventMapper {
         case "Stop",
              "stop",
              "AfterAgent",
+             "agentStop",
+             "AgentStop",
              "task_complete",
              "agent-turn-complete":
             return .idle

--- a/Alas/Sources/Harness/AgentLifecycleEventMapper.swift
+++ b/Alas/Sources/Harness/AgentLifecycleEventMapper.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+enum AgentLifecycleEventMapper {
+    static func map(_ rawEvent: String) -> ActivityEvent? {
+        if let event = ActivityEvent(rawValue: rawEvent) {
+            return event
+        }
+
+        switch rawEvent {
+        case "SessionStart", "sessionStart", "session_start":
+            return .attached
+        case "SessionEnd", "sessionEnd", "session_end":
+            return .detached
+        case "UserPromptSubmit",
+             "PostToolUse",
+             "PostToolUseFailure",
+             "BeforeAgent",
+             "AfterTool",
+             "userPromptSubmitted",
+             "postToolUse",
+             "task_started":
+            return .busy
+        case "PermissionRequest",
+             "PreToolUse",
+             "preToolUse",
+             "exec_approval_request",
+             "apply_patch_approval_request",
+             "request_user_input":
+            return .permissionRequest
+        case "Stop",
+             "stop",
+             "AfterAgent",
+             "task_complete",
+             "agent-turn-complete":
+            return .idle
+        default:
+            return nil
+        }
+    }
+}

--- a/Alas/Sources/Harness/AlasHookCommand.swift
+++ b/Alas/Sources/Harness/AlasHookCommand.swift
@@ -13,12 +13,13 @@ enum AlasHookCommand {
     static func compositeCommand(
         events: [ActivityEvent],
         agent: AgentKind,
-        forwardStdinAsBody: Bool
+        forwardStdinAsBody: Bool,
+        stdoutResponse: String? = nil
     ) -> String {
         precondition(!events.isEmpty, "compositeCommand needs at least one event")
 
         if events.count == 1, !forwardStdinAsBody {
-            return managed(envelopePipeline(event: events[0], agent: agent))
+            return managed(envelopePipeline(event: events[0], agent: agent), stdoutResponse: stdoutResponse)
         }
 
         // When forwardStdinAsBody is true, the LAST event carries the body and
@@ -39,11 +40,19 @@ enum AlasHookCommand {
         if forwardStdinAsBody {
             steps.append(bodyEnvelopePipeline(event: events.last!, agent: agent))
         }
-        return managed("{ \(steps.joined(separator: "; ")); }")
+        return managed("{ \(steps.joined(separator: "; ")); }", stdoutResponse: stdoutResponse)
     }
 
-    private static func managed(_ pipeline: String) -> String {
-        "\(envCheck) && \(pipeline) >/dev/null 2>&1 || true \(ownershipSentinel)"
+    private static func managed(_ pipeline: String, stdoutResponse: String? = nil) -> String {
+        guard let stdoutResponse else {
+            return "\(envCheck) && \(pipeline) >/dev/null 2>&1 || true \(ownershipSentinel)"
+        }
+        let responseStep = #"printf '%s\n' \#(singleQuoted(stdoutResponse))"#
+        return "\(envCheck) && { \(responseStep); \(pipeline) >/dev/null 2>&1; } || true \(ownershipSentinel)"
+    }
+
+    private static func singleQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: #"'\''"#))'"
     }
 
     private static func envelopePipeline(event: ActivityEvent, agent: AgentKind) -> String {

--- a/Alas/Sources/Harness/AlasHookCommand.swift
+++ b/Alas/Sources/Harness/AlasHookCommand.swift
@@ -48,7 +48,7 @@ enum AlasHookCommand {
             return "\(envCheck) && \(pipeline) >/dev/null 2>&1 || true \(ownershipSentinel)"
         }
         let responseStep = #"printf '%s\n' \#(singleQuoted(stdoutResponse))"#
-        return "\(envCheck) && { \(responseStep); \(pipeline) >/dev/null 2>&1; } || true \(ownershipSentinel)"
+        return "{ \(responseStep); \(envCheck) && \(pipeline) >/dev/null 2>&1 || true; } \(ownershipSentinel)"
     }
 
     private static func singleQuoted(_ value: String) -> String {

--- a/Alas/Sources/Harness/ClaudeInstaller.swift
+++ b/Alas/Sources/Harness/ClaudeInstaller.swift
@@ -88,12 +88,12 @@ struct ClaudeInstaller: AgentInstaller, Sendable {
             "Notification": [hookGroup(command: Self.awaitingInputAndNotify, matcher: "permission_prompt|idle_prompt|elicitation_dialog")],
             // Stop fires when Claude finishes responding — the moment we want
             // to surface the "Claude finished" notification. Intentionally
-            // omit SessionEnd: it fires on /clear, /resume, logout, and
-            // session close (per Claude's hook docs), so sending idle there
-            // produces a false "finished" notification (and a duplicate
-            // after the last real Stop) for events that aren't actually
-            // response-completion. Process-exit teardown still happens
-            // naturally via HarnessService's detector clear.
+            // keep idle notification off SessionEnd: it fires on /clear,
+            // /resume, logout, and session close (per Claude's hook docs), so
+            // sending idle there produces a false "finished" notification
+            // (and a duplicate after the last real Stop) for events that
+            // aren't actually response-completion. The SessionEnd detached
+            // hook above still records lifecycle teardown.
             "Stop": [hookGroup(command: Self.idleAndNotify)],
         ]
     }

--- a/Alas/Sources/Harness/ClaudeInstaller.swift
+++ b/Alas/Sources/Harness/ClaudeInstaller.swift
@@ -81,11 +81,13 @@ struct ClaudeInstaller: AgentInstaller, Sendable {
             ],
             "PostToolUse": [hookGroup(command: Self.busy, matcher: "")],
             "PermissionRequest": [hookGroup(command: Self.permissionRequest)],
-            // Scope to input/permission-prompt notification types; an empty
+            // Scope to input notification types; an empty
             // matcher would fire on every Claude Notification (status updates,
             // background messages, etc.) and produce false "needs input"
             // notifications. Mirrors the filter the old wrapper script applied.
-            "Notification": [hookGroup(command: Self.awaitingInputAndNotify, matcher: "permission_prompt|idle_prompt|elicitation_dialog")],
+            // Permission prompts are handled by the dedicated PermissionRequest
+            // hook above so they do not double-emit awaiting-input state.
+            "Notification": [hookGroup(command: Self.awaitingInputAndNotify, matcher: "idle_prompt|elicitation_dialog")],
             // Stop fires when Claude finishes responding — the moment we want
             // to surface the "Claude finished" notification. Intentionally
             // keep idle notification off SessionEnd: it fires on /clear,

--- a/Alas/Sources/Harness/ClaudeInstaller.swift
+++ b/Alas/Sources/Harness/ClaudeInstaller.swift
@@ -63,15 +63,24 @@ struct ClaudeInstaller: AgentInstaller, Sendable {
         events: [.awaitingInput], agent: .claude, forwardStdinAsBody: true)
     private static let idleAndNotify = AlasHookCommand.compositeCommand(
         events: [.idle], agent: .claude, forwardStdinAsBody: true)
+    private static let attached = AlasHookCommand.compositeCommand(
+        events: [.attached], agent: .claude, forwardStdinAsBody: false)
+    private static let detached = AlasHookCommand.compositeCommand(
+        events: [.detached], agent: .claude, forwardStdinAsBody: false)
+    private static let permissionRequest = AlasHookCommand.compositeCommand(
+        events: [.permissionRequest], agent: .claude, forwardStdinAsBody: false)
 
     private func hooksByEvent() -> [String: [[String: Any]]] {
         [
+            "SessionStart": [hookGroup(command: Self.attached)],
+            "SessionEnd": [hookGroup(command: Self.detached)],
             "UserPromptSubmit": [hookGroup(command: Self.busy)],
             "PreToolUse": [
                 hookGroup(command: Self.busy, matcher: ""),
                 hookGroup(command: Self.awaitingInput, matcher: "AskUserQuestion|ExitPlanMode"),
             ],
             "PostToolUse": [hookGroup(command: Self.busy, matcher: "")],
+            "PermissionRequest": [hookGroup(command: Self.permissionRequest)],
             // Scope to input/permission-prompt notification types; an empty
             // matcher would fire on every Claude Notification (status updates,
             // background messages, etc.) and produce false "needs input"

--- a/Alas/Sources/Harness/CodexInstaller.swift
+++ b/Alas/Sources/Harness/CodexInstaller.swift
@@ -89,9 +89,15 @@ struct CodexInstaller: AgentInstaller, Sendable {
         events: [.busy], agent: .codex, forwardStdinAsBody: false)
     private static let idleAndNotify = AlasHookCommand.compositeCommand(
         events: [.idle], agent: .codex, forwardStdinAsBody: true)
+    private static let attached = AlasHookCommand.compositeCommand(
+        events: [.attached], agent: .codex, forwardStdinAsBody: false)
+    private static let detached = AlasHookCommand.compositeCommand(
+        events: [.detached], agent: .codex, forwardStdinAsBody: false)
 
     private func hooksByEvent() -> [String: [[String: Any]]] {
         [
+            "SessionStart": [flatEntry(command: Self.attached)],
+            "SessionEnd": [flatEntry(command: Self.detached)],
             "UserPromptSubmit": [flatEntry(command: Self.busy)],
             "Stop": [flatEntry(command: Self.idleAndNotify)],
         ]

--- a/Alas/Sources/Harness/CopilotInstaller.swift
+++ b/Alas/Sources/Harness/CopilotInstaller.swift
@@ -50,11 +50,13 @@ struct CopilotInstaller: Sendable {
                 "version": 1,
                 "alas_marker": managedMarker,
                 "hooks": [
+                    "agentStop": [entry(command: idle)],
+                    "permissionRequest": [entry(command: permissionCommand)],
                     "sessionStart": [entry(command: attached)],
                     "sessionEnd": [entry(command: detached)],
                     "userPromptSubmitted": [entry(command: busy)],
+                    "preToolUse": [entry(command: busy)],
                     "postToolUse": [entry(command: busy)],
-                    "preToolUse": [entry(command: permissionCommand)],
                 ],
             ],
             options: [.prettyPrinted, .sortedKeys]
@@ -70,17 +72,7 @@ struct CopilotInstaller: Sendable {
     }
 
     private func updateGitInfoExcludeIfPresent() throws {
-        let gitInfoURL = projectRootURL
-            .appendingPathComponent(".git", isDirectory: true)
-            .appendingPathComponent("info", isDirectory: true)
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: gitInfoURL.path, isDirectory: &isDirectory),
-              isDirectory.boolValue
-        else {
-            return
-        }
-
-        let excludeURL = gitInfoURL.appendingPathComponent("exclude", isDirectory: false)
+        guard let excludeURL = try resolveGitInfoExcludeURLIfPresent() else { return }
         let existing: String
         if FileManager.default.fileExists(atPath: excludeURL.path) {
             do {
@@ -100,7 +92,55 @@ struct CopilotInstaller: Sendable {
         }
         updated.append(Self.excludedHookPath)
         updated.append("\n")
+        try FileManager.default.createDirectory(
+            at: excludeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         try updated.write(to: excludeURL, atomically: true, encoding: .utf8)
+    }
+
+    private func resolveGitInfoExcludeURLIfPresent() throws -> URL? {
+        let dotGitURL = projectRootURL.appendingPathComponent(".git", isDirectory: false)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: dotGitURL.path, isDirectory: &isDirectory) else {
+            return nil
+        }
+        if isDirectory.boolValue {
+            let infoURL = dotGitURL.appendingPathComponent("info", isDirectory: true)
+            guard FileManager.default.fileExists(atPath: infoURL.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue
+            else {
+                return nil
+            }
+            return infoURL.appendingPathComponent("exclude", isDirectory: false)
+        }
+
+        let gitFile = try String(contentsOf: dotGitURL, encoding: .utf8)
+        guard let firstLine = gitFile.split(separator: "\n").first else { return nil }
+        let prefix = "gitdir:"
+        guard firstLine.lowercased().hasPrefix(prefix) else { return nil }
+        let rawGitDir = firstLine.dropFirst(prefix.count)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawGitDir.isEmpty else { return nil }
+
+        let gitDirURL: URL
+        if rawGitDir.hasPrefix("/") {
+            gitDirURL = URL(fileURLWithPath: rawGitDir, isDirectory: true)
+        } else {
+            gitDirURL = URL(
+                fileURLWithPath: (projectRootURL.path as NSString)
+                    .appendingPathComponent(rawGitDir),
+                isDirectory: true
+            ).standardizedFileURL
+        }
+        guard FileManager.default.fileExists(atPath: gitDirURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            return nil
+        }
+        return gitDirURL
+            .appendingPathComponent("info", isDirectory: true)
+            .appendingPathComponent("exclude", isDirectory: false)
     }
 
     private static let attached = AlasHookCommand.compositeCommand(
@@ -119,6 +159,13 @@ struct CopilotInstaller: Sendable {
 
     private static let busy = AlasHookCommand.compositeCommand(
         events: [.busy],
+        agent: .copilot,
+        forwardStdinAsBody: false,
+        stdoutResponse: "{}"
+    )
+
+    private static let idle = AlasHookCommand.compositeCommand(
+        events: [.idle],
         agent: .copilot,
         forwardStdinAsBody: false,
         stdoutResponse: "{}"

--- a/Alas/Sources/Harness/CopilotInstaller.swift
+++ b/Alas/Sources/Harness/CopilotInstaller.swift
@@ -32,7 +32,11 @@ struct CopilotInstaller: Sendable {
             withIntermediateDirectories: true
         )
         try Self.hookData().write(to: hookURL, options: .atomic)
-        try updateGitInfoExcludeIfPresent()
+        do {
+            try updateGitInfoExcludeIfPresent()
+        } catch {
+            // Git ignore metadata is best-effort; the hook install should still succeed.
+        }
     }
 
     private func validateProjectRoot() throws {
@@ -78,7 +82,7 @@ struct CopilotInstaller: Sendable {
             do {
                 existing = try String(contentsOf: excludeURL, encoding: .utf8)
             } catch {
-                throw CopilotInstallerError.excludeUnreadable(excludeURL.path)
+                return
             }
         } else {
             existing = ""
@@ -202,15 +206,12 @@ struct CopilotInstaller: Sendable {
 
 enum CopilotInstallerError: Error, LocalizedError, Equatable {
     case invalidProjectRoot(String)
-    case excludeUnreadable(String)
     case unmanagedHookExists(String)
 
     var errorDescription: String? {
         switch self {
         case .invalidProjectRoot(let path):
             return "Copilot hooks can only be installed in an existing project directory. Missing or invalid path: \(path)."
-        case .excludeUnreadable(let path):
-            return "Could not read the Git exclude file at \(path). The Copilot hook was not added to it."
         case .unmanagedHookExists(let path):
             return "An unmanaged Copilot hook already exists at \(path). Remove it before installing the Alas hook."
         }

--- a/Alas/Sources/Harness/CopilotInstaller.swift
+++ b/Alas/Sources/Harness/CopilotInstaller.swift
@@ -61,6 +61,7 @@ struct CopilotInstaller: Sendable {
                     "userPromptSubmitted": [entry(command: busy)],
                     "preToolUse": [entry(command: busy)],
                     "postToolUse": [entry(command: busy)],
+                    "postToolUseFailure": [entry(command: busy)],
                 ],
             ],
             options: [.prettyPrinted, .sortedKeys]

--- a/Alas/Sources/Harness/CopilotInstaller.swift
+++ b/Alas/Sources/Harness/CopilotInstaller.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+struct CopilotInstaller: Sendable {
+    let projectRootURL: URL
+
+    private static let managedMarker = "alas-managed-copilot-hook-v1"
+    private static let excludedHookPath = ".github/hooks/alas-notify.json"
+
+    private var hookURL: URL {
+        projectRootURL
+            .appendingPathComponent(".github", isDirectory: true)
+            .appendingPathComponent("hooks", isDirectory: true)
+            .appendingPathComponent("alas-notify.json", isDirectory: false)
+    }
+
+    init(projectRootURL: URL) {
+        self.projectRootURL = projectRootURL
+    }
+
+    func install() throws {
+        try validateProjectRoot()
+
+        if FileManager.default.fileExists(atPath: hookURL.path) {
+            let contents = (try? String(contentsOf: hookURL, encoding: .utf8)) ?? ""
+            guard contents.contains(Self.managedMarker) else {
+                throw CopilotInstallerError.unmanagedHookExists(hookURL.path)
+            }
+        }
+
+        try FileManager.default.createDirectory(
+            at: hookURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Self.hookData().write(to: hookURL, options: .atomic)
+        try updateGitInfoExcludeIfPresent()
+    }
+
+    private func validateProjectRoot() throws {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: projectRootURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            throw CopilotInstallerError.invalidProjectRoot(projectRootURL.path)
+        }
+    }
+
+    private static func hookData() throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: [
+                "version": 1,
+                "alas_marker": managedMarker,
+                "hooks": [
+                    "sessionStart": [entry(command: attached)],
+                    "sessionEnd": [entry(command: detached)],
+                    "userPromptSubmitted": [entry(command: busy)],
+                    "postToolUse": [entry(command: busy)],
+                    "preToolUse": [entry(command: permissionCommand)],
+                ],
+            ],
+            options: [.prettyPrinted, .sortedKeys]
+        )
+    }
+
+    private static func entry(command: String) -> [String: Any] {
+        [
+            "type": "command",
+            "bash": command,
+            "timeoutSec": 5,
+        ]
+    }
+
+    private func updateGitInfoExcludeIfPresent() throws {
+        let gitInfoURL = projectRootURL
+            .appendingPathComponent(".git", isDirectory: true)
+            .appendingPathComponent("info", isDirectory: true)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: gitInfoURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            return
+        }
+
+        let excludeURL = gitInfoURL.appendingPathComponent("exclude", isDirectory: false)
+        let existing: String
+        if FileManager.default.fileExists(atPath: excludeURL.path) {
+            do {
+                existing = try String(contentsOf: excludeURL, encoding: .utf8)
+            } catch {
+                throw CopilotInstallerError.excludeUnreadable(excludeURL.path)
+            }
+        } else {
+            existing = ""
+        }
+        let lines = existing.split(separator: "\n", omittingEmptySubsequences: false)
+        guard !lines.contains(Substring(Self.excludedHookPath)) else { return }
+
+        var updated = existing
+        if !updated.isEmpty, !updated.hasSuffix("\n") {
+            updated.append("\n")
+        }
+        updated.append(Self.excludedHookPath)
+        updated.append("\n")
+        try updated.write(to: excludeURL, atomically: true, encoding: .utf8)
+    }
+
+    private static let attached = AlasHookCommand.compositeCommand(
+        events: [.attached],
+        agent: .copilot,
+        forwardStdinAsBody: false,
+        stdoutResponse: "{}"
+    )
+
+    private static let detached = AlasHookCommand.compositeCommand(
+        events: [.detached],
+        agent: .copilot,
+        forwardStdinAsBody: false,
+        stdoutResponse: "{}"
+    )
+
+    private static let busy = AlasHookCommand.compositeCommand(
+        events: [.busy],
+        agent: .copilot,
+        forwardStdinAsBody: false,
+        stdoutResponse: "{}"
+    )
+
+    private static let permissionCommand = AlasHookCommand.compositeCommand(
+        events: [.permissionRequest],
+        agent: .copilot,
+        forwardStdinAsBody: false,
+        stdoutResponse: "{}"
+    )
+}
+
+enum CopilotInstallerError: Error, LocalizedError, Equatable {
+    case invalidProjectRoot(String)
+    case excludeUnreadable(String)
+    case unmanagedHookExists(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidProjectRoot(let path):
+            return "Copilot hooks can only be installed in an existing project directory. Missing or invalid path: \(path)."
+        case .excludeUnreadable(let path):
+            return "Could not read the Git exclude file at \(path). The Copilot hook was not added to it."
+        case .unmanagedHookExists(let path):
+            return "An unmanaged Copilot hook already exists at \(path). Remove it before installing the Alas hook."
+        }
+    }
+}

--- a/Alas/Sources/Harness/CopilotInstaller.swift
+++ b/Alas/Sources/Harness/CopilotInstaller.swift
@@ -138,9 +138,30 @@ struct CopilotInstaller: Sendable {
         else {
             return nil
         }
-        return gitDirURL
+
+        let commonDirURL = try resolveCommonGitDirURL(from: gitDirURL) ?? gitDirURL
+        return commonDirURL
             .appendingPathComponent("info", isDirectory: true)
             .appendingPathComponent("exclude", isDirectory: false)
+    }
+
+    private func resolveCommonGitDirURL(from gitDirURL: URL) throws -> URL? {
+        let commonDirFileURL = gitDirURL.appendingPathComponent("commondir", isDirectory: false)
+        guard FileManager.default.fileExists(atPath: commonDirFileURL.path) else { return nil }
+
+        let commonDirFile = try String(contentsOf: commonDirFileURL, encoding: .utf8)
+        guard let firstLine = commonDirFile.split(separator: "\n").first else { return nil }
+        let rawCommonDir = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawCommonDir.isEmpty else { return nil }
+
+        if rawCommonDir.hasPrefix("/") {
+            return URL(fileURLWithPath: rawCommonDir, isDirectory: true)
+        }
+        return URL(
+            fileURLWithPath: (gitDirURL.path as NSString)
+                .appendingPathComponent(rawCommonDir),
+            isDirectory: true
+        ).standardizedFileURL
     }
 
     private static let attached = AlasHookCommand.compositeCommand(

--- a/Alas/Sources/Harness/CursorInstaller.swift
+++ b/Alas/Sources/Harness/CursorInstaller.swift
@@ -64,10 +64,24 @@ struct CursorInstaller: AgentInstaller, Sendable {
         events: [.awaitingInput], agent: .cursor, forwardStdinAsBody: true)
     private static let idleAndNotify = AlasHookCommand.compositeCommand(
         events: [.idle], agent: .cursor, forwardStdinAsBody: true)
+    private static let attached = AlasHookCommand.compositeCommand(
+        events: [.attached], agent: .cursor, forwardStdinAsBody: false)
+    private static let detached = AlasHookCommand.compositeCommand(
+        events: [.detached], agent: .cursor, forwardStdinAsBody: false)
+    private static let permissionRequestAndContinue = AlasHookCommand.compositeCommand(
+        events: [.permissionRequest],
+        agent: .cursor,
+        forwardStdinAsBody: false,
+        stdoutResponse: #"{"continue":true}"#
+    )
 
     private func hooksByEvent() -> [String: [[String: Any]]] {
         [
+            "sessionStart": [flatEntry(command: Self.attached)],
+            "sessionEnd": [flatEntry(command: Self.detached)],
             "beforeSubmitPrompt": [flatEntry(command: Self.busy)],
+            "beforeShellExecution": [flatEntry(command: Self.permissionRequestAndContinue)],
+            "beforeMCPExecution": [flatEntry(command: Self.permissionRequestAndContinue)],
             "afterAgentResponse": [flatEntry(command: Self.awaitingInputAndNotify)],
             "stop": [flatEntry(command: Self.idleAndNotify)],
         ]

--- a/Alas/Sources/Harness/GeminiInstaller.swift
+++ b/Alas/Sources/Harness/GeminiInstaller.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+struct GeminiInstaller: AgentInstaller, Sendable {
+    let agent = AgentKind.gemini
+    let settingsURL: URL
+
+    init(
+        homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        settingsURL: URL? = nil
+    ) {
+        self.settingsURL = settingsURL ?? homeDirectoryURL
+            .appendingPathComponent(".gemini", isDirectory: true)
+            .appendingPathComponent("settings.json", isDirectory: false)
+    }
+
+    func installState() -> InstallState {
+        let canonical = canonicalPlacementsByEvent()
+        guard !canonical.isEmpty else { return .notInstalled }
+        do {
+            let json = try JSONHookSettingsFile.load(at: settingsURL)
+            let hooks = json["hooks"] as? [String: Any] ?? [:]
+            let actual = managedPlacementsByEvent(in: hooks)
+            if actual.values.allSatisfy(\.isEmpty) { return .notInstalled }
+            return actual == canonical ? .installed : .outdated
+        } catch {
+            return .notInstalled
+        }
+    }
+
+    func install() async throws {
+        var json = try JSONHookSettingsFile.load(at: settingsURL)
+        let existing = json["hooks"] as? [String: Any] ?? [:]
+        var hooks = JSONHookSettingsFile.pruneManaged(from: existing)
+        for (event, entries) in hooksByEvent() {
+            var current = hooks[event] as? [[String: Any]] ?? []
+            current.append(contentsOf: entries)
+            hooks[event] = current
+        }
+        json["hooks"] = hooks
+        try JSONHookSettingsFile.write(json, to: settingsURL)
+    }
+
+    func uninstall() throws {
+        var json = try JSONHookSettingsFile.load(at: settingsURL)
+        let existing = json["hooks"] as? [String: Any] ?? [:]
+        json["hooks"] = JSONHookSettingsFile.pruneManaged(from: existing)
+        try JSONHookSettingsFile.write(json, to: settingsURL)
+    }
+
+    private static let attached = AlasHookCommand.compositeCommand(
+        events: [.attached], agent: .gemini, forwardStdinAsBody: false, stdoutResponse: "{}")
+    private static let detached = AlasHookCommand.compositeCommand(
+        events: [.detached], agent: .gemini, forwardStdinAsBody: false, stdoutResponse: "{}")
+    private static let busy = AlasHookCommand.compositeCommand(
+        events: [.busy], agent: .gemini, forwardStdinAsBody: false, stdoutResponse: "{}")
+    private static let idleAndNotify = AlasHookCommand.compositeCommand(
+        events: [.idle], agent: .gemini, forwardStdinAsBody: true, stdoutResponse: "{}")
+
+    private func hooksByEvent() -> [String: [[String: Any]]] {
+        [
+            "SessionStart": [hookGroup(command: Self.attached)],
+            "SessionEnd": [hookGroup(command: Self.detached)],
+            "BeforeAgent": [hookGroup(command: Self.busy)],
+            "AfterTool": [hookGroup(command: Self.busy)],
+            "AfterAgent": [hookGroup(command: Self.idleAndNotify)],
+        ]
+    }
+
+    private func hookGroup(command: String, timeout: Int = 10) -> [String: Any] {
+        [
+            "hooks": [["type": "command", "command": command, "timeout": timeout]]
+        ]
+    }
+
+    private struct Placement: Hashable {
+        let command: String
+    }
+
+    private func canonicalPlacementsByEvent() -> [String: Set<Placement>] {
+        var result: [String: Set<Placement>] = [:]
+        for (event, groups) in hooksByEvent() {
+            var placements = Set<Placement>()
+            for group in groups {
+                for hook in (group["hooks"] as? [[String: Any]]) ?? [] {
+                    if let cmd = hook["command"] as? String {
+                        placements.insert(Placement(command: cmd))
+                    }
+                }
+            }
+            result[event] = placements
+        }
+        return result
+    }
+
+    private func managedPlacementsByEvent(in hooks: [String: Any]) -> [String: Set<Placement>] {
+        var result: [String: Set<Placement>] = [:]
+        for event in canonicalPlacementsByEvent().keys { result[event] = [] }
+        for (event, value) in hooks {
+            guard let groups = value as? [[String: Any]] else { continue }
+            var placements = Set<Placement>()
+            for group in groups {
+                for hook in (group["hooks"] as? [[String: Any]]) ?? [] {
+                    if let cmd = hook["command"] as? String,
+                       AlasHookCommand.isManagedCommand(cmd)
+                    {
+                        placements.insert(Placement(command: cmd))
+                    }
+                }
+            }
+            if placements.isEmpty { continue }
+            result[event, default: []].formUnion(placements)
+        }
+        return result
+    }
+}

--- a/Alas/Sources/Harness/HarnessDetector.swift
+++ b/Alas/Sources/Harness/HarnessDetector.swift
@@ -44,7 +44,7 @@ final class HarnessDetector {
     static func matchKind(processName: String) -> HarnessKind? {
         for kind in HarnessKind.allCases {
             for name in kind.processNames {
-                if processName == name || processName.hasPrefix(name + "-") {
+                if processName == name || (name.count > 2 && processName.hasPrefix(name + "-")) {
                     return kind
                 }
             }

--- a/Alas/Sources/Harness/HarnessKind.swift
+++ b/Alas/Sources/Harness/HarnessKind.swift
@@ -4,6 +4,10 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable {
     case claudeCode = "claude-code"
     case codex      = "codex-cli"
     case cursor     = "cursor-agent"
+    case gemini     = "gemini"
+    case opencode   = "opencode"
+    case pi         = "pi"
+    case copilot    = "copilot"
 
     var id: String { rawValue }
 
@@ -12,6 +16,10 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable {
         case .claudeCode: return "Claude Code"
         case .codex:      return "Codex"
         case .cursor:     return "Cursor"
+        case .gemini:     return "Gemini CLI"
+        case .opencode:   return "opencode"
+        case .pi:         return "Pi"
+        case .copilot:    return "Copilot"
         }
     }
 
@@ -20,6 +28,10 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable {
         case .claudeCode: return ["claude"]
         case .codex:      return ["codex"]
         case .cursor:     return ["cursor-agent"]
+        case .gemini:     return ["gemini"]
+        case .opencode:   return ["opencode"]
+        case .pi:         return ["pi"]
+        case .copilot:    return ["copilot"]
         }
     }
 
@@ -31,6 +43,10 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable {
         case .claudeCode: return .claude
         case .codex:      return .codex
         case .cursor:     return .cursor
+        case .gemini:     return .gemini
+        case .opencode:   return .opencode
+        case .pi:         return .pi
+        case .copilot:    return .copilot
         }
     }
 }
@@ -38,9 +54,13 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable {
 extension AgentKind {
     var asHarnessKind: HarnessKind {
         switch self {
-        case .claude: return .claudeCode
-        case .codex:  return .codex
-        case .cursor: return .cursor
+        case .claude:   return .claudeCode
+        case .codex:    return .codex
+        case .cursor:   return .cursor
+        case .gemini:   return .gemini
+        case .opencode: return .opencode
+        case .pi:       return .pi
+        case .copilot:  return .copilot
         }
     }
 }

--- a/Alas/Sources/Harness/HarnessKind.swift
+++ b/Alas/Sources/Harness/HarnessKind.swift
@@ -34,3 +34,13 @@ enum HarnessKind: String, Codable, CaseIterable, Identifiable {
         }
     }
 }
+
+extension AgentKind {
+    var asHarnessKind: HarnessKind {
+        switch self {
+        case .claude: return .claudeCode
+        case .codex:  return .codex
+        case .cursor: return .cursor
+        }
+    }
+}

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -136,7 +136,7 @@ final class HarnessService {
             )
             if previousState != .permissionRequest, shouldNotifyOnAwaiting(),
                let lookup = stateLookup(event.sessionId) {
-                notifications.notifyHarnessAwaiting(
+                notifications.notifyHarnessPermission(
                     agent: event.agent, body: event.body,
                     projectId: lookup.projectId, worktreeId: lookup.worktreeId,
                     sessionId: event.sessionId

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -94,7 +94,7 @@ final class HarnessService {
         let previousState = activityBySession[event.sessionId]?.state
 
         switch event.event {
-        case .busy:
+        case .attached, .busy:
             // Cancel any pending cursor-idle debounce — work is actually ongoing.
             if event.agent == .cursor {
                 cursorIdleDebouncers.removeValue(forKey: event.sessionId)?.cancel()
@@ -116,6 +116,25 @@ final class HarnessService {
                 lastBody: event.body, updatedAt: Date()
             )
             if previousState != .awaitingInput, shouldNotifyOnAwaiting(),
+               let lookup = stateLookup(event.sessionId) {
+                notifications.notifyHarnessAwaiting(
+                    agent: event.agent, body: event.body,
+                    projectId: lookup.projectId, worktreeId: lookup.worktreeId,
+                    sessionId: event.sessionId
+                )
+            }
+
+        case .permissionRequest:
+            // Cancel pending cursor-idle debounce; permission requests are a real state change.
+            if event.agent == .cursor {
+                cursorIdleDebouncers.removeValue(forKey: event.sessionId)?.cancel()
+                pendingCursorIdleEvents.removeValue(forKey: event.sessionId)
+            }
+            activityBySession[event.sessionId] = HarnessActivityState(
+                agent: event.agent, state: .permissionRequest, pid: event.pid,
+                lastBody: event.body, updatedAt: Date()
+            )
+            if previousState != .permissionRequest, shouldNotifyOnAwaiting(),
                let lookup = stateLookup(event.sessionId) {
                 notifications.notifyHarnessAwaiting(
                     agent: event.agent, body: event.body,
@@ -150,6 +169,11 @@ final class HarnessService {
             } else {
                 commitIdle(event: event, stateLookup: stateLookup)
             }
+
+        case .detached:
+            cursorIdleDebouncers.removeValue(forKey: event.sessionId)?.cancel()
+            pendingCursorIdleEvents.removeValue(forKey: event.sessionId)
+            activityBySession.removeValue(forKey: event.sessionId)
         }
     }
 
@@ -204,7 +228,7 @@ final class HarnessService {
         for id in ids {
             guard let activity = activityBySession[id] else { continue }
             switch activity.state {
-            case .awaitingInput: awaitingIds.append(id)
+            case .awaitingInput, .permissionRequest: awaitingIds.append(id)
             case .busy:          runningIds.append(id)
             case .idle:          break
             }

--- a/Alas/Sources/Harness/NotificationService.swift
+++ b/Alas/Sources/Harness/NotificationService.swift
@@ -54,6 +54,21 @@ final class NotificationService {
         notificationAdder(req)
     }
 
+    func notifyHarnessPermission(agent: AgentKind, body: String?,
+                                 projectId: String, worktreeId: String, sessionId: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "\(agent.displayName) needs permission"
+        content.body = body ?? "Session is waiting for you."
+        content.sound = .default
+        content.userInfo = [
+            "projectId": projectId,
+            "worktreeId": worktreeId,
+            "sessionId": sessionId
+        ]
+        let req = UNNotificationRequest(identifier: "\(sessionId)-permission", content: content, trigger: nil)
+        notificationAdder(req)
+    }
+
     func notifyHarnessFinished(agent: AgentKind, body: String?,
                                projectId: String, worktreeId: String, sessionId: String) {
         guard enabled else { return }

--- a/Alas/Sources/Harness/OpenCodeInstaller.swift
+++ b/Alas/Sources/Harness/OpenCodeInstaller.swift
@@ -124,6 +124,10 @@ struct OpenCodeInstaller: AgentInstaller, Sendable {
               if (status === "idle") notify("idle", sessionIdFrom(event));
               return;
             }
+            if (type === "session.idle" && !isChildSession(event)) {
+              notify("idle", sessionIdFrom(event));
+              return;
+            }
             if (type === "session.error" && !isChildSession(event)) {
               notify("idle", sessionIdFrom(event));
               return;

--- a/Alas/Sources/Harness/OpenCodeInstaller.swift
+++ b/Alas/Sources/Harness/OpenCodeInstaller.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+struct OpenCodeInstaller: AgentInstaller, Sendable {
+    let agent = AgentKind.opencode
+    let pluginURL: URL
+
+    private static let managedMarker = "alas-managed-opencode-hook"
+
+    init(
+        homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        pluginURL: URL? = nil
+    ) {
+        self.pluginURL = pluginURL ?? homeDirectoryURL
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("opencode", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent("alas-notify.js", isDirectory: false)
+    }
+
+    func installState() -> InstallState {
+        guard FileManager.default.fileExists(atPath: pluginURL.path) else { return .notInstalled }
+        guard let contents = try? String(contentsOf: pluginURL, encoding: .utf8) else { return .outdated }
+        return contents.contains(Self.managedMarker) ? .installed : .outdated
+    }
+
+    func install() async throws {
+        if FileManager.default.fileExists(atPath: pluginURL.path) {
+            let contents = (try? String(contentsOf: pluginURL, encoding: .utf8)) ?? ""
+            guard contents.contains(Self.managedMarker) else {
+                throw OpenCodeInstallerError.unmanagedPluginExists(pluginURL.path)
+            }
+        }
+        try FileManager.default.createDirectory(
+            at: pluginURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Self.pluginContent.write(to: pluginURL, atomically: true, encoding: .utf8)
+    }
+
+    func uninstall() throws {
+        guard FileManager.default.fileExists(atPath: pluginURL.path),
+              let contents = try? String(contentsOf: pluginURL, encoding: .utf8),
+              contents.contains(Self.managedMarker)
+        else {
+            return
+        }
+        try FileManager.default.removeItem(at: pluginURL)
+    }
+
+    private static let pluginContent = #"""
+    // alas-managed-opencode-hook
+    import * as childProcess from "node:child_process";
+
+    function envelope(event, sessionId) {
+      return JSON.stringify({
+        v: 1,
+        event,
+        agent: "opencode",
+        session_id: sessionId || process.env.ALAS_SESSION_ID || "opencode",
+        pid: Number(process.ppid || 0)
+      });
+    }
+
+    function sessionIdFrom(event) {
+      return event?.properties?.info?.id || event?.properties?.sessionID || event?.sessionID || event?.id || process?.env?.ALAS_SESSION_ID;
+    }
+
+    function isChildSession(event) {
+      return Boolean(event?.properties?.info?.parentID || event?.properties?.parentID || event?.parentID);
+    }
+
+    function statusTypeFrom(event) {
+      return event?.properties?.status?.type || event?.properties?.info?.status?.type || event?.status?.type || event?.status;
+    }
+
+    function permissionPayloadFrom(event) {
+      return event?.properties?.permission || event?.properties?.input || event?.properties?.output || event?.properties || event;
+    }
+
+    function notify(event, sessionId) {
+      try {
+        if (typeof process === "undefined" || !process.env || !process.env.ALAS_SOCKET_PATH) return;
+        const nc = childProcess.spawn("/usr/bin/nc", ["-U", "-w1", process.env.ALAS_SOCKET_PATH], {
+          stdio: ["pipe", "ignore", "ignore"]
+        });
+        nc.on("error", () => {});
+        nc.stdin.on("error", () => {});
+        nc.stdin.end(envelope(event, sessionId) + "\n");
+      } catch (_) {}
+    }
+
+    function permissionPayloadStatus(payload) {
+      if (!payload) return undefined;
+      return payload.status || payload.type || payload.state || payload.action || payload.permission?.status || payload.input?.status || payload.output?.status;
+    }
+
+    function permissionSessionId(event, payload) {
+      return payload?.sessionID || payload?.session_id || payload?.properties?.sessionID || payload?.properties?.info?.id || sessionIdFrom(event);
+    }
+
+    function shouldNotifyPermissionRequest(payload) {
+      const status = permissionPayloadStatus(payload);
+      if (!status) return true;
+      if (status === "ask" || status === "asked") return true;
+      return status !== "approved" && status !== "deny" && status !== "denied" && status !== "rejected" && status !== "cancelled" && status !== "canceled" && status !== "responded" && status !== "replied";
+    }
+
+    export const AlasNotifyPlugin = async () => {
+      return {
+        event: async ({ event }) => {
+          try {
+            const type = event?.type;
+            if (type === "session.created" && !isChildSession(event)) {
+              notify("attached", sessionIdFrom(event));
+              return;
+            }
+            if (type === "session.deleted" && !isChildSession(event)) {
+              notify("detached", sessionIdFrom(event));
+              return;
+            }
+            if (type === "session.status" && !isChildSession(event)) {
+              const status = statusTypeFrom(event);
+              if (status === "busy") notify("busy", sessionIdFrom(event));
+              if (status === "idle") notify("idle", sessionIdFrom(event));
+              return;
+            }
+            if (type === "session.error" && !isChildSession(event)) {
+              notify("idle", sessionIdFrom(event));
+              return;
+            }
+            if (type === "permission.asked") {
+              const payload = permissionPayloadFrom(event);
+              if (shouldNotifyPermissionRequest(payload)) {
+                notify("permission_request", permissionSessionId(event, payload));
+              }
+            }
+          } catch (_) {}
+        }
+      };
+    };
+    """#
+}
+
+enum OpenCodeInstallerError: Error, LocalizedError {
+    case unmanagedPluginExists(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unmanagedPluginExists(let path):
+            return "An unmanaged OpenCode plugin already exists at \(path). Remove it before installing the Alas hook plugin."
+        }
+    }
+}

--- a/Alas/Sources/Harness/PiInstaller.swift
+++ b/Alas/Sources/Harness/PiInstaller.swift
@@ -59,7 +59,7 @@ struct PiInstaller: AgentInstaller, Sendable {
       before_agent_start: "busy",
       tool_execution_end: "busy",
       agent_end: "idle",
-      session_shutdown: "idle"
+      session_shutdown: "detached"
     };
 
     function envValue(name: string): string | undefined {

--- a/Alas/Sources/Harness/PiInstaller.swift
+++ b/Alas/Sources/Harness/PiInstaller.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+struct PiInstaller: AgentInstaller, Sendable {
+    let agent = AgentKind.pi
+    let extensionURL: URL
+
+    private static let managedMarker = "alas-managed-pi-hook"
+
+    init(
+        homeDirectoryURL: URL = FileManager.default.homeDirectoryForCurrentUser,
+        extensionURL: URL? = nil
+    ) {
+        self.extensionURL = extensionURL ?? homeDirectoryURL
+            .appendingPathComponent(".pi", isDirectory: true)
+            .appendingPathComponent("agent", isDirectory: true)
+            .appendingPathComponent("extensions", isDirectory: true)
+            .appendingPathComponent("alas-notify.ts", isDirectory: false)
+    }
+
+    func installState() -> InstallState {
+        guard FileManager.default.fileExists(atPath: extensionURL.path) else { return .notInstalled }
+        guard let contents = try? String(contentsOf: extensionURL, encoding: .utf8) else { return .outdated }
+        return contents.contains(Self.managedMarker) ? .installed : .outdated
+    }
+
+    func install() async throws {
+        if FileManager.default.fileExists(atPath: extensionURL.path) {
+            let contents = (try? String(contentsOf: extensionURL, encoding: .utf8)) ?? ""
+            guard contents.contains(Self.managedMarker) else {
+                throw PiInstallerError.unmanagedExtensionExists(extensionURL.path)
+            }
+        }
+        try FileManager.default.createDirectory(
+            at: extensionURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Self.extensionContent.write(to: extensionURL, atomically: true, encoding: .utf8)
+    }
+
+    func uninstall() throws {
+        guard FileManager.default.fileExists(atPath: extensionURL.path),
+              let contents = try? String(contentsOf: extensionURL, encoding: .utf8),
+              contents.contains(Self.managedMarker)
+        else {
+            return
+        }
+        try FileManager.default.removeItem(at: extensionURL)
+    }
+
+    private static let extensionContent = #"""
+    // alas-managed-pi-hook
+    import * as childProcess from "node:child_process";
+
+    declare const process: any;
+
+    const eventMap: Record<string, string> = {
+      session_start: "attached",
+      session_end: "detached",
+      before_agent_start: "busy",
+      tool_execution_end: "busy",
+      agent_end: "idle",
+      session_shutdown: "idle"
+    };
+
+    function envValue(name: string): string | undefined {
+      try {
+        if (typeof process !== "undefined" && process?.env) return process.env[name];
+      } catch (_) {}
+      return undefined;
+    }
+
+    function sessionIdFrom(event: any, ctx: any): string {
+      return ctx?.session_id || ctx?.sessionId || ctx?.session?.id || event?.session_id || event?.sessionId || event?.session?.id || envValue("ALAS_SESSION_ID") || "pi";
+    }
+
+    function parentPid(): number {
+      try {
+        if (typeof process !== "undefined") return Number(process.ppid || process.pid || 0);
+      } catch (_) {}
+      return 0;
+    }
+
+    function envelope(eventName: string, event: any, ctx: any): string {
+      return JSON.stringify({
+        v: 1,
+        agent: "pi",
+        event: eventName,
+        session_id: sessionIdFrom(event, ctx),
+        pid: parentPid()
+      });
+    }
+
+    function notify(eventName: string, event: any, ctx: any): void {
+      try {
+        if (ctx && ctx.hasUI === false) return;
+        const socketPath = envValue("ALAS_SOCKET_PATH");
+        if (!socketPath) return;
+        const mappedEvent = eventMap[eventName];
+        if (!mappedEvent) return;
+        const child = childProcess.spawn("/usr/bin/nc", ["-U", "-w1", socketPath], {
+          stdio: ["pipe", "ignore", "ignore"]
+        });
+        const body = envelope(mappedEvent, event, ctx) + "\n";
+        try {
+          if (child?.stdin?.end) {
+            child.on?.("error", () => {});
+            child.stdin.on?.("error", () => {});
+            child.stdin.end(body);
+            return;
+          }
+        } catch (_) {}
+      } catch (_) {}
+    }
+
+    function register(pi: any, eventName: string): void {
+      try {
+        pi?.on?.(eventName, async (event: any, ctx: any) => {
+          try {
+            notify(eventName, event, ctx);
+          } catch (_) {}
+        });
+      } catch (_) {}
+    }
+
+    export default function (pi) {
+      try {
+        pi.on("session_start", async (event: any, ctx: any) => {
+          try {
+            notify("session_start", event, ctx);
+          } catch (_) {}
+        });
+        pi.on("session_end", async (event: any, ctx: any) => {
+          try {
+            notify("session_end", event, ctx);
+          } catch (_) {}
+        });
+        pi.on("before_agent_start", async (event: any, ctx: any) => {
+          try {
+            notify("before_agent_start", event, ctx);
+          } catch (_) {}
+        });
+        pi.on("tool_execution_end", async (event: any, ctx: any) => {
+          try {
+            notify("tool_execution_end", event, ctx);
+          } catch (_) {}
+        });
+        pi.on("agent_end", async (event: any, ctx: any) => {
+          try {
+            notify("agent_end", event, ctx);
+          } catch (_) {}
+        });
+        pi.on("session_shutdown", async (event: any, ctx: any) => {
+          try {
+            notify("session_shutdown", event, ctx);
+          } catch (_) {}
+        });
+      } catch (_) {
+        try {
+          register(pi, "session_start");
+          register(pi, "session_end");
+          register(pi, "before_agent_start");
+          register(pi, "tool_execution_end");
+          register(pi, "agent_end");
+          register(pi, "session_shutdown");
+        } catch (_) {}
+      }
+    }
+    """#
+}
+
+enum PiInstallerError: Error, LocalizedError {
+    case unmanagedExtensionExists(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unmanagedExtensionExists(let path):
+            return "An unmanaged Pi extension already exists at \(path). Remove it before installing the Alas hook extension."
+        }
+    }
+}

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -113,7 +113,7 @@ struct TerminalPane: View {
                                 desc: "Show a clickable notification when a detected harness is waiting for input.") {
                         AlasToggle(on: state.bind(\.harness.notifyOnAwaiting))
                     }
-                    ForEach(AgentKind.allCases) { agent in
+                    ForEach(installerRegistry.supportedAgents) { agent in
                         SettingsRow(name: agent.displayName) {
                             HStack {
                                 let state = installerRegistry.installer(for: agent)?.installState() ?? .notInstalled

--- a/AlasTests/AgentBuiltinsTests.swift
+++ b/AlasTests/AgentBuiltinsTests.swift
@@ -2,9 +2,9 @@ import Testing
 @testable import Alas
 
 struct AgentBuiltinsTests {
-    @Test func catalogHasExactlySixEntriesInDeterministicOrder() {
+    @Test func catalogHasExactlySevenEntriesInDeterministicOrder() {
         let ids = AgentBuiltins.catalog.map(\.id)
-        #expect(ids == ["claude", "codex", "cursor-agent", "pi", "opencode", "gemini"])
+        #expect(ids == ["claude", "codex", "cursor-agent", "pi", "opencode", "gemini", "copilot"])
     }
 
     @Test func everyEntryIsMarkedBuiltin() {
@@ -39,6 +39,18 @@ struct AgentBuiltinsTests {
     @Test func entryLookupReturnsCorrectEntryForKnownId() {
         let e = AgentBuiltins.entry(id: "gemini")
         #expect(e?.displayName == "Gemini CLI")
+    }
+
+    @Test func copilotBuiltinMatchesRequiredDefinition() {
+        let e = AgentBuiltins.entry(id: "copilot")
+        #expect(e?.displayName == "Copilot")
+        #expect(e?.binary == "copilot")
+        #expect(e?.binaryOverride == nil)
+        #expect(e?.promptModeArgs == ["-i"])
+        #expect(e?.bypassPermissionsFlag == "--allow-tool=write")
+        #expect(e?.isBuiltin == true)
+        #expect(e?.isEnabled == true)
+        #expect(e?.builtinLogoAssetName == "agent-copilot")
     }
 
     @Test func entryLookupReturnsNilForUnknownId() {

--- a/AlasTests/AgentHookSocketServerTests.swift
+++ b/AlasTests/AgentHookSocketServerTests.swift
@@ -57,6 +57,22 @@ struct AgentHookSocketServerTests {
         #expect(received?.sessionId == "s1")
     }
 
+    @Test func aliasEnvelope_dispatchesMappedEvent() async throws {
+        let (dir, cleanup) = tmpSocketDir()
+        defer { cleanup() }
+        let path = "\(dir)/test.sock"
+        let server = AgentHookSocketServer(socketPath: path)
+        defer { server.shutdown() }
+
+        let json = #"{"v":1,"event":"SessionStart","agent":"claude","session_id":"s1","pid":123}"#
+        let (response, received) = try await awaitEvent(on: server, timeoutMs: 2000) {
+            try sendToSocket(path: path, payload: json)
+        }
+
+        #expect(response.contains("\"ok\":true") || response.contains("\"ok\": true"))
+        #expect(received?.event == .attached)
+    }
+
     @Test func malformedJSON_returnsError() async throws {
         let (dir, cleanup) = tmpSocketDir()
         defer { cleanup() }

--- a/AlasTests/AgentLifecycleEventMapperTests.swift
+++ b/AlasTests/AgentLifecycleEventMapperTests.swift
@@ -19,6 +19,7 @@ struct AgentLifecycleEventMapperTests {
     @Test func cursorAndSupersetStyleEvents_mapToLifecycleEvents() {
         #expect(AgentLifecycleEventMapper.map("userPromptSubmitted") == .busy)
         #expect(AgentLifecycleEventMapper.map("postToolUse") == .busy)
+        #expect(AgentLifecycleEventMapper.map("agentStop") == .idle)
         #expect(AgentLifecycleEventMapper.map("task_started") == .busy)
         #expect(AgentLifecycleEventMapper.map("task_complete") == .idle)
     }

--- a/AlasTests/AgentLifecycleEventMapperTests.swift
+++ b/AlasTests/AgentLifecycleEventMapperTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import Alas
+
+struct AgentLifecycleEventMapperTests {
+    @Test func claudeStyleEvents_mapToLifecycleEvents() {
+        #expect(AgentLifecycleEventMapper.map("SessionStart") == .attached)
+        #expect(AgentLifecycleEventMapper.map("SessionEnd") == .detached)
+        #expect(AgentLifecycleEventMapper.map("PermissionRequest") == .permissionRequest)
+        #expect(AgentLifecycleEventMapper.map("PreToolUse") == .permissionRequest)
+    }
+
+    @Test func codexStyleEvents_mapToLifecycleEvents() {
+        #expect(AgentLifecycleEventMapper.map("exec_approval_request") == .permissionRequest)
+        #expect(AgentLifecycleEventMapper.map("apply_patch_approval_request") == .permissionRequest)
+        #expect(AgentLifecycleEventMapper.map("request_user_input") == .permissionRequest)
+        #expect(AgentLifecycleEventMapper.map("agent-turn-complete") == .idle)
+    }
+
+    @Test func cursorAndSupersetStyleEvents_mapToLifecycleEvents() {
+        #expect(AgentLifecycleEventMapper.map("userPromptSubmitted") == .busy)
+        #expect(AgentLifecycleEventMapper.map("postToolUse") == .busy)
+        #expect(AgentLifecycleEventMapper.map("task_started") == .busy)
+        #expect(AgentLifecycleEventMapper.map("task_complete") == .idle)
+    }
+
+    @Test func normalizedEvents_mapToThemselves() {
+        #expect(AgentLifecycleEventMapper.map("busy") == .busy)
+        #expect(AgentLifecycleEventMapper.map("awaiting_input") == .awaitingInput)
+        #expect(AgentLifecycleEventMapper.map("permission_request") == .permissionRequest)
+        #expect(AgentLifecycleEventMapper.map("idle") == .idle)
+        #expect(AgentLifecycleEventMapper.map("attached") == .attached)
+        #expect(AgentLifecycleEventMapper.map("detached") == .detached)
+    }
+
+    @Test func unknownEvent_returnsNil() {
+        #expect(AgentLifecycleEventMapper.map("future_event") == nil)
+    }
+}

--- a/AlasTests/AgentLifecycleEventMapperTests.swift
+++ b/AlasTests/AgentLifecycleEventMapperTests.swift
@@ -18,7 +18,9 @@ struct AgentLifecycleEventMapperTests {
 
     @Test func cursorAndSupersetStyleEvents_mapToLifecycleEvents() {
         #expect(AgentLifecycleEventMapper.map("userPromptSubmitted") == .busy)
+        #expect(AgentLifecycleEventMapper.map("preToolUse") == .busy)
         #expect(AgentLifecycleEventMapper.map("postToolUse") == .busy)
+        #expect(AgentLifecycleEventMapper.map("permissionRequest") == .permissionRequest)
         #expect(AgentLifecycleEventMapper.map("agentStop") == .idle)
         #expect(AgentLifecycleEventMapper.map("task_started") == .busy)
         #expect(AgentLifecycleEventMapper.map("task_complete") == .idle)

--- a/AlasTests/AgentLifecycleEventMapperTests.swift
+++ b/AlasTests/AgentLifecycleEventMapperTests.swift
@@ -20,6 +20,7 @@ struct AgentLifecycleEventMapperTests {
         #expect(AgentLifecycleEventMapper.map("userPromptSubmitted") == .busy)
         #expect(AgentLifecycleEventMapper.map("preToolUse") == .busy)
         #expect(AgentLifecycleEventMapper.map("postToolUse") == .busy)
+        #expect(AgentLifecycleEventMapper.map("postToolUseFailure") == .busy)
         #expect(AgentLifecycleEventMapper.map("permissionRequest") == .permissionRequest)
         #expect(AgentLifecycleEventMapper.map("agentStop") == .idle)
         #expect(AgentLifecycleEventMapper.map("task_started") == .busy)

--- a/AlasTests/AgentRegistryTests.swift
+++ b/AlasTests/AgentRegistryTests.swift
@@ -2,6 +2,14 @@ import Testing
 @testable import Alas
 
 struct AgentRegistryTests {
+    private struct StubInstaller: AgentInstaller {
+        let agent: AgentKind
+
+        func installState() -> InstallState { .notInstalled }
+        func install() async throws {}
+        func uninstall() throws {}
+    }
+
     @Test func defaultRegistryEnumeratesBuiltinsInCatalogOrder() {
         let r = AgentRegistry(
             builtinState: [:],
@@ -48,7 +56,7 @@ struct AgentRegistryTests {
         let r = AgentRegistry(builtinState: [:], customs: [custom], installedIds: [])
         let ids = r.agents.map(\.id)
         #expect(ids.last == "custom-uuid")
-        #expect(ids.count == 7)
+        #expect(ids.count == 8)
     }
 
     @Test func installedFiltersToDetectedAgentsAcrossBuiltinsAndCustoms() {
@@ -153,5 +161,20 @@ struct AgentRegistryTests {
         )
         #expect(r.agents.first(where: { $0.id == "c-installed" })!.isEnabled == true)
         #expect(r.agents.first(where: { $0.id == "c-missing"   })!.isEnabled == false)
+    }
+
+    @Test func defaultInstallerRegistryExposesOnlyAgentsWithInstallers() {
+        let registry = AgentInstallerRegistry()
+
+        #expect(registry.supportedAgents == [.claude, .codex, .cursor])
+    }
+
+    @Test func supportedInstallerAgentsFollowsRegisteredInstallers() {
+        let registry = AgentInstallerRegistry(installers: [
+            StubInstaller(agent: .gemini),
+            StubInstaller(agent: .opencode),
+        ])
+
+        #expect(registry.supportedAgents == [.gemini, .opencode])
     }
 }

--- a/AlasTests/AgentRegistryTests.swift
+++ b/AlasTests/AgentRegistryTests.swift
@@ -166,7 +166,7 @@ struct AgentRegistryTests {
     @Test func defaultInstallerRegistryExposesOnlyAgentsWithInstallers() {
         let registry = AgentInstallerRegistry()
 
-        #expect(registry.supportedAgents == [.claude, .codex, .cursor, .gemini, .opencode])
+        #expect(registry.supportedAgents == [.claude, .codex, .cursor, .gemini, .opencode, .pi])
     }
 
     @Test func supportedInstallerAgentsFollowsRegisteredInstallers() {

--- a/AlasTests/AgentRegistryTests.swift
+++ b/AlasTests/AgentRegistryTests.swift
@@ -166,7 +166,7 @@ struct AgentRegistryTests {
     @Test func defaultInstallerRegistryExposesOnlyAgentsWithInstallers() {
         let registry = AgentInstallerRegistry()
 
-        #expect(registry.supportedAgents == [.claude, .codex, .cursor, .gemini])
+        #expect(registry.supportedAgents == [.claude, .codex, .cursor, .gemini, .opencode])
     }
 
     @Test func supportedInstallerAgentsFollowsRegisteredInstallers() {

--- a/AlasTests/AgentRegistryTests.swift
+++ b/AlasTests/AgentRegistryTests.swift
@@ -166,7 +166,7 @@ struct AgentRegistryTests {
     @Test func defaultInstallerRegistryExposesOnlyAgentsWithInstallers() {
         let registry = AgentInstallerRegistry()
 
-        #expect(registry.supportedAgents == [.claude, .codex, .cursor])
+        #expect(registry.supportedAgents == [.claude, .codex, .cursor, .gemini])
     }
 
     @Test func supportedInstallerAgentsFollowsRegisteredInstallers() {

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -31,6 +31,19 @@ struct AgentTerminalLaunchTests {
         return project
     }
 
+    private func tmpDir() -> (dir: URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (dir, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    private func copilotHookURL(in root: URL) -> URL {
+        root
+            .appendingPathComponent(".github", isDirectory: true)
+            .appendingPathComponent("hooks", isDirectory: true)
+            .appendingPathComponent("alas-notify.json", isDirectory: false)
+    }
+
     private struct MemoryStore: PersistenceStoreProtocol {
         func write<T: Encodable>(_: T, to _: URL) throws {}
         func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
@@ -164,5 +177,120 @@ struct AgentTerminalLaunchTests {
         } else {
             Issue.record("Expected a terminal tab")
         }
+    }
+
+    @Test func launchingCopilotInstallsHookBeforeOpeningTerminal() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        var project = project(mode: .useGlobal, useBypass: false)
+        project.path = dir.path
+        let worktree = Worktree(
+            id: "wt",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: dir,
+            status: .clean,
+            lastActivity: Date()
+        )
+        let hookURL = copilotHookURL(in: dir)
+        var hookExistedBeforeOpen = false
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, _ in
+                hookExistedBeforeOpen = FileManager.default.fileExists(atPath: hookURL.path)
+                return AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
+            }
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        state.agentRegistry = AgentRegistry(
+            builtinState: [:],
+            customs: [],
+            installedIds: ["copilot"]
+        )
+
+        _ = try state.openAgentTerminalTab(for: worktree, agentId: "copilot")
+
+        #expect(hookExistedBeforeOpen)
+        #expect(FileManager.default.fileExists(atPath: hookURL.path))
+    }
+
+    @Test func launchingNonCopilotDoesNotCreateCopilotHook() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        var project = project(mode: .useGlobal, useBypass: false)
+        project.path = dir.path
+        let worktree = Worktree(
+            id: "wt",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: dir,
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, _ in
+                AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
+            }
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        state.agentRegistry = AgentRegistry(
+            builtinState: [:],
+            customs: [agent()],
+            installedIds: ["test-agent"]
+        )
+
+        _ = try state.openAgentTerminalTab(for: worktree, agentId: "test-agent")
+
+        #expect(!FileManager.default.fileExists(atPath: copilotHookURL(in: dir).path))
+    }
+
+    @Test func launchingCopilotWithUnmanagedHookDoesNotOpenTerminal() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        var project = project(mode: .useGlobal, useBypass: false)
+        project.path = dir.path
+        let worktree = Worktree(
+            id: "wt",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: dir,
+            status: .clean,
+            lastActivity: Date()
+        )
+        let hookURL = copilotHookURL(in: dir)
+        try FileManager.default.createDirectory(
+            at: hookURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try #"{"version":1,"hooks":{}}"#.write(to: hookURL, atomically: true, encoding: .utf8)
+        var openerCalled = false
+        var launchErrorTitle: String?
+        let state = AppState(
+            store: MemoryStore(),
+            fileActionErrorHandler: { title, _ in
+                launchErrorTitle = title
+            },
+            terminalSessionOpener: { _, _, _, _, _, _ in
+                openerCalled = true
+                return AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
+            }
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+        state.agentRegistry = AgentRegistry(
+            builtinState: [:],
+            customs: [],
+            installedIds: ["copilot"]
+        )
+
+        #expect(throws: CopilotInstallerError.self) {
+            _ = try state.openAgentTerminalTab(for: worktree, agentId: "copilot")
+        }
+
+        #expect(!openerCalled)
+        #expect(launchErrorTitle == "Launch Agent Failed")
     }
 }

--- a/AlasTests/AlasHookCommandTests.swift
+++ b/AlasTests/AlasHookCommandTests.swift
@@ -40,6 +40,27 @@ struct AlasHookCommandTests {
         return obj
     }
 
+    private func runShellCommandWithoutAlasEnv(_ command: String) throws -> (status: Int32, stdout: String, stderr: String) {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        proc.arguments = ["-c", command]
+        var env = ProcessInfo.processInfo.environment
+        env.removeValue(forKey: "ALAS_SOCKET_PATH")
+        env.removeValue(forKey: "ALAS_SESSION_ID")
+        proc.environment = env
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        proc.standardOutput = outPipe
+        proc.standardError = errPipe
+        try proc.run()
+        proc.waitUntilExit()
+
+        let stdout = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return (proc.terminationStatus, stdout, stderr)
+    }
+
     @Test func busyWithoutBody_producesSimpleCommand() {
         let cmd = AlasHookCommand.compositeCommand(
             events: [.busy], agent: .codex, forwardStdinAsBody: false
@@ -69,9 +90,24 @@ struct AlasHookCommandTests {
         let responseStep = #"printf '%s\n' '{"continue":true}'"#
         let deliveryStep = #"printf '{"v":1,"event":"busy""#
 
-        #expect(cmd.contains("{ \(responseStep);"))
+        #expect(cmd.hasPrefix("{ \(responseStep);"))
         #expect(cmd.contains(deliveryStep))
         #expect(cmd.range(of: responseStep)!.lowerBound < cmd.range(of: deliveryStep)!.lowerBound)
+    }
+
+    @Test func stdoutResponse_printsWithoutAlasEnvironment() throws {
+        let cmd = AlasHookCommand.compositeCommand(
+            events: [.permissionRequest],
+            agent: .cursor,
+            forwardStdinAsBody: false,
+            stdoutResponse: #"{"continue":true}"#
+        )
+
+        let result = try runShellCommandWithoutAlasEnv(cmd)
+
+        #expect(result.status == 0)
+        #expect(result.stdout == #"{"continue":true}"# + "\n")
+        #expect(result.stderr == "")
     }
 
     @Test func stdoutResponse_escapesSingleQuotes() {

--- a/AlasTests/AlasHookCommandTests.swift
+++ b/AlasTests/AlasHookCommandTests.swift
@@ -52,6 +52,48 @@ struct AlasHookCommandTests {
         #expect(!cmd.contains("payload=$(cat"))
     }
 
+    @Test func stdoutResponse_isAbsentByDefault() {
+        let cmd = AlasHookCommand.compositeCommand(
+            events: [.busy], agent: .codex, forwardStdinAsBody: false
+        )
+        #expect(!cmd.contains("printf '%s\\n'"))
+    }
+
+    @Test func stdoutResponse_printsBeforeHookDelivery() {
+        let cmd = AlasHookCommand.compositeCommand(
+            events: [.busy],
+            agent: .codex,
+            forwardStdinAsBody: false,
+            stdoutResponse: #"{"continue":true}"#
+        )
+        let responseStep = #"printf '%s\n' '{"continue":true}'"#
+        let deliveryStep = #"printf '{"v":1,"event":"busy""#
+
+        #expect(cmd.contains("{ \(responseStep);"))
+        #expect(cmd.contains(deliveryStep))
+        #expect(cmd.range(of: responseStep)!.lowerBound < cmd.range(of: deliveryStep)!.lowerBound)
+    }
+
+    @Test func stdoutResponse_escapesSingleQuotes() {
+        let cmd = AlasHookCommand.compositeCommand(
+            events: [.busy],
+            agent: .codex,
+            forwardStdinAsBody: false,
+            stdoutResponse: "can't"
+        )
+        #expect(cmd.contains(#"printf '%s\n' 'can'\''t'"#))
+    }
+
+    @Test func stdoutResponse_preservesSentinelSuffix() {
+        let cmd = AlasHookCommand.compositeCommand(
+            events: [.busy],
+            agent: .codex,
+            forwardStdinAsBody: false,
+            stdoutResponse: "{}"
+        )
+        #expect(cmd.hasSuffix(Self.sentinel))
+    }
+
     @Test func idleWithBody_includesPayloadExtraction() {
         let cmd = AlasHookCommand.compositeCommand(
             events: [.idle], agent: .claude, forwardStdinAsBody: true

--- a/AlasTests/ClaudeInstallerTests.swift
+++ b/AlasTests/ClaudeInstallerTests.swift
@@ -36,6 +36,8 @@ struct ClaudeInstallerTests {
         #expect(installedHooks["SessionStart"] != nil)
         #expect(installedHooks["SessionEnd"] != nil)
         #expect(installedHooks["PermissionRequest"] != nil)
+        let notifications = installedHooks["Notification"] as! [[String: Any]]
+        #expect(notifications[0]["matcher"] as? String == "idle_prompt|elicitation_dialog")
 
         // Third-party entry survives
         var json = installed

--- a/AlasTests/ClaudeInstallerTests.swift
+++ b/AlasTests/ClaudeInstallerTests.swift
@@ -31,8 +31,14 @@ struct ClaudeInstallerTests {
         try await installer.install()
         #expect(installer.installState() == .installed)
 
+        let installed = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        let installedHooks = installed["hooks"] as! [String: Any]
+        #expect(installedHooks["SessionStart"] != nil)
+        #expect(installedHooks["SessionEnd"] != nil)
+        #expect(installedHooks["PermissionRequest"] != nil)
+
         // Third-party entry survives
-        var json = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        var json = installed
         var hooks = json["hooks"] as! [String: Any]
         var stopEntries = hooks["Stop"] as! [[String: Any]]
         stopEntries.append(["hooks": [["type": "command", "command": "/usr/local/bin/my-hook"]]])
@@ -68,6 +74,21 @@ struct ClaudeInstallerTests {
             json["hooks"] = hooks
             try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted).write(to: url)
         }
+
+        #expect(installer.installState() == .outdated)
+    }
+
+    @Test func installState_missingLifecyclePlacement_outdated() async throws {
+        let (url, cleanup) = tmpSettingsURL()
+        defer { cleanup() }
+        let installer = ClaudeInstaller(settingsURL: url)
+        try await installer.install()
+
+        var json = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        var hooks = json["hooks"] as! [String: Any]
+        hooks.removeValue(forKey: "SessionStart")
+        json["hooks"] = hooks
+        try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted).write(to: url)
 
         #expect(installer.installState() == .outdated)
     }

--- a/AlasTests/CodexInstallerTests.swift
+++ b/AlasTests/CodexInstallerTests.swift
@@ -36,8 +36,35 @@ struct CodexInstallerTests {
         #expect(enableCalled)
         #expect(installer.installState() == .installed)
 
+        let installed = try JSONSerialization.jsonObject(with: Data(contentsOf: hooksURL)) as! [String: Any]
+        let installedHooks = installed["hooks"] as! [String: Any]
+        #expect(installedHooks["SessionStart"] != nil)
+        #expect(installedHooks["SessionEnd"] != nil)
+
         try installer.uninstall()
         #expect(installer.installState() == .notInstalled)
+    }
+
+    @Test func installState_missingLifecyclePlacement_outdated() async throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        let hooksURL = dir.appendingPathComponent("hooks.json")
+        let configURL = dir.appendingPathComponent("config.toml")
+        try "[features]\nhooks = true\n".write(to: configURL, atomically: true, encoding: .utf8)
+
+        let installer = CodexInstaller(
+            hooksURL: hooksURL, configURL: configURL,
+            runEnableHooks: { .init(status: 0, stderr: "") }
+        )
+        try await installer.install()
+
+        var json = try JSONSerialization.jsonObject(with: Data(contentsOf: hooksURL)) as! [String: Any]
+        var hooks = json["hooks"] as! [String: Any]
+        hooks.removeValue(forKey: "SessionEnd")
+        json["hooks"] = hooks
+        try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted).write(to: hooksURL)
+
+        #expect(installer.installState() == .outdated)
     }
 
     /// Codex review (#102): a stale install with the right managed commands

--- a/AlasTests/CopilotInstallerTests.swift
+++ b/AlasTests/CopilotInstallerTests.swift
@@ -39,6 +39,7 @@ struct CopilotInstallerTests {
             "userPromptSubmitted": "busy",
             "preToolUse": "busy",
             "postToolUse": "busy",
+            "postToolUseFailure": "busy",
         ]
         #expect(Set(hooks.keys) == Set(expectedEvents.keys))
         for (event, activity) in expectedEvents {

--- a/AlasTests/CopilotInstallerTests.swift
+++ b/AlasTests/CopilotInstallerTests.swift
@@ -32,11 +32,13 @@ struct CopilotInstallerTests {
 
         let hooks = installed["hooks"] as! [String: Any]
         let expectedEvents = [
+            "agentStop": "idle",
+            "permissionRequest": "permission_request",
             "sessionStart": "attached",
             "sessionEnd": "detached",
             "userPromptSubmitted": "busy",
+            "preToolUse": "busy",
             "postToolUse": "busy",
-            "preToolUse": "permission_request",
         ]
         #expect(Set(hooks.keys) == Set(expectedEvents.keys))
         for (event, activity) in expectedEvents {
@@ -99,6 +101,26 @@ struct CopilotInstallerTests {
         let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
         #expect(exclude.contains("existing-pattern\n"))
         #expect(exclude.contains(".github/hooks/alas-notify.json\n"))
+    }
+
+    @Test func installAddsHookPathToLinkedWorktreeInfoExclude() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        let gitDir = dir.appendingPathComponent("actual-git-dir", isDirectory: true)
+        let infoURL = gitDir.appendingPathComponent("info", isDirectory: true)
+        try FileManager.default.createDirectory(at: infoURL, withIntermediateDirectories: true)
+        try "gitdir: actual-git-dir\n".write(
+            to: dir.appendingPathComponent(".git", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try CopilotInstaller(projectRootURL: dir).install()
+
+        let excludeURL = infoURL.appendingPathComponent("exclude", isDirectory: false)
+        let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
+        #expect(exclude.contains(".github/hooks/alas-notify.json\n"))
+        #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent(".git/info/exclude").path))
     }
 
     @Test func installPreservesExcludeWhenExistingExcludeCannotBeDecoded() throws {

--- a/AlasTests/CopilotInstallerTests.swift
+++ b/AlasTests/CopilotInstallerTests.swift
@@ -144,11 +144,10 @@ struct CopilotInstallerTests {
         let invalidUTF8 = Data([0xff, 0xfe, 0xfd])
         try invalidUTF8.write(to: excludeURL)
 
-        #expect(throws: CopilotInstallerError.self) {
-            try CopilotInstaller(projectRootURL: dir).install()
-        }
+        try CopilotInstaller(projectRootURL: dir).install()
 
         #expect(try Data(contentsOf: excludeURL) == invalidUTF8)
+        #expect(FileManager.default.fileExists(atPath: hookURL(in: dir).path))
     }
 
     @Test func excludeUpdateIsIdempotent() throws {

--- a/AlasTests/CopilotInstallerTests.swift
+++ b/AlasTests/CopilotInstallerTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct CopilotInstallerTests {
+    private func tmpDir() -> (dir: URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return (dir, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    private func hookURL(in root: URL) -> URL {
+        root
+            .appendingPathComponent(".github", isDirectory: true)
+            .appendingPathComponent("hooks", isDirectory: true)
+            .appendingPathComponent("alas-notify.json", isDirectory: false)
+    }
+
+    private func installedJSON(in root: URL) throws -> [String: Any] {
+        try JSONSerialization.jsonObject(with: Data(contentsOf: hookURL(in: root))) as! [String: Any]
+    }
+
+    @Test func installWritesManagedHookJSON() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+
+        try CopilotInstaller(projectRootURL: dir).install()
+
+        let installed = try installedJSON(in: dir)
+        #expect(installed["version"] as? Int == 1)
+        #expect(installed["alas_marker"] as? String == "alas-managed-copilot-hook-v1")
+
+        let hooks = installed["hooks"] as! [String: Any]
+        let expectedEvents = [
+            "sessionStart": "attached",
+            "sessionEnd": "detached",
+            "userPromptSubmitted": "busy",
+            "postToolUse": "busy",
+            "preToolUse": "permission_request",
+        ]
+        #expect(Set(hooks.keys) == Set(expectedEvents.keys))
+        for (event, activity) in expectedEvents {
+            let entries = hooks[event] as! [[String: Any]]
+            #expect(entries.count == 1)
+            #expect(entries[0]["type"] as? String == "command")
+            #expect(entries[0]["timeoutSec"] as? Int == 5)
+            let command = entries[0]["bash"] as! String
+            #expect(command.contains(#""agent":"copilot""#))
+            #expect(command.contains(#""event":"\#(activity)""#))
+            #expect(command.contains("{}"))
+            #expect(command.hasSuffix(AlasHookCommand.ownershipSentinel))
+        }
+    }
+
+    @Test func installCreatesParentDirectories() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+
+        try CopilotInstaller(projectRootURL: dir).install()
+
+        #expect(FileManager.default.fileExists(atPath: hookURL(in: dir).path))
+    }
+
+    @Test func installRejectsMissingProjectRootWithoutCreatingDirectories() throws {
+        let (parent, cleanup) = tmpDir()
+        defer { cleanup() }
+        let missingRoot = parent.appendingPathComponent("missing-root", isDirectory: true)
+
+        #expect(throws: CopilotInstallerError.self) {
+            try CopilotInstaller(projectRootURL: missingRoot).install()
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: missingRoot.path))
+    }
+
+    @Test func installRejectsProjectRootThatIsNotDirectory() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        let fileURL = dir.appendingPathComponent("project-file")
+        try "not a directory".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        #expect(throws: CopilotInstallerError.self) {
+            try CopilotInstaller(projectRootURL: fileURL).install()
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: hookURL(in: fileURL).path))
+    }
+
+    @Test func installAddsHookPathToGitInfoExcludeWhenGitInfoExists() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        let infoURL = dir.appendingPathComponent(".git/info", isDirectory: true)
+        try FileManager.default.createDirectory(at: infoURL, withIntermediateDirectories: true)
+        let excludeURL = infoURL.appendingPathComponent("exclude")
+        try "existing-pattern\n".write(to: excludeURL, atomically: true, encoding: .utf8)
+
+        try CopilotInstaller(projectRootURL: dir).install()
+
+        let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
+        #expect(exclude.contains("existing-pattern\n"))
+        #expect(exclude.contains(".github/hooks/alas-notify.json\n"))
+    }
+
+    @Test func installPreservesExcludeWhenExistingExcludeCannotBeDecoded() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        let infoURL = dir.appendingPathComponent(".git/info", isDirectory: true)
+        try FileManager.default.createDirectory(at: infoURL, withIntermediateDirectories: true)
+        let excludeURL = infoURL.appendingPathComponent("exclude")
+        let invalidUTF8 = Data([0xff, 0xfe, 0xfd])
+        try invalidUTF8.write(to: excludeURL)
+
+        #expect(throws: CopilotInstallerError.self) {
+            try CopilotInstaller(projectRootURL: dir).install()
+        }
+
+        #expect(try Data(contentsOf: excludeURL) == invalidUTF8)
+    }
+
+    @Test func excludeUpdateIsIdempotent() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        let infoURL = dir.appendingPathComponent(".git/info", isDirectory: true)
+        try FileManager.default.createDirectory(at: infoURL, withIntermediateDirectories: true)
+
+        let installer = CopilotInstaller(projectRootURL: dir)
+        try installer.install()
+        try installer.install()
+
+        let excludeURL = infoURL.appendingPathComponent("exclude")
+        let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
+        let occurrences = exclude.components(separatedBy: ".github/hooks/alas-notify.json").count - 1
+        #expect(occurrences == 1)
+    }
+
+    @Test func installDoesNotCreateExcludeWhenGitInfoDoesNotExist() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+
+        try CopilotInstaller(projectRootURL: dir).install()
+
+        let excludeURL = dir.appendingPathComponent(".git/info/exclude")
+        #expect(!FileManager.default.fileExists(atPath: excludeURL.path))
+    }
+
+    @Test func installPreservesUnmanagedExistingHookFileAndThrows() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        let url = hookURL(in: dir)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try #"{"version":1,"hooks":{}}"#.write(to: url, atomically: true, encoding: .utf8)
+
+        #expect(throws: CopilotInstallerError.self) {
+            try CopilotInstaller(projectRootURL: dir).install()
+        }
+        let error = CopilotInstallerError.unmanagedHookExists(url.path)
+        #expect(error.localizedDescription.contains("unmanaged Copilot hook"))
+        #expect(try String(contentsOf: url, encoding: .utf8) == #"{"version":1,"hooks":{}}"#)
+    }
+
+    @Test func reinstallReplacesManagedHookFile() throws {
+        let (dir, cleanup) = tmpDir()
+        defer { cleanup() }
+        let url = hookURL(in: dir)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try #"{"alas_marker":"alas-managed-copilot-hook-v1","hooks":{"old":[]}}"#
+            .write(to: url, atomically: true, encoding: .utf8)
+
+        try CopilotInstaller(projectRootURL: dir).install()
+
+        let installed = try installedJSON(in: dir)
+        let hooks = installed["hooks"] as! [String: Any]
+        #expect(hooks["old"] == nil)
+        #expect(hooks["sessionStart"] != nil)
+    }
+}

--- a/AlasTests/CopilotInstallerTests.swift
+++ b/AlasTests/CopilotInstallerTests.swift
@@ -106,10 +106,19 @@ struct CopilotInstallerTests {
     @Test func installAddsHookPathToLinkedWorktreeInfoExclude() throws {
         let (dir, cleanup) = tmpDir()
         defer { cleanup() }
-        let gitDir = dir.appendingPathComponent("actual-git-dir", isDirectory: true)
-        let infoURL = gitDir.appendingPathComponent("info", isDirectory: true)
-        try FileManager.default.createDirectory(at: infoURL, withIntermediateDirectories: true)
-        try "gitdir: actual-git-dir\n".write(
+        let mainGitDir = dir.appendingPathComponent("main-git-dir", isDirectory: true)
+        let worktreeGitDir = mainGitDir
+            .appendingPathComponent("worktrees", isDirectory: true)
+            .appendingPathComponent("linked", isDirectory: true)
+        let commonInfoURL = mainGitDir.appendingPathComponent("info", isDirectory: true)
+        try FileManager.default.createDirectory(at: commonInfoURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: worktreeGitDir, withIntermediateDirectories: true)
+        try "../..".write(
+            to: worktreeGitDir.appendingPathComponent("commondir", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "gitdir: main-git-dir/worktrees/linked\n".write(
             to: dir.appendingPathComponent(".git", isDirectory: false),
             atomically: true,
             encoding: .utf8
@@ -117,9 +126,12 @@ struct CopilotInstallerTests {
 
         try CopilotInstaller(projectRootURL: dir).install()
 
-        let excludeURL = infoURL.appendingPathComponent("exclude", isDirectory: false)
+        let excludeURL = commonInfoURL.appendingPathComponent("exclude", isDirectory: false)
         let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
         #expect(exclude.contains(".github/hooks/alas-notify.json\n"))
+        #expect(!FileManager.default.fileExists(
+            atPath: worktreeGitDir.appendingPathComponent("info/exclude", isDirectory: false).path
+        ))
         #expect(!FileManager.default.fileExists(atPath: dir.appendingPathComponent(".git/info/exclude").path))
     }
 

--- a/AlasTests/CursorInstallerTests.swift
+++ b/AlasTests/CursorInstallerTests.swift
@@ -23,6 +23,22 @@ struct CursorInstallerTests {
         try await installer.install()
         #expect(installer.installState() == .installed)
 
+        let installed = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        let installedHooks = installed["hooks"] as! [String: Any]
+        #expect(installedHooks["sessionStart"] != nil)
+        #expect(installedHooks["sessionEnd"] != nil)
+        #expect(installedHooks["beforeShellExecution"] != nil)
+        #expect(installedHooks["beforeMCPExecution"] != nil)
+
+        for event in ["beforeShellExecution", "beforeMCPExecution"] {
+            let entries = installedHooks[event] as! [[String: Any]]
+            #expect(entries.count == 1)
+            let command = entries[0]["command"] as! String
+            #expect(command.contains(#"printf '%s\n' '{"continue":true}'"#))
+            #expect(command.contains(#""event":"permission_request""#))
+            #expect(command.hasSuffix(AlasHookCommand.ownershipSentinel))
+        }
+
         try installer.uninstall()
         #expect(installer.installState() == .notInstalled)
     }
@@ -65,6 +81,21 @@ struct CursorInstallerTests {
         before.append(contentsOf: stop)
         hooks["beforeSubmitPrompt"] = before
         hooks.removeValue(forKey: "stop")
+        json["hooks"] = hooks
+        try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted).write(to: url)
+
+        #expect(installer.installState() == .outdated)
+    }
+
+    @Test func installState_missingLifecyclePlacement_outdated() async throws {
+        let (url, cleanup) = tmpSettingsURL()
+        defer { cleanup() }
+        let installer = CursorInstaller(settingsURL: url)
+        try await installer.install()
+
+        var json = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        var hooks = json["hooks"] as! [String: Any]
+        hooks.removeValue(forKey: "beforeShellExecution")
         json["hooks"] = hooks
         try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted).write(to: url)
 

--- a/AlasTests/GeminiInstallerTests.swift
+++ b/AlasTests/GeminiInstallerTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct GeminiInstallerTests {
+    private func tmpSettingsURL() -> (url: URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("settings.json")
+        return (url, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    @Test func installCreatesNestedHooksInEmptySettingsFile() async throws {
+        let (url, cleanup) = tmpSettingsURL()
+        defer { cleanup() }
+        let installer = GeminiInstaller(settingsURL: url)
+
+        try await installer.install()
+
+        let installed = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        let hooks = installed["hooks"] as! [String: Any]
+        #expect(Set(hooks.keys) == Set(["SessionStart", "SessionEnd", "BeforeAgent", "AfterTool", "AfterAgent"]))
+
+        for event in ["SessionStart", "SessionEnd", "BeforeAgent", "AfterTool", "AfterAgent"] {
+            let groups = hooks[event] as! [[String: Any]]
+            #expect(groups.count == 1)
+            let innerHooks = groups[0]["hooks"] as! [[String: Any]]
+            #expect(innerHooks.count == 1)
+            #expect(innerHooks[0]["type"] as? String == "command")
+        }
+    }
+
+    @Test func hookCommandsAreManagedAndIncludeGeminiEventsAndStdoutResponse() async throws {
+        let (url, cleanup) = tmpSettingsURL()
+        defer { cleanup() }
+        let installer = GeminiInstaller(settingsURL: url)
+
+        try await installer.install()
+
+        let installed = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        let hooks = installed["hooks"] as! [String: Any]
+        let expectations: [String: String] = [
+            "SessionStart": ActivityEvent.attached.rawValue,
+            "SessionEnd": ActivityEvent.detached.rawValue,
+            "BeforeAgent": ActivityEvent.busy.rawValue,
+            "AfterTool": ActivityEvent.busy.rawValue,
+            "AfterAgent": ActivityEvent.idle.rawValue,
+        ]
+
+        for (geminiEvent, alasEvent) in expectations {
+            let groups = hooks[geminiEvent] as! [[String: Any]]
+            let innerHooks = groups[0]["hooks"] as! [[String: Any]]
+            let command = innerHooks[0]["command"] as! String
+            #expect(command.hasSuffix(AlasHookCommand.ownershipSentinel))
+            #expect(command.contains(#""agent":"gemini""#))
+            #expect(command.contains(#""event":"\#(alasEvent)""#))
+            #expect(command.contains(#"printf '%s\n' '{}'"#))
+        }
+    }
+
+    @Test func installStateInstalledForFreshCanonicalConfig() async throws {
+        let (url, cleanup) = tmpSettingsURL()
+        defer { cleanup() }
+        let installer = GeminiInstaller(settingsURL: url)
+
+        try await installer.install()
+
+        #expect(installer.installState() == .installed)
+    }
+
+    @Test func installStateOutdatedWhenCanonicalPlacementMissing() async throws {
+        let (url, cleanup) = tmpSettingsURL()
+        defer { cleanup() }
+        let installer = GeminiInstaller(settingsURL: url)
+        try await installer.install()
+
+        var json = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        var hooks = json["hooks"] as! [String: Any]
+        hooks.removeValue(forKey: "AfterTool")
+        json["hooks"] = hooks
+        try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted).write(to: url)
+
+        #expect(installer.installState() == .outdated)
+    }
+
+    @Test func installStateOutdatedWhenCanonicalPlacementStale() async throws {
+        let (url, cleanup) = tmpSettingsURL()
+        defer { cleanup() }
+        let installer = GeminiInstaller(settingsURL: url)
+        try await installer.install()
+
+        var json = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        var hooks = json["hooks"] as! [String: Any]
+        var groups = hooks["AfterAgent"] as! [[String: Any]]
+        var innerHooks = groups[0]["hooks"] as! [[String: Any]]
+        innerHooks[0]["command"] = "old-command # alas-managed-hook"
+        groups[0]["hooks"] = innerHooks
+        hooks["AfterAgent"] = groups
+        json["hooks"] = hooks
+        try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted).write(to: url)
+
+        #expect(installer.installState() == .outdated)
+    }
+
+    @Test func uninstallRemovesManagedHooksAndPreservesUnmanagedHooksAndSettings() async throws {
+        let (url, cleanup) = tmpSettingsURL()
+        defer { cleanup() }
+        let installer = GeminiInstaller(settingsURL: url)
+
+        let seed: [String: Any] = [
+            "theme": "dark",
+            "hooks": [
+                "AfterAgent": [
+                    [
+                        "hooks": [
+                            ["type": "command", "command": "/usr/local/bin/user-after-agent"],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: seed, options: .prettyPrinted).write(to: url)
+        try await installer.install()
+
+        try installer.uninstall()
+
+        let final = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+        #expect(final["theme"] as? String == "dark")
+        let hooks = final["hooks"] as! [String: Any]
+        let afterAgent = hooks["AfterAgent"] as! [[String: Any]]
+        let innerHooks = afterAgent[0]["hooks"] as! [[String: Any]]
+        #expect(innerHooks.count == 1)
+        #expect(innerHooks[0]["command"] as? String == "/usr/local/bin/user-after-agent")
+    }
+}

--- a/AlasTests/HarnessDetectorTests.swift
+++ b/AlasTests/HarnessDetectorTests.swift
@@ -12,6 +12,12 @@ struct HarnessDetectorTests {
     @Test func matchesCursor() {
         #expect(HarnessDetector.matchKind(processName: "cursor-agent") == .cursor)
     }
+    @Test func matchesAdditionalAgentProcesses() {
+        #expect(HarnessDetector.matchKind(processName: "gemini") == .gemini)
+        #expect(HarnessDetector.matchKind(processName: "opencode") == .opencode)
+        #expect(HarnessDetector.matchKind(processName: "pi") == .pi)
+        #expect(HarnessDetector.matchKind(processName: "copilot") == .copilot)
+    }
     @Test func unknownReturnsNil() {
         #expect(HarnessDetector.matchKind(processName: "zsh") == nil)
     }
@@ -22,6 +28,10 @@ struct HarnessDetectorTests {
         #expect(HarnessDetector.matchKind(processName: "claude-code") == .claudeCode)
         #expect(HarnessDetector.matchKind(processName: "codex-cli") == .codex)
         #expect(HarnessDetector.matchKind(processName: "cursor-agent-dev") == .cursor)
+        #expect(HarnessDetector.matchKind(processName: "copilot-dev") == .copilot)
+    }
+    @Test func doesNotPrefixMatchShortProcessNames() {
+        #expect(HarnessDetector.matchKind(processName: "pi-dev") == nil)
     }
     @Test func doesNotMatchSubstring() {
         #expect(HarnessDetector.matchKind(processName: "claudefoo") == nil)

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import UserNotifications
 @testable import Alas
 
+@Suite(.serialized)
 struct HarnessServiceTests {
     private func makeEvent(
         event: ActivityEvent, agent: AgentKind = .claude,
@@ -26,6 +27,29 @@ struct HarnessServiceTests {
         let collector = RequestCollector()
         service.notifications.notificationAdder = { collector.requests.append($0) }
         return (service, collector)
+    }
+
+    private func waitForMainQueue() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func waitForActivity(
+        _ service: HarnessService,
+        sessionId: String = "session-1",
+        where predicate: @escaping (HarnessService.HarnessActivityState?) -> Bool
+    ) async {
+        for _ in 0..<20 {
+            await waitForMainQueue()
+            if predicate(service.activityBySession[sessionId]) {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        await waitForMainQueue()
     }
 
     @Test func awaitingNotificationPostsOnlyWhenEnteringAwaitingState() {
@@ -84,6 +108,74 @@ struct HarnessServiceTests {
             stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
         )
         #expect(service.activityBySession["session-1"]?.lastBody == nil)
+    }
+
+    @Test func attachedSetsSessionBusy() {
+        let (service, _) = makeService()
+        service.handleSocketEvent(
+            makeEvent(event: .attached, agent: .codex, body: "attached"),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+
+        #expect(service.activityBySession["session-1"]?.state == .busy)
+        #expect(service.activityBySession["session-1"]?.agent == .codex)
+        #expect(service.activityBySession["session-1"]?.lastBody == nil)
+    }
+
+    @Test func detachedRemovesSessionActivity() {
+        let (service, _) = makeService()
+        service.handleSocketEvent(
+            makeEvent(event: .busy),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .detached),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+
+        #expect(service.activityBySession["session-1"] == nil)
+    }
+
+    @Test func permissionRequestSetsStateBodyAndAwaitingSummary() {
+        let (service, _) = makeService()
+        service.handleSocketEvent(
+            makeEvent(event: .busy, sessionId: "s1"),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .permissionRequest, agent: .cursor, sessionId: "s2", body: "Allow command?"),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+
+        #expect(service.activityBySession["s2"]?.state == .permissionRequest)
+        #expect(service.activityBySession["s2"]?.lastBody == "Allow command?")
+
+        let summary = service.summary(forSessionIds: ["s1", "s2"])
+        #expect(summary?.state == .awaiting)
+        #expect(summary?.agent == .cursor)
+        #expect(summary?.primarySessionId == "s2")
+        #expect(summary?.runningSessionCount == 1)
+        #expect(summary?.awaitingSessionCount == 1)
+    }
+
+    @Test func permissionRequestPostsPermissionNotificationWithFallbackBody() {
+        let (service, collector) = makeService()
+        service.handleSocketEvent(
+            makeEvent(event: .permissionRequest, agent: .codex, body: nil),
+            stateLookup: { _ in (projectId: "p1", worktreeId: "w1") },
+            shouldNotifyOnAwaiting: { true }
+        )
+
+        #expect(service.activityBySession["session-1"]?.state == .permissionRequest)
+        #expect(collector.requests.count == 1)
+        #expect(collector.requests[0].content.title == "Codex needs permission")
+        #expect(collector.requests[0].content.body == "Session is waiting for you.")
+    }
+
+    @Test func agentKindMapsToHarnessKind() {
+        #expect(AgentKind.claude.asHarnessKind == .claudeCode)
+        #expect(AgentKind.codex.asHarnessKind == .codex)
+        #expect(AgentKind.cursor.asHarnessKind == .cursor)
     }
 
     @Test func summary_returnsNil_whenIdsEmpty() {
@@ -173,7 +265,7 @@ struct HarnessServiceTests {
         )
         #expect(service.activityBySession["session-1"]?.state == .busy)
 
-        try await Task.sleep(nanoseconds: 80_000_000) // 80 ms > 50 ms
+        await waitForActivity(service) { $0?.state == .idle }
         #expect(service.activityBySession["session-1"]?.state == .idle)
     }
 
@@ -194,7 +286,7 @@ struct HarnessServiceTests {
             shouldNotifyOnAwaiting: { false }
         )
 
-        try await Task.sleep(nanoseconds: 80_000_000)
+        await waitForActivity(service) { $0?.state == .idle && $0?.lastBody == "second" }
         #expect(service.activityBySession["session-1"]?.state == .idle)
         #expect(service.activityBySession["session-1"]?.lastBody == "second")
         #expect(collector.requests.count == 1)
@@ -217,7 +309,8 @@ struct HarnessServiceTests {
             stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
         )
 
-        try await Task.sleep(nanoseconds: 80_000_000)
+        try await Task.sleep(nanoseconds: 150_000_000)
+        await waitForMainQueue()
         #expect(service.activityBySession["session-1"]?.state == .busy)
     }
 
@@ -236,8 +329,30 @@ struct HarnessServiceTests {
             stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
         )
 
-        try await Task.sleep(nanoseconds: 80_000_000)
+        try await Task.sleep(nanoseconds: 150_000_000)
+        await waitForMainQueue()
         #expect(service.activityBySession["session-1"]?.state == .awaitingInput)
+    }
+
+    @Test func cursorIdleDebounce_isCancelledByPermissionRequest() async throws {
+        let (service, _) = makeService(cursorIdleDebounceInterval: 0.05)
+        service.handleSocketEvent(
+            makeEvent(event: .busy, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .idle, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+        service.handleSocketEvent(
+            makeEvent(event: .permissionRequest, agent: .cursor),
+            stateLookup: { _ in nil }, shouldNotifyOnAwaiting: { false }
+        )
+
+        await waitForActivity(service) { $0?.state == .permissionRequest }
+        try await Task.sleep(nanoseconds: 150_000_000)
+        await waitForMainQueue()
+        #expect(service.activityBySession["session-1"]?.state == .permissionRequest)
     }
 
     @Test func claudeIdle_isNotDebounced() {
@@ -265,7 +380,8 @@ struct HarnessServiceTests {
         )
         service.forgetSession("session-1")
 
-        try await Task.sleep(nanoseconds: 80_000_000)
+        try await Task.sleep(nanoseconds: 150_000_000)
+        await waitForMainQueue()
         #expect(service.activityBySession["session-1"] == nil)
     }
 }

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -176,6 +176,20 @@ struct HarnessServiceTests {
         #expect(AgentKind.claude.asHarnessKind == .claudeCode)
         #expect(AgentKind.codex.asHarnessKind == .codex)
         #expect(AgentKind.cursor.asHarnessKind == .cursor)
+        #expect(AgentKind.gemini.asHarnessKind == .gemini)
+        #expect(AgentKind.opencode.asHarnessKind == .opencode)
+        #expect(AgentKind.pi.asHarnessKind == .pi)
+        #expect(AgentKind.copilot.asHarnessKind == .copilot)
+    }
+
+    @Test func harnessKindMapsToAgentKind() {
+        #expect(HarnessKind.claudeCode.asAgentKind == .claude)
+        #expect(HarnessKind.codex.asAgentKind == .codex)
+        #expect(HarnessKind.cursor.asAgentKind == .cursor)
+        #expect(HarnessKind.gemini.asAgentKind == .gemini)
+        #expect(HarnessKind.opencode.asAgentKind == .opencode)
+        #expect(HarnessKind.pi.asAgentKind == .pi)
+        #expect(HarnessKind.copilot.asAgentKind == .copilot)
     }
 
     @Test func summary_returnsNil_whenIdsEmpty() {

--- a/AlasTests/OpenCodeInstallerTests.swift
+++ b/AlasTests/OpenCodeInstallerTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct OpenCodeInstallerTests {
+    private func tmpPluginURL() -> (url: URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let url = dir
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("opencode", isDirectory: true)
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent("alas-notify.js", isDirectory: false)
+        return (url, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    @Test func defaultPluginPathUsesOpenCodePluginsDirectory() {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let installer = OpenCodeInstaller(homeDirectoryURL: home)
+
+        #expect(installer.pluginURL.path == home
+            .appendingPathComponent(".config/opencode/plugins/alas-notify.js")
+            .path)
+    }
+
+    @Test func installWritesManagedPluginAndCreatesParentDirectories() async throws {
+        let (url, cleanup) = tmpPluginURL()
+        defer { cleanup() }
+        let installer = OpenCodeInstaller(pluginURL: url)
+
+        try await installer.install()
+
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        #expect(installer.installState() == .installed)
+    }
+
+    @Test func pluginContentContainsRequiredHooksAndNotificationDetails() async throws {
+        let (url, cleanup) = tmpPluginURL()
+        defer { cleanup() }
+        let installer = OpenCodeInstaller(pluginURL: url)
+
+        try await installer.install()
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        for required in [
+            "alas-managed-opencode-hook",
+            "export const AlasNotifyPlugin = async () =>",
+            "return {",
+            "event: async ({ event }) =>",
+            #"type === "permission.asked""#,
+            #"notify("permission_request""#,
+            "session.status",
+            "ALAS_SOCKET_PATH",
+            "node:child_process",
+            "childProcess.spawn",
+            "/usr/bin/nc",
+            #"agent: "opencode""#,
+            "attached",
+            "detached",
+            "busy",
+            "idle",
+            "permission_request",
+        ] {
+            #expect(content.contains(required))
+        }
+        #expect(!content.contains("export default"))
+        #expect(!content.contains(#""permission.ask""#))
+        #expect(!content.contains(#""permission.asked":"#))
+        #expect(!content.contains(#""permission.asked": async"#))
+    }
+
+    @Test func pluginContentGuardsChildSessionsForAllRootActivityEvents() async throws {
+        let (url, cleanup) = tmpPluginURL()
+        defer { cleanup() }
+        let installer = OpenCodeInstaller(pluginURL: url)
+
+        try await installer.install()
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        for type in ["session.created", "session.deleted", "session.status", "session.error"] {
+            #expect(content.contains(#"type === "\#(type)" && !isChildSession(event)"#))
+        }
+    }
+
+    @Test func installStateOutdatedForExistingUnmanagedPlugin() throws {
+        let (url, cleanup) = tmpPluginURL()
+        defer { cleanup() }
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "export default {};".write(to: url, atomically: true, encoding: .utf8)
+        let installer = OpenCodeInstaller(pluginURL: url)
+
+        #expect(installer.installState() == .outdated)
+    }
+
+    @Test func installPreservesUnmanagedPluginAndThrows() async throws {
+        let (url, cleanup) = tmpPluginURL()
+        defer { cleanup() }
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let unmanaged = "export const CustomPlugin = async () => ({ name: 'custom' });"
+        try unmanaged.write(to: url, atomically: true, encoding: .utf8)
+        let installer = OpenCodeInstaller(pluginURL: url)
+
+        await #expect(throws: OpenCodeInstallerError.self) {
+            try await installer.install()
+        }
+
+        #expect(try String(contentsOf: url, encoding: .utf8) == unmanaged)
+        #expect(installer.installState() == .outdated)
+    }
+
+    @Test func uninstallRemovesManagedPlugin() async throws {
+        let (url, cleanup) = tmpPluginURL()
+        defer { cleanup() }
+        let installer = OpenCodeInstaller(pluginURL: url)
+        try await installer.install()
+
+        try installer.uninstall()
+
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+        #expect(installer.installState() == .notInstalled)
+    }
+
+    @Test func uninstallPreservesUnmanagedPlugin() throws {
+        let (url, cleanup) = tmpPluginURL()
+        defer { cleanup() }
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let unmanaged = "export default { name: 'custom' };"
+        try unmanaged.write(to: url, atomically: true, encoding: .utf8)
+        let installer = OpenCodeInstaller(pluginURL: url)
+
+        try installer.uninstall()
+
+        #expect(try String(contentsOf: url, encoding: .utf8) == unmanaged)
+        #expect(installer.installState() == .outdated)
+    }
+}

--- a/AlasTests/OpenCodeInstallerTests.swift
+++ b/AlasTests/OpenCodeInstallerTests.swift
@@ -49,6 +49,7 @@ struct OpenCodeInstallerTests {
             #"type === "permission.asked""#,
             #"notify("permission_request""#,
             "session.status",
+            "session.idle",
             "ALAS_SOCKET_PATH",
             "node:child_process",
             "childProcess.spawn",
@@ -76,7 +77,7 @@ struct OpenCodeInstallerTests {
         try await installer.install()
 
         let content = try String(contentsOf: url, encoding: .utf8)
-        for type in ["session.created", "session.deleted", "session.status", "session.error"] {
+        for type in ["session.created", "session.deleted", "session.status", "session.idle", "session.error"] {
             #expect(content.contains(#"type === "\#(type)" && !isChildSession(event)"#))
         }
     }

--- a/AlasTests/PiInstallerTests.swift
+++ b/AlasTests/PiInstallerTests.swift
@@ -61,6 +61,8 @@ struct PiInstallerTests {
         ] {
             #expect(content.contains(required))
         }
+        #expect(content.contains(#"session_shutdown: "detached""#))
+        #expect(!content.contains(#"session_shutdown: "idle""#))
         #expect(!content.contains("export default {"))
         #expect(!content.contains(#"session_start: handle("session_start")"#))
     }

--- a/AlasTests/PiInstallerTests.swift
+++ b/AlasTests/PiInstallerTests.swift
@@ -1,0 +1,119 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct PiInstallerTests {
+    private func tmpExtensionURL() -> (url: URL, cleanup: () -> Void) {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let url = dir
+            .appendingPathComponent(".pi", isDirectory: true)
+            .appendingPathComponent("agent", isDirectory: true)
+            .appendingPathComponent("extensions", isDirectory: true)
+            .appendingPathComponent("alas-notify.ts", isDirectory: false)
+        return (url, { try? FileManager.default.removeItem(at: dir) })
+    }
+
+    @Test func defaultExtensionPathUsesPiExtensionsDirectory() {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let installer = PiInstaller(homeDirectoryURL: home)
+
+        #expect(installer.extensionURL.path == home
+            .appendingPathComponent(".pi/agent/extensions/alas-notify.ts")
+            .path)
+    }
+
+    @Test func installWritesManagedExtensionAndCreatesParentDirectories() async throws {
+        let (url, cleanup) = tmpExtensionURL()
+        defer { cleanup() }
+        let installer = PiInstaller(extensionURL: url)
+
+        try await installer.install()
+
+        #expect(FileManager.default.fileExists(atPath: url.path))
+        #expect(installer.installState() == .installed)
+    }
+
+    @Test func extensionContentContainsRequiredHooksAndNotificationDetails() async throws {
+        let (url, cleanup) = tmpExtensionURL()
+        defer { cleanup() }
+        let installer = PiInstaller(extensionURL: url)
+
+        try await installer.install()
+
+        let content = try String(contentsOf: url, encoding: .utf8)
+        for required in [
+            "alas-managed-pi-hook",
+            "export default function (pi)",
+            "ALAS_SOCKET_PATH",
+            "/usr/bin/nc",
+            #"agent: "pi""#,
+            "ctx.hasUI === false",
+            #"pi.on("session_start""#,
+            #"pi.on("session_end""#,
+            #"pi.on("before_agent_start""#,
+            #"pi.on("tool_execution_end""#,
+            #"pi.on("agent_end""#,
+            #"pi.on("session_shutdown""#,
+            "attached",
+            "detached",
+            "busy",
+            "idle",
+        ] {
+            #expect(content.contains(required))
+        }
+        #expect(!content.contains("export default {"))
+        #expect(!content.contains(#"session_start: handle("session_start")"#))
+    }
+
+    @Test func installStateOutdatedForExistingUnmanagedExtension() throws {
+        let (url, cleanup) = tmpExtensionURL()
+        defer { cleanup() }
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "export default {};".write(to: url, atomically: true, encoding: .utf8)
+        let installer = PiInstaller(extensionURL: url)
+
+        #expect(installer.installState() == .outdated)
+    }
+
+    @Test func installPreservesUnmanagedExtensionAndThrows() async throws {
+        let (url, cleanup) = tmpExtensionURL()
+        defer { cleanup() }
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let unmanaged = "export default { name: 'custom' };"
+        try unmanaged.write(to: url, atomically: true, encoding: .utf8)
+        let installer = PiInstaller(extensionURL: url)
+
+        await #expect(throws: PiInstallerError.self) {
+            try await installer.install()
+        }
+
+        #expect(try String(contentsOf: url, encoding: .utf8) == unmanaged)
+        #expect(installer.installState() == .outdated)
+    }
+
+    @Test func uninstallRemovesManagedExtension() async throws {
+        let (url, cleanup) = tmpExtensionURL()
+        defer { cleanup() }
+        let installer = PiInstaller(extensionURL: url)
+        try await installer.install()
+
+        try installer.uninstall()
+
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+        #expect(installer.installState() == .notInstalled)
+    }
+
+    @Test func uninstallPreservesUnmanagedExtension() throws {
+        let (url, cleanup) = tmpExtensionURL()
+        defer { cleanup() }
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let unmanaged = "export default { name: 'custom' };"
+        try unmanaged.write(to: url, atomically: true, encoding: .utf8)
+        let installer = PiInstaller(extensionURL: url)
+
+        try installer.uninstall()
+
+        #expect(try String(contentsOf: url, encoding: .utf8) == unmanaged)
+        #expect(installer.installState() == .outdated)
+    }
+}

--- a/docs/superpowers/specs/2026-05-20-agent-hook-lifecycle-expansion-design.md
+++ b/docs/superpowers/specs/2026-05-20-agent-hook-lifecycle-expansion-design.md
@@ -1,0 +1,199 @@
+# Agent Hook Lifecycle Expansion Design
+
+Date: 2026-05-20
+Status: Approved for implementation planning
+
+## Goal
+
+Expand Alas' agent hook support in two directions:
+
+- richer normalized lifecycle events, so terminal status can distinguish work, permission prompts, session attachment, and session detachment;
+- more built-in hook-capable agents, starting with Gemini, OpenCode, Pi, and Copilot after the existing Claude, Codex, and Cursor integrations are updated.
+
+This design is informed by an audit of `superset-sh/superset` at commit `e344f27`. Superset's strongest pattern is its lifecycle taxonomy: it maps many native agent event names into a small set of app-level events, especially separating `SessionStart` / `SessionEnd` from per-turn work.
+
+## Non-Goals
+
+- Do not replace Alas' UNIX socket hook transport with HTTP.
+- Do not add broad PATH wrapper management for every agent in the first implementation.
+- Do not change the existing notification preferences or badge UI beyond what is necessary to represent the new states.
+- Do not require every new agent to support every lifecycle event before it can be added.
+
+## Normalized Lifecycle Model
+
+Extend the current `ActivityEvent` / `ActivityState` model with these event meanings:
+
+- `busy`: the agent is actively processing a user prompt or doing work.
+- `awaiting_input`: the agent needs user-facing input, such as an ask-user-question flow.
+- `idle`: the agent completed a turn.
+- `permission_request`: the agent is blocked on tool, shell, MCP, patch, or approval permission.
+- `attached`: an agent session is associated with an Alas terminal.
+- `detached`: an agent session ended or detached from an Alas terminal.
+
+`attached` and `detached` are session-binding signals, not work signals. They should not trigger "finished" notifications. `permission_request` can initially reuse the same user-facing notification pathway as `awaiting_input`, but it must remain distinct in the model and tests.
+
+Unknown future native events should continue to be ignored successfully, preserving the current defensive behavior.
+
+## Native Event Mapping
+
+Add a small mapping layer that translates native hook event names to normalized Alas lifecycle events. Keep the mapping local to the harness domain rather than spreading equivalent decisions across each installer.
+
+The initial alias set should include:
+
+- Session attachment: `SessionStart`, `sessionStart`, `session_start`
+- Session detachment: `SessionEnd`, `sessionEnd`, `session_end`
+- Work start/progress: `UserPromptSubmit`, `PostToolUse`, `PostToolUseFailure`, `BeforeAgent`, `AfterTool`, `userPromptSubmitted`, `postToolUse`, `task_started`
+- Permission/input needed: `PermissionRequest`, narrowed `Notification` matchers, `PreToolUse`, `preToolUse`, `exec_approval_request`, `apply_patch_approval_request`, `request_user_input`
+- Work stop: `Stop`, `stop`, `AfterAgent`, `task_complete`, `agent-turn-complete`
+
+Mappings should be tested as pure logic. Agent installers can still choose which native events they register, but once an event arrives the app should classify it through the shared mapper.
+
+## Existing Agent Updates
+
+### Claude
+
+Keep the current high-signal Claude hooks for prompt submit, tool use, notification, and stop. Add `SessionStart` / `SessionEnd` only if the currently supported Claude hook schema emits them reliably enough to bind and clear terminal identity without false work states.
+
+`PermissionRequest` should map to `permission_request` where supported. Existing `Notification` matchers for permission and idle prompts should continue to avoid broad false positives.
+
+### Codex
+
+Keep `UserPromptSubmit` and `Stop`. Add `SessionStart` / `SessionEnd` if Codex native hooks support them in the installed hooks format Alas already manages.
+
+Codex approval-related events should map to `permission_request` if they become available through the current hooks surface. Do not depend on wrapper-only session log parsing for the first pass.
+
+### Cursor
+
+Extend Cursor hook registration beyond prompt/response/stop:
+
+- `sessionStart` -> `attached`
+- `sessionEnd` -> `detached`
+- `beforeSubmitPrompt` -> `busy`
+- `beforeShellExecution` -> `permission_request`
+- `beforeMCPExecution` -> `permission_request`
+- `stop` -> `idle`
+
+Cursor's existing idle debounce should remain. Permission events should cancel pending idle debounce the same way `busy` and `awaiting_input` do.
+
+## New Built-In Agents
+
+### Gemini
+
+Add Gemini hook support using its settings file if the current CLI hook schema supports it:
+
+- `SessionStart` -> `attached`
+- `SessionEnd` -> `detached`
+- `BeforeAgent` -> `busy`
+- `AfterTool` -> `busy`
+- `AfterAgent` -> `idle`
+
+The hook command must print whatever minimal valid response Gemini expects so it never blocks the agent loop. If that requirement cannot be satisfied with the same shell command envelope Alas uses today, Gemini should get a small agent-specific command script rather than forcing complexity into `AlasHookCommand`.
+
+### OpenCode
+
+Prefer OpenCode's plugin mechanism over global wrapper-only behavior. The plugin should activate only inside Alas terminals and should:
+
+- emit `attached` and `detached` for root sessions;
+- emit `busy` on root-session busy transitions;
+- emit `idle` once per busy period on root-session idle/error;
+- emit `permission_request` on permission ask events;
+- filter child or subagent sessions where the OpenCode event data exposes parent/root session identity.
+
+Do not write a global OpenCode plugin path if an Alas-scoped config path can avoid dev/prod or multi-instance conflicts.
+
+### Pi
+
+Add Pi hook support through its extension/plugin mechanism if available:
+
+- session start/end -> `attached` / `detached`
+- before agent start -> `busy`
+- tool execution end -> `busy`
+- agent end or session shutdown -> `idle`
+
+The implementation should skip non-interactive/subagent contexts when Pi exposes a reliable UI/session flag. If that flag is absent, default to supporting interactive sessions and document the possible subagent flicker.
+
+### Copilot
+
+Add Copilot after the first three new agents unless its hook format proves simpler than expected. Copilot appears to rely on project-level hook files, so the implementation should avoid permanently dirtying repositories:
+
+- write a dedicated managed hook file only when launching Copilot from an Alas terminal;
+- add that hook file to `.git/info/exclude` when possible;
+- preserve any existing project hook files;
+- map session start/end, user prompt submit, post-tool-use, and pre-tool-use events into the normalized lifecycle.
+
+## Installer Structure
+
+Keep `AgentInstallerRegistry` explicit. Add installers one at a time rather than making every `AgentDefinition` automatically hook-capable.
+
+Each installer should expose:
+
+- the managed agent kind/id;
+- the settings or plugin file it mutates, if any;
+- a canonical event map used for install-state comparison;
+- install, uninstall, and stale-managed-entry pruning behavior;
+- tests covering preservation of user hooks and detection of outdated managed hooks.
+
+If an agent requires a generated script or plugin file, that file should be versioned with a managed marker so future app versions can identify and replace stale entries without removing user-owned configuration.
+
+## Data Flow
+
+1. An agent-native hook fires.
+2. The managed hook command or plugin emits a versioned Alas envelope through `ALAS_SOCKET_PATH`.
+3. `AgentHookSocketServer` decodes the envelope and ignores unknown events successfully.
+4. The shared mapper converts native names or already-normalized names to an Alas lifecycle event.
+5. `HarnessService` updates session state:
+   - `busy`: running state, cancel pending idle debounce;
+   - `awaiting_input`: awaiting state and optional input notification;
+   - `permission_request`: permission-needed state and optional attention notification;
+   - `idle`: finished state and optional completion notification;
+   - `attached`: bind agent/session identity without marking work;
+   - `detached`: clear active binding and transient running/permission state.
+
+## Error Handling
+
+Hook failures must never break the agent command. All hook commands should remain best-effort and time-bounded.
+
+Malformed hook envelopes should still return an error response where possible. Unknown but well-formed events should be acknowledged and ignored.
+
+For settings files:
+
+- invalid JSON should not be overwritten;
+- user-owned hooks must be preserved;
+- managed entries should be compared per event so stale placement is detected;
+- managed entries from older Alas hook versions should be pruned by marker/path when possible.
+
+## Testing
+
+Add focused Swift Testing coverage for:
+
+- native event mapping aliases;
+- decoding new normalized events;
+- `HarnessService` handling for `attached`, `detached`, and `permission_request`;
+- no completion notification for `attached` or `detached`;
+- permission events canceling Cursor idle debounce;
+- installer install-state comparisons for new event placements;
+- user hook preservation for each new installer;
+- stale managed hook replacement for each generated settings/plugin file.
+
+Manual verification should run the standard project checks:
+
+```sh
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Manual agent smoke checks should cover Claude, Codex, Cursor, Gemini, OpenCode, Pi, and Copilot where installed locally.
+
+## Rollout
+
+Implement in reviewable slices:
+
+1. Lifecycle model and mapper, with tests and no new agents.
+2. Update Claude, Codex, and Cursor installers to use the richer lifecycle.
+3. Add Gemini installer.
+4. Add OpenCode installer/plugin.
+5. Add Pi installer/extension.
+6. Add Copilot project-hook support.
+
+Each slice should leave the app usable if later agents are not installed on the user's machine.


### PR DESCRIPTION
## Summary

Adds richer lifecycle event support for agent hooks and expands built-in hook installers for Gemini, OpenCode, Pi, and GitHub Copilot.

## Details

- Adds shared lifecycle event mapping and richer busy, idle, attached, detached, and permission states.
- Extends built-in agent coverage and terminal launch identity handling.
- Adds hook installer support for Gemini, OpenCode, Pi, and Copilot.
- Handles Copilot permission and tool-use events separately, including linked-worktree exclude handling.
- Updates focused tests for lifecycle mapping and the new installers.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused lifecycle/installer test run for AgentLifecycleEventMapper, CopilotInstaller, AgentTerminalLaunch, OpenCodeInstaller, and PiInstaller

Full local `xcodebuild ... test` remains inconclusive in this environment because the wrapper session stays open after the underlying Xcode/test processes have exited.