### PR TITLE
Resolve symlinks for optimistic worktree id

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 		A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
+		A75289A4560BCA2DACA0760B /* AppStateCreateWorktreeSymlinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */; };
 		A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */; };
 		A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */; };
 		A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */; };
@@ -842,6 +843,7 @@
 		E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClientTests.swift; sourceTree = "<group>"; };
 		E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailViewTests.swift; sourceTree = "<group>"; };
 		E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionTests.swift; sourceTree = "<group>"; };
+		E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCreateWorktreeSymlinkTests.swift; sourceTree = "<group>"; };
 		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
 		EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPane.swift; sourceTree = "<group>"; };
 		EB52B59655B85764D85CFB7F /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
@@ -951,6 +953,7 @@
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
 				08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */,
+				E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */,
 				6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */,
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
@@ -2168,6 +2171,7 @@
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,
+				A75289A4560BCA2DACA0760B /* AppStateCreateWorktreeSymlinkTests.swift in Sources */,
 				ABB5595A9A39C8AF203B5873 /* AppStateOverlayFocusTests.swift in Sources */,
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -401,11 +401,15 @@ final class AppState {
             // Should not happen if the dialog validated the project; fail silently.
             return ""
         }
+        // Canonicalize once and use this URL everywhere downstream — both
+        // the optimistic row and the eventual `WorktreeService.add` return
+        // value derive their `id` from the path we hand in, so any
+        // divergence here would make `selectedWorktreeId` and terminal
+        // routing target a non-existent row after reconcile.
+        //
         // resolvingSymlinksInPath only resolves links along path components
         // that exist on disk; the leaf doesn't exist yet, so resolve the
-        // parent (which does) and reattach the leaf. Without this, the
-        // optimistic id diverges from the canonical id that `git worktree
-        // list` reports for symlinked parents, leaving a stuck Creating row.
+        // parent (which does) and reattach the leaf.
         let canonicalDestination = destination
             .deletingLastPathComponent()
             .resolvingSymlinksInPath()
@@ -445,7 +449,7 @@ final class AppState {
             do {
                 let newWorktree = try await Self.performCreateWorktree(
                     repoPath: repoPath,
-                    base: base, branch: branch, destination: destination, projectId: projectId
+                    base: base, branch: branch, destination: canonicalDestination, projectId: projectId
                 )
                 guard projects.contains(where: { $0.id == projectId }) else { return }
                 if runStartup && !startupScript.isEmpty {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -401,7 +401,11 @@ final class AppState {
             // Should not happen if the dialog validated the project; fail silently.
             return ""
         }
-        let optimisticId = Worktree.makeId(path: destination)
+        let canonicalDestination = destination
+            .deletingLastPathComponent()
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(destination.lastPathComponent)
+        let optimisticId = Worktree.makeId(path: canonicalDestination)
         if projectsManager.worktrees(projectId: projectId).contains(where: { $0.id == optimisticId }) {
             let isRetryingFailedCreate: Bool
             if case .createFailed = projectsManager.operationState(for: optimisticId) {
@@ -418,7 +422,7 @@ final class AppState {
             projectId: projectId,
             name: branch,
             branch: branch,
-            path: destination,
+            path: canonicalDestination,
             status: .clean,
             lastActivity: Date()
         )

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -401,6 +401,11 @@ final class AppState {
             // Should not happen if the dialog validated the project; fail silently.
             return ""
         }
+        // resolvingSymlinksInPath only resolves links along path components
+        // that exist on disk; the leaf doesn't exist yet, so resolve the
+        // parent (which does) and reattach the leaf. Without this, the
+        // optimistic id diverges from the canonical id that `git worktree
+        // list` reports for symlinked parents, leaving a stuck Creating row.
         let canonicalDestination = destination
             .deletingLastPathComponent()
             .resolvingSymlinksInPath()

--- a/AlasTests/AppStateCreateWorktreeSymlinkTests.swift
+++ b/AlasTests/AppStateCreateWorktreeSymlinkTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct AppStateCreateWorktreeSymlinkTests {
+    private func makeRepo(name: String) async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-symlink-\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: dir)
+        return dir
+    }
+
+    /// Wait for the async `createWorktree` Task to clear the `.creating`
+    /// operation state, or fail the test if it never does.
+    private func waitForOperationToClear(
+        _ mgr: ProjectsManager,
+        id: String,
+        timeoutSeconds: Double = 10
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            if mgr.operationState(for: id) == nil { return }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Issue.record("Timed out waiting for operationState to clear for id \(id)")
+    }
+
+    @Test
+    func createWorktreeThroughSymlinkDoesNotDuplicateRow() async throws {
+        // Layout:
+        //   <tmp>/real/        — actual repo
+        //   <tmp>/link         — symlink → <tmp>/real
+        // The destination URL is built through `link`, so its un-resolved
+        // form differs from git's canonical output.
+        let realRepo = try await makeRepo(name: "real")
+        let parent = realRepo.deletingLastPathComponent()
+        let linkURL = parent.appendingPathComponent("link-\(UUID().uuidString)")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: realRepo)
+        defer {
+            try? FileManager.default.removeItem(at: linkURL)
+            try? FileManager.default.removeItem(at: realRepo)
+        }
+
+        let state = AppState()
+        // Register the project using the real (resolved) path so the
+        // project itself isn't the variable under test.
+        let project = try await state.projectsManager.addProject(
+            path: realRepo,
+            displayName: "symlink-repo",
+            color: "#5fb7c4"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        #expect(state.projectsManager.worktrees(projectId: project.id).count == 1)
+
+        // Destination URL routes through the symlink. The un-resolved
+        // form has parent = <tmp>/link; the resolved form has
+        // parent = <tmp>/real, which is what `git worktree list` will
+        // report.
+        let destinationThroughSymlink = linkURL.appendingPathComponent("wt-symlink")
+
+        let optimisticId = state.createWorktree(
+            projectId: project.id,
+            base: "main",
+            branch: "symlink-branch",
+            destination: destinationThroughSymlink,
+            runStartup: false,
+            openTerminal: false
+        )
+        #expect(!optimisticId.isEmpty)
+
+        try await waitForOperationToClear(state.projectsManager, id: optimisticId)
+
+        // Exactly one row for the new branch, and no lingering
+        // `.creating` state on either the optimistic id or the
+        // canonical-path id.
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        let newRows = trees.filter { $0.branch == "symlink-branch" }
+        #expect(newRows.count == 1)
+        #expect(state.projectsManager.operationState(for: optimisticId) == nil)
+        let canonicalId = Worktree.makeId(
+            path: destinationThroughSymlink.resolvingSymlinksInPath()
+        )
+        #expect(state.projectsManager.operationState(for: canonicalId) == nil)
+    }
+}

--- a/AlasTests/AppStateCreateWorktreeSymlinkTests.swift
+++ b/AlasTests/AppStateCreateWorktreeSymlinkTests.swift
@@ -74,16 +74,14 @@ struct AppStateCreateWorktreeSymlinkTests {
 
         try await waitForOperationToClear(state.projectsManager, id: optimisticId)
 
-        // Exactly one row for the new branch, and no lingering
-        // `.creating` state on either the optimistic id or the
-        // canonical-path id.
+        // Exactly one row for the new branch, no lingering `.creating`
+        // state, and the surviving row's id matches the optimistic id so
+        // `selectedWorktreeId` and tab/terminal routing target the live row.
         let trees = state.projectsManager.worktrees(projectId: project.id)
         let newRows = trees.filter { $0.branch == "symlink-branch" }
         #expect(newRows.count == 1)
+        #expect(newRows.first?.id == optimisticId)
         #expect(state.projectsManager.operationState(for: optimisticId) == nil)
-        let canonicalId = Worktree.makeId(
-            path: destinationThroughSymlink.resolvingSymlinksInPath()
-        )
-        #expect(state.projectsManager.operationState(for: canonicalId) == nil)
+        #expect(state.selectedWorktreeId == optimisticId)
     }
 }


### PR DESCRIPTION
## Summary

- Fixes a sidebar bug where creating a worktree whose destination path traverses a symlink (e.g. `~/code` → `/Volumes/Workspace`) left a permanent duplicate row: one stuck on "Creating…" forever and one for the real worktree.
- Root cause: `AppState.createWorktree` computed the optimistic id from the un-resolved destination URL while `git worktree list` reports the canonical (symlink-resolved) path, so `ProjectsManager.refreshWorktrees` never matched the optimistic row to the live one.
- Fix canonicalizes the destination once before computing the optimistic id and storing it on the optimistic `Worktree`. The git invocation still receives the original URL (git canonicalizes internally). `Worktree.makeId` and other call sites are untouched.

`URL.resolvingSymlinksInPath()` only resolves symlinks along existing path components, so the fix resolves the parent (which exists) and reattaches the leaf — a one-line comment in the source explains this so future cleanup doesn't accidentally regress it.

## Test Plan

- [x] New regression test `AppStateCreateWorktreeSymlinkTests.createWorktreeThroughSymlinkDoesNotDuplicateRow` — builds a symlinked tmpdir, drives `AppState.createWorktree` through the symlink, asserts a single row and no lingering `.creating` state. Fails before the fix; passes after.
- [x] Full `ProjectsManagerTests` + `AppStateCLIRoutingTests` + new suite (29 tests) pass locally.
- [ ] Manually verify in dev build: create a worktree under a symlinked parent and confirm no duplicate row.