### PR TITLE
Add 'Delete Worktree, Keep Branch…' context-menu item

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1685,6 +1685,16 @@ final class AppState {
         }.value
     }
 
+    /// Resolve whether `git branch -d` should run after `git worktree remove`.
+    /// `keepBranch == true` (a per-operation override) always wins — the local
+    /// branch is preserved regardless of the global setting.
+    nonisolated static func resolveDeleteBranchIfMerged(
+        globalDeleteOnRemove: Bool,
+        keepBranch: Bool
+    ) -> Bool {
+        globalDeleteOnRemove && !keepBranch
+    }
+
     /// Permissive substring check: git's exact wording around dirty/submodule
     /// worktrees varies by version. If the match misses, the caller surfaces
     /// the raw stderr instead, which is acceptable degradation.

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1536,7 +1536,8 @@ final class AppState {
                 action: "Delete",
                 branch: worktree.branch,
                 dirtyCount: dirty.count,
-                onDiskDestructive: true
+                onDiskDestructive: true,
+                keepBranch: keepBranch
             ) {
             case .save: saveBuffersFirst = true
             case .discard: saveBuffersFirst = false
@@ -1753,16 +1754,22 @@ final class AppState {
         action: String,
         branch: String,
         dirtyCount: Int,
-        onDiskDestructive: Bool
+        onDiskDestructive: Bool,
+        keepBranch: Bool = false
     ) -> DirtyBufferChoice {
         let alert = NSAlert()
         alert.messageText = "\(action) worktree '\(branch)'?"
         let countSentence = dirtyCount == 1
             ? "1 file has unsaved changes."
             : "\(dirtyCount) files have unsaved changes."
-        let actionSentence = onDiskDestructive
-            ? "This removes its files from disk. The local branch will be deleted if merged."
-            : "The worktree itself stays on disk."
+        let actionSentence: String
+        if onDiskDestructive {
+            actionSentence = keepBranch
+                ? "This removes its files from disk. The local branch will be kept."
+                : "This removes its files from disk. The local branch will be deleted if merged."
+        } else {
+            actionSentence = "The worktree itself stays on disk."
+        }
         alert.informativeText = "\(countSentence) Saving will write them to disk; discarding will lose them. \(actionSentence)"
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Save & \(action)")

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1525,11 +1525,11 @@ final class AppState {
     /// Delete a worktree from disk. Shows a confirm dialog; on dirty-tree
     /// failure sets `pendingForceDeleteWorktree` so SwiftUI can present a
     /// state-driven confirmation. Cleans up in-app state on success.
-    func deleteWorktree(_ worktree: Worktree) {
+    func deleteWorktree(_ worktree: Worktree, keepBranch: Bool = false) {
         let dirty = dirtyEditorTabIds(worktreeId: worktree.id)
         let saveBuffersFirst: Bool
         if dirty.isEmpty {
-            guard confirmDeleteWorktree(branch: worktree.branch) else { return }
+            guard confirmDeleteWorktree(branch: worktree.branch, keepBranch: keepBranch) else { return }
             saveBuffersFirst = false
         } else {
             switch promptForDirtyBuffers(
@@ -1551,7 +1551,10 @@ final class AppState {
             return
         }
         let repoPath = URL(fileURLWithPath: project.path)
-        let deleteBranch = config.worktrees.deleteBranchOnRemove
+        let deleteBranch = Self.resolveDeleteBranchIfMerged(
+            globalDeleteOnRemove: config.worktrees.deleteBranchOnRemove,
+            keepBranch: keepBranch
+        )
 
         let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
         let removedIndex = siblingsBefore.firstIndex(where: { $0.id == worktree.id }) ?? 0
@@ -1715,10 +1718,12 @@ final class AppState {
         return nil
     }
 
-    private func confirmDeleteWorktree(branch: String) -> Bool {
+    private func confirmDeleteWorktree(branch: String, keepBranch: Bool) -> Bool {
         let alert = NSAlert()
         alert.messageText = "Delete worktree '\(branch)'?"
-        alert.informativeText = "This removes its files from disk. The local branch will be deleted if merged."
+        alert.informativeText = keepBranch
+            ? "This removes its files from disk. The local branch will be kept."
+            : "This removes its files from disk. The local branch will be deleted if merged."
         alert.alertStyle = .warning
         let deleteButton = alert.addButton(withTitle: "Delete")
         alert.addButton(withTitle: "Cancel")

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -25,6 +25,8 @@ struct RepoGroupView: View {
     let onRevealInFinder: (Worktree) -> Void
     let onArchive: (Worktree) -> Void
     let onDelete: (Worktree) -> Void
+    let onDeleteKeepBranch: (Worktree) -> Void
+    let showKeepBranchOption: Bool
     let onActivateHarness: (Worktree) -> Void
     let onCopyError: (String) -> Void
     let onRetryCreate: (Worktree) -> Void
@@ -119,6 +121,8 @@ struct RepoGroupView: View {
                             onRevealInFinder: { onRevealInFinder(wt) },
                             onArchive: { onArchive(wt) },
                             onDelete: { onDelete(wt) },
+                            onDeleteKeepBranch: { onDeleteKeepBranch(wt) },
+                            showKeepBranchOption: showKeepBranchOption,
                             onActivateHarness: { onActivateHarness(wt) },
                             onCopyError: onCopyError,
                             onRemoveFailed: { onRemoveFailed(wt) },

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -78,6 +78,8 @@ struct SidebarView: View {
                                 },
                                 onArchive: { wt in state.archiveWorktree(wt) },
                                 onDelete: { wt in state.deleteWorktree(wt) },
+                                onDeleteKeepBranch: { wt in state.deleteWorktree(wt, keepBranch: true) },
+                                showKeepBranchOption: state.config.worktrees.deleteBranchOnRemove,
                                 onActivateHarness: { wt in
                                     let ids = state.tabs.tabs(forWorktree: wt.id).flatMap { tab -> [String] in
                                         if case .terminal(let s) = tab { return s.root.leaves().map(\.sessionId) }

--- a/Alas/Sources/Sidebar/WorktreeRowView.swift
+++ b/Alas/Sources/Sidebar/WorktreeRowView.swift
@@ -12,6 +12,8 @@ struct WorktreeRowView: View {
     let onRevealInFinder: () -> Void
     let onArchive: () -> Void
     let onDelete: () -> Void
+    let onDeleteKeepBranch: () -> Void
+    let showKeepBranchOption: Bool
     let onActivateHarness: () -> Void
     let onCopyError: (String) -> Void
     let onRemoveFailed: () -> Void
@@ -139,6 +141,9 @@ struct WorktreeRowView: View {
                 Divider()
                 Button("Archive", action: onArchive)
                 Button("Delete Worktree…", role: .destructive, action: onDelete)
+                if showKeepBranchOption {
+                    Button("Delete Worktree, Keep Branch…", role: .destructive, action: onDeleteKeepBranch)
+                }
             }
         }
     }

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -287,6 +287,17 @@ struct AppStateCleanupTests {
         #expect(AppState.forceDeleteReason(for: "") == nil)
     }
 
+    @Test func resolveDeleteBranchIfMergedRespectsKeepBranchOverride() {
+        // Global on, no override → delete branch.
+        #expect(AppState.resolveDeleteBranchIfMerged(globalDeleteOnRemove: true, keepBranch: false) == true)
+        // Global on, override on → keep branch.
+        #expect(AppState.resolveDeleteBranchIfMerged(globalDeleteOnRemove: true, keepBranch: true) == false)
+        // Global off, no override → keep branch (existing behavior).
+        #expect(AppState.resolveDeleteBranchIfMerged(globalDeleteOnRemove: false, keepBranch: false) == false)
+        // Global off, override on → keep branch.
+        #expect(AppState.resolveDeleteBranchIfMerged(globalDeleteOnRemove: false, keepBranch: true) == false)
+    }
+
     @Test func cancelForceDeleteClearsPendingState() async throws {
         let repo = try await makeRepo(name: "cancel-force")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/RepoGroupViewLayoutTests.swift
+++ b/AlasTests/RepoGroupViewLayoutTests.swift
@@ -51,6 +51,8 @@ struct RepoGroupViewLayoutTests {
             onRevealInFinder: { _ in },
             onArchive: { _ in },
             onDelete: { _ in },
+            onDeleteKeepBranch: { _ in },
+            showKeepBranchOption: false,
             onActivateHarness: { _ in },
             onCopyError: { _ in },
             onRetryCreate: { _ in },


### PR DESCRIPTION
## Summary

- Adds a second destructive item to the worktree row's right-click menu, **Delete Worktree, Keep Branch…**, that removes the worktree but never deletes the local branch — independent of the global `worktrees.deleteBranchOnRemove` setting.
- The new item appears only when the global setting is **on** (otherwise it would duplicate the existing "Delete Worktree…" behavior).
- Confirm-alert text adjusts: existing item still says "…The local branch will be deleted if merged.", new item says "…The local branch will be kept."
- Force-delete-after-dirty inherits the choice automatically — `PendingForceDeleteWorktree` already carries the resolved `deleteBranchIfMerged`.

## Test plan

- [ ] With Settings → Worktrees → "Delete branch on remove" **on**, right-click a worktree: both items appear.
- [ ] Toggle the setting **off**: the second item disappears without restart.
- [ ] Toggle back **on**: the second item reappears.
- [ ] Merge a throwaway branch and delete via "Delete Worktree…" — branch is gone.
- [ ] Merge another throwaway branch and delete via "Delete Worktree, Keep Branch…" — branch remains.
- [ ] Repeat the keep-branch flow on a dirty worktree to confirm the force-delete prompt still keeps the branch.

Spec: `docs/superpowers/specs/2026-05-21-delete-worktree-keep-branch-design.md` (gitignored).