### PR TITLE
ci: add macOS Intel (x86_64) release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,10 +179,15 @@ jobs:
       - name: Get version from tag
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
-      - name: Download DMG and compute checksum
+      - name: Download DMGs and compute checksums
         run: |
-          curl -fsSL "https://github.com/mrmans0n/alas/releases/download/v${VERSION}/Alas-${VERSION}-arm64.dmg" -o alas.dmg
-          echo "SHA_ARM=$(shasum -a 256 alas.dmg | cut -d' ' -f1)" >> "$GITHUB_ENV"
+          curl -fsSL "https://github.com/mrmans0n/alas/releases/download/v${VERSION}/Alas-${VERSION}-arm64.dmg" -o alas-arm64.dmg
+          curl -fsSL "https://github.com/mrmans0n/alas/releases/download/v${VERSION}/Alas-${VERSION}-x86_64.dmg" -o alas-x86_64.dmg
+          # Both shasum lines emit just the digest; the cut prevents stray
+          # filename data from leaking into the env var (which update-cask.py
+          # validates regex-strictly).
+          echo "SHA_ARM=$(shasum -a 256 alas-arm64.dmg | cut -d' ' -f1)" >> "$GITHUB_ENV"
+          echo "SHA_INTEL=$(shasum -a 256 alas-x86_64.dmg | cut -d' ' -f1)" >> "$GITHUB_ENV"
 
       - name: Checkout homebrew-tap
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     # notary queue is slow, so worst-case notary time alone is 60 min.
     # 90 min leaves ~30 min headroom for build/package/upload even when
     # both notary submissions hit their per-call timeout.
-    timeout-minutes: 90
+    timeout-minutes: 150
     steps:
       - name: Checkout (with submodules)
         uses: actions/checkout@v6
@@ -46,17 +46,22 @@ jobs:
         with:
           path: |
             .build/ghostty
+            ~/Library/Caches/Alas/GhosttyKit
           key: ghostty-${{ runner.os }}-${{ hashFiles('.ghostty-pin') }}
-
-      - name: Build Ghostty xcframework
-        # Must run before xcodebuild — Xcode validates xcframework refs at
-        # build description time, before preBuildScripts run.
-        run: ./scripts/build-ghostty.sh
 
       - name: Generate project
         run: xcodegen
 
-      - name: Build release app
+      - name: Compute version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      # --- arm64 pass -------------------------------------------------------
+      - name: Build Ghostty xcframework (arm64)
+        env:
+          ALAS_GHOSTTY_TARGET_ARCH: arm64
+        run: ./scripts/build-ghostty.sh
+
+      - name: Build release app (arm64)
         run: |
           xcodebuild -project Alas.xcodeproj -scheme Alas \
             -configuration Release \
@@ -64,10 +69,7 @@ jobs:
             -destination 'platform=macOS,arch=arm64' \
             -quiet build
 
-      - name: Compute version from tag
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
-
-      - name: Sign + notarize + staple .app
+      - name: Sign + notarize + staple .app (arm64)
         env:
           MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
           MACOS_CERTIFICATE_PASSWORD:   ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -77,15 +79,66 @@ jobs:
           MACOS_NOTARY_TEAM_ID:         ${{ secrets.MACOS_NOTARY_TEAM_ID }}
         run: ./scripts/sign-and-notarize.sh build/Build/Products/Release/Alas.app
 
-      - name: Package .app (zip + DMG)
+      - name: Package .app — arm64 (zip + DMG)
         run: ./scripts/package-app.sh build/Build/Products/Release/Alas.app "Alas-${VERSION}-arm64"
 
-      - name: Notarize + staple DMG
+      - name: Notarize + staple DMG (arm64)
         env:
           MACOS_NOTARY_APPLE_ID:     ${{ secrets.MACOS_NOTARY_APPLE_ID }}
           MACOS_NOTARY_APP_PASSWORD: ${{ secrets.MACOS_NOTARY_APP_PASSWORD }}
           MACOS_NOTARY_TEAM_ID:      ${{ secrets.MACOS_NOTARY_TEAM_ID }}
         run: ./scripts/notarize-and-staple-dmg.sh "build/Build/Products/Release/Alas-${VERSION}-arm64.dmg"
+
+      # --- x86_64 pass ------------------------------------------------------
+      - name: Reset worktree + keychain + DerivedData for x86_64 pass
+        # Wipe the per-arch ghostty worktree dir + xcodebuild DerivedData so the
+        # second pass starts clean. Without this, xcodebuild may keep the arm64
+        # .app at the same DerivedData path and confuse the codesign/notary
+        # step. The shared Ghostty cache at ~/Library/Caches/Alas/GhosttyKit
+        # is *not* wiped — the x86_64 build will hit it on subsequent CI runs.
+        # The signing keychain MUST also be wiped: sign-and-notarize.sh creates
+        # a keychain at a fixed path ($RUNNER_TEMP/signing.keychain-db) and
+        # `security create-keychain` errors when that file already exists, so
+        # the second pass would fail without this. cleanup-signing-keychain.sh
+        # is idempotent — calling it mid-run is safe; the final `if: always()`
+        # cleanup step at job end still runs against the x86_64 keychain.
+        run: |
+          rm -rf .build/ghostty
+          rm -rf build/Build/Products/Release/Alas.app
+          ./scripts/cleanup-signing-keychain.sh
+
+      - name: Build Ghostty xcframework (x86_64)
+        env:
+          ALAS_GHOSTTY_TARGET_ARCH: x86_64
+        run: ./scripts/build-ghostty.sh
+
+      - name: Build release app (x86_64)
+        run: |
+          xcodebuild -project Alas.xcodeproj -scheme Alas \
+            -configuration Release \
+            -derivedDataPath build \
+            -destination 'platform=macOS,arch=x86_64' \
+            -quiet build
+
+      - name: Sign + notarize + staple .app (x86_64)
+        env:
+          MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD:   ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          MACOS_SIGNING_IDENTITY:       ${{ secrets.MACOS_SIGNING_IDENTITY }}
+          MACOS_NOTARY_APPLE_ID:        ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          MACOS_NOTARY_APP_PASSWORD:    ${{ secrets.MACOS_NOTARY_APP_PASSWORD }}
+          MACOS_NOTARY_TEAM_ID:         ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+        run: ./scripts/sign-and-notarize.sh build/Build/Products/Release/Alas.app
+
+      - name: Package .app — x86_64 (zip + DMG)
+        run: ./scripts/package-app.sh build/Build/Products/Release/Alas.app "Alas-${VERSION}-x86_64"
+
+      - name: Notarize + staple DMG (x86_64)
+        env:
+          MACOS_NOTARY_APPLE_ID:     ${{ secrets.MACOS_NOTARY_APPLE_ID }}
+          MACOS_NOTARY_APP_PASSWORD: ${{ secrets.MACOS_NOTARY_APP_PASSWORD }}
+          MACOS_NOTARY_TEAM_ID:      ${{ secrets.MACOS_NOTARY_TEAM_ID }}
+        run: ./scripts/notarize-and-staple-dmg.sh "build/Build/Products/Release/Alas-${VERSION}-x86_64.dmg"
 
       - name: Cleanup signing keychain
         if: always()
@@ -110,6 +163,8 @@ jobs:
           files: |
             build/Build/Products/Release/Alas-*-arm64.app.zip
             build/Build/Products/Release/Alas-*-arm64.dmg
+            build/Build/Products/Release/Alas-*-x86_64.app.zip
+            build/Build/Products/Release/Alas-*-x86_64.dmg
 
   update-homebrew:
     name: Update Homebrew Cask

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,10 @@ jobs:
     # main HEAD requirement). Submodule + zig@0.15 are required for the
     # Ghostty xcframework build.
     runs-on: macos-26
-    # Two notarytool --wait --timeout 30m calls in this job (one for the
-    # .app, one for the .dmg) can each consume up to 30 min if Apple's
-    # notary queue is slow, so worst-case notary time alone is 60 min.
-    # 90 min leaves ~30 min headroom for build/package/upload even when
-    # both notary submissions hit their per-call timeout.
+    # Four notarytool --wait --timeout 30m calls in this job (one .app and
+    # one DMG per arch). Worst-case notary time alone is 120 min if Apple's
+    # queue is slow on all four submissions. 150 min leaves ~30 min headroom
+    # for build/package/upload even when every notary call hits its timeout.
     timeout-minutes: 150
     steps:
       - name: Checkout (with submodules)
@@ -90,12 +89,14 @@ jobs:
         run: ./scripts/notarize-and-staple-dmg.sh "build/Build/Products/Release/Alas-${VERSION}-arm64.dmg"
 
       # --- x86_64 pass ------------------------------------------------------
-      - name: Reset worktree + keychain + DerivedData for x86_64 pass
-        # Wipe the per-arch ghostty worktree dir + xcodebuild DerivedData so the
-        # second pass starts clean. Without this, xcodebuild may keep the arm64
-        # .app at the same DerivedData path and confuse the codesign/notary
-        # step. The shared Ghostty cache at ~/Library/Caches/Alas/GhosttyKit
-        # is *not* wiped — the x86_64 build will hit it on subsequent CI runs.
+      - name: Reset ghostty worktree + signing keychain for x86_64 pass
+        # Wipe the per-arch ghostty worktree dir + the Alas.app build product
+        # from the arm64 pass so the x86_64 xcodebuild writes a fresh Alas.app
+        # at the same DerivedData path. (Intermediate object files at
+        # build/Build/Intermediates.noindex/ are intentionally left alone —
+        # xcodebuild rebuilds arch-specific objects on its own.) The shared
+        # Ghostty cache at ~/Library/Caches/Alas/GhosttyKit is *not* wiped —
+        # the x86_64 build will hit it on subsequent CI runs.
         # The signing keychain MUST also be wiped: sign-and-notarize.sh creates
         # a keychain at a fixed path ($RUNNER_TEMP/signing.keychain-db) and
         # `security create-keychain` errors when that file already exists, so

--- a/.github/workflows/update-cask.py
+++ b/.github/workflows/update-cask.py
@@ -17,6 +17,13 @@ for name, value in (("SHA_ARM", SHA_ARM), ("SHA_INTEL", SHA_INTEL)):
     if not _SHA_RE.fullmatch(value):
         sys.exit(f"error: {name} is not a 64-char lowercase hex sha256 ({value!r})")
 
+# Reject tags that would inject quotes/newlines/backslashes into the rendered
+# .rb file. The regex matches strict semver plus a permissive suffix for
+# pre-release/dry-run tags like "0.0.0-intel-test" or "1.2.3-rc1".
+_VERSION_RE = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+(?:[a-zA-Z0-9._-]*)")
+if not _VERSION_RE.fullmatch(VERSION):
+    sys.exit(f"error: VERSION does not look like a semver-ish tag ({VERSION!r})")
+
 CASK = f'''\
 cask "alas" do
   version "{VERSION}"
@@ -49,6 +56,10 @@ cask "alas" do
 end
 '''
 
+# Path is relative to cwd — run from the homebrew-tap repo root.
+# release.yml sets `working-directory: homebrew-tap` for this step; the
+# Task 3 dry-run in the plan writes a stray Casks/ alongside this repo,
+# which is rm'd before commit.
 path = pathlib.Path("Casks/alas.rb")
 path.parent.mkdir(parents=True, exist_ok=True)
 path.write_text(CASK)

--- a/.github/workflows/update-cask.py
+++ b/.github/workflows/update-cask.py
@@ -1,22 +1,39 @@
 #!/usr/bin/env python3
-"""Generate the alas Homebrew cask file."""
+"""Generate the alas Homebrew cask file for both arm64 and x86_64."""
 import os
 import pathlib
+import re
+import sys
 
 VERSION = os.environ["VERSION"]
 SHA_ARM = os.environ["SHA_ARM"]
+SHA_INTEL = os.environ["SHA_INTEL"]
+
+# Reject anything that isn't a 64-char lowercase hex digest. Catches the
+# zero-byte-download failure mode where one of the curl steps in release.yml
+# silently produced an empty file, which would otherwise ship a useless cask.
+_SHA_RE = re.compile(r"[a-f0-9]{64}")
+for name, value in (("SHA_ARM", SHA_ARM), ("SHA_INTEL", SHA_INTEL)):
+    if not _SHA_RE.fullmatch(value):
+        sys.exit(f"error: {name} is not a 64-char lowercase hex sha256 ({value!r})")
 
 CASK = f'''\
 cask "alas" do
   version "{VERSION}"
-  sha256 "{SHA_ARM}"
 
-  url "https://github.com/mrmans0n/alas/releases/download/v#{{version}}/Alas-#{{version}}-arm64.dmg"
+  on_arm do
+    sha256 "{SHA_ARM}"
+    url "https://github.com/mrmans0n/alas/releases/download/v#{{version}}/Alas-#{{version}}-arm64.dmg"
+  end
+  on_intel do
+    sha256 "{SHA_INTEL}"
+    url "https://github.com/mrmans0n/alas/releases/download/v#{{version}}/Alas-#{{version}}-x86_64.dmg"
+  end
+
   name "Alas"
   desc "AI parallel agent orchestrator"
   homepage "https://github.com/mrmans0n/alas"
 
-  depends_on arch: :arm64
   depends_on macos: :sonoma
 
   app "Alas.app"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### 🏗️ Internal
+
+- release pipeline now publishes both arm64 and x86_64 DMGs; Homebrew cask serves both via `on_arm`/`on_intel`.
+
 ## [0.3.8] - 2026-05-21
 
 ### ✨ Features

--- a/scripts/build-ghostty.sh
+++ b/scripts/build-ghostty.sh
@@ -145,11 +145,25 @@ build_and_install_local() {
       echo "error: zig not found (looked at ${zig_bin}). Install with: brew install zig@0.15, or set ALAS_ZIG_BIN" >&2
       exit 1
     fi
+    # Zig uses the LLVM triple name `aarch64`, not Apple's `arm64`. Translate
+    # before passing to zig; everything else (cache path, fingerprint, env
+    # var) keeps the Apple name for consistency with `uname -m` and Xcode.
+    # Pin macOS 14.0 in the triple so the embedded LC_BUILD_VERSION minos is
+    # deterministic and matches project.yml's MACOSX_DEPLOYMENT_TARGET (14.0)
+    # — without this, the embedded minos floats with whatever floor zig
+    # picks for the bare `*-macos` triple, which is not stable across zig
+    # releases. Note: zig 0.15 requires at least a two-component version
+    # (14.0), not a bare major (14), to parse the triple correctly.
+    case "${target_arch}" in
+      arm64)  zig_arch="aarch64" ;;
+      x86_64) zig_arch="x86_64" ;;
+      *)      echo "error: unsupported target_arch '${target_arch}'" >&2; exit 1 ;;
+    esac
     "${zig_bin}" build \
       -Doptimize=ReleaseFast \
       -Demit-xcframework=true \
       -Dsentry=false \
-      -Dtarget="${target_arch}-macos" \
+      -Dtarget="${zig_arch}-macos.14.0" \
       --prefix "${ghostty_build_root}" \
       --cache-dir "${ghostty_local_cache_dir}" \
       --global-cache-dir "${ghostty_global_cache_dir}"

--- a/scripts/build-ghostty.sh
+++ b/scripts/build-ghostty.sh
@@ -64,7 +64,12 @@ xcframework_path="${ghostty_build_root}/GhosttyKit.xcframework"
 ghostty_resources_path="${ghostty_build_root}/share/ghostty"
 ghostty_terminfo_path="${ghostty_build_root}/share/terminfo"
 
-arch="$(uname -m)"
+# Target arch for the Ghostty build. Defaults to the host arch (uname -m)
+# so local dev keeps working unchanged; CI sets this explicitly to produce
+# both arm64 and x86_64 slices from one Apple Silicon runner via zig's
+# cross-compilation.
+target_arch="${ALAS_GHOSTTY_TARGET_ARCH:-$(uname -m)}"
+arch="${target_arch}"
 ghostty_cache_root_default="${HOME}/Library/Caches/Alas/GhosttyKit"
 ghostty_cache_root="${ALAS_GHOSTTY_CACHE_DIR:-${ghostty_cache_root_default}}/${arch}"
 ghostty_cache_keep="${ALAS_GHOSTTY_CACHE_KEEP:-5}"
@@ -104,6 +109,10 @@ print_fingerprint() {
       else
         echo "no-zig"
       fi
+      # Target arch participates in the fingerprint: a different -Dtarget
+      # produces a different binary even at identical Ghostty/toolchain state,
+      # so two arches must not share a cache entry.
+      printf 'target=%s\n' "${target_arch}"
     } | shasum -a 256 | awk '{print $1}'
   )
 }
@@ -140,6 +149,7 @@ build_and_install_local() {
       -Doptimize=ReleaseFast \
       -Demit-xcframework=true \
       -Dsentry=false \
+      -Dtarget="${target_arch}-macos" \
       --prefix "${ghostty_build_root}" \
       --cache-dir "${ghostty_local_cache_dir}" \
       --global-cache-dir "${ghostty_global_cache_dir}"

--- a/scripts/tests/build-ghostty/fixtures/stub-zig.sh
+++ b/scripts/tests/build-ghostty/fixtures/stub-zig.sh
@@ -6,6 +6,20 @@ if [ -n "${STUB_ZIG_INVOCATION_LOG:-}" ]; then
   echo "$(date +%s) $*" >> "${STUB_ZIG_INVOCATION_LOG}"
 fi
 
+# Record the -Dtarget=... value (if present) into a sibling log so tests can
+# assert that the build script forwarded the target arch correctly. We only
+# write the most recent value; tests that need history can inspect the main
+# invocation log instead.
+if [ -n "${STUB_ZIG_INVOCATION_LOG:-}" ]; then
+  for arg in "$@"; do
+    case "$arg" in
+      -Dtarget=*)
+        printf '%s\n' "${arg#-Dtarget=}" > "$(dirname "${STUB_ZIG_INVOCATION_LOG}")/stub-zig.target.log"
+        ;;
+    esac
+  done
+fi
+
 # Parse --prefix; everything else ignored.
 prefix=""
 while [ $# -gt 0 ]; do

--- a/scripts/tests/build-ghostty/fixtures/stub-zig.sh
+++ b/scripts/tests/build-ghostty/fixtures/stub-zig.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Log this invocation so tests can count zig calls.
+# Log this invocation so tests can count zig calls. Also record the
+# -Dtarget=... value (if present) into a sibling log so tests can assert
+# the build script forwarded the target arch correctly.
 if [ -n "${STUB_ZIG_INVOCATION_LOG:-}" ]; then
   echo "$(date +%s) $*" >> "${STUB_ZIG_INVOCATION_LOG}"
-fi
-
-# Record the -Dtarget=... value (if present) into a sibling log so tests can
-# assert that the build script forwarded the target arch correctly. We only
-# write the most recent value; tests that need history can inspect the main
-# invocation log instead.
-if [ -n "${STUB_ZIG_INVOCATION_LOG:-}" ]; then
   for arg in "$@"; do
     case "$arg" in
       -Dtarget=*)

--- a/scripts/tests/build-ghostty/test_19_target_arch_override.sh
+++ b/scripts/tests/build-ghostty/test_19_target_arch_override.sh
@@ -30,3 +30,26 @@ assert_eq "$(stub_invocations)" "1" "shared cache hit for x86_64 skips zig"
 run_build_script ALAS_GHOSTTY_TARGET_ARCH=arm64
 assert_eq "$(stub_invocations)" "2" "different target arch forces rebuild"
 assert_dir_exists "${CACHE_DIR}/arm64"
+
+# Direct fingerprint comparison: confirms target_arch participates in the
+# fingerprint (catches regressions where someone removes target_arch from
+# print_fingerprint without breaking the count-based assertions above).
+fp_x86="$(env -i \
+  HOME="${SANDBOX}/home" \
+  PATH="${PATH}" \
+  SRCROOT="${SRCROOT}" \
+  ALAS_ZIG_BIN="${STUB_ZIG}" \
+  ALAS_GHOSTTY_CACHE_DIR="${CACHE_DIR}" \
+  ALAS_GHOSTTY_TARGET_ARCH=x86_64 \
+  "${BUILD_SCRIPT}" --print-fingerprint)"
+
+fp_arm="$(env -i \
+  HOME="${SANDBOX}/home" \
+  PATH="${PATH}" \
+  SRCROOT="${SRCROOT}" \
+  ALAS_ZIG_BIN="${STUB_ZIG}" \
+  ALAS_GHOSTTY_CACHE_DIR="${CACHE_DIR}" \
+  ALAS_GHOSTTY_TARGET_ARCH=arm64 \
+  "${BUILD_SCRIPT}" --print-fingerprint)"
+
+[ "${fp_x86}" != "${fp_arm}" ] || fail "fingerprint identical for x86_64 and arm64"

--- a/scripts/tests/build-ghostty/test_19_target_arch_override.sh
+++ b/scripts/tests/build-ghostty/test_19_target_arch_override.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. "$(dirname "$0")/lib.sh"
+trap teardown_sandbox EXIT
+
+setup_sandbox
+
+# Build with explicit target arch override (cross-compile path).
+run_build_script ALAS_GHOSTTY_TARGET_ARCH=x86_64
+
+# Stub zig should have been invoked once and seen the -Dtarget flag.
+assert_eq "$(stub_invocations)" "1" "zig invoked once on cold build"
+target_seen="$(cat "${SANDBOX}/stub-zig.target.log" 2>/dev/null || echo '')"
+assert_eq "${target_seen}" "x86_64-macos" "stub-zig saw -Dtarget=x86_64-macos"
+
+# Shared cache must be keyed under the TARGET arch, not the host arch.
+assert_dir_exists "${CACHE_DIR}/x86_64"
+host_arch="$(uname -m)"
+if [ "${host_arch}" != "x86_64" ]; then
+  assert_not_exists "${CACHE_DIR}/${host_arch}"
+fi
+
+# Cold rebuild after wiping the worktree fingerprint but keeping the cache.
+# Same target arch must hit the cache (one prior invocation, still one now).
+rm -f "${SRCROOT}/.build/ghostty/fingerprint"
+run_build_script ALAS_GHOSTTY_TARGET_ARCH=x86_64
+assert_eq "$(stub_invocations)" "1" "shared cache hit for x86_64 skips zig"
+
+# Switching the target arch must produce a different fingerprint and rebuild.
+run_build_script ALAS_GHOSTTY_TARGET_ARCH=arm64
+assert_eq "$(stub_invocations)" "2" "different target arch forces rebuild"
+assert_dir_exists "${CACHE_DIR}/arm64"

--- a/scripts/tests/build-ghostty/test_19_target_arch_override.sh
+++ b/scripts/tests/build-ghostty/test_19_target_arch_override.sh
@@ -11,7 +11,7 @@ run_build_script ALAS_GHOSTTY_TARGET_ARCH=x86_64
 # Stub zig should have been invoked once and seen the -Dtarget flag.
 assert_eq "$(stub_invocations)" "1" "zig invoked once on cold build"
 target_seen="$(cat "${SANDBOX}/stub-zig.target.log" 2>/dev/null || echo '')"
-assert_eq "${target_seen}" "x86_64-macos" "stub-zig saw -Dtarget=x86_64-macos"
+assert_eq "${target_seen}" "x86_64-macos.14.0" "stub-zig saw -Dtarget=x86_64-macos.14.0 for x86_64 build"
 
 # Shared cache must be keyed under the TARGET arch, not the host arch.
 assert_dir_exists "${CACHE_DIR}/x86_64"
@@ -30,6 +30,8 @@ assert_eq "$(stub_invocations)" "1" "shared cache hit for x86_64 skips zig"
 run_build_script ALAS_GHOSTTY_TARGET_ARCH=arm64
 assert_eq "$(stub_invocations)" "2" "different target arch forces rebuild"
 assert_dir_exists "${CACHE_DIR}/arm64"
+target_seen_arm="$(cat "${SANDBOX}/stub-zig.target.log" 2>/dev/null || echo '')"
+assert_eq "${target_seen_arm}" "aarch64-macos.14.0" "stub-zig saw -Dtarget=aarch64-macos.14.0 for arm64 build (translated from Apple name)"
 
 # Direct fingerprint comparison: confirms target_arch participates in the
 # fingerprint (catches regressions where someone removes target_arch from


### PR DESCRIPTION
## Summary

- Adds a second build pass to `release.yml` that cross-compiles the Ghostty xcframework and `xcodebuild`s Alas for `x86_64` on the same Apple Silicon runner.
- Homebrew cask (`update-cask.py`) now serves both architectures via `on_arm` / `on_intel` blocks; the `update-homebrew` job downloads both DMGs and computes both shasums.
- `nightly.yml` and PR CI (`build.yml`) are untouched — Intel ships on tagged releases only.
- `build-ghostty.sh` accepts a new `ALAS_GHOSTTY_TARGET_ARCH` env var (defaults to `uname -m`), translates Apple's `arm64` to LLVM's `aarch64` for zig's `-Dtarget`, and pins the macOS floor to `.14.0` to keep the embedded `LC_BUILD_VERSION minos` stable.

## Design + plan

- Spec: `docs/superpowers/specs/2026-05-21-macos-intel-releases-design.md`
- Plan: `docs/superpowers/plans/2026-05-21-macos-intel-releases.md`

Both are gitignored under `docs/superpowers/`; they live on disk for local context only.

## Test plan

- [x] `bash scripts/tests/build-ghostty/run.sh` — 19/19 (added `test_19_target_arch_override.sh` exercising the env override, cache keying, cache hit on rerun, arch-switch rebuild, fingerprint divergence, and the arm64→aarch64 translation in the actual `-Dtarget` value).
- [x] Local cold-cache `ALAS_GHOSTTY_TARGET_ARCH=x86_64 ./scripts/build-ghostty.sh` — real zig cross-compile, exits 0.
- [x] Local cold-cache `ALAS_GHOSTTY_TARGET_ARCH=arm64 ./scripts/build-ghostty.sh` — real zig build with translated triple, exits 0.
- [x] Local `xcodebuild ... -destination 'platform=macOS,arch=x86_64'` — produces a thin `x86_64` `Alas.app` binary (verified via `lipo -info`).
- [ ] First real `v*` tag produces both `-arm64.dmg` and `-x86_64.dmg` on the GitHub Release, both stapled.
- [ ] `brew install alas` works on an Apple Silicon Mac.
- [ ] `brew install alas` works on an Intel Mac.

## Notes

- The original implementation passed `-Dtarget=arm64-macos` to zig, which fails with `UnknownArchitecture` — zig 0.15 uses the LLVM name `aarch64`. The unit tests passed because the stub-zig fixture didn't validate the target string. End-to-end local verification caught it; the fix translates `arm64` → `aarch64` before invoking zig and the tests now assert the translated value.
- Ghostty's own `-Demit-xcframework=true` lipo's both arches into the xcframework regardless of `-Dtarget`. The resulting Ghostty static lib is universal; the Alas binary itself is correctly thin per arch. This is pre-existing Ghostty build behavior.