### PR TITLE
Render markdown frontmatter as metadata table

### DIFF
--- a/Alas/Sources/Code/Markdown/MarkdownParser.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownParser.swift
@@ -1,12 +1,122 @@
 import Foundation
 import Markdown
 
+struct MarkdownParseResult {
+    let document: Document
+    let frontmatter: MarkdownFrontmatter?
+}
+
+struct MarkdownFrontmatter: Equatable {
+    let entries: [MarkdownFrontmatterEntry]
+
+    var isEmpty: Bool {
+        entries.isEmpty
+    }
+}
+
+struct MarkdownFrontmatterEntry: Equatable {
+    let key: String
+    let value: String
+}
+
 /// Thin wrapper over `swift-markdown`'s `Document.init(parsing:options:)`.
 /// Provides a single, tested entry point so the renderer never has to
 /// remember the option set. GFM tables, task lists, strikethrough, and
 /// autolinks are enabled by default in current `swift-markdown` releases.
 enum MarkdownParser {
-    static func parse(_ source: String) -> Document {
-        Document(parsing: source)
+    static func parse(_ source: String) -> MarkdownParseResult {
+        let extracted = extractFrontmatter(from: source)
+        return MarkdownParseResult(
+            document: Document(parsing: extracted.body),
+            frontmatter: extracted.frontmatter
+        )
+    }
+
+    static func parseDocument(_ source: String) -> Document {
+        parse(source).document
+    }
+
+    private static func extractFrontmatter(from source: String) -> (frontmatter: MarkdownFrontmatter?, body: String) {
+        guard let opening = firstLine(in: source),
+              trimmedDelimiter(opening.text) == "---" else {
+            return (nil, source)
+        }
+
+        var searchIndex = opening.fullRange.upperBound
+        while searchIndex < source.endIndex {
+            guard let line = line(in: source, startingAt: searchIndex) else {
+                break
+            }
+            if trimmedDelimiter(line.text) == "---" {
+                let frontmatterText = String(source[opening.fullRange.upperBound..<line.fullRange.lowerBound])
+                let entries = parseFrontmatterEntries(frontmatterText)
+                let frontmatter = entries.isEmpty ? nil : MarkdownFrontmatter(entries: entries)
+                let body = String(source[line.fullRange.upperBound...])
+                return (frontmatter, body)
+            }
+            searchIndex = line.fullRange.upperBound
+        }
+
+        return (nil, source)
+    }
+
+    private static func parseFrontmatterEntries(_ source: String) -> [MarkdownFrontmatterEntry] {
+        var entries: [MarkdownFrontmatterEntry] = []
+        for rawLine in source.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty, !line.hasPrefix("#"),
+                  let separator = line.firstIndex(of: ":") else {
+                continue
+            }
+
+            let key = line[..<separator].trimmingCharacters(in: .whitespaces)
+            guard !key.isEmpty else { continue }
+
+            let valueStart = line.index(after: separator)
+            let rawValue = line[valueStart...].trimmingCharacters(in: .whitespaces)
+            entries.append(MarkdownFrontmatterEntry(
+                key: String(key),
+                value: stripMatchingQuotes(from: String(rawValue))
+            ))
+        }
+        return entries
+    }
+
+    private static func stripMatchingQuotes(from value: String) -> String {
+        guard value.count >= 2,
+              let first = value.first,
+              let last = value.last,
+              (first == "\"" && last == "\"") || (first == "'" && last == "'") else {
+            return value
+        }
+        return String(value.dropFirst().dropLast())
+    }
+
+    private static func firstLine(in source: String) -> (text: Substring, fullRange: Range<String.Index>)? {
+        guard !source.isEmpty else { return nil }
+        return line(in: source, startingAt: source.startIndex)
+    }
+
+    private static func line(
+        in source: String,
+        startingAt start: String.Index
+    ) -> (text: Substring, fullRange: Range<String.Index>)? {
+        guard start < source.endIndex else { return nil }
+
+        let lineEnd = source[start...].firstIndex(of: "\n") ?? source.endIndex
+        var textEnd = lineEnd
+        if textEnd > start {
+            let beforeEnd = source.index(before: textEnd)
+            if source[beforeEnd] == "\r" {
+                textEnd = beforeEnd
+            }
+        }
+
+        let fullEnd = lineEnd < source.endIndex ? source.index(after: lineEnd) : source.endIndex
+        return (source[start..<textEnd], start..<fullEnd)
+    }
+
+    private static func trimmedDelimiter(_ text: Substring) -> String {
+        text.trimmingCharacters(in: .whitespaces)
     }
 }

--- a/Alas/Sources/Code/Markdown/MarkdownParser.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownParser.swift
@@ -70,6 +70,7 @@ enum MarkdownParser {
             guard !line.isEmpty, !line.hasPrefix("#") else {
                 continue
             }
+            guard rawLine.first?.isWhitespace != true else { return nil }
             guard let separator = line.firstIndex(of: ":") else { return nil }
 
             let key = line[..<separator].trimmingCharacters(in: .whitespaces)

--- a/Alas/Sources/Code/Markdown/MarkdownParser.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownParser.swift
@@ -64,13 +64,18 @@ enum MarkdownParser {
     }
 
     private static func parseFrontmatterEntries(_ source: String) -> [MarkdownFrontmatterEntry]? {
-        var entries: [MarkdownFrontmatterEntry] = []
-        for rawLine in source.components(separatedBy: .newlines) {
+        let contentLines = source.components(separatedBy: .newlines).compactMap { rawLine -> (raw: String, line: String, indent: Int)? in
             let line = rawLine.trimmingCharacters(in: .whitespaces)
-            guard !line.isEmpty, !line.hasPrefix("#") else {
-                continue
-            }
-            guard rawLine.first?.isWhitespace != true else { return nil }
+            guard !line.isEmpty, !line.hasPrefix("#") else { return nil }
+            return (rawLine, line, rawLine.prefix(while: { $0.isWhitespace }).count)
+        }
+        let baseIndent = contentLines.map(\.indent).min() ?? 0
+
+        var entries: [MarkdownFrontmatterEntry] = []
+        for contentLine in contentLines {
+            let dedentedLine = contentLine.raw.dropFirst(baseIndent)
+            guard dedentedLine.first?.isWhitespace != true else { return nil }
+            let line = dedentedLine.trimmingCharacters(in: .whitespaces)
             guard let separator = line.firstIndex(of: ":") else { return nil }
 
             let key = line[..<separator].trimmingCharacters(in: .whitespaces)

--- a/Alas/Sources/Code/Markdown/MarkdownParser.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownParser.swift
@@ -50,7 +50,10 @@ enum MarkdownParser {
             if trimmedDelimiter(line.text) == "---" {
                 let frontmatterText = String(source[opening.fullRange.upperBound..<line.fullRange.lowerBound])
                 let entries = parseFrontmatterEntries(frontmatterText)
-                let frontmatter = entries.isEmpty ? nil : MarkdownFrontmatter(entries: entries)
+                guard !entries.isEmpty else {
+                    return (nil, source)
+                }
+                let frontmatter = MarkdownFrontmatter(entries: entries)
                 let body = String(source[line.fullRange.upperBound...])
                 return (frontmatter, body)
             }

--- a/Alas/Sources/Code/Markdown/MarkdownParser.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownParser.swift
@@ -38,7 +38,7 @@ enum MarkdownParser {
 
     private static func extractFrontmatter(from source: String) -> (frontmatter: MarkdownFrontmatter?, body: String) {
         guard let opening = firstLine(in: source),
-              trimmedDelimiter(opening.text) == "---" else {
+              isFrontmatterDelimiter(opening.text) else {
             return (nil, source)
         }
 
@@ -47,7 +47,7 @@ enum MarkdownParser {
             guard let line = line(in: source, startingAt: searchIndex) else {
                 break
             }
-            if trimmedDelimiter(line.text) == "---" {
+            if isFrontmatterDelimiter(line.text) {
                 let frontmatterText = String(source[opening.fullRange.upperBound..<line.fullRange.lowerBound])
                 guard let entries = parseFrontmatterEntries(frontmatterText),
                       !entries.isEmpty else {
@@ -125,7 +125,8 @@ enum MarkdownParser {
         return (source[start..<textEnd], start..<fullEnd)
     }
 
-    private static func trimmedDelimiter(_ text: Substring) -> String {
-        text.trimmingCharacters(in: .whitespaces)
+    private static func isFrontmatterDelimiter(_ text: Substring) -> Bool {
+        guard text.hasPrefix("---") else { return false }
+        return text.dropFirst(3).allSatisfy(\.isWhitespace)
     }
 }

--- a/Alas/Sources/Code/Markdown/MarkdownParser.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownParser.swift
@@ -49,8 +49,8 @@ enum MarkdownParser {
             }
             if trimmedDelimiter(line.text) == "---" {
                 let frontmatterText = String(source[opening.fullRange.upperBound..<line.fullRange.lowerBound])
-                let entries = parseFrontmatterEntries(frontmatterText)
-                guard !entries.isEmpty else {
+                guard let entries = parseFrontmatterEntries(frontmatterText),
+                      !entries.isEmpty else {
                     return (nil, source)
                 }
                 let frontmatter = MarkdownFrontmatter(entries: entries)
@@ -63,17 +63,17 @@ enum MarkdownParser {
         return (nil, source)
     }
 
-    private static func parseFrontmatterEntries(_ source: String) -> [MarkdownFrontmatterEntry] {
+    private static func parseFrontmatterEntries(_ source: String) -> [MarkdownFrontmatterEntry]? {
         var entries: [MarkdownFrontmatterEntry] = []
         for rawLine in source.components(separatedBy: .newlines) {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
-            guard !line.isEmpty, !line.hasPrefix("#"),
-                  let separator = line.firstIndex(of: ":") else {
+            guard !line.isEmpty, !line.hasPrefix("#") else {
                 continue
             }
+            guard let separator = line.firstIndex(of: ":") else { return nil }
 
             let key = line[..<separator].trimmingCharacters(in: .whitespaces)
-            guard !key.isEmpty else { continue }
+            guard !key.isEmpty else { return nil }
 
             let valueStart = line.index(after: separator)
             let rawValue = line[valueStart...].trimmingCharacters(in: .whitespaces)

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -63,6 +63,7 @@ final class MarkdownRenderer {
 
     func render(
         document: Document,
+        frontmatter: MarkdownFrontmatter? = nil,
         theme: Theme,
         monospacedFontFamily: String,
         monospacedFontSize: Int,
@@ -81,6 +82,10 @@ final class MarkdownRenderer {
         self.inStrikethrough = false
         self.listDepth = 0
         self.slugCounts = [:]
+
+        if let frontmatter, !frontmatter.isEmpty {
+            renderFrontmatterTable(frontmatter)
+        }
 
         for child in document.children {
             visit(child)
@@ -404,6 +409,51 @@ final class MarkdownRenderer {
         return paragraph
     }
 
+    private func renderFrontmatterTable(_ frontmatter: MarkdownFrontmatter) {
+        let columnCount = 2
+        let textTable = NSTextTable()
+        textTable.numberOfColumns = columnCount
+        textTable.layoutAlgorithm = .automaticLayoutAlgorithm
+        textTable.collapsesBorders = true
+        textTable.hidesEmptyCells = false
+
+        var renderedCells: [RenderedTableCell] = [
+            RenderedTableCell(
+                content: NSAttributedString(string: "Key", attributes: bodyAttributes()),
+                row: 0,
+                column: 0,
+                isHeader: true,
+                alignment: .left
+            ),
+            RenderedTableCell(
+                content: NSAttributedString(string: "Value", attributes: bodyAttributes()),
+                row: 0,
+                column: 1,
+                isHeader: true,
+                alignment: .left
+            )
+        ]
+
+        for (index, entry) in frontmatter.entries.enumerated() {
+            renderedCells.append(RenderedTableCell(
+                content: NSAttributedString(string: entry.key, attributes: bodyAttributes()),
+                row: index + 1,
+                column: 0,
+                isHeader: false,
+                alignment: .left
+            ))
+            renderedCells.append(RenderedTableCell(
+                content: NSAttributedString(string: entry.value, attributes: bodyAttributes()),
+                row: index + 1,
+                column: 1,
+                isHeader: false,
+                alignment: .left
+            ))
+        }
+
+        appendTableCells(renderedCells, table: textTable, columnCount: columnCount)
+    }
+
     private func visitTable(_ table: Markdown.Table) {
         let headerCells = Array(table.head.cells)
         let bodyRows = Array(table.body.rows)
@@ -457,6 +507,14 @@ final class MarkdownRenderer {
             }
         }
 
+        appendTableCells(renderedCells, table: textTable, columnCount: columnCount)
+    }
+
+    private func appendTableCells(
+        _ renderedCells: [RenderedTableCell],
+        table textTable: NSTextTable,
+        columnCount: Int
+    ) {
         for cell in renderedCells {
             let mutable = NSMutableAttributedString(attributedString: cell.content)
             let style = tableParagraphStyle(

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -208,9 +208,10 @@ struct MarkdownTabView: View {
                 if Task.isCancelled { return }
             }
             let source = buffer.storage.string
-            let doc = MarkdownParser.parse(source)
+            let parsed = MarkdownParser.parse(source)
             let result = MarkdownRenderer().render(
-                document: doc,
+                document: parsed.document,
+                frontmatter: parsed.frontmatter,
                 theme: theme,
                 monospacedFontFamily: fontFamily,
                 monospacedFontSize: fontSize,

--- a/AlasTests/MarkdownParserTests.swift
+++ b/AlasTests/MarkdownParserTests.swift
@@ -143,6 +143,14 @@ struct MarkdownParserTests {
         #expect(parsed.document.children.contains(where: { $0 is Paragraph }))
     }
 
+    @Test func leavesIndentedFrontmatterLikeCodeBlockAsMarkdown() {
+        let parsed = MarkdownParser.parse("    ---\n    title: Example\n    ---\n\nBody")
+
+        #expect(parsed.frontmatter == nil)
+        #expect(parsed.document.children.contains(where: { $0 is CodeBlock }))
+        #expect(parsed.document.children.contains(where: { $0 is Paragraph }))
+    }
+
     @Test func leavesDocumentsWithoutFrontmatterUnchanged() {
         let parsed = MarkdownParser.parse("Hello\n\n---\n\nWorld")
 

--- a/AlasTests/MarkdownParserTests.swift
+++ b/AlasTests/MarkdownParserTests.swift
@@ -109,6 +109,21 @@ struct MarkdownParserTests {
         #expect(parsed.document.children.contains(where: { $0 is Paragraph }))
     }
 
+    @Test func leavesNestedYamlFrontmatterBlockAsMarkdown() {
+        let parsed = MarkdownParser.parse("""
+        ---
+        author:
+          name: Bob
+        ---
+
+        Body
+        """)
+
+        #expect(parsed.frontmatter == nil)
+        #expect(parsed.document.children.contains(where: { $0 is ThematicBreak }))
+        #expect(parsed.document.children.contains(where: { $0 is Paragraph }))
+    }
+
     @Test func leavesDocumentsWithoutFrontmatterUnchanged() {
         let parsed = MarkdownParser.parse("Hello\n\n---\n\nWorld")
 

--- a/AlasTests/MarkdownParserTests.swift
+++ b/AlasTests/MarkdownParserTests.swift
@@ -109,6 +109,25 @@ struct MarkdownParserTests {
         #expect(parsed.document.children.contains(where: { $0 is Paragraph }))
     }
 
+    @Test func parsesIndentedFrontmatterEntries() {
+        let parsed = MarkdownParser.parse("""
+        ---
+          title: Release Notes
+          draft: false
+        ---
+
+        # Body
+        """)
+
+        #expect(parsed.frontmatter?.entries == [
+            MarkdownFrontmatterEntry(key: "title", value: "Release Notes"),
+            MarkdownFrontmatterEntry(key: "draft", value: "false")
+        ])
+
+        let heading = parsed.document.child(at: 0) as? Heading
+        #expect(heading?.plainText == "Body")
+    }
+
     @Test func leavesNestedYamlFrontmatterBlockAsMarkdown() {
         let parsed = MarkdownParser.parse("""
         ---

--- a/AlasTests/MarkdownParserTests.swift
+++ b/AlasTests/MarkdownParserTests.swift
@@ -4,13 +4,13 @@ import Markdown
 
 struct MarkdownParserTests {
     @Test func parsesSimpleParagraph() {
-        let doc = MarkdownParser.parse("Hello, world.")
+        let doc = MarkdownParser.parseDocument("Hello, world.")
         #expect(doc.childCount == 1)
         #expect(doc.child(at: 0) is Paragraph)
     }
 
     @Test func parsesHeadings() {
-        let doc = MarkdownParser.parse("# Title")
+        let doc = MarkdownParser.parseDocument("# Title")
         let heading = doc.child(at: 0) as? Heading
         #expect(heading?.level == 1)
     }
@@ -21,12 +21,12 @@ struct MarkdownParserTests {
         | - | - |
         | 1 | 2 |
         """
-        let doc = MarkdownParser.parse(source)
+        let doc = MarkdownParser.parseDocument(source)
         #expect(doc.children.contains(where: { $0 is Table }))
     }
 
     @Test func parsesTaskList() {
-        let doc = MarkdownParser.parse("- [x] done\n- [ ] todo")
+        let doc = MarkdownParser.parseDocument("- [x] done\n- [ ] todo")
         let list = doc.child(at: 0) as? UnorderedList
         let items = list?.listItems.map { $0 } ?? []
         #expect(items.count == 2)
@@ -35,10 +35,65 @@ struct MarkdownParserTests {
     }
 
     @Test func parsesStrikethrough() {
-        let doc = MarkdownParser.parse("~~gone~~")
+        let doc = MarkdownParser.parseDocument("~~gone~~")
         // Walk down to find a Strikethrough node.
         let para = doc.child(at: 0) as? Paragraph
         let hasStrike = para?.children.contains(where: { $0 is Strikethrough }) ?? false
         #expect(hasStrike)
+    }
+
+    @Test func parsesLeadingFrontmatterEntries() {
+        let parsed = MarkdownParser.parse("""
+        ---
+        title: "Release Notes"
+        date: 2026-05-21
+        draft: false
+        tags: [swift, markdown]
+        # ignored
+        invalid
+        ---
+
+        # Body
+        """)
+
+        #expect(parsed.frontmatter?.entries == [
+            MarkdownFrontmatterEntry(key: "title", value: "Release Notes"),
+            MarkdownFrontmatterEntry(key: "date", value: "2026-05-21"),
+            MarkdownFrontmatterEntry(key: "draft", value: "false"),
+            MarkdownFrontmatterEntry(key: "tags", value: "[swift, markdown]")
+        ])
+
+        let heading = parsed.document.child(at: 0) as? Heading
+        #expect(heading?.plainText == "Body")
+    }
+
+    @Test func stripsEmptyFrontmatterWithoutMetadata() {
+        let parsed = MarkdownParser.parse("""
+        ---
+        ---
+
+        Body
+        """)
+
+        #expect(parsed.frontmatter == nil)
+        #expect(parsed.document.childCount == 1)
+        #expect(parsed.document.child(at: 0) is Paragraph)
+    }
+
+    @Test func leavesDocumentsWithoutFrontmatterUnchanged() {
+        let parsed = MarkdownParser.parse("Hello\n\n---\n\nWorld")
+
+        #expect(parsed.frontmatter == nil)
+        #expect(parsed.document.children.contains(where: { $0 is ThematicBreak }))
+    }
+
+    @Test func leavesUnclosedFrontmatterAsMarkdown() {
+        let parsed = MarkdownParser.parse("""
+        ---
+        title: Missing close
+        """)
+
+        #expect(parsed.frontmatter == nil)
+        #expect(parsed.document.children.contains(where: { $0 is ThematicBreak }))
     }
 }

--- a/AlasTests/MarkdownParserTests.swift
+++ b/AlasTests/MarkdownParserTests.swift
@@ -67,7 +67,7 @@ struct MarkdownParserTests {
         #expect(heading?.plainText == "Body")
     }
 
-    @Test func stripsEmptyFrontmatterWithoutMetadata() {
+    @Test func leavesEmptyFrontmatterBlockAsMarkdown() {
         let parsed = MarkdownParser.parse("""
         ---
         ---
@@ -76,8 +76,22 @@ struct MarkdownParserTests {
         """)
 
         #expect(parsed.frontmatter == nil)
-        #expect(parsed.document.childCount == 1)
-        #expect(parsed.document.child(at: 0) is Paragraph)
+        #expect(parsed.document.children.contains(where: { $0 is ThematicBreak }))
+        #expect(parsed.document.children.contains(where: { $0 is Paragraph }))
+    }
+
+    @Test func leavesMalformedFrontmatterBlockAsMarkdown() {
+        let parsed = MarkdownParser.parse("""
+        ---
+        invalid
+        ---
+
+        Body
+        """)
+
+        #expect(parsed.frontmatter == nil)
+        #expect(parsed.document.children.contains(where: { $0 is ThematicBreak }))
+        #expect(parsed.document.children.contains(where: { $0 is Paragraph }))
     }
 
     @Test func leavesDocumentsWithoutFrontmatterUnchanged() {

--- a/AlasTests/MarkdownParserTests.swift
+++ b/AlasTests/MarkdownParserTests.swift
@@ -50,7 +50,6 @@ struct MarkdownParserTests {
         draft: false
         tags: [swift, markdown]
         # ignored
-        invalid
         ---
 
         # Body
@@ -84,6 +83,22 @@ struct MarkdownParserTests {
         let parsed = MarkdownParser.parse("""
         ---
         invalid
+        ---
+
+        Body
+        """)
+
+        #expect(parsed.frontmatter == nil)
+        #expect(parsed.document.children.contains(where: { $0 is ThematicBreak }))
+        #expect(parsed.document.children.contains(where: { $0 is Paragraph }))
+    }
+
+    @Test func leavesMixedYamlFrontmatterBlockAsMarkdown() {
+        let parsed = MarkdownParser.parse("""
+        ---
+        title: Release Notes
+        tags:
+        - swift
         ---
 
         Body

--- a/AlasTests/MarkdownRendererTests.swift
+++ b/AlasTests/MarkdownRendererTests.swift
@@ -6,8 +6,10 @@ import AppKit
 struct MarkdownRendererTests {
     static func render(_ source: String) throws -> MarkdownRenderResult {
         let theme = try Theme.loadBundled(id: "cool-slate")
+        let parsed = MarkdownParser.parse(source)
         return MarkdownRenderer().render(
-            document: MarkdownParser.parse(source),
+            document: parsed.document,
+            frontmatter: parsed.frontmatter,
             theme: theme,
             monospacedFontFamily: "SF Mono",
             monospacedFontSize: 13,
@@ -226,6 +228,52 @@ struct MarkdownRendererTests {
         #expect(headerBlock?.borderColor(for: .minX) != nil)
     }
 
+    @Test func rendersFrontmatterAsNativeMetadataTable() throws {
+        let r = try MarkdownRendererTests.render("""
+        ---
+        title: Example
+        date: 2026-05-21
+        ---
+
+        # Body
+        """)
+        let s = r.attributedString.string
+
+        #expect(s.contains("Key"))
+        #expect(s.contains("Value"))
+        #expect(s.contains("title"))
+        #expect(s.contains("Example"))
+        #expect(s.contains("Body"))
+        #expect(!s.contains("---"))
+
+        let keyBlock = tableBlock(at: "Key", in: r.attributedString)
+        let titleBlock = tableBlock(at: "title", in: r.attributedString)
+        let exampleBlock = tableBlock(at: "Example", in: r.attributedString)
+        #expect(keyBlock != nil)
+        #expect(titleBlock != nil)
+        #expect(exampleBlock != nil)
+        #expect(keyBlock?.startingRow == 0)
+        #expect(titleBlock?.startingRow == 1)
+        #expect(exampleBlock?.startingColumn == 1)
+        #expect(keyBlock?.backgroundColor != nil)
+        #expect(titleBlock?.borderColor(for: .minX) != nil)
+    }
+
+    @Test func renderingWithoutFrontmatterStaysUnchanged() throws {
+        let withNoFrontmatter = try MarkdownRendererTests.render("Hello\n\n---\n\nWorld")
+        let directDocument = MarkdownParser.parseDocument("Hello\n\n---\n\nWorld")
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let direct = MarkdownRenderer().render(
+            document: directDocument,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+
+        #expect(withNoFrontmatter.attributedString.string == direct.attributedString.string)
+    }
+
     @Test func tableCellsPreserveInlineMarkdownAttributes() throws {
         let source = """
         | Link | Styled |
@@ -323,7 +371,7 @@ struct MarkdownRendererTests {
 
         let theme = try Theme.loadBundled(id: "cool-slate")
         let r = MarkdownRenderer().render(
-            document: MarkdownParser.parse("![alt](dot.png)"),
+            document: MarkdownParser.parseDocument("![alt](dot.png)"),
             theme: theme,
             monospacedFontFamily: "SF Mono",
             monospacedFontSize: 13,
@@ -337,7 +385,7 @@ struct MarkdownRendererTests {
     @Test func rendersRemoteImagePlaceholderAndRecordsRef() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
         let r = MarkdownRenderer().render(
-            document: MarkdownParser.parse("![logo](https://example.com/logo.png)"),
+            document: MarkdownParser.parseDocument("![logo](https://example.com/logo.png)"),
             theme: theme,
             monospacedFontFamily: "SF Mono",
             monospacedFontSize: 13,


### PR DESCRIPTION
## Summary
- Detect leading YAML frontmatter in markdown documents and strip it before body parsing
- Render frontmatter key/value pairs as a native metadata table using the existing markdown table styling
- Preserve normal markdown preview behavior for the remaining body and files without frontmatter

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- MarkdownParserTests and MarkdownRendererTests