### PR TITLE
Refresh terminal integration actions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
 		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
+		CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */; };
 		CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */; };
 		CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */; };
 		CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */; };
@@ -640,6 +641,7 @@
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstallerTests.swift; sourceTree = "<group>"; };
 		6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindControllerTests.swift; sourceTree = "<group>"; };
+		606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalIntegrationActionsTests.swift; sourceTree = "<group>"; };
 		60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderValidationTests.swift; sourceTree = "<group>"; };
 		61C69060B922A729DD807920 /* LSPURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPURI.swift; sourceTree = "<group>"; };
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
@@ -1094,6 +1096,7 @@
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
 				4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */,
+				606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */,
 				71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */,
 				50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */,
 				B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */,
@@ -2344,6 +2347,7 @@
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
 				BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */,
+				CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */,
 				42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */,
 				7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */,
 				BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */,

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -5,6 +5,7 @@ struct TerminalPane: View {
     @Environment(\.theme) var theme
 
     @State private var hookStatus: [AgentKind: String] = [:]
+    @State private var installStates: [AgentKind: InstallState] = [:]
     private let installerRegistry = AgentInstallerRegistry()
 
     var body: some View {
@@ -116,13 +117,16 @@ struct TerminalPane: View {
                     ForEach(installerRegistry.supportedAgents) { agent in
                         SettingsRow(name: agent.displayName) {
                             HStack {
-                                let state = installerRegistry.installer(for: agent)?.installState() ?? .notInstalled
-                                AlasButton(
-                                    title: state == .installed ? "Reinstall" : state == .outdated ? "Update" : "Install",
-                                    action: { installAgent(agent) }
-                                )
-                                if state == .installed {
-                                    AlasButton(title: "Uninstall", action: { uninstallAgent(agent) })
+                                let integrationState = installState(for: agent)
+                                ForEach(TerminalIntegrationActions.actions(for: integrationState)) { action in
+                                    AlasButton(title: action.title) {
+                                        switch action.kind {
+                                        case .install:
+                                            installAgent(agent)
+                                        case .uninstall:
+                                            uninstallAgent(agent)
+                                        }
+                                    }
                                 }
                                 if let status = hookStatus[agent] {
                                     Text(status).font(.system(size: 11))
@@ -135,6 +139,26 @@ struct TerminalPane: View {
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
         }
+        .onAppear {
+            refreshInstallStates()
+        }
+    }
+
+    private func installState(for agent: AgentKind) -> InstallState {
+        if let state = installStates[agent] {
+            return state
+        }
+        return installerRegistry.installer(for: agent)?.installState() ?? .notInstalled
+    }
+
+    private func refreshInstallStates() {
+        for agent in installerRegistry.supportedAgents {
+            refreshInstallState(for: agent)
+        }
+    }
+
+    private func refreshInstallState(for agent: AgentKind) {
+        installStates[agent] = installerRegistry.installer(for: agent)?.installState() ?? .notInstalled
     }
 
     private func installAgent(_ agent: AgentKind) {
@@ -142,8 +166,10 @@ struct TerminalPane: View {
         Task {
             do {
                 try await installer.install()
+                refreshInstallState(for: agent)
                 hookStatus[agent] = "Installed"
             } catch {
+                refreshInstallState(for: agent)
                 hookStatus[agent] = "Error: \(error.localizedDescription)"
             }
         }
@@ -153,9 +179,36 @@ struct TerminalPane: View {
         guard let installer = installerRegistry.installer(for: agent) else { return }
         do {
             try installer.uninstall()
-            hookStatus[agent] = nil
+            refreshInstallState(for: agent)
+            hookStatus[agent] = "Uninstalled"
         } catch {
+            refreshInstallState(for: agent)
             hookStatus[agent] = "Error: \(error.localizedDescription)"
+        }
+    }
+}
+
+struct TerminalIntegrationAction: Equatable, Identifiable {
+    enum Kind: Equatable {
+        case install
+        case uninstall
+    }
+
+    let kind: Kind
+    let title: String
+
+    var id: String { title }
+}
+
+enum TerminalIntegrationActions {
+    static func actions(for installState: InstallState) -> [TerminalIntegrationAction] {
+        switch installState {
+        case .notInstalled:
+            return [TerminalIntegrationAction(kind: .install, title: "Install")]
+        case .outdated:
+            return [TerminalIntegrationAction(kind: .install, title: "Update")]
+        case .installed:
+            return [TerminalIntegrationAction(kind: .uninstall, title: "Uninstall")]
         }
     }
 }

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -5,8 +5,9 @@ struct TerminalPane: View {
     @Environment(\.theme) var theme
 
     @State private var hookStatus: [AgentKind: String] = [:]
-    @State private var installStates: [AgentKind: InstallState] = [:]
+    @State private var installStateRefreshToken = 0
     private let installerRegistry = AgentInstallerRegistry()
+    private let installStateRefreshTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
 
     var body: some View {
         ScrollView {
@@ -117,7 +118,7 @@ struct TerminalPane: View {
                     ForEach(installerRegistry.supportedAgents) { agent in
                         SettingsRow(name: agent.displayName) {
                             HStack {
-                                let integrationState = installState(for: agent)
+                                let integrationState = installState(for: agent, refreshToken: installStateRefreshToken)
                                 ForEach(TerminalIntegrationActions.actions(for: integrationState)) { action in
                                     AlasButton(title: action.title) {
                                         switch action.kind {
@@ -142,23 +143,17 @@ struct TerminalPane: View {
         .onAppear {
             refreshInstallStates()
         }
+        .onReceive(installStateRefreshTimer) { _ in
+            refreshInstallStates()
+        }
     }
 
-    private func installState(for agent: AgentKind) -> InstallState {
-        if let state = installStates[agent] {
-            return state
-        }
+    private func installState(for agent: AgentKind, refreshToken _: Int) -> InstallState {
         return installerRegistry.installer(for: agent)?.installState() ?? .notInstalled
     }
 
     private func refreshInstallStates() {
-        for agent in installerRegistry.supportedAgents {
-            refreshInstallState(for: agent)
-        }
-    }
-
-    private func refreshInstallState(for agent: AgentKind) {
-        installStates[agent] = installerRegistry.installer(for: agent)?.installState() ?? .notInstalled
+        installStateRefreshToken &+= 1
     }
 
     private func installAgent(_ agent: AgentKind) {
@@ -166,10 +161,10 @@ struct TerminalPane: View {
         Task {
             do {
                 try await installer.install()
-                refreshInstallState(for: agent)
+                refreshInstallStates()
                 hookStatus[agent] = "Installed"
             } catch {
-                refreshInstallState(for: agent)
+                refreshInstallStates()
                 hookStatus[agent] = "Error: \(error.localizedDescription)"
             }
         }
@@ -179,10 +174,10 @@ struct TerminalPane: View {
         guard let installer = installerRegistry.installer(for: agent) else { return }
         do {
             try installer.uninstall()
-            refreshInstallState(for: agent)
+            refreshInstallStates()
             hookStatus[agent] = "Uninstalled"
         } catch {
-            refreshInstallState(for: agent)
+            refreshInstallStates()
             hookStatus[agent] = "Error: \(error.localizedDescription)"
         }
     }

--- a/AlasTests/TerminalIntegrationActionsTests.swift
+++ b/AlasTests/TerminalIntegrationActionsTests.swift
@@ -1,0 +1,27 @@
+import Testing
+
+@testable import Alas
+
+@Suite("TerminalIntegrationActions")
+struct TerminalIntegrationActionsTests {
+    @Test("not installed integrations show install only")
+    func notInstalledActions() {
+        #expect(TerminalIntegrationActions.actions(for: .notInstalled) == [
+            TerminalIntegrationAction(kind: .install, title: "Install")
+        ])
+    }
+
+    @Test("outdated integrations show update only")
+    func outdatedActions() {
+        #expect(TerminalIntegrationActions.actions(for: .outdated) == [
+            TerminalIntegrationAction(kind: .install, title: "Update")
+        ])
+    }
+
+    @Test("installed integrations show uninstall only")
+    func installedActions() {
+        #expect(TerminalIntegrationActions.actions(for: .installed) == [
+            TerminalIntegrationAction(kind: .uninstall, title: "Uninstall")
+        ])
+    }
+}


### PR DESCRIPTION
## Summary
- refresh terminal integration install state after install and uninstall operations
- derive Settings -> Terminal action buttons from deterministic install state
- add focused Swift Testing coverage for action resolution

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/TerminalIntegrationActionsTests

Note: Full xcodebuild test was attempted but hung silently for over 10 minutes with the app test host still running, so it was interrupted.