### PR TITLE
Prevent invalid git ref input

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
 		87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */; };
+		881EB8E37CE9D947A2C74564 /* GitRefNameInputFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
 		8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */; };
 		8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */; };
@@ -363,6 +364,7 @@
 		CB6D9F5929D97FAB3A264F47 /* AppConfigAgentsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */; };
 		CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */; };
 		CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */; };
+		CD227C48AA85A5E74A92DF3F /* GitRefNameInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */; };
 		CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */; };
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
 		CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */; };
@@ -564,6 +566,7 @@
 		3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputRow.swift; sourceTree = "<group>"; };
 		35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
 		35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelper.swift; sourceTree = "<group>"; };
+		35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilterTests.swift; sourceTree = "<group>"; };
 		364213292935A05F3B52F51F /* Paths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Paths.swift; sourceTree = "<group>"; };
 		364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallerHostTests.swift; sourceTree = "<group>"; };
 		36992F601C8EB6C3D45B584F /* SearchKbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKbd.swift; sourceTree = "<group>"; };
@@ -737,6 +740,7 @@
 		9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolverTests.swift; sourceTree = "<group>"; };
 		9DCC5576ACD7C49EB6915992 /* CommitComposerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerStateTests.swift; sourceTree = "<group>"; };
 		9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipe.swift; sourceTree = "<group>"; };
+		9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilter.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
 		A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStripTests.swift; sourceTree = "<group>"; };
 		A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTree.swift; sourceTree = "<group>"; };
@@ -1026,6 +1030,7 @@
 				D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */,
 				6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */,
 				8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */,
+				35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */,
 				F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */,
 				38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
@@ -1145,6 +1150,7 @@
 				339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */,
 				BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */,
 				269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */,
+				9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */,
 				B7CE7B4DAFDB65A79308FB63 /* GitService.swift */,
 				90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */,
 				D2F90D03073708AA01531533 /* GitService+Staging.swift */,
@@ -2029,6 +2035,7 @@
 				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,
 				B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */,
 				175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */,
+				CD227C48AA85A5E74A92DF3F /* GitRefNameInputFilter.swift in Sources */,
 				DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */,
 				0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */,
 				12035048B950CE0197604F89 /* GitService.swift in Sources */,
@@ -2263,6 +2270,7 @@
 				D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */,
 				D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */,
 				513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */,
+				881EB8E37CE9D947A2C74564 /* GitRefNameInputFilterTests.swift in Sources */,
 				2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */,
 				1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,

--- a/Alas/Sources/Dialogs/BranchPicker.swift
+++ b/Alas/Sources/Dialogs/BranchPicker.swift
@@ -57,7 +57,7 @@ struct BranchPicker: View {
     private var popoverBody: some View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
-                AlasField(text: $selection, placeholder: "Branch or ref", monospaced: true)
+                AlasField(text: $selection, placeholder: "Branch or ref", monospaced: true, inputFilter: .refName)
                 AlasField(text: $search, placeholder: "Search branches...")
             }
             .padding(8)

--- a/Alas/Sources/Dialogs/BranchPicker.swift
+++ b/Alas/Sources/Dialogs/BranchPicker.swift
@@ -57,7 +57,7 @@ struct BranchPicker: View {
     private var popoverBody: some View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 6) {
-                AlasField(text: $selection, placeholder: "Branch or ref", monospaced: true, inputFilter: .refName)
+                AlasField(text: $selection, placeholder: "Branch or ref", monospaced: true)
                 AlasField(text: $search, placeholder: "Search branches...")
             }
             .padding(8)

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -48,7 +48,13 @@ struct NewWorktreeDialog: View {
                     )
                 }
                 DialogField(label: "Branch name") {
-                    AlasField(text: $branch, monospaced: true, focusOnAppear: true, onSubmit: submitCreate)
+                    AlasField(
+                        text: $branch,
+                        monospaced: true,
+                        focusOnAppear: true,
+                        onSubmit: submitCreate,
+                        inputFilter: .branchName
+                    )
                 }
                 HStack(spacing: 10) {
                     AlasToggle(on: $runStartup)

--- a/Alas/Sources/Git/GitRefNameInputFilter.swift
+++ b/Alas/Sources/Git/GitRefNameInputFilter.swift
@@ -6,24 +6,30 @@ struct GitRefNameInputFilter: Equatable {
         case paste
     }
 
-    static let branchName = GitRefNameInputFilter(allowsTrailingSlashOnPaste: false)
-    static let branchPrefix = GitRefNameInputFilter(allowsTrailingSlashOnPaste: true)
-    static let refName = GitRefNameInputFilter(allowsTrailingSlashOnPaste: false)
+    static let branchName = GitRefNameInputFilter(allowsTrailingSlashOnPaste: false, allowsRevisionSyntax: false)
+    static let branchPrefix = GitRefNameInputFilter(allowsTrailingSlashOnPaste: true, allowsRevisionSyntax: false)
+    static let refName = GitRefNameInputFilter(allowsTrailingSlashOnPaste: false, allowsRevisionSyntax: true)
 
     private let allowsTrailingSlashOnPaste: Bool
+    private let allowsRevisionSyntax: Bool
 
-    private init(allowsTrailingSlashOnPaste: Bool) {
+    private init(allowsTrailingSlashOnPaste: Bool, allowsRevisionSyntax: Bool) {
         self.allowsTrailingSlashOnPaste = allowsTrailingSlashOnPaste
+        self.allowsRevisionSyntax = allowsRevisionSyntax
     }
 
     func sanitize(_ rawValue: String, mode: Mode) -> String {
         let filteredScalars = rawValue.unicodeScalars.compactMap { scalar -> UnicodeScalar? in
             if scalar.properties.generalCategory == .control { return nil }
             if CharacterSet.whitespacesAndNewlines.contains(scalar) { return nil }
-            if Self.forbiddenScalars.contains(scalar) { return nil }
+            if !allowsRevisionSyntax && Self.forbiddenScalars.contains(scalar) { return nil }
             return scalar
         }
         var value = String(String.UnicodeScalarView(filteredScalars))
+
+        if allowsRevisionSyntax {
+            return value
+        }
 
         value = value.replacingOccurrences(of: "@{", with: "@")
         while value.contains("//") {

--- a/Alas/Sources/Git/GitRefNameInputFilter.swift
+++ b/Alas/Sources/Git/GitRefNameInputFilter.swift
@@ -35,7 +35,11 @@ struct GitRefNameInputFilter: Equatable {
 
         var components = value.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
         for index in components.indices {
-            components[index] = sanitizeComponent(components[index], mode: mode)
+            components[index] = sanitizeComponent(
+                components[index],
+                mode: mode,
+                isFirstComponent: index == components.startIndex
+            )
         }
 
         while components.first == "" {
@@ -63,12 +67,12 @@ struct GitRefNameInputFilter: Equatable {
         return sanitize(next, mode: mode)
     }
 
-    private func sanitizeComponent(_ rawComponent: String, mode: Mode) -> String {
+    private func sanitizeComponent(_ rawComponent: String, mode: Mode, isFirstComponent: Bool) -> String {
         var component = rawComponent
         while component.hasPrefix(".") {
             component.removeFirst()
         }
-        while component.hasPrefix("-") {
+        while isFirstComponent && component.hasPrefix("-") {
             component.removeFirst()
         }
         while component.contains("..") {

--- a/Alas/Sources/Git/GitRefNameInputFilter.swift
+++ b/Alas/Sources/Git/GitRefNameInputFilter.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+struct GitRefNameInputFilter: Equatable {
+    enum Mode {
+        case editing
+        case paste
+    }
+
+    static let branchName = GitRefNameInputFilter(allowsTrailingSlashOnPaste: false)
+    static let branchPrefix = GitRefNameInputFilter(allowsTrailingSlashOnPaste: true)
+    static let refName = GitRefNameInputFilter(allowsTrailingSlashOnPaste: false)
+
+    private let allowsTrailingSlashOnPaste: Bool
+
+    private init(allowsTrailingSlashOnPaste: Bool) {
+        self.allowsTrailingSlashOnPaste = allowsTrailingSlashOnPaste
+    }
+
+    func sanitize(_ rawValue: String, mode: Mode) -> String {
+        let filteredScalars = rawValue.unicodeScalars.compactMap { scalar -> UnicodeScalar? in
+            if scalar.properties.generalCategory == .control { return nil }
+            if CharacterSet.whitespacesAndNewlines.contains(scalar) { return nil }
+            if Self.forbiddenScalars.contains(scalar) { return nil }
+            return scalar
+        }
+        var value = String(String.UnicodeScalarView(filteredScalars))
+
+        value = value.replacingOccurrences(of: "@{", with: "@")
+        while value.contains("//") {
+            value = value.replacingOccurrences(of: "//", with: "/")
+        }
+        while value.hasPrefix("/") {
+            value.removeFirst()
+        }
+
+        var components = value.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        for index in components.indices {
+            components[index] = sanitizeComponent(components[index], mode: mode)
+        }
+
+        while components.first == "" {
+            components.removeFirst()
+        }
+        while components.count > 1, components.dropLast().contains("") {
+            if let index = components.dropLast().firstIndex(of: "") {
+                components.remove(at: index)
+            }
+        }
+
+        if mode == .paste && !allowsTrailingSlashOnPaste {
+            while components.last == "" {
+                components.removeLast()
+            }
+        }
+
+        return components.joined(separator: "/")
+    }
+
+    func applyingReplacement(to currentValue: String, range: NSRange, replacement: String) -> String {
+        let current = currentValue as NSString
+        let next = current.replacingCharacters(in: range, with: replacement)
+        let mode: Mode = replacement.count > 1 ? .paste : .editing
+        return sanitize(next, mode: mode)
+    }
+
+    private func sanitizeComponent(_ rawComponent: String, mode: Mode) -> String {
+        var component = rawComponent
+        while component.hasPrefix(".") {
+            component.removeFirst()
+        }
+        while component.hasPrefix("-") {
+            component.removeFirst()
+        }
+        while component.contains("..") {
+            component = component.replacingOccurrences(of: "..", with: ".")
+        }
+        while component.hasSuffix(".lock") {
+            component.removeLast(".lock".count)
+        }
+        if mode == .paste {
+            while component.hasSuffix(".") {
+                component.removeLast()
+            }
+        }
+        if component == "@" {
+            return ""
+        }
+        return component
+    }
+
+    private static let forbiddenScalars = Set("~^:?*[\\".unicodeScalars)
+}

--- a/Alas/Sources/Git/GitRefNameInputFilter.swift
+++ b/Alas/Sources/Git/GitRefNameInputFilter.swift
@@ -6,30 +6,23 @@ struct GitRefNameInputFilter: Equatable {
         case paste
     }
 
-    static let branchName = GitRefNameInputFilter(allowsTrailingSlashOnPaste: false, allowsRevisionSyntax: false)
-    static let branchPrefix = GitRefNameInputFilter(allowsTrailingSlashOnPaste: true, allowsRevisionSyntax: false)
-    static let refName = GitRefNameInputFilter(allowsTrailingSlashOnPaste: false, allowsRevisionSyntax: true)
+    static let branchName = GitRefNameInputFilter(allowsTrailingSlashOnPaste: false)
+    static let branchPrefix = GitRefNameInputFilter(allowsTrailingSlashOnPaste: true)
 
     private let allowsTrailingSlashOnPaste: Bool
-    private let allowsRevisionSyntax: Bool
 
-    private init(allowsTrailingSlashOnPaste: Bool, allowsRevisionSyntax: Bool) {
+    private init(allowsTrailingSlashOnPaste: Bool) {
         self.allowsTrailingSlashOnPaste = allowsTrailingSlashOnPaste
-        self.allowsRevisionSyntax = allowsRevisionSyntax
     }
 
     func sanitize(_ rawValue: String, mode: Mode) -> String {
         let filteredScalars = rawValue.unicodeScalars.compactMap { scalar -> UnicodeScalar? in
             if scalar.properties.generalCategory == .control { return nil }
             if CharacterSet.whitespacesAndNewlines.contains(scalar) { return nil }
-            if !allowsRevisionSyntax && Self.forbiddenScalars.contains(scalar) { return nil }
+            if Self.forbiddenScalars.contains(scalar) { return nil }
             return scalar
         }
         var value = String(String.UnicodeScalarView(filteredScalars))
-
-        if allowsRevisionSyntax {
-            return value
-        }
 
         value = value.replacingOccurrences(of: "@{", with: "@")
         while value.contains("//") {

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -26,7 +26,7 @@ struct WorktreesPane: View {
                     SettingsRow(name: "Branch prefix",
                                 desc: "Default prefix when creating a new worktree.") {
                         VStack(alignment: .leading, spacing: 2) {
-                            AlasField(text: branchPrefixBinding, monospaced: true)
+                            AlasField(text: branchPrefixBinding, monospaced: true, inputFilter: .branchPrefix)
                             if let prefixError = branchPrefixError {
                                 Text(prefixError)
                                     .font(.system(size: 11))
@@ -36,7 +36,7 @@ struct WorktreesPane: View {
                     }
                     SettingsRow(name: "Base branch",
                                 desc: "Default base branch for new worktrees; repo branches can be selected in the create dialog.") {
-                        AlasField(text: bind(\.worktrees.baseBranch), monospaced: true)
+                        AlasField(text: bind(\.worktrees.baseBranch), monospaced: true, inputFilter: .refName)
                     }
                 }
                 // trackUpstream / autoFetch / fetchIntervalMinutes / pruneStale

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -36,7 +36,7 @@ struct WorktreesPane: View {
                     }
                     SettingsRow(name: "Base branch",
                                 desc: "Default base branch for new worktrees; repo branches can be selected in the create dialog.") {
-                        AlasField(text: bind(\.worktrees.baseBranch), monospaced: true, inputFilter: .refName)
+                        AlasField(text: bind(\.worktrees.baseBranch), monospaced: true)
                     }
                 }
                 // trackUpstream / autoFetch / fetchIntervalMinutes / pruneStale

--- a/Alas/Sources/UI/AlasField.swift
+++ b/Alas/Sources/UI/AlasField.swift
@@ -8,18 +8,20 @@ struct AlasField: View {
     var focusOnAppear: Bool = false
     var onSubmit: (() -> Void)? = nil
     var leadingIcon: String? = nil
+    var inputFilter: GitRefNameInputFilter? = nil
     @Environment(\.theme) var theme
 
     var body: some View {
-        if focusOnAppear || onSubmit != nil {
+        if focusOnAppear || onSubmit != nil || inputFilter != nil {
             AlasNSTextField(
                 text: $text,
                 placeholder: placeholder,
                 monospaced: monospaced,
                 focusOnAppear: focusOnAppear,
-                onSubmit: onSubmit
+                onSubmit: onSubmit,
+                inputFilter: inputFilter
             )
-            .frame(height: 28)
+            .fieldChrome(theme: theme)
         } else {
             let field = TextField(placeholder, text: $text)
                 .textFieldStyle(.plain)
@@ -62,6 +64,7 @@ private struct AlasNSTextField: NSViewRepresentable {
     var monospaced: Bool
     var focusOnAppear: Bool
     var onSubmit: (() -> Void)?
+    var inputFilter: GitRefNameInputFilter?
 
     func makeNSView(context: Context) -> AlasNSTextFieldView {
         let field = AlasNSTextFieldView()
@@ -82,6 +85,7 @@ private struct AlasNSTextField: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: AlasNSTextFieldView, context: Context) {
+        context.coordinator.parent = self
         if nsView.stringValue != text {
             nsView.stringValue = text
         }
@@ -110,17 +114,55 @@ private struct AlasNSTextField: NSViewRepresentable {
         }
 
         @objc func action(_ sender: NSTextField) {
-            if sender.stringValue != parent.text {
-                parent.text = sender.stringValue
+            let value = parent.inputFilter?.sanitize(sender.stringValue, mode: .editing) ?? sender.stringValue
+            if sender.stringValue != value {
+                sender.stringValue = value
+            }
+            if value != parent.text {
+                parent.text = value
             }
             parent.onSubmit?()
         }
 
         func controlTextDidChange(_ obj: Notification) {
             guard let field = obj.object as? NSTextField else { return }
-            if field.stringValue != parent.text {
-                parent.text = field.stringValue
+            let value = parent.inputFilter?.sanitize(field.stringValue, mode: .editing) ?? field.stringValue
+            if field.stringValue != value {
+                field.stringValue = value
             }
+            if value != parent.text {
+                parent.text = value
+            }
+        }
+
+        func control(
+            _ control: NSControl,
+            textView: NSTextView,
+            shouldChangeCharactersIn affectedCharRange: NSRange,
+            replacementString: String?
+        ) -> Bool {
+            guard let inputFilter = parent.inputFilter, let replacementString else { return true }
+
+            let proposed = (textView.string as NSString)
+                .replacingCharacters(in: affectedCharRange, with: replacementString)
+            let sanitized = inputFilter.applyingReplacement(
+                to: textView.string,
+                range: affectedCharRange,
+                replacement: replacementString
+            )
+            guard sanitized != proposed else { return true }
+
+            textView.string = sanitized
+            let insertionLocation = min(
+                (sanitized as NSString).length,
+                affectedCharRange.location + (replacementString as NSString).length
+            )
+            textView.setSelectedRange(NSRange(location: insertionLocation, length: 0))
+            if let field = control as? NSTextField {
+                field.stringValue = sanitized
+            }
+            parent.text = sanitized
+            return false
         }
     }
 }

--- a/AlasTests/GitRefNameInputFilterTests.swift
+++ b/AlasTests/GitRefNameInputFilterTests.swift
@@ -96,34 +96,4 @@ struct GitRefNameInputFilterTests {
         #expect(filtered == "feature/login")
         #expect(GitNameValidator.validateBranchName(filtered) == .valid)
     }
-
-    @Test func refNamePreservesBareDashCommitIsh() {
-        let filtered = GitRefNameInputFilter.refName.applyingReplacement(
-            to: "",
-            range: NSRange(location: 0, length: 0),
-            replacement: "-"
-        )
-
-        #expect(filtered == "-")
-    }
-
-    @Test func refNamePreservesPreviousCheckoutRevisionSyntax() {
-        let filtered = GitRefNameInputFilter.refName.applyingReplacement(
-            to: "",
-            range: NSRange(location: 0, length: 0),
-            replacement: "@{-1}"
-        )
-
-        #expect(filtered == "@{-1}")
-    }
-
-    @Test func refNamePreservesCommonCommitIshOperators() {
-        let filtered = GitRefNameInputFilter.refName.applyingReplacement(
-            to: "",
-            range: NSRange(location: 0, length: 0),
-            replacement: "main~1^{commit}"
-        )
-
-        #expect(filtered == "main~1^{commit}")
-    }
 }

--- a/AlasTests/GitRefNameInputFilterTests.swift
+++ b/AlasTests/GitRefNameInputFilterTests.swift
@@ -96,4 +96,34 @@ struct GitRefNameInputFilterTests {
         #expect(filtered == "feature/login")
         #expect(GitNameValidator.validateBranchName(filtered) == .valid)
     }
+
+    @Test func refNamePreservesBareDashCommitIsh() {
+        let filtered = GitRefNameInputFilter.refName.applyingReplacement(
+            to: "",
+            range: NSRange(location: 0, length: 0),
+            replacement: "-"
+        )
+
+        #expect(filtered == "-")
+    }
+
+    @Test func refNamePreservesPreviousCheckoutRevisionSyntax() {
+        let filtered = GitRefNameInputFilter.refName.applyingReplacement(
+            to: "",
+            range: NSRange(location: 0, length: 0),
+            replacement: "@{-1}"
+        )
+
+        #expect(filtered == "@{-1}")
+    }
+
+    @Test func refNamePreservesCommonCommitIshOperators() {
+        let filtered = GitRefNameInputFilter.refName.applyingReplacement(
+            to: "",
+            range: NSRange(location: 0, length: 0),
+            replacement: "main~1^{commit}"
+        )
+
+        #expect(filtered == "main~1^{commit}")
+    }
 }

--- a/AlasTests/GitRefNameInputFilterTests.swift
+++ b/AlasTests/GitRefNameInputFilterTests.swift
@@ -32,14 +32,25 @@ struct GitRefNameInputFilterTests {
         #expect(filtered == "")
     }
 
-    @Test func pasteStripsLeadingDashesFromPathComponents() {
+    @Test func pasteStripsLeadingDashesOnlyFromFirstPathComponent() {
         let filtered = GitRefNameInputFilter.branchName.applyingReplacement(
             to: "",
             range: NSRange(location: 0, length: 0),
             replacement: "-feature/-login"
         )
 
-        #expect(filtered == "feature/login")
+        #expect(filtered == "feature/-login")
+        #expect(GitNameValidator.validateBranchName(filtered) == .valid)
+    }
+
+    @Test func pastePreservesValidDashPrefixedNestedPathComponents() {
+        let filtered = GitRefNameInputFilter.branchName.applyingReplacement(
+            to: "",
+            range: NSRange(location: 0, length: 0),
+            replacement: "feature/-dash"
+        )
+
+        #expect(filtered == "feature/-dash")
         #expect(GitNameValidator.validateBranchName(filtered) == .valid)
     }
 

--- a/AlasTests/GitRefNameInputFilterTests.swift
+++ b/AlasTests/GitRefNameInputFilterTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GitRefNameInputFilterTests {
+    @Test func editingBlocksCharactersThatCannotAppearInGitRefs() {
+        let filtered = GitRefNameInputFilter.branchName.sanitize(
+            "feat bad~name^with:chars?and*glob[set]\\tail\n",
+            mode: .editing
+        )
+
+        #expect(filtered == "featbadnamewithcharsandglobset]tail")
+    }
+
+    @Test func editingBlocksInvalidSingleCharacterInsertion() {
+        let filtered = GitRefNameInputFilter.branchName.applyingReplacement(
+            to: "feature/login",
+            range: NSRange(location: "feature".count, length: 0),
+            replacement: ":"
+        )
+
+        #expect(filtered == "feature/login")
+    }
+
+    @Test func editingBlocksLeadingDashInsertion() {
+        let filtered = GitRefNameInputFilter.branchName.applyingReplacement(
+            to: "",
+            range: NSRange(location: 0, length: 0),
+            replacement: "-"
+        )
+
+        #expect(filtered == "")
+    }
+
+    @Test func pasteStripsLeadingDashesFromPathComponents() {
+        let filtered = GitRefNameInputFilter.branchName.applyingReplacement(
+            to: "",
+            range: NSRange(location: 0, length: 0),
+            replacement: "-feature/-login"
+        )
+
+        #expect(filtered == "feature/login")
+        #expect(GitNameValidator.validateBranchName(filtered) == .valid)
+    }
+
+    @Test func editingAllowsSlashSeparatorsWhileTyping() {
+        let filtered = GitRefNameInputFilter.branchName.applyingReplacement(
+            to: "feature",
+            range: NSRange(location: "feature".count, length: 0),
+            replacement: "/"
+        )
+
+        #expect(filtered == "feature/")
+    }
+
+    @Test func pasteCannotLeaveInvalidBranchNameSequences() {
+        let filtered = GitRefNameInputFilter.branchName.applyingReplacement(
+            to: "",
+            range: NSRange(location: 0, length: 0),
+            replacement: "/bad name//..hidden/@{1}/fix.lock/trailing."
+        )
+
+        #expect(filtered == "badname/hidden/@1}/fix/trailing")
+        #expect(GitNameValidator.validateBranchName(filtered) == .valid)
+    }
+
+    @Test func pastePreservesTrailingSlashForBranchPrefix() {
+        let filtered = GitRefNameInputFilter.branchPrefix.applyingReplacement(
+            to: "",
+            range: NSRange(location: 0, length: 0),
+            replacement: "feature//bad name/"
+        )
+
+        #expect(filtered == "feature/badname/")
+        #expect(GitNameValidator.validateBranchPrefix(filtered) == .valid)
+    }
+
+    @Test func pasteDropsTrailingSlashForBranchNames() {
+        let filtered = GitRefNameInputFilter.branchName.applyingReplacement(
+            to: "",
+            range: NSRange(location: 0, length: 0),
+            replacement: "feature/login/"
+        )
+
+        #expect(filtered == "feature/login")
+        #expect(GitNameValidator.validateBranchName(filtered) == .valid)
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared git ref input filter for branch names and branch prefixes
- apply filtering where Alas creates new branch refs, while leaving manual/base refs raw for git validation
- cover invalid character typing and paste sanitization in focused tests

## Validation
- `swiftformat Alas AlasTests --lint`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-pr229-dd3 -only-testing:AlasTests/GitRefNameInputFilterTests test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -derivedDataPath /tmp/alas-pr229-dd3 -quiet build`
- GitHub Actions Build #907 passed