### PR TITLE
Add advanced project cleanup settings

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
 		08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */; };
+		095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
 		0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
@@ -44,6 +45,7 @@
 		139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */; };
 		13E762EA8D84EFE6F0228806 /* AgentTerminalLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */; };
 		14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2EB554CB6AF797545DB95D /* HeadReader.swift */; };
+		162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
 		1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */; };
@@ -223,6 +225,7 @@
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
 		7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159FE807399835B0821E1CAB /* EnvBuilder.swift */; };
+		7A2C912B677A34391361B720 /* AdvancedSettingsVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */; };
 		7A816022DD913BC76F5EBA7F /* InstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */; };
 		7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CA79B71B4AA72697392702 /* NumstatParser.swift */; };
 		7B309C87C042B3A18AB31D0F /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49B5B544A3432F8D8105268 /* SearchModel.swift */; };
@@ -684,7 +687,7 @@
 		768D12909DD5233659AC4E03 /* RepoGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupView.swift; sourceTree = "<group>"; };
 		76F2498E56CBAF84CB67166C /* HarnessKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessKind.swift; sourceTree = "<group>"; };
 		781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionPicker.swift; sourceTree = "<group>"; };
-		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = .build/ghostty/GhosttyKit.xcframework; sourceTree = "<group>"; };
+		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = "$(SRCROOT)/.build/ghostty/GhosttyKit.xcframework"; sourceTree = "<group>"; };
 		784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecentsTests.swift; sourceTree = "<group>"; };
 		7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstaller.swift; sourceTree = "<group>"; };
 		795056B6AD803D2B555FC866 /* RightPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStore.swift; sourceTree = "<group>"; };
@@ -728,6 +731,7 @@
 		93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltins.swift; sourceTree = "<group>"; };
 		9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfoTests.swift; sourceTree = "<group>"; };
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
+		94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibility.swift; sourceTree = "<group>"; };
 		9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAction.swift; sourceTree = "<group>"; };
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
 		97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroupViewTests.swift; sourceTree = "<group>"; };
@@ -830,6 +834,7 @@
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
+		D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibilityTests.swift; sourceTree = "<group>"; };
 		D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewShortcutTests.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D2F90D03073708AA01531533 /* GitService+Staging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Staging.swift"; sourceTree = "<group>"; };
@@ -854,6 +859,7 @@
 		DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoader.swift; sourceTree = "<group>"; };
 		E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTabView.swift; sourceTree = "<group>"; };
 		E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeatureTests.swift; sourceTree = "<group>"; };
+		E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedPane.swift; sourceTree = "<group>"; };
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
 		E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteFailedWorktreeView.swift; sourceTree = "<group>"; };
 		E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndex.swift; sourceTree = "<group>"; };
@@ -951,6 +957,7 @@
 		1A6B0ED8FD355C82542D35C4 /* AlasTests */ = {
 			isa = PBXGroup;
 			children = (
+				D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */,
 				36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */,
 				4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */,
 				FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */,
@@ -1311,6 +1318,8 @@
 			isa = PBXGroup;
 			children = (
 				E63FA8816D43E1A08AE8164B /* .gitkeep */,
+				E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */,
+				94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */,
 				C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */,
 				5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */,
 				4B450918CC98255AD9170586 /* AppearancePane.swift */,
@@ -1930,6 +1939,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */,
+				7A2C912B677A34391361B720 /* AdvancedSettingsVisibility.swift in Sources */,
 				F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */,
 				2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */,
 				D6B39CE8878BB196FF2277B6 /* AgentDefinition.swift in Sources */,
@@ -2190,6 +2201,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,
 				FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */,
 				7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */,
 				2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */,
@@ -2520,7 +2532,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"\".build/ghostty\"",
+					"\"$(SRCROOT)/.build/ghostty\"",
 				);
 				INFOPLIST_FILE = Alas/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2562,7 +2574,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"\".build/ghostty\"",
+					"\"$(SRCROOT)/.build/ghostty\"",
 				);
 				INFOPLIST_FILE = Alas/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -629,8 +629,9 @@ final class AppState {
         startProjectGitWatcher(for: project)
     }
 
-    func removeProject(id: String) {
-        guard let project = projects.first(where: { $0.id == id }) else { return }
+    @discardableResult
+    func removeProject(id: String) -> Bool {
+        guard let project = projects.first(where: { $0.id == id }) else { return false }
 
         let mainId = Worktree.makeId(path: URL(fileURLWithPath: project.path))
         let liveWorktrees = projectsManager.worktrees(projectId: id)
@@ -674,12 +675,12 @@ final class AppState {
             ) {
             case .save:
                 for entry in dirtyByWorktree {
-                    guard saveDirtyBuffers(in: entry.worktree) else { return }
+                    guard saveDirtyBuffers(in: entry.worktree) else { return false }
                 }
             case .discard:
                 break
             case .cancel:
-                return
+                return false
             }
         }
 
@@ -696,6 +697,40 @@ final class AppState {
             try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId))
             try? FileManager.default.removeItem(at: Paths.buffersDir(forWorktreeId: worktreeId))
         }
+        return true
+    }
+
+    @discardableResult
+    func clearAllProjects() -> Int {
+        let ids = projects.map(\.id)
+        var removed = 0
+        for id in ids {
+            guard removeProject(id: id) else { break }
+            removed += 1
+        }
+        return removed
+    }
+
+    @discardableResult
+    func clearProjectsWithoutWorktrees() async -> Int {
+        var staleProjectIds: [String] = []
+        for project in projects {
+            let didRefresh = (try? await projectsManager.refreshWorktrees(projectId: project.id)) != nil
+            if !didRefresh, !FileManager.default.fileExists(atPath: project.path) {
+                staleProjectIds.append(project.id)
+                continue
+            }
+            if projectsManager.worktrees(projectId: project.id).isEmpty {
+                staleProjectIds.append(project.id)
+            }
+        }
+
+        var removed = 0
+        for id in staleProjectIds {
+            guard removeProject(id: id) else { break }
+            removed += 1
+        }
+        return removed
     }
 
     /// Start a ProjectGitWatcher for `project` and wire its callbacks into

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -715,11 +715,14 @@ final class AppState {
     func clearProjectsWithoutWorktrees() async -> Int {
         var staleProjectIds: [String] = []
         for project in projects {
-            let didRefresh = (try? await projectsManager.refreshWorktrees(projectId: project.id)) != nil
-            if !didRefresh, !FileManager.default.fileExists(atPath: project.path) {
+            do {
+                try await projectsManager.refreshWorktrees(projectId: project.id)
+            } catch {
+                guard !FileManager.default.fileExists(atPath: project.path) else { continue }
                 staleProjectIds.append(project.id)
                 continue
             }
+
             if projectsManager.worktrees(projectId: project.id).isEmpty {
                 staleProjectIds.append(project.id)
             }

--- a/Alas/Sources/Settings/AdvancedPane.swift
+++ b/Alas/Sources/Settings/AdvancedPane.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+struct AdvancedPane: View {
+    @Bindable var state: AppState
+    @Environment(\.theme) var theme
+    @State private var pendingAction: CleanupAction?
+    @State private var cleanupMessage: String?
+    @State private var isCleaningStaleProjects = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Advanced").font(.system(size: 18, weight: .semibold))
+                Text("Destructive maintenance actions for Alas project tracking.")
+                    .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
+                    .padding(.bottom, 12)
+
+                SettingsGroup(title: "Cleanup") {
+                    SettingsRow(
+                        name: "Clear all projects",
+                        desc: "Stops tracking every project and closes associated tabs. Files on disk are not deleted."
+                    ) {
+                        AlasButton(title: "Clear All Projects...", icon: "trash", style: .normal) {
+                            pendingAction = .clearAll
+                        }
+                    }
+                    SettingsRow(
+                        name: "Clear projects without worktrees",
+                        desc: "Refreshes project worktrees, then removes only projects with no worktree entries."
+                    ) {
+                        AlasButton(title: staleProjectsButtonTitle, icon: "trash", style: .normal) {
+                            pendingAction = .clearWithoutWorktrees
+                        }
+                        .disabled(isCleaningStaleProjects)
+                    }
+                }
+
+                if let cleanupMessage {
+                    Text(cleanupMessage)
+                        .font(.system(size: 11.5))
+                        .foregroundColor(theme.color("fg-dim"))
+                        .padding(.top, 8)
+                }
+            }
+            .padding(.horizontal, 32).padding(.vertical, 24)
+        }
+        .alert(
+            pendingAction?.title ?? "",
+            isPresented: Binding(
+                get: { pendingAction != nil },
+                set: { if !$0 { pendingAction = nil } }
+            ),
+            presenting: pendingAction
+        ) { action in
+            Button(action.destructiveButtonTitle, role: .destructive) {
+                run(action)
+            }
+            Button("Cancel", role: .cancel) {
+                pendingAction = nil
+            }
+        } message: { action in
+            Text(action.message(projectCount: state.projects.count))
+        }
+    }
+
+    private var staleProjectsButtonTitle: String {
+        isCleaningStaleProjects ? "Clearing..." : "Clear Projects Without Worktrees..."
+    }
+
+    private func run(_ action: CleanupAction) {
+        pendingAction = nil
+        switch action {
+        case .clearAll:
+            let removed = state.clearAllProjects()
+            cleanupMessage = removed == 1
+                ? "Removed 1 project from Alas."
+                : "Removed \(removed) projects from Alas."
+        case .clearWithoutWorktrees:
+            isCleaningStaleProjects = true
+            cleanupMessage = "Refreshing projects..."
+            Task { @MainActor in
+                let removed = await state.clearProjectsWithoutWorktrees()
+                isCleaningStaleProjects = false
+                cleanupMessage = removed == 1
+                    ? "Removed 1 project without worktrees from Alas."
+                    : "Removed \(removed) projects without worktrees from Alas."
+            }
+        }
+    }
+
+    private enum CleanupAction: Identifiable {
+        case clearAll
+        case clearWithoutWorktrees
+
+        var id: String {
+            switch self {
+            case .clearAll: return "clearAll"
+            case .clearWithoutWorktrees: return "clearWithoutWorktrees"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .clearAll:
+                return "Clear all projects?"
+            case .clearWithoutWorktrees:
+                return "Clear projects without worktrees?"
+            }
+        }
+
+        var destructiveButtonTitle: String {
+            switch self {
+            case .clearAll:
+                return "Clear All Projects"
+            case .clearWithoutWorktrees:
+                return "Clear Projects Without Worktrees"
+            }
+        }
+
+        func message(projectCount: Int) -> String {
+            switch self {
+            case .clearAll:
+                return "Alas will stop tracking all \(projectCount) projects and close associated tabs. No repository or worktree files will be deleted from disk. If editor tabs have unsaved changes, you will be asked to save or discard them."
+            case .clearWithoutWorktrees:
+                return "Alas will refresh every project, then stop tracking only projects whose Git worktree list is empty. No repository or worktree files will be deleted from disk. If editor tabs have unsaved changes, you will be asked to save or discard them."
+            }
+        }
+    }
+}

--- a/Alas/Sources/Settings/AdvancedSettingsVisibility.swift
+++ b/Alas/Sources/Settings/AdvancedSettingsVisibility.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct AdvancedSettingsVisibility {
+    static var debugFileURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".alas", isDirectory: true)
+            .appendingPathComponent(".debug")
+    }
+
+    static func isEnabled(
+        fileManager: FileManager = .default,
+        debugFileURL: URL = Self.debugFileURL
+    ) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: debugFileURL.path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
+    }
+}

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
 enum SettingsSection: String, CaseIterable, Identifiable {
-    case agents, appearance, changes, code, shortcuts, terminal, worktrees
+    case agents, appearance, changes, code, shortcuts, terminal, worktrees, advanced
     var id: String { rawValue }
     var label: String {
         switch self {
+        case .advanced:   return "Advanced"
         case .agents:     return "Agents"
         case .appearance: return "Appearance"
         case .changes:    return "Changes"
@@ -16,6 +17,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     }
     var icon: String {
         switch self {
+        case .advanced:   return "wrench.and.screwdriver"
         case .agents:     return "sparkle"
         case .appearance: return "palette"
         case .changes:    return "diff"
@@ -29,11 +31,12 @@ enum SettingsSection: String, CaseIterable, Identifiable {
 
 struct SettingsNavView: View {
     @Binding var selection: SettingsSection
+    var showsAdvanced: Bool
     @Environment(\.theme) var theme
 
     var body: some View {
         VStack(spacing: 1) {
-            ForEach(SettingsSection.allCases.sorted(by: { $0.label < $1.label })) { section in
+            ForEach(sections) { section in
                 Button { selection = section } label: {
                     HStack(spacing: 9) {
                         Icon(name: section.icon, size: 14,
@@ -61,5 +64,11 @@ struct SettingsNavView: View {
         .frame(width: 200)
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .trailing)
+    }
+
+    private var sections: [SettingsSection] {
+        SettingsSection.allCases
+            .filter { showsAdvanced || $0 != .advanced }
+            .sorted(by: { $0.label < $1.label })
     }
 }

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum SettingsSection: String, CaseIterable, Identifiable {
-    case agents, appearance, changes, code, shortcuts, terminal, worktrees, advanced
+    case advanced, agents, appearance, changes, code, shortcuts, terminal, worktrees
     var id: String { rawValue }
     var label: String {
         switch self {

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsWindow: View {
     @Bindable var state: AppState
     @State private var section: SettingsSection = .agents
+    @State private var showsAdvanced = AdvancedSettingsVisibility.isEnabled()
 
     var body: some View {
         let theme = state.themeStore.current
@@ -26,9 +27,10 @@ struct SettingsWindow: View {
             .overlay(Divider().opacity(0.5), alignment: .bottom)
 
             HStack(spacing: 0) {
-                SettingsNavView(selection: $section)
+                SettingsNavView(selection: $section, showsAdvanced: showsAdvanced)
                 Group {
                     switch section {
+                    case .advanced:   AdvancedPane(state: state)
                     case .agents:     AgentsPane(state: state) { section = $0 }
                     case .appearance: AppearancePane(state: state)
                     case .changes:    ChangesPane(state: state)
@@ -60,7 +62,13 @@ struct SettingsWindow: View {
         .background(WindowConfigurator())
         .environment(\.theme, theme)
         .ignoresSafeArea()
-        .onAppear { state.rescanAgents() }
+        .onAppear {
+            showsAdvanced = AdvancedSettingsVisibility.isEnabled()
+            if !showsAdvanced, section == .advanced {
+                section = .agents
+            }
+            state.rescanAgents()
+        }
     }
 
     private func closeWindow() {

--- a/AlasTests/AdvancedSettingsVisibilityTests.swift
+++ b/AlasTests/AdvancedSettingsVisibilityTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct AdvancedSettingsVisibilityTests {
+    @Test func enabledWhenDebugFileExistsEvenIfEmpty() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-debug-visibility-\(UUID().uuidString)", isDirectory: true)
+        let debugFile = root.appendingPathComponent(".debug")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data().write(to: debugFile)
+
+        #expect(AdvancedSettingsVisibility.isEnabled(debugFileURL: debugFile))
+    }
+
+    @Test func disabledWhenDebugPathIsMissingOrDirectory() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-debug-visibility-\(UUID().uuidString)", isDirectory: true)
+        let missing = root.appendingPathComponent(".debug")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(AdvancedSettingsVisibility.isEnabled(debugFileURL: missing) == false)
+
+        try FileManager.default.createDirectory(at: missing, withIntermediateDirectories: true)
+        #expect(AdvancedSettingsVisibility.isEnabled(debugFileURL: missing) == false)
+    }
+}

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -5,6 +5,23 @@ import Foundation
 @Suite(.serialized)
 @MainActor
 struct AppStateCleanupTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        var config: AppConfig? = nil
+        var projectsFile: ProjectsFile? = nil
+
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? {
+            if T.self == AppConfig.self {
+                return config as? T
+            }
+            if T.self == ProjectsFile.self {
+                return projectsFile as? T
+            }
+            return nil
+        }
+    }
+
     private func makeRepo(name: String) async throws -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-cleanup-\(name)-\(UUID().uuidString)")
@@ -345,6 +362,98 @@ struct AppStateCleanupTests {
 
         #expect(state.projects.contains(where: { $0.id == project.id }) == false)
         #expect(state.tabs.tabs(forWorktree: wt.id).isEmpty)
+    }
+
+    @Test func clearAllProjectsRemovesEveryProject() async throws {
+        let repoA = try await makeRepo(name: "clear-all-a")
+        let repoB = try await makeRepo(name: "clear-all-b")
+        defer {
+            try? FileManager.default.removeItem(at: repoA)
+            try? FileManager.default.removeItem(at: repoB)
+        }
+
+        let state = AppState(store: MemoryStore())
+        let projectA = try await state.projectsManager.addProject(
+            path: repoA, displayName: "clearA", color: "#5fb7c4"
+        )
+        let projectB = try await state.projectsManager.addProject(
+            path: repoB, displayName: "clearB", color: "#c89d6f"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: projectA.id)
+        try await state.projectsManager.refreshWorktrees(projectId: projectB.id)
+
+        let worktreeId = try #require(state.projectsManager.worktrees(projectId: projectA.id).first?.id)
+        state.selectedWorktreeId = worktreeId
+        state.tabs.appendTerminal(worktreeId: worktreeId, title: "term", sessionId: "s1")
+
+        let removed = state.clearAllProjects()
+
+        #expect(removed == 2)
+        #expect(state.projects.isEmpty)
+        #expect(state.selectedWorktreeId == nil)
+        #expect(state.tabs.tabs(forWorktree: worktreeId).isEmpty)
+    }
+
+    @Test func clearProjectsWithoutWorktreesKeepsProjectsWithLiveWorktrees() async throws {
+        let repo = try await makeRepo(name: "clear-without-worktrees-keep")
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-missing-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let liveProject = ProjectConfig(
+            id: UUID().uuidString,
+            name: "live",
+            path: repo.path,
+            color: "#5fb7c4",
+            addedAt: Date()
+        )
+        let staleProject = ProjectConfig(
+            id: UUID().uuidString,
+            name: "stale",
+            path: missing.path,
+            color: "#c89d6f",
+            addedAt: Date()
+        )
+        let state = AppState(
+            store: MemoryStore(projectsFile: ProjectsFile(projects: [liveProject, staleProject]))
+        )
+
+        let removed = await state.clearProjectsWithoutWorktrees()
+
+        #expect(removed == 1)
+        #expect(state.projects.map(\.id) == [liveProject.id])
+        #expect(state.projectsManager.worktrees(projectId: liveProject.id).isEmpty == false)
+    }
+
+    @Test func clearProjectsWithoutWorktreesRemovesMissingProjectWithStaleRows() async throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-missing-\(UUID().uuidString)")
+        let staleProject = ProjectConfig(
+            id: UUID().uuidString,
+            name: "stale",
+            path: missing.path,
+            color: "#c89d6f",
+            addedAt: Date()
+        )
+        let state = AppState(
+            store: MemoryStore(projectsFile: ProjectsFile(projects: [staleProject]))
+        )
+        let staleWorktree = Worktree(
+            id: Worktree.makeId(path: missing),
+            projectId: staleProject.id,
+            name: "main",
+            branch: "main",
+            path: missing,
+            status: .clean,
+            lastActivity: Date()
+        )
+        state.projectsManager.insertOptimisticWorktree(staleWorktree)
+        #expect(state.projectsManager.worktrees(projectId: staleProject.id).isEmpty == false)
+
+        let removed = await state.clearProjectsWithoutWorktrees()
+
+        #expect(removed == 1)
+        #expect(state.projects.isEmpty)
     }
 
     @Test func removeProjectResetsSelectionWhenSelectedWorktreeIsRemoved() async throws {

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -456,6 +456,29 @@ struct AppStateCleanupTests {
         #expect(state.projects.isEmpty)
     }
 
+    @Test func clearProjectsWithoutWorktreesKeepsProjectWhenRefreshFailsButPathExists() async throws {
+        let nonRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-refresh-fails-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: nonRepo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: nonRepo) }
+
+        let project = ProjectConfig(
+            id: UUID().uuidString,
+            name: "non-repo",
+            path: nonRepo.path,
+            color: "#5fb7c4",
+            addedAt: Date()
+        )
+        let state = AppState(
+            store: MemoryStore(projectsFile: ProjectsFile(projects: [project]))
+        )
+
+        let removed = await state.clearProjectsWithoutWorktrees()
+
+        #expect(removed == 0)
+        #expect(state.projects.map(\.id) == [project.id])
+    }
+
     @Test func removeProjectResetsSelectionWhenSelectedWorktreeIsRemoved() async throws {
         let repoA = try await makeRepo(name: "remove-sel-a")
         let repoB = try await makeRepo(name: "remove-sel-b")

--- a/project.yml
+++ b/project.yml
@@ -57,7 +57,7 @@ targets:
         CFBundleIconFile: AppIcon
         CFBundleIconName: AppIcon
     dependencies:
-      - framework: .build/ghostty/GhosttyKit.xcframework
+      - framework: $(SRCROOT)/.build/ghostty/GhosttyKit.xcframework
         embed: false
         link: true
         codeSign: false


### PR DESCRIPTION
## Summary
- Add debug-gated Advanced settings section controlled by ~/.alas/.debug
- Add confirmed cleanup actions for clearing all projects or only projects without worktrees
- Add focused tests for debug visibility and cleanup behavior

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- Focused tests for Advanced settings cleanup and visibility

Full xcodebuild test still hangs in the app test host in this worktree.