### PR TITLE
feat: add purple submodule badge to directories in files pane

### DIFF
--- a/Alas/Resources/Themes/cool-slate.json
+++ b/Alas/Resources/Themes/cool-slate.json
@@ -21,6 +21,7 @@
     "del": "oklch(0.72 0.16 25)",
     "mod": "oklch(0.80 0.13 85)",
     "info": "oklch(0.76 0.11 230)",
+    "submodule": "oklch(0.74 0.11 295)",
     "warn": "oklch(0.80 0.13 65)",
     "syntax-keyword": "oklch(0.78 0.10 295)",
     "syntax-type": "oklch(0.80 0.09 215)",

--- a/Alas/Resources/Themes/light.json
+++ b/Alas/Resources/Themes/light.json
@@ -21,6 +21,7 @@
     "del": "oklch(0.50 0.18 25)",
     "mod": "oklch(0.60 0.14 85)",
     "info": "oklch(0.55 0.13 230)",
+    "submodule": "oklch(0.55 0.12 295)",
     "warn": "oklch(0.60 0.14 65)",
     "syntax-keyword": "oklch(0.50 0.13 295)",
     "syntax-type": "oklch(0.45 0.10 215)",

--- a/Alas/Sources/Git/FileTreeBuilder.swift
+++ b/Alas/Sources/Git/FileTreeBuilder.swift
@@ -6,7 +6,8 @@ enum FileTreeBuilder {
         badges: [String: String],
         visibility: [String: FileVisibility] = [:],
         directories: Set<String> = [],
-        lazyDirectories: Set<String> = []
+        lazyDirectories: Set<String> = [],
+        submodules: Set<String> = []
     ) -> [FileTreeNode] {
         var roots: [String: TreeBuildNode] = [:]
         let nestedDirectories = nestedDirectoryPaths(paths)
@@ -21,6 +22,7 @@ enum FileTreeBuilder {
                 directories: directories,
                 lazyDirectories: lazyDirectories,
                 nestedDirectories: nestedDirectories,
+                submodules: submodules,
                 prefix: ""
             )
         }
@@ -34,6 +36,7 @@ enum FileTreeBuilder {
         var badge: String?
         var visibility: FileVisibility
         var childrenState: DirectoryChildrenState
+        var isSubmodule: Bool
         var children: [String: TreeBuildNode] = [:]
         init(
             name: String,
@@ -41,7 +44,8 @@ enum FileTreeBuilder {
             isDir: Bool,
             badge: String?,
             visibility: FileVisibility,
-            childrenState: DirectoryChildrenState
+            childrenState: DirectoryChildrenState,
+            isSubmodule: Bool = false
         ) {
             self.name = name
             self.path = path
@@ -49,6 +53,7 @@ enum FileTreeBuilder {
             self.badge = badge
             self.visibility = visibility
             self.childrenState = childrenState
+            self.isSubmodule = isSubmodule
         }
     }
 
@@ -61,6 +66,7 @@ enum FileTreeBuilder {
         directories: Set<String>,
         lazyDirectories: Set<String>,
         nestedDirectories: Set<String>,
+        submodules: Set<String>,
         prefix: String
     ) {
         guard let head = parts.first else { return }
@@ -73,7 +79,7 @@ enum FileTreeBuilder {
         )
         let hasNestedChildren = nestedDirectories.contains(nodePath)
         let explicitDirectory = hasDirectoryMetadata && !hasNestedChildren
-        let isDir = !isLeaf || explicitDirectory
+        let isDir = !isLeaf || explicitDirectory || submodules.contains(nodePath)
         if isLeaf {
             let badge = badges[fullPath]
             if hasDirectoryMetadata && hasNestedChildren {
@@ -82,7 +88,8 @@ enum FileTreeBuilder {
                     path: nodePath,
                     into: &map,
                     visibility: visibility,
-                    lazyDirectories: lazyDirectories
+                    lazyDirectories: lazyDirectories,
+                    submodules: submodules
                 )
                 if badge == nil { return }
             }
@@ -95,12 +102,14 @@ enum FileTreeBuilder {
                     isDir: isDir,
                     badge: badge,
                     visibility: nodeVisibility(nodePath, visibility: visibility),
-                    childrenState: childrenState(path: nodePath, isDir: isDir, lazyDirectories: lazyDirectories)
+                    childrenState: childrenState(path: nodePath, isDir: isDir, lazyDirectories: lazyDirectories),
+                    isSubmodule: submodules.contains(nodePath) && isDir
                 )
             } else {
                 existing?.badge = badge
                 existing?.visibility = nodeVisibility(nodePath, visibility: visibility)
                 existing?.childrenState = childrenState(path: nodePath, isDir: isDir, lazyDirectories: lazyDirectories)
+                existing?.isSubmodule = submodules.contains(nodePath) && isDir
             }
         } else {
             let key = nodeKey(name: head, isDir: true)
@@ -111,10 +120,12 @@ enum FileTreeBuilder {
                 isDir: true,
                 badge: nil,
                 visibility: nodeVisibility(nodePath, visibility: visibility),
-                childrenState: childrenState(path: nodePath, isDir: true, lazyDirectories: lazyDirectories)
+                childrenState: childrenState(path: nodePath, isDir: true, lazyDirectories: lazyDirectories),
+                isSubmodule: submodules.contains(nodePath)
             )
             dir.visibility = nodeVisibility(nodePath, visibility: visibility)
             dir.childrenState = childrenState(path: nodePath, isDir: true, lazyDirectories: lazyDirectories)
+            dir.isSubmodule = submodules.contains(nodePath)
             map[key] = dir
             insert(
                 parts: Array(parts.dropFirst()),
@@ -125,6 +136,7 @@ enum FileTreeBuilder {
                 directories: directories,
                 lazyDirectories: lazyDirectories,
                 nestedDirectories: nestedDirectories,
+                submodules: submodules,
                 prefix: nodePath
             )
         }
@@ -135,7 +147,8 @@ enum FileTreeBuilder {
         path: String,
         into map: inout [String: TreeBuildNode],
         visibility: [String: FileVisibility],
-        lazyDirectories: Set<String>
+        lazyDirectories: Set<String>,
+        submodules: Set<String>
     ) {
         let key = nodeKey(name: name, isDir: true)
         let dir = map[key] ?? TreeBuildNode(
@@ -144,10 +157,12 @@ enum FileTreeBuilder {
             isDir: true,
             badge: nil,
             visibility: nodeVisibility(path, visibility: visibility),
-            childrenState: childrenState(path: path, isDir: true, lazyDirectories: lazyDirectories)
+            childrenState: childrenState(path: path, isDir: true, lazyDirectories: lazyDirectories),
+            isSubmodule: submodules.contains(path)
         )
         dir.visibility = nodeVisibility(path, visibility: visibility)
         dir.childrenState = childrenState(path: path, isDir: true, lazyDirectories: lazyDirectories)
+        dir.isSubmodule = submodules.contains(path)
         map[key] = dir
     }
 
@@ -199,7 +214,8 @@ enum FileTreeBuilder {
                 children: kids,
                 badge: node.badge,
                 visibility: node.visibility,
-                childrenState: node.childrenState
+                childrenState: node.childrenState,
+                isSubmodule: node.isSubmodule
             )
         }
     }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -330,13 +330,34 @@ extension GitService {
             Self.logger.error("file tree root scan failed for \(worktreePath.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
 
+        let submodules = (try? await submodulePaths(worktreePath: worktreePath)) ?? []
+
         return FileTreeBuilder.build(
             paths: Array(paths),
             badges: badges,
             visibility: visibility,
             directories: directories,
-            lazyDirectories: lazyDirectories
+            lazyDirectories: lazyDirectories,
+            submodules: submodules
         )
+    }
+
+    func submodulePaths(worktreePath: URL) async throws -> Set<String> {
+        let result = try await Process.git(["ls-files", "--stage", "-z"], cwd: worktreePath)
+        guard result.exitCode == 0 else { return [] }
+        var paths = Set<String>()
+        // With -z the format is: "<mode> <sha> <stage>\t<path>\0 ..."
+        // — lines separated by \0 so paths with spaces are verbatim.
+        let entries = result.stdout.split(separator: "\0", omittingEmptySubsequences: true)
+        for entry in entries {
+            guard let tab = entry.firstIndex(of: "\t") else { continue }
+            let meta = String(entry[..<tab])
+            let path = String(entry[entry.index(after: tab)...])
+            let parts = meta.split(separator: " ", omittingEmptySubsequences: true)
+            guard parts.count == 3, parts[0] == "160000" else { continue }
+            paths.insert(path)
+        }
+        return paths
     }
 
     func fileTreeChildren(worktreePath: URL, path: String) async throws -> [FileTreeNode] {
@@ -383,12 +404,15 @@ extension GitService {
             visibility[path] = .tracked
         }
 
+        let submodules = (try? await submodulePaths(worktreePath: worktreePath)) ?? []
+
         let built = FileTreeBuilder.build(
             paths: childPaths,
             badges: [:],
             visibility: visibility,
             directories: directories,
-            lazyDirectories: lazyDirectories
+            lazyDirectories: lazyDirectories,
+            submodules: submodules
         )
         guard !path.isEmpty else { return built }
         return findFileTreeNode(path: path, in: built)?.children ?? []

--- a/Alas/Sources/Git/GitTypes.swift
+++ b/Alas/Sources/Git/GitTypes.swift
@@ -58,6 +58,7 @@ struct FileTreeNode: Identifiable, Equatable, Codable {
     var badge: String?        // "A"|"M"|"D"|"R" if status non-empty
     var visibility: FileVisibility = .tracked
     var childrenState: DirectoryChildrenState = .loaded
+    var isSubmodule: Bool = false
 
     enum Kind: String, Codable { case dir, file }
 }

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -23,59 +23,71 @@ struct FilesTabView: View {
     }
 
     private func renderNode(_ node: FileTreeNode, depth: Int) -> AnyView {
-        if node.kind == .dir {
-            let open = openPaths.contains(node.path)
-            return AnyView(
-                Group {
-                    Button {
-                        if open {
-                            openPaths.remove(node.path)
-                        } else {
-                            openPaths.insert(node.path)
-                            onLoadChildren(node.path)
-                        }
-                    } label: {
-                        HStack(spacing: 6) {
-                            Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
-                            Icon(name: "folder", size: 11, color: folderColor(for: node, open: open))
-                            Text(node.name)
-                                .font(.system(size: 11.5, design: .monospaced))
-                                .foregroundColor(rowForeground(for: node))
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                            Spacer()
-                            if isOffGit(node) {
-                                visibilityPill(node)
+                if node.kind == .dir {
+                    let open = openPaths.contains(node.path)
+                    let canExpand = !node.isSubmodule
+                    return AnyView(
+                        Group {
+                            Button {
+                                guard canExpand else { return }
+                                if open {
+                                    openPaths.remove(node.path)
+                                } else {
+                                    openPaths.insert(node.path)
+                                    onLoadChildren(node.path)
+                                }
+                            } label: {
+                                HStack(spacing: 6) {
+                                    if canExpand {
+                                        Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+                                    } else {
+                                        Color.clear.frame(width: 10, height: 10)
+                                    }
+                                    Icon(name: "folder", size: 11, color: folderColor(for: node, open: open))
+                                    Text(node.name)
+                                        .font(.system(size: 11.5, design: .monospaced))
+                                        .foregroundColor(rowForeground(for: node))
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                    Spacer()
+                                    if node.isSubmodule {
+                                        submodulePill
+                                    }
+                                    if let badge = node.badge {
+                                        StatusBadge(status: badge)
+                                    }
+                                    if isOffGit(node) {
+                                        visibilityPill(node)
+                                    }
+                                }
+                                .padding(.leading, CGFloat(12 + depth * 14))
+                                .padding(.trailing, 12)
+                                .padding(.vertical, 4)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .opacity(isOffGit(node) ? 0.72 : 1.0)
+                                .overlay(alignment: .leading) {
+                                    if isOffGit(node) {
+                                        ghostRail(depth: depth)
+                                    }
+                                }
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                            if open && canExpand {
+                                switch node.childrenState {
+                                case .loading:
+                                    treeMessage("Loading...", depth: depth + 1)
+                                    renderChildren(of: node, depth: depth + 1)
+                                case .failed:
+                                    treeMessage("Could not load children", depth: depth + 1)
+                                    renderChildren(of: node, depth: depth + 1)
+                                case .loaded:
+                                    renderChildren(of: node, depth: depth + 1)
+                                case .notLoaded:
+                                    EmptyView()
+                                }
                             }
                         }
-                        .padding(.leading, CGFloat(12 + depth * 14))
-                        .padding(.trailing, 12)
-                        .padding(.vertical, 4)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .opacity(isOffGit(node) ? 0.72 : 1.0)
-                        .overlay(alignment: .leading) {
-                            if isOffGit(node) {
-                                ghostRail(depth: depth)
-                            }
-                        }
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    if open {
-                        switch node.childrenState {
-                        case .loading:
-                            treeMessage("Loading...", depth: depth + 1)
-                            renderChildren(of: node, depth: depth + 1)
-                        case .failed:
-                            treeMessage("Could not load children", depth: depth + 1)
-                            renderChildren(of: node, depth: depth + 1)
-                        case .loaded:
-                            renderChildren(of: node, depth: depth + 1)
-                        case .notLoaded:
-                            EmptyView()
-                        }
-                    }
-                }
                 .task(id: loadTaskID(for: node, open: open)) {
                     if shouldAutoLoadChildren(for: node, open: open) {
                         onLoadChildren(node.path)
@@ -182,6 +194,16 @@ struct FilesTabView: View {
             .padding(.horizontal, 5)
             .padding(.vertical, 1)
             .background(theme.color("bg-4").opacity(0.75))
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+
+    private var submodulePill: some View {
+        Text("submodule")
+            .font(.system(size: 9, weight: .semibold, design: .monospaced))
+            .foregroundColor(theme.color("submodule"))
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(theme.color("submodule").opacity(0.18))
             .clipShape(RoundedRectangle(cornerRadius: 3))
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -171,6 +171,7 @@ final class RightPaneState {
                         var refreshed = existing
                         refreshed.badge = child.badge ?? existing.badge
                         refreshed.visibility = mergedVisibility(existing: existing.visibility, incoming: child.visibility)
+                        refreshed.isSubmodule = child.isSubmodule || existing.isSubmodule
                         refreshed.childrenState = mergedChildrenState(existing: existing.childrenState, incoming: child.childrenState)
                         if refreshed.children == nil {
                             refreshed.children = child.children

--- a/AlasTests/FileTreeBuilderTests.swift
+++ b/AlasTests/FileTreeBuilderTests.swift
@@ -142,6 +142,42 @@ struct FileTreeBuilderTests {
         #expect(trackedFile.visibility == .tracked)
     }
 
+    @Test func marksSubmoduleDirectory() {
+        let tree = FileTreeBuilder.build(
+            paths: ["Submodule"],
+            badges: [:],
+            directories: ["Submodule"],
+            submodules: ["Submodule"]
+        )
+        let node = tree.first { $0.path == "Submodule" }!
+        #expect(node.kind == .dir)
+        #expect(node.isSubmodule == true)
+    }
+
+    @Test func nonSubmoduleDirectoryStaysFalse() {
+        let tree = FileTreeBuilder.build(
+            paths: ["Sources/App.swift"],
+            badges: [:],
+            directories: ["Sources"]
+        )
+        let node = tree.first { $0.path == "Sources" }!
+        #expect(node.kind == .dir)
+        #expect(node.isSubmodule == false)
+    }
+
+    @Test func marksSubmoduleLeafAsDirectoryWithoutDirectoryMetadata() {
+        // A submodule represented only by its gitlink path has no directory
+        // metadata in the `directories` set, but should still be a dir.
+        let tree = FileTreeBuilder.build(
+            paths: ["Submodule"],
+            badges: [:],
+            submodules: ["Submodule"]
+        )
+        let node = tree.first { $0.path == "Submodule" }!
+        #expect(node.kind == .dir)
+        #expect(node.isSubmodule == true)
+    }
+
     private func assertPreservesFileAndDirectoryPathCollisions(
         _ paths: [String],
         directories: Set<String> = [],

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -340,4 +340,81 @@ struct GitServiceTests {
         #expect(children.contains { $0.path == "Sources/App.swift" && $0.visibility == .tracked })
         #expect(children.contains { $0.path == "Sources/cache.log" && $0.visibility == .ignored })
     }
+
+    @Test func submodulePathsDetectsRegisteredSubmodules() async throws {
+        let repo = try await makeRepo()
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alassubmodule-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: submoduleRepo)
+        }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: submoduleRepo)
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: repo
+        )
+
+        let svc = GitService()
+        let paths = try await svc.submodulePaths(worktreePath: repo)
+        #expect(paths == ["Deps/Submodule"])
+    }
+
+    @Test func submodulePathsHandlesSpacedSubmodulePath() async throws {
+        let repo = try await makeRepo()
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-spaced-sub-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: submoduleRepo)
+        }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: submoduleRepo)
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Space Name"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"],
+            cwd: repo
+        )
+
+        let svc = GitService()
+        let paths = try await svc.submodulePaths(worktreePath: repo)
+        #expect(paths == ["Deps/Space Name"])
+    }
+
+    @Test func submodulePathsHandlesDeletedSubmodule() async throws {
+        let repo = try await makeRepo()
+        let submoduleRepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-deletedsub-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: submoduleRepo)
+        }
+        try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: submoduleRepo)
+        _ = try await Process.git(
+            ["-c", "protocol.file.allow=always", "submodule", "add", "-q", submoduleRepo.path, "Deps/Submodule"],
+            cwd: repo
+        )
+        _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
+
+        // Remove the submodule directory from disk without running submodule deinit
+        try FileManager.default.removeItem(at: repo.appendingPathComponent("Deps/Submodule"))
+
+        let svc = GitService()
+        let paths = try await svc.submodulePaths(worktreePath: repo)
+        #expect(paths == ["Deps/Submodule"])
+    }
 }


### PR DESCRIPTION
<!-- gg:managed:start -->
- Add isSubmodule flag to FileTreeNode (GitTypes.swift)
- FileTreeBuilder accepts submodules Set and marks matching dirs
- GitService detects submodules via git submodule status
- files pane renders purple submodule pill next to directory names
- RightPaneState.mergingChildren preserves isSubmodule across lazy loads
- Theme: add submodule token (purplish) to cool-slate and light themes
- Tests for FileTreeBuilder and GitService submodule detection
<!-- gg:managed:end -->