### PR TITLE
Image diff polish: union-canvas alignment, 30% rename detection, SVG support

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		42D8417781E790CA6AA49F7E /* CursorInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */; };
 		43EC5CF874B360B9092691A5 /* OKLCHTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */; };
 		4421A9D1E7481B49701B3131 /* mason-lsps.json in Resources */ = {isa = PBXBuildFile; fileRef = F0D567F7F894902AD192D220 /* mason-lsps.json */; };
+		443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */; };
 		449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */; };
 		4565825A901B119DCD1037ED /* SymbolsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */; };
 		45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC68B05B719B9235865027F /* ThreePaneSizing.swift */; };
@@ -298,6 +299,7 @@
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
 		9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
+		9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */; };
 		9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
 		9D6FE5A4589D73A7480CE2B2 /* IndentationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */; };
@@ -683,6 +685,7 @@
 		638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffEndToEndTests.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
+		650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometry.swift; sourceTree = "<group>"; };
 		65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstaller.swift; sourceTree = "<group>"; };
 		6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateOverlayFocusTests.swift; sourceTree = "<group>"; };
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
@@ -804,6 +807,7 @@
 		AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstallerTests.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
+		AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometryTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
@@ -1170,6 +1174,7 @@
 				C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */,
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
+				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
 				321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */,
@@ -1738,6 +1743,7 @@
 				802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */,
 				9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */,
 				E22E44126BAFC8F3B515BAC0 /* ScrollEventCapturingView.swift */,
+				650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */,
 			);
 			path = ImageDiff;
 			sourceTree = "<group>";
@@ -2271,6 +2277,7 @@
 				AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */,
 				6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */,
 				5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */,
+				443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */,
 				B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */,
 				4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */,
 				CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */,
@@ -2473,6 +2480,7 @@
 				75B5EE5F1761CF5C830F0549 /* TitlelessWindowTests.swift in Sources */,
 				9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
+				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
 				E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */,
 				98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */,

--- a/Alas/Sources/Center/ImageDiff/GitService+ImageDiff.swift
+++ b/Alas/Sources/Center/ImageDiff/GitService+ImageDiff.swift
@@ -3,6 +3,8 @@ import Foundation
 import os
 
 extension GitService {
+    private static let imageDiffLogger = Logger(subsystem: "io.nlopez.alas", category: "git-service")
+
     /// Commit variant. Returns the before/after `NSImage`s for an image
     /// file changed in commit `sha`. The caller passes the
     /// `CommitChangedFile` (which already carries status + originalPath)
@@ -54,10 +56,6 @@ extension GitService {
             afterFrameCount: frameCount(for: after)
         )
     }
-}
-
-extension GitService {
-    private static let imageDiffLogger = Logger(subsystem: "io.nlopez.alas", category: "git-service")
 
     /// Working-copy variant. Returns the before/after `NSImage`s and the
     /// kind of change (added/deleted/renamed/modified) for an image file.

--- a/Alas/Sources/Center/ImageDiff/GitService+ImageDiff.swift
+++ b/Alas/Sources/Center/ImageDiff/GitService+ImageDiff.swift
@@ -67,7 +67,14 @@ extension GitService {
         relativePath: String,
         staged: Bool
     ) async throws -> ImageDiffPair {
-        let entries = try await status(worktreePath: worktreePath)
+        // Use a dedicated status fetch with a more permissive rename
+        // threshold than `GitService.status(...)` uses for the rest of
+        // the app. Image renames frequently come with significant edits
+        // (logo redesign, compression change, format conversion), and
+        // git's default 50%-similarity heuristic misses those. A 30%
+        // threshold catches the realistic cases without producing false
+        // pairings between unrelated images.
+        let entries = try await imageDiffStatus(worktreePath: worktreePath)
         // A path can appear twice in status when it has both staged AND
         // unstaged changes. Pick the entry whose stage matches the caller's
         // intent; fall back to the other side only if the requested stage
@@ -174,5 +181,27 @@ extension GitService {
               let value = rep.value(forProperty: .frameCount) as? Int
         else { return image == nil ? 0 : 1 }
         return value
+    }
+
+    /// Internal: `git status` with a more permissive rename threshold
+    /// than the app-wide `GitService.status(...)`. The image-diff path
+    /// needs this because real image renames (logo redesigns, format
+    /// conversions, palette swaps) frequently fall below git's default
+    /// 50% similarity threshold.
+    ///
+    /// Mirrors `status(...)`'s arg shape and parses via the same
+    /// `StatusParser`, but doesn't enrich with numstat — the loader
+    /// only needs `path`/`status`/`stage`/`renameFrom`.
+    fileprivate func imageDiffStatus(worktreePath: URL) async throws -> [ChangedFile] {
+        let result = try await Process.git(
+            [
+                "status", "--porcelain=v2", "-z",
+                "--untracked-files=all",
+                "--find-renames=30%",
+            ],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else { return [] }
+        return try StatusParser.parse(result.stdout)
     }
 }

--- a/Alas/Sources/Center/ImageDiff/ImageDiffOverlayView.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffOverlayView.swift
@@ -3,6 +3,12 @@ import SwiftUI
 /// Single canvas. `before` painted opaque; `after` painted on top with
 /// adjustable opacity. Slider labelled "Before … After" so direction is
 /// obvious without legends.
+///
+/// Both images are placed top-left on a shared "union" canvas sized to
+/// `max(beforeW, afterW) × max(beforeH, afterH)` at their natural pixel
+/// dimensions, then the union canvas is scaled to fit the viewport.
+/// This way an image that grew or shrank between revisions visibly does
+/// so in the overlay, instead of both being silently fit to the same box.
 struct ImageDiffOverlayView: View {
     let before: NSImage
     let after: NSImage
@@ -17,20 +23,39 @@ struct ImageDiffOverlayView: View {
     }
 
     private var canvas: some View {
-        ZStack {
-            ImageCheckerboardBackground()
-            Image(nsImage: before)
-                .resizable()
-                .interpolation(.none)
-                .aspectRatio(contentMode: .fit)
-            Image(nsImage: after)
-                .resizable()
-                .interpolation(.none)
-                .aspectRatio(contentMode: .fit)
-                .opacity(opacity)
+        GeometryReader { proxy in
+            let geom = UnionCanvasGeometry(
+                before: before.size, after: after.size, viewport: proxy.size
+            )
+            ZStack {
+                ImageCheckerboardBackground()
+                ZStack(alignment: .topLeading) {
+                    Image(nsImage: before)
+                        .resizable()
+                        .interpolation(.none)
+                        .frame(
+                            width: before.size.width * geom.scale,
+                            height: before.size.height * geom.scale
+                        )
+                    Image(nsImage: after)
+                        .resizable()
+                        .interpolation(.none)
+                        .frame(
+                            width: after.size.width * geom.scale,
+                            height: after.size.height * geom.scale
+                        )
+                        .opacity(opacity)
+                }
+                .frame(
+                    width: geom.scaledUnionSize.width,
+                    height: geom.scaledUnionSize.height,
+                    alignment: .topLeading
+                )
+                .offset(x: geom.origin.x, y: geom.origin.y)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .clipped()
         }
-        .clipped()
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var slider: some View {

--- a/Alas/Sources/Center/ImageDiff/ImageDiffPair.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffPair.swift
@@ -8,6 +8,6 @@ struct ImageDiffPair {
     let after: NSImage?
     let oldPath: String?       // non-nil only when `kind == .renamed`
     let kind: ImageDiffPairKind
-    let beforeFrameCount: Int  // 1 for non-multi-frame; >1 for animated GIFs
-    let afterFrameCount: Int
+    let beforeFrameCount: Int  // 0 when `before` is nil; 1 for static; >1 for animated GIFs
+    let afterFrameCount: Int   // 0 when `after`  is nil; 1 for static; >1 for animated GIFs
 }

--- a/Alas/Sources/Center/ImageDiff/ImageDiffSwipeView.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffSwipeView.swift
@@ -3,6 +3,12 @@ import SwiftUI
 /// Single canvas. `after` painted full; `before` clipped to the left of a
 /// draggable vertical handle. Handle default at 50%, clamped to canvas
 /// bounds.
+///
+/// Both images are placed top-left on a shared "union" canvas sized to
+/// `max(beforeW, afterW) × max(beforeH, afterH)` at their natural pixel
+/// dimensions, then the union canvas is scaled to fit the viewport. The
+/// handle position is in viewport coordinates, so dragging spans the full
+/// width including any letter-boxed space around the union canvas.
 struct ImageDiffSwipeView: View {
     let before: NSImage
     let after: NSImage
@@ -15,31 +21,61 @@ struct ImageDiffSwipeView: View {
 
     var body: some View {
         GeometryReader { proxy in
-            let w = proxy.size.width
-            let handleX = handleFraction * w
+            let geom = UnionCanvasGeometry(
+                before: before.size, after: after.size, viewport: proxy.size
+            )
+            let handleX = handleFraction * proxy.size.width
+            // Convert the handle x to union-canvas local coords. The
+            // mask clips the `before` image to the strip x ∈ [0, clipX]
+            // of the union canvas. Outside the union canvas, the handle
+            // is still draggable but the clip has no visual effect.
+            let clipX = max(0, min(geom.scaledUnionSize.width, handleX - geom.origin.x))
 
             ZStack(alignment: .topLeading) {
                 ImageCheckerboardBackground()
-                Image(nsImage: after)
-                    .resizable()
-                    .interpolation(.none)
-                    .aspectRatio(contentMode: .fit)
-                Image(nsImage: before)
-                    .resizable()
-                    .interpolation(.none)
-                    .aspectRatio(contentMode: .fit)
-                    .mask(
-                        Rectangle()
-                            .frame(width: handleX, height: proxy.size.height)
-                            .position(x: handleX / 2, y: proxy.size.height / 2)
-                    )
+                ZStack(alignment: .topLeading) {
+                    Image(nsImage: after)
+                        .resizable()
+                        .interpolation(.none)
+                        .frame(
+                            width: after.size.width * geom.scale,
+                            height: after.size.height * geom.scale
+                        )
+                    Image(nsImage: before)
+                        .resizable()
+                        .interpolation(.none)
+                        .frame(
+                            width: before.size.width * geom.scale,
+                            height: before.size.height * geom.scale
+                        )
+                        .mask(
+                            Rectangle()
+                                .frame(
+                                    width: clipX,
+                                    height: geom.scaledUnionSize.height
+                                )
+                                .position(
+                                    x: clipX / 2,
+                                    y: geom.scaledUnionSize.height / 2
+                                )
+                        )
+                }
+                .frame(
+                    width: geom.scaledUnionSize.width,
+                    height: geom.scaledUnionSize.height,
+                    alignment: .topLeading
+                )
+                .offset(x: geom.origin.x, y: geom.origin.y)
+
                 handle(at: handleX, height: proxy.size.height)
             }
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        handleFraction = Self.clampFraction(value.location.x / max(w, 1))
+                        handleFraction = Self.clampFraction(
+                            value.location.x / max(proxy.size.width, 1)
+                        )
                     }
             )
             .overlay(alignment: .topLeading) {

--- a/Alas/Sources/Center/ImageDiff/UnionCanvasGeometry.swift
+++ b/Alas/Sources/Center/ImageDiff/UnionCanvasGeometry.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Geometry for placing two NSImages of potentially differing dimensions
+/// onto a shared "union" canvas, top-left aligned, then fitting the union
+/// into a viewport at a common scale. Used by overlay and swipe modes.
+///
+/// The two images are rendered at their natural pixel sizes (scaled by a
+/// single factor), so a size change between revisions is visible. The
+/// union canvas (= `max(W) × max(H)`) is then centered in the viewport.
+///
+/// All sizes are in points / display units, not pixels.
+struct UnionCanvasGeometry: Equatable {
+    let beforeSize: CGSize
+    let afterSize: CGSize
+    let viewport: CGSize
+
+    init(before: CGSize, after: CGSize, viewport: CGSize) {
+        self.beforeSize = before
+        self.afterSize = after
+        self.viewport = viewport
+    }
+
+    var unionSize: CGSize {
+        CGSize(
+            width: max(beforeSize.width, afterSize.width),
+            height: max(beforeSize.height, afterSize.height)
+        )
+    }
+
+    /// The common scale that fits the union canvas inside the viewport,
+    /// preserving aspect ratio. Returns 1.0 when the union or viewport is
+    /// degenerate so callers don't divide by zero downstream.
+    var scale: CGFloat {
+        let u = unionSize
+        guard u.width > 0, u.height > 0,
+              viewport.width > 0, viewport.height > 0
+        else { return 1.0 }
+        return min(viewport.width / u.width, viewport.height / u.height)
+    }
+
+    var scaledUnionSize: CGSize {
+        let u = unionSize
+        return CGSize(width: u.width * scale, height: u.height * scale)
+    }
+
+    /// Top-left position of the union canvas inside the viewport so the
+    /// canvas is centered.
+    var origin: CGPoint {
+        let s = scaledUnionSize
+        return CGPoint(
+            x: (viewport.width - s.width) / 2,
+            y: (viewport.height - s.height) / 2
+        )
+    }
+}

--- a/Alas/Sources/Center/ImageFileType.swift
+++ b/Alas/Sources/Center/ImageFileType.swift
@@ -12,6 +12,7 @@ enum ImageFileType {
         "heic",
         "heif",
         "webp",
+        "svg",
     ]
 
     static func isSupported(relativePath: String) -> Bool {

--- a/AlasTests/UnionCanvasGeometryTests.swift
+++ b/AlasTests/UnionCanvasGeometryTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct UnionCanvasGeometryTests {
+    @Test func identicalSizesScaleToFitViewport() {
+        let g = UnionCanvasGeometry(
+            before: CGSize(width: 100, height: 100),
+            after: CGSize(width: 100, height: 100),
+            viewport: CGSize(width: 200, height: 200)
+        )
+        #expect(g.unionSize == CGSize(width: 100, height: 100))
+        #expect(g.scale == 2.0)
+        #expect(g.scaledUnionSize == CGSize(width: 200, height: 200))
+        #expect(g.origin == .zero)
+    }
+
+    @Test func mismatchedDimensionsUseUnionMax() {
+        let g = UnionCanvasGeometry(
+            before: CGSize(width: 100, height: 50),
+            after: CGSize(width: 50, height: 200),
+            viewport: CGSize(width: 200, height: 400)
+        )
+        // Union = 100×200; viewport = 200×400. Both axes want scale=2 →
+        // scaledUnion = 200×400, perfectly fills viewport.
+        #expect(g.unionSize == CGSize(width: 100, height: 200))
+        #expect(g.scale == 2.0)
+        #expect(g.scaledUnionSize == CGSize(width: 200, height: 400))
+        #expect(g.origin == .zero)
+    }
+
+    @Test func limitingAxisDeterminesScale() {
+        let g = UnionCanvasGeometry(
+            before: CGSize(width: 200, height: 100),
+            after: CGSize(width: 200, height: 100),
+            viewport: CGSize(width: 100, height: 100)
+        )
+        // Union = 200×100; viewport = 100×100. Width-limited: scale = 0.5.
+        #expect(g.scale == 0.5)
+        #expect(g.scaledUnionSize == CGSize(width: 100, height: 50))
+        // Centered vertically: (100-50)/2 = 25.
+        #expect(g.origin == CGPoint(x: 0, y: 25))
+    }
+
+    @Test func degenerateUnionReturnsIdentityScale() {
+        let g = UnionCanvasGeometry(
+            before: .zero, after: .zero,
+            viewport: CGSize(width: 200, height: 200)
+        )
+        #expect(g.scale == 1.0)
+    }
+
+    @Test func degenerateViewportReturnsIdentityScale() {
+        let g = UnionCanvasGeometry(
+            before: CGSize(width: 100, height: 100),
+            after: CGSize(width: 100, height: 100),
+            viewport: .zero
+        )
+        #expect(g.scale == 1.0)
+    }
+}


### PR DESCRIPTION
Follow-up to #231 addressing the v2 / known-limitations list from that PR's final code review.

## Summary

Three independent improvements, each in its own commit:

1. **`chore`** Cosmetic polish — consolidate the two `extension GitService` blocks in `GitService+ImageDiff.swift` into one, fix the `beforeFrameCount` doc comment to mention the `0 when nil` case, add `"svg"` to `ImageFileType.supportedExtensions` (rasterized via NSImage; the four image-diff modes work on rasterized SVG out of the box).
2. **`feat`** Overlay and Swipe modes now place both images top-left on a shared "union canvas" sized to `max(W) × max(H)` at their natural pixel dimensions, then fit the union into the viewport at a common scale. Previously both images aspect-fit independently in a shared box, hiding actual resolution changes between revisions. Matches Android Studio's behavior and the Difference mode's existing alignment. Pulled the geometry math into a `UnionCanvasGeometry` value type with 5 unit tests.
3. **`feat`** Image-diff loader now runs its own `git status` with `--find-renames=30%` instead of reusing the app-wide 50%-default. Image renames frequently come with significant edits (logo redesigns, palette swaps, format conversions) that fall below 50% similarity; the 30% threshold catches the realistic cases without false-positive pairings. Scoped to the image-diff path only — the app-wide status query that drives the Changes pane keeps git's default behavior.

## Test plan

- [ ] Open a worktree with two PNGs of different resolution (e.g. one 100×100, one 200×200). View them in overlay and swipe modes — confirm the smaller image visibly occupies less of the canvas (it should, with the union-canvas alignment), not the same size as the larger image.
- [ ] `git mv old.png new.png` and modify the file noticeably (e.g. recolor, recompress) so the two blobs share less than 50% but more than 30%. Click the file in the working-copy diff — confirm it shows up as renamed (with the `RENAMED old → new` chip) instead of an add+delete pair.
- [ ] Verify non-image files in the Changes pane are still classified the same way as before (no change to RightPaneState's rename behavior).
- [ ] View an SVG file in a worktree where it has been modified. Confirm the image-diff view opens for it (rasterized) instead of falling through to the text-hunk view.
- [ ] Existing image-diff tests still pass: side-by-side linked pan/zoom, swipe handle clamping, mode-switcher disable-and-snap, resolver, loader, difference computer.

## Coverage added

- `UnionCanvasGeometryTests`: 5 unit tests (identical sizes, mismatched dimensions, limiting axis, degenerate union, degenerate viewport).
- Existing `ImageDiffPairLoaderTests` continue to pass against the new `imageDiffStatus` fetch path.