### PR TITLE
Show file tree loading inline

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 		D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */; };
 		D8ACECF849D38029FB56C303 /* CenterTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0307CFD55404D01F14A5B602 /* CenterTypography.swift */; };
 		DA5ED6D708DD8C0B5563AB4F /* WindowDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */; };
+		DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */; };
 		DAD02DC484C697D856B0CD6A /* CommitComposerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D733701E36E13A7A23748A37 /* CommitComposerState.swift */; };
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
@@ -517,6 +518,7 @@
 		0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateUnstagePathsTests.swift; sourceTree = "<group>"; };
 		0AF8152B18C9D6290724122F /* HoverFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeature.swift; sourceTree = "<group>"; };
 		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
+		0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabLoadingIndicatorTests.swift; sourceTree = "<group>"; };
 		0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewController.swift; sourceTree = "<group>"; };
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
 		0E6600436B01C75D85C01FFA /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
@@ -1077,6 +1079,7 @@
 				25493E3B18A1AB94EA6985C3 /* EventHolder.swift */,
 				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
 				1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */,
+				0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */,
 				3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */,
 				2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */,
 				A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */,
@@ -2371,6 +2374,7 @@
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
 				6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */,
 				A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */,
+				DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */,
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -23,71 +23,75 @@ struct FilesTabView: View {
     }
 
     private func renderNode(_ node: FileTreeNode, depth: Int) -> AnyView {
-                if node.kind == .dir {
-                    let open = openPaths.contains(node.path)
-                    let canExpand = !node.isSubmodule
-                    return AnyView(
-                        Group {
-                            Button {
-                                guard canExpand else { return }
-                                if open {
-                                    openPaths.remove(node.path)
-                                } else {
-                                    openPaths.insert(node.path)
-                                    onLoadChildren(node.path)
-                                }
-                            } label: {
-                                HStack(spacing: 6) {
-                                    if canExpand {
-                                        Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
-                                    } else {
-                                        Color.clear.frame(width: 10, height: 10)
-                                    }
-                                    Icon(name: "folder", size: 11, color: folderColor(for: node, open: open))
-                                    Text(node.name)
-                                        .font(.system(size: 11.5, design: .monospaced))
-                                        .foregroundColor(rowForeground(for: node))
-                                        .lineLimit(1)
-                                        .truncationMode(.middle)
-                                    Spacer()
-                                    if node.isSubmodule {
-                                        submodulePill
-                                    }
-                                    if let badge = node.badge {
-                                        StatusBadge(status: badge)
-                                    }
-                                    if isOffGit(node) {
-                                        visibilityPill(node)
-                                    }
-                                }
-                                .padding(.leading, CGFloat(12 + depth * 14))
-                                .padding(.trailing, 12)
-                                .padding(.vertical, 4)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .opacity(isOffGit(node) ? 0.72 : 1.0)
-                                .overlay(alignment: .leading) {
-                                    if isOffGit(node) {
-                                        ghostRail(depth: depth)
-                                    }
-                                }
-                                .contentShape(Rectangle())
+        if node.kind == .dir {
+            let open = openPaths.contains(node.path)
+            let canExpand = !node.isSubmodule
+            return AnyView(
+                Group {
+                    Button {
+                        guard canExpand else { return }
+                        if open {
+                            openPaths.remove(node.path)
+                        } else {
+                            openPaths.insert(node.path)
+                            onLoadChildren(node.path)
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            if canExpand {
+                                Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+                            } else {
+                                Color.clear.frame(width: 10, height: 10)
                             }
-                            .buttonStyle(.plain)
-                            if open && canExpand {
-                                switch node.childrenState {
-                                case .loading:
-                                    treeMessage("Loading...", depth: depth + 1)
-                                    renderChildren(of: node, depth: depth + 1)
-                                case .failed:
-                                    treeMessage("Could not load children", depth: depth + 1)
-                                    renderChildren(of: node, depth: depth + 1)
-                                case .loaded:
-                                    renderChildren(of: node, depth: depth + 1)
-                                case .notLoaded:
-                                    EmptyView()
-                                }
+                            Icon(name: "folder", size: 11, color: folderColor(for: node, open: open))
+                            Text(node.name)
+                                .font(.system(size: 11.5, design: .monospaced))
+                                .foregroundColor(rowForeground(for: node))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            if node.isSubmodule {
+                                submodulePill
+                            }
+                            if let badge = node.badge {
+                                StatusBadge(status: badge)
+                            }
+                            if isOffGit(node) {
+                                visibilityPill(node)
+                            }
+                            if Self.showsInlineLoadingIndicator(for: node, open: open, canExpand: canExpand) {
+                                ProgressView()
+                                    .controlSize(.mini)
+                                    .scaleEffect(0.55)
+                                    .frame(width: 12, height: 12)
+                                    .accessibilityLabel("Loading \(node.name)")
                             }
                         }
+                        .padding(.leading, CGFloat(12 + depth * 14))
+                        .padding(.trailing, 12)
+                        .padding(.vertical, 4)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .opacity(isOffGit(node) ? 0.72 : 1.0)
+                        .overlay(alignment: .leading) {
+                            if isOffGit(node) {
+                                ghostRail(depth: depth)
+                            }
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    if open && canExpand {
+                        switch node.childrenState {
+                        case .loading, .loaded:
+                            renderChildren(of: node, depth: depth + 1)
+                        case .failed:
+                            treeMessage("Could not load children", depth: depth + 1)
+                            renderChildren(of: node, depth: depth + 1)
+                        case .notLoaded:
+                            EmptyView()
+                        }
+                    }
+                }
                 .task(id: loadTaskID(for: node, open: open)) {
                     if shouldAutoLoadChildren(for: node, open: open) {
                         onLoadChildren(node.path)
@@ -135,6 +139,14 @@ struct FilesTabView: View {
 
     private func shouldAutoLoadChildren(for node: FileTreeNode, open: Bool) -> Bool {
         open && shouldAutoLoadChildren(node.path, node.childrenState)
+    }
+
+    nonisolated static func showsInlineLoadingIndicator(
+        for node: FileTreeNode,
+        open: Bool,
+        canExpand: Bool
+    ) -> Bool {
+        open && canExpand && node.kind == .dir && node.childrenState == .loading
     }
 
     private func renderChildren(of node: FileTreeNode, depth: Int) -> some View {

--- a/AlasTests/FilesTabLoadingIndicatorTests.swift
+++ b/AlasTests/FilesTabLoadingIndicatorTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct FilesTabLoadingIndicatorTests {
+    @Test func inlineLoadingIndicatorOnlyShowsForOpenLoadingDirectories() {
+        let loadingDirectory = FileTreeNode(
+            name: "Sources",
+            path: "Sources",
+            kind: .dir,
+            children: [],
+            badge: nil,
+            visibility: .tracked,
+            childrenState: .loading
+        )
+        let loadingFile = FileTreeNode(
+            name: "README.md",
+            path: "README.md",
+            kind: .file,
+            children: nil,
+            badge: nil,
+            visibility: .tracked,
+            childrenState: .loading
+        )
+
+        #expect(FilesTabView.showsInlineLoadingIndicator(
+            for: loadingDirectory,
+            open: true,
+            canExpand: true
+        ))
+        #expect(!FilesTabView.showsInlineLoadingIndicator(
+            for: loadingDirectory,
+            open: false,
+            canExpand: true
+        ))
+        #expect(!FilesTabView.showsInlineLoadingIndicator(
+            for: loadingDirectory,
+            open: true,
+            canExpand: false
+        ))
+        #expect(!FilesTabView.showsInlineLoadingIndicator(
+            for: loadingFile,
+            open: true,
+            canExpand: true
+        ))
+    }
+
+    @Test func inlineLoadingIndicatorDoesNotShowForFinishedDirectoryStates() {
+        for state in [DirectoryChildrenState.loaded, .notLoaded, .failed] {
+            let node = FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: state
+            )
+
+            #expect(!FilesTabView.showsInlineLoadingIndicator(
+                for: node,
+                open: true,
+                canExpand: true
+            ))
+        }
+    }
+}

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -177,6 +177,37 @@ struct RightPaneStateFileTreeTests {
         #expect(result.nodes == tree)
     }
 
+    @Test func mergingChildrenForLoadingDirectoryPreservesExistingChildren() {
+        let tree = [
+            FileTreeNode(
+                name: "Sources",
+                path: "Sources",
+                kind: .dir,
+                children: [
+                    FileTreeNode(
+                        name: "App.swift",
+                        path: "Sources/App.swift",
+                        kind: .file,
+                        children: nil,
+                        badge: "M",
+                        visibility: .tracked,
+                        childrenState: .loaded
+                    )
+                ],
+                badge: nil,
+                visibility: .tracked,
+                childrenState: .loaded
+            )
+        ]
+
+        let result = RightPaneState.mergingChildren(in: tree, for: "Sources", with: [], state: .loading)
+        let sources = result.nodes.first
+
+        #expect(result.didMerge)
+        #expect(sources?.childrenState == .loading)
+        #expect(sources?.children?.map(\.path) == ["Sources/App.swift"])
+    }
+
     @Test func invalidatingFileTreeChildLoadsStartsNewGenerationAndClearsTracking() {
         let path = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-filetree-generation-\(UUID().uuidString)")


### PR DESCRIPTION
## Summary
- replace the standalone file-tree loading row with an inline spinner on the expanding directory row
- keep existing children rendered while a directory reloads
- add focused Swift Testing coverage for the loading indicator predicate and file-tree merge behavior

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- targeted FilesTabLoadingIndicatorTests and RightPaneStateFileTreeTests passed
- full xcodebuild test was attempted twice but hung in Xcode's SwiftBuild service wait loop