### PR TITLE
Move sidebar reveal to center header

### DIFF
--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -58,6 +58,11 @@ struct CenterPaneView: View {
                 onLaunchAgent: { agentId in
                     _ = try? state.openAgentTerminalTab(for: worktree, agentId: agentId)
                 },
+                onRevealRightSidebar: {
+                    state.config.rightPaneVisible = true
+                    state.saveConfig()
+                },
+                rightSidebarHidden: !state.config.rightPaneVisible,
                 onMove: { draggedId, destinationId in
                     state.tabs.moveTab(worktreeId: worktree.id, fromId: draggedId, toId: destinationId)
                 }

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -17,6 +17,8 @@ struct TabBarView: View {
     let onNewTerminal: () -> Void
     let enabledAgents: [AgentDefinition]
     let onLaunchAgent: (String) -> Void
+    let onRevealRightSidebar: () -> Void
+    let rightSidebarHidden: Bool
     let onMove: (TabID, TabID) -> Void
     @Environment(\.theme) var theme
 
@@ -86,7 +88,11 @@ struct TabBarView: View {
                 agents: enabledAgents,
                 onLaunchAgent: onLaunchAgent
             )
-            .padding(.trailing, 8)
+            .padding(.trailing, rightSidebarHidden ? 2 : 8)
+            if rightSidebarHidden {
+                ToolbarIconButton(iconName: "sidebar.right", tooltip: "Show right sidebar", action: onRevealRightSidebar)
+                    .padding(.trailing, 8)
+            }
         }
         .frame(height: 34)
         .background(theme.color("bg-2"))

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -4,17 +4,12 @@ struct SidebarHeaderView: View {
     let onSettings: () -> Void
     let onAddProject: () -> Void
     let onSearch: () -> Void
-    let onRevealRightSidebar: () -> Void
-    let rightSidebarHidden: Bool
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             TrafficLights()
             Spacer()
             HStack(alignment: .center, spacing: 2) {
-                if rightSidebarHidden {
-                    ToolbarBtn(icon: "sidebar.right", action: onRevealRightSidebar)
-                }
                 ToolbarBtn(icon: "search", action: onSearch)
                 ToolbarBtn(icon: "folder-plus", action: onAddProject)
                 ToolbarBtn(icon: "gear", action: onSettings)

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -24,12 +24,7 @@ struct SidebarView: View {
                     onAddProject: onAddProject,
                     onSearch: {
                         NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
-                    },
-                    onRevealRightSidebar: {
-                        state.config.rightPaneVisible = true
-                        state.saveConfig()
-                    },
-                    rightSidebarHidden: !state.config.rightPaneVisible
+                    }
                 )
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {

--- a/AlasTests/SidebarHeaderViewTests.swift
+++ b/AlasTests/SidebarHeaderViewTests.swift
@@ -3,8 +3,7 @@ import SwiftUI
 import AppKit
 @testable import Alas
 
-/// Smoke tests for SidebarHeaderView to guard against crashes when rendering
-/// with the right-sidebar reveal button visible and hidden.
+/// Smoke tests for SidebarHeaderView to guard against crashes when rendering.
 @Suite(.serialized)
 @MainActor
 struct SidebarHeaderViewTests {
@@ -12,27 +11,11 @@ struct SidebarHeaderViewTests {
         try! ThemeStore().current
     }
 
-    @Test func headerWithHiddenRightSidebarRendersWithoutCrashing() {
+    @Test func headerRendersWithoutCrashing() {
         let view = SidebarHeaderView(
             onSettings: {},
             onAddProject: {},
-            onSearch: {},
-            onRevealRightSidebar: {},
-            rightSidebarHidden: true
-        )
-        .environment(\.theme, currentTheme())
-        let controller = NSHostingController(rootView: view)
-        controller.view.layoutSubtreeIfNeeded()
-        #expect(controller.view != nil)
-    }
-
-    @Test func headerWithVisibleRightSidebarRendersWithoutCrashing() {
-        let view = SidebarHeaderView(
-            onSettings: {},
-            onAddProject: {},
-            onSearch: {},
-            onRevealRightSidebar: {},
-            rightSidebarHidden: false
+            onSearch: {}
         )
         .environment(\.theme, currentTheme())
         let controller = NSHostingController(rootView: view)

--- a/AlasTests/TouchTargetSmokeTests.swift
+++ b/AlasTests/TouchTargetSmokeTests.swift
@@ -59,6 +59,8 @@ struct TouchTargetSmokeTests {
             onNewTerminal: { },
             enabledAgents: [],
             onLaunchAgent: { _ in },
+            onRevealRightSidebar: { },
+            rightSidebarHidden: false,
             onMove: { _, _ in }
         )
         .environment(\.theme, currentTheme())
@@ -86,6 +88,47 @@ struct TouchTargetSmokeTests {
             onNewTerminal: { },
             enabledAgents: [],
             onLaunchAgent: { _ in },
+            onRevealRightSidebar: { },
+            rightSidebarHidden: false,
+            onMove: { _, _ in }
+        )
+        .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func tabBarViewWithRightSidebarRevealRendersWithoutCrashing() {
+        let tab = Tab.editor(EditorTabState(
+            id: "t1",
+            title: "hello.swift",
+            relativePath: "hello.swift",
+            revealLine: nil,
+            revealCharacter: nil,
+            externalAbsolutePath: nil,
+            originatingRelativePath: nil,
+            markdownViewMode: nil,
+            markdownSplitFraction: nil
+        ))
+        let view = TabBarView(
+            tabs: [tab],
+            activeId: tab.id,
+            harnessLookup: { _ in nil },
+            dirtyLookup: { _ in false },
+            onActivate: { _ in },
+            onClose: { _ in },
+            onCloseOthers: { _ in },
+            onCloseAll: { },
+            onCloseToLeft: { _ in },
+            onCloseToRight: { _ in },
+            onCopyPath: { _ in },
+            onCopyRelativePath: { _ in },
+            onRenameTerminal: { _ in },
+            onNewTerminal: { },
+            enabledAgents: [],
+            onLaunchAgent: { _ in },
+            onRevealRightSidebar: { },
+            rightSidebarHidden: true,
             onMove: { _, _ in }
         )
         .environment(\.theme, currentTheme())


### PR DESCRIPTION
Moves the hidden right-sidebar reveal control from the left sidebar header to the far right of the center panel header actions, immediately after the AI terminal button.