### PR TITLE
Add right sidebar toggle shortcut

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02E429B37288215EBC89571 /* CommitHeaderView.swift */; };
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
 		4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */; };
+		4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		512A41C0AB75B8D35424EBCD /* DeletingWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */; };
 		51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25493E3B18A1AB94EA6985C3 /* EventHolder.swift */; };
@@ -817,6 +818,7 @@
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateLoadOlderTests.swift; sourceTree = "<group>"; };
+		B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneVisibilityTests.swift; sourceTree = "<group>"; };
 		B44D759586280250330A9A04 /* FontSizeCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizeCommands.swift; sourceTree = "<group>"; };
 		B4C486F9097A2B145D101E2C /* AlasButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasButton.swift; sourceTree = "<group>"; };
 		B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentInstaller.swift; sourceTree = "<group>"; };
@@ -1150,6 +1152,7 @@
 				5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */,
 				B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
+				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
@@ -2455,6 +2458,7 @@
 				35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */,
 				FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
+				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -74,7 +74,7 @@ struct AlasApp: App {
                 .disabled(!state.hasActiveCodeEditorTab)
             }
             CommandGroup(after: .toolbar) {
-                Button("Toggle Right Pane") {
+                Button("Toggle Right Sidebar") {
                     NotificationCenter.default.post(name: .alasToggleRightPane, object: nil)
                 }
                 .keyboardShortcut(state.shortcut(for: .toggleRightPane))

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -297,6 +297,11 @@ final class AppState {
         })
     }
 
+    func toggleRightPaneVisibility() {
+        config.rightPaneVisible.toggle()
+        _ = saveConfig()
+    }
+
     /// Tear down tabs, terminals, harness state, and editor buffers for any
     /// worktree IDs that existed in `beforeIds` but are absent after a refresh.
     /// Also re-points selection if the selected worktree was removed.

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -312,8 +312,7 @@ private struct RootBaseHandlers: ViewModifier {
     func body(content: Content) -> some View {
         let a = content
             .onReceive(NotificationCenter.default.publisher(for: .alasToggleRightPane)) { _ in
-                state.config.rightPaneVisible.toggle()
-                state.saveConfig()
+                state.toggleRightPaneVisibility()
             }
         let b = a
             .onReceive(NotificationCenter.default.publisher(for: .alasCreateProject)) { _ in

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -43,7 +43,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .searchFiles:              return "Search Files"
         case .switchRepository:         return "Switch Repository"
         case .findAndReplace:           return "Find and Replace"
-        case .toggleRightPane:          return "Toggle Right Pane"
+        case .toggleRightPane:          return "Toggle Right Sidebar"
         case .createProject:            return "Create Project"
         case .newWorktree:              return "New Worktree"
         case .newTerminalTab:           return "New Terminal Tab"
@@ -96,7 +96,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .searchFiles:              return .init(key: "p",          modifiers: [.command])
         case .switchRepository:         return .init(key: "k",          modifiers: [.command])
         case .findAndReplace:           return .init(key: "f",          modifiers: [.command, .option])
-        case .toggleRightPane:          return .init(key: "return",     modifiers: [.command, .option])
+        case .toggleRightPane:          return .init(key: "b",          modifiers: [.command, .option])
         case .createProject:            return .init(key: "n",          modifiers: [.command, .shift])
         case .newWorktree:              return .init(key: "n",          modifiers: [.command, .option])
         case .newTerminalTab:           return .init(key: "t",          modifiers: [.command])

--- a/AlasTests/RightPaneVisibilityTests.swift
+++ b/AlasTests/RightPaneVisibilityTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct RightPaneVisibilityTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    @Test func toggleRightPaneVisibilityHidesAndShowsAgain() {
+        let state = AppState(store: MemoryStore())
+        #expect(state.config.rightPaneVisible)
+
+        state.toggleRightPaneVisibility()
+        #expect(!state.config.rightPaneVisible)
+
+        state.toggleRightPaneVisibility()
+        #expect(state.config.rightPaneVisible)
+    }
+}

--- a/AlasTests/ShortcutActionTests.swift
+++ b/AlasTests/ShortcutActionTests.swift
@@ -23,7 +23,7 @@ struct ShortcutActionTests {
             (.searchFiles,          "p",          [.command]),
             (.switchRepository,     "k",          [.command]),
             (.findAndReplace,       "f",          [.command, .option]),
-            (.toggleRightPane,      "return",     [.command, .option]),
+            (.toggleRightPane,      "b",          [.command, .option]),
             (.createProject,        "n",          [.command, .shift]),
             (.newWorktree,          "n",          [.command, .option]),
             (.newTerminalTab,       "t",          [.command]),


### PR DESCRIPTION
## Summary
- Set the configurable right sidebar toggle shortcut default to Option+Command+B
- Rename the shortcut label to Toggle Right Sidebar while preserving the existing Codable action
- Add AppState toggle coverage for hide/show behavior

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- focused shortcut/right-sidebar tests