### PR TITLE
fix: discover shell PATH at startup for git hook compatibility

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46BDE72E52818061452ECB /* CommitRowTests.swift */; };
 		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
 		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
+		B574D2D5DF3129E326DCFCCF /* ShellEnvResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */; };
 		B614CD7F894DD6908C903254 /* InstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */; };
 		B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */; };
 		B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */; };
@@ -466,6 +467,7 @@
 		F4B9A51A40365909B7644561 /* ShortcutsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6821B71680094791995C4975 /* ShortcutsPane.swift */; };
 		F60AF5FD23412D018F263322 /* NotificationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */; };
 		F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */; };
+		F6CC80D1E8D2D36251C83A1D /* ShellEnvResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */; };
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
 		F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169FC38D03727F34855EB521 /* AlasFieldTests.swift */; };
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
@@ -511,6 +513,7 @@
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
 		09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffMode.swift; sourceTree = "<group>"; };
+		09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolverTests.swift; sourceTree = "<group>"; };
 		0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPair.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
 		0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigHarnessTests.swift; sourceTree = "<group>"; };
@@ -901,6 +904,7 @@
 		DDE8B45ECF898B83A616586D /* SubHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubHeader.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
 		DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoader.swift; sourceTree = "<group>"; };
+		DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolver.swift; sourceTree = "<group>"; };
 		E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTabView.swift; sourceTree = "<group>"; };
 		E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeatureTests.swift; sourceTree = "<group>"; };
 		E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedPane.swift; sourceTree = "<group>"; };
@@ -1150,6 +1154,7 @@
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
 				9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
+				09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */,
 				00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */,
 				2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */,
 				60F628A45666E477DD695AD7 /* ShortcutRecorderValidationTests.swift */,
@@ -1227,6 +1232,7 @@
 				9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */,
 				C6CA79B71B4AA72697392702 /* NumstatParser.swift */,
 				79DDEA496740F5B0B5EE808B /* Process+Git.swift */,
+				DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */,
 				91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */,
 				6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */,
 				FCE6979EDAEAE45BC2A49A20 /* CommitAI */,
@@ -2244,6 +2250,7 @@
 				730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */,
 				8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */,
 				D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */,
+				F6CC80D1E8D2D36251C83A1D /* ShellEnvResolver.swift in Sources */,
 				90BB0EFFD7E0EF8DE64296E6 /* ShortcutAction.swift in Sources */,
 				2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */,
 				724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */,
@@ -2454,6 +2461,7 @@
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
 				2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
+				B574D2D5DF3129E326DCFCCF /* ShellEnvResolverTests.swift in Sources */,
 				01F51F05BA5DD24D4FBC4B4B /* ShortcutActionTests.swift in Sources */,
 				B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */,
 				64402D666DBDAA9B98D641F6 /* ShortcutRecorderValidationTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -287,6 +287,13 @@ final class AppState {
         // we'd resolve to a 0-element id list. RootView calls reloadTabs() after
         // refreshAll() returns.
         rightPaneStore.appState = self
+
+        // Kick off a background resolution of the user's login-shell PATH so
+        // every `Process.git()` invocation uses the same environment a terminal
+        // session would (Homebrew, nvm, rbenv, etc.). Fire-and-forget: if it
+        // hasn't finished by the first git command, gitEnv() falls back to the
+        // process PATH (same behaviour as before).
+        ShellEnvResolver.shared.resolve()
     }
 
     /// All worktree IDs currently known to the projects manager (including

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -167,6 +167,9 @@ extension Process {
     static func gitEnv() -> [String: String] {
         var env = ProcessInfo.processInfo.environment
         env["GIT_OPTIONAL_LOCKS"] = "0"
+        if let shellPath = ShellEnvResolver.shared.resolvedPath {
+            env["PATH"] = shellPath
+        }
         return env
     }
 

--- a/Alas/Sources/Git/ShellEnvResolver.swift
+++ b/Alas/Sources/Git/ShellEnvResolver.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+final class ShellEnvResolver {
+    static let shared = ShellEnvResolver()
+
+    private let lock = NSLock()
+    private var _resolvedPath: String?
+
+    var resolvedPath: String? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _resolvedPath
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _resolvedPath = newValue
+        }
+    }
+
+    func resolve() {
+        Task {
+            let path = await Self.discoverShellPath()
+            lock.lock()
+            _resolvedPath = path
+            lock.unlock()
+        }
+    }
+
+    private static func discoverShellPath() async -> String? {
+        let candidates = shellCandidates()
+        for shell in candidates {
+            if let path = try? await runShellAndGetPATH(shell: shell) {
+                let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+        }
+        return nil
+    }
+
+    private static func shellCandidates() -> [String] {
+        var list: [String] = []
+        if let shell = ProcessInfo.processInfo.environment["SHELL"] { list.append(shell) }
+        list.append("/bin/zsh")
+        list.append("/bin/sh")
+        return list
+    }
+
+    private static let sentinelStart = "___ALAS_PATH___"
+    private static let sentinelEnd = "___ALAS_END___"
+
+    private static func runShellAndGetPATH(shell: String) async throws -> String {
+        let result = try await Process.run(
+            shell,
+            args: [
+                "-l", "-i", "-c",
+                #"printf '%s' "\#(sentinelStart)"; printenv PATH; printf '%s' "\#(sentinelEnd)""#
+            ],
+            timeout: 2
+        )
+        guard result.exitCode == 0 else { return "" }
+        let raw = result.stdout
+        guard let start = raw.range(of: sentinelStart)?.upperBound,
+              let end = raw.range(of: sentinelEnd, range: start..<raw.endIndex)?.lowerBound,
+              start < end else { return "" }
+        let path = raw[start..<end].trimmingCharacters(in: .newlines)
+        return path
+    }
+}

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -99,10 +99,12 @@ struct ProcessGitTests {
         // Stronger than the keyed tests above: a broken implementation that
         // returned a hardcoded minimal dict (PATH/HOME only) would pass the
         // single-key checks. Verify the whole parent env round-trips, with
-        // the single deliberate exception of GIT_OPTIONAL_LOCKS.
+        // the deliberate exceptions of GIT_OPTIONAL_LOCKS (always overridden)
+        // and PATH (overridden when ShellEnvResolver discovered a login-shell
+        // PATH, which happens in integration test environments).
         let parent = ProcessInfo.processInfo.environment
         let env = Process.gitEnv()
-        for (key, value) in parent where key != "GIT_OPTIONAL_LOCKS" {
+        for (key, value) in parent where key != "GIT_OPTIONAL_LOCKS" && key != "PATH" {
             #expect(env[key] == value, "key \(key) was dropped or changed")
         }
     }
@@ -129,5 +131,24 @@ struct ProcessGitTests {
         let result = try await Process.git(["--version"])
         #expect(result.exitCode == 0)
         #expect(result.stdout.contains("git version"))
+    }
+
+    @Test func gitEnvPrefersResolvedShellPath() {
+        let prior = ShellEnvResolver.shared.resolvedPath
+        ShellEnvResolver.shared.resolvedPath = "/custom/shell/bin"
+        defer { ShellEnvResolver.shared.resolvedPath = prior }
+
+        let env = Process.gitEnv()
+        #expect(env["PATH"] == "/custom/shell/bin")
+        #expect(env["GIT_OPTIONAL_LOCKS"] == "0")
+    }
+
+    @Test func gitEnvFallsBackToProcessPathWhenResolverIsNil() {
+        let prior = ShellEnvResolver.shared.resolvedPath
+        ShellEnvResolver.shared.resolvedPath = nil
+        defer { ShellEnvResolver.shared.resolvedPath = prior }
+
+        let env = Process.gitEnv()
+        #expect(env["PATH"] == ProcessInfo.processInfo.environment["PATH"])
     }
 }

--- a/AlasTests/ShellEnvResolverTests.swift
+++ b/AlasTests/ShellEnvResolverTests.swift
@@ -1,0 +1,27 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct ShellEnvResolverTests {
+    @Test func discoverShellPathSkipsMissingShellBinary() async {
+        let resolver = ShellEnvResolver()
+
+        #expect(resolver.resolvedPath == nil)
+
+        // We can't easily force all shell candidates to be missing at runtime
+        // (the real $SHELL, /bin/zsh, and /bin/sh all exist on macOS), so
+        // this test simply asserts the resolver initializes safely and does
+        // not crash when queried.
+        #expect(resolver.resolvedPath == nil)
+    }
+
+    @Test func shellEnvResolverSetsAndReadsResolvedPath() {
+        let resolver = ShellEnvResolver()
+        #expect(resolver.resolvedPath == nil)
+        resolver.resolvedPath = "/custom/bin"
+        #expect(resolver.resolvedPath == "/custom/bin")
+        resolver.resolvedPath = nil
+        #expect(resolver.resolvedPath == nil)
+    }
+}


### PR DESCRIPTION
## Problem

When Alas is launched from Finder/Dock, macOS assigns the GUI process a minimal system PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). `Process.git()` inherited this truncated PATH, so pre-commit hooks that rely on tools from Homebrew, nvm, rbenv, etc. failed with "command not found".

## Solution

Add `ShellEnvResolver`, which runs the user's login shell (`$SHELL -l -c 'printenv PATH'`) once at app startup, caches the result, and makes every `Process.git()` invocation transparently use the full shell PATH (with fallback to the process PATH when unavailable).

## Changes

- `Alas/Sources/Git/ShellEnvResolver.swift` — new singleton to discover and cache the login-shell PATH with 2s timeout.
- `Alas/Sources/Git/Process+Git.swift` — `gitEnv()` merges the resolved PATH when available.
- `Alas/Sources/App/AppState.swift` — triggers resolution during app init.
- Tests for override and fallback behavior.
