### PR TITLE
fix: shrink agent logos in tab bar sparkle menu

### DIFF
--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct TabBarView: View {
@@ -213,7 +214,11 @@ private struct AgentSparkleMenu: View {
                         Label {
                             Text(agent.displayName)
                         } icon: {
-                            AgentLogoView(agent: agent, size: 16)
+                            // SwiftUI Menu renders items as NSMenuItems and ignores
+                            // SwiftUI frame sizing on custom icon views; it draws the
+                            // backing NSImage at its native pixel size. Hand it an
+                            // NSImage copy whose .size is clamped to 16pt.
+                            Image(nsImage: menuIconImage(for: agent))
                         }
                     }
                 }
@@ -227,5 +232,18 @@ private struct AgentSparkleMenu: View {
         .menuIndicator(.hidden)
         .fixedSize()
         .help(agents.isEmpty ? "No enabled agents" : "Launch agent")
+    }
+
+    private func menuIconImage(for agent: AgentDefinition) -> NSImage {
+        if let asset = agent.builtinLogoAssetName,
+           let source = NSImage(named: asset) {
+            let copy = source.copy() as? NSImage ?? source
+            copy.size = NSSize(width: 16, height: 16)
+            return copy
+        }
+        let fallback = NSImage(systemSymbolName: "sparkle", accessibilityDescription: nil)
+            ?? NSImage()
+        fallback.size = NSSize(width: 16, height: 16)
+        return fallback
     }
 }


### PR DESCRIPTION
## Summary
- The tab bar ✨ "Launch agent" menu rendered each agent logo at the asset's native size (256×256 PNG) instead of the intended 16pt, producing a massive, broken-looking popup.
- Root cause: SwiftUI `Menu` renders entries as `NSMenuItem`s and ignores SwiftUI frame sizing on custom views in `Label`'s icon slot — the backing `NSImage` is drawn at its `.size`.
- Fix: in `AgentSparkleMenu`, pass `Image(nsImage:)` of an `NSImage` *copy* whose `.size` is clamped to 16pt (copying so we don't shrink the cached asset for other readers in the sidebar, launcher dialog, and settings pane). Falls back to the `sparkle` SF Symbol for custom agents with no logo asset.

## Test plan
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -configuration Debug build` succeeds.
- [ ] Open the tab bar ✨ menu — each agent row shows a 16pt logo aligned with the row text (matching the in-row treatment in `AgentLauncherDialog` and `AgentsPane`).
- [ ] Sidebar / launcher dialog / settings pane logos still render at their normal size (verifying the `NSImage.copy()` didn't mutate the shared cached asset).