### PR TITLE
Resolve symlinks when opening files from the file tree

### DIFF
--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -829,12 +829,19 @@ final class EditorBuffer {
         loading = true
         defer { loading = false }
         let url = worktreeRoot.appendingPathComponent(relativePath)
-        guard FileManager.default.fileExists(atPath: url.path) else {
+        let resolvedURL = url.resolvingSymlinksInPath()
+        guard FileManager.default.fileExists(atPath: resolvedURL.path) else {
             storage.setAttributedString(NSAttributedString(string: "(unable to read file)"))
             readOnly = true
             return
         }
-        guard let raw = try? String(contentsOf: url, encoding: .utf8) else {
+        let isDirectory = (try? resolvedURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+        guard !isDirectory else {
+            storage.setAttributedString(NSAttributedString(string: "(unable to read file)"))
+            readOnly = true
+            return
+        }
+        guard let raw = try? String(contentsOf: resolvedURL, encoding: .utf8) else {
             storage.setAttributedString(NSAttributedString(string: "(read-only: file is not valid UTF-8)"))
             readOnly = true
             return
@@ -844,10 +851,12 @@ final class EditorBuffer {
         storage.setAttributedString(NSAttributedString(string: canonical))
         originalText = canonical
         lineEnding = detected
-        updateOriginalFileAttributes(from: url)
-        // External buffers remain read-only even after a successful reload;
-        // the isExternal flag is the authoritative source of read-only-ness.
-        readOnly = isExternal ? true : false
+        updateOriginalFileAttributes(from: resolvedURL)
+        // Symlink-backed buffers are read-only to preserve semantics:
+        // save() writes to the unresolved path, which would replace the
+        // symlink entry instead of updating its target.
+        let isSymlink = (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true
+        readOnly = isExternal || isSymlink ? true : false
     }
 }
 

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -65,6 +65,21 @@ struct EditorBufferTests {
         #expect(buffer.dirty == false)
     }
 
+    @Test func coldLoadResolvesSymlinkToTargetContents() throws {
+        let root = tempWorktree()
+        let target = root.appendingPathComponent("real.txt")
+        try "hello from symlink target\n".write(to: target, atomically: true, encoding: .utf8)
+
+        let linkURL = root.appendingPathComponent("link.txt")
+        try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: target)
+
+        let buffer = EditorBuffer(worktreeRoot: root, relativePath: "link.txt")
+
+        #expect(buffer.storage.string == "hello from symlink target\n")
+        #expect(buffer.readOnly == true)
+        #expect(buffer.dirty == false)
+    }
+
     @Test func saveWritesContentAndClearsDirty() throws {
         let root = tempWorktree()
         _ = try writeFile(root, "a.txt", "hello\n")


### PR DESCRIPTION
When tapping a symlink in the Files pane, the editor would treat the symlink itself as a binary file and show "(read-only: file is not valid UTF-8)". This PR fixes EditorBuffer.loadFromDisk() to resolve symlinks before reading contents.

Changes:
- Resolve symlinks via URL.resolvingSymlinksInPath() before reading
- Guard against directories (treat as unreadable)
- Add test coldLoadResolvesSymlinkToTargetContents() verifying symlink resolution