### PR TITLE
feat(selector): flatten ⌘K into a single grouped worktree list

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -374,7 +374,8 @@ final class AppState {
                 self?.selectedWorktreeId = id
             },
             openNewProject: openNewProject,
-            openNewWorktree: openNewWorktree
+            openNewWorktree: openNewWorktree,
+            currentWorktreeId: { [weak self] in self?.selectedWorktreeId }
         )
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -361,13 +361,15 @@ final class AppState {
                 guard let self else { return RepoSelectorRecents() }
                 return RepoSelectorRecents(
                     projectIds: self.config.recentProjectIds,
-                    worktreeIdsByProject: self.config.recentWorktreeIdsByProject
+                    worktreeIdsByProject: self.config.recentWorktreeIdsByProject,
+                    recentWorktreeRefs: self.config.recentWorktreeRefs
                 )
             },
             writeRecents: { [weak self] r in
                 guard let self else { return }
                 self.config.recentProjectIds = r.projectIds
                 self.config.recentWorktreeIdsByProject = r.worktreeIdsByProject
+                self.config.recentWorktreeRefs = r.recentWorktreeRefs
                 _ = self.saveConfig()
             },
             focusWorktree: { [weak self] id in

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -1,9 +1,16 @@
+import AppKit
 import SwiftUI
 
 struct RepoSelectorDialog: View {
     @Bindable var appState: AppState
     @Environment(\.theme) private var theme
     @FocusState private var inputFocused: Bool
+    /// Screen-coords cursor position from the most recently accepted hover.
+    /// Used to ignore hovers that fire because the row scrolled under a
+    /// stationary cursor (rather than the cursor actually moving). Without
+    /// this guard, keyboard navigation fights with the scrolled-into-place
+    /// row claiming hover and snapping selection back.
+    @State private var lastHoverLocation: CGPoint?
 
     var body: some View {
         if appState.isRepoSelectorOpen {
@@ -89,7 +96,12 @@ struct RepoSelectorDialog: View {
                                 appState.repoSelector.setSelectedIndex(idx, in: rows)
                                 activate(rows: rows)
                             },
-                            onHover: { appState.repoSelector.setSelectedIndex(idx, in: rows) }
+                            onHover: {
+                                let current = NSEvent.mouseLocation
+                                if lastHoverLocation == current { return }
+                                lastHoverLocation = current
+                                appState.repoSelector.setSelectedIndex(idx, in: rows)
+                            }
                         )
                         .id(idx)
                     }
@@ -98,7 +110,11 @@ struct RepoSelectorDialog: View {
             }
             .frame(minHeight: 200, maxHeight: 420)
             .onChange(of: appState.repoSelector.scrollToSelectionTick) { _, _ in
-                proxy.scrollTo(appState.repoSelector.selectedIndex, anchor: .center)
+                // anchor: nil scrolls just enough to make the row visible.
+                // .center would re-center on every arrow press, shifting the
+                // list under the cursor and triggering hover-induced
+                // selection bouncing.
+                proxy.scrollTo(appState.repoSelector.selectedIndex)
             }
         }
     }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -13,15 +13,12 @@ struct RepoSelectorDialog: View {
                     .onTapGesture { close() }
 
                 VStack(spacing: 0) {
-                    if case .worktrees(let projectId) = appState.repoSelector.step {
-                        breadcrumb(projectId: projectId)
-                    }
                     inputRow
                     Divider().background(theme.color("line"))
                     rowList
                     footer
                 }
-                .frame(width: 480)
+                .frame(width: 720)
                 .frame(maxHeight: 520)
                 .background(theme.color("bg-1").opacity(0.92))
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
@@ -53,7 +50,7 @@ struct RepoSelectorDialog: View {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 12))
                 .foregroundColor(theme.color("fg-faint"))
-            TextField(placeholder, text: Bindable(appState.repoSelector).query)
+            TextField("Switch worktree…", text: Bindable(appState.repoSelector).query)
                 .textFieldStyle(.plain)
                 .focused($inputFocused)
                 .font(.system(size: 14))
@@ -61,32 +58,6 @@ struct RepoSelectorDialog: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
-    }
-
-    private var placeholder: String {
-        switch appState.repoSelector.step {
-        case .repos:
-            return "Switch repository…"
-        case .worktrees(let projectId):
-            let name = appState.projects.first(where: { $0.id == projectId })?.name ?? ""
-            return "Switch worktree in \(name)…"
-        }
-    }
-
-    private func breadcrumb(projectId: String) -> some View {
-        let name = appState.projects.first(where: { $0.id == projectId })?.name ?? ""
-        return HStack(spacing: 6) {
-            Image(systemName: "chevron.left")
-                .font(.system(size: 10, weight: .semibold))
-            Text(name)
-                .font(.system(size: 12, weight: .medium))
-        }
-        .foregroundColor(theme.color("fg-dim"))
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
-        .onTapGesture { popToRepos() }
     }
 
     private var rowList: some View {
@@ -116,10 +87,6 @@ struct RepoSelectorDialog: View {
                 .padding(.vertical, 4)
             }
             .frame(minHeight: 200, maxHeight: 420)
-            // Scroll to the selected row when the keyboard moves selection.
-            // We watch `scrollToSelectionTick` (bumped by ↑/↓) instead of
-            // `selectedIndex` itself so hover-driven selection doesn't fight
-            // the user's scroll input.
             .onChange(of: appState.repoSelector.scrollToSelectionTick) { _, _ in
                 proxy.scrollTo(appState.repoSelector.selectedIndex, anchor: .center)
             }
@@ -130,7 +97,7 @@ struct RepoSelectorDialog: View {
         HStack(spacing: 12) {
             label("↑↓ navigate")
             label("↵ open")
-            label("esc \(escLabel)")
+            label("esc close")
             Spacer()
         }
         .padding(.horizontal, 14)
@@ -146,13 +113,6 @@ struct RepoSelectorDialog: View {
         Text(s)
             .font(.system(size: 11))
             .foregroundColor(theme.color("fg-faint"))
-    }
-
-    private var escLabel: String {
-        switch appState.repoSelector.step {
-        case .repos: return "close"
-        case .worktrees: return "back"
-        }
     }
 
     // MARK: - Actions
@@ -174,16 +134,9 @@ struct RepoSelectorDialog: View {
         switch result {
         case .focused, .openedNewWorktree, .openedNewProject:
             appState.isRepoSelectorOpen = false
-        case .pushed:
-            requestInputFocus()
         case .noop:
             break
         }
-    }
-
-    private func popToRepos() {
-        appState.repoSelector.popToRepos()
-        requestInputFocus()
     }
 
     private func close() {
@@ -209,12 +162,7 @@ struct RepoSelectorDialog: View {
         let rows = model.rows(environment: env)
         switch press.key {
         case .escape:
-            switch model.step {
-            case .repos:
-                close()
-            case .worktrees:
-                popToRepos()
-            }
+            close()
             return .handled
         case .upArrow:
             model.moveSelectionUp(in: rows)

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -52,6 +52,12 @@ struct RepoSelectorDialog: View {
             .transition(.opacity.combined(with: .offset(y: -6)))
             .onAppear {
                 appState.repoSelector.open()
+                // `open()` resets query to "" — but if it was already "",
+                // didSet skips and selectedIndex stays at 0, which lands on
+                // the RECENT or first project header (non-selectable). Snap
+                // forward so ↵ on first open activates the top worktree.
+                let rows = appState.repoSelector.rows(environment: environment())
+                appState.repoSelector.setSelectedIndex(0, in: rows)
                 requestInputFocus()
             }
             .onChange(of: appState.isRepoSelectorOpen) { _, isOpen in

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -18,6 +18,16 @@ struct RepoSelectorDialog: View {
                     rowList
                     footer
                 }
+                .onChange(of: appState.repoSelector.query) { _, _ in
+                    // After a query change, model.didSet has reset
+                    // selectedIndex to 0. In empty-query mode row 0 is a
+                    // header (RECENT/PROJECT), which isn't selectable —
+                    // snap forward to the nearest selectable row using the
+                    // fresh row list.
+                    let env = environment()
+                    let rows = appState.repoSelector.rows(environment: env)
+                    appState.repoSelector.setSelectedIndex(0, in: rows)
+                }
                 .frame(width: 720)
                 .frame(maxHeight: 520)
                 .background(theme.color("bg-1").opacity(0.92))

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorEnvironment.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorEnvironment.swift
@@ -19,4 +19,7 @@ struct RepoSelectorEnvironment {
     var openNewProject: () -> Void
     /// Open `NewWorktreeDialog` for the given project.
     var openNewWorktree: (_ projectId: String) -> Void
+    /// The worktree currently focused in the app (`AppState.selectedWorktreeId`).
+    /// Used to mark the "current" worktree in the list.
+    var currentWorktreeId: () -> String?
 }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -7,20 +7,13 @@ import Observation
 @Observable
 @MainActor
 final class RepoSelectorModel {
-    enum Step: Equatable {
-        case repos
-        case worktrees(projectId: String)
-    }
+    private static let recentLimit = 5
 
     var isOpen: Bool = false
-    private(set) var step: Step = .repos
     var query: String = "" {
         didSet {
             // Reset selection so a shrinking filter never strands the cursor
-            // on a stale row (especially the trailing `+ New worktree…`).
-            // Also bump the scroll tick — the list may have been scrolled
-            // down via keyboard nav before the filter changed, and we need
-            // the view to snap back to the new top.
+            // on a stale row. Bump the scroll tick so the view snaps back.
             if query != oldValue {
                 selectedIndex = 0
                 scrollToSelectionTick &+= 1
@@ -28,22 +21,14 @@ final class RepoSelectorModel {
         }
     }
     private(set) var selectedIndex: Int = 0
-    /// Bumped by keyboard navigation (Up/Down). The view scrolls the
-    /// selected row into view on changes to this — not on `selectedIndex`
-    /// itself — so hover-driven selection doesn't fight the user's scroll.
+    /// Bumped by keyboard navigation. The view scrolls the selected row into
+    /// view on changes to this — not on `selectedIndex` itself — so
+    /// hover-driven selection doesn't fight the user's scroll.
     private(set) var scrollToSelectionTick: Int = 0
 
-    // Snapshot of step-1 state preserved across a push so popToRepos can
-    // restore both the query and (where possible) the selection.
-    private var savedReposQuery: String = ""
-    private var savedReposSelectedIndex: Int = 0
-
     func open() {
-        step = .repos
         query = ""
         selectedIndex = 0
-        savedReposQuery = ""
-        savedReposSelectedIndex = 0
         isOpen = true
     }
 
@@ -51,158 +36,159 @@ final class RepoSelectorModel {
         isOpen = false
     }
 
-    /// Compute the rows for the current step. Pure — does not mutate `self`.
-    /// Callers re-invoke whenever inputs (query, step, projects, recents)
-    /// change.
+    // MARK: - Row generation
+
+    /// Compute the rows for the current query state. Pure — does not mutate
+    /// `self`. Callers re-invoke whenever inputs (query, projects, recents,
+    /// worktrees, currentWorktreeId) change.
     func rows(environment env: RepoSelectorEnvironment) -> [RepoSelectorRow] {
-        switch step {
-        case .repos:
-            return repoRows(environment: env)
-        case .worktrees(let projectId):
-            return worktreeRows(projectId: projectId, environment: env)
-        }
-    }
-
-    // MARK: - Step 1 rows
-
-    private func repoRows(environment env: RepoSelectorEnvironment) -> [RepoSelectorRow] {
         let projects = env.projects()
         guard !projects.isEmpty else { return [.emptyHint(.noProjects)] }
-
         if query.isEmpty {
-            return emptyQueryRepoRows(projects: projects, environment: env)
+            return emptyQueryRows(projects: projects, environment: env)
         } else {
-            return filteredRepoRows(projects: projects)
+            return filteredRows(projects: projects, environment: env)
         }
     }
 
-    private func emptyQueryRepoRows(
+    private func emptyQueryRows(
         projects: [ProjectConfig],
         environment env: RepoSelectorEnvironment
     ) -> [RepoSelectorRow] {
-        let validIds = Set(projects.map(\.id))
-        let recentIds = env.readRecents().liveProjectIds(validProjectIds: validIds)
-        let projectsById = Dictionary(uniqueKeysWithValues: projects.map { ($0.id, $0) })
+        let currentId = env.currentWorktreeId()
+        let worktreesByProject = Dictionary(
+            uniqueKeysWithValues: projects.map { ($0.id, env.visibleWorktrees($0.id)) }
+        )
+        let recents = env.readRecents()
 
-        let recentRows: [RepoSelectorRow] = recentIds.compactMap { id in
-            projectsById[id].map { .repo($0, indices: []) }
-        }
-        let recentSet = Set(recentIds)
-        let rest = projects
-            .filter { !recentSet.contains($0.id) }
-            .map { RepoSelectorRow.repo($0, indices: []) }
+        var rows: [RepoSelectorRow] = []
 
-        if recentRows.isEmpty { return rest }
-        if rest.isEmpty { return recentRows }
-        return recentRows + [.divider(label: "All repositories")] + rest
-    }
+        // RECENT section: flatten all per-project recents, dedupe, take 5.
+        let recentRows = recentSectionRows(
+            projects: projects,
+            worktreesByProject: worktreesByProject,
+            recents: recents,
+            currentId: currentId
+        )
+        if !recentRows.isEmpty {
+            rows.append(.recentHeader)
+            rows.append(contentsOf: recentRows)
+        }
 
-    private func filteredRepoRows(projects: [ProjectConfig]) -> [RepoSelectorRow] {
-        struct Scored {
-            let project: ProjectConfig
-            let result: FuzzyMatch.Result
-        }
-        let scored: [Scored] = projects.compactMap { p in
-            guard let r = FuzzyMatch.score(query: query, target: p.name) else { return nil }
-            return Scored(project: p, result: r)
-        }
-        return scored
-            .sorted { a, b in
-                if a.result.score != b.result.score { return a.result.score > b.result.score }
-                return a.project.name.localizedCaseInsensitiveCompare(b.project.name) == .orderedAscending
+        // Project sections, ordered by recency of their most-recently-touched
+        // worktree (alpha as the tie-breaker / no-recents fallback).
+        let projectOrder = orderedProjects(
+            projects: projects,
+            worktreesByProject: worktreesByProject,
+            recents: recents
+        )
+        for project in projectOrder {
+            rows.append(.projectHeader(projectId: project.id))
+            let worktrees = worktreesByProject[project.id] ?? []
+            let validIds = Set(worktrees.map(\.id))
+            let recentIds = recents.liveWorktreeIds(in: project.id, validWorktreeIds: validIds)
+            let recentSet = Set(recentIds)
+            let byId = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0) })
+            for id in recentIds {
+                guard let w = byId[id] else { continue }
+                rows.append(.worktree(w, indices: [], isCurrent: w.id == currentId))
             }
-            .map { .repo($0.project, indices: $0.result.indices) }
-    }
-
-    // MARK: - Step transitions
-
-    func pushRepo(projectId: String) {
-        savedReposQuery = query
-        savedReposSelectedIndex = selectedIndex
-        step = .worktrees(projectId: projectId)
-        query = ""
-        selectedIndex = 0
-        // Reset the scroll position too — without this, the freshly-pushed
-        // worktree list could remain scrolled to wherever the repo list was.
-        scrollToSelectionTick &+= 1
-    }
-
-    func popToRepos() {
-        step = .repos
-        query = savedReposQuery
-        selectedIndex = savedReposSelectedIndex
-        scrollToSelectionTick &+= 1
-    }
-
-    // MARK: - Step 2 rows
-
-    private func worktreeRows(
-        projectId: String,
-        environment env: RepoSelectorEnvironment
-    ) -> [RepoSelectorRow] {
-        let worktrees = env.visibleWorktrees(projectId)
-
-        let listed: [RepoSelectorRow]
-        if query.isEmpty {
-            listed = emptyQueryWorktreeRows(
-                projectId: projectId,
-                worktrees: worktrees,
-                environment: env
-            )
-        } else {
-            listed = filteredWorktreeRows(worktrees: worktrees)
+            let rest = worktrees
+                .filter { !recentSet.contains($0.id) }
+                .sorted { a, b in
+                    a.branch.localizedCaseInsensitiveCompare(b.branch) == .orderedAscending
+                }
+            for w in rest {
+                rows.append(.worktree(w, indices: [], isCurrent: w.id == currentId))
+            }
+            rows.append(.action(.newWorktreeForRepo(projectId: project.id)))
         }
 
-        var rows = listed
-        // Only separate the worktree list from the action with a divider
-        // when there's something above it. Otherwise the divider would land
-        // at row 0 and swallow the default selection.
-        if !listed.isEmpty {
-            rows.append(.divider(label: ""))
-        }
-        rows.append(.action(.newWorktreeForRepo(projectId: projectId)))
+        rows.append(.actionsHeader)
+        rows.append(.action(.newProject))
         return rows
     }
 
-    private func emptyQueryWorktreeRows(
-        projectId: String,
-        worktrees: [Worktree],
-        environment env: RepoSelectorEnvironment
+    private func recentSectionRows(
+        projects: [ProjectConfig],
+        worktreesByProject: [String: [Worktree]],
+        recents: RepoSelectorRecents,
+        currentId: String?
     ) -> [RepoSelectorRow] {
-        let validIds = Set(worktrees.map(\.id))
-        let recentIds = env.readRecents().liveWorktreeIds(in: projectId, validWorktreeIds: validIds)
-        let byId = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0) })
-        let recentRows: [RepoSelectorRow] = recentIds.compactMap {
-            byId[$0].map { .worktree($0, indices: []) }
+        // Build per-project recent slices, then interleave by the order they
+        // appear in `recents.projectIds` (most-recently-touched project first).
+        // We dedupe by worktree id and stop at `recentLimit`.
+        let validProjectIds = Set(projects.map(\.id))
+        let projectOrderIds = recents.liveProjectIds(validProjectIds: validProjectIds)
+        var seen = Set<String>()
+        var output: [(Worktree, Bool)] = []
+        outer: for projectId in projectOrderIds {
+            let wts = worktreesByProject[projectId] ?? []
+            let validIds = Set(wts.map(\.id))
+            let recentIds = recents.liveWorktreeIds(in: projectId, validWorktreeIds: validIds)
+            let byId = Dictionary(uniqueKeysWithValues: wts.map { ($0.id, $0) })
+            for id in recentIds {
+                if seen.contains(id) { continue }
+                guard let w = byId[id] else { continue }
+                seen.insert(id)
+                output.append((w, w.id == currentId))
+                if output.count >= Self.recentLimit { break outer }
+            }
         }
-        let recentSet = Set(recentIds)
-        let rest = worktrees
-            .filter { !recentSet.contains($0.id) }
-            .map { RepoSelectorRow.worktree($0, indices: []) }
-        return recentRows + rest
+        return output.map { .worktree($0.0, indices: [], isCurrent: $0.1) }
     }
 
-    private func filteredWorktreeRows(worktrees: [Worktree]) -> [RepoSelectorRow] {
+    /// Projects ordered by the recency of their most-recently-touched
+    /// worktree. Projects with no recents fall back to alpha order on name.
+    private func orderedProjects(
+        projects: [ProjectConfig],
+        worktreesByProject: [String: [Worktree]],
+        recents: RepoSelectorRecents
+    ) -> [ProjectConfig] {
+        // Build a "most-recent index" per project: lower = more recent.
+        // Projects with no recents get .max so they sort to the back.
+        let validProjectIds = Set(projects.map(\.id))
+        let recentProjectIds = recents.liveProjectIds(validProjectIds: validProjectIds)
+        let projectRecencyIndex: [String: Int] = Dictionary(
+            uniqueKeysWithValues: recentProjectIds.enumerated().map { ($0.element, $0.offset) }
+        )
+        return projects.sorted { a, b in
+            let ai = projectRecencyIndex[a.id] ?? Int.max
+            let bi = projectRecencyIndex[b.id] ?? Int.max
+            if ai != bi { return ai < bi }
+            return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
+        }
+    }
+
+    private func filteredRows(
+        projects: [ProjectConfig],
+        environment env: RepoSelectorEnvironment
+    ) -> [RepoSelectorRow] {
         struct Scored {
             let worktree: Worktree
             let result: FuzzyMatch.Result
         }
-        let scored: [Scored] = worktrees.compactMap { w in
-            guard let r = FuzzyMatch.score(query: query, target: w.branch) else { return nil }
-            return Scored(worktree: w, result: r)
+        let currentId = env.currentWorktreeId()
+        var scored: [Scored] = []
+        for project in projects {
+            for w in env.visibleWorktrees(project.id) {
+                if let r = FuzzyMatch.score(query: query, target: w.branch) {
+                    scored.append(Scored(worktree: w, result: r))
+                }
+            }
         }
         return scored
             .sorted { a, b in
                 if a.result.score != b.result.score { return a.result.score > b.result.score }
-                return a.worktree.branch.localizedCaseInsensitiveCompare(b.worktree.branch) == .orderedAscending
+                return a.worktree.branch.localizedCaseInsensitiveCompare(b.worktree.branch)
+                    == .orderedAscending
             }
-            .map { .worktree($0.worktree, indices: $0.result.indices) }
+            .map { .worktree($0.worktree, indices: $0.result.indices, isCurrent: $0.worktree.id == currentId) }
     }
 
     // MARK: - Activation
 
     enum Activation: Equatable {
-        case pushed(projectId: String)
         case focused(worktreeId: String)
         case openedNewWorktree(projectId: String)
         case openedNewProject
@@ -213,52 +199,23 @@ final class RepoSelectorModel {
     func activate(rows: [RepoSelectorRow], environment env: RepoSelectorEnvironment) -> Activation {
         guard !rows.isEmpty else { return .noop }
         let safeIndex = max(0, min(rows.count - 1, selectedIndex))
-        let row = rows[safeIndex]
-
-        switch row {
-        case .repo(let project, _):
-            return activateRepo(project, environment: env)
-
-        case .worktree(let worktree, _):
+        switch rows[safeIndex] {
+        case .worktree(let worktree, _, _):
             return focus(worktree: worktree, environment: env)
-
         case .action(.newWorktreeForRepo(let projectId)):
             env.openNewWorktree(projectId)
             close()
             return .openedNewWorktree(projectId: projectId)
-
         case .action(.newProject):
             env.openNewProject()
             close()
             return .openedNewProject
-
         case .emptyHint(.noProjects):
             env.openNewProject()
             close()
             return .openedNewProject
-
-        case .divider:
+        case .recentHeader, .projectHeader, .actionsHeader:
             return .noop
-        }
-    }
-
-    private func activateRepo(
-        _ project: ProjectConfig,
-        environment env: RepoSelectorEnvironment
-    ) -> Activation {
-        let wts = env.visibleWorktrees(project.id)
-        switch wts.count {
-        case 0:
-            // Activation on a repo with no open worktrees has nowhere to
-            // navigate, so jump straight to creating one.
-            env.openNewWorktree(project.id)
-            close()
-            return .openedNewWorktree(projectId: project.id)
-        case 1:
-            return focus(worktree: wts[0], environment: env)
-        default:
-            pushRepo(projectId: project.id)
-            return .pushed(projectId: project.id)
         }
     }
 
@@ -278,23 +235,21 @@ final class RepoSelectorModel {
     // MARK: - Selection
 
     func moveSelectionDown(in rows: [RepoSelectorRow]) {
-        let next = nextSelectable(from: selectedIndex, step: 1, in: rows)
-        if let next {
+        if let next = scan(from: selectedIndex, step: 1, in: rows) {
             selectedIndex = next
             scrollToSelectionTick &+= 1
         }
     }
 
     func moveSelectionUp(in rows: [RepoSelectorRow]) {
-        let prev = nextSelectable(from: selectedIndex, step: -1, in: rows)
-        if let prev {
+        if let prev = scan(from: selectedIndex, step: -1, in: rows) {
             selectedIndex = prev
             scrollToSelectionTick &+= 1
         }
     }
 
     /// Set selection directly, snapping forward (then backward) to the
-    /// nearest selectable row if the target is a divider. Used on hover.
+    /// nearest selectable row if the target is a header. Used on hover.
     func setSelectedIndex(_ index: Int, in rows: [RepoSelectorRow]) {
         guard !rows.isEmpty else {
             selectedIndex = 0
@@ -305,7 +260,6 @@ final class RepoSelectorModel {
             selectedIndex = clamped
             return
         }
-        // Try forward first, then backward.
         if let fwd = scan(from: clamped, step: 1, in: rows) {
             selectedIndex = fwd
         } else if let back = scan(from: clamped, step: -1, in: rows) {
@@ -313,23 +267,6 @@ final class RepoSelectorModel {
         } else {
             selectedIndex = clamped
         }
-    }
-
-    /// Resets selection to the first selectable row. Called after recomputes.
-    func resetSelectionToFirstSelectable(in rows: [RepoSelectorRow]) {
-        if let idx = scan(from: -1, step: 1, in: rows) {
-            selectedIndex = idx
-        } else {
-            selectedIndex = 0
-        }
-    }
-
-    private func nextSelectable(
-        from index: Int,
-        step: Int,
-        in rows: [RepoSelectorRow]
-    ) -> Int? {
-        scan(from: index, step: step, in: rows)
     }
 
     private func scan(from index: Int, step: Int, in rows: [RepoSelectorRow]) -> Int? {

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -127,13 +127,58 @@ final class RepoSelectorModel {
         let refs = recents.liveRecentWorktreeRefs(
             projectsWithVisibleWorktrees: visibleByProject
         )
+        let effectiveRefs = refs.isEmpty
+            ? legacyRecentRefs(
+                projects: projects,
+                worktreesByProject: worktreesByProject,
+                visibleByProject: visibleByProject,
+                recents: recents
+            )
+            : refs
+
         var output: [RepoSelectorRow] = []
-        for ref in refs {
+        for ref in effectiveRefs {
             guard let w = worktreeByPair[ref.projectId]?[ref.worktreeId] else { continue }
             output.append(.worktree(w, indices: [], isCurrent: w.id == currentId))
             if output.count >= Self.recentLimit { break }
         }
         return output
+    }
+
+    /// Synthesize cross-project recents from the legacy per-project lists
+    /// for users upgrading from configs that pre-date `recentWorktreeRefs`.
+    /// Interleaves projects round-robin (most-recently-touched project's
+    /// most-recent worktree first), which is the best approximation
+    /// possible without per-worktree timestamps. The next `focus()` call
+    /// populates the flat list and this fallback stops being used.
+    private func legacyRecentRefs(
+        projects: [ProjectConfig],
+        worktreesByProject: [String: [Worktree]],
+        visibleByProject: [String: Set<String>],
+        recents: RepoSelectorRecents
+    ) -> [RepoSelectorRecents.RecentWorktreeRef] {
+        let validProjectIds = Set(projects.map(\.id))
+        let projectOrder = recents.liveProjectIds(validProjectIds: validProjectIds)
+        guard !projectOrder.isEmpty else { return [] }
+
+        let perProject: [(projectId: String, ids: [String])] = projectOrder.map { pid in
+            let visible = visibleByProject[pid] ?? []
+            let ids = recents.liveWorktreeIds(in: pid, validWorktreeIds: visible)
+            return (pid, ids)
+        }
+        guard perProject.contains(where: { !$0.ids.isEmpty }) else { return [] }
+
+        var refs: [RepoSelectorRecents.RecentWorktreeRef] = []
+        var slot = 0
+        let maxSlots = perProject.map(\.ids.count).max() ?? 0
+        while slot < maxSlots && refs.count < Self.recentLimit {
+            for entry in perProject where slot < entry.ids.count {
+                refs.append(.init(projectId: entry.projectId, worktreeId: entry.ids[slot]))
+                if refs.count >= Self.recentLimit { break }
+            }
+            slot += 1
+        }
+        return refs
     }
 
     /// Projects ordered by the recency of their most-recently-touched

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -115,27 +115,25 @@ final class RepoSelectorModel {
         recents: RepoSelectorRecents,
         currentId: String?
     ) -> [RepoSelectorRow] {
-        // Build per-project recent slices, then interleave by the order they
-        // appear in `recents.projectIds` (most-recently-touched project first).
-        // We dedupe by worktree id and stop at `recentLimit`.
-        let validProjectIds = Set(projects.map(\.id))
-        let projectOrderIds = recents.liveProjectIds(validProjectIds: validProjectIds)
-        var seen = Set<String>()
-        var output: [(Worktree, Bool)] = []
-        outer: for projectId in projectOrderIds {
-            let wts = worktreesByProject[projectId] ?? []
-            let validIds = Set(wts.map(\.id))
-            let recentIds = recents.liveWorktreeIds(in: projectId, validWorktreeIds: validIds)
-            let byId = Dictionary(uniqueKeysWithValues: wts.map { ($0.id, $0) })
-            for id in recentIds {
-                if seen.contains(id) { continue }
-                guard let w = byId[id] else { continue }
-                seen.insert(id)
-                output.append((w, w.id == currentId))
-                if output.count >= Self.recentLimit { break outer }
-            }
+        // Consume the flat global recency list directly so the RECENT
+        // section is strict cross-project recency rather than per-project
+        // drain order.
+        let visibleByProject: [String: Set<String>] = worktreesByProject.mapValues {
+            Set($0.map(\.id))
         }
-        return output.map { .worktree($0.0, indices: [], isCurrent: $0.1) }
+        let worktreeByPair: [String: [String: Worktree]] = worktreesByProject.mapValues {
+            Dictionary(uniqueKeysWithValues: $0.map { ($0.id, $0) })
+        }
+        let refs = recents.liveRecentWorktreeRefs(
+            projectsWithVisibleWorktrees: visibleByProject
+        )
+        var output: [RepoSelectorRow] = []
+        for ref in refs {
+            guard let w = worktreeByPair[ref.projectId]?[ref.worktreeId] else { continue }
+            output.append(.worktree(w, indices: [], isCurrent: w.id == currentId))
+            if output.count >= Self.recentLimit { break }
+        }
+        return output
     }
 
     /// Projects ordered by the recency of their most-recently-touched

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRecents.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRecents.swift
@@ -6,16 +6,30 @@ import Foundation
 struct RepoSelectorRecents: Equatable {
     static let projectCap = 5
     static let worktreeCapPerProject = 5
+    static let recentWorktreeRefCap = 5
+
+    /// A (project, worktree) pair used by the global RECENT list. We need
+    /// the project id because the worktree id alone isn't enough to look
+    /// up its project in `visibleWorktrees`.
+    struct RecentWorktreeRef: Codable, Equatable {
+        let projectId: String
+        let worktreeId: String
+    }
 
     var projectIds: [String] = []
     var worktreeIdsByProject: [String: [String]] = [:]
+    /// Cross-project, globally-recency-ordered worktree list. Capped at
+    /// `recentWorktreeRefCap`. Newer entries are at the front.
+    var recentWorktreeRefs: [RecentWorktreeRef] = []
 
     init(
         projectIds: [String] = [],
-        worktreeIdsByProject: [String: [String]] = [:]
+        worktreeIdsByProject: [String: [String]] = [:],
+        recentWorktreeRefs: [RecentWorktreeRef] = []
     ) {
         self.projectIds = projectIds
         self.worktreeIdsByProject = worktreeIdsByProject
+        self.recentWorktreeRefs = recentWorktreeRefs
     }
 
     mutating func bumpProject(_ id: String) {
@@ -34,6 +48,21 @@ struct RepoSelectorRecents: Equatable {
             list.removeLast(list.count - Self.worktreeCapPerProject)
         }
         worktreeIdsByProject[projectId] = list
+
+        // Maintain the flat cross-project recency list. Dedupe by the
+        // (projectId, worktreeId) pair, prepend, and trim to the cap.
+        recentWorktreeRefs.removeAll {
+            $0.projectId == projectId && $0.worktreeId == id
+        }
+        recentWorktreeRefs.insert(
+            RecentWorktreeRef(projectId: projectId, worktreeId: id),
+            at: 0
+        )
+        if recentWorktreeRefs.count > Self.recentWorktreeRefCap {
+            recentWorktreeRefs.removeLast(
+                recentWorktreeRefs.count - Self.recentWorktreeRefCap
+            )
+        }
     }
 
     /// Returns projectIds filtered to those still present in the supplied
@@ -45,5 +74,17 @@ struct RepoSelectorRecents: Equatable {
     /// Returns the recents for a project filtered to ids still present.
     func liveWorktreeIds(in projectId: String, validWorktreeIds: Set<String>) -> [String] {
         (worktreeIdsByProject[projectId] ?? []).filter { validWorktreeIds.contains($0) }
+    }
+
+    /// Returns `recentWorktreeRefs` filtered to refs whose worktree is
+    /// still visible in its project. Refs whose `projectId` isn't in the
+    /// map are dropped entirely.
+    func liveRecentWorktreeRefs(
+        projectsWithVisibleWorktrees: [String: Set<String>]
+    ) -> [RecentWorktreeRef] {
+        recentWorktreeRefs.filter { ref in
+            guard let visible = projectsWithVisibleWorktrees[ref.projectId] else { return false }
+            return visible.contains(ref.worktreeId)
+        }
     }
 }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRow.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRow.swift
@@ -4,11 +4,12 @@ import Foundation
 /// fuzzy-match positions (matching `FuzzyMatch.Result.indices`) for
 /// highlighting; empty when no query is active.
 enum RepoSelectorRow: Equatable {
-    case repo(ProjectConfig, indices: [Int])
-    case worktree(Worktree, indices: [Int])
+    case worktree(Worktree, indices: [Int], isCurrent: Bool)
     case action(Action)
     case emptyHint(EmptyHint)
-    case divider(label: String)
+    case recentHeader
+    case projectHeader(projectId: String)
+    case actionsHeader
 
     enum Action: Equatable {
         case newProject
@@ -16,14 +17,14 @@ enum RepoSelectorRow: Equatable {
     }
 
     enum EmptyHint: Equatable {
-        /// Step 1 with zero configured projects at all.
+        /// Zero configured projects.
         case noProjects
     }
 
     /// True when keyboard navigation should be able to land on this row.
     var isSelectable: Bool {
         switch self {
-        case .divider: return false
+        case .recentHeader, .projectHeader, .actionsHeader: return false
         default: return true
         }
     }

--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorRowView.swift
@@ -9,16 +9,45 @@ struct RepoSelectorRowView: View {
     @Environment(\.theme) private var theme
 
     var body: some View {
-        ZStack(alignment: .leading) {
-            if isSelected, row.isSelectable {
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(theme.color("bg-4"))
-                    .padding(.horizontal, 4)
-            }
-            content
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
+        switch row {
+        case .recentHeader:
+            headerLabel("Recent")
+        case .projectHeader(let projectId):
+            headerLabel(projectsById[projectId]?.name ?? "")
+        case .actionsHeader:
+            headerRule
+        case .emptyHint(.noProjects):
+            emptyHintRow
+        default:
+            selectableRow
         }
+    }
+
+    private var emptyHintRow: some View {
+        Text("No repositories. Press ⇥ to add one.")
+            .font(.system(size: 12))
+            .foregroundColor(theme.color("fg-dim"))
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 16)
+            .contentShape(Rectangle())
+            .onTapGesture { onTap() }
+            .onHover { hovering in if hovering { onHover() } }
+    }
+
+    // MARK: - Selectable rows
+
+    private var selectableRow: some View {
+        ZStack(alignment: .leading) {
+            Rectangle()
+                .fill(isSelected ? theme.color("accent-soft") : Color.clear)
+            Rectangle()
+                .fill(isSelected ? theme.color("accent") : Color.clear)
+                .frame(width: 2)
+                .frame(maxHeight: .infinity)
+            content
+                .padding(.horizontal, 14)
+        }
+        .frame(height: 28)
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
         .onTapGesture {
@@ -32,75 +61,68 @@ struct RepoSelectorRowView: View {
     @ViewBuilder
     private var content: some View {
         switch row {
-        case .repo(let project, let indices):
-            HStack(spacing: 8) {
-                RepoDot(color: project.color, letter: String(project.name.prefix(1)).uppercased())
-                Highlighted(text: project.name, indices: indices)
-                    .font(.system(size: 12))
-                    .foregroundColor(theme.color("fg"))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                Spacer(minLength: 0)
-            }
-
-        case .worktree(let worktree, let indices):
-            HStack(spacing: 8) {
-                if let project = projectsById[worktree.projectId] {
-                    Circle()
-                        .fill(Color(hex: project.color))
-                        .frame(width: 8, height: 8)
-                }
-                Highlighted(text: worktree.branch, indices: indices)
-                    .font(.system(size: 12, design: .monospaced))
-                    .foregroundColor(theme.color("fg"))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                Spacer(minLength: 0)
-                statusText(for: worktree)
-                    .font(.system(size: 11))
-                    .foregroundColor(theme.color("fg-faint"))
-            }
+        case .worktree(let worktree, let indices, let isCurrent):
+            worktreeContent(worktree: worktree, indices: indices, isCurrent: isCurrent)
 
         case .action(.newWorktreeForRepo):
-            HStack(spacing: 8) {
-                Image(systemName: "plus")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(theme.color("fg-faint"))
-                Text("New worktree…")
-                    .font(.system(size: 12))
-                    .foregroundColor(theme.color("fg"))
-                Spacer(minLength: 0)
-            }
+            actionContent(label: "New worktree…")
 
         case .action(.newProject):
-            HStack(spacing: 8) {
-                Image(systemName: "plus")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(theme.color("fg-faint"))
-                Text("Add project…")
-                    .font(.system(size: 12))
-                    .foregroundColor(theme.color("fg"))
-                Spacer(minLength: 0)
-            }
+            actionContent(label: "Add project…")
 
-        case .emptyHint(.noProjects):
-            Text("No repositories. Press ⇥ to add one.")
+        case .emptyHint, .recentHeader, .projectHeader, .actionsHeader:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func worktreeContent(worktree: Worktree, indices: [Int], isCurrent: Bool) -> some View {
+        HStack(spacing: 10) {
+            if let project = projectsById[worktree.projectId] {
+                RepoDot(color: project.color, letter: String(project.name.prefix(1)).uppercased())
+            }
+            if isCurrent {
+                Circle()
+                    .fill(theme.color("accent"))
+                    .frame(width: 5, height: 5)
+                    .overlay(
+                        Circle()
+                            .stroke(theme.color("accent").opacity(0.25), lineWidth: 2)
+                    )
+            }
+            Highlighted(text: worktree.branch, indices: indices)
+                .font(.system(size: 12.5, weight: isCurrent ? .semibold : .medium, design: .monospaced))
+                .foregroundColor(theme.color("fg"))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+            Spacer(minLength: 8)
+            statusText(for: worktree)
+            if let project = projectsById[worktree.projectId] {
+                Text(project.name)
+                    .font(.system(size: 10, design: .monospaced))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(theme.color("bg-3"))
+                    .foregroundColor(theme.color("fg-faint"))
+                    .clipShape(Capsule())
+            }
+            if isSelected {
+                SearchKbd(label: "↵")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func actionContent(label: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "plus")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.color("fg-faint"))
+                .frame(width: 16)
+            Text(label)
                 .font(.system(size: 12))
-                .foregroundColor(theme.color("fg-dim"))
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.vertical, 16)
-
-        case .divider(let label):
-            HStack(spacing: 6) {
-                Text(label.uppercased())
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundColor(theme.color("fg-faint"))
-                Rectangle()
-                    .fill(theme.color("line-soft"))
-                    .frame(height: 0.5)
-            }
-            .padding(.top, 6)
-            .padding(.bottom, 2)
+                .foregroundColor(theme.color("fg"))
+            Spacer(minLength: 0)
         }
     }
 
@@ -108,11 +130,46 @@ struct RepoSelectorRowView: View {
     private func statusText(for w: Worktree) -> some View {
         if w.addedLines == 0, w.deletedLines == 0 {
             Text("clean")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-faint"))
         } else {
             HStack(spacing: 4) {
-                if w.addedLines > 0 { Text("+\(w.addedLines)").foregroundColor(theme.color("add")) }
-                if w.deletedLines > 0 { Text("−\(w.deletedLines)").foregroundColor(theme.color("del")) }
+                if w.addedLines > 0 {
+                    Text("+\(w.addedLines)")
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("add"))
+                }
+                if w.deletedLines > 0 {
+                    Text("−\(w.deletedLines)")
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("del"))
+                }
             }
         }
+    }
+
+    // MARK: - Headers
+
+    private func headerLabel(_ text: String) -> some View {
+        HStack(spacing: 6) {
+            Text(text.uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(theme.color("fg-faint"))
+            Rectangle()
+                .fill(theme.color("line-soft"))
+                .frame(height: 0.5)
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 8)
+        .padding(.bottom, 2)
+    }
+
+    private var headerRule: some View {
+        Rectangle()
+            .fill(theme.color("line-soft"))
+            .frame(height: 0.5)
+            .padding(.horizontal, 14)
+            .padding(.top, 6)
+            .padding(.bottom, 2)
     }
 }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -33,6 +33,7 @@ struct AppConfig: Codable, Equatable {
     var files: Files
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
+    var recentWorktreeRefs: [RepoSelectorRecents.RecentWorktreeRef] = []
     var sidebarChromeOverrides: [String: SidebarChromeOverride] = [:]
     var shortcutOverrides: [String: ShortcutBinding?] = [:]
 
@@ -213,6 +214,7 @@ struct AppConfig: Codable, Equatable {
         files: Files(showIgnored: true),
         recentProjectIds: [],
         recentWorktreeIdsByProject: [:],
+        recentWorktreeRefs: [],
         sidebarChromeOverrides: SidebarChromeOverride.bundledDefaults,
         shortcutOverrides: [:]
     )
@@ -248,7 +250,7 @@ extension AppConfig {
              general, worktrees, terminal, harness, code, markdown, changes,
              agents,
              files,
-             recentProjectIds, recentWorktreeIdsByProject,
+             recentProjectIds, recentWorktreeIdsByProject, recentWorktreeRefs,
              sidebarChromeOverrides,
              shortcutOverrides
     }
@@ -351,6 +353,8 @@ extension AppConfig {
         recentProjectIds = (try? c.decode([String].self, forKey: .recentProjectIds)) ?? []
         recentWorktreeIdsByProject =
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]
+        recentWorktreeRefs =
+            (try? c.decode([RepoSelectorRecents.RecentWorktreeRef].self, forKey: .recentWorktreeRefs)) ?? []
         sidebarChromeOverrides =
             (try? c.decode([String: SidebarChromeOverride].self, forKey: .sidebarChromeOverrides)) ?? [:]
         shortcutOverrides =

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -4,7 +4,7 @@ import Foundation
 
 @MainActor
 struct RepoSelectorModelTests {
-    // MARK: - Helpers
+    // MARK: - Fixtures
 
     private func project(_ id: String, name: String? = nil) -> ProjectConfig {
         ProjectConfig(
@@ -33,7 +33,8 @@ struct RepoSelectorModelTests {
     private func env(
         projects: [ProjectConfig] = [],
         worktrees: [String: [Worktree]] = [:],
-        recents: RepoSelectorRecents = RepoSelectorRecents()
+        recents: RepoSelectorRecents = RepoSelectorRecents(),
+        currentWorktreeId: String? = nil
     ) -> RepoSelectorEnvironment {
         var recentsBox = recents
         return RepoSelectorEnvironment(
@@ -43,158 +44,281 @@ struct RepoSelectorModelTests {
             writeRecents: { recentsBox = $0 },
             focusWorktree: { _ in },
             openNewProject: { },
-            openNewWorktree: { _ in }
+            openNewWorktree: { _ in },
+            currentWorktreeId: { currentWorktreeId }
         )
     }
 
-    // MARK: - Empty query
+    // MARK: - Empty-projects state
 
-    @Test func emptyQueryNoRecentsListsProjectsInOrder() {
+    @Test func emptyProjectsShowsNoProjectsHint() {
         let model = RepoSelectorModel()
-        let e = env(projects: [project("a"), project("b"), project("c")])
-        let rows = model.rows(environment: e)
-        #expect(rows == [
-            .repo(project("a"), indices: []),
-            .repo(project("b"), indices: []),
-            .repo(project("c"), indices: []),
+        let e = env(projects: [])
+        #expect(model.rows(environment: e) == [.emptyHint(.noProjects)])
+    }
+
+    // MARK: - Empty-query state
+
+    @Test func emptyQueryNoRecentsSingleProjectListsHeaderWorktreesActionThenAddProject() {
+        let model = RepoSelectorModel()
+        let w1 = worktree("w1", projectId: "p1")
+        let e = env(
+            projects: [project("p1")],
+            worktrees: ["p1": [w1]]
+        )
+        #expect(model.rows(environment: e) == [
+            .projectHeader(projectId: "p1"),
+            .worktree(w1, indices: [], isCurrent: false),
+            .action(.newWorktreeForRepo(projectId: "p1")),
+            .actionsHeader,
+            .action(.newProject)
         ])
     }
 
-    @Test func emptyQueryWithRecentsPutsRecentsFirstWithDivider() {
+    @Test func emptyQueryWithRecentsPutsRecentHeaderAndRecentRowsFirst() {
         let model = RepoSelectorModel()
+        let pAlas = project("p-alas", name: "alas")
+        let pAcme = project("p-acme", name: "acme")
+        let alasMain = worktree("alas-main", projectId: "p-alas", branch: "main")
+        let alasFeat = worktree("alas-feat", projectId: "p-alas", branch: "feat")
+        let acmeMain = worktree("acme-main", projectId: "p-acme", branch: "main")
         var r = RepoSelectorRecents()
-        r.bumpProject("b")
-        r.bumpProject("c")  // most recent: c, then b
+        r.bumpWorktree("alas-main", in: "p-alas")  // older
+        r.bumpWorktree("acme-main", in: "p-acme")  // newer → first
+        r.bumpProject("p-alas")
+        r.bumpProject("p-acme")  // newest project
         let e = env(
-            projects: [project("a"), project("b"), project("c")],
+            projects: [pAlas, pAcme],
+            worktrees: [
+                "p-alas": [alasMain, alasFeat],
+                "p-acme": [acmeMain]
+            ],
+            recents: r
+        )
+
+        let rows = model.rows(environment: e)
+        // RECENT header + the two recent worktrees (newest first)
+        #expect(rows.prefix(3) == [
+            .recentHeader,
+            .worktree(acmeMain, indices: [], isCurrent: false),
+            .worktree(alasMain, indices: [], isCurrent: false)
+        ])
+        // Then projects in recency order: acme first, then alas
+        let acmeIdx = rows.firstIndex(of: .projectHeader(projectId: "p-acme"))
+        let alasIdx = rows.firstIndex(of: .projectHeader(projectId: "p-alas"))
+        #expect(acmeIdx != nil && alasIdx != nil && acmeIdx! < alasIdx!)
+        // Trailing actions header + add-project action.
+        #expect(rows.suffix(2) == [.actionsHeader, .action(.newProject)])
+    }
+
+    @Test func emptyQueryWithNoRecentsOmitsRecentHeader() {
+        let model = RepoSelectorModel()
+        let e = env(
+            projects: [project("p1")],
+            worktrees: ["p1": [worktree("w1", projectId: "p1")]]
+        )
+        let rows = model.rows(environment: e)
+        #expect(!rows.contains(.recentHeader))
+    }
+
+    @Test func emptyQueryRecentsLimitsToFive() {
+        let model = RepoSelectorModel()
+        let wts: [Worktree] = (1...7).map { worktree("w\($0)", projectId: "p1", branch: "b\($0)") }
+        var r = RepoSelectorRecents()
+        r.bumpProject("p1")
+        // bump in reverse so w1 ends up most recent
+        for w in wts.reversed() { r.bumpWorktree(w.id, in: "p1") }
+        // The store caps at 5 per project (see RepoSelectorRecents.worktreeCapPerProject)
+        // and the model caps at 5 across the whole RECENT section. Either bound is
+        // enough to keep this test honest; with one project both bounds apply.
+        let e = env(
+            projects: [project("p1")],
+            worktrees: ["p1": wts],
             recents: r
         )
         let rows = model.rows(environment: e)
-        #expect(rows == [
-            .repo(project("c"), indices: []),
-            .repo(project("b"), indices: []),
-            .divider(label: "All repositories"),
-            .repo(project("a"), indices: []),
-        ])
+        let recentWorktrees: [Worktree] = rows
+            .prefix(while: { $0 != .projectHeader(projectId: "p1") })
+            .compactMap { if case .worktree(let w, _, _) = $0 { return w } else { return nil } }
+        #expect(recentWorktrees.count == 5)
     }
 
-    @Test func emptyQueryDropsDanglingRecents() {
+    @Test func emptyQueryProjectSectionOrdersByRecencyThenAlpha() {
         let model = RepoSelectorModel()
+        let p1 = project("p1")
+        let wa = worktree("wa", projectId: "p1", branch: "a")
+        let wb = worktree("wb", projectId: "p1", branch: "b")
+        let wc = worktree("wc", projectId: "p1", branch: "c")
         var r = RepoSelectorRecents()
-        r.bumpProject("missing")
-        r.bumpProject("a")
-        let e = env(projects: [project("a")], recents: r)
+        r.bumpWorktree("wb", in: "p1")  // wb is the only recency hit
+        let e = env(
+            projects: [p1],
+            worktrees: ["p1": [wa, wb, wc]],
+            recents: r
+        )
         let rows = model.rows(environment: e)
-        #expect(rows == [.repo(project("a"), indices: [])])
+        // Inside p1's section: wb (recent) first, then wa, wc (alphabetical).
+        let inSection: [Worktree] = rows
+            .drop(while: { $0 != .projectHeader(projectId: "p1") })
+            .dropFirst()
+            .prefix(while: { row in
+                if case .action(.newWorktreeForRepo) = row { return false }
+                return true
+            })
+            .compactMap { if case .worktree(let w, _, _) = $0 { return w } else { return nil } }
+        #expect(inSection == [wb, wa, wc])
     }
 
-    @Test func emptyQueryEmptyProjectsShowsNoProjectsHint() {
+    @Test func emptyQueryProjectWithZeroWorktreesStillShowsHeaderAndNewWorktreeAction() {
         let model = RepoSelectorModel()
-        let e = env(projects: [])
+        let e = env(
+            projects: [project("p1")],
+            worktrees: ["p1": []]
+        )
         let rows = model.rows(environment: e)
-        #expect(rows == [.emptyHint(.noProjects)])
+        #expect(rows.contains(.projectHeader(projectId: "p1")))
+        #expect(rows.contains(.action(.newWorktreeForRepo(projectId: "p1"))))
     }
 
-    // MARK: - Non-empty query
-
-    @Test func nonEmptyQueryFiltersAndRanks() {
+    @Test func isCurrentSetForCurrentWorktreeInBothRecentAndProjectSections() {
         let model = RepoSelectorModel()
-        model.query = "ala"
-        let e = env(projects: [
-            project("p1", name: "alas"),
-            project("p2", name: "other"),
-            project("p3", name: "alacrity"),
-        ])
+        let p1 = project("p1")
+        let w1 = worktree("w1", projectId: "p1")
+        var r = RepoSelectorRecents()
+        r.bumpProject("p1")
+        r.bumpWorktree("w1", in: "p1")
+        let e = env(
+            projects: [p1],
+            worktrees: ["p1": [w1]],
+            recents: r,
+            currentWorktreeId: "w1"
+        )
         let rows = model.rows(environment: e)
-        // Both "alas" and "alacrity" match; ordering relies on FuzzyMatch
-        // (shorter target ranks higher because the span penalty is smaller).
-        // We only assert containment + that "other" was dropped.
-        let names: [String] = rows.compactMap {
-            if case .repo(let p, _) = $0 { return p.name } else { return nil }
+        let currentMarks = rows.compactMap { row -> Bool? in
+            if case .worktree(_, _, let isCurrent) = row { return isCurrent } else { return nil }
         }
-        #expect(names.contains("alas"))
-        #expect(names.contains("alacrity"))
-        #expect(!names.contains("other"))
-        #expect(!rows.contains { if case .divider = $0 { return true } else { return false } })
+        // Two .worktree rows (one in Recent, one in the project section); both flagged.
+        #expect(currentMarks == [true, true])
     }
 
-    @Test func nonEmptyQueryIncludesFuzzyIndices() {
+    // MARK: - Filter mode
+
+    @Test func filterModeProducesFlatFuzzyRankedWorktrees() {
         let model = RepoSelectorModel()
-        model.query = "al"
-        let e = env(projects: [project("p1", name: "alas")])
+        let p1 = project("p1")
+        let p2 = project("p2")
+        let main = worktree("w1", projectId: "p1", branch: "main")
+        let checkout = worktree("w2", projectId: "p2", branch: "feat/checkout")
+        let check = worktree("w3", projectId: "p2", branch: "fix/check-flake")
+        let e = env(
+            projects: [p1, p2],
+            worktrees: ["p1": [main], "p2": [checkout, check]]
+        )
+        model.query = "check"
         let rows = model.rows(environment: e)
-        guard case .repo(_, let indices) = rows.first else {
-            Issue.record("expected first row to be a repo")
+        // Headers and action rows are absent in filter mode.
+        #expect(!rows.contains(where: {
+            if case .recentHeader = $0 { return true }
+            if case .projectHeader = $0 { return true }
+            if case .actionsHeader = $0 { return true }
+            if case .action = $0 { return true }
+            return false
+        }))
+        let branches: [String] = rows.compactMap {
+            if case .worktree(let w, _, _) = $0 { return w.branch } else { return nil }
+        }
+        #expect(branches.contains("feat/checkout"))
+        #expect(branches.contains("fix/check-flake"))
+        #expect(!branches.contains("main"))
+    }
+
+    @Test func filterModeAttachesFuzzyMatchIndices() {
+        let model = RepoSelectorModel()
+        let p1 = project("p1")
+        let main = worktree("w1", projectId: "p1", branch: "main")
+        let e = env(projects: [p1], worktrees: ["p1": [main]])
+        model.query = "ma"
+        let rows = model.rows(environment: e)
+        guard case .worktree(_, let indices, _) = rows.first else {
+            Issue.record("expected first row to be a worktree")
             return
         }
         #expect(indices == [0, 1])
     }
 
+    @Test func filterModePropagatesCurrentFlag() {
+        let model = RepoSelectorModel()
+        let p1 = project("p1")
+        let main = worktree("w1", projectId: "p1", branch: "main")
+        let e = env(
+            projects: [p1],
+            worktrees: ["p1": [main]],
+            currentWorktreeId: "w1"
+        )
+        model.query = "ma"
+        let rows = model.rows(environment: e)
+        guard case .worktree(_, _, let isCurrent) = rows.first else {
+            Issue.record("expected first row to be a worktree")
+            return
+        }
+        #expect(isCurrent == true)
+    }
+
     // MARK: - Selection movement
 
-    @Test func moveSelectionDownSkipsDivider() {
+    @Test func moveSelectionDownSkipsAllHeaderKinds() {
         let model = RepoSelectorModel()
+        let w1 = worktree("w1", projectId: "p1")
         let rows: [RepoSelectorRow] = [
-            .repo(project("a"), indices: []),
-            .divider(label: "All repositories"),
-            .repo(project("b"), indices: []),
-        ]
-        model.moveSelectionDown(in: rows)  // 0 -> 2 (skip divider at 1)
-        #expect(model.selectedIndex == 2)
-    }
-
-    @Test func moveSelectionUpSkipsDivider() {
-        let model = RepoSelectorModel()
-        let rows: [RepoSelectorRow] = [
-            .repo(project("a"), indices: []),
-            .divider(label: "All repositories"),
-            .repo(project("b"), indices: []),
-        ]
-        model.setSelectedIndex(2, in: rows)
-        model.moveSelectionUp(in: rows)
-        #expect(model.selectedIndex == 0)
-    }
-
-    @Test func moveSelectionDownClampsAtBottom() {
-        let model = RepoSelectorModel()
-        let rows: [RepoSelectorRow] = [
-            .repo(project("a"), indices: []),
-            .repo(project("b"), indices: []),
+            .recentHeader,
+            .worktree(w1, indices: [], isCurrent: false),
+            .projectHeader(projectId: "p1"),
+            .worktree(w1, indices: [], isCurrent: false),
+            .actionsHeader,
+            .action(.newProject)
         ]
         model.setSelectedIndex(1, in: rows)
         model.moveSelectionDown(in: rows)
+        #expect(model.selectedIndex == 3)  // skipped projectHeader at 2
+        model.moveSelectionDown(in: rows)
+        #expect(model.selectedIndex == 5)  // skipped actionsHeader at 4
+    }
+
+    @Test func moveSelectionUpSkipsAllHeaderKinds() {
+        let model = RepoSelectorModel()
+        let w1 = worktree("w1", projectId: "p1")
+        let rows: [RepoSelectorRow] = [
+            .recentHeader,
+            .worktree(w1, indices: [], isCurrent: false),
+            .projectHeader(projectId: "p1"),
+            .worktree(w1, indices: [], isCurrent: false),
+            .actionsHeader,
+            .action(.newProject)
+        ]
+        model.setSelectedIndex(5, in: rows)
+        model.moveSelectionUp(in: rows)
+        #expect(model.selectedIndex == 3)
+        model.moveSelectionUp(in: rows)
         #expect(model.selectedIndex == 1)
     }
 
-    @Test func moveSelectionUpClampsAtTop() {
+    @Test func setSelectedIndexSnapsAwayFromAnyHeader() {
         let model = RepoSelectorModel()
+        let w1 = worktree("w1", projectId: "p1")
         let rows: [RepoSelectorRow] = [
-            .repo(project("a"), indices: []),
-            .repo(project("b"), indices: []),
+            .recentHeader,
+            .worktree(w1, indices: [], isCurrent: false)
         ]
-        model.moveSelectionUp(in: rows)
-        #expect(model.selectedIndex == 0)
-    }
-
-    @Test func setSelectedIndexSnapsAwayFromDivider() {
-        let model = RepoSelectorModel()
-        let rows: [RepoSelectorRow] = [
-            .repo(project("a"), indices: []),
-            .divider(label: "All repositories"),
-            .repo(project("b"), indices: []),
-        ]
-        model.setSelectedIndex(1, in: rows)  // divider; snap to next selectable
-        #expect(model.selectedIndex == 2)
+        model.setSelectedIndex(0, in: rows)
+        #expect(model.selectedIndex == 1)
     }
 
     @Test func changingQueryResetsSelectionToZero() {
-        // Without this reset, a user could move selection down then type a
-        // filter that shrinks the list and inadvertently activate the
-        // trailing "+ New worktree…" action.
         let model = RepoSelectorModel()
+        let w1 = worktree("w1", projectId: "p1")
         let rows: [RepoSelectorRow] = [
-            .repo(project("a"), indices: []),
-            .repo(project("b"), indices: []),
+            .worktree(w1, indices: [], isCurrent: false),
+            .worktree(w1, indices: [], isCurrent: false)
         ]
         model.setSelectedIndex(1, in: rows)
         #expect(model.selectedIndex == 1)
@@ -202,129 +326,27 @@ struct RepoSelectorModelTests {
         #expect(model.selectedIndex == 0)
     }
 
-    // MARK: - Push / pop
-
-    @Test func pushRepoSwitchesStepAndResetsQuery() {
-        let model = RepoSelectorModel()
-        model.query = "ala"
-        model.pushRepo(projectId: "p1")
-        #expect(model.step == .worktrees(projectId: "p1"))
-        #expect(model.query == "")
-        #expect(model.selectedIndex == 0)
-    }
-
-    @Test func popToReposRestoresQueryAndStep() {
-        let model = RepoSelectorModel()
-        model.query = "ala"
-        let e = env(projects: [project("p1", name: "alas"), project("p2", name: "other")])
-        _ = model.rows(environment: e)
-        model.setSelectedIndex(0, in: model.rows(environment: e))
-        model.pushRepo(projectId: "p1")
-        model.popToRepos()
-        #expect(model.step == .repos)
-        #expect(model.query == "ala")
-        #expect(model.selectedIndex == 0)
-    }
-
-    // MARK: - Step 2 rows
-
-    @Test func step2EmptyQueryListsRecentsThenRestThenAction() {
-        let model = RepoSelectorModel()
-        var r = RepoSelectorRecents()
-        r.bumpWorktree("w3", in: "p1")
-        r.bumpWorktree("w1", in: "p1")  // most recent
-        let wts = [
-            worktree("w1", projectId: "p1"),
-            worktree("w2", projectId: "p1"),
-            worktree("w3", projectId: "p1"),
-        ]
-        let e = env(
-            projects: [project("p1")],
-            worktrees: ["p1": wts],
-            recents: r
-        )
-        model.pushRepo(projectId: "p1")
-        let rows = model.rows(environment: e)
-        #expect(rows == [
-            .worktree(wts[0], indices: []),                                    // w1 (most recent)
-            .worktree(wts[2], indices: []),                                    // w3 (next recent)
-            .worktree(wts[1], indices: []),                                    // w2 (rest, sidebar order)
-            .divider(label: ""),
-            .action(.newWorktreeForRepo(projectId: "p1")),
-        ])
-    }
-
-    @Test func step2NonEmptyQueryFiltersAndKeepsActionRow() {
-        let model = RepoSelectorModel()
-        let wts = [
-            worktree("w1", projectId: "p1", branch: "main"),
-            worktree("w2", projectId: "p1", branch: "feature/login"),
-            worktree("w3", projectId: "p1", branch: "feature/repo-selector"),
-        ]
-        let e = env(projects: [project("p1")], worktrees: ["p1": wts])
-        model.pushRepo(projectId: "p1")
-        model.query = "feat"
-        let rows = model.rows(environment: e)
-        let branches: [String] = rows.compactMap {
-            if case .worktree(let w, _) = $0 { return w.branch } else { return nil }
-        }
-        #expect(branches.contains("feature/login"))
-        #expect(branches.contains("feature/repo-selector"))
-        #expect(!branches.contains("main"))
-        // The action row remains at the bottom regardless of query.
-        #expect(rows.last == .action(.newWorktreeForRepo(projectId: "p1")))
-    }
-
-    @Test func step2NoMatchesOmitsDividerSoActionRowIsTheDefault() {
-        // When the filter excludes every worktree, the divider would otherwise
-        // land at row 0 (because the leading list is empty) and swallow the
-        // default selection. The action row must remain the only thing in the
-        // list so Return on selectedIndex == 0 still creates a new worktree.
-        let model = RepoSelectorModel()
-        let wts = [worktree("w1", projectId: "p1", branch: "main")]
-        let e = env(projects: [project("p1")], worktrees: ["p1": wts])
-        model.pushRepo(projectId: "p1")
-        model.query = "nope"
-        let rows = model.rows(environment: e)
-        #expect(rows == [.action(.newWorktreeForRepo(projectId: "p1"))])
-    }
-
     // MARK: - Activation
 
-    @Test func activateProjectWithMultipleWorktreesPushesNoFocusNoRecents() {
-        let model = RepoSelectorModel()
-        var focused: String? = nil
-        var writtenRecents: RepoSelectorRecents? = nil
-        let wts = [
-            worktree("w1", projectId: "p1"),
-            worktree("w2", projectId: "p1"),
-        ]
-        var e = env(projects: [project("p1")], worktrees: ["p1": wts])
-        e.focusWorktree = { focused = $0 }
-        e.writeRecents = { writtenRecents = $0 }
-
-        let rows = model.rows(environment: e)
-        model.setSelectedIndex(0, in: rows)
-        let result = model.activate(rows: rows, environment: e)
-
-        #expect(result == .pushed(projectId: "p1"))
-        #expect(model.step == .worktrees(projectId: "p1"))
-        #expect(focused == nil)
-        #expect(writtenRecents == nil)
-    }
-
-    @Test func activateProjectWithOneWorktreeFocusesClosesAndBumpsRecents() {
+    @Test func activateWorktreeFocusesClosesAndBumpsRecents() {
         let model = RepoSelectorModel()
         model.isOpen = true
         var focused: String? = nil
         var writtenRecents: RepoSelectorRecents? = nil
-        let wts = [worktree("w1", projectId: "p1")]
-        var e = env(projects: [project("p1")], worktrees: ["p1": wts])
+        let w1 = worktree("w1", projectId: "p1")
+        var e = env(projects: [project("p1")], worktrees: ["p1": [w1]])
         e.focusWorktree = { focused = $0 }
         e.writeRecents = { writtenRecents = $0 }
 
         let rows = model.rows(environment: e)
-        model.setSelectedIndex(0, in: rows)
+        // First selectable row is the worktree (under the projectHeader).
+        guard let widx = rows.firstIndex(where: {
+            if case .worktree = $0 { return true } else { return false }
+        }) else {
+            Issue.record("expected a worktree row")
+            return
+        }
+        model.setSelectedIndex(widx, in: rows)
         let result = model.activate(rows: rows, environment: e)
 
         #expect(result == .focused(worktreeId: "w1"))
@@ -334,82 +356,61 @@ struct RepoSelectorModelTests {
         #expect(writtenRecents?.worktreeIdsByProject["p1"] == ["w1"])
     }
 
-    @Test func activateProjectWithZeroWorktreesOpensNewWorktreeFlow() {
+    @Test func activateNewWorktreeForRepoDelegatesAndCloses() {
         let model = RepoSelectorModel()
         model.isOpen = true
-        var focused: String? = nil
-        var writtenRecents: RepoSelectorRecents? = nil
         var openedFor: String? = nil
-        var e = env(projects: [project("p1")], worktrees: ["p1": []])
-        e.focusWorktree = { focused = $0 }
-        e.writeRecents = { writtenRecents = $0 }
+        var e = env(projects: [project("p1")], worktrees: ["p1": [worktree("w1", projectId: "p1")]])
         e.openNewWorktree = { openedFor = $0 }
 
         let rows = model.rows(environment: e)
-        model.setSelectedIndex(0, in: rows)
+        guard let aidx = rows.firstIndex(where: {
+            if case .action(.newWorktreeForRepo) = $0 { return true } else { return false }
+        }) else {
+            Issue.record("expected a newWorktreeForRepo action")
+            return
+        }
+        model.setSelectedIndex(aidx, in: rows)
         let result = model.activate(rows: rows, environment: e)
 
         #expect(result == .openedNewWorktree(projectId: "p1"))
         #expect(openedFor == "p1")
         #expect(model.isOpen == false)
-        #expect(focused == nil)
-        #expect(writtenRecents == nil)
     }
 
-    @Test func activateWorktreeRowFocusesAndBumpsBothRecents() {
+    @Test func activateNewProjectDelegatesAndCloses() {
         let model = RepoSelectorModel()
         model.isOpen = true
-        var focused: String? = nil
-        var writtenRecents: RepoSelectorRecents? = nil
-        let wts = [worktree("w1", projectId: "p1"), worktree("w2", projectId: "p1")]
-        var e = env(projects: [project("p1")], worktrees: ["p1": wts])
-        e.focusWorktree = { focused = $0 }
-        e.writeRecents = { writtenRecents = $0 }
+        var opened = false
+        var e = env(projects: [project("p1")], worktrees: ["p1": [worktree("w1", projectId: "p1")]])
+        e.openNewProject = { opened = true }
 
-        model.pushRepo(projectId: "p1")
         let rows = model.rows(environment: e)
-        // index 1 is w2 in this list (w1 first since no recents)
-        model.setSelectedIndex(1, in: rows)
+        guard let idx = rows.firstIndex(of: .action(.newProject)) else {
+            Issue.record("expected a newProject action")
+            return
+        }
+        model.setSelectedIndex(idx, in: rows)
         let result = model.activate(rows: rows, environment: e)
 
-        #expect(result == .focused(worktreeId: "w2"))
-        #expect(focused == "w2")
-        #expect(model.isOpen == false)
-        #expect(writtenRecents?.projectIds == ["p1"])
-        #expect(writtenRecents?.worktreeIdsByProject["p1"] == ["w2"])
-    }
-
-    @Test func activateNewWorktreeActionDelegatesAndCloses() {
-        let model = RepoSelectorModel()
-        model.isOpen = true
-        var openedFor: String? = nil
-        var e = env(projects: [project("p1")], worktrees: ["p1": [worktree("w1", projectId: "p1"), worktree("w2", projectId: "p1")]])
-        e.openNewWorktree = { openedFor = $0 }
-
-        model.pushRepo(projectId: "p1")
-        let rows = model.rows(environment: e)
-        // last row is the action
-        model.setSelectedIndex(rows.count - 1, in: rows)
-        let result = model.activate(rows: rows, environment: e)
-
-        #expect(result == .openedNewWorktree(projectId: "p1"))
-        #expect(openedFor == "p1")
+        #expect(result == .openedNewProject)
+        #expect(opened)
         #expect(model.isOpen == false)
     }
 
     @Test func activateNoProjectsHintDelegatesToNewProject() {
         let model = RepoSelectorModel()
         model.isOpen = true
-        var openedNewProject = false
+        var opened = false
         var e = env(projects: [])
-        e.openNewProject = { openedNewProject = true }
+        e.openNewProject = { opened = true }
 
         let rows = model.rows(environment: e)
         model.setSelectedIndex(0, in: rows)
         let result = model.activate(rows: rows, environment: e)
 
         #expect(result == .openedNewProject)
-        #expect(openedNewProject)
+        #expect(opened)
         #expect(model.isOpen == false)
     }
 }

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -200,6 +200,71 @@ struct RepoSelectorModelTests {
         #expect(recentIds == ["w4", "w3", "w2", "w1"])
     }
 
+    @Test func emptyQueryBackfillsRecentFromLegacyPerProjectListsWhenFlatRefsEmpty() {
+        // Upgrade case: a config written before `recentWorktreeRefs` existed
+        // only carries `projectIds` + `worktreeIdsByProject`. The RECENT
+        // section should still populate (round-robin interleaved across
+        // projects in projectIds order) instead of being empty until the
+        // next focus.
+        let model = RepoSelectorModel()
+        let pA = project("A")
+        let pB = project("B")
+        let aWts: [Worktree] = (1...3).map { worktree("a\($0)", projectId: "A", branch: "A/\($0)") }
+        let bWts: [Worktree] = (1...2).map { worktree("b\($0)", projectId: "B", branch: "B/\($0)") }
+        var r = RepoSelectorRecents()
+        // Legacy shape — `recentWorktreeRefs` left empty on purpose.
+        r.projectIds = ["B", "A"]  // B is the most recently touched project
+        r.worktreeIdsByProject = ["A": ["a1", "a2", "a3"], "B": ["b1", "b2"]]
+        let e = env(
+            projects: [pA, pB],
+            worktrees: ["A": aWts, "B": bWts],
+            recents: r
+        )
+        let rows = model.rows(environment: e)
+        let recentIds: [String] = rows
+            .dropFirst()  // skip .recentHeader
+            .prefix(while: { row in
+                if case .projectHeader = row { return false }
+                return true
+            })
+            .compactMap { if case .worktree(let w, _, _) = $0 { return w.id } else { return nil } }
+        // Round-robin from projectIds order ["B", "A"]:
+        //   slot 0: b1, a1
+        //   slot 1: b2, a2
+        //   slot 2: a3   (B exhausted)
+        // Cap is 5, so all of these fit.
+        #expect(recentIds == ["b1", "a1", "b2", "a2", "a3"])
+    }
+
+    @Test func emptyQueryDoesNotBackfillWhenFlatRefsArePopulated() {
+        // Once `recentWorktreeRefs` exists, it's authoritative — the
+        // backfill must not contribute.
+        let model = RepoSelectorModel()
+        let pA = project("A")
+        let pB = project("B")
+        let aWts = [worktree("a1", projectId: "A", branch: "A/1")]
+        let bWts = [worktree("b1", projectId: "B", branch: "B/1")]
+        var r = RepoSelectorRecents()
+        r.projectIds = ["A", "B"]
+        r.worktreeIdsByProject = ["A": ["a1"], "B": ["b1"]]
+        // Only B's worktree in the flat list — A's a1 must not be backfilled.
+        r.recentWorktreeRefs = [.init(projectId: "B", worktreeId: "b1")]
+        let e = env(
+            projects: [pA, pB],
+            worktrees: ["A": aWts, "B": bWts],
+            recents: r
+        )
+        let rows = model.rows(environment: e)
+        let recentIds: [String] = rows
+            .dropFirst()
+            .prefix(while: { row in
+                if case .projectHeader = row { return false }
+                return true
+            })
+            .compactMap { if case .worktree(let w, _, _) = $0 { return w.id } else { return nil } }
+        #expect(recentIds == ["b1"])
+    }
+
     @Test func emptyQueryProjectSectionOrdersByRecencyThenAlpha() {
         let model = RepoSelectorModel()
         let p1 = project("p1")

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -121,26 +121,83 @@ struct RepoSelectorModelTests {
         #expect(!rows.contains(.recentHeader))
     }
 
-    @Test func emptyQueryRecentsLimitsToFive() {
+    @Test func emptyQueryRecentsLimitsToFiveAcrossMultipleProjects() {
+        // Two projects, each with several recents. Pumping the flat global
+        // recents list past 5 must still produce exactly 5 RECENT rows —
+        // this exercises the model's `recentLimit` independently of the
+        // per-project store cap.
         let model = RepoSelectorModel()
-        let wts: [Worktree] = (1...7).map { worktree("w\($0)", projectId: "p1", branch: "b\($0)") }
+        let p1 = project("p1")
+        let p2 = project("p2")
+        let p1Wts: [Worktree] = (1...4).map {
+            worktree("p1-w\($0)", projectId: "p1", branch: "p1/b\($0)")
+        }
+        let p2Wts: [Worktree] = (1...4).map {
+            worktree("p2-w\($0)", projectId: "p2", branch: "p2/b\($0)")
+        }
         var r = RepoSelectorRecents()
         r.bumpProject("p1")
-        // bump in reverse so w1 ends up most recent
-        for w in wts.reversed() { r.bumpWorktree(w.id, in: "p1") }
-        // The store caps at 5 per project (see RepoSelectorRecents.worktreeCapPerProject)
-        // and the model caps at 5 across the whole RECENT section. Either bound is
-        // enough to keep this test honest; with one project both bounds apply.
+        r.bumpProject("p2")
+        // Interleaved bumps across projects so the flat list is genuinely
+        // cross-project. Final order (newest first):
+        //   p2-w4, p1-w4, p2-w3, p1-w3, p2-w2, p1-w2, p2-w1, p1-w1
+        for i in 1...4 {
+            r.bumpWorktree("p1-w\(i)", in: "p1")
+            r.bumpWorktree("p2-w\(i)", in: "p2")
+        }
         let e = env(
-            projects: [project("p1")],
-            worktrees: ["p1": wts],
+            projects: [p1, p2],
+            worktrees: ["p1": p1Wts, "p2": p2Wts],
             recents: r
         )
         let rows = model.rows(environment: e)
+        // Take the RECENT section: everything between `.recentHeader` and
+        // the first `.projectHeader`.
+        guard rows.first == .recentHeader else {
+            Issue.record("expected RECENT header at row 0, got \(rows.first as Any)")
+            return
+        }
         let recentWorktrees: [Worktree] = rows
-            .prefix(while: { $0 != .projectHeader(projectId: "p1") })
+            .dropFirst()
+            .prefix(while: { row in
+                if case .projectHeader = row { return false }
+                return true
+            })
             .compactMap { if case .worktree(let w, _, _) = $0 { return w } else { return nil } }
+        // Exactly the global cap — neither bucketed by project nor over-long.
         #expect(recentWorktrees.count == 5)
+        // Order is strict global recency, not project-bucketed.
+        #expect(recentWorktrees.map(\.id) == ["p2-w4", "p1-w4", "p2-w3", "p1-w3", "p2-w2"])
+    }
+
+    @Test func emptyQueryRecentSectionIsGloballyOrderedNotProjectBucketed() {
+        // Spec example: A/w1 → A/w2 → B/w3 → A/w4 ⇒ [w4, w3, w2, w1].
+        let model = RepoSelectorModel()
+        let pA = project("A")
+        let pB = project("B")
+        let aW1 = worktree("w1", projectId: "A", branch: "A/w1")
+        let aW2 = worktree("w2", projectId: "A", branch: "A/w2")
+        let aW4 = worktree("w4", projectId: "A", branch: "A/w4")
+        let bW3 = worktree("w3", projectId: "B", branch: "B/w3")
+        var r = RepoSelectorRecents()
+        r.bumpWorktree("w1", in: "A")
+        r.bumpWorktree("w2", in: "A")
+        r.bumpWorktree("w3", in: "B")
+        r.bumpWorktree("w4", in: "A")
+        let e = env(
+            projects: [pA, pB],
+            worktrees: ["A": [aW1, aW2, aW4], "B": [bW3]],
+            recents: r
+        )
+        let rows = model.rows(environment: e)
+        let recentIds: [String] = rows
+            .dropFirst()  // skip .recentHeader
+            .prefix(while: { row in
+                if case .projectHeader = row { return false }
+                return true
+            })
+            .compactMap { if case .worktree(let w, _, _) = $0 { return w.id } else { return nil } }
+        #expect(recentIds == ["w4", "w3", "w2", "w1"])
     }
 
     @Test func emptyQueryProjectSectionOrdersByRecencyThenAlpha() {

--- a/AlasTests/RepoSelectorRecentsTests.swift
+++ b/AlasTests/RepoSelectorRecentsTests.swift
@@ -52,4 +52,67 @@ struct RepoSelectorRecentsTests {
         let r = RepoSelectorRecents()
         #expect(r.liveWorktreeIds(in: "missing", validWorktreeIds: ["w1"]) == [])
     }
+
+    // MARK: - Flat global recents (recentWorktreeRefs)
+
+    @Test func bumpWorktreeUpdatesRecentWorktreeRefsAcrossProjects() {
+        var r = RepoSelectorRecents()
+        r.bumpWorktree("w1", in: "A")
+        r.bumpWorktree("w2", in: "A")
+        r.bumpWorktree("w3", in: "B")
+        r.bumpWorktree("w4", in: "A")
+        // Newest first; cross-project order is preserved (NOT bucketed by project).
+        #expect(r.recentWorktreeRefs == [
+            .init(projectId: "A", worktreeId: "w4"),
+            .init(projectId: "B", worktreeId: "w3"),
+            .init(projectId: "A", worktreeId: "w2"),
+            .init(projectId: "A", worktreeId: "w1"),
+        ])
+    }
+
+    @Test func bumpWorktreeDedupesByProjectAndWorktreePair() {
+        var r = RepoSelectorRecents()
+        r.bumpWorktree("w1", in: "A")
+        r.bumpWorktree("w1", in: "B")  // different project; both entries kept
+        r.bumpWorktree("w1", in: "A")  // moves A/w1 back to the front
+        #expect(r.recentWorktreeRefs == [
+            .init(projectId: "A", worktreeId: "w1"),
+            .init(projectId: "B", worktreeId: "w1"),
+        ])
+    }
+
+    @Test func bumpWorktreeCapsRecentWorktreeRefsAtFive() {
+        var r = RepoSelectorRecents()
+        for i in 1...7 {
+            r.bumpWorktree("w\(i)", in: "A")
+        }
+        #expect(r.recentWorktreeRefs.count == RepoSelectorRecents.recentWorktreeRefCap)
+        #expect(r.recentWorktreeRefs.map(\.worktreeId) == ["w7", "w6", "w5", "w4", "w3"])
+    }
+
+    @Test func liveRecentWorktreeRefsFiltersDanglingByPair() {
+        var r = RepoSelectorRecents()
+        r.bumpWorktree("w1", in: "A")
+        r.bumpWorktree("w2", in: "B")
+        r.bumpWorktree("w3", in: "A")
+        // B/w2 visible; A/w1 not visible (dropped); A/w3 visible.
+        let live = r.liveRecentWorktreeRefs(projectsWithVisibleWorktrees: [
+            "A": ["w3"],
+            "B": ["w2"],
+        ])
+        #expect(live == [
+            .init(projectId: "A", worktreeId: "w3"),
+            .init(projectId: "B", worktreeId: "w2"),
+        ])
+    }
+
+    @Test func liveRecentWorktreeRefsDropsRefsForUnknownProject() {
+        var r = RepoSelectorRecents()
+        r.bumpWorktree("w1", in: "A")
+        r.bumpWorktree("w2", in: "missing")
+        let live = r.liveRecentWorktreeRefs(projectsWithVisibleWorktrees: [
+            "A": ["w1"],
+        ])
+        #expect(live == [.init(projectId: "A", worktreeId: "w1")])
+    }
 }


### PR DESCRIPTION
## Summary

- Collapses the ⌘K dialog from a two-step drill-down (pick repo → pick worktree) into a single surface listing every worktree across every project: grouped by project with a `RECENT` section on top when the query is empty, flat fuzzy-ranked list while filtering.
- Row visuals adopt ⌘P's `FileResultRow` styling — sidebar `RepoDot` squircle, branch name + dirty status + project capsule, accent-soft selection bg with a 2pt accent left bar, `↵` kbd hint on the selected row. The dialog widened from 480 → 720 px to match ⌘P.
- Adds a `recentWorktreeRefs: [(projectId, worktreeId)]` field to `RepoSelectorRecents` so `RECENT` reflects true cross-project recency rather than a per-project bucketed view. Additive Codable change, permissive decode — old configs load unchanged.
- Marks the currently-focused worktree with a small accent dot and a slightly bolder branch in both its `RECENT` spot and its project section.
- Fixes a hover-vs-scroll feedback loop where `scrollTo(_, anchor: .center)` re-centered the selected row on every arrow press, moving the list under a stationary cursor and causing the new row under it to claim hover and snap selection back. The fix drops the `.center` anchor and guards `onHover` with `NSEvent.mouseLocation`.

## Test plan

- [ ] `xcodegen && xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build` — green
- [ ] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RepoSelectorModelTests -only-testing:AlasTests/RepoSelectorRecentsTests test` — green
- [ ] Open ⌘K — dialog is 720 px, RECENT header at top, per-project sections below ordered by recency, each ending with `+ New worktree in <project>…`, trailing rule + `+ Add project…`
- [ ] Current worktree shows the accent dot and bolder branch in both RECENT and its project section
- [ ] Type a filter — headers and action rows disappear, list is flat fuzzy-ranked; clear the filter and selection lands on a worktree row, not on the RECENT header
- [ ] Arrow up/down skips all header kinds; mouse hover updates selection on actual motion but does not fight keyboard navigation when the list scrolls
- [ ] Activations: worktree row focuses; `+ New worktree in X` opens the new-worktree dialog for X; `+ Add project…` opens the add-project dialog
- [ ] ⌘P unchanged