### PR TITLE
Stabilize right sidebar tree chevrons

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
+		188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
@@ -798,6 +799,7 @@
 		A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabStateTests.swift; sourceTree = "<group>"; };
 		A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileTypeTests.swift; sourceTree = "<group>"; };
 		A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClient.swift; sourceTree = "<group>"; };
+		A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChevronStabilityTests.swift; sourceTree = "<group>"; };
 		A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDirectionTests.swift; sourceTree = "<group>"; };
 		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -1053,6 +1055,7 @@
 				71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */,
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
+				A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */,
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
 				E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */,
 				7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */,
@@ -2348,6 +2351,7 @@
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
+				188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */,
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,
 				01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */,
 				1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */,

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -40,8 +40,9 @@ struct FilesTabView: View {
                         HStack(spacing: 6) {
                             if canExpand {
                                 Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+                                    .frame(width: 14, height: 14)
                             } else {
-                                Color.clear.frame(width: 10, height: 10)
+                                Color.clear.frame(width: 14, height: 14)
                             }
                             Icon(name: "folder", size: 11, color: folderColor(for: node, open: open))
                             Text(node.name)

--- a/Alas/Sources/Right/SectionHeader.swift
+++ b/Alas/Sources/Right/SectionHeader.swift
@@ -15,6 +15,7 @@ struct SectionHeader<Trailing: View>: View {
         Button(action: onToggle) {
             HStack(spacing: 6) {
                 Icon(name: expanded ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+                    .frame(width: 14, height: 14)
                 Text(title.uppercased())
                     .font(.system(size: 11, weight: .semibold))
                     .tracking(0.5)

--- a/Alas/Sources/Right/SubHeader.swift
+++ b/Alas/Sources/Right/SubHeader.swift
@@ -15,6 +15,7 @@ struct SubHeader: View {
         Button(action: onToggle) {
             HStack(spacing: 5) {
                 Icon(name: expanded ? "chev-down" : "chev-right", size: 9, color: theme.color("fg-faint"))
+                    .frame(width: 12, height: 12)
                 Text(title)
                     .font(.system(size: 10.5, weight: .semibold))
                     .foregroundColor(theme.color("fg-muted"))

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -182,6 +182,7 @@ struct WorkingTreeSectionView: View {
                     } label: {
                         HStack(spacing: 6) {
                             Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
+                                .frame(width: 14, height: 14)
                             Icon(name: "folder", size: 11, color: open ? theme.color("accent") : theme.color("fg-dim"))
                             Text(node.name)
                                 .font(.system(size: 11.5, design: .monospaced))

--- a/AlasTests/ChevronStabilityTests.swift
+++ b/AlasTests/ChevronStabilityTests.swift
@@ -1,0 +1,84 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+/// Verifies that the fixed-frame chevron approach keeps the title text
+/// anchored at the same horizontal position when toggling expand/collapse.
+/// Mirrors the pixel-scan strategy in ``RepoGroupViewLayoutTests``.
+@Suite(.serialized)
+@MainActor
+struct ChevronStabilityTests {
+    // MARK: - SectionHeader
+
+    @Test func sectionHeaderTitleDoesNotShiftWhenToggled() throws {
+        let collapsedX = try titleMinX(sectionHeaderExpanded: false)
+        let expandedX = try titleMinX(sectionHeaderExpanded: true)
+
+        #expect(collapsedX == expandedX)
+    }
+
+    // MARK: - SubHeader
+
+    @Test func subHeaderTitleDoesNotShiftWhenToggled() throws {
+        let collapsedX = try titleMinX(subHeaderExpanded: false)
+        let expandedX = try titleMinX(subHeaderExpanded: true)
+
+        #expect(collapsedX == expandedX)
+    }
+
+    // MARK: - Helpers
+
+    private func titleMinX(sectionHeaderExpanded expanded: Bool) throws -> Int {
+        let view = SectionHeader(
+            title: "Working tree",
+            count: 3,
+            expanded: expanded,
+            onToggle: {}
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        // At @2x the chevron frame (14pt) + padding (12pt) + spacing (6pt) = 32pt → 64px.
+        // Chevron glyph can overflow up to ~48px. Scan from 50 to clear it.
+        return try firstOpaqueX(view: view, width: 260, height: 40, scanFromPixel: 50)
+    }
+
+    private func titleMinX(subHeaderExpanded expanded: Bool) throws -> Int {
+        let view = SubHeader(
+            title: "Staged",
+            count: 2,
+            expanded: expanded,
+            onToggle: {}
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        // At @2x: padding (12pt) + frame (12pt) + spacing (5pt) = 29pt → 58px.
+        // Scan from 46 to clear chevron glyph overflow.
+        return try firstOpaqueX(view: view, width: 260, height: 34, scanFromPixel: 46)
+    }
+
+    /// Renders a view to a @2x bitmap and returns the min-X (in device pixels)
+    /// of the first opaque pixel at or past ``scanFromPixel``, i.e. the
+    /// leftmost edge of the title text.
+    private func firstOpaqueX<V: View>(view: V, width: Int, height: Int, scanFromPixel: Int) throws -> Int {
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: width, height: height)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let bitmap = try #require(
+            controller.view.bitmapImageRepForCachingDisplay(in: controller.view.bounds)
+        )
+        controller.view.cacheDisplay(in: controller.view.bounds, to: bitmap)
+
+        var minX: Int?
+        for y in 0..<bitmap.pixelsHigh {
+            for x in scanFromPixel..<bitmap.pixelsWide {
+                guard let c = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.sRGB) else { continue }
+                if c.alphaComponent > 0.5 {
+                    minX = min(minX ?? x, x)
+                }
+            }
+        }
+        return try #require(minX)
+    }
+}


### PR DESCRIPTION
## Summary
- Stabilize right-sidebar Files and Changes tree chevron frames so expanded/collapsed glyph changes do not shift layout
- Match the existing fixed-frame chevron pattern used by repo group rows
- Add focused pixel-scan coverage for title position stability

## Testing
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test --filter ChevronStabilityTests