### PR TITLE
Replace tab activity dot with tinted terminal icon

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
 		6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */; };
 		6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795056B6AD803D2B555FC866 /* RightPaneStore.swift */; };
+		6DDB5FC604A28D699350C3BD /* TabActivityIconTintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */; };
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
@@ -513,6 +514,7 @@
 		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
 		05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
+		07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityIconTintTests.swift; sourceTree = "<group>"; };
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
 		09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffMode.swift; sourceTree = "<group>"; };
@@ -1176,6 +1178,7 @@
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
 				CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */,
 				D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */,
+				07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
 				4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */,
@@ -2487,6 +2490,7 @@
 				3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */,
 				CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */,
 				B092D71B3D727B89EAF5D753 /* SymbolsFeatureTests.swift in Sources */,
+				6DDB5FC604A28D699350C3BD /* TabActivityIconTintTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
 				BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */,

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -115,7 +115,7 @@ private struct TabButton: View {
     var body: some View {
         HStack(spacing: 6) {
             Icon(name: tab.iconName, size: 11,
-                 color: active ? theme.color("accent") : theme.color("fg-faint"))
+                 color: iconColor)
             Text(tab.title)
                 .font(.system(size: 11.5))
                 .foregroundColor(active ? theme.color("fg") : theme.color("fg-dim"))
@@ -124,10 +124,6 @@ private struct TabButton: View {
                 Image(systemName: "lock.fill")
                     .font(.system(size: 9))
                     .foregroundStyle(theme.color("fg-faint"))
-            }
-            if let info = harnessInfo {
-                Circle().fill(stateColor(info.state)).frame(width: 6, height: 6)
-                    .opacity(info.state == .busy ? 0.85 : 1)
             }
             if showClose {
                 Button(action: onClose) {
@@ -165,6 +161,13 @@ private struct TabButton: View {
         )
         .contentShape(Rectangle())
         .onTapGesture(perform: onActivate)
+    }
+
+    private var iconColor: Color {
+        if let info = harnessInfo, info.state != .idle {
+            return stateColor(info.state)
+        }
+        return active ? theme.color("accent") : theme.color("fg-faint")
     }
 
     private func stateColor(_ s: ActivityState) -> Color {

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -164,7 +164,7 @@ private struct TabButton: View {
     }
 
     private var iconColor: Color {
-        if let info = harnessInfo, info.state != .idle {
+        if let info = harnessInfo {
             return stateColor(info.state)
         }
         return active ? theme.color("accent") : theme.color("fg-faint")

--- a/AlasTests/TabActivityIconTintTests.swift
+++ b/AlasTests/TabActivityIconTintTests.swift
@@ -1,0 +1,79 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+/// Verifies that tab width remains stable across all activity states now that
+/// the separate activity dot has been replaced by tinting the terminal icon.
+@Suite(.serialized)
+@MainActor
+struct TabActivityIconTintTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test func tabWidthIsStableAcrossActivityStates() {
+        let tab = Tab.terminal(TerminalTabState(id: "t1", title: "bash", sessionId: "s1"))
+        let states: [ActivityState?] = [nil, .idle, .busy, .awaitingInput, .permissionRequest]
+        let widths = states.map { state in
+            tabBarWidth(tab: tab, activityState: state)
+        }
+        // All widths must be identical — no layout shift from activity state changes.
+        for width in widths {
+            #expect(width == widths[0])
+        }
+    }
+
+    @Test func editorTabWidthIsStableWithAndWithoutHarness() {
+        let tab = Tab.editor(EditorTabState(
+            id: "e1",
+            title: "hello.swift",
+            relativePath: "hello.swift",
+            revealLine: nil,
+            revealCharacter: nil,
+            externalAbsolutePath: nil,
+            originatingRelativePath: nil,
+            markdownViewMode: nil,
+            markdownSplitFraction: nil
+        ))
+        let withoutHarness = tabBarWidth(tab: tab, activityState: nil)
+        let withHarness = tabBarWidth(tab: tab, activityState: .busy)
+        #expect(withoutHarness == withHarness)
+    }
+
+    // MARK: - Helpers
+
+    private func tabBarWidth(tab: Tab, activityState: ActivityState?) -> CGFloat {
+        let lookup: (TabID) -> (agent: AgentKind, state: ActivityState)? = { _ in
+            guard let state = activityState else { return nil }
+            return (agent: .codex, state: state)
+        }
+        let view = TabBarView(
+            tabs: [tab],
+            activeId: tab.id,
+            harnessLookup: lookup,
+            dirtyLookup: { _ in false },
+            onActivate: { _ in },
+            onClose: { _ in },
+            onCloseOthers: { _ in },
+            onCloseAll: { },
+            onCloseToLeft: { _ in },
+            onCloseToRight: { _ in },
+            onCopyPath: { _ in },
+            onCopyRelativePath: { _ in },
+            onRenameTerminal: { _ in },
+            onNewTerminal: { },
+            enabledAgents: [],
+            onLaunchAgent: { _ in },
+            onRevealRightSidebar: { },
+            rightSidebarHidden: false,
+            onMove: { _, _ in }
+        )
+        .environment(\.theme, currentTheme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 800, height: 34)
+        controller.view.layoutSubtreeIfNeeded()
+        return controller.view.fittingSize.width
+    }
+}

--- a/AlasTests/TabActivityIconTintTests.swift
+++ b/AlasTests/TabActivityIconTintTests.swift
@@ -8,12 +8,15 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct TabActivityIconTintTests {
+    private typealias AppTab = Alas.Tab
+    private typealias AppTabID = Alas.TabID
+
     private func currentTheme() -> Theme {
         try! ThemeStore().current
     }
 
     @Test func tabWidthIsStableAcrossActivityStates() {
-        let tab = Tab.terminal(TerminalTabState(id: "t1", title: "bash", sessionId: "s1"))
+        let tab = AppTab.terminal(TerminalTabState(id: "t1", title: "bash", sessionId: "s1"))
         let states: [ActivityState?] = [nil, .idle, .busy, .awaitingInput, .permissionRequest]
         let widths = states.map { state in
             tabBarWidth(tab: tab, activityState: state)
@@ -25,7 +28,7 @@ struct TabActivityIconTintTests {
     }
 
     @Test func editorTabWidthIsStableWithAndWithoutHarness() {
-        let tab = Tab.editor(EditorTabState(
+        let tab = AppTab.editor(EditorTabState(
             id: "e1",
             title: "hello.swift",
             relativePath: "hello.swift",
@@ -43,8 +46,8 @@ struct TabActivityIconTintTests {
 
     // MARK: - Helpers
 
-    private func tabBarWidth(tab: Tab, activityState: ActivityState?) -> CGFloat {
-        let lookup: (TabID) -> (agent: AgentKind, state: ActivityState)? = { _ in
+    private func tabBarWidth(tab: AppTab, activityState: ActivityState?) -> CGFloat {
+        let lookup: (AppTabID) -> (agent: AgentKind, state: ActivityState)? = { _ in
             guard let state = activityState else { return nil }
             return (agent: .codex, state: state)
         }


### PR DESCRIPTION
## Summary
- remove the separate tab activity dot
- tint the tab icon green/orange/neutral based on harness activity state
- add layout tests proving tab width stays stable across activity states
- preserve neutral tint for idle harness tabs after Codex review

## Tests
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/TabActivityIconTintTests test`
- Full local `xcodebuild ... test` was attempted, but local unrelated suites failed/stalled (`ImageFileTypeTests`, `WorktreeServiceTests.addSucceedsWhenLfsFilterIsMissing`) while the targeted tab tests passed.