### PR TITLE
Apply code font settings to diff panes

### DIFF
--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -114,6 +114,8 @@ struct CenterPaneView: View {
                             worktreePath: worktree.path,
                             relativePath: s.relativePath,
                             staged: s.staged,
+                            codeFontFamily: state.config.code.fontFamily,
+                            codeFontSize: CGFloat(state.config.code.fontSize),
                             onOpenFile: openAvailable
                                 ? { state.openFile(relativePath: s.relativePath, worktreeId: worktree.id) }
                                 : nil,

--- a/Alas/Sources/Center/CenterTypography.swift
+++ b/Alas/Sources/Center/CenterTypography.swift
@@ -22,6 +22,38 @@ enum CenterTypography {
     static func textLineSpacing(forFontSize size: CGFloat) -> CGFloat {
         (lineHeightMultiple - 1) * size * 1.2
     }
+
+    static func resolveCodeFont(family: String, size: CGFloat) -> NSFont {
+        guard !family.isEmpty else {
+            return .monospacedSystemFont(ofSize: size, weight: .regular)
+        }
+        // The picker stores family names (e.g. "JetBrains Mono"), but
+        // NSFont(name:size:) requires the PostScript name of a specific
+        // face ("JetBrainsMono-Regular"). Walk the family's members and
+        // pick the face closest to regular weight (NSFontManager weight 5).
+        let members = NSFontManager.shared.availableMembers(ofFontFamily: family) ?? []
+        if !members.isEmpty {
+            let sorted = members.sorted { lhs, rhs in
+                let lw = (lhs.count > 2 ? lhs[2] as? Int : nil) ?? 5
+                let rw = (rhs.count > 2 ? rhs[2] as? Int : nil) ?? 5
+                return abs(lw - 5) < abs(rw - 5)
+            }
+            if let psName = sorted.first?.first as? String,
+               let font = NSFont(name: psName, size: size) {
+                return font
+            }
+        }
+        if let font = NSFont(name: family, size: size) { return font }
+        let descriptor = NSFontDescriptor(fontAttributes: [.family: family])
+        if let font = NSFont(descriptor: descriptor, size: size) { return font }
+        return .monospacedSystemFont(ofSize: size, weight: .regular)
+    }
+
+    /// Build a SwiftUI `Font` from the user's code font config, using the
+    /// same family-name resolution as the editor's `NSTextView`.
+    static func codeFont(family: String, size: CGFloat) -> Font {
+        Font(resolveCodeFont(family: family, size: size))
+    }
 }
 
 extension View {

--- a/Alas/Sources/Center/Commit/CommitDiffView.swift
+++ b/Alas/Sources/Center/Commit/CommitDiffView.swift
@@ -8,6 +8,8 @@ struct CommitDiffView: View {
     let diff: ParsedDiff
     let loading: Bool
     let error: String?
+    var codeFontFamily: String = ""
+    var codeFontSize: CGFloat = 13
     let onOpenFile: (() -> Void)?
 
     @Environment(\.theme) private var theme
@@ -76,11 +78,11 @@ struct CommitDiffView: View {
         HStack(spacing: 6) {
             HStack(spacing: 6) {
                 Text((path as NSString).lastPathComponent)
-                    .font(.system(size: 12, design: .monospaced))
+                    .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
                     .foregroundColor(titleHovering ? theme.color("accent") : theme.color("fg"))
                 Text("·").foregroundColor(theme.color("fg-faint"))
                 Text((path as NSString).deletingLastPathComponent)
-                    .font(.system(size: 11))
+                    .font(.system(size: codeFontSize - 2))
                     .foregroundColor(titleHovering ? theme.color("accent") : theme.color("fg-dim"))
             }
             .contentShape(Rectangle())
@@ -107,7 +109,7 @@ struct CommitDiffView: View {
             ProgressView().padding()
         } else if let error {
             Text("Could not load diff for \(path): \(error)")
-                .font(.system(size: 11))
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 2))
                 .foregroundColor(theme.color("del"))
                 .padding()
         } else if diff.hunks.isEmpty {
@@ -118,7 +120,7 @@ struct CommitDiffView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(diff.hunks.enumerated()), id: \.offset) { (_, hunk) in
-                        HunkView(hunk: hunk, fileExtension: (path as NSString).pathExtension)
+                        HunkView(hunk: hunk, fileExtension: (path as NSString).pathExtension, codeFontFamily: codeFontFamily, codeFontSize: codeFontSize)
                     }
                 }
                 .padding(.vertical, 8)

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -85,6 +85,8 @@ struct CommitTabView: View {
                             diff: diff,
                             loading: loadingDiff,
                             error: diffError,
+                            codeFontFamily: appState.config.code.fontFamily,
+                            codeFontSize: CGFloat(appState.config.code.fontSize),
                             onOpenFile: openAvailable
                                 ? { appState.openFile(relativePath: path, worktreeId: worktreeId) }
                                 : nil

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -4,6 +4,8 @@ struct DiffTabView: View {
     let worktreePath: URL
     let relativePath: String
     let staged: Bool
+    var codeFontFamily: String = ""
+    var codeFontSize: CGFloat = 13
     let onOpenFile: (() -> Void)?
     let onRequestDiscardFile: (() -> Void)?
     @Environment(\.theme) var theme
@@ -81,7 +83,7 @@ struct DiffTabView: View {
             header
             if let error {
                 Text(error)
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 2))
                     .foregroundColor(theme.color("del"))
                     .padding(.horizontal, 14).padding(.vertical, 6)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -99,6 +101,8 @@ struct DiffTabView: View {
                             HunkView(
                                 hunk: hunk,
                                 fileExtension: (relativePath as NSString).pathExtension,
+                                codeFontFamily: codeFontFamily,
+                                codeFontSize: codeFontSize,
                                 onStage: actions.stage,
                                 onDiscard: actions.discard
                             )
@@ -138,7 +142,7 @@ struct DiffTabView: View {
     private var header: some View {
         HStack(spacing: 12) {
             Text((relativePath as NSString).lastPathComponent)
-                .font(.system(size: 12, design: .monospaced))
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
                 .foregroundColor(theme.color("fg"))
             if staged {
                 Text("STAGED")
@@ -150,7 +154,7 @@ struct DiffTabView: View {
             }
             Text("·").foregroundColor(theme.color("fg-faint"))
             Text((relativePath as NSString).deletingLastPathComponent)
-                .font(.system(size: 11.5))
+                .font(.system(size: codeFontSize - 1.5))
                 .foregroundColor(theme.color("fg-dim"))
             Spacer()
             if shouldShowChangeSummary(additions: totalAdd, deletions: totalDel) {
@@ -158,7 +162,7 @@ struct DiffTabView: View {
                     Text("+\(totalAdd)").foregroundColor(theme.color("add"))
                     Text("−\(totalDel)").foregroundColor(theme.color("del"))
                 }
-                .font(.system(size: 11.5, design: .monospaced))
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 1.5))
             }
             HStack(spacing: 4) {
                 if let onOpenFile {
@@ -301,6 +305,8 @@ struct DiffTabView: View {
 struct HunkView: View {
     let hunk: ParsedDiff.Hunk
     let fileExtension: String
+    var codeFontFamily: String = ""
+    var codeFontSize: CGFloat = 13
     var onStage:   (() -> Void)? = nil
     var onDiscard: (() -> Void)? = nil
     @Environment(\.theme) var theme
@@ -309,7 +315,7 @@ struct HunkView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 8) {
                 Text(hunk.header)
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(CenterTypography.codeFont(family: codeFontFamily, size: headerFontSize))
                     .foregroundColor(theme.color("fg-dim"))
                 Spacer(minLength: 8)
                 if onStage != nil {
@@ -331,7 +337,7 @@ struct HunkView: View {
                     Text(highlightedLine(line.text, ext: fileExtension))
                     Spacer(minLength: 0)
                 }
-                .font(.system(size: 12.5, design: .monospaced))
+                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
                 .padding(.horizontal, 14)
                 .centerPanelRowSpacing()
                 .background(rowBg(line))
@@ -414,6 +420,9 @@ struct HunkView: View {
         case .context: return .clear
         }
     }
+
+    /// The hunk header (@@…@@) is rendered slightly smaller than diff content.
+    private var headerFontSize: CGFloat { (codeFontSize * 0.85).rounded() }
 
     private func markerColor(_ l: ParsedDiff.Hunk.Line) -> Color {
         switch l.kind {

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -50,33 +50,7 @@ final class CodeEditorCoordinator {
     private let highlightSession = TreeSitterHighlighter.Session()
 
     static func resolveFont(family: String, size: CGFloat) -> NSFont {
-        guard !family.isEmpty else {
-            return .monospacedSystemFont(ofSize: size, weight: .regular)
-        }
-        // The picker stores family names (e.g. "JetBrains Mono"), but
-        // NSFont(name:size:) requires the PostScript name of a specific
-        // face ("JetBrainsMono-Regular"). Walk the family's members and
-        // pick the face closest to regular weight (NSFontManager weight 5)
-        // so multi-face families resolve to a real face instead of nil.
-        let members = NSFontManager.shared.availableMembers(ofFontFamily: family) ?? []
-        if !members.isEmpty {
-            let sorted = members.sorted { lhs, rhs in
-                let lw = (lhs.count > 2 ? lhs[2] as? Int : nil) ?? 5
-                let rw = (rhs.count > 2 ? rhs[2] as? Int : nil) ?? 5
-                return abs(lw - 5) < abs(rw - 5)
-            }
-            if let psName = sorted.first?.first as? String,
-               let font = NSFont(name: psName, size: size) {
-                return font
-            }
-        }
-        // Last-resort fallbacks: try the user's string verbatim (covers the
-        // case where they typed a PostScript name themselves), then a font
-        // descriptor by family, then the system default.
-        if let font = NSFont(name: family, size: size) { return font }
-        let descriptor = NSFontDescriptor(fontAttributes: [.family: family])
-        if let font = NSFont(descriptor: descriptor, size: size) { return font }
-        return .monospacedSystemFont(ofSize: size, weight: .regular)
+        CenterTypography.resolveCodeFont(family: family, size: size)
     }
 
     init(appState: AppState) {

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -106,6 +106,64 @@ struct DiffSelectableTextTests {
         #expect(controller.view != nil)
     }
 
+    // MARK: Code font configuration
+
+    @Test func codeFontResolutionReturnsMonospacedForEmptyFamily() {
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        #expect(font.isFixedPitch)
+        #expect(font.pointSize == 13)
+    }
+
+    @Test func codeFontResolutionMatchesEditorForNamedFamily() {
+        let diffFont = CenterTypography.resolveCodeFont(family: "SF Mono", size: 14)
+        let editorFont = CodeEditorCoordinator.resolveFont(family: "SF Mono", size: 14)
+        #expect(diffFont.fontName == editorFont.fontName)
+        #expect(diffFont.pointSize == editorFont.pointSize)
+    }
+
+    @Test func codeFontRendersForConfiguredFamilyName() {
+        let font = CenterTypography.codeFont(family: "SF Mono", size: 14)
+        #expect(font != Font.system(size: 14))
+    }
+
+    @Test func hunkViewRendersWithCustomFontSize() {
+        for size: CGFloat in [8, 13, 24, 64] {
+            let view = HunkView(hunk: sampleHunk(), fileExtension: "swift", codeFontFamily: "", codeFontSize: size)
+                .environment(\.theme, currentTheme())
+            let controller = NSHostingController(rootView: view)
+            controller.view.layoutSubtreeIfNeeded()
+            #expect(controller.view != nil)
+        }
+    }
+
+    @Test func hunkViewRendersWithCustomFontFamily() {
+        let view = HunkView(hunk: sampleHunk(), fileExtension: "swift", codeFontFamily: "Menlo", codeFontSize: 15)
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func commitDiffViewRendersWithCustomFont() {
+        let diff = ParsedDiff(hunks: [sampleHunk()])
+        let view = CommitDiffView(
+            worktreePath: URL(fileURLWithPath: "/tmp"),
+            sha: "abc1234",
+            file: sampleFile(),
+            path: "Sources/App.swift",
+            diff: diff,
+            loading: false,
+            error: nil,
+            codeFontFamily: "Menlo",
+            codeFontSize: 18,
+            onOpenFile: nil
+        )
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
     @Test func hunkViewWithPlainTextExtensionRendersWithoutCrashing() {
         let hunk = ParsedDiff.Hunk(
             header: "@@ -1,3 +1,3 @@",


### PR DESCRIPTION
## Summary
- thread Settings > Code font family and size into working-tree and commit diff panes
- share code font family resolution between editor text views and SwiftUI diff text
- keep diff header/stat fonts scaled from the configured code font size

## Testing
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffSelectableTextTests test

Full xcodebuild test was attempted but hung in a test-launched Alas.app process and was interrupted after 440s.