### PR TITLE
feat(right-pane): nudge when worktree is out of sync

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -427,6 +427,7 @@
 		DAD02DC484C697D856B0CD6A /* CommitComposerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D733701E36E13A7A23748A37 /* CommitComposerState.swift */; };
 		DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */; };
 		DC394B7740FAEBD2F8ACB61F /* LSPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */; };
+		DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */; };
 		DD18C5FF006D18BC66964D94 /* TerminalTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */; };
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
@@ -448,6 +449,7 @@
 		E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
 		E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */; };
+		E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */; };
 		E6CB573877637461E11CACAF /* InstallRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */; };
 		E703B4895A0337310A17FED6 /* GitService+ImageDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EFC853C0D2EB4AC2B01D9E /* GitService+ImageDiff.swift */; };
 		E7C047F37A5C7100149FED4A /* ImageDiffPairResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */; };
@@ -457,6 +459,7 @@
 		E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */; };
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */; };
+		EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
 		EE02460865C6A4ED1046B13F /* AgentLifecycleEventMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */; };
@@ -557,6 +560,7 @@
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
+		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
 		1DACC2D855F4316038CB40C7 /* CommitComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerView.swift; sourceTree = "<group>"; };
 		1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouterTests.swift; sourceTree = "<group>"; };
@@ -747,6 +751,7 @@
 		802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeView.swift; sourceTree = "<group>"; };
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
 		822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModel.swift; sourceTree = "<group>"; };
+		82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBehindStatusTests.swift; sourceTree = "<group>"; };
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
 		856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscardTests.swift; sourceTree = "<group>"; };
@@ -862,6 +867,7 @@
 		C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcherTests.swift; sourceTree = "<group>"; };
 		C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizingTests.swift; sourceTree = "<group>"; };
 		C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTabView.swift; sourceTree = "<group>"; };
+		C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowHeightTests.swift; sourceTree = "<group>"; };
 		C6CA79B71B4AA72697392702 /* NumstatParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParser.swift; sourceTree = "<group>"; };
 		C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
 		C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStrip.swift; sourceTree = "<group>"; };
@@ -1100,6 +1106,7 @@
 				6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */,
 				8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */,
 				35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */,
+				82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */,
 				F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */,
 				38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
@@ -1158,6 +1165,7 @@
 				3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */,
 				5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */,
 				B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */,
+				1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */,
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
 				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
@@ -1189,6 +1197,7 @@
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
+				C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
 				321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */,
@@ -2398,6 +2407,7 @@
 				D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */,
 				513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */,
 				881EB8E37CE9D947A2C74564 /* GitRefNameInputFilterTests.swift in Sources */,
+				EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */,
 				2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */,
 				1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,
@@ -2468,6 +2478,7 @@
 				8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */,
 				35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */,
 				FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */,
+				DCACB5B624BFFE7C50DA6C61 /* RightPaneStateSyncStatusTests.swift in Sources */,
 				57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */,
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
@@ -2501,6 +2512,7 @@
 				9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
+				E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
 				E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */,
 				98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */,

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -971,6 +971,17 @@ extension GitService {
         case revListFailed(stderr: String)
     }
 
+    /// Reads the current branch name for a worktree. Returns empty string
+    /// when HEAD is detached or the branch is unborn (no commits yet).
+    func currentBranch(worktreePath: URL) async throws -> String {
+        let result = try await Process.git(
+            ["symbolic-ref", "--short", "-q", "HEAD"],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else { return "" }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// Resolves the base ref to compare against for a given worktree.
     /// Returns nil when neither `origin/<base>` nor local `<base>` exists.
     /// `remote == nil` means "no fetch path; use the local ref as-is".

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -776,14 +776,28 @@ extension GitService {
             }
         }
 
-        // Step 2: If no upstream, try the base branch (if it resolves locally).
+        // Step 2: If no upstream, try the base branch. Prefer `origin/<base>`
+        // over local `<base>` — the remote-tracking ref is usually current
+        // after a fetch, while the local branch can be stale (especially in
+        // worktrees that never check out the base branch directly). This also
+        // matches the ref the rebase affordance targets via `resolveBaseRef`,
+        // so the Commits section stays consistent with what the user just
+        // rebased onto.
         var baseName: String? = nil
         if upstreamName == nil, let base = baseBranch, !base.isEmpty {
-            let verify = try await Process.git(
-                ["rev-parse", "--verify", "--quiet", base],
+            let origin = try await Process.git(
+                ["show-ref", "--verify", "--quiet", "refs/remotes/origin/\(base)"],
                 cwd: worktree
             )
-            if verify.exitCode == 0 { baseName = base }
+            if origin.exitCode == 0 {
+                baseName = "origin/\(base)"
+            } else {
+                let local = try await Process.git(
+                    ["show-ref", "--verify", "--quiet", "refs/heads/\(base)"],
+                    cwd: worktree
+                )
+                if local.exitCode == 0 { baseName = base }
+            }
         }
 
         // Step 3: If neither resolves, bail out.
@@ -937,5 +951,129 @@ extension GitService {
             ))
         }
         return commits
+    }
+}
+
+extension GitService {
+    /// One probe of HEAD's behind-count against an arbitrary ref. Used both
+    /// for "behind base" (origin/main) and "behind upstream" (origin/<branch>).
+    struct BehindStatus: Equatable, Sendable {
+        let ref: String      // e.g. "origin/main" or "origin/my-feature"
+        let sha: String      // SHA of ref at probe time
+        let count: Int       // git rev-list --count HEAD..<ref>
+        let probedAt: Date
+    }
+
+    /// Errors emitted by `behindStatus`. Either git invocation can fail
+    /// (e.g. ref disappeared between resolution and the probe).
+    enum BehindStatusError: Error, Equatable, Sendable {
+        case revParseFailed(stderr: String)
+        case revListFailed(stderr: String)
+    }
+
+    /// Resolves the base ref to compare against for a given worktree.
+    /// Returns nil when neither `origin/<base>` nor local `<base>` exists.
+    /// `remote == nil` means "no fetch path; use the local ref as-is".
+    func resolveBaseRef(
+        worktreePath: URL,
+        baseBranch: String
+    ) async throws -> (remote: String?, baseRef: String)? {
+        guard !baseBranch.isEmpty else { return nil }
+
+        // Prefer origin/<base>.
+        let originRef = "refs/remotes/origin/\(baseBranch)"
+        let originCheck = try await Process.git(
+            ["show-ref", "--verify", "--quiet", originRef],
+            cwd: worktreePath
+        )
+        if originCheck.exitCode == 0 {
+            return (remote: "origin", baseRef: "origin/\(baseBranch)")
+        }
+
+        // Fall back to local <base>.
+        let localCheck = try await Process.git(
+            ["show-ref", "--verify", "--quiet", "refs/heads/\(baseBranch)"],
+            cwd: worktreePath
+        )
+        if localCheck.exitCode == 0 {
+            return (remote: nil, baseRef: baseBranch)
+        }
+
+        return nil
+    }
+
+    /// Resolves the upstream tracking ref (e.g. `origin/my-feature`) of the
+    /// current branch, or nil when none is configured. Used to detect when
+    /// the local HEAD is behind a ref that someone else (or another machine)
+    /// pushed to.
+    func resolveUpstreamRef(worktreePath: URL) async throws -> (remote: String, ref: String)? {
+        let result = try await Process.git(
+            ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else { return nil }
+        let name = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, name != "@{u}" else { return nil }
+        // `name` is "<remote>/<branch>"; take the first segment as remote.
+        guard let slash = name.firstIndex(of: "/") else { return nil }
+        let remote = String(name[..<slash])
+        return (remote: remote, ref: name)
+    }
+
+    /// Computes behind-count of HEAD relative to `ref`, plus the resolved
+    /// SHA of `ref`. `probedAt` is stamped to `Date()` at call time.
+    /// Throws `BehindStatusError` when either git invocation exits non-zero;
+    /// callers catch and treat as a transient probe failure.
+    func behindStatus(
+        worktreePath: URL,
+        ref: String
+    ) async throws -> BehindStatus {
+        let shaResult = try await Process.git(
+            ["rev-parse", ref],
+            cwd: worktreePath
+        )
+        guard shaResult.exitCode == 0 else {
+            throw BehindStatusError.revParseFailed(stderr: shaResult.stderr)
+        }
+        let sha = shaResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let countResult = try await Process.git(
+            ["rev-list", "--count", "HEAD..\(ref)"],
+            cwd: worktreePath
+        )
+        guard countResult.exitCode == 0,
+              let behind = Int(countResult.stdout.trimmingCharacters(in: .whitespacesAndNewlines))
+        else {
+            throw BehindStatusError.revListFailed(stderr: countResult.stderr)
+        }
+
+        return BehindStatus(
+            ref: ref,
+            sha: sha,
+            count: behind,
+            probedAt: Date()
+        )
+    }
+
+    /// Runs `git fetch <remote> <branch>` and returns the completion time.
+    /// Throws if the subprocess exits non-zero so callers can log.
+    @discardableResult
+    func fetchRef(
+        worktreePath: URL,
+        remote: String,
+        branch: String
+    ) async throws -> Date {
+        let result = try await Process.git(
+            ["fetch", remote, branch],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else {
+            throw NSError(
+                domain: "GitService.fetchRef",
+                code: Int(result.exitCode),
+                userInfo: [NSLocalizedDescriptionKey: result.stderr]
+            )
+        }
+        return Date()
     }
 }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1014,9 +1014,20 @@ extension GitService {
         guard result.exitCode == 0 else { return nil }
         let name = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty, name != "@{u}" else { return nil }
-        // `name` is "<remote>/<branch>"; take the first segment as remote.
-        guard let slash = name.firstIndex(of: "/") else { return nil }
-        let remote = String(name[..<slash])
+        // `name` is "<remote>/<branch>". Both segments may contain slashes
+        // (`foo/bar` is a valid remote name, `release/v1` is a valid branch
+        // name), so we can't split on the first slash. Match against the
+        // configured remotes and pick the longest one that prefixes `name`.
+        let remotesResult = try await Process.git(["remote"], cwd: worktreePath)
+        guard remotesResult.exitCode == 0 else { return nil }
+        let remotes = remotesResult.stdout
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard let remote = remotes
+            .filter({ name.hasPrefix($0 + "/") })
+            .max(by: { $0.count < $1.count })
+        else { return nil }
         return (remote: remote, ref: name)
     }
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -79,6 +79,8 @@ struct ChangesTabView: View {
                     comparisonRef: rps.comparisonRef,
                     hasMoreOlder: rps.hasMoreOlder,
                     isLoadingOlder: rps.isLoadingOlder,
+                    behindBase: rps.showBehindBaseChip ? rps.behindBase : nil,
+                    behindUpstream: rps.showBehindUpstreamChip ? rps.behindUpstream : nil,
                     expanded: $rps.commitsExpanded,
                     onSelect: onSelectCommit,
                     onCopySHA: copyCommitSHA,

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -1,11 +1,32 @@
 import SwiftUI
 
+/// Small pill shown in the Commits section header trailing slot when the
+/// worktree is behind a tracked ref (base trunk or its own upstream).
+/// Purely informative.
+struct BehindChip: View {
+    let text: String
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 9.5, weight: .semibold))
+            .foregroundColor(theme.color("accent"))
+            .lineLimit(1)
+            .padding(.horizontal, 6).padding(.vertical, 1)
+            .background(theme.color("accent").opacity(0.12))
+            .clipShape(Capsule())
+    }
+}
+
 struct CommitsSectionView: View {
     let commits: [CommitInfo]
     let olderCommits: [CommitInfo]
     let comparisonRef: String?
     let hasMoreOlder: Bool
     let isLoadingOlder: Bool
+    let behindBase: GitService.BehindStatus?
+    let behindUpstream: GitService.BehindStatus?
     @Binding var expanded: Bool
     let onSelect: (CommitInfo) -> Void
     let onCopySHA: (CommitInfo) -> Void
@@ -21,14 +42,22 @@ struct CommitsSectionView: View {
                 expanded: expanded,
                 onToggle: { expanded.toggle() }
             ) {
-                if let comparisonRef {
-                    HStack(spacing: 4) {
-                        Icon(name: "branch", size: 10, color: theme.color("fg-faint"))
-                        Text(comparisonRef)
-                            .font(.system(size: 10.5, design: .monospaced))
-                            .foregroundColor(theme.color("fg-faint"))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
+                HStack(spacing: 6) {
+                    if let s = behindBase {
+                        BehindChip(text: "\(s.count) behind \(s.ref)")
+                    }
+                    if let s = behindUpstream {
+                        BehindChip(text: "\(s.count) behind \(s.ref)")
+                    }
+                    if let comparisonRef {
+                        HStack(spacing: 4) {
+                            Icon(name: "branch", size: 10, color: theme.color("fg-faint"))
+                            Text(comparisonRef)
+                                .font(.system(size: 10.5, design: .monospaced))
+                                .foregroundColor(theme.color("fg-faint"))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
                     }
                 }
             }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -150,7 +150,17 @@ final class RightPaneState {
             self.fileTree = tree
             self.commits = commits
             self.comparisonRef = ref
+            let previousBranch = self.currentBranch
             self.currentBranch = (try? await br) ?? self.currentBranch
+            if previousBranch != self.currentBranch {
+                // Branch changed (typically an in-worktree `git checkout`).
+                // The behind chips were probed against the OLD branch's base
+                // and upstream — clear them so the header doesn't render
+                // stale counts, then re-probe in the background.
+                self.behindBase = nil
+                self.behindUpstream = nil
+                Task { @MainActor in await self.refreshSyncStatus() }
+            }
             // Gate the Amend toggle: an unborn branch (no commits yet)
             // has nothing to amend. If the probe itself throws, default
             // to `true` so we never wrongly disable the control on a

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -42,6 +42,12 @@ final class RightPaneState {
     var behindBase: GitService.BehindStatus? = nil
     var behindUpstream: GitService.BehindStatus? = nil
 
+    /// Live branch name, refreshed on each `refresh()`. The `worktree.branch`
+    /// snapshot captured at construction goes stale after a `git checkout`
+    /// inside the same worktree, so the chip predicates read this instead.
+    /// Empty when HEAD is detached or unborn.
+    var currentBranch: String
+
     /// `true` once `refresh()` has decided the initial `activeTab`. After
     /// that, the user's tab choice is sticky and refreshes leave it alone.
     private var didInitDefaultTab: Bool = false
@@ -74,8 +80,8 @@ final class RightPaneState {
     var showBehindBaseChip: Bool {
         guard let s = behindBase else { return false }
         guard s.count > 0 else { return false }
-        guard !worktree.branch.isEmpty else { return false } // detached HEAD
-        guard worktree.branch != baseBranch else { return false }
+        guard !currentBranch.isEmpty else { return false } // detached HEAD
+        guard currentBranch != baseBranch else { return false }
         return true
     }
 
@@ -84,13 +90,14 @@ final class RightPaneState {
     var showBehindUpstreamChip: Bool {
         guard let s = behindUpstream else { return false }
         guard s.count > 0 else { return false }
-        guard !worktree.branch.isEmpty else { return false } // detached HEAD
+        guard !currentBranch.isEmpty else { return false } // detached HEAD
         return true
     }
 
     init(worktree: Worktree, baseBranch: String) {
         self.worktree = worktree
         self.baseBranch = baseBranch
+        self.currentBranch = worktree.branch
         self.watcher = WorktreeWatcher(path: worktree.path)
         watcher.onChange = { [weak self] in
             Task { @MainActor in await self?.refresh() }
@@ -135,6 +142,7 @@ final class RightPaneState {
             self.isLoadingOlder = false
             async let s = git.status(worktreePath: worktree.path)
             async let c = git.commitsAhead(at: worktree.path, baseBranch: baseBranch)
+            async let br = git.currentBranch(worktreePath: worktree.path)
             let entries = try await s
             let tree = try await git.fileTree(worktreePath: worktree.path, statusEntries: entries)
             let (commits, ref) = try await c
@@ -142,6 +150,7 @@ final class RightPaneState {
             self.fileTree = tree
             self.commits = commits
             self.comparisonRef = ref
+            self.currentBranch = (try? await br) ?? self.currentBranch
             // Gate the Amend toggle: an unborn branch (no commits yet)
             // has nothing to amend. If the probe itself throws, default
             // to `true` so we never wrongly disable the control on a

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -34,6 +34,14 @@ final class RightPaneState {
     var hasMoreOlder: Bool = true
     var isLoadingOlder: Bool = false
 
+    // Sync-nudge state. All fields are in-memory only; nothing is
+    // persisted to AppConfig. Two independent conditions:
+    //   - behindBase: HEAD is behind the trunk base (origin/main).
+    //   - behindUpstream: HEAD is behind its own remote tracking branch
+    //     (someone else pushed to it, or you pushed from elsewhere).
+    var behindBase: GitService.BehindStatus? = nil
+    var behindUpstream: GitService.BehindStatus? = nil
+
     /// `true` once `refresh()` has decided the initial `activeTab`. After
     /// that, the user's tab choice is sticky and refreshes leave it alone.
     private var didInitDefaultTab: Bool = false
@@ -54,6 +62,32 @@ final class RightPaneState {
     private let watcher: WorktreeWatcher
     private let logger = Logger(subsystem: "io.nlopez.alas", category: "right-pane-state")
 
+    @ObservationIgnored
+    private var syncStatusTimer: Task<Void, Never>? = nil
+
+    /// Refresh interval for `syncStatusTimer`. 5 minutes per design;
+    /// constant in v1.
+    @ObservationIgnored
+    private let syncStatusInterval: UInt64 = 5 * 60 * 1_000_000_000 // ns
+
+    /// True iff the "behind base" chip should be shown.
+    var showBehindBaseChip: Bool {
+        guard let s = behindBase else { return false }
+        guard s.count > 0 else { return false }
+        guard !worktree.branch.isEmpty else { return false } // detached HEAD
+        guard worktree.branch != baseBranch else { return false }
+        return true
+    }
+
+    /// True iff the "behind upstream" chip should be shown. Independent of
+    /// `showBehindBaseChip` — both can be true simultaneously.
+    var showBehindUpstreamChip: Bool {
+        guard let s = behindUpstream else { return false }
+        guard s.count > 0 else { return false }
+        guard !worktree.branch.isEmpty else { return false } // detached HEAD
+        return true
+    }
+
     init(worktree: Worktree, baseBranch: String) {
         self.worktree = worktree
         self.baseBranch = baseBranch
@@ -66,9 +100,26 @@ final class RightPaneState {
     func start() {
         watcher.start()
         Task { @MainActor in await self.refresh() }
+        Task { @MainActor in await self.refreshSyncStatus() }
+        syncStatusTimer?.cancel()
+        syncStatusTimer = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: self?.syncStatusInterval ?? 0)
+                } catch {
+                    return // cancelled
+                }
+                guard let self else { return }
+                await self.refreshSyncStatus()
+            }
+        }
     }
 
-    func stop() { watcher.stop() }
+    func stop() {
+        watcher.stop()
+        syncStatusTimer?.cancel()
+        syncStatusTimer = nil
+    }
 
     @MainActor
     func refresh() async {
@@ -652,6 +703,83 @@ final class RightPaneState {
                 self.composer.clearAmendPrefillIfUnchanged()
                 self.composer.amendWarning = false
             }
+        }
+    }
+
+    /// Probes the worktree's "behind" status against the trunk base AND
+    /// against the branch's own upstream tracking ref (when one exists).
+    /// Fetches each resolvable remote ref when the last probe was older
+    /// than 30s. Errors are logged but never surfaced; chips reflect the
+    /// last successful probe (or stay hidden if none has succeeded yet).
+    @MainActor
+    func refreshSyncStatus() async {
+        await refreshBehindBase()
+        await refreshBehindUpstream()
+    }
+
+    @MainActor
+    private func refreshBehindBase() async {
+        do {
+            guard let resolved = try await git.resolveBaseRef(
+                worktreePath: worktree.path,
+                baseBranch: baseBranch
+            ) else {
+                behindBase = nil
+                return
+            }
+            if let remote = resolved.remote {
+                let last = behindBase?.probedAt ?? .distantPast
+                if Date().timeIntervalSince(last) > 30 {
+                    do {
+                        try await git.fetchRef(
+                            worktreePath: worktree.path,
+                            remote: remote,
+                            branch: baseBranch
+                        )
+                    } catch {
+                        logger.error("base fetch failed for \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    }
+                }
+            }
+            self.behindBase = try await git.behindStatus(
+                worktreePath: worktree.path,
+                ref: resolved.baseRef
+            )
+        } catch {
+            logger.error("behind-base probe failed for \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    @MainActor
+    private func refreshBehindUpstream() async {
+        do {
+            guard let upstream = try await git.resolveUpstreamRef(
+                worktreePath: worktree.path
+            ) else {
+                behindUpstream = nil
+                return
+            }
+            // Upstream ref looks like "origin/<branch>"; the local branch name
+            // is what we fetch.
+            let branchName = String(upstream.ref.dropFirst(upstream.remote.count + 1))
+            let last = behindUpstream?.probedAt ?? .distantPast
+            if Date().timeIntervalSince(last) > 30 {
+                do {
+                    try await git.fetchRef(
+                        worktreePath: worktree.path,
+                        remote: upstream.remote,
+                        branch: branchName
+                    )
+                } catch {
+                    logger.error("upstream fetch failed for \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
+            }
+            self.behindUpstream = try await git.behindStatus(
+                worktreePath: worktree.path,
+                ref: upstream.ref
+            )
+        } catch {
+            logger.error("behind-upstream probe failed for \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -66,4 +66,15 @@ final class RightPaneStore {
         state.start()
         activeId = id
     }
+
+    /// Stops the currently-active state's background work. Call when the
+    /// right pane is hidden or no worktree is selected, so the FSEvents
+    /// watcher and the 5-min sync timer don't keep running with no
+    /// consumer.
+    func deactivate() {
+        if let prev = activeId, let prevState = states[prev] {
+            prevState.stop()
+        }
+        activeId = nil
+    }
 }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -6,13 +6,20 @@ import Observation
 final class RightPaneStore {
     private var states: [String: RightPaneState] = [:]
 
+    /// Id of the state currently being surfaced in the UI. Only that state
+    /// runs its background sync timer + watcher; others sit cached but
+    /// quiescent until they're requested again.
+    private var activeId: String? = nil
+
     /// Weak back-reference used to close diff tabs after a successful discard.
     /// Set by `AppState` after both objects exist. Weak so the store doesn't
     /// retain the app.
     weak var appState: AppState?
 
     func state(for worktree: Worktree, baseBranch: String) -> RightPaneState {
-        if let existing = states[worktree.id] {
+        let id = worktree.id
+        let result: RightPaneState
+        if let existing = states[id] {
             // Keep the cached state in sync with the currently-configured
             // base branch. If it changed (Settings → Worktrees → Base branch),
             // update the field and trigger a refresh so commitsAhead runs
@@ -23,25 +30,34 @@ final class RightPaneStore {
                 existing.baseBranch = baseBranch
                 Task { @MainActor in await existing.refresh() }
             }
-            return existing
-        }
-        let new = RightPaneState(worktree: worktree, baseBranch: baseBranch)
-        let worktreeId = worktree.id
-        new.closeDiffTabs = { [weak self] paths in
-            guard let app = self?.appState else { return }
-            let pathSet = Set(paths)
-            for tab in app.tabs.tabs(forWorktree: worktreeId) {
-                if case .diff(let s) = tab, pathSet.contains(s.relativePath) {
-                    app.closeTab(worktreeId: worktreeId, tabId: s.id)
+            result = existing
+        } else {
+            let new = RightPaneState(worktree: worktree, baseBranch: baseBranch)
+            new.closeDiffTabs = { [weak self] paths in
+                guard let app = self?.appState else { return }
+                let pathSet = Set(paths)
+                for tab in app.tabs.tabs(forWorktree: id) {
+                    if case .diff(let s) = tab, pathSet.contains(s.relativePath) {
+                        app.closeTab(worktreeId: id, tabId: s.id)
+                    }
                 }
             }
+            states[id] = new
+            result = new
         }
-        states[worktree.id] = new
-        new.start()
-        return new
+        activate(id, on: result)
+        return result
     }
 
-    func releaseUnselected(keep id: String) {
-        _ = id
+    /// Marks `id` as the currently-displayed worktree. Stops the previously
+    /// active state's filesystem watcher and sync timer so background work
+    /// doesn't leak across every worktree the user has ever opened.
+    private func activate(_ id: String, on state: RightPaneState) {
+        guard activeId != id else { return }
+        if let prev = activeId, let prevState = states[prev] {
+            prevState.stop()
+        }
+        state.start()
+        activeId = id
     }
 }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -28,7 +28,13 @@ final class RightPaneStore {
             // sticky activeTab choice.
             if existing.baseBranch != baseBranch {
                 existing.baseBranch = baseBranch
-                Task { @MainActor in await existing.refresh() }
+                // Clear the prior probe so the chip doesn't show a stale
+                // count against the OLD base while the new probe runs.
+                existing.behindBase = nil
+                Task { @MainActor in
+                    await existing.refresh()
+                    await existing.refreshSyncStatus()
+                }
             }
             result = existing
         } else {

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -66,6 +66,13 @@ struct RightPaneView: View {
         .task(id: worktree.id) {
             await rps.refresh()
         }
+        // When the right pane is hidden or unmounted (no worktree selected),
+        // stop the active state's filesystem watcher and 5-min sync timer
+        // so they don't keep running with no UI consumer. Re-mounting
+        // restarts via `state(for:)`'s activate hook.
+        .onDisappear {
+            state.rightPaneStore.deactivate()
+        }
         // Host the discard confirmation here (not on ChangesTabView) so
         // diff-tab Discard actions still present the alert when the right
         // pane is on the Files tab — `requestDiscardFile` sets pending state

--- a/AlasTests/GitServiceBehindStatusTests.swift
+++ b/AlasTests/GitServiceBehindStatusTests.swift
@@ -75,6 +75,33 @@ struct GitServiceBehindStatusTests {
         #expect(resolved?.ref == "origin/main")
     }
 
+    @Test func resolveUpstreamRefHandlesRemoteNameWithSlash() async throws {
+        // Configure a remote whose name contains a slash. Without robust
+        // parsing the splitter would pick "foo" as the remote and silently
+        // fail to fetch.
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-behind-slash-\(UUID().uuidString)")
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-behind-slash-rmt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "root"], cwd: repo)
+        _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
+        _ = try await Process.git(["remote", "add", "foo/bar", remote.path], cwd: repo)
+        _ = try await Process.git(["push", "-q", "-u", "foo/bar", "main"], cwd: repo)
+
+        let svc = GitService()
+        let resolved = try await svc.resolveUpstreamRef(worktreePath: repo)
+        #expect(resolved?.remote == "foo/bar")
+        #expect(resolved?.ref == "foo/bar/main")
+    }
+
     @Test func resolveUpstreamRefReturnsNilForUnpushedBranch() async throws {
         let (repo, remote) = try await makeRepoWithRemote()
         defer {

--- a/AlasTests/GitServiceBehindStatusTests.swift
+++ b/AlasTests/GitServiceBehindStatusTests.swift
@@ -1,0 +1,164 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct GitServiceBehindStatusTests {
+    private func makeRepoWithRemote() async throws -> (URL, URL) {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-behind-\(UUID().uuidString)")
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-behind-rmt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+        _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
+        _ = try await Process.git(["remote", "add", "origin", remote.path], cwd: repo)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: repo)
+        return (repo, remote)
+    }
+
+    @Test func resolveBaseRefPrefersOrigin() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let svc = GitService()
+        let resolved = try await svc.resolveBaseRef(worktreePath: repo, baseBranch: "main")
+        #expect(resolved?.remote == "origin")
+        #expect(resolved?.baseRef == "origin/main")
+    }
+
+    @Test func resolveBaseRefFallsBackToLocalBase() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-behind-loc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: dir)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: dir)
+
+        let svc = GitService()
+        let resolved = try await svc.resolveBaseRef(worktreePath: dir, baseBranch: "main")
+        #expect(resolved?.remote == nil)
+        #expect(resolved?.baseRef == "main")
+    }
+
+    @Test func resolveBaseRefReturnsNilWhenNoBaseExists() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-behind-nil-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        _ = try await Process.git(["init", "-q", "-b", "feature"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: dir)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "x"], cwd: dir)
+
+        let svc = GitService()
+        let resolved = try await svc.resolveBaseRef(worktreePath: dir, baseBranch: "main")
+        #expect(resolved == nil)
+    }
+
+    @Test func resolveUpstreamRefReturnsTrackedRef() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let svc = GitService()
+        let resolved = try await svc.resolveUpstreamRef(worktreePath: repo)
+        #expect(resolved?.remote == "origin")
+        #expect(resolved?.ref == "origin/main")
+    }
+
+    @Test func resolveUpstreamRefReturnsNilForUnpushedBranch() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+
+        let svc = GitService()
+        let resolved = try await svc.resolveUpstreamRef(worktreePath: repo)
+        #expect(resolved == nil)
+    }
+
+    @Test func behindStatusReturnsCount() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "m1"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "m2"], cwd: repo)
+        _ = try await Process.git(["push", "-q", "origin", "main"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "feature"], cwd: repo)
+
+        let svc = GitService()
+        let status = try await svc.behindStatus(worktreePath: repo, ref: "origin/main")
+        #expect(status.ref == "origin/main")
+        #expect(status.count == 2)
+        #expect(status.sha.count == 40)
+    }
+
+    @Test func behindStatusBehindZeroWhenInSync() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let svc = GitService()
+        let status = try await svc.behindStatus(worktreePath: repo, ref: "origin/main")
+        #expect(status.ref == "origin/main")
+        #expect(status.count == 0)
+    }
+
+    @Test func behindStatusThrowsWhenRefMissing() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-behind-miss-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: dir)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: dir)
+
+        let svc = GitService()
+        await #expect(throws: GitService.BehindStatusError.self) {
+            _ = try await svc.behindStatus(worktreePath: dir, ref: "origin/nope")
+        }
+    }
+
+    @Test func fetchRefUpdatesRemoteTrackingRef() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let consumer = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-behind-cons-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: consumer) }
+        _ = try await Process.git(["clone", "-q", remote.path, consumer.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "c@e"], cwd: consumer)
+        _ = try await Process.git(["config", "user.name", "c"], cwd: consumer)
+
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "new"], cwd: repo)
+        _ = try await Process.git(["push", "-q", "origin", "main"], cwd: repo)
+
+        let svc = GitService()
+        let before = try await svc.behindStatus(worktreePath: consumer, ref: "origin/main")
+        #expect(before.count == 0)
+
+        try await svc.fetchRef(worktreePath: consumer, remote: "origin", branch: "main")
+
+        let after = try await svc.behindStatus(worktreePath: consumer, ref: "origin/main")
+        #expect(after.count == 1)
+    }
+}

--- a/AlasTests/RightPaneStateSyncStatusTests.swift
+++ b/AlasTests/RightPaneStateSyncStatusTests.swift
@@ -1,0 +1,268 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct RightPaneStateSyncStatusTests {
+    private func makeWorktree(at path: URL, branch: String) -> Worktree {
+        Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: "test-project",
+            name: branch,
+            branch: branch,
+            path: path,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    private func makeRepoOnFeature() async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "root"], cwd: tmp)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: tmp)
+        return tmp
+    }
+
+    // MARK: - showBehindBaseChip
+
+    @Test func baseChipHiddenWhenStatusNil() async throws {
+        let repo = try await makeRepoOnFeature()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: "feature"),
+            baseBranch: "main"
+        )
+        #expect(state.showBehindBaseChip == false)
+    }
+
+    @Test func baseChipVisibleWhenBehindOnNonBaseBranch() async throws {
+        let repo = try await makeRepoOnFeature()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: "feature"),
+            baseBranch: "main"
+        )
+        state.behindBase = GitService.BehindStatus(
+            ref: "origin/main",
+            sha: "deadbeef",
+            count: 3,
+            probedAt: Date()
+        )
+        #expect(state.showBehindBaseChip == true)
+    }
+
+    @Test func baseChipHiddenWhenCountZero() async throws {
+        let repo = try await makeRepoOnFeature()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: "feature"),
+            baseBranch: "main"
+        )
+        state.behindBase = GitService.BehindStatus(
+            ref: "origin/main",
+            sha: "deadbeef",
+            count: 0,
+            probedAt: Date()
+        )
+        #expect(state.showBehindBaseChip == false)
+    }
+
+    @Test func baseChipHiddenOnBaseBranchItself() async throws {
+        let repo = try await makeRepoOnFeature()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: "main"),
+            baseBranch: "main"
+        )
+        state.behindBase = GitService.BehindStatus(
+            ref: "origin/main",
+            sha: "deadbeef",
+            count: 5,
+            probedAt: Date()
+        )
+        #expect(state.showBehindBaseChip == false)
+    }
+
+    @Test func baseChipHiddenOnDetachedHead() async throws {
+        let repo = try await makeRepoOnFeature()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: ""),
+            baseBranch: "main"
+        )
+        state.behindBase = GitService.BehindStatus(
+            ref: "origin/main",
+            sha: "deadbeef",
+            count: 3,
+            probedAt: Date()
+        )
+        #expect(state.showBehindBaseChip == false)
+    }
+
+    // MARK: - showBehindUpstreamChip
+
+    @Test func upstreamChipHiddenWhenStatusNil() async throws {
+        let repo = try await makeRepoOnFeature()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: "feature"),
+            baseBranch: "main"
+        )
+        #expect(state.showBehindUpstreamChip == false)
+    }
+
+    @Test func upstreamChipVisibleEvenOnBaseBranch() async throws {
+        // Unlike base chip, the upstream chip CAN show when current branch
+        // equals baseBranch — local main could be behind origin/main and we
+        // want to nudge that.
+        let repo = try await makeRepoOnFeature()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: "main"),
+            baseBranch: "main"
+        )
+        state.behindUpstream = GitService.BehindStatus(
+            ref: "origin/main",
+            sha: "deadbeef",
+            count: 1,
+            probedAt: Date()
+        )
+        #expect(state.showBehindUpstreamChip == true)
+    }
+
+    @Test func upstreamChipHiddenOnDetachedHead() async throws {
+        let repo = try await makeRepoOnFeature()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: ""),
+            baseBranch: "main"
+        )
+        state.behindUpstream = GitService.BehindStatus(
+            ref: "origin/feature",
+            sha: "deadbeef",
+            count: 2,
+            probedAt: Date()
+        )
+        #expect(state.showBehindUpstreamChip == false)
+    }
+
+    // MARK: - refreshSyncStatus integration
+
+    private func makeFeatureWithRemoteAhead() async throws -> (publisher: URL, consumer: URL, remote: URL) {
+        let publisher = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-pub-\(UUID().uuidString)")
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-rmt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: publisher, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: publisher)
+        _ = try await Process.git(["config", "user.email", "p@e"], cwd: publisher)
+        _ = try await Process.git(["config", "user.name", "p"], cwd: publisher)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "root"], cwd: publisher)
+        _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
+        _ = try await Process.git(["remote", "add", "origin", remote.path], cwd: publisher)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: publisher)
+
+        let consumer = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-cons-\(UUID().uuidString)")
+        _ = try await Process.git(["clone", "-q", remote.path, consumer.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "c@e"], cwd: consumer)
+        _ = try await Process.git(["config", "user.name", "c"], cwd: consumer)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: consumer)
+
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "new on main"], cwd: publisher)
+        _ = try await Process.git(["push", "-q", "origin", "main"], cwd: publisher)
+
+        return (publisher, consumer, remote)
+    }
+
+    @Test func refreshSyncStatusPopulatesBehindBase() async throws {
+        let (publisher, consumer, remote) = try await makeFeatureWithRemoteAhead()
+        defer {
+            try? FileManager.default.removeItem(at: publisher)
+            try? FileManager.default.removeItem(at: consumer)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: consumer, branch: "feature"),
+            baseBranch: "main"
+        )
+        await state.refreshSyncStatus()
+        #expect(state.behindBase?.ref == "origin/main")
+        #expect(state.behindBase?.count == 1)
+        #expect(state.behindUpstream == nil) // no upstream set on feature
+    }
+
+    @Test func refreshSyncStatusClearsBehindBaseWhenNoBaseRef() async throws {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-nb-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: repo) }
+        _ = try await Process.git(["init", "-q", "-b", "feature"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "x"], cwd: repo)
+
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: "feature"),
+            baseBranch: "main"
+        )
+        state.behindBase = GitService.BehindStatus(
+            ref: "origin/main",
+            sha: "deadbeef",
+            count: 3,
+            probedAt: Date()
+        )
+        await state.refreshSyncStatus()
+        #expect(state.behindBase == nil)
+    }
+
+    @Test func refreshSyncStatusPopulatesBehindUpstreamWhenSomeoneElsePushed() async throws {
+        // Two clones of the same bare remote — clone A pushes a new commit
+        // to main; clone B should detect "behind origin/main" via the
+        // upstream path (since B is ON main, so it has @{u} = origin/main).
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-up-rmt-\(UUID().uuidString)")
+        let cloneA = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-up-a-\(UUID().uuidString)")
+        let cloneB = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-up-b-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: remote)
+            try? FileManager.default.removeItem(at: cloneA)
+            try? FileManager.default.removeItem(at: cloneB)
+        }
+        _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
+        // Seed with one commit by cloneA.
+        _ = try await Process.git(["clone", "-q", remote.path, cloneA.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "a@e"], cwd: cloneA)
+        _ = try await Process.git(["config", "user.name", "a"], cwd: cloneA)
+        _ = try await Process.git(["checkout", "-q", "-b", "main"], cwd: cloneA)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "seed"], cwd: cloneA)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: cloneA)
+        // cloneB clones at the same SHA.
+        _ = try await Process.git(["clone", "-q", remote.path, cloneB.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "b@e"], cwd: cloneB)
+        _ = try await Process.git(["config", "user.name", "b"], cwd: cloneB)
+        // cloneA pushes a new commit.
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "from A"], cwd: cloneA)
+        _ = try await Process.git(["push", "-q", "origin", "main"], cwd: cloneA)
+
+        let state = RightPaneState(
+            worktree: makeWorktree(at: cloneB, branch: "main"),
+            baseBranch: "main"
+        )
+        await state.refreshSyncStatus()
+        // cloneB is on main; behindBase is suppressed by the predicate
+        // (currentBranch == baseBranch) but the field is populated.
+        // The interesting nudge here is behindUpstream.
+        #expect(state.behindUpstream?.ref == "origin/main")
+        #expect(state.behindUpstream?.count == 1)
+        #expect(state.showBehindUpstreamChip == true)
+    }
+}


### PR DESCRIPTION
## Summary
- Small informational chips on the Commits section header surface when the worktree is behind a tracked ref: `N behind origin/main` (trunk) and/or `N behind origin/<branch>` (your own pushed ref).
- Background fetch + probe every 5 min while the worktree is the displayed one, throttled to once per 30s on demand. Errors are logged, never surfaced.
- Also tightens a pre-existing rough edge in `GitService.commitsAhead`: when there's no upstream, the fallback now prefers `origin/<base>` over local `<base>`, so the Commits section's comparison ref doesn't drift just because you never check out the base branch in this worktree.

## Test plan
- [ ] Open a worktree on a feature branch and let `origin/main` advance (or pull from another machine). Within 5 min the trunk chip appears next to the `vs origin/main` label.
- [ ] Push the same branch from another machine; the upstream chip appears alongside.
- [ ] Switch the worktree back to `main`: trunk chip is suppressed (we're on base); upstream chip can still show.
- [ ] Detached HEAD: no chips.
- [ ] Worktree where no base ref resolves (no `origin/main`, no local `main`): no chips, no errors.
- [ ] `xcodebuild test -only-testing:AlasTests/GitServiceBehindStatusTests` and `RightPaneStateSyncStatusTests` pass locally.