### PR TITLE
feat: add Kotlin LSP support (pull diagnostics)

### DIFF
--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -39,6 +39,7 @@ final class CodeEditorCoordinator {
     /// publish again. Internal so tests can seed it.
     var lastDiagnosticsByURI: [String: [LSPDiagnostic]] = [:]
     let symbolsFeature = SymbolsFeature()
+    private var pullDiagnosticsTask: Task<Void, Never>?
     private var hover: HoverFeature?
     private var definition: DefinitionFeature?
     private var hoverHighlight: HoverHighlightFeature?
@@ -361,6 +362,8 @@ final class CodeEditorCoordinator {
     /// buffer is already bound, its layout manager and edit observer are torn
     /// down first so the text view stops rendering the old storage.
     private func bindBuffer(_ buffer: EditorBuffer, theme: Theme) {
+        pullDiagnosticsTask?.cancel()
+        pullDiagnosticsTask = nil
         let isRebind = self.buffer != nil
         if let previous = self.buffer {
             if let token = editObserverToken {
@@ -415,6 +418,8 @@ final class CodeEditorCoordinator {
             hasPendingDidChange = false
         }
         pendingTextEdits.removeAll()
+        pullDiagnosticsTask?.cancel()
+        pullDiagnosticsTask = nil
         diagnosticsTask?.cancel()
         diagnosticsTask = nil
         diagnosticsSetupTask?.cancel()
@@ -474,6 +479,7 @@ final class CodeEditorCoordinator {
         guard let buffer, let language = currentLanguage else { return }
         let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
         let text = buffer.storage.string
+        let theme = currentTheme
         Task {
             await appState.lsp.didChange(
                 worktreeRoot: buffer.worktreeRoot,
@@ -482,6 +488,11 @@ final class CodeEditorCoordinator {
                 text: text,
                 edits: edits
             )
+            if let theme,
+               let client = appState.lsp.client(forFile: url, worktreeRoot: buffer.worktreeRoot, language: language),
+               await client.supportsPullDiagnostics {
+                await self.performPullDiagnostics(client: client, uri: url.lspURI, theme: theme)
+            }
         }
     }
 
@@ -586,6 +597,9 @@ final class CodeEditorCoordinator {
                   let client else { return }
             await self.subscribeDiagnostics(for: client, theme: theme)
             await self.symbolsFeature.refresh(client: client, uri: url.lspURI)
+            if await client.supportsPullDiagnostics {
+                self.startPullDiagnosticsIfNeeded(for: client, uri: url.lspURI, theme: theme)
+            }
         }
     }
 
@@ -597,6 +611,36 @@ final class CodeEditorCoordinator {
                 await MainActor.run {
                     self?.processDiagnosticsBatch(batch, theme: theme)
                 }
+            }
+        }
+    }
+
+    private func performPullDiagnostics(client: LSPClient, uri: String, theme: Theme) async {
+        guard !Task.isCancelled else { return }
+        do {
+            if let diags = try await client.requestDiagnostics(uri: uri, previousResultId: nil) {
+                let batch = LSPPublishDiagnosticsParams(uri: uri, diagnostics: diags)
+                await MainActor.run {
+                    self.processDiagnosticsBatch(batch, theme: theme)
+                }
+            }
+        } catch {
+            // Best-effort.
+        }
+    }
+
+    private func startPullDiagnosticsIfNeeded(for client: LSPClient, uri: String, theme: Theme) {
+        pullDiagnosticsTask?.cancel()
+        pullDiagnosticsTask = Task { [weak self] in
+            guard let self else { return }
+            var first = true
+            while !Task.isCancelled {
+                if !first {
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
+                    guard !Task.isCancelled else { return }
+                }
+                first = false
+                await self.performPullDiagnostics(client: client, uri: uri, theme: theme)
             }
         }
     }

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -166,6 +166,7 @@ private enum RegexFallbackHighlighter {
         case "md", "markdown": return "markdown"
         case "py": return "python"
         case "ts", "tsx", "js", "jsx": return "ts"
+        case "kt", "kts": return "kotlin"
         default: return "plain"
         }
     }
@@ -192,6 +193,16 @@ private enum RegexFallbackHighlighter {
             return ["def", "class", "if", "elif", "else", "for", "while", "return", "try",
                     "except", "finally", "import", "from", "as", "with", "yield",
                     "True", "False", "None", "lambda", "pass", "break", "continue"]
+        case "kotlin":
+            return [
+                "val", "var", "fun", "class", "interface", "object", "sealed", "open", "abstract", "override",
+                "lateinit", "companion", "data", "enum", "annotation", "typealias", "import", "package",
+                "if", "else", "when", "while", "do", "for", "in", "return", "break", "continue",
+                "throw", "try", "catch", "finally", "true", "false", "null", "this", "super",
+                "is", "as", "by", "where", "out", "reified", "inline", "noinline", "crossinline",
+                "operator", "infix", "tailrec", "suspend", "internal", "public", "private", "protected",
+                "expect", "actual", "const", "vararg", "dynamic", "external"
+            ]
         default:
             return []
         }

--- a/Alas/Sources/Code/LSP/LSPClient.swift
+++ b/Alas/Sources/Code/LSP/LSPClient.swift
@@ -161,6 +161,31 @@ actor LSPClient {
         return (try? JSONDecoder().decode([LSPTextEdit].self, from: raw)) ?? []
     }
 
+    /// Sends `textDocument/diagnostic` (LSP 3.17 pull diagnostics).
+    /// Returns diagnostics on a full report, `nil` on unchanged (caller
+    /// reuses cached diagnostics), or throws on error.
+    func requestDiagnostics(uri: String, previousResultId: String?) async throws -> [LSPDiagnostic]? {
+        guard supportsPullDiagnostics else { return nil }
+        var params: [String: Any] = [
+            "textDocument": ["uri": uri]
+        ]
+        if let previousResultId {
+            params["previousResultId"] = previousResultId
+        }
+        let raw = try await sendRequest(method: "textDocument/diagnostic", params: params)
+        guard let raw, raw.count > 4 else { return nil }
+        // Attempt full report decoding first.
+        if let report = try? JSONDecoder().decode(LSPFullDocumentDiagnosticReport.self, from: raw) {
+            return report.items
+        }
+        // Attempt unchanged report — caller receives nil and reuses cache.
+        if let _ = try? JSONDecoder().decode(LSPUnchangedDocumentDiagnosticReport.self, from: raw) {
+            return nil
+        }
+        // Legacy fallback: some servers omit `kind` and return bare [Diagnostic].
+        return try? JSONDecoder().decode([LSPDiagnostic].self, from: raw)
+    }
+
     func shutdown() async {
         // Send the polite handshake only if we ever reached `.ready`. For
         // clients that died during `initialize()` (or never started), the

--- a/Alas/Sources/Code/LSP/LSPClient.swift
+++ b/Alas/Sources/Code/LSP/LSPClient.swift
@@ -13,6 +13,7 @@ actor LSPClient {
     private var pending: [LSPID: CheckedContinuation<Data?, Error>] = [:]
     private var textDocumentSyncKind: TextDocumentSyncKind = .full
     private(set) var supportsDocumentFormatting: Bool = false
+    private(set) var supportsPullDiagnostics: Bool = false
     // `AsyncStream` is single-consumer — values are delivered to whichever
     // iterator races to read first, not broadcast. Multiple coordinators
     // sharing one client (two tabs in the same worktree/language) used to
@@ -71,6 +72,7 @@ actor LSPClient {
         let caps = Self.decodeCapabilities(from: rawResult)
         textDocumentSyncKind = caps.syncKind
         supportsDocumentFormatting = caps.supportsFormatting
+        supportsPullDiagnostics = caps.supportsPullDiagnostics
         try sendNotification(method: "initialized", params: [String: Any]())
         state = .ready
     }
@@ -224,14 +226,20 @@ actor LSPClient {
         }
     }
 
-    private static func decodeCapabilities(from data: Data?) -> (syncKind: TextDocumentSyncKind, supportsFormatting: Bool) {
-        guard let data else { return (.full, false) }
+    private static func decodeCapabilities(from data: Data?) -> (syncKind: TextDocumentSyncKind, supportsFormatting: Bool, supportsPullDiagnostics: Bool) {
+        guard let data else { return (.full, false, false) }
         struct InitializeResult: Decodable {
             let capabilities: ServerCapabilities
         }
         struct ServerCapabilities: Decodable {
             let textDocumentSync: TextDocumentSync?
             let documentFormattingProvider: DocumentFormattingProvider?
+            let diagnosticProvider: DiagnosticProvider?
+        }
+        struct DiagnosticProvider: Decodable {
+            let identifier: String?
+            let interFileDependencies: Bool?
+            let workspaceDiagnostics: Bool?
         }
         enum DocumentFormattingProvider: Decodable {
             case unsupported
@@ -274,7 +282,7 @@ actor LSPClient {
         }
 
         guard let result = try? JSONDecoder().decode(InitializeResult.self, from: data) else {
-            return (.full, false)
+            return (.full, false, false)
         }
         let syncKind: TextDocumentSyncKind = {
             guard let sync = result.capabilities.textDocumentSync else { return .full }
@@ -283,7 +291,8 @@ actor LSPClient {
             }
         }()
         let supportsFormatting = result.capabilities.documentFormattingProvider?.isSupported ?? false
-        return (syncKind, supportsFormatting)
+        let supportsPullDiagnostics = result.capabilities.diagnosticProvider != nil
+        return (syncKind, supportsFormatting, supportsPullDiagnostics)
     }
 
     private static func fullRange(for text: String) -> LSPRange {

--- a/Alas/Sources/Code/LSP/LSPMessages.swift
+++ b/Alas/Sources/Code/LSP/LSPMessages.swift
@@ -154,6 +154,24 @@ struct LSPLocationLink: Codable, Hashable, Sendable {
     let targetSelectionRange: LSPRange
 }
 
+// MARK: - Pull Diagnostics
+
+enum LSPDocumentDiagnosticReportKind: String, Codable {
+    case full = "full"
+    case unchanged = "unchanged"
+}
+
+struct LSPFullDocumentDiagnosticReport: Codable {
+    let kind: LSPDocumentDiagnosticReportKind
+    let resultId: String?
+    let items: [LSPDiagnostic]
+}
+
+struct LSPUnchangedDocumentDiagnosticReport: Codable {
+    let kind: LSPDocumentDiagnosticReportKind
+    let resultId: String
+}
+
 // MARK: - Hover / Definition / Symbols / Diagnostics
 
 struct LSPHoverResult: Decodable, Sendable {

--- a/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerRegistry.swift
@@ -39,10 +39,8 @@ struct LanguageServerRegistry {
             enabled: true
         ),
         // JetBrains kotlin-lsp uses pull-based diagnostics
-        // (`textDocument/diagnostic`) and the LSPClient currently only
-        // handles push-based `publishDiagnostics`. Ship the preset
-        // disabled so it's discoverable in Settings but doesn't silently
-        // open .kt/.kts files with diagnostics that never arrive.
+        // (`textDocument/diagnostic`). The client now supports both push
+        // and pull models, so the preset is enabled by default.
         LanguageServerConfig(
             language: "kotlin",
             extensions: ["kt", "kts"],
@@ -54,7 +52,7 @@ struct LanguageServerRegistry {
                 "settings.gradle.kts", "settings.gradle",
                 "pom.xml", ".git"
             ],
-            enabled: false
+            enabled: true
         ),
         LanguageServerConfig(
             language: "markdown",

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -29,6 +29,15 @@ struct TreeSitterHighlighterTests {
         #expect(spans.isEmpty)
     }
 
+    @Test("fallback highlighter recognizes Kotlin")
+    func fallbackHighlighterRecognizesKotlin() throws {
+        let kt = TreeSitterHighlighter.highlight(source: "fun main() { println(\"hi\") }", fileExtension: "kt")
+        let kts = TreeSitterHighlighter.highlight(source: "val x = 1", fileExtension: "kts")
+        #expect(kt.contains(where: { $0.capture == .keyword }))
+        #expect(kt.contains(where: { $0.capture == .string }))
+        #expect(kts.contains(where: { $0.capture == .keyword }))
+    }
+
     @Test("string literal captured")
     func stringLiteral() throws {
         let src = #"let x = "hi""#

--- a/AlasTests/Code/LSP/LSPClientTests.swift
+++ b/AlasTests/Code/LSP/LSPClientTests.swift
@@ -187,6 +187,21 @@ struct LSPClientLifecycleTests {
         transport.finish()
     }
 
+    @Test("decode capabilities extracts pull diagnostics support")
+    func decodeCapabilitiesExtractsPullDiagnostics() async throws {
+        let transport = FakeTransport()
+        let client = LSPClient(transport: transport, language: "kotlin", rootURI: "file:///tmp")
+        transport.onSend = { sent in
+            if sent.contains("\"method\":\"initialize\"") {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"diagnosticProvider":{"identifier":null,"interFileDependencies":true,"workspaceDiagnostics":false}}}}"#)
+            }
+        }
+        try await client.initialize()
+        let supportsPull = await client.supportsPullDiagnostics
+        #expect(supportsPull)
+        transport.finish()
+    }
+
     @Test("full text sync keeps full-document changes")
     func fullTextSyncUsesFullDocumentPayload() async throws {
         let transport = FakeTransport()

--- a/AlasTests/Code/LSP/LSPClientTests.swift
+++ b/AlasTests/Code/LSP/LSPClientTests.swift
@@ -218,4 +218,56 @@ struct LSPClientLifecycleTests {
         #expect(!change.contains(#""range":"#))
         transport.finish()
     }
+
+    @Test("requestDiagnostics decodes full report")
+    func requestDiagnosticsDecodesFullReport() async throws {
+        let transport = FakeTransport()
+        let client = LSPClient(transport: transport, language: "kotlin", rootURI: "file:///tmp")
+        transport.onSend = { sent in
+            if sent.contains("\"method\":\"initialize\"") {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"diagnosticProvider":{}}}}"#)
+            } else if sent.contains("\"method\":\"textDocument/diagnostic\"") {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":2,"result":{"kind":"full","items":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":5}},"severity":1,"message":"error"}]}}"#)
+            }
+        }
+        try await client.initialize()
+        let diags = try await client.requestDiagnostics(uri: "file:///tmp/x.kt", previousResultId: nil)
+        #expect(diags?.count == 1)
+        #expect(diags?.first?.message == "error")
+        transport.finish()
+    }
+
+    @Test("requestDiagnostics returns nil on unchanged report")
+    func requestDiagnosticsUnchangedReport() async throws {
+        let transport = FakeTransport()
+        let client = LSPClient(transport: transport, language: "kotlin", rootURI: "file:///tmp")
+        transport.onSend = { sent in
+            if sent.contains("\"method\":\"initialize\"") {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"diagnosticProvider":{}}}}"#)
+            } else if sent.contains("\"method\":\"textDocument/diagnostic\"") {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":2,"result":{"kind":"unchanged","resultId":"abc"}}"#)
+            }
+        }
+        try await client.initialize()
+        let diags = try await client.requestDiagnostics(uri: "file:///tmp/x.kt", previousResultId: nil)
+        #expect(diags == nil)
+        transport.finish()
+    }
+
+    @Test("requestDiagnostics includes previousResultId when non-nil")
+    func requestDiagnosticsIncludesPreviousResultId() async throws {
+        let transport = FakeTransport()
+        let client = LSPClient(transport: transport, language: "kotlin", rootURI: "file:///tmp")
+        transport.onSend = { sent in
+            if sent.contains("\"method\":\"initialize\"") {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"diagnosticProvider":{}}}}"#)
+            } else if sent.contains("\"method\":\"textDocument/diagnostic\"") {
+                #expect(sent.contains("\"previousResultId\":\"prev123\""))
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":2,"result":{"kind":"full","items":[]}}"#)
+            }
+        }
+        try await client.initialize()
+        _ = try await client.requestDiagnostics(uri: "file:///tmp/x.kt", previousResultId: "prev123")
+        transport.finish()
+    }
 }


### PR DESCRIPTION
## Summary

Adds first-class Kotlin support for `.kt` and `.kts` files by wiring the JetBrains `kotlin-lsp` server into the Alas editor.

### What changed

1. **Syntax highlighting** — added Kotlin regex fallback with 40+ keywords, plus string/comment/number/type coloring. Works even before the LSP initializes.
2. **Enabled preset** — flipped the built-in Kotlin language server config from `enabled: false` to `true`. Updated the comment to note that pull diagnostics are now supported.
3. **LSP pull diagnostics** — implemented `textDocument/diagnostic` (LSP 3.17):
   - Added `LSPDocumentDiagnosticReportKind`, `LSPFullDocumentDiagnosticReport`, and `LSPUnchangedDocumentDiagnosticReport` types.
   - Extended `LSPClient` to parse `diagnosticProvider` from server capabilities.
   - Added `requestDiagnostics(uri:previousResultId:)` method.
   - Wired `CodeEditorCoordinator` to start a 2-second polling loop after `didOpen` and trigger an immediate pull after each `didChange`.

### Test plan

- [ ] Open a `.kt` file — syntax highlighting (keywords, strings, comments) should work.
- [ ] With `kotlin-lsp` installed and enabled in Settings → Code, introduce a syntax error — diagnostics (red squiggles) should appear within ~2 seconds.
- [ ] Fix the error — squiggles should clear.
- [ ] No regressions on Swift, Rust, TypeScript, etc. (push-diagnostic servers unaffected).