### PR TITLE
feat: refresh behind chips when HEAD changes

### DIFF
--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -982,6 +982,18 @@ extension GitService {
         return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Returns the current HEAD SHA for the worktree.
+    func revParseHEAD(worktreePath: URL) async throws -> String {
+        let result = try await Process.git(
+            ["rev-parse", "HEAD"],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else {
+            throw BehindStatusError.revParseFailed(stderr: result.stderr)
+        }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// Resolves the base ref to compare against for a given worktree.
     /// Returns nil when neither `origin/<base>` nor local `<base>` exists.
     /// `remote == nil` means "no fetch path; use the local ref as-is".

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -989,7 +989,7 @@ extension GitService {
             cwd: worktreePath
         )
         guard result.exitCode == 0 else {
-            throw BehindStatusError.revParseFailed(stderr: result.stderr)
+            throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
         }
         return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -9,6 +9,7 @@ struct ProcessResult {
 enum ProcessError: Error {
     case launchFailed(String)
     case timedOut(executable: String, args: [String], seconds: TimeInterval)
+    case nonZeroExit(Int32, String)
 }
 
 extension Process {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -48,6 +48,11 @@ final class RightPaneState {
     /// Empty when HEAD is detached or unborn.
     var currentBranch: String
 
+    /// Live HEAD SHA, refreshed on each `refresh()`. Detects rebase, reset,
+    /// amend, fast-forward, etc. so the behind chips update even when the
+    /// branch name hasn't changed.
+    var currentHeadSHA: String = ""
+
     /// `true` once `refresh()` has decided the initial `activeTab`. After
     /// that, the user's tab choice is sticky and refreshes leave it alone.
     private var didInitDefaultTab: Bool = false
@@ -152,8 +157,11 @@ final class RightPaneState {
             self.comparisonRef = ref
             let previousBranch = self.currentBranch
             self.currentBranch = (try? await br) ?? self.currentBranch
-            if previousBranch != self.currentBranch {
-                // Branch changed (typically an in-worktree `git checkout`).
+            let previousHeadSHA = self.currentHeadSHA
+            let headSHA = (try? await self.git.revParseHEAD(worktreePath: self.worktree.path)) ?? self.currentHeadSHA
+            self.currentHeadSHA = headSHA
+            if previousBranch != self.currentBranch || previousHeadSHA != self.currentHeadSHA {
+                // Branch or HEAD changed (checkout, rebase, reset, amend, …).
                 // The behind chips were probed against the OLD branch's base
                 // and upstream — clear them so the header doesn't render
                 // stale counts, then re-probe in the background.

--- a/AlasTests/GitServiceBehindStatusTests.swift
+++ b/AlasTests/GitServiceBehindStatusTests.swift
@@ -188,5 +188,4 @@ struct GitServiceBehindStatusTests {
         let after = try await svc.behindStatus(worktreePath: consumer, ref: "origin/main")
         #expect(after.count == 1)
     }
-
 }

--- a/AlasTests/GitServiceBehindStatusTests.swift
+++ b/AlasTests/GitServiceBehindStatusTests.swift
@@ -189,14 +189,4 @@ struct GitServiceBehindStatusTests {
         #expect(after.count == 1)
     }
 
-    @Test func revParseHEADReturnsSHA() async throws {
-        let (repo, remote) = try await makeRepoWithRemote()
-        defer {
-            try? FileManager.default.removeItem(at: repo)
-            try? FileManager.default.removeItem(at: remote)
-        }
-        let svc = GitService()
-        let sha = try await svc.revParseHEAD(worktreePath: repo)
-        #expect(sha.count == 40)
-    }
 }

--- a/AlasTests/GitServiceBehindStatusTests.swift
+++ b/AlasTests/GitServiceBehindStatusTests.swift
@@ -188,4 +188,15 @@ struct GitServiceBehindStatusTests {
         let after = try await svc.behindStatus(worktreePath: consumer, ref: "origin/main")
         #expect(after.count == 1)
     }
+
+    @Test func revParseHEADReturnsSHA() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let svc = GitService()
+        let sha = try await svc.revParseHEAD(worktreePath: repo)
+        #expect(sha.count == 40)
+    }
 }

--- a/AlasTests/GitServiceTests.swift
+++ b/AlasTests/GitServiceTests.swift
@@ -417,4 +417,31 @@ struct GitServiceTests {
         let paths = try await svc.submodulePaths(worktreePath: repo)
         #expect(paths == ["Deps/Submodule"])
     }
+
+    private func makeRepoWithRemote() async throws -> (URL, URL) {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-revparse-\(UUID().uuidString)")
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-revparse-rmt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: repo)
+        _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
+        _ = try await Process.git(["remote", "add", "origin", remote.path], cwd: repo)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: repo)
+        return (repo, remote)
+    }
+
+    @Test func revParseHEADReturnsSHA() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let svc = GitService()
+        let sha = try await svc.revParseHEAD(worktreePath: repo)
+        #expect(sha.count == 40)
+    }
 }

--- a/AlasTests/RightPaneStateSyncStatusTests.swift
+++ b/AlasTests/RightPaneStateSyncStatusTests.swift
@@ -265,4 +265,64 @@ struct RightPaneStateSyncStatusTests {
         #expect(state.behindUpstream?.count == 1)
         #expect(state.showBehindUpstreamChip == true)
     }
+
+    // MARK: - rebase-triggered refresh
+
+    private func makeFeatureBehindRemoteMain() async throws -> (repo: URL, remote: URL) {
+        let repo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-reb-\(UUID().uuidString)")
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-reb-rmt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: repo)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: repo)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "root"], cwd: repo)
+        _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
+        _ = try await Process.git(["remote", "add", "origin", remote.path], cwd: repo)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: repo)
+
+        // Create feature behind origin/main by one commit.
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat-1"], cwd: repo)
+
+        // Push one commit to origin/main from a separate clone so feature is behind.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-sync-reb-tmp-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        _ = try await Process.git(["clone", "-q", remote.path, tmp.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "x@e"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "x"], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "main-1"], cwd: tmp)
+        _ = try await Process.git(["push", "-q", "origin", "main"], cwd: tmp)
+
+        return (repo, remote)
+    }
+
+    @Test func refreshSyncStatusFiresOnRebase() async throws {
+        let (repo, remote) = try await makeFeatureBehindRemoteMain()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: repo, branch: "feature"),
+            baseBranch: "main"
+        )
+
+        // First refresh — feature is behind origin/main.
+        await state.refresh()
+        // The background refreshSyncStatus task needs a moment to finish on MainActor.
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(state.behindBase?.count == 1, "feature should be behind origin/main by 1 commit")
+
+        // Rebase feature onto origin/main — now in sync.
+        _ = try await Process.git(["rebase", "origin/main"], cwd: repo)
+
+        // Second refresh — HEAD SHA changed (same branch), so refreshSyncStatus
+        // should fire and update behindBase to 0.
+        await state.refresh()
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(state.behindBase?.count == 0, "after rebase feature should be in sync with origin/main")
+    }
 }


### PR DESCRIPTION
## Summary
- Add `GitService.revParseHEAD()` to read the current HEAD SHA
- Track `currentHeadSHA` in `RightPaneState` alongside `currentBranch`
- Trigger `refreshSyncStatus()` when either branch or HEAD changes
- This makes the behind-main/upstream chips refresh after rebase, reset, amend, etc.

## Test Plan
- `GitServiceTests.revParseHEADReturnsSHA` verifies SHA parsing
- `RightPaneStateSyncStatusTests.refreshSyncStatusFiresOnRebase` verifies the chip updates from 1 to 0 after a rebase