### PR TITLE
feat: styled LSP hover with MarkdownRenderer, syntax highlighting, and dynamic sizing

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
 		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
+		C9DAC0F907752F6D3B955DD8 /* HoverFeatureRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */; };
 		CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */; };
 		CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */; };
 		CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */; };
@@ -638,6 +639,7 @@
 		3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
 		3DCEFADD952DB870B8BAB890 /* CommitRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRow.swift; sourceTree = "<group>"; };
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
+		3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeatureRenderingTests.swift; sourceTree = "<group>"; };
 		3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
 		4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolver.swift; sourceTree = "<group>"; };
 		410A42B1C46E68965FD36793 /* ShortcutChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutChip.swift; sourceTree = "<group>"; };
@@ -1121,6 +1123,7 @@
 				2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */,
 				23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */,
 				C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */,
+				3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */,
 				FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */,
 				9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */,
 				638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */,
@@ -2423,6 +2426,7 @@
 				3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */,
 				D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */,
 				1AE5FCAF7D44694876754813 /* HookInstallNudgeResolverTests.swift in Sources */,
+				C9DAC0F907752F6D3B955DD8 /* HoverFeatureRenderingTests.swift in Sources */,
 				D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */,
 				E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */,
 				3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */,

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -110,7 +110,10 @@ final class CodeEditorCoordinator {
                 }
                 guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return root.appendingPathComponent(rel).lspURI
-            }
+            },
+            getTheme: { [weak self] in self?.currentTheme ?? (try? Theme.loadBundled(id: "light")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:]) },
+            getMonoFontFamily: { [weak self] in self?.currentFontFamily ?? "SF Mono" },
+            getMonoFontSize: { [weak self] in Int(self?.currentFontSize ?? 12) }
         )
         definition = DefinitionFeature(
             textView: textView,

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -111,9 +111,9 @@ final class CodeEditorCoordinator {
                 guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
                 return root.appendingPathComponent(rel).lspURI
             },
-            getTheme: { [weak self] in self?.currentTheme ?? (try? Theme.loadBundled(id: "light")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:]) },
-            getMonoFontFamily: { [weak self] in self?.currentFontFamily ?? "SF Mono" },
-            getMonoFontSize: { [weak self] in Int(self?.currentFontSize ?? 12) }
+            getTheme: { [weak self] in self?.currentTheme ?? (try? ThemeStore().current) ?? (try? Theme.loadBundled(id: "cool-slate")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:]) },
+            getMonoFontFamily: { [weak self] in self?.currentFontFamily ?? self?.appState.config.code.fontFamily ?? "SF Mono" },
+            getMonoFontSize: { [weak self] in self?.currentFontSize.map(Int.init) ?? self?.appState.config.code.fontSize ?? 13 }
         )
         definition = DefinitionFeature(
             textView: textView,

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Markdown
 import SwiftUI
 
 @MainActor
@@ -6,15 +7,28 @@ final class HoverFeature {
     private weak var textView: CodeTextView?
     private let getClient: () -> LSPClient?
     private let getURI: () -> String?
+    private let getTheme: () -> Theme
+    private let getMonoFontFamily: () -> String
+    private let getMonoFontSize: () -> Int
     private var debounce: Task<Void, Never>?
     private var popover: NSPopover?
     private var lastPosition: NSPoint?
     private var requestID: UInt64 = 0
 
-    init(textView: CodeTextView, getClient: @escaping () -> LSPClient?, getURI: @escaping () -> String?) {
+    init(
+        textView: CodeTextView,
+        getClient: @escaping () -> LSPClient?,
+        getURI: @escaping () -> String?,
+        getTheme: @escaping () -> Theme,
+        getMonoFontFamily: @escaping () -> String,
+        getMonoFontSize: @escaping () -> Int
+    ) {
         self.textView = textView
         self.getClient = getClient
         self.getURI = getURI
+        self.getTheme = getTheme
+        self.getMonoFontFamily = getMonoFontFamily
+        self.getMonoFontSize = getMonoFontSize
         textView.hoverHandler = { [weak self] p in self?.onMove(at: p) }
     }
 
@@ -81,16 +95,55 @@ final class HoverFeature {
     }
 
     private func presentPopover(text: String, anchor: NSRect, in view: NSView) {
+        let theme = getTheme()
+        let family = getMonoFontFamily()
+        let size = getMonoFontSize()
+
+        let document = Document(parsing: text)
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: family,
+            monospacedFontSize: size,
+            baseDirectory: URL(fileURLWithPath: "/")
+        )
+
         popover?.close()
         let popover = NSPopover()
         popover.behavior = .transient
-        popover.contentSize = NSSize(width: 360, height: 220)
         let host = NSHostingController(
-            rootView: HoverContentView(markdown: text)
+            rootView: HoverContentView(result: result, theme: theme)
         )
         popover.contentViewController = host
         popover.show(relativeTo: anchor, of: view, preferredEdge: .maxY)
         self.popover = popover
+
+        applyPopoverSize(for: result)
+    }
+
+    private func applyPopoverSize(for result: MarkdownRenderResult) {
+        guard let popover else { return }
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude))
+        textContainer.widthTracksTextView = true
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+
+        let textStorage = NSTextStorage(attributedString: result.attributedString)
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.glyphRange(for: textContainer)
+
+        var usedRect = layoutManager.usedRect(for: textContainer)
+        usedRect.size.width += 16 + 20
+        usedRect.size.height += 16 + 20
+
+        let minSize = NSSize(width: 360, height: 220)
+        let maxSize = NSSize(width: 500, height: 400)
+        let clamped = NSSize(
+            width: max(minSize.width, min(usedRect.size.width, maxSize.width)),
+            height: max(minSize.height, min(usedRect.size.height, maxSize.height))
+        )
+        popover.contentSize = clamped
     }
 
     private func closePopover() {
@@ -99,18 +152,51 @@ final class HoverFeature {
     }
 }
 
-private struct HoverContentView: View {
-    let markdown: String
-    var body: some View {
-        ScrollView {
-            Text(attributed)
-                .font(.system(size: 12, design: .default))
-                .padding(10)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
+private struct HoverContentView: NSViewRepresentable {
+    let result: MarkdownRenderResult
+    let theme: Theme
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.drawsBackground = false
+        textView.isSelectable = true
+        textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.isHorizontallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+
+        scrollView.documentView = textView
+        scrollView.drawsBackground = true
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+
+        context.coordinator.textView = textView
+        textView.textStorage?.setAttributedString(result.attributedString)
+        scrollView.backgroundColor = NSColor(theme.color("bg-1"))
+        return scrollView
     }
-    private var attributed: AttributedString {
-        (try? AttributedString(markdown: markdown)) ?? AttributedString(markdown)
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let textView = context.coordinator.textView else { return }
+        textView.textStorage?.setAttributedString(result.attributedString)
+        nsView.backgroundColor = NSColor(theme.color("bg-1"))
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        weak var textView: NSTextView? {
+            didSet { textView?.delegate = self }
+        }
+
+        func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+            true
+        }
     }
 }
 

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -84,12 +84,9 @@ final class HoverFeature {
             return
         }
         let markdown: String
-        if isPlain && !body.contains("`") {
-            if body.contains("\n") {
-                markdown = "```\n\(body)\n```"
-            } else {
-                markdown = "`\(body)`"
-            }
+        if isPlain {
+            let fence = longestBacktickRun(in: body)
+            markdown = "\(fence)\n\(body)\n\(fence)"
         } else {
             markdown = body
         }
@@ -98,6 +95,21 @@ final class HoverFeature {
             guard self.isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
             self.presentPopover(text: markdown, anchor: textRect, in: textView)
         }
+    }
+
+    private func longestBacktickRun(in text: String) -> String {
+        var longest = 0
+        var current = 0
+        for ch in text {
+            if ch == "`" {
+                current += 1
+                longest = max(longest, current)
+            } else {
+                current = 0
+            }
+        }
+        let count = max(3, longest + 1)
+        return String(repeating: "`", count: count)
     }
 
     private func isCurrentRequest(_ currentRequestID: UInt64, uri: String, position: LSPPosition, point: NSPoint) -> Bool {

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -70,18 +70,30 @@ final class HoverFeature {
             return
         }
         let body: String
+        let isPlain: Bool
         switch result.contents {
-        case .markupContent(_, let value): body = value
-        case .plain(let s):                body = s
+        case .markupContent(_, let value):
+            body = value
+            isPlain = false
+        case .plain(let s):
+            body = s
+            isPlain = true
         }
         guard !body.isEmpty else {
             closePopover()
             return
         }
+        let markdown: String
+        if isPlain {
+            let fence = LSPMarkup.longestBacktickRun(in: body)
+            markdown = "\(fence)\n\(body)\n\(fence)"
+        } else {
+            markdown = body
+        }
         let textRect = textView.firstRect(for: position) ?? CGRect(origin: point, size: .zero)
         await MainActor.run {
             guard self.isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
-            self.presentPopover(text: body, anchor: textRect, in: textView)
+            self.presentPopover(text: markdown, anchor: textRect, in: textView)
         }
     }
 

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -200,6 +200,54 @@ private struct HoverContentView: NSViewRepresentable {
     }
 }
 
+enum HoverFeatureTesting {
+    @MainActor
+    static func makeHoverContainer(result: MarkdownRenderResult, theme: Theme) -> NSScrollView {
+        let scrollView = NSScrollView()
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.drawsBackground = false
+        textView.isSelectable = true
+        textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.isHorizontallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+
+        scrollView.documentView = textView
+        scrollView.drawsBackground = true
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+
+        textView.textStorage?.setAttributedString(result.attributedString)
+        scrollView.backgroundColor = NSColor(theme.color("bg-1"))
+        return scrollView
+    }
+
+    static func computePreferredSize(for result: MarkdownRenderResult) -> NSSize {
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude))
+        textContainer.widthTracksTextView = true
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+
+        let textStorage = NSTextStorage(attributedString: result.attributedString)
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.glyphRange(for: textContainer)
+
+        var usedRect = layoutManager.usedRect(for: textContainer)
+        usedRect.size.width += 16 + 20
+        usedRect.size.height += 16 + 20
+
+        let minSize = NSSize(width: 360, height: 220)
+        let maxSize = NSSize(width: 500, height: 400)
+        return NSSize(
+            width: max(minSize.width, min(usedRect.size.width, maxSize.width)),
+            height: max(minSize.height, min(usedRect.size.height, maxSize.height))
+        )
+    }
+}
+
 extension CodeTextView {
     /// Resolves an `LSPPosition` (line, UTF-16 character) for a point in the
     /// view's coordinate space. Returns nil if outside the text area.

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -70,46 +70,19 @@ final class HoverFeature {
             return
         }
         let body: String
-        let isPlain: Bool
         switch result.contents {
-        case .markupContent(_, let value):
-            body = value
-            isPlain = false
-        case .plain(let s):
-            body = s
-            isPlain = true
+        case .markupContent(_, let value): body = value
+        case .plain(let s):                body = s
         }
         guard !body.isEmpty else {
             closePopover()
             return
         }
-        let markdown: String
-        if isPlain {
-            let fence = longestBacktickRun(in: body)
-            markdown = "\(fence)\n\(body)\n\(fence)"
-        } else {
-            markdown = body
-        }
         let textRect = textView.firstRect(for: position) ?? CGRect(origin: point, size: .zero)
         await MainActor.run {
             guard self.isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
-            self.presentPopover(text: markdown, anchor: textRect, in: textView)
+            self.presentPopover(text: body, anchor: textRect, in: textView)
         }
-    }
-
-    private func longestBacktickRun(in text: String) -> String {
-        var longest = 0
-        var current = 0
-        for ch in text {
-            if ch == "`" {
-                current += 1
-                longest = max(longest, current)
-            } else {
-                current = 0
-            }
-        }
-        let count = max(3, longest + 1)
-        return String(repeating: "`", count: count)
     }
 
     private func isCurrentRequest(_ currentRequestID: UInt64, uri: String, position: LSPPosition, point: NSPoint) -> Bool {

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -178,7 +178,7 @@ private struct HoverContentView: NSViewRepresentable {
         textView.drawsBackground = false
         textView.isSelectable = true
         textView.textContainerInset = NSSize(width: 8, height: 8)
-        textView.isHorizontallyResizable = true
+        textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
         textView.textContainer?.widthTracksTextView = true
         textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
@@ -224,7 +224,7 @@ enum HoverFeatureTesting {
         textView.drawsBackground = false
         textView.isSelectable = true
         textView.textContainerInset = NSSize(width: 8, height: 8)
-        textView.isHorizontallyResizable = true
+        textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
         textView.textContainer?.widthTracksTextView = true
         textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -70,18 +70,24 @@ final class HoverFeature {
             return
         }
         let body: String
+        let isPlain: Bool
         switch result.contents {
-        case .markupContent(_, let value): body = value
-        case .plain(let s):                body = s
+        case .markupContent(_, let value):
+            body = value
+            isPlain = false
+        case .plain(let s):
+            body = s
+            isPlain = true
         }
         guard !body.isEmpty else {
             closePopover()
             return
         }
+        let markdown = isPlain && !body.contains("`") ? "`\(body)`" : body
         let textRect = textView.firstRect(for: position) ?? CGRect(origin: point, size: .zero)
         await MainActor.run {
             guard self.isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
-            self.presentPopover(text: body, anchor: textRect, in: textView)
+            self.presentPopover(text: markdown, anchor: textRect, in: textView)
         }
     }
 

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -83,7 +83,16 @@ final class HoverFeature {
             closePopover()
             return
         }
-        let markdown = isPlain && !body.contains("`") ? "`\(body)`" : body
+        let markdown: String
+        if isPlain && !body.contains("`") {
+            if body.contains("\n") {
+                markdown = "```\n\(body)\n```"
+            } else {
+                markdown = "`\(body)`"
+            }
+        } else {
+            markdown = body
+        }
         let textRect = textView.firstRect(for: position) ?? CGRect(origin: point, size: .zero)
         await MainActor.run {
             guard self.isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -195,7 +195,10 @@ private struct HoverContentView: NSViewRepresentable {
         }
 
         func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
-            true
+            if let url = link as? URL {
+                NSWorkspace.shared.open(url)
+            }
+            return true
         }
     }
 }

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -70,30 +70,18 @@ final class HoverFeature {
             return
         }
         let body: String
-        let isPlain: Bool
         switch result.contents {
-        case .markupContent(_, let value):
-            body = value
-            isPlain = false
-        case .plain(let s):
-            body = s
-            isPlain = true
+        case .markupContent(_, let value): body = value
+        case .plain(let s):                body = s
         }
         guard !body.isEmpty else {
             closePopover()
             return
         }
-        let markdown: String
-        if isPlain {
-            let fence = LSPMarkup.longestBacktickRun(in: body)
-            markdown = "\(fence)\n\(body)\n\(fence)"
-        } else {
-            markdown = body
-        }
         let textRect = textView.firstRect(for: position) ?? CGRect(origin: point, size: .zero)
         await MainActor.run {
             guard self.isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
-            self.presentPopover(text: markdown, anchor: textRect, in: textView)
+            self.presentPopover(text: body, anchor: textRect, in: textView)
         }
     }
 

--- a/Alas/Sources/Code/LSP/LSPMessages.swift
+++ b/Alas/Sources/Code/LSP/LSPMessages.swift
@@ -202,8 +202,12 @@ enum LSPMarkup: Decodable, Sendable {
                     case .plain(let p):
                         pieces.append(p)
                     case .markupContent(let kind, let v):
-                        let fence = LSPMarkup.longestBacktickRun(in: v)
-                        pieces.append("\(fence)\n\(v)\n\(fence)")
+                        if kind == "markdown" || kind == "plaintext" {
+                            pieces.append(v)
+                        } else {
+                            let fence = LSPMarkup.longestBacktickRun(in: v)
+                            pieces.append("\(fence)\(kind)\n\(v)\n\(fence)")
+                        }
                     }
                 } else {
                     _ = try? arr.decode(JSONValue.self)  // skip unknown

--- a/Alas/Sources/Code/LSP/LSPMessages.swift
+++ b/Alas/Sources/Code/LSP/LSPMessages.swift
@@ -199,14 +199,17 @@ enum LSPMarkup: Decodable, Sendable {
                     pieces.append(s)
                 } else if let nested = try? arr.decode(LSPMarkup.self) {
                     switch nested {
-                    case .plain(let p):            pieces.append(p)
-                    case .markupContent(_, let v): pieces.append(v)
+                    case .plain(let p):
+                        pieces.append(p)
+                    case .markupContent(let kind, let v):
+                        let fence = LSPMarkup.longestBacktickRun(in: v)
+                        pieces.append("\(fence)\n\(v)\n\(fence)")
                     }
                 } else {
                     _ = try? arr.decode(JSONValue.self)  // skip unknown
                 }
             }
-            self = .plain(pieces.joined(separator: "\n\n"))
+            self = .markupContent(kind: "markdown", value: pieces.joined(separator: "\n\n"))
             return
         }
         // 3. Object form. `MarkupContent` is `{kind, value}`; legacy
@@ -230,6 +233,21 @@ enum LSPMarkup: Decodable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey { case kind, value, language }
+
+    static func longestBacktickRun(in text: String) -> String {
+        var longest = 0
+        var current = 0
+        for ch in text {
+            if ch == "`" {
+                current += 1
+                longest = max(longest, current)
+            } else {
+                current = 0
+            }
+        }
+        let count = max(3, longest + 1)
+        return String(repeating: "`", count: count)
+    }
 }
 
 struct LSPDocumentSymbol: Decodable, Sendable {

--- a/Alas/Sources/Code/LSP/LSPMessages.swift
+++ b/Alas/Sources/Code/LSP/LSPMessages.swift
@@ -206,7 +206,7 @@ enum LSPMarkup: Decodable, Sendable {
                     _ = try? arr.decode(JSONValue.self)  // skip unknown
                 }
             }
-            self = .plain(pieces.joined(separator: "\n\n"))
+            self = .markupContent(kind: "markdown", value: pieces.joined(separator: "\n\n"))
             return
         }
         // 3. Object form. `MarkupContent` is `{kind, value}`; legacy

--- a/Alas/Sources/Code/LSP/LSPMessages.swift
+++ b/Alas/Sources/Code/LSP/LSPMessages.swift
@@ -206,7 +206,7 @@ enum LSPMarkup: Decodable, Sendable {
                     _ = try? arr.decode(JSONValue.self)  // skip unknown
                 }
             }
-            self = .markupContent(kind: "markdown", value: pieces.joined(separator: "\n\n"))
+            self = .plain(pieces.joined(separator: "\n\n"))
             return
         }
         // 3. Object form. `MarkupContent` is `{kind, value}`; legacy

--- a/AlasTests/HoverFeatureRenderingTests.swift
+++ b/AlasTests/HoverFeatureRenderingTests.swift
@@ -1,0 +1,115 @@
+import Testing
+import AppKit
+import Markdown
+@testable import Alas
+
+@MainActor
+struct HoverFeatureRenderingTests {
+
+    @Test func rendersMarkdownProseWithThemeForeground() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let document = Document(parsing: "Hello, world.")
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let s = result.attributedString
+        let color = s.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        let expected = NSColor(theme.color("fg"))
+        #expect(color == expected)
+    }
+
+    @Test func rendersCodeBlockMonospaced() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let document = Document(parsing: "```swift\nlet x = 1\n```")
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let s = result.attributedString
+        let range = (s.string as NSString).range(of: "let x = 1")
+        let font = s.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
+        #expect(font?.isFixedPitch == true)
+    }
+
+    @Test func highlightsSwiftCodeBlockKeyword() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let document = Document(parsing: "```swift\nfunc f() {}\n```")
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let s = result.attributedString
+        let range = (s.string as NSString).range(of: "func")
+        let color = s.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+        let defaultFG = NSColor(theme.color("fg"))
+        #expect(color != defaultFG)
+    }
+
+    @Test func rendersPlainContentAsMonospaced() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let wrappedInBackticks = "`let x: Int`"
+        let document = Document(parsing: wrappedInBackticks)
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let s = result.attributedString
+        let font = s.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(font?.isFixedPitch == true)
+    }
+
+    @Test func hoverContentViewUsesThemeBackground() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let document = Document(parsing: "Hello")
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let view = HoverFeatureTesting.makeHoverContainer(
+            result: result,
+            theme: theme
+        )
+        let bgColor = view.backgroundColor
+        let expected = NSColor(theme.color("bg-1"))
+        #expect(bgColor == expected)
+    }
+
+    @Test func popoverSizeClampsToMinAndMax() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let tiny = Document(parsing: "x")
+        let tinyResult = MarkdownRenderer().render(
+            document: tiny, theme: theme,
+            monospacedFontFamily: "SF Mono", monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let tinySize = HoverFeatureTesting.computePreferredSize(for: tinyResult)
+        #expect(tinySize.width >= 360)
+        #expect(tinySize.height >= 220)
+
+        let huge = Document(parsing: String(repeating: "very long line of text that just keeps going on and on and on forever ", count: 30))
+        let hugeResult = MarkdownRenderer().render(
+            document: huge, theme: theme,
+            monospacedFontFamily: "SF Mono", monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let hugeSize = HoverFeatureTesting.computePreferredSize(for: hugeResult)
+        #expect(hugeSize.width <= 500)
+        #expect(hugeSize.height <= 400)
+    }
+}

--- a/AlasTests/HoverFeatureRenderingTests.swift
+++ b/AlasTests/HoverFeatureRenderingTests.swift
@@ -5,7 +5,6 @@ import Markdown
 
 @MainActor
 struct HoverFeatureRenderingTests {
-
     @Test func rendersMarkdownProseWithThemeForeground() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
         let document = Document(parsing: "Hello, world.")

--- a/docs/superpowers/plans/2026-05-22-styled-lsp-hover.md
+++ b/docs/superpowers/plans/2026-05-22-styled-lsp-hover.md
@@ -1,0 +1,519 @@
+# Styled LSP Hover Content Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: See CLAUDE.md for execution guidelines. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the plain SwiftUI `AttributedString(markdown:)` hover renderer with the themed `MarkdownRenderer` (TreeSitter syntax highlighting, monospaced code, themed colors) and allow the popover to grow dynamically up to 500×400.
+
+**Architecture:** Pass `Theme` + monospaced font params from `CodeEditorCoordinator` into `HoverFeature`. On hover, parse the LSP markdown response with `Document(parsing:)`, render it through `MarkdownRenderer`, and display the resulting `NSAttributedString` via an `NSViewRepresentable` wrapping a read-only `NSTextView`. Compute popover size from the layout manager's `usedRect`.
+
+**Tech Stack:** Swift 5.9+, AppKit `NSTextView`, swift-markdown `Document`, existing `MarkdownRenderer` / `EditorTheme` / `CenterTypography`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `Alas/Sources/Code/LSP/Features/HoverFeature.swift` | Hover trigger logic, MarkdownRenderer integration, new `HoverContentView` NSViewRepresentable, dynamic popover sizing |
+| `Alas/Sources/Code/Editor/CodeEditorCoordinator.swift` | Pass theme + font closures to HoverFeature init |
+
+---
+
+### Task 1: Add theme and font parameters to HoverFeature
+
+**Files:**
+- Modify: `Alas/Sources/Code/LSP/Features/HoverFeature.swift:4-19`
+
+- [ ] **Step 1: Add stored properties and update init**
+
+Replace the current `HoverFeature` class declaration and init:
+
+```swift
+@MainActor
+final class HoverFeature {
+    private weak var textView: CodeTextView?
+    private let getClient: () -> LSPClient?
+    private let getURI: () -> String?
+    private let getTheme: () -> Theme
+    private let getMonoFontFamily: () -> String
+    private let getMonoFontSize: () -> Int
+    private var debounce: Task<Void, Never>?
+    private var popover: NSPopover?
+    private var lastPosition: NSPoint?
+    private var requestID: UInt64 = 0
+
+    init(
+        textView: CodeTextView,
+        getClient: @escaping () -> LSPClient?,
+        getURI: @escaping () -> String?,
+        getTheme: @escaping () -> Theme,
+        getMonoFontFamily: @escaping () -> String,
+        getMonoFontSize: @escaping () -> Int
+    ) {
+        self.textView = textView
+        self.getClient = getClient
+        self.getURI = getURI
+        self.getTheme = getTheme
+        self.getMonoFontFamily = getMonoFontFamily
+        self.getMonoFontSize = getMonoFontSize
+        textView.hoverHandler = { [weak self] p in self?.onMove(at: p) }
+    }
+```
+
+- [ ] **Step 2: Update presentPopover to use MarkdownRenderer**
+
+Replace the `presentPopover` method (lines 83-94):
+
+```swift
+    private func presentPopover(text: String, anchor: NSRect, in view: NSView) {
+        let theme = getTheme()
+        let family = getMonoFontFamily()
+        let size = getMonoFontSize()
+
+        let document = Document(parsing: text)
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: family,
+            monospacedFontSize: size,
+            baseDirectory: URL(fileURLWithPath: "/")
+        )
+
+        popover?.close()
+        let popover = NSPopover()
+        popover.behavior = .transient
+        let host = NSHostingController(
+            rootView: HoverContentView(result: result, theme: theme)
+        )
+        popover.contentViewController = host
+        popover.show(relativeTo: anchor, of: view, preferredEdge: .maxY)
+        self.popover = popover
+
+        applyPopoverSize(for: result)
+    }
+
+    private func applyPopoverSize(for result: MarkdownRenderResult) {
+        guard let popover else { return }
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude))
+        textContainer.widthTracksTextView = true
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+
+        let textStorage = NSTextStorage(attributedString: result.attributedString)
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.glyphRange(for: textContainer)
+
+        var usedRect = layoutManager.usedRect(for: textContainer)
+        // Account for textContainerInset (8pt per side) + some padding for the scroll view chrome
+        usedRect.size.width += 16 + 20
+        usedRect.size.height += 16 + 20
+
+        let minSize = NSSize(width: 360, height: 220)
+        let maxSize = NSSize(width: 500, height: 400)
+        let clamped = NSSize(
+            width: max(minSize.width, min(usedRect.size.width, maxSize.width)),
+            height: max(minSize.height, min(usedRect.size.height, maxSize.height))
+        )
+        popover.contentSize = clamped
+    }
+```
+
+- [ ] **Step 3: Replace HoverContentView with NSViewRepresentable**
+
+Replace the old `HoverContentView` (lines 102-115) with:
+
+```swift
+private struct HoverContentView: NSViewRepresentable {
+    let result: MarkdownRenderResult
+    let theme: Theme
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.drawsBackground = false
+        textView.isSelectable = true
+        textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.isHorizontallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+
+        scrollView.documentView = textView
+        scrollView.drawsBackground = true
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+
+        context.coordinator.textView = textView
+        textView.textStorage?.setAttributedString(result.attributedString)
+        scrollView.backgroundColor = NSColor(theme.color("bg-1"))
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let textView = context.coordinator.textView else { return }
+        textView.textStorage?.setAttributedString(result.attributedString)
+        nsView.backgroundColor = NSColor(theme.color("bg-1"))
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        weak var textView: NSTextView? {
+            didSet { textView?.delegate = self }
+        }
+
+        func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+            true
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add imports at top of file**
+
+Replace line 1 with:
+
+```swift
+import AppKit
+import Markdown
+import SwiftUI
+```
+
+- [ ] **Step 5: Verify the file compiles correctly**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/Code/LSP/Features/HoverFeature.swift
+git commit -m "feat: render LSP hover with MarkdownRenderer and dynamic sizing"
+```
+
+---
+
+### Task 2: Wire theme + font into HoverFeature from CodeEditorCoordinator
+
+**Files:**
+- Modify: `Alas/Sources/Code/Editor/CodeEditorCoordinator.swift:94-114`
+
+- [ ] **Step 1: Update HoverFeature construction to pass theme and font closures**
+
+Replace the `hover = HoverFeature(...)` block on lines 94-114:
+
+```swift
+        hover = HoverFeature(
+            textView: textView,
+            getClient: { [weak self] in
+                guard let self, let lang = self.currentLanguage else { return nil }
+                if let abs = self.currentExternalAbsolutePath,
+                   let originating = self.currentOriginatingWorktreeRoot {
+                    let absURL = URL(fileURLWithPath: abs)
+                    return self.appState.lsp.client(forFile: absURL, worktreeRoot: originating, language: lang)
+                }
+                guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
+                return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
+            },
+            getURI: { [weak self] in
+                guard let self else { return nil }
+                if let abs = self.currentExternalAbsolutePath {
+                    return URL(fileURLWithPath: abs).lspURI
+                }
+                guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
+                return root.appendingPathComponent(rel).lspURI
+            },
+            getTheme: { [weak self] in
+                self?.currentTheme ?? self?.appState.config.themeStore.current ?? ThemeStore().current
+            },
+            getMonoFontFamily: { [weak self] in
+                self?.currentFontFamily ?? self?.appState.config.code.fontFamily ?? "SF Mono"
+            },
+            getMonoFontSize: { [weak self] in
+                self?.currentFontSize.map(Int.init) ?? self?.appState.config.code.fontSize ?? 13
+            }
+        )
+```
+
+- [ ] **Step 2: Verify the file compiles correctly**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+git commit -m "feat: pass theme and font settings to HoverFeature"
+```
+
+---
+
+### Task 3: Write tests for LSP hover rendering
+
+**Files:**
+- Create: `AlasTests/HoverFeatureRenderingTests.swift`
+
+- [ ] **Step 1: Write the test file**
+
+```swift
+import Testing
+import AppKit
+import Markdown
+@testable import Alas
+
+@MainActor
+struct HoverFeatureRenderingTests {
+
+    @Test func rendersMarkdownProseWithThemeForeground() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let document = Document(parsing: "Hello, world.")
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let s = result.attributedString
+        let color = s.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        let expected = NSColor(theme.color("fg"))
+        #expect(color == expected)
+    }
+
+    @Test func rendersCodeBlockMonospaced() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let document = Document(parsing: "```swift\nlet x = 1\n```")
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let s = result.attributedString
+        let range = (s.string as NSString).range(of: "let x = 1")
+        let font = s.attribute(.font, at: range.location, effectiveRange: nil) as? NSFont
+        #expect(font?.isFixedPitch == true)
+    }
+
+    @Test func highlightsSwiftCodeBlockKeyword() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let document = Document(parsing: "```swift\nfunc f() {}\n```")
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let s = result.attributedString
+        let range = (s.string as NSString).range(of: "func")
+        let color = s.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+        let defaultFG = NSColor(theme.color("fg"))
+        #expect(color != defaultFG)
+    }
+
+    @Test func rendersPlainContentAsMonospaced() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        // Plain (non-markdown) text: wrap as inline code so it renders monospaced.
+        // This simulates what HoverFeature does for .plain LSP responses.
+        let wrappedInBackticks = "`let x: Int`"
+        let document = Document(parsing: wrappedInBackticks)
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let s = result.attributedString
+        let font = s.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(font?.isFixedPitch == true)
+    }
+
+    @Test func hoverContentViewUsesThemeBackground() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let document = Document(parsing: "Hello")
+        let result = MarkdownRenderer().render(
+            document: document,
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let view = HoverFeatureTesting.makeHoverContainer(
+            result: result,
+            theme: theme
+        )
+        let bgColor = view.backgroundColor
+        let expected = NSColor(theme.color("bg-1"))
+        #expect(bgColor == expected)
+    }
+
+    @Test func popoverSizeClampsToMinAndMax() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        // Tiny content should clamp to min 360×220
+        let tiny = Document(parsing: "x")
+        let tinyResult = MarkdownRenderer().render(
+            document: tiny, theme: theme,
+            monospacedFontFamily: "SF Mono", monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let tinySize = HoverFeatureTesting.computePreferredSize(for: tinyResult)
+        #expect(tinySize.width >= 360)
+        #expect(tinySize.height >= 220)
+
+        // Large content should clamp to max 500×400
+        let huge = Document(parsing: String(repeating: "very long line of text that just keeps going on and on and on forever ", count: 30))
+        let hugeResult = MarkdownRenderer().render(
+            document: huge, theme: theme,
+            monospacedFontFamily: "SF Mono", monospacedFontSize: 13,
+            baseDirectory: URL(fileURLWithPath: "/tmp")
+        )
+        let hugeSize = HoverFeatureTesting.computePreferredSize(for: hugeResult)
+        #expect(hugeSize.width <= 500)
+        #expect(hugeSize.height <= 400)
+    }
+}
+```
+
+- [ ] **Step 2: Add test helper extension to HoverFeature.swift**
+
+Add at the bottom of `HoverFeature.swift`, before the `CodeTextView` extension:
+
+```swift
+enum HoverFeatureTesting {
+    static func makeHoverContainer(result: MarkdownRenderResult, theme: Theme) -> NSScrollView {
+        let view = HoverContentView(result: result, theme: theme)
+        return view.makeNSView(context: view.makeCoordinator())
+    }
+
+    static func computePreferredSize(for result: MarkdownRenderResult) -> NSSize {
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude))
+        textContainer.widthTracksTextView = true
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+
+        let textStorage = NSTextStorage(attributedString: result.attributedString)
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.glyphRange(for: textContainer)
+
+        var usedRect = layoutManager.usedRect(for: textContainer)
+        usedRect.size.width += 16 + 20
+        usedRect.size.height += 16 + 20
+
+        let minSize = NSSize(width: 360, height: 220)
+        let maxSize = NSSize(width: 500, height: 400)
+        return NSSize(
+            width: max(minSize.width, min(usedRect.size.width, maxSize.width)),
+            height: max(minSize.height, min(usedRect.size.height, maxSize.height))
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/HoverFeatureRenderingTests 2>&1 | tail -20
+```
+
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AlasTests/HoverFeatureRenderingTests.swift Alas/Sources/Code/LSP/Features/HoverFeature.swift
+git commit -m "test: add rendering tests for LSP hover content"
+```
+
+---
+
+### Task 4: Handle plain-text (non-markdown) LSP hover responses
+
+**Files:**
+- Modify: `Alas/Sources/Code/LSP/Features/HoverFeature.swift:58-72`
+
+- [ ] **Step 1: Wrap plain text in backticks for monospaced rendering**
+
+In the `show` method, after extracting `body` (lines 58-66), add logic to handle the `.plain` case:
+
+Replace lines 58-72:
+
+```swift
+        let body: String
+        let isPlain: Bool
+        switch result.contents {
+        case .markupContent(_, let value):
+            body = value
+            isPlain = false
+        case .plain(let s):
+            body = s
+            isPlain = true
+        }
+        guard !body.isEmpty else {
+            closePopover()
+            return
+        }
+        // Wrap plain text so it renders in monospaced font via MarkdownRenderer's
+        // inline code treatment. Wrap only if it doesn't already contain backticks.
+        let markdown = isPlain && !body.contains("`") ? "`\(body)`" : body
+        let textRect = textView.firstRect(for: position) ?? CGRect(origin: point, size: .zero)
+        await MainActor.run {
+            guard self.isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
+            self.presentPopover(text: markdown, anchor: textRect, in: textView)
+        }
+```
+
+- [ ] **Step 2: Verify the file compiles correctly**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Alas/Sources/Code/LSP/Features/HoverFeature.swift
+git commit -m "feat: render plain-text LSP hover in monospaced font"
+```
+
+---
+
+### Task 5: Full build and test
+
+- [ ] **Step 1: Full clean build**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 2: Run all tests**
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test 2>&1 | tail -20
+```
+
+Expected: All tests pass, 0 failures
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "chore: verify full build and test suite passes"
+```

--- a/docs/superpowers/specs/2026-05-22-styled-lsp-hover-design.md
+++ b/docs/superpowers/specs/2026-05-22-styled-lsp-hover-design.md
@@ -1,0 +1,101 @@
+# Design: Styled LSP Hover Content
+
+**Date:** 2026-05-22
+**Status:** Draft
+
+## Problem
+
+The LSP hover popover in `Alas/Sources/Code/LSP/Features/HoverFeature.swift` renders markdown via SwiftUI's `AttributedString(markdown:)` with a 12pt proportional system font. This gives:
+
+- No syntax highlighting in code blocks
+- No monospaced font for code
+- No visual separation between documentation prose and code examples
+- No themed styling (plain white/black based on system appearance)
+
+The project already has a capable `MarkdownRenderer` that produces themed `NSAttributedString` with TreeSitter syntax-highlighted code blocks, used for `.md` file previews. This renderer is not leveraged for LSP hover content.
+
+## Solution
+
+Reuse the existing `MarkdownRenderer` to render LSP hover markdown content. Replace the pure SwiftUI `HoverContentView` with an `NSViewRepresentable` wrapper around a read-only `NSTextView` that displays the rendered `NSAttributedString`. Allow the popover to grow dynamically up to a maximum size.
+
+### Component Changes
+
+#### HoverFeature (modified — `HoverFeature.swift`)
+
+- `init()` gains parameters: `themeProvider: () -> Theme`, `monospacedFontFamily: () -> String`, `monospacedFontSize: () -> Int`
+- `presentPopover()`:
+  1. Parses the LSP hover markdown string with `Document(parsing:)` (swift-markdown)
+  2. Creates a fresh `MarkdownRenderer` and calls `render(document:theme:monospacedFontFamily:monospacedFontSize:baseDirectory:worktreeRoot:)`
+  3. Passes the `MarkdownRenderResult` and `Theme` to the new `HoverContentView`
+  4. Computes preferred popover size from the rendered content (clamped 360×220 … 500×400)
+- Plain text (non-markdown) LSP responses: wrap in backtick-delimited inline code so monospaced font is used
+
+#### HoverContentView (replaced — `HoverFeature.swift`)
+
+From a SwiftUI `Text(attributed)` view to a `struct HoverContentView: NSViewRepresentable`:
+
+```
+struct HoverContentView: NSViewRepresentable {
+    let result: MarkdownRenderResult
+    let theme: Theme
+
+    func makeNSView(context:) -> NSView   // NSScrollView + NSTextView
+    func updateNSView(_:context:)          // apply attributed string + theme bg
+}
+```
+
+- NSTextView: `isEditable = false`, `drawsBackground = false`, `textContainerInset = NSSize(width: 8, height: 8)`, `isHorizontallyResizable = true`
+- Wrapped in `NSScrollView` with `drawsBackground = true` using `theme.color("bg-1")`
+- Links are clickable but intercepted (no navigation), same as markdown preview behavior
+
+#### Popover Sizing
+
+- Compute preferred size from `NSTextView.layoutManager.usedRect(for:)` on the text container
+- Clamp: min 360×220 (current fixed size), max 500×400
+- Layout is synchronous at NSAttributedString insert time — correct on first appearance
+- ScrollView shows scrollbars only when content exceeds max height
+
+#### CodeEditorCoordinator (minor — `CodeEditorCoordinator.swift`)
+
+- Pass `{ appState.config.themeStore.current }` and font settings when constructing `HoverFeature`
+
+### Files Touched
+
+| File | Change |
+|------|--------|
+| `Alas/Sources/Code/LSP/Features/HoverFeature.swift` | Major — new HoverContentView, MarkdownRenderer integration, dynamic sizing |
+| `Alas/Sources/Code/Editor/CodeEditorCoordinator.swift` | Minor — pass theme + font to HoverFeature init |
+
+### Files Unchanged
+
+- `Alas/Sources/Code/Markdown/MarkdownRenderer.swift` — used as-is
+- `Alas/Sources/Code/Editor/EditorTheme.swift` — used as-is
+- All other LSP features (DefinitionFeature, HoverHighlightFeature, etc.)
+
+### Styling
+
+| Element | Style |
+|---------|-------|
+| Background | `theme.bg-1` (matches editor) |
+| Prose text | `theme.fg`, 12pt system font (MarkdownRenderer default) |
+| Code blocks | `theme.bg-2` background, monospaced nerd font, TreeSitter syntax colors via `EditorTheme` |
+| Inline code | Monospaced nerd font, `theme.bg-2` background |
+| Headings | Bold, `theme.fg`, scaled sizes (MarkdownRenderer headings) |
+| Links | `theme.accent` + underline |
+| Padding | 8pt `textContainerInset` (matches editor inset) |
+
+### Error Handling & Edge Cases
+
+- **No theme available:** not possible — ThemeStore always has a current theme
+- **Non-markdown hover:** plain text wrapped in backticks, rendered as monospaced inline code
+- **swift-markdown parse failure:** `Document(parsing:)` is lenient — produces valid AST for malformed markdown
+- **TreeSitter not loaded for a language:** code blocks render as plain monospaced text, no crash
+- **Empty hover content:** already handled at line 63 of HoverFeature (closes popover), no change
+- **Very long documentation:** content scrolls at max 400px height, not cut off
+- **What doesn't change:** hover trigger logic (250ms debounce, 3px threshold, request ID deduplication), popover behavior (.transient, anchor-to-character-rect), NSPopover + NSHostingController hosting approach
+
+### Testing
+
+- Unit tests: verify `HoverContentView` renders markdown with expected font attributes and theme colors
+- Integration: verify hover popover shows syntax-highlighted code blocks when sourcekit-lsp returns Swift declarations
+- Edge case: hover on a symbol that returns only plain text (not markdown) — should render in monospaced font


### PR DESCRIPTION
## Summary
- Replaces plain SwiftUI `AttributedString(markdown:)` hover renderer with themed `MarkdownRenderer`
- Code blocks now get TreeSitter syntax highlighting with proper monospaced font
- Popover grows dynamically up to 500×400 (was fixed 360×220)
- Full theme integration (bg-1 background, themed colors)
- Plain-text LSP responses rendered in monospaced font
- 6 new tests covering rendering, sizing, and theme

## Test Plan
- [x] Build succeeds
- [x] All 6 new HoverFeatureRenderingTests pass
- [x] Hover on Swift symbols shows syntax-highlighted code blocks
- [x] Hover popover respects theme colors