### PR TITLE
Add LSP-backed editor autocomplete

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		3B82344338BD29F6B8B6D8EC /* FileIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D1797A096A39AE6CB5EA00 /* FileIndex.swift */; };
 		3BB7766DF1D9BF15098432F5 /* CommitDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF335AB8B3061C889A348B3 /* CommitDetails.swift */; };
 		3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C1705E68E97111E85D83F3 /* RightPaneState.swift */; };
+		3C5E243B78F3461F75AB02A8 /* CodeTextViewCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */; };
 		3CD81DD1B1FF8C1EA849237C /* TerminalSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */; };
 		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
 		3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */; };
@@ -136,6 +137,7 @@
 		3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */; };
 		3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64C0B7363363C77718B446C /* CopilotInstaller.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
+		412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
@@ -220,6 +222,7 @@
 		6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */; };
 		6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795056B6AD803D2B555FC866 /* RightPaneStore.swift */; };
 		6DDB5FC604A28D699350C3BD /* TabActivityIconTintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */; };
+		6E52521BCD52ED8DB496E74B /* CompletionDocumentationRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */; };
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
@@ -276,6 +279,7 @@
 		8B2A37F58F2C7D842204A596 /* ImageDiffOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87F114EBEEACCC95B9EF8D5 /* ImageDiffOverlayView.swift */; };
 		8C60AB3736F2160FC2A49281 /* CommitComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DACC2D855F4316038CB40C7 /* CommitComposerView.swift */; };
 		8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */; };
+		8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */; };
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
@@ -345,6 +349,7 @@
 		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
 		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
 		B574D2D5DF3129E326DCFCCF /* ShellEnvResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */; };
+		B5E38A6134CDE9F8D5EA76D1 /* CompletionWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */; };
 		B614CD7F894DD6908C903254 /* InstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */; };
 		B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */; };
 		B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */; };
@@ -382,6 +387,7 @@
 		C55B79DC0AAE96CFA14BE76F /* CommitFilesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */; };
 		C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDEA496740F5B0B5EE808B /* Process+Git.swift */; };
 		C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */; };
+		C7A839C87B7C9F70F5BD6631 /* CompletionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B0831638833C386E5CC9E8 /* CompletionEngine.swift */; };
 		C7AACF777FF0DAD9ACA426F3 /* AgentLifecycleEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */; };
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
@@ -396,6 +402,7 @@
 		CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */; };
 		CD227C48AA85A5E74A92DF3F /* GitRefNameInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */; };
 		CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */; };
+		CDE156FA8E19E85437E79908 /* CompletionFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */; };
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
 		CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */; };
 		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
@@ -410,6 +417,7 @@
 		D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */; };
 		D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */; };
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
+		D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
 		D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */; };
 		D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */; };
@@ -434,6 +442,7 @@
 		DE41CB04CDC89D09346494A5 /* LineEndingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB52B59655B85764D85CFB7F /* LineEndingTests.swift */; };
 		DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */; };
 		DEBB0627BD0426369D18CAD4 /* FileSearchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */; };
+		DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */; };
 		DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */; };
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
 		E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */; };
@@ -487,6 +496,7 @@
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
 		FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */; };
 		FF7DDFC667CE2E3964B51FA5 /* LSPInstallProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */; };
+		FFC747D542D806E6CF6FCD03 /* CompletionPopup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348D2E5F6030BB9F2BDEFA26 /* CompletionPopup.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -601,6 +611,7 @@
 		2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstallerTests.swift; sourceTree = "<group>"; };
 		2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReaderTests.swift; sourceTree = "<group>"; };
 		30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorCoordinator.swift; sourceTree = "<group>"; };
+		31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowController.swift; sourceTree = "<group>"; };
 		321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherTests.swift; sourceTree = "<group>"; };
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
 		32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandle.swift; sourceTree = "<group>"; };
@@ -609,6 +620,7 @@
 		339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeBuilder.swift; sourceTree = "<group>"; };
 		3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindow.swift; sourceTree = "<group>"; };
 		345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistryTests.swift; sourceTree = "<group>"; };
+		348D2E5F6030BB9F2BDEFA26 /* CompletionPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionPopup.swift; sourceTree = "<group>"; };
 		3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputRow.swift; sourceTree = "<group>"; };
 		35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
 		35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelper.swift; sourceTree = "<group>"; };
@@ -649,6 +661,7 @@
 		41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeBanner.swift; sourceTree = "<group>"; };
 		4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceView.swift; sourceTree = "<group>"; };
 		4261E417947C1A21E77C1587 /* GitStatusCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCache.swift; sourceTree = "<group>"; };
+		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
 		45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigShortcutsCodingTests.swift; sourceTree = "<group>"; };
@@ -668,6 +681,7 @@
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
 		4FE58EF9CF8EC461667D9430 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinatesTests.swift; sourceTree = "<group>"; };
+		50B0831638833C386E5CC9E8 /* CompletionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngine.swift; sourceTree = "<group>"; };
 		515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavView.swift; sourceTree = "<group>"; };
 		519CFB3707E8DDBDECD6C5D1 /* Alas.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alas.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitTests.swift; sourceTree = "<group>"; };
@@ -745,6 +759,7 @@
 		79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilderTests.swift; sourceTree = "<group>"; };
 		7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEnvironment.swift; sourceTree = "<group>"; };
 		7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewAutoPairTests.swift; sourceTree = "<group>"; };
+		7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeatureTests.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
 		7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointingHandCursor.swift; sourceTree = "<group>"; };
 		7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCacheTests.swift; sourceTree = "<group>"; };
@@ -764,6 +779,7 @@
 		881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputer.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
+		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
@@ -893,6 +909,7 @@
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstaller.swift; sourceTree = "<group>"; };
 		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
+		CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRendererTests.swift; sourceTree = "<group>"; };
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
@@ -903,6 +920,7 @@
 		D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceTests.swift; sourceTree = "<group>"; };
 		D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilterTests.swift; sourceTree = "<group>"; };
 		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
+		D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeature.swift; sourceTree = "<group>"; };
 		D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolver.swift; sourceTree = "<group>"; };
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D64C0B7363363C77718B446C /* CopilotInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstaller.swift; sourceTree = "<group>"; };
@@ -922,6 +940,7 @@
 		DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoader.swift; sourceTree = "<group>"; };
 		DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolver.swift; sourceTree = "<group>"; };
 		E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTabView.swift; sourceTree = "<group>"; };
+		E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngineTests.swift; sourceTree = "<group>"; };
 		E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeatureTests.swift; sourceTree = "<group>"; };
 		E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedPane.swift; sourceTree = "<group>"; };
 		E1703FC5CD7DF16F4450E274 /* DiffParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParser.swift; sourceTree = "<group>"; };
@@ -951,6 +970,7 @@
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
 		ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewIndentationTests.swift; sourceTree = "<group>"; };
+		ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRenderer.swift; sourceTree = "<group>"; };
 		EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParserTests.swift; sourceTree = "<group>"; };
 		EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
 		EECB91379591DA21D216A894 /* RelativeTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTime.swift; sourceTree = "<group>"; };
@@ -1069,6 +1089,7 @@
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
 				E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */,
 				7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */,
+				436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */,
 				ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */,
 				A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */,
 				2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */,
@@ -1276,6 +1297,10 @@
 		31CE84DE21D266EF233D2D1E /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */,
+				E0CD4F3AC6DD83BC45459475 /* CompletionEngineTests.swift */,
+				7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */,
+				89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */,
 				7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */,
 				412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */,
 				100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */,
@@ -1688,6 +1713,11 @@
 		BF7999E71D2618AC30DF14E4 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */,
+				50B0831638833C386E5CC9E8 /* CompletionEngine.swift */,
+				D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */,
+				348D2E5F6030BB9F2BDEFA26 /* CompletionPopup.swift */,
+				31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */,
 				F12340A649892955245BECB7 /* DefinitionFeature.swift */,
 				781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */,
 				0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */,
@@ -2117,6 +2147,11 @@
 				11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */,
 				BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */,
 				CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */,
+				8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */,
+				C7A839C87B7C9F70F5BD6631 /* CompletionEngine.swift in Sources */,
+				D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */,
+				FFC747D542D806E6CF6FCD03 /* CompletionPopup.swift in Sources */,
+				412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */,
 				A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */,
 				A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */,
 				3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */,
@@ -2370,6 +2405,7 @@
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,
 				01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */,
 				1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */,
+				3C5E243B78F3461F75AB02A8 /* CodeTextViewCompletionTests.swift in Sources */,
 				CF12433D8F30CEA05088FFB0 /* CodeTextViewIndentationTests.swift in Sources */,
 				C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */,
 				6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */,
@@ -2382,6 +2418,10 @@
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,
 				17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */,
 				4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */,
+				6E52521BCD52ED8DB496E74B /* CompletionDocumentationRendererTests.swift in Sources */,
+				DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */,
+				CDE156FA8E19E85437E79908 /* CompletionFeatureTests.swift in Sources */,
+				B5E38A6134CDE9F8D5EA76D1 /* CompletionWindowControllerTests.swift in Sources */,
 				5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */,

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -43,12 +43,23 @@ final class CodeEditorCoordinator {
     private var hover: HoverFeature?
     private var definition: DefinitionFeature?
     private var hoverHighlight: HoverHighlightFeature?
+    private var completion: CompletionFeature?
 
     private var editObserverToken: EditorBuffer.EditObserverToken?
     private var didChangeTask: Task<Void, Never>?
     private var hasPendingDidChange = false
     private var pendingTextEdits: [EditorTextEdit] = []
     private let highlightSession = TreeSitterHighlighter.Session()
+
+    private struct LSPDidChangePayload {
+        let worktreeRoot: URL
+        let relativePath: String
+        let fileURL: URL
+        let language: String
+        let text: String
+        let edits: [EditorTextEdit]?
+        let theme: Theme?
+    }
 
     static func resolveFont(family: String, size: CGFloat) -> NSFont {
         CenterTypography.resolveCodeFont(family: family, size: size)
@@ -98,10 +109,10 @@ final class CodeEditorCoordinator {
                 if let abs = self.currentExternalAbsolutePath,
                    let originating = self.currentOriginatingWorktreeRoot {
                     let absURL = URL(fileURLWithPath: abs)
-                    return self.appState.lsp.client(forFile: absURL, worktreeRoot: originating, language: lang)
+                    return self.appState.lsp.openedClient(forFile: absURL, worktreeRoot: originating, language: lang)
                 }
                 guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
-                return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
+                return self.appState.lsp.openedClient(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
             },
             getURI: { [weak self] in
                 guard let self else { return nil }
@@ -122,10 +133,10 @@ final class CodeEditorCoordinator {
                 if let abs = self.currentExternalAbsolutePath,
                    let originating = self.currentOriginatingWorktreeRoot {
                     let absURL = URL(fileURLWithPath: abs)
-                    return self.appState.lsp.client(forFile: absURL, worktreeRoot: originating, language: lang)
+                    return self.appState.lsp.openedClient(forFile: absURL, worktreeRoot: originating, language: lang)
                 }
                 guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
-                return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
+                return self.appState.lsp.openedClient(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
             },
             getURI: { [weak self] in
                 guard let self else { return nil }
@@ -183,10 +194,10 @@ final class CodeEditorCoordinator {
                 if let abs = self.currentExternalAbsolutePath,
                    let originating = self.currentOriginatingWorktreeRoot {
                     let absURL = URL(fileURLWithPath: abs)
-                    return self.appState.lsp.client(forFile: absURL, worktreeRoot: originating, language: lang)
+                    return self.appState.lsp.openedClient(forFile: absURL, worktreeRoot: originating, language: lang)
                 }
                 guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
-                return self.appState.lsp.client(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
+                return self.appState.lsp.openedClient(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
             },
             getURI: { [weak self] in
                 guard let self else { return nil }
@@ -196,6 +207,44 @@ final class CodeEditorCoordinator {
                 guard let root = self.currentRoot,
                       let rel = self.currentRelativePath else { return nil }
                 return root.appendingPathComponent(rel).lspURI
+            }
+        )
+        completion = CompletionFeature(
+            textView: textView,
+            getClient: { [weak self] in
+                guard let self, let lang = self.currentLanguage else { return nil }
+                if let abs = self.currentExternalAbsolutePath,
+                   let originating = self.currentOriginatingWorktreeRoot {
+                    let absURL = URL(fileURLWithPath: abs)
+                    return self.appState.lsp.openedClient(forFile: absURL, worktreeRoot: originating, language: lang)
+                }
+                guard let root = self.currentRoot, let rel = self.currentRelativePath else { return nil }
+                return self.appState.lsp.openedClient(forFile: root.appendingPathComponent(rel), worktreeRoot: root, language: lang)
+            },
+            getURI: { [weak self] in
+                guard let self else { return nil }
+                if let abs = self.currentExternalAbsolutePath {
+                    return URL(fileURLWithPath: abs).lspURI
+                }
+                guard let root = self.currentRoot,
+                      let rel = self.currentRelativePath else { return nil }
+                return root.appendingPathComponent(rel).lspURI
+            },
+            isEnabled: { [weak self] in
+                guard let self,
+                      self.currentExternalAbsolutePath == nil,
+                      self.currentLanguage != nil,
+                      self.buffer?.isExternal != true,
+                      self.buffer?.readOnly == false else {
+                    return false
+                }
+                return true
+            },
+            getTheme: { [weak self] in self?.currentTheme ?? (try? ThemeStore().current) ?? (try? Theme.loadBundled(id: "cool-slate")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:]) },
+            getMonoFontFamily: { [weak self] in self?.currentFontFamily ?? self?.appState.config.code.fontFamily ?? "SF Mono" },
+            getMonoFontSize: { [weak self] in self?.currentFontSize.map(Int.init) ?? self?.appState.config.code.fontSize ?? 13 },
+            prepareForCompletionRequest: { [weak self] in
+                await self?.flushPendingLSPDidChangeForCompletion()
             }
         )
 
@@ -251,6 +300,7 @@ final class CodeEditorCoordinator {
 
         if pathChanged {
             hoverHighlight?.cancelAndClear()
+            completion?.cancelAndDismiss()
             didChangeTask?.cancel()
             hasPendingDidChange = false
             pendingTextEdits.removeAll()
@@ -410,10 +460,16 @@ final class CodeEditorCoordinator {
         hover = nil
         definition = nil
         hoverHighlight = nil
+        completion?.cancelAndDismiss()
+        completion = nil
         textView?.hoverHandler = nil
         textView?.commandClickHandler = nil
         textView?.flagsChangedHandler = nil
         textView?.mouseExitedHandler = nil
+        textView?.completionManualTriggerHandler = nil
+        textView?.completionChangeHandler = nil
+        textView?.completionSelectionChangeHandler = nil
+        textView?.completionKeyHandler = nil
         textView?.increaseFontSizeHandler = nil
         textView?.decreaseFontSizeHandler = nil
         textView?.resetFontSizeHandler = nil
@@ -453,22 +509,60 @@ final class CodeEditorCoordinator {
     }
 
     private func notifyLSPDidChange(edits: [EditorTextEdit]? = nil) {
-        guard let buffer, let language = currentLanguage else { return }
+        guard let payload = makeLSPDidChangePayload(edits: edits) else { return }
+        Task { [weak self] in
+            await self?.sendLSPDidChange(payload, awaitPullDiagnostics: true)
+        }
+    }
+
+    private func flushPendingLSPDidChangeForCompletion() async {
+        didChangeTask?.cancel()
+        guard hasPendingDidChange else { return }
+
+        hasPendingDidChange = false
+        if let theme = currentTheme {
+            runHighlight(theme: theme)
+        }
+        let edits = pendingTextEdits
+        pendingTextEdits.removeAll()
+        guard let payload = makeLSPDidChangePayload(edits: edits) else { return }
+        await sendLSPDidChange(payload, awaitPullDiagnostics: false)
+    }
+
+    private func makeLSPDidChangePayload(edits: [EditorTextEdit]? = nil) -> LSPDidChangePayload? {
+        guard let buffer, let language = currentLanguage else { return nil }
         let url = buffer.worktreeRoot.appendingPathComponent(buffer.relativePath)
-        let text = buffer.storage.string
-        let theme = currentTheme
-        Task {
-            await appState.lsp.didChange(
-                worktreeRoot: buffer.worktreeRoot,
-                fileURL: url,
-                languageId: language,
-                text: text,
-                edits: edits
-            )
-            if let theme,
-               let client = appState.lsp.client(forFile: url, worktreeRoot: buffer.worktreeRoot, language: language),
-               await client.supportsPullDiagnostics {
-                await self.performPullDiagnostics(client: client, uri: url.lspURI, theme: theme)
+        return LSPDidChangePayload(
+            worktreeRoot: buffer.worktreeRoot,
+            relativePath: buffer.relativePath,
+            fileURL: url,
+            language: language,
+            text: buffer.storage.string,
+            edits: edits,
+            theme: currentTheme
+        )
+    }
+
+    private func sendLSPDidChange(_ payload: LSPDidChangePayload, awaitPullDiagnostics: Bool) async {
+        await appState.lsp.didChange(
+            worktreeRoot: payload.worktreeRoot,
+            fileURL: payload.fileURL,
+            languageId: payload.language,
+            text: payload.text,
+            edits: payload.edits
+        )
+        guard currentRoot == payload.worktreeRoot,
+              currentRelativePath == payload.relativePath,
+              currentLanguage == payload.language else { return }
+        if let theme = payload.theme,
+           let client = appState.lsp.client(forFile: payload.fileURL, worktreeRoot: payload.worktreeRoot, language: payload.language),
+           await client.supportsPullDiagnostics {
+            if awaitPullDiagnostics {
+                await performPullDiagnostics(client: client, uri: payload.fileURL.lspURI, theme: theme)
+            } else {
+                Task { [weak self] in
+                    await self?.performPullDiagnostics(client: client, uri: payload.fileURL.lspURI, theme: theme)
+                }
             }
         }
     }

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -6,6 +6,13 @@ import AppKit
 /// dirty tracking, save, file-watch, and LSP `didChange` are all
 /// orchestrated by the buffer + coordinator pair.
 final class CodeTextView: NSTextView, FontSizeResponder {
+    enum CompletionKeyAction: Equatable {
+        case acceptTop
+        case acceptSelected
+        case moveSelection(Int)
+        case dismiss
+    }
+
     private static let pairedDelimiters: [Character: Character] = [
         "(": ")",
         "[": "]",
@@ -21,6 +28,10 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     var commandClickHandler: ((NSPoint) -> Void)?
     var flagsChangedHandler: ((NSEvent) -> Void)?
     var mouseExitedHandler: (() -> Void)?
+    var completionManualTriggerHandler: (() -> Void)?
+    var completionChangeHandler: (() -> Void)?
+    var completionSelectionChangeHandler: (() -> Void)?
+    var completionKeyHandler: ((CompletionKeyAction) -> Bool)?
     var indentationMode: IndentationMode = .plain
 
     var autoPairDisabled: Bool = false
@@ -33,6 +44,9 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     private var multiCursorSelectedRanges: [NSValue]?
     private var possibleColumnSelectionDrag: ColumnSelectionDrag?
+    private var suppressCompletionChangeNotifications = false
+    private var suppressCompletionSelectionNotifications = false
+    private var isApplyingSelectionChange = false
 
     private struct ColumnSelectionDrag {
         let startPoint: NSPoint
@@ -72,11 +86,29 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     }
 
     override func setSelectedRange(_ charRange: NSRange) {
+        let wasApplyingSelectionChange = isApplyingSelectionChange
+        let shouldNotify = !wasApplyingSelectionChange
+        isApplyingSelectionChange = true
+        defer {
+            isApplyingSelectionChange = wasApplyingSelectionChange
+            if shouldNotify {
+                notifyCompletionSelectionChanged()
+            }
+        }
         multiCursorSelectedRanges = nil
         super.setSelectedRange(charRange)
     }
 
     override func setSelectedRanges(_ ranges: [NSValue], affinity: NSSelectionAffinity, stillSelecting stillSelectingFlag: Bool) {
+        let wasApplyingSelectionChange = isApplyingSelectionChange
+        let shouldNotify = !wasApplyingSelectionChange
+        isApplyingSelectionChange = true
+        defer {
+            isApplyingSelectionChange = wasApplyingSelectionChange
+            if shouldNotify {
+                notifyCompletionSelectionChanged()
+            }
+        }
         let normalized = normalizedRanges(from: ranges)
         guard normalized.count > 1 else {
             multiCursorSelectedRanges = nil
@@ -187,7 +219,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
                 location: edit.originalRange.location + delta,
                 length: edit.originalRange.length
             )
-            super.insertText(edit.replacement, replacementRange: effectiveRange)
+            insertTextAfterTextEdit(edit.replacement, replacementRange: effectiveRange)
             let finalSelection = NSRange(
                 location: edit.resultingSelection.location + delta,
                 length: edit.resultingSelection.length
@@ -196,7 +228,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             delta += (edit.replacement as NSString).length - edit.originalRange.length
         }
         undoManager?.endUndoGrouping()
-        setSelectedRanges(finalSelections, affinity: .downstream, stillSelecting: false)
+        setSelectedRangesAfterTextEdit(finalSelections, affinity: .downstream, stillSelecting: false)
     }
 
     private func editForCharacter(_ character: Character, at range: NSRange) -> MultiCursorEdit? {
@@ -240,10 +272,15 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     // MARK: - Text insertion overrides
 
+    override func didChangeText() {
+        super.didChangeText()
+        notifyCompletionChanged()
+    }
+
     override func insertText(_ insertString: Any, replacementRange: NSRange) {
         guard isEditable else { return }
         guard let text = Self.string(from: insertString) else {
-            super.insertText(insertString, replacementRange: replacementRange)
+            insertTextAfterTextEdit(insertString, replacementRange: replacementRange)
             return
         }
 
@@ -267,17 +304,17 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         }
 
         if autoPairDisabled {
-            super.insertText(insertString, replacementRange: replacementRange)
+            insertTextAfterTextEdit(insertString, replacementRange: replacementRange)
             return
         }
         guard text.count == 1, let character = text.first else {
-            super.insertText(insertString, replacementRange: replacementRange)
+            insertTextAfterTextEdit(insertString, replacementRange: replacementRange)
             return
         }
 
         let range = effectiveReplacementRange(replacementRange)
         guard range.location != NSNotFound, NSMaxRange(range) <= (string as NSString).length else {
-            super.insertText(insertString, replacementRange: replacementRange)
+            insertTextAfterTextEdit(insertString, replacementRange: replacementRange)
             return
         }
 
@@ -285,8 +322,8 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         if Self.closingDelimiters.contains(character),
            indentationMode == .bracketAware,
            let edit = IndentationHelper.closingDelimiterEdit(in: string, selectedRange: range, delimiter: character, mode: indentationMode) {
-            super.insertText(edit.replacement, replacementRange: edit.replacementRange)
-            setSelectedRange(NSRange(location: edit.replacementRange.location + edit.selectedLocationDelta, length: 0))
+            insertTextAfterTextEdit(edit.replacement, replacementRange: edit.replacementRange)
+            setSelectedRangeAfterTextEdit(NSRange(location: edit.replacementRange.location + edit.selectedLocationDelta, length: 0))
             return
         }
 
@@ -306,7 +343,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             return
         }
 
-        super.insertText(insertString, replacementRange: replacementRange)
+        insertTextAfterTextEdit(insertString, replacementRange: replacementRange)
     }
 
     override func insertNewline(_ sender: Any?) {
@@ -314,6 +351,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             super.insertNewline(sender)
             return
         }
+        if routeCompletionKey(.acceptSelected) { return }
 
         if !hasMultipleSelections {
             insertNewlineSingleCursor(sender)
@@ -360,6 +398,122 @@ final class CodeTextView: NSTextView, FontSizeResponder {
         applyMultiCursorEdits(edits)
     }
 
+    override func complete(_ sender: Any?) {
+        if let completionManualTriggerHandler {
+            completionManualTriggerHandler()
+        } else {
+            super.complete(sender)
+        }
+    }
+
+    override func insertTab(_ sender: Any?) {
+        if routeCompletionKey(.acceptTop) { return }
+        super.insertTab(sender)
+    }
+
+    override func moveUp(_ sender: Any?) {
+        if routeCompletionKey(.moveSelection(-1)) { return }
+        super.moveUp(sender)
+    }
+
+    override func moveDown(_ sender: Any?) {
+        if routeCompletionKey(.moveSelection(1)) { return }
+        super.moveDown(sender)
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        if routeCompletionKey(.dismiss) { return }
+        super.cancelOperation(sender)
+    }
+
+    func completionAnchorRect() -> NSRect? {
+        let selection = selectedRange()
+        let nsLength = (string as NSString).length
+        guard selection.location != NSNotFound, selection.location <= nsLength else { return nil }
+
+        if let window {
+            var screenRect = firstRect(forCharacterRange: NSRange(location: selection.location, length: 0), actualRange: nil)
+            guard screenRect.origin.x.isFinite,
+                  screenRect.origin.y.isFinite,
+                  screenRect.height.isFinite,
+                  screenRect.height > 0 else { return nil }
+            screenRect.size.width = max(screenRect.width.isFinite ? screenRect.width : 0, 1)
+            let windowRect = window.convertFromScreen(screenRect)
+            var localRect = convert(windowRect, from: nil)
+            localRect.size.width = max(localRect.width, 1)
+            return localRect
+        }
+
+        return localInsertionRect(at: selection.location)
+    }
+
+    private func localInsertionRect(at location: Int) -> NSRect? {
+        guard let layoutManager, let textContainer else { return nil }
+        layoutManager.ensureLayout(for: textContainer)
+        return fallbackInsertionRect(at: location, layoutManager: layoutManager, textContainer: textContainer)
+    }
+
+    func applyCompletionEdits(_ edits: [CompletionTextEdit], finalSelection: NSRange) {
+        let sorted = edits.sorted {
+            $0.range.location < $1.range.location ||
+                ($0.range.location == $1.range.location && $0.range.length < $1.range.length)
+        }
+
+        let wasSuppressingNotifications = suppressCompletionChangeNotifications
+        suppressCompletionChangeNotifications = true
+
+        undoManager?.beginUndoGrouping()
+        for edit in sorted.reversed() {
+            insertTextAfterTextEdit(edit.replacementText, replacementRange: edit.range)
+        }
+        undoManager?.endUndoGrouping()
+
+        setSelectedRangeAfterTextEdit(finalSelection)
+        suppressCompletionChangeNotifications = wasSuppressingNotifications
+        if !wasSuppressingNotifications {
+            notifyCompletionChanged()
+        }
+    }
+
+    private func fallbackInsertionRect(at location: Int, layoutManager: NSLayoutManager, textContainer: NSTextContainer) -> NSRect {
+        let nsString = string as NSString
+        let lineHeight = font.map { layoutManager.defaultLineHeight(for: $0) } ?? 1
+        let containerRect: NSRect
+
+        if nsString.length == 0 {
+            containerRect = NSRect(x: 0, y: 0, width: 1, height: lineHeight)
+        } else if location == nsString.length, previousCharacter(before: location) == "\n" {
+            let extra = layoutManager.extraLineFragmentRect
+            if !extra.isEmpty {
+                containerRect = NSRect(x: extra.minX, y: extra.minY, width: 1, height: max(extra.height, lineHeight))
+            } else {
+                let lineCount = nsString.components(separatedBy: "\n").count - 1
+                containerRect = NSRect(x: 0, y: CGFloat(lineCount) * lineHeight, width: 1, height: lineHeight)
+            }
+        } else if location == nsString.length {
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: location - 1)
+            let glyphRect = layoutManager.boundingRect(forGlyphRange: NSRange(location: glyphIndex, length: 1), in: textContainer)
+            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+            containerRect = NSRect(x: glyphRect.maxX, y: lineRect.minY, width: 1, height: lineRect.height)
+        } else {
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: location)
+            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+            containerRect = NSRect(
+                x: layoutManager.location(forGlyphAt: glyphIndex).x,
+                y: lineRect.minY,
+                width: 1,
+                height: lineRect.height
+            )
+        }
+
+        return NSRect(
+            x: textContainerOrigin.x + containerRect.minX,
+            y: textContainerOrigin.y + containerRect.minY,
+            width: max(containerRect.width, 1),
+            height: max(containerRect.height, lineHeight)
+        )
+    }
+
     private func indexAtPoint(_ point: NSPoint) -> Int {
         guard let lm = self.layoutManager,
               let container = self.textContainer else { return NSNotFound }
@@ -382,8 +536,8 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             return
         }
         if let edit = IndentationHelper.newlineEdit(in: string, selectedRange: range, mode: indentationMode) {
-            super.insertText(edit.replacement, replacementRange: range)
-            setSelectedRange(NSRange(location: range.location + edit.selectedLocationDelta, length: 0))
+            insertTextAfterTextEdit(edit.replacement, replacementRange: range)
+            setSelectedRangeAfterTextEdit(NSRange(location: range.location + edit.selectedLocationDelta, length: 0))
         } else {
             super.insertNewline(sender)
         }
@@ -677,6 +831,41 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
     // MARK: - Private helpers
 
+    private func notifyCompletionChanged() {
+        guard !suppressCompletionChangeNotifications else { return }
+        completionChangeHandler?()
+    }
+
+    private func notifyCompletionSelectionChanged() {
+        guard !suppressCompletionSelectionNotifications else { return }
+        completionSelectionChangeHandler?()
+    }
+
+    private func setSelectedRangeAfterTextEdit(_ range: NSRange) {
+        let wasSuppressing = suppressCompletionSelectionNotifications
+        suppressCompletionSelectionNotifications = true
+        setSelectedRange(range)
+        suppressCompletionSelectionNotifications = wasSuppressing
+    }
+
+    private func setSelectedRangesAfterTextEdit(_ ranges: [NSValue], affinity: NSSelectionAffinity, stillSelecting: Bool) {
+        let wasSuppressing = suppressCompletionSelectionNotifications
+        suppressCompletionSelectionNotifications = true
+        setSelectedRanges(ranges, affinity: affinity, stillSelecting: stillSelecting)
+        suppressCompletionSelectionNotifications = wasSuppressing
+    }
+
+    private func insertTextAfterTextEdit(_ insertString: Any, replacementRange: NSRange) {
+        let wasSuppressing = suppressCompletionSelectionNotifications
+        suppressCompletionSelectionNotifications = true
+        super.insertText(insertString, replacementRange: replacementRange)
+        suppressCompletionSelectionNotifications = wasSuppressing
+    }
+
+    private func routeCompletionKey(_ action: CompletionKeyAction) -> Bool {
+        completionKeyHandler?(action) ?? false
+    }
+
     private static func string(from insertString: Any) -> String? {
         if let string = insertString as? String { return string }
         if let attributed = insertString as? NSAttributedString { return attributed.string }
@@ -696,12 +885,12 @@ final class CodeTextView: NSTextView, FontSizeResponder {
 
         let selectedText = range.length > 0 ? current.substring(with: range) : ""
         let replacement = "\(opening)\(selectedText)\(closing)"
-        super.insertText(replacement, replacementRange: range)
+        insertTextAfterTextEdit(replacement, replacementRange: range)
 
         if range.length > 0 {
-            setSelectedRange(NSRange(location: range.location + 1, length: range.length))
+            setSelectedRangeAfterTextEdit(NSRange(location: range.location + 1, length: range.length))
         } else {
-            setSelectedRange(NSRange(location: range.location + 1, length: 0))
+            setSelectedRangeAfterTextEdit(NSRange(location: range.location + 1, length: 0))
         }
     }
 

--- a/Alas/Sources/Code/LSP/Features/CompletionDocumentationRenderer.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionDocumentationRenderer.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Markdown
+
+@MainActor
+enum CompletionDocumentationRenderer {
+    static func render(
+        _ documentation: String,
+        theme: Theme,
+        monospacedFontFamily: String,
+        monospacedFontSize: Int
+    ) -> MarkdownRenderResult {
+        MarkdownRenderer().render(
+            document: Document(parsing: documentation),
+            theme: theme,
+            monospacedFontFamily: monospacedFontFamily,
+            monospacedFontSize: monospacedFontSize,
+            baseDirectory: URL(fileURLWithPath: "/")
+        )
+    }
+}

--- a/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionEngine.swift
@@ -1,0 +1,320 @@
+import Foundation
+
+struct CompletionPrefix: Equatable, Sendable {
+    let text: String
+    let range: NSRange
+}
+
+enum CompletionCandidateSource: Equatable, Sendable {
+    case lsp
+    case buffer
+}
+
+struct CompletionCandidate: Identifiable, Equatable, Sendable {
+    let id = UUID()
+    let label: String
+    let detail: String?
+    let kind: Int?
+    let documentation: String?
+    let sortText: String?
+    let filterText: String?
+    let replacementText: String
+    let textEdit: LSPTextEdit?
+    let additionalTextEdits: [LSPTextEdit]
+    let source: CompletionCandidateSource
+
+    static func == (lhs: CompletionCandidate, rhs: CompletionCandidate) -> Bool {
+        lhs.label == rhs.label &&
+        lhs.detail == rhs.detail &&
+        lhs.kind == rhs.kind &&
+        lhs.documentation == rhs.documentation &&
+        lhs.sortText == rhs.sortText &&
+        lhs.filterText == rhs.filterText &&
+        lhs.replacementText == rhs.replacementText &&
+        lhs.textEdit == rhs.textEdit &&
+        lhs.additionalTextEdits == rhs.additionalTextEdits &&
+        lhs.source == rhs.source
+    }
+}
+
+struct CompletionTextEdit: Equatable, Sendable {
+    let range: NSRange
+    let replacementText: String
+}
+
+struct CompletionEditPlan: Equatable, Sendable {
+    /// Original-buffer ranges sorted ascending; consumers must apply edits in reverse order.
+    let edits: [CompletionTextEdit]
+    let finalSelection: NSRange
+}
+
+enum CompletionEngine {
+    static func prefix(in text: String, caret: Int) -> CompletionPrefix? {
+        let ns = text as NSString
+        guard caret >= 0, caret <= ns.length else { return nil }
+
+        var start = caret
+        while start > 0, isIdentifierChar(ns.character(at: start - 1)) {
+            start -= 1
+        }
+
+        let range = NSRange(location: start, length: caret - start)
+        return CompletionPrefix(text: ns.substring(with: range), range: range)
+    }
+
+    static func lspCandidates(
+        from items: [LSPCompletionItem],
+        prefix: CompletionPrefix,
+        memberAccessOnly: Bool = false
+    ) -> [CompletionCandidate] {
+        let candidates = items.compactMap { item -> CompletionCandidate? in
+            guard !memberAccessOnly || isMemberAccessCandidate(item) else {
+                return nil
+            }
+
+            let filter = item.filterText ?? item.label
+            guard prefix.text.isEmpty ||
+                    hasCaseInsensitivePrefix(filter, prefix.text) ||
+                    hasCaseInsensitivePrefix(item.label, prefix.text) else {
+                return nil
+            }
+
+            let rawReplacement = item.textEdit?.newText ?? item.insertText ?? item.label
+            let replacement = item.insertTextFormat == .snippet
+                ? plainText(fromSnippet: rawReplacement)
+                : rawReplacement
+
+            return CompletionCandidate(
+                label: item.label,
+                detail: item.detail,
+                kind: item.kind,
+                documentation: documentationText(item.documentation),
+                sortText: item.sortText,
+                filterText: item.filterText,
+                replacementText: replacement,
+                textEdit: item.textEdit,
+                additionalTextEdits: item.additionalTextEdits ?? [],
+                source: .lsp
+            )
+        }
+
+        return rank(candidates, prefix: prefix)
+    }
+
+    static func bufferWordCandidates(in text: String, prefix: CompletionPrefix, limit: Int = 24) -> [CompletionCandidate] {
+        guard (prefix.text as NSString).length >= 3, limit > 0 else { return [] }
+
+        let ns = text as NSString
+        var seen = Set<String>()
+        var words: [String] = []
+        var index = 0
+
+        while index < ns.length {
+            guard isIdentifierChar(ns.character(at: index)) else {
+                index += 1
+                continue
+            }
+
+            let start = index
+            while index < ns.length, isIdentifierChar(ns.character(at: index)) {
+                index += 1
+            }
+
+            let word = ns.substring(with: NSRange(location: start, length: index - start))
+            if word != prefix.text,
+               hasCaseInsensitivePrefix(word, prefix.text),
+               seen.insert(word).inserted {
+                words.append(word)
+            }
+        }
+
+        return words.prefix(limit).map { word in
+            CompletionCandidate(
+                label: word,
+                detail: "Current buffer",
+                kind: nil,
+                documentation: nil,
+                sortText: nil,
+                filterText: word,
+                replacementText: word,
+                textEdit: nil,
+                additionalTextEdits: [],
+                source: .buffer
+            )
+        }
+    }
+
+    static func completionTriggerSuffix(in text: String, caret: Int, triggers: [String]) -> String? {
+        let ns = text as NSString
+        guard caret >= 0, caret <= ns.length else { return nil }
+
+        return triggers
+            .filter { !$0.isEmpty }
+            .sorted { lhs, rhs in
+                let lhsLength = (lhs as NSString).length
+                let rhsLength = (rhs as NSString).length
+                if lhsLength == rhsLength {
+                    return lhs < rhs
+                }
+                return lhsLength > rhsLength
+            }
+            .first { trigger in
+                let length = (trigger as NSString).length
+                guard length <= caret else { return false }
+                let suffixRange = NSRange(location: caret - length, length: length)
+                return ns.substring(with: suffixRange) == trigger
+            }
+    }
+
+    static func editPlan(accepting candidate: CompletionCandidate, prefix: CompletionPrefix, in text: String) -> CompletionEditPlan? {
+        let primaryRange: NSRange
+        if let textEdit = candidate.textEdit {
+            guard let range = nsRange(for: textEdit.range, in: text) else { return nil }
+            if shouldReplacePrefixForCaretInsertion(range: range, replacement: candidate.replacementText, prefix: prefix) {
+                primaryRange = prefix.range
+            } else {
+                primaryRange = range
+            }
+        } else {
+            primaryRange = prefix.range
+        }
+
+        let primary = CompletionTextEdit(range: primaryRange, replacementText: candidate.replacementText)
+        var edits: [CompletionTextEdit] = []
+
+        for additional in candidate.additionalTextEdits {
+            guard let range = nsRange(for: additional.range, in: text) else { continue }
+            let edit = CompletionTextEdit(range: range, replacementText: additional.newText)
+            guard !overlaps(edit.range, primary.range),
+                  edits.allSatisfy({ !overlaps($0.range, edit.range) }) else {
+                continue
+            }
+            edits.append(edit)
+        }
+
+        edits.append(primary)
+        edits.sort { lhs, rhs in
+            if lhs.range.location == rhs.range.location {
+                return lhs.range.length < rhs.range.length
+            }
+            return lhs.range.location < rhs.range.location
+        }
+
+        let primaryResultEnd = primary.range.location + (primary.replacementText as NSString).length
+        let priorAdditionalDelta = edits
+            .filter { $0.range.location < primary.range.location }
+            .reduce(0) { partial, edit in
+                partial + (edit.replacementText as NSString).length - edit.range.length
+            }
+
+        return CompletionEditPlan(
+            edits: edits,
+            finalSelection: NSRange(location: primaryResultEnd + priorAdditionalDelta, length: 0)
+        )
+    }
+
+    static func plainText(fromSnippet snippet: String) -> String {
+        var result = snippet
+        result = result.replacingOccurrences(
+            of: #"\$\{\d+\|([^,}|]+)(?:,[^}|]+)*\|\}"#,
+            with: "$1",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\$\{\d+:([^}]+)\}"#,
+            with: "$1",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\$\{\d+\}"#,
+            with: "",
+            options: .regularExpression
+        )
+        result = result.replacingOccurrences(
+            of: #"\$\d+"#,
+            with: "",
+            options: .regularExpression
+        )
+        return result
+    }
+
+    private static func rank(_ candidates: [CompletionCandidate], prefix: CompletionPrefix) -> [CompletionCandidate] {
+        candidates.sorted { lhs, rhs in
+            let lhsFilter = lhs.filterText ?? lhs.label
+            let rhsFilter = rhs.filterText ?? rhs.label
+            let lhsStarts = hasCaseInsensitivePrefix(lhsFilter, prefix.text)
+            let rhsStarts = hasCaseInsensitivePrefix(rhsFilter, prefix.text)
+            if lhsStarts != rhsStarts {
+                return lhsStarts
+            }
+
+            let lhsSort = lhs.sortText ?? lhs.label
+            let rhsSort = rhs.sortText ?? rhs.label
+            return lhsSort.localizedCaseInsensitiveCompare(rhsSort) == .orderedAscending
+        }
+    }
+
+    private static func documentationText(_ markup: LSPMarkup?) -> String? {
+        guard let markup else { return nil }
+        switch markup {
+        case .markupContent(_, let value):
+            return value
+        case .plain(let value):
+            return value
+        }
+    }
+
+    private static func isMemberAccessCandidate(_ item: LSPCompletionItem) -> Bool {
+        guard let kind = item.kind else { return true }
+        switch kind {
+        case 2, 3, 4, 5, 6, 10, 12, 20, 21, 23, 24:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func nsRange(for range: LSPRange, in text: String) -> NSRange? {
+        guard let start = TextEditCoordinates.utf16Offset(from: range.start, in: text),
+              let end = TextEditCoordinates.utf16Offset(from: range.end, in: text),
+              start <= end else {
+            return nil
+        }
+        return NSRange(location: start, length: end - start)
+    }
+
+    private static func overlaps(_ lhs: NSRange, _ rhs: NSRange) -> Bool {
+        if lhs.length == 0, rhs.length == 0 {
+            return lhs.location == rhs.location
+        }
+        if lhs.length == 0 {
+            return rhs.location <= lhs.location && lhs.location < NSMaxRange(rhs)
+        }
+        if rhs.length == 0 {
+            return lhs.location <= rhs.location && rhs.location < NSMaxRange(lhs)
+        }
+        return NSIntersectionRange(lhs, rhs).length > 0
+    }
+
+    private static func shouldReplacePrefixForCaretInsertion(
+        range: NSRange,
+        replacement: String,
+        prefix: CompletionPrefix
+    ) -> Bool {
+        !prefix.text.isEmpty &&
+            range.length == 0 &&
+            range.location == NSMaxRange(prefix.range) &&
+            hasCaseInsensitivePrefix(replacement, prefix.text)
+    }
+
+    private static func hasCaseInsensitivePrefix(_ text: String, _ prefix: String) -> Bool {
+        prefix.isEmpty || text.range(of: prefix, options: [.caseInsensitive, .anchored]) != nil
+    }
+
+    private static func isIdentifierChar(_ character: unichar) -> Bool {
+        (character >= 0x41 && character <= 0x5A) ||
+        (character >= 0x61 && character <= 0x7A) ||
+        (character >= 0x30 && character <= 0x39) ||
+        character == 0x5F
+    }
+}

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -1,0 +1,375 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class CompletionFeature {
+    private weak var textView: CodeTextView?
+    private let getClient: () -> LSPClient?
+    private let getURI: () -> String?
+    private let isEnabled: () -> Bool
+    private let getTheme: () -> Theme
+    private let getMonoFontFamily: () -> String
+    private let getMonoFontSize: () -> Int
+    private let prepareForCompletionRequest: @MainActor () async -> Void
+
+    private var debounceTask: Task<Void, Never>?
+    private var requestTask: Task<Void, Never>?
+    private var requestID: UInt64 = 0
+    private var candidates: [CompletionCandidate] = []
+    private var prefix: CompletionPrefix?
+    private var selection: Int = 0
+    private let suggestionWindow = CompletionWindowController()
+    private var isRefreshing = false
+
+    private let automaticDebounceNanos: UInt64 = 120_000_000
+    private let requestTimeoutNanos: UInt64 = 900_000_000
+    private let fallbackTriggerCharacters = [".", "->", "::"]
+    private static let memberAccessTriggerCharacters: Set<String> = [".", "->", "::"]
+
+    init(
+        textView: CodeTextView,
+        getClient: @escaping () -> LSPClient?,
+        getURI: @escaping () -> String?,
+        isEnabled: @escaping () -> Bool,
+        getTheme: @escaping () -> Theme = {
+            (try? Theme.loadBundled(id: "cool-slate")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:])
+        },
+        getMonoFontFamily: @escaping () -> String = { "SF Mono" },
+        getMonoFontSize: @escaping () -> Int = { 13 },
+        prepareForCompletionRequest: @escaping @MainActor () async -> Void = {}
+    ) {
+        self.textView = textView
+        self.getClient = getClient
+        self.getURI = getURI
+        self.isEnabled = isEnabled
+        self.getTheme = getTheme
+        self.getMonoFontFamily = getMonoFontFamily
+        self.getMonoFontSize = getMonoFontSize
+        self.prepareForCompletionRequest = prepareForCompletionRequest
+
+        textView.completionManualTriggerHandler = { [weak self] in
+            self?.triggerManual()
+        }
+        textView.completionChangeHandler = { [weak self] in
+            self?.scheduleAutomatic()
+        }
+        textView.completionSelectionChangeHandler = { [weak self] in
+            self?.cancelAndDismiss()
+        }
+        textView.completionKeyHandler = { [weak self] action in
+            self?.handleKey(action) ?? false
+        }
+    }
+
+    func cancelAndDismiss() {
+        debounceTask?.cancel()
+        requestTask?.cancel()
+        debounceTask = nil
+        requestTask = nil
+        requestID &+= 1
+        candidates.removeAll()
+        prefix = nil
+        selection = 0
+        isRefreshing = false
+        closeUI()
+    }
+
+    private func triggerManual() {
+        debounceTask?.cancel()
+        debounceTask = nil
+        startCompletion(trigger: .invoked, triggerCharacter: nil, allowEmptyPrefix: true, allowBufferFallback: true)
+    }
+
+    private func scheduleAutomatic() {
+        guard hasSessionPreconditions() else {
+            cancelAndDismiss()
+            return
+        }
+
+        debounceTask?.cancel()
+        invalidateActiveSessionForChange()
+        debounceTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: automaticDebounceNanos)
+            guard !Task.isCancelled else { return }
+            debounceTask = nil
+            let triggerCharacter = await automaticTriggerCharacter()
+            guard !Task.isCancelled else { return }
+            startCompletion(
+                trigger: triggerCharacter == nil ? .invoked : .triggerCharacter,
+                triggerCharacter: triggerCharacter,
+                allowEmptyPrefix: triggerCharacter != nil,
+                allowBufferFallback: triggerCharacter == nil,
+                memberAccessOnly: Self.isMemberAccessTriggerCharacter(triggerCharacter)
+            )
+        }
+    }
+
+    static func isMemberAccessTriggerCharacter(_ triggerCharacter: String?) -> Bool {
+        guard let triggerCharacter else { return false }
+        return memberAccessTriggerCharacters.contains(triggerCharacter)
+    }
+
+    private func automaticTriggerCharacter() async -> String? {
+        guard let textView,
+              let client = getClient() else { return nil }
+
+        let configuredTriggers = await client.completionTriggerCharacters
+        let triggers = configuredTriggers.isEmpty ? fallbackTriggerCharacters : configuredTriggers
+        return CompletionEngine.completionTriggerSuffix(
+            in: textView.string,
+            caret: textView.selectedRange().location,
+            triggers: triggers
+        )
+    }
+
+    private func startCompletion(
+        trigger: LSPCompletionTriggerKind,
+        triggerCharacter: String?,
+        allowEmptyPrefix: Bool,
+        allowBufferFallback: Bool,
+        memberAccessOnly: Bool = false
+    ) {
+        guard hasSessionPreconditions(),
+              let textView,
+              let uri = getURI() else {
+            cancelAndDismiss()
+            return
+        }
+
+        let caret = textView.selectedRange().location
+        let bufferText = textView.string
+        guard let prefix = CompletionEngine.prefix(in: bufferText, caret: caret),
+              allowEmptyPrefix || !prefix.text.isEmpty else {
+            cancelAndDismiss()
+            return
+        }
+
+        self.prefix = prefix
+        requestTask?.cancel()
+        requestID &+= 1
+        let currentRequestID = requestID
+        let timeoutNanos = requestTimeoutNanos
+        let position = TextEditCoordinates.lspPosition(utf16Offset: caret, in: bufferText)
+        let client = getClient()
+        let context = LSPCompletionContext(triggerKind: trigger, triggerCharacter: triggerCharacter)
+
+        requestTask = Task { [weak self] in
+            await self?.prepareForCompletionRequest()
+            guard !Task.isCancelled else { return }
+
+            let lspItems: [LSPCompletionItem]
+            if let client, let position {
+                lspItems = await Self.requestCompletionWithTimeout(
+                    client: client,
+                    uri: uri,
+                    position: position,
+                    context: context,
+                    timeoutNanos: timeoutNanos
+                )
+            } else {
+                lspItems = []
+            }
+
+            guard !Task.isCancelled else { return }
+            await MainActor.run { [weak self] in
+                guard let self,
+                      self.requestID == currentRequestID,
+                      self.getURI() == uri,
+                      let activeTextView = self.textView,
+                      self.hasSessionPreconditions(),
+                      activeTextView.selectedRange().location == caret,
+                      CompletionEngine.prefix(in: activeTextView.string, caret: caret) == prefix else {
+                    return
+                }
+                self.present(
+                    items: lspItems,
+                    prefix: prefix,
+                    bufferText: activeTextView.string,
+                    allowBufferFallback: allowBufferFallback,
+                    memberAccessOnly: memberAccessOnly
+                )
+            }
+        }
+    }
+
+    private nonisolated static func requestCompletionWithTimeout(
+        client: LSPClient,
+        uri: String,
+        position: LSPPosition,
+        context: LSPCompletionContext,
+        timeoutNanos: UInt64
+    ) async -> [LSPCompletionItem] {
+        await withTaskGroup(of: [LSPCompletionItem].self) { group in
+            group.addTask {
+                ((try? await client.completion(uri: uri, position: position, context: context))?.items) ?? []
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutNanos)
+                return []
+            }
+
+            let first = await group.next() ?? []
+            group.cancelAll()
+            return first
+        }
+    }
+
+    private func present(
+        items: [LSPCompletionItem],
+        prefix: CompletionPrefix,
+        bufferText: String,
+        allowBufferFallback: Bool,
+        memberAccessOnly: Bool
+    ) {
+        var next = CompletionEngine.lspCandidates(
+            from: items,
+            prefix: prefix,
+            memberAccessOnly: memberAccessOnly
+        )
+        if allowBufferFallback {
+            let buffer = CompletionEngine.bufferWordCandidates(in: bufferText, prefix: prefix)
+            next.append(contentsOf: buffer.filter { bufferCandidate in
+                !next.contains { $0.label == bufferCandidate.label }
+            })
+        }
+
+        guard !next.isEmpty else {
+            cancelAndDismiss()
+            return
+        }
+
+        candidates = next
+        self.prefix = prefix
+        isRefreshing = false
+        selection = min(max(selection, 0), next.count - 1)
+        showPopup()
+    }
+
+    private func showPopup() {
+        guard let textView,
+              let anchor = textView.completionAnchorRect() else {
+            cancelAndDismiss()
+            return
+        }
+
+        let rows = candidates.map {
+            CompletionPopupRow(
+                id: $0.id,
+                label: $0.label,
+                detail: $0.detail,
+                kind: $0.kind,
+                source: $0.source
+            )
+        }
+        let documentationText = candidates.indices.contains(selection) ? candidates[selection].documentation : nil
+        let theme = getTheme()
+        let documentation = documentationText.flatMap { text -> MarkdownRenderResult? in
+            guard !text.isEmpty else { return nil }
+            return CompletionDocumentationRenderer.render(
+                text,
+                theme: theme,
+                monospacedFontFamily: getMonoFontFamily(),
+                monospacedFontSize: getMonoFontSize()
+            )
+        }
+        suggestionWindow.show(
+            rows: rows,
+            selection: selection,
+            documentation: documentation,
+            theme: theme,
+            anchor: anchor,
+            in: textView
+        ) { [weak self] index in
+            self?.accept(index: index)
+        }
+    }
+
+    private func handleKey(_ action: CodeTextView.CompletionKeyAction) -> Bool {
+        if case .dismiss = action, suggestionWindow.isVisible || !candidates.isEmpty || isRefreshing {
+            cancelAndDismiss()
+            return true
+        }
+
+        guard !isRefreshing, !candidates.isEmpty else { return false }
+        guard suggestionWindow.isVisible else {
+            cancelAndDismiss()
+            return false
+        }
+
+        switch action {
+        case .acceptTop:
+            accept(index: 0)
+            return true
+        case .acceptSelected:
+            accept(index: selection)
+            return true
+        case .moveSelection(let delta):
+            selection = min(max(0, selection + delta), candidates.count - 1)
+            showPopup()
+            return true
+        case .dismiss:
+            return false
+        }
+    }
+
+    private func accept(index: Int) {
+        guard let textView,
+              candidates.indices.contains(index),
+              let prefix,
+              canAcceptCompletion(prefix: prefix, in: textView) else {
+            cancelAndDismiss()
+            return
+        }
+
+        let candidate = candidates[index]
+        guard let plan = CompletionEngine.editPlan(accepting: candidate, prefix: prefix, in: textView.string) else {
+            cancelAndDismiss()
+            return
+        }
+
+        textView.applyCompletionEdits(plan.edits, finalSelection: plan.finalSelection)
+        cancelAndDismiss()
+    }
+
+    private func closeUI() {
+        suggestionWindow.hide()
+    }
+
+    private func invalidateActiveSessionForChange() {
+        requestTask?.cancel()
+        requestTask = nil
+        requestID &+= 1
+        prefix = nil
+        isRefreshing = true
+    }
+
+    private func canAcceptCompletion(prefix: CompletionPrefix, in textView: CodeTextView) -> Bool {
+        let text = textView.string
+        let length = (text as NSString).length
+        let currentSelection = textView.selectedRange()
+        let caret = NSMaxRange(prefix.range)
+
+        guard prefix.range.location != NSNotFound,
+              prefix.range.location >= 0,
+              prefix.range.length >= 0,
+              caret <= length,
+              currentSelection.location == caret,
+              currentSelection.length == 0 else {
+            return false
+        }
+
+        return CompletionEngine.prefix(in: text, caret: caret) == prefix
+    }
+
+    private func hasSessionPreconditions() -> Bool {
+        guard isEnabled(),
+              let textView,
+              textView.isEditable,
+              textView.selectedRanges.count == 1,
+              textView.selectedRange().length == 0 else {
+            return false
+        }
+        return true
+    }
+}

--- a/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionPopup.swift
@@ -1,0 +1,186 @@
+import AppKit
+import SwiftUI
+
+private let popupMaxHeight: CGFloat = 260
+
+struct CompletionPopupRow: Identifiable, Equatable {
+    let id: UUID
+    let label: String
+    let detail: String?
+    let kind: Int?
+    let source: CompletionCandidateSource
+}
+
+struct CompletionPopup: View {
+    let rows: [CompletionPopupRow]
+    let selection: Int
+    let documentation: MarkdownRenderResult?
+    let theme: Theme
+    let onChoose: (Int) -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+                            rowView(row)
+                                .id(index)
+                                .background(index == selection ? Color.accentColor.opacity(0.24) : Color.clear)
+                                .contentShape(Rectangle())
+                                .onTapGesture { onChoose(index) }
+                        }
+                    }
+                }
+                .onAppear {
+                    scrollSelection(selection, proxy: proxy)
+                }
+                .onChange(of: selection) { _, nextSelection in
+                    scrollSelection(nextSelection, proxy: proxy)
+                }
+                .frame(width: 320, height: popupMaxHeight, alignment: .topLeading)
+            }
+
+            if let documentation, documentation.attributedString.length > 0 {
+                Divider()
+
+                CompletionDocumentationView(result: documentation, theme: theme)
+                .frame(width: 320, height: popupMaxHeight, alignment: .topLeading)
+            }
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+        .overlay {
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func scrollSelection(_ selection: Int, proxy: ScrollViewProxy) {
+        guard rows.indices.contains(selection) else { return }
+        DispatchQueue.main.async {
+            withAnimation(nil) {
+                proxy.scrollTo(selection, anchor: .center)
+            }
+        }
+    }
+
+    private func rowView(_ row: CompletionPopupRow) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(kindLabel(row.kind, source: row.source))
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .frame(width: 18, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(row.label)
+                    .font(.system(size: 12, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                if let detail = row.detail, !detail.isEmpty {
+                    Text(detail)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct CompletionDocumentationView: NSViewRepresentable {
+    let result: MarkdownRenderResult
+    let theme: Theme
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.drawsBackground = false
+        textView.isSelectable = true
+        textView.textContainerInset = NSSize(width: 10, height: 10)
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.linkTextAttributes = linkAttributes(theme: theme)
+
+        scrollView.documentView = textView
+        scrollView.drawsBackground = true
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.borderType = .noBorder
+
+        context.coordinator.textView = textView
+        textView.textStorage?.setAttributedString(result.attributedString)
+        scrollView.backgroundColor = NSColor(theme.color("bg-1"))
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let textView = context.coordinator.textView else { return }
+        textView.textStorage?.setAttributedString(result.attributedString)
+        textView.linkTextAttributes = linkAttributes(theme: theme)
+        nsView.backgroundColor = NSColor(theme.color("bg-1"))
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    private func linkAttributes(theme: Theme) -> [NSAttributedString.Key: Any] {
+        [
+            .foregroundColor: NSColor(theme.color("accent")),
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        weak var textView: NSTextView? {
+            didSet { textView?.delegate = self }
+        }
+
+        func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+            if let url = link as? URL {
+                NSWorkspace.shared.open(url)
+            } else if let string = link as? String, let url = URL(string: string) {
+                NSWorkspace.shared.open(url)
+            }
+            return true
+        }
+    }
+}
+
+private func kindLabel(_ kind: Int?, source: CompletionCandidateSource) -> String {
+    if source == .buffer {
+        return "W"
+    }
+
+    switch kind {
+    case 2:
+        return "M"
+    case 3:
+        return "F"
+    case 5:
+        return "C"
+    case 6:
+        return "V"
+    case 7:
+        return "K"
+    case 10:
+        return "P"
+    case 12:
+        return "Fn"
+    case 13:
+        return "T"
+    default:
+        return "S"
+    }
+}

--- a/Alas/Sources/Code/LSP/Features/CompletionWindowController.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionWindowController.swift
@@ -1,0 +1,124 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class CompletionWindowController {
+    static let panelHidesOnDeactivate = true
+
+    private final class CompletionPanel: NSPanel {
+        override var canBecomeKey: Bool { false }
+        override var canBecomeMain: Bool { false }
+    }
+
+    private let maxHeight: CGFloat = 260
+    private let listWidth: CGFloat = 320
+    private let screenPadding: CGFloat = 6
+    private let caretGap: CGFloat = 4
+
+    private var panel: CompletionPanel?
+    private var hostingController: NSHostingController<CompletionPopup>?
+
+    var isVisible: Bool {
+        panel?.isVisible == true
+    }
+
+    func show(
+        rows: [CompletionPopupRow],
+        selection: Int,
+        documentation: MarkdownRenderResult?,
+        theme: Theme,
+        anchor: NSRect,
+        in textView: CodeTextView,
+        onChoose: @escaping (Int) -> Void
+    ) {
+        let hasDocumentation = (documentation?.attributedString.length ?? 0) > 0
+        let size = NSSize(width: hasDocumentation ? listWidth * 2 : listWidth, height: maxHeight)
+        let root = CompletionPopup(rows: rows, selection: selection, documentation: documentation, theme: theme, onChoose: onChoose)
+        let panel = ensurePanel(size: size)
+        hostingController?.rootView = root
+        panel.setFrame(frame(for: size, anchor: anchor, in: textView), display: true, animate: false)
+
+        attach(panel, to: textView.window)
+        if !panel.isVisible {
+            panel.orderFront(nil)
+        }
+    }
+
+    func hide() {
+        if let panel {
+            panel.parent?.removeChildWindow(panel)
+        }
+        panel?.orderOut(nil)
+    }
+
+    private func ensurePanel(size: NSSize) -> CompletionPanel {
+        if let panel {
+            return panel
+        }
+
+        let hostingController = NSHostingController(
+            rootView: CompletionPopup(
+                rows: [],
+                selection: 0,
+                documentation: nil,
+                theme: (try? Theme.loadBundled(id: "cool-slate")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:]),
+                onChoose: { _ in }
+            )
+        )
+        let panel = CompletionPanel(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.contentViewController = hostingController
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.level = .normal
+        panel.collectionBehavior = [.transient, .ignoresCycle]
+        panel.hidesOnDeactivate = Self.panelHidesOnDeactivate
+        self.hostingController = hostingController
+        self.panel = panel
+        return panel
+    }
+
+    func attach(_ panel: NSWindow, to parentWindow: NSWindow?) {
+        guard let parentWindow else { return }
+
+        if panel.parent !== parentWindow {
+            panel.parent?.removeChildWindow(panel)
+            parentWindow.addChildWindow(panel, ordered: .above)
+        }
+        panel.level = parentWindow.level
+    }
+
+    private func frame(for size: NSSize, anchor: NSRect, in textView: CodeTextView) -> NSRect {
+        guard let window = textView.window else {
+            return NSRect(origin: .zero, size: size)
+        }
+
+        let windowRect = textView.convert(anchor, to: nil)
+        let screenRect = window.convertToScreen(windowRect)
+        let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame ?? screenRect
+        let x = min(
+            max(screenRect.minX, visibleFrame.minX + screenPadding),
+            visibleFrame.maxX - size.width - screenPadding
+        )
+        let belowY = screenRect.minY - size.height - caretGap
+        let aboveY = screenRect.maxY + caretGap
+        let y: CGFloat
+        if belowY >= visibleFrame.minY + screenPadding {
+            y = belowY
+        } else {
+            y = min(aboveY, visibleFrame.maxY - size.height - screenPadding)
+        }
+
+        return NSRect(
+            x: x,
+            y: max(y, visibleFrame.minY + screenPadding),
+            width: size.width,
+            height: size.height
+        )
+    }
+}

--- a/Alas/Sources/Code/LSP/LSPClient.swift
+++ b/Alas/Sources/Code/LSP/LSPClient.swift
@@ -3,6 +3,11 @@ import Foundation
 actor LSPClient {
     enum State { case starting, initializing, ready, dead }
     enum TextDocumentSyncKind: Int { case none = 0, full = 1, incremental = 2 }
+
+    private struct InitializeParams: Encodable, Sendable {
+        let processId: Int
+        let rootUri: String
+    }
     private static let shutdownTimeoutNanoseconds: UInt64 = 2_000_000_000
 
     let language: String
@@ -14,6 +19,7 @@ actor LSPClient {
     private var textDocumentSyncKind: TextDocumentSyncKind = .full
     private(set) var supportsDocumentFormatting: Bool = false
     private(set) var supportsPullDiagnostics: Bool = false
+    private(set) var completionTriggerCharacters: [String] = []
     // `AsyncStream` is single-consumer — values are delivered to whichever
     // iterator races to read first, not broadcast. Multiple coordinators
     // sharing one client (two tabs in the same worktree/language) used to
@@ -55,24 +61,16 @@ actor LSPClient {
     func initialize() async throws {
         try transport.start()
         state = .initializing
-        let params: [String: Any] = [
-            "processId": Int(ProcessInfo.processInfo.processIdentifier),
-            "rootUri": rootURI,
-            "capabilities": [
-                "textDocument": [
-                    "hover": ["contentFormat": ["markdown", "plaintext"]],
-                    "definition": [:],
-                    "documentSymbol": ["hierarchicalDocumentSymbolSupport": true],
-                    "publishDiagnostics": [:],
-                    "formatting": ["dynamicRegistration": false]
-                ]
-            ] as [String: Any]
-        ]
+        let params = InitializeParams(
+            processId: Int(ProcessInfo.processInfo.processIdentifier),
+            rootUri: rootURI
+        )
         let rawResult = try await sendRequest(method: "initialize", params: params)
         let caps = Self.decodeCapabilities(from: rawResult)
         textDocumentSyncKind = caps.syncKind
         supportsDocumentFormatting = caps.supportsFormatting
         supportsPullDiagnostics = caps.supportsPullDiagnostics
+        completionTriggerCharacters = caps.completionTriggerCharacters
         try sendNotification(method: "initialized", params: [String: Any]())
         state = .ready
     }
@@ -150,6 +148,20 @@ actor LSPClient {
         return (try? JSONDecoder().decode([LSPDocumentSymbol].self, from: raw)) ?? []
     }
 
+    func completion(uri: String, position: LSPPosition, context: LSPCompletionContext?) async throws -> LSPCompletionResult {
+        let params = LSPCompletionParams(
+            textDocument: LSPTextDocumentIdentifier(uri: uri),
+            position: position,
+            context: context
+        )
+        let raw = try await sendRequest(method: "textDocument/completion", params: params)
+        guard let raw, raw.count > 4 else {
+            return LSPCompletionResult(isIncomplete: false, items: [])
+        }
+        return (try? JSONDecoder().decode(LSPCompletionResult.self, from: raw))
+            ?? LSPCompletionResult(isIncomplete: false, items: [])
+    }
+
     func formatting(uri: String, options: LSPFormattingOptions) async throws -> [LSPTextEdit] {
         guard supportsDocumentFormatting else { return [] }
         let params = LSPDocumentFormattingParams(
@@ -220,7 +232,12 @@ actor LSPClient {
             method: method,
             params: params.map { AnyEncodable($0) }
         )
-        let data = try JSONEncoder().encode(req)
+        let data: Data
+        if method == "initialize", let initializeParams = params as? InitializeParams {
+            data = try Self.encodeInitializeRequest(id: id, params: initializeParams)
+        } else {
+            data = try Self.outgoingJSONEncoder().encode(req)
+        }
         let timeoutTask = timeoutNanoseconds.map { timeoutNanoseconds in
             Task {
                 do {
@@ -251,8 +268,13 @@ actor LSPClient {
         }
     }
 
-    private static func decodeCapabilities(from data: Data?) -> (syncKind: TextDocumentSyncKind, supportsFormatting: Bool, supportsPullDiagnostics: Bool) {
-        guard let data else { return (.full, false, false) }
+    private static func decodeCapabilities(from data: Data?) -> (
+        syncKind: TextDocumentSyncKind,
+        supportsFormatting: Bool,
+        supportsPullDiagnostics: Bool,
+        completionTriggerCharacters: [String]
+    ) {
+        guard let data else { return (.full, false, false, []) }
         struct InitializeResult: Decodable {
             let capabilities: ServerCapabilities
         }
@@ -260,11 +282,15 @@ actor LSPClient {
             let textDocumentSync: TextDocumentSync?
             let documentFormattingProvider: DocumentFormattingProvider?
             let diagnosticProvider: DiagnosticProvider?
+            let completionProvider: CompletionProvider?
         }
         struct DiagnosticProvider: Decodable {
             let identifier: String?
             let interFileDependencies: Bool?
             let workspaceDiagnostics: Bool?
+        }
+        struct CompletionProvider: Decodable {
+            let triggerCharacters: [String]?
         }
         enum DocumentFormattingProvider: Decodable {
             case unsupported
@@ -307,7 +333,7 @@ actor LSPClient {
         }
 
         guard let result = try? JSONDecoder().decode(InitializeResult.self, from: data) else {
-            return (.full, false, false)
+            return (.full, false, false, [])
         }
         let syncKind: TextDocumentSyncKind = {
             guard let sync = result.capabilities.textDocumentSync else { return .full }
@@ -317,7 +343,8 @@ actor LSPClient {
         }()
         let supportsFormatting = result.capabilities.documentFormattingProvider?.isSupported ?? false
         let supportsPullDiagnostics = result.capabilities.diagnosticProvider != nil
-        return (syncKind, supportsFormatting, supportsPullDiagnostics)
+        let triggerCharacters = result.capabilities.completionProvider?.triggerCharacters ?? []
+        return (syncKind, supportsFormatting, supportsPullDiagnostics, triggerCharacters)
     }
 
     private static func fullRange(for text: String) -> LSPRange {
@@ -350,8 +377,34 @@ actor LSPClient {
 
     private nonisolated func sendNotification(method: String, params: Any?) throws {
         let note = LSPNotification(method: method, params: params.map { AnyEncodable($0) })
-        let data = try JSONEncoder().encode(note)
+        let data = try Self.outgoingJSONEncoder().encode(note)
         try transport.send(data)
+    }
+
+    private nonisolated static func outgoingJSONEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .withoutEscapingSlashes
+        return encoder
+    }
+
+    private nonisolated static func encodeInitializeRequest(id: LSPID, params: InitializeParams) throws -> Data {
+        let idString: String
+        switch id {
+        case .int(let value):
+            idString = String(value)
+        case .string(let value):
+            idString = try jsonString(value)
+        }
+        let rootUri = try jsonString(params.rootUri)
+        let json = """
+        {"jsonrpc":"2.0","id":\(idString),"method":"initialize","params":{"processId":\(params.processId),"rootUri":\(rootUri),"capabilities":{"textDocument":{"hover":{"contentFormat":["markdown","plaintext"]},"definition":{},"documentSymbol":{"hierarchicalDocumentSymbolSupport":true},"publishDiagnostics":{},"formatting":{"dynamicRegistration":false},"completion":{"dynamicRegistration":false,"completionItem":{"documentationFormat":["markdown","plaintext"],"snippetSupport":false},"contextSupport":true}}}}}
+        """
+        return Data(json.utf8)
+    }
+
+    private nonisolated static func jsonString(_ value: String) throws -> String {
+        let data = try outgoingJSONEncoder().encode(value)
+        return String(decoding: data, as: UTF8.self)
     }
 
     private func consume() async {

--- a/Alas/Sources/Code/LSP/LSPMessages.swift
+++ b/Alas/Sources/Code/LSP/LSPMessages.swift
@@ -315,4 +315,135 @@ struct LSPTextDocumentIdentifier: Codable, Hashable, Sendable {
 struct LSPTextEdit: Codable, Hashable, Sendable {
     let range: LSPRange
     let newText: String
+
+    init(range: LSPRange, newText: String) {
+        self.range = range
+        self.newText = newText
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.newText = try container.decode(String.self, forKey: .newText)
+        if let range = try container.decodeIfPresent(LSPRange.self, forKey: .range) {
+            self.range = range
+        } else if let replace = try container.decodeIfPresent(LSPRange.self, forKey: .replace) {
+            self.range = replace
+        } else {
+            self.range = try container.decode(LSPRange.self, forKey: .insert)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(range, forKey: .range)
+        try container.encode(newText, forKey: .newText)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case range
+        case newText
+        case insert
+        case replace
+    }
+}
+
+// MARK: - Completion
+
+struct LSPCompletionParams: Codable, Hashable, Sendable {
+    let textDocument: LSPTextDocumentIdentifier
+    let position: LSPPosition
+    let context: LSPCompletionContext?
+}
+
+struct LSPCompletionContext: Codable, Hashable, Sendable {
+    let triggerKind: LSPCompletionTriggerKind
+    let triggerCharacter: String?
+}
+
+enum LSPCompletionTriggerKind: Int, Codable, Hashable, Sendable {
+    case invoked = 1
+    case triggerCharacter = 2
+    case triggerForIncompleteCompletions = 3
+}
+
+enum LSPInsertTextFormat: Int, Codable, Hashable, Sendable {
+    case plainText = 1
+    case snippet = 2
+}
+
+struct LSPCompletionItem: Decodable, Sendable {
+    let label: String
+    let kind: Int?
+    let detail: String?
+    let documentation: LSPMarkup?
+    let sortText: String?
+    let filterText: String?
+    let insertText: String?
+    let insertTextFormat: LSPInsertTextFormat?
+    let textEdit: LSPTextEdit?
+    let additionalTextEdits: [LSPTextEdit]?
+
+    init(
+        label: String,
+        kind: Int?,
+        detail: String?,
+        documentation: LSPMarkup?,
+        sortText: String?,
+        filterText: String?,
+        insertText: String?,
+        insertTextFormat: LSPInsertTextFormat?,
+        textEdit: LSPTextEdit?,
+        additionalTextEdits: [LSPTextEdit]?
+    ) {
+        self.label = label
+        self.kind = kind
+        self.detail = detail
+        self.documentation = documentation
+        self.sortText = sortText
+        self.filterText = filterText
+        self.insertText = insertText
+        self.insertTextFormat = insertTextFormat
+        self.textEdit = textEdit
+        self.additionalTextEdits = additionalTextEdits
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case label
+        case kind
+        case detail
+        case documentation
+        case sortText
+        case filterText
+        case insertText
+        case insertTextFormat
+        case textEdit
+        case additionalTextEdits
+    }
+}
+
+struct LSPCompletionResult: Decodable, Sendable {
+    let isIncomplete: Bool
+    let items: [LSPCompletionItem]
+
+    init(isIncomplete: Bool, items: [LSPCompletionItem]) {
+        self.isIncomplete = isIncomplete
+        self.items = items
+    }
+
+    init(from decoder: Decoder) throws {
+        if let items = try? [LSPCompletionItem](from: decoder) {
+            self.isIncomplete = false
+            self.items = items
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.isIncomplete = try container.decodeIfPresent(Bool.self, forKey: .isIncomplete) ?? false
+        self.items = try container.decode([LSPCompletionItem].self, forKey: .items)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case isIncomplete
+        case items
+    }
 }

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -296,7 +296,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
     func clientWhenReady(forFile fileURL: URL, worktreeRoot: URL, language: String, timeout: TimeInterval = 30) async -> LSPClient? {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
-            if let c = client(forFile: fileURL, worktreeRoot: worktreeRoot, language: language) { return c }
+            if let c = openedClient(forFile: fileURL, worktreeRoot: worktreeRoot, language: language) { return c }
             try? await Task.sleep(nanoseconds: 50_000_000) // 50 ms
             if Task.isCancelled { return nil }
         }
@@ -311,6 +311,20 @@ final class WorkspaceLSPManager: DocumentFormatter {
         let uri = fileURL.lspURI
         guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot) else { return nil }
         return holders[key]?.client
+    }
+
+    /// Returns the client only after the specific file has completed the
+    /// initialize + didOpen path. Request/notification features should use
+    /// this instead of `client(forFile:)` so they never talk to a server that
+    /// is still starting or has not seen the document yet.
+    func openedClient(forFile fileURL: URL, worktreeRoot: URL, language: String) -> LSPClient? {
+        let uri = fileURL.lspURI
+        guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot),
+              let holder = holders[key],
+              holder.openedURIs.contains(uri) else {
+            return nil
+        }
+        return holder.client
     }
 
     /// True when `fileURL` has already been delivered to a live (non-dead)

--- a/AlasTests/Code/LSP/Features/CompletionDocumentationRendererTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionDocumentationRendererTests.swift
@@ -1,0 +1,21 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+struct CompletionDocumentationRendererTests {
+    @Test func rendersDocumentationWithMarkdownRenderer() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let result = CompletionDocumentationRenderer.render(
+            "```swift\nfunc f() {}\n```",
+            theme: theme,
+            monospacedFontFamily: "SF Mono",
+            monospacedFontSize: 13
+        )
+
+        let range = (result.attributedString.string as NSString).range(of: "func")
+        let color = result.attributedString.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+
+        #expect(color != NSColor(theme.color("fg")))
+    }
+}

--- a/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionEngineTests.swift
@@ -1,0 +1,373 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("CompletionEngine")
+struct CompletionEngineTests {
+    @Test("detects identifier prefix before caret")
+    func prefixBeforeCaret() {
+        let text = "tabs.op"
+        let prefix = CompletionEngine.prefix(in: text, caret: (text as NSString).length)
+        #expect(prefix == CompletionPrefix(text: "op", range: NSRange(location: 5, length: 2)))
+    }
+
+    @Test("manual completion allows empty prefix")
+    func emptyPrefixAtBoundary() {
+        let prefix = CompletionEngine.prefix(in: "tabs.", caret: 5)
+        #expect(prefix == CompletionPrefix(text: "", range: NSRange(location: 5, length: 0)))
+    }
+
+    @Test("extracts buffer-word fallback candidates")
+    func bufferWordFallback() {
+        let candidates = CompletionEngine.bufferWordCandidates(
+            in: "openEditor openExternalEditor openedTabs openEditor",
+            prefix: CompletionPrefix(text: "ope", range: NSRange(location: 0, length: 3))
+        )
+        #expect(candidates.map(\.label) == ["openEditor", "openExternalEditor", "openedTabs"])
+        #expect(candidates.allSatisfy { $0.source == .buffer })
+    }
+
+    @Test("suppresses buffer-word fallback for short prefixes")
+    func bufferWordFallbackRequiresSpecificPrefix() {
+        let candidates = CompletionEngine.bufferWordCandidates(
+            in: "openEditor openExternalEditor openedTabs",
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2))
+        )
+
+        #expect(candidates.isEmpty)
+    }
+
+    @Test("normalizes and ranks LSP items")
+    func normalizeLSPItems() {
+        let items = [
+            LSPCompletionItem.testing(label: "openBeta", sortText: "002", filterText: "openBeta"),
+            LSPCompletionItem.testing(label: "zebra", sortText: "003", filterText: nil),
+            LSPCompletionItem.testing(label: "openAlpha", sortText: "001", filterText: "openAlpha")
+        ]
+
+        let candidates = CompletionEngine.lspCandidates(
+            from: items,
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2))
+        )
+
+        #expect(candidates.map(\.label) == ["openAlpha", "openBeta"])
+        #expect(candidates.allSatisfy { $0.source == .lsp })
+    }
+
+    @Test("filters LSP items by prefix instead of substring")
+    func lspCandidatesRequirePrefixMatch() {
+        let items = [
+            LSPCompletionItem.testing(label: "openEditor", sortText: nil, filterText: "openEditor"),
+            LSPCompletionItem.testing(label: "tabsOpenEditor", sortText: nil, filterText: "tabsOpenEditor")
+        ]
+
+        let candidates = CompletionEngine.lspCandidates(
+            from: items,
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2))
+        )
+
+        #expect(candidates.map(\.label) == ["openEditor"])
+    }
+
+    @Test("trigger completions keep member-like LSP items")
+    func triggerCompletionFiltersGlobalKinds() {
+        let items = [
+            LSPCompletionItem.testing(label: "count", kind: 10, sortText: nil, filterText: nil),
+            LSPCompletionItem.testing(label: "append", kind: 2, sortText: nil, filterText: nil),
+            LSPCompletionItem.testing(label: "String", kind: 7, sortText: nil, filterText: nil),
+            LSPCompletionItem.testing(label: "if", kind: 14, sortText: nil, filterText: nil)
+        ]
+
+        let candidates = CompletionEngine.lspCandidates(
+            from: items,
+            prefix: CompletionPrefix(text: "", range: NSRange(location: 4, length: 0)),
+            memberAccessOnly: true
+        )
+
+        #expect(candidates.map(\.label) == ["append", "count"])
+    }
+
+    @Test("matches longest completion trigger suffix before caret")
+    func completionTriggerSuffix() {
+        #expect(CompletionEngine.completionTriggerSuffix(
+            in: "foo->",
+            caret: 5,
+            triggers: [">", "->", "."]
+        ) == "->")
+        #expect(CompletionEngine.completionTriggerSuffix(
+            in: "Foo::",
+            caret: 5,
+            triggers: [":", "::", "."]
+        ) == "::")
+        #expect(CompletionEngine.completionTriggerSuffix(
+            in: "foo.",
+            caret: 4,
+            triggers: ["->", "."]
+        ) == ".")
+    }
+
+    @Test("uses textEdit newText before insertText")
+    func textEditReplacementPrecedence() {
+        let item = LSPCompletionItem.testing(
+            label: "openEditor",
+            sortText: nil,
+            filterText: "openEditor",
+            insertText: "insertTextValue",
+            textEdit: LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 0), end: LSPPosition(line: 0, character: 2)),
+                newText: "textEditValue"
+            )
+        )
+
+        let candidates = CompletionEngine.lspCandidates(
+            from: [item],
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 0, length: 2))
+        )
+
+        #expect(candidates.first?.replacementText == "textEditValue")
+    }
+
+    @Test("strips snippet placeholders to conservative plain text")
+    func stripsSnippetPlaceholders() {
+        #expect(CompletionEngine.plainText(fromSnippet: "openEditor(${1:path})$0") == "openEditor(path)")
+        #expect(CompletionEngine.plainText(fromSnippet: "${1|public,private|} func ${2:name}()") == "public func name()")
+        #expect(CompletionEngine.plainText(fromSnippet: "value${1}.${2}") == "value.")
+    }
+
+    @Test("plans primary prefix replacement")
+    func plansPrimaryPrefixReplacement() {
+        let candidate = CompletionCandidate(
+            label: "openEditor",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openEditor",
+            textEdit: nil,
+            additionalTextEdits: [],
+            source: .lsp
+        )
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 5, length: 2)),
+            in: "tabs.op"
+        )
+        #expect(plan == CompletionEditPlan(edits: [
+            CompletionTextEdit(range: NSRange(location: 5, length: 2), replacementText: "openEditor")
+        ], finalSelection: NSRange(location: 15, length: 0)))
+    }
+
+    @Test("uses prefix replacement when LSP textEdit inserts full candidate at caret")
+    func plansCaretInsertionTextEditAsPrefixReplacement() {
+        let candidate = CompletionCandidate(
+            label: "openEditor",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openEditor",
+            textEdit: LSPTextEdit(
+                range: LSPRange(
+                    start: LSPPosition(line: 0, character: 7),
+                    end: LSPPosition(line: 0, character: 7)
+                ),
+                newText: "openEditor"
+            ),
+            additionalTextEdits: [],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 5, length: 2)),
+            in: "tabs.op"
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 5, length: 2), replacementText: "openEditor")
+        ])
+        #expect(plan?.finalSelection == NSRange(location: 15, length: 0))
+        #expect(plan.flatMap { apply($0, to: "tabs.op") } == "tabs.openEditor")
+    }
+
+    @Test("plans textEdit plus non-overlapping additional edits")
+    func plansAdditionalTextEdits() {
+        let text = "let value = op\n"
+        let primary = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 12), end: LSPPosition(line: 0, character: 14)),
+            newText: "openEditor"
+        )
+        let importEdit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 0), end: LSPPosition(line: 0, character: 0)),
+            newText: "import Foundation\n"
+        )
+        let candidate = CompletionCandidate(
+            label: "openEditor",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openEditor",
+            textEdit: primary,
+            additionalTextEdits: [importEdit],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 12, length: 2)),
+            in: text
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 0, length: 0), replacementText: "import Foundation\n"),
+            CompletionTextEdit(range: NSRange(location: 12, length: 2), replacementText: "openEditor")
+        ])
+        #expect(plan?.finalSelection == NSRange(location: 40, length: 0))
+        #expect(plan.flatMap { apply($0, to: text) } == "import Foundation\nlet value = openEditor\n")
+    }
+
+    @Test("plans LSP textEdit after UTF-16 surrogate pair")
+    func plansTextEditAfterSurrogatePair() {
+        let text = "let icon = \"😀\"\nlet value = op\n"
+        let primary = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 1, character: 12), end: LSPPosition(line: 1, character: 14)),
+            newText: "openEditor"
+        )
+        let candidate = CompletionCandidate(
+            label: "openEditor",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openEditor",
+            textEdit: primary,
+            additionalTextEdits: [],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 28, length: 2)),
+            in: text
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 28, length: 2), replacementText: "openEditor")
+        ])
+        #expect(plan?.finalSelection == NSRange(location: 38, length: 0))
+        #expect(plan.flatMap { apply($0, to: text) } == "let icon = \"😀\"\nlet value = openEditor\n")
+    }
+
+    @Test("rejects overlapping additional edits")
+    func rejectsOverlappingAdditionalEdits() {
+        let text = "let value = op\n"
+        let primary = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 12), end: LSPPosition(line: 0, character: 14)),
+            newText: "openEditor"
+        )
+        let overlap = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 13), end: LSPPosition(line: 0, character: 14)),
+            newText: "x"
+        )
+        let candidate = CompletionCandidate(
+            label: "openEditor",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "openEditor",
+            textEdit: primary,
+            additionalTextEdits: [overlap],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "op", range: NSRange(location: 12, length: 2)),
+            in: text
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 12, length: 2), replacementText: "openEditor")
+        ])
+    }
+
+    @Test("rejects same-position insertion additional edits")
+    func rejectsSamePositionInsertionAdditionalEdits() {
+        let text = ""
+        let primary = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 0), end: LSPPosition(line: 0, character: 0)),
+            newText: "primary"
+        )
+        let samePositionInsert = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 0), end: LSPPosition(line: 0, character: 0)),
+            newText: "additional"
+        )
+        let candidate = CompletionCandidate(
+            label: "primary",
+            detail: nil,
+            kind: nil,
+            documentation: nil,
+            sortText: nil,
+            filterText: nil,
+            replacementText: "primary",
+            textEdit: primary,
+            additionalTextEdits: [samePositionInsert],
+            source: .lsp
+        )
+
+        let plan = CompletionEngine.editPlan(
+            accepting: candidate,
+            prefix: CompletionPrefix(text: "", range: NSRange(location: 0, length: 0)),
+            in: text
+        )
+
+        #expect(plan?.edits == [
+            CompletionTextEdit(range: NSRange(location: 0, length: 0), replacementText: "primary")
+        ])
+    }
+}
+
+private func apply(_ plan: CompletionEditPlan, to text: String) -> String? {
+    let storage = NSMutableString(string: text)
+    for edit in plan.edits.reversed() {
+        guard edit.range.location >= 0,
+              edit.range.length >= 0,
+              NSMaxRange(edit.range) <= storage.length else {
+            return nil
+        }
+        storage.replaceCharacters(in: edit.range, with: edit.replacementText)
+    }
+    return storage as String
+}
+
+private extension LSPCompletionItem {
+    static func testing(
+        label: String,
+        kind: Int? = nil,
+        sortText: String?,
+        filterText: String?,
+        insertText: String? = nil,
+        insertTextFormat: LSPInsertTextFormat? = nil,
+        textEdit: LSPTextEdit? = nil
+    ) -> LSPCompletionItem {
+        LSPCompletionItem(
+            label: label,
+            kind: kind,
+            detail: nil,
+            documentation: nil,
+            sortText: sortText,
+            filterText: filterText,
+            insertText: insertText,
+            insertTextFormat: insertTextFormat,
+            textEdit: textEdit,
+            additionalTextEdits: nil
+        )
+    }
+}

--- a/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionFeatureTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct CompletionFeatureTests {
+    private func makeTextView(_ text: String) -> CodeTextView {
+        let storage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        return textView
+    }
+
+    @Test("trigger completion flushes pending document changes before request")
+    func triggerCompletionFlushesBeforeRequest() async throws {
+        let transport = FakeTransport()
+        let client = LSPClient(transport: transport, language: "swift", rootURI: "file:///tmp")
+        var events: [String] = []
+        var completionRequest = ""
+        transport.onSend = { sent in
+            if sent.contains(#""method":"initialize""#) {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"completionProvider":{"triggerCharacters":["."]}}}}"#)
+            } else if sent.contains(#""method":"textDocument/completion""#) {
+                events.append("completion")
+                completionRequest = sent
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":2,"result":{"isIncomplete":false,"items":[]}}"#)
+            }
+        }
+        try await client.initialize()
+
+        let textView = makeTextView("foo.")
+        let feature = CompletionFeature(
+            textView: textView,
+            getClient: { client },
+            getURI: { "file:///tmp/foo.swift" },
+            isEnabled: { true },
+            prepareForCompletionRequest: {
+                events.append("flush")
+            }
+        )
+
+        textView.completionChangeHandler?()
+        try await waitForCompletionRequest(events: { events })
+
+        #expect(events == ["flush", "completion"])
+        #expect(completionRequest.contains(#""triggerKind":2"#))
+        #expect(completionRequest.contains(#""triggerCharacter":".""#))
+        feature.cancelAndDismiss()
+        transport.finish()
+    }
+
+    @Test("member-only filtering is limited to member access triggers")
+    func memberOnlyFilteringTriggerCharacters() {
+        #expect(CompletionFeature.isMemberAccessTriggerCharacter("."))
+        #expect(CompletionFeature.isMemberAccessTriggerCharacter("->"))
+        #expect(CompletionFeature.isMemberAccessTriggerCharacter("::"))
+        #expect(!CompletionFeature.isMemberAccessTriggerCharacter("/"))
+        #expect(!CompletionFeature.isMemberAccessTriggerCharacter("\""))
+        #expect(!CompletionFeature.isMemberAccessTriggerCharacter(nil))
+    }
+
+    private func waitForCompletionRequest(events: () -> [String]) async throws {
+        let deadline = Date().addingTimeInterval(2)
+        while !events().contains("completion"), Date() < deadline {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+    }
+}

--- a/AlasTests/Code/LSP/Features/CompletionWindowControllerTests.swift
+++ b/AlasTests/Code/LSP/Features/CompletionWindowControllerTests.swift
@@ -1,0 +1,12 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct CompletionWindowControllerTests {
+    @Test("suggestion panel hides when the app deactivates")
+    func suggestionPanelHidesWhenAppDeactivates() {
+        #expect(CompletionWindowController.panelHidesOnDeactivate)
+    }
+}

--- a/AlasTests/Code/LSP/LSPClientTests.swift
+++ b/AlasTests/Code/LSP/LSPClientTests.swift
@@ -121,6 +121,53 @@ struct LSPClientLifecycleTests {
         transport.finish()
     }
 
+    @Test("completion request sends document position and context")
+    func completion() async throws {
+        let transport = FakeTransport()
+        let client = LSPClient(transport: transport, language: "swift", rootURI: "file:///tmp")
+        transport.onSend = { sent in
+            if sent.contains(#""method":"initialize""#) {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}"#)
+            } else if sent.contains(#""method":"textDocument/completion""#) {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":2,"result":{"isIncomplete":false,"items":[{"label":"openEditor","kind":2}]}}"#)
+            }
+        }
+
+        try await client.initialize()
+        #expect((transport.sent.first ?? "").contains(#""completion":{"dynamicRegistration":false"#))
+
+        let result = try await client.completion(
+            uri: "file:///tmp/AppState.swift",
+            position: LSPPosition(line: 4, character: 12),
+            context: LSPCompletionContext(triggerKind: .invoked, triggerCharacter: nil)
+        )
+
+        let request = transport.sent.last ?? ""
+        #expect(request.contains(#""method":"textDocument/completion""#))
+        #expect(request.contains(#""uri":"file:///tmp/AppState.swift""#))
+        #expect(request.contains(#""line":4"#))
+        #expect(request.contains(#""character":12"#))
+        #expect(request.contains(#""triggerKind":1"#))
+        #expect(result.items.map(\.label) == ["openEditor"])
+        transport.finish()
+    }
+
+    @Test("initialize stores completion trigger characters")
+    func completionTriggerCharacters() async throws {
+        let transport = FakeTransport()
+        let client = LSPClient(transport: transport, language: "cpp", rootURI: "file:///tmp")
+        transport.onSend = { sent in
+            if sent.contains(#""method":"initialize""#) {
+                transport.deliverFrame(#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"completionProvider":{"triggerCharacters":[".","->","::"]}}}}"#)
+            }
+        }
+
+        try await client.initialize()
+
+        #expect(await client.completionTriggerCharacters == [".", "->", "::"])
+        transport.finish()
+    }
+
     @Test("incremental text sync sends a ranged full replacement")
     func incrementalTextSyncUsesRange() async throws {
         let transport = FakeTransport()

--- a/AlasTests/Code/LSP/LSPMessagesTests.swift
+++ b/AlasTests/Code/LSP/LSPMessagesTests.swift
@@ -46,4 +46,109 @@ struct LSPMessagesTests {
         let p2 = try JSONDecoder().decode(LSPPosition.self, from: data)
         #expect(p == p2)
     }
+
+    @Test("decodes completion result from an item array")
+    func decodeCompletionItemArray() throws {
+        let data = """
+        [
+          {
+            "label": "openEditor",
+            "kind": 2,
+            "detail": "(relativePath: String)",
+            "documentation": {"kind": "markdown", "value": "Opens a file."},
+            "sortText": "001",
+            "filterText": "openEditor",
+            "insertText": "openEditor(relativePath:)",
+            "insertTextFormat": 1,
+            "textEdit": {
+              "range": {
+                "start": {"line": 3, "character": 8},
+                "end": {"line": 3, "character": 10}
+              },
+              "newText": "openEditor"
+            },
+            "additionalTextEdits": [
+              {
+                "range": {
+                  "start": {"line": 0, "character": 0},
+                  "end": {"line": 0, "character": 0}
+                },
+                "newText": "import Foundation\\n"
+              }
+            ]
+          }
+        ]
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(LSPCompletionResult.self, from: data)
+
+        #expect(result.isIncomplete == false)
+        #expect(result.items.count == 1)
+        let item = try #require(result.items.first)
+        #expect(item.label == "openEditor")
+        #expect(item.kind == 2)
+        #expect(item.detail == "(relativePath: String)")
+        #expect(item.sortText == "001")
+        #expect(item.filterText == "openEditor")
+        #expect(item.insertText == "openEditor(relativePath:)")
+        #expect(item.insertTextFormat == .plainText)
+        #expect(item.textEdit?.newText == "openEditor")
+        #expect(item.textEdit?.range.start == LSPPosition(line: 3, character: 8))
+        #expect(item.additionalTextEdits?.first?.newText == "import Foundation\n")
+        if case .markupContent(let kind, let value) = item.documentation {
+            #expect(kind == "markdown")
+            #expect(value == "Opens a file.")
+        } else {
+            Issue.record("expected markdown documentation")
+        }
+    }
+
+    @Test("decodes completion insert replace text edit")
+    func decodeCompletionInsertReplaceTextEdit() throws {
+        let data = """
+        [
+          {
+            "label": "append",
+            "textEdit": {
+              "newText": "append",
+              "insert": {
+                "start": {"line": 1, "character": 4},
+                "end": {"line": 1, "character": 7}
+              },
+              "replace": {
+                "start": {"line": 1, "character": 4},
+                "end": {"line": 1, "character": 10}
+              }
+            }
+          }
+        ]
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(LSPCompletionResult.self, from: data)
+
+        let edit = try #require(result.items.first?.textEdit)
+        #expect(edit.newText == "append")
+        #expect(edit.range == LSPRange(
+            start: LSPPosition(line: 1, character: 4),
+            end: LSPPosition(line: 1, character: 10)
+        ))
+    }
+
+    @Test("decodes completion result from CompletionList")
+    func decodeCompletionList() throws {
+        let data = """
+        {
+          "isIncomplete": true,
+          "items": [
+            {"label": "openExternalEditor", "kind": 2, "detail": "(absoluteURL: URL)"}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let result = try JSONDecoder().decode(LSPCompletionResult.self, from: data)
+
+        #expect(result.isIncomplete == true)
+        #expect(result.items.map(\.label) == ["openExternalEditor"])
+        #expect(result.items.first?.detail == "(absoluteURL: URL)")
+    }
 }

--- a/AlasTests/CodeTextViewCompletionTests.swift
+++ b/AlasTests/CodeTextViewCompletionTests.swift
@@ -1,0 +1,211 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct CodeTextViewCompletionTests {
+    private func makeTextView(_ text: String = "") -> CodeTextView {
+        let storage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        textView.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        return textView
+    }
+
+    @Test func completeCallsManualTriggerHandler() {
+        let textView = makeTextView()
+        var calls = 0
+        textView.completionManualTriggerHandler = {
+            calls += 1
+        }
+
+        textView.complete(nil)
+
+        #expect(calls == 1)
+    }
+
+    @Test func insertTabRoutesAcceptTopAndDoesNotMutateTextWhenHandled() {
+        let textView = makeTextView("let value = open")
+        var actions: [CodeTextView.CompletionKeyAction] = []
+        textView.completionKeyHandler = { action in
+            actions.append(action)
+            return true
+        }
+
+        textView.insertTab(nil)
+
+        #expect(actions == [.acceptTop])
+        #expect(textView.string == "let value = open")
+    }
+
+    @Test func insertNewlineRoutesAcceptSelectedAndDoesNotMutateTextWhenHandled() {
+        let textView = makeTextView("let value = open")
+        var actions: [CodeTextView.CompletionKeyAction] = []
+        textView.completionKeyHandler = { action in
+            actions.append(action)
+            return true
+        }
+
+        textView.insertNewline(nil)
+
+        #expect(actions == [.acceptSelected])
+        #expect(textView.string == "let value = open")
+    }
+
+    @Test func cancelOperationRoutesDismiss() {
+        let textView = makeTextView()
+        var actions: [CodeTextView.CompletionKeyAction] = []
+        textView.completionKeyHandler = { action in
+            actions.append(action)
+            return true
+        }
+
+        textView.cancelOperation(nil)
+
+        #expect(actions == [.dismiss])
+    }
+
+    @Test func moveUpAndDownRouteSelectionMovement() {
+        let textView = makeTextView("alpha\nbeta")
+        var actions: [CodeTextView.CompletionKeyAction] = []
+        textView.completionKeyHandler = { action in
+            actions.append(action)
+            return true
+        }
+
+        textView.moveUp(nil)
+        textView.moveDown(nil)
+
+        #expect(actions == [.moveSelection(-1), .moveSelection(1)])
+    }
+
+    @Test func applyCompletionEditsUsesOriginalBufferRangesAndSetsFinalSelection() {
+        let textView = makeTextView("let value = op\n")
+        textView.applyCompletionEdits([
+            CompletionTextEdit(range: NSRange(location: 0, length: 0), replacementText: "import Foundation\n"),
+            CompletionTextEdit(range: NSRange(location: 12, length: 2), replacementText: "openEditor")
+        ], finalSelection: NSRange(location: 40, length: 0))
+
+        #expect(textView.string == "import Foundation\nlet value = openEditor\n")
+        #expect(textView.selectedRange() == NSRange(location: 40, length: 0))
+    }
+
+    @Test func applyCompletionEditsCoalescesCompletionChangeNotification() {
+        let textView = makeTextView("let value = op\n")
+        var changeCount = 0
+        textView.completionChangeHandler = {
+            changeCount += 1
+        }
+
+        textView.applyCompletionEdits([
+            CompletionTextEdit(range: NSRange(location: 0, length: 0), replacementText: "import Foundation\n"),
+            CompletionTextEdit(range: NSRange(location: 12, length: 2), replacementText: "openEditor")
+        ], finalSelection: NSRange(location: 40, length: 0))
+
+        #expect(changeCount == 1)
+    }
+
+    @Test func selectionMoveDoesNotTriggerAutomaticCompletionChange() {
+        let textView = makeTextView("let value = open")
+        var changeCount = 0
+        var selectionChangeCount = 0
+        textView.completionChangeHandler = {
+            changeCount += 1
+        }
+        textView.completionSelectionChangeHandler = {
+            selectionChangeCount += 1
+        }
+
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+
+        #expect(changeCount == 0)
+        #expect(selectionChangeCount == 1)
+    }
+
+    @Test func textEditWithProgrammaticSelectionTriggersOnlyTextChange() {
+        let textView = makeTextView()
+        var changeCount = 0
+        var selectionChangeCount = 0
+        textView.completionChangeHandler = {
+            changeCount += 1
+        }
+        textView.completionSelectionChangeHandler = {
+            selectionChangeCount += 1
+        }
+
+        textView.insertText("(", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "()")
+        #expect(changeCount == 1)
+        #expect(selectionChangeCount == 0)
+    }
+
+    @Test func completionAnchorAtEndOfTextIsAfterLastCharacter() throws {
+        let textView = makeTextView("foo")
+        textView.textContainerInset = .zero
+        textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        if let textContainer = textView.textContainer {
+            textView.layoutManager?.ensureLayout(for: textContainer)
+        }
+
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        let beforeLast = try #require(textView.completionAnchorRect())
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+        let end = try #require(textView.completionAnchorRect())
+
+        #expect(end.minX > beforeLast.minX)
+    }
+
+    @Test func completionAnchorAfterTrailingNewlineUsesEmptyFinalLine() throws {
+        let textView = makeTextView("foo\n")
+        textView.textContainerInset = .zero
+        textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        if let textContainer = textView.textContainer {
+            textView.layoutManager?.ensureLayout(for: textContainer)
+        }
+
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        let firstLine = try #require(textView.completionAnchorRect())
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+        let finalLine = try #require(textView.completionAnchorRect())
+
+        #expect(finalLine.minY > firstLine.minY)
+        #expect(finalLine.minX <= firstLine.minX + 1)
+    }
+
+    @Test func windowBackedCompletionAnchorAcceptsInsertionRect() throws {
+        let textView = makeTextView("foo")
+        textView.frame = NSRect(x: 0, y: 0, width: 240, height: 120)
+        textView.textContainerInset = .zero
+        textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 100, y: 100, width: 240, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.close() }
+        window.contentView = NSView(frame: NSRect(x: 0, y: 0, width: 240, height: 120))
+        window.contentView?.addSubview(textView)
+        window.makeKeyAndOrderFront(nil)
+        window.makeFirstResponder(textView)
+        window.layoutIfNeeded()
+        textView.layoutSubtreeIfNeeded()
+        if let textContainer = textView.textContainer {
+            textView.layoutManager?.ensureLayout(for: textContainer)
+        }
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+
+        let rect = try #require(textView.completionAnchorRect())
+
+        #expect(rect.height > 0)
+        #expect(rect.width >= 1)
+        #expect(rect.origin.x.isFinite)
+        #expect(rect.origin.y.isFinite)
+    }
+}

--- a/docs/superpowers/specs/2026-05-22-autocomplete-design.md
+++ b/docs/superpowers/specs/2026-05-22-autocomplete-design.md
@@ -1,0 +1,171 @@
+# IDE Autocomplete Design
+
+## Context
+
+Alas already has a native AppKit-backed code editor with LSP features for diagnostics, hover, definitions, symbols, formatting, and language-server installation. `EditorBuffer` owns file contents, dirty state, hot-exit snapshots, file watching, LSP document open/close, and debounced `didChange`. `CodeEditorCoordinator` owns mounted editor features such as hover, definition, hover highlight, diagnostics rendering, syntax highlighting, and active client/URI lookup.
+
+Autocomplete should extend this existing LSP path instead of introducing a parallel editor or language-service lifecycle.
+
+## Goals
+
+- Provide IDE-level autocomplete in code editor panes.
+- Support both automatic suggestions while typing and a manual completion trigger.
+- Use LSP completions as the primary source.
+- Show a compact popup for suggestions and documentation.
+- Fall back to current-buffer word completions when LSP is unavailable, slow, or returns no useful items.
+- Keep v1 focused: no snippet expansion engine, no persistent ranking, no workspace-symbol fallback, and no signature-help integration.
+
+## User Experience
+
+Autocomplete appears only in editable in-worktree editor buffers with a single caret. It is disabled for read-only external buffers, multi-cursor mode, unsupported languages, and states where there is no usable caret position.
+
+Automatic suggestions appear after a short debounce when typing creates a useful prefix. Manual completion opens through an explicit keyboard command and may request completions even for a short or empty prefix when an LSP client is ready.
+
+The visual model follows the popup-first design that replaced inline preview after user testing:
+
+- A compact popup anchored near the caret lists completions.
+- `Tab` accepts the top match.
+- `Return` accepts the selected popup item.
+- Up/down arrows move the popup selection.
+- `Esc` dismisses the current completion session.
+- Continued typing filters existing candidates and may schedule a fresh LSP request.
+
+Completion closes on cursor movement, selection changes, buffer rebind, tab switch, unsupported edit states, or stale request results.
+
+## Architecture
+
+Autocomplete is a new coordinator-owned LSP feature, parallel to hover and definition.
+
+### `CodeTextView`
+
+`CodeTextView` remains the editor surface. It should expose the small hooks needed by completion:
+
+- Key routing while a completion session is open.
+- Caret-to-LSP-position and caret-rect helpers.
+- Safe text edit application through the normal `NSTextView` editing path.
+- Session invalidation signals for selection movement and editing states that should dismiss completion.
+
+The view should not own LSP request logic or candidate ranking.
+
+### `CodeEditorCoordinator`
+
+`CodeEditorCoordinator` constructs and tears down `CompletionFeature` alongside `HoverFeature`, `DefinitionFeature`, and `HoverHighlightFeature`. It should pass closures that resolve the active `LSPClient` and document URI using the same patterns already used by hover and definition, including external-origin handling where applicable.
+
+Coordinator rebind/detach paths must dismiss active completion UI and cancel outstanding completion work.
+
+### `CompletionFeature`
+
+`CompletionFeature` owns the completion session:
+
+- Automatic debounce and manual trigger handling.
+- LSP request cancellation and stale-response guards.
+- Candidate normalization, filtering, ranking, and fallback merging.
+- Popup presentation.
+- Keyboard navigation and acceptance.
+- Applying the accepted item into the editor.
+
+The feature should be `@MainActor` for UI state, with async LSP requests guarded by request IDs, active URI checks, and current caret position checks before presenting results.
+
+### LSP Layer
+
+`LSPMessages` gains typed completion models for request parameters and results. `LSPClient` gains `completion(uri:position:context:)`.
+
+`WorkspaceLSPManager` does not need a new lifecycle role for v1. `EditorBuffer` already opens documents, updates text through debounced `didChange`, and closes documents when buffers are released. Completion should use the active client that already serves the open document.
+
+## Completion Data
+
+The decoder must support both valid LSP result shapes:
+
+- `CompletionItem[]`
+- `CompletionList`
+
+Completion items should preserve:
+
+- `label`
+- `kind`
+- `detail`
+- `documentation`
+- `sortText`
+- `filterText`
+- `insertText`
+- `insertTextFormat`
+- `textEdit`
+- `additionalTextEdits`
+
+v1 treats plain-text insertions as first-class. Snippet-formatted items may be shown, but acceptance uses a conservative plain-text fallback rather than interpreting placeholder syntax. Snippet expansion is explicitly out of scope for this design.
+
+## Candidate Sources
+
+LSP completions are the primary source. Current-buffer word completions are a fallback source when LSP is unavailable, times out, or returns no useful candidates. The fallback should:
+
+- Extract identifier-like words from the active buffer.
+- Exclude the current prefix as an exact duplicate.
+- Prefer words that start with the typed prefix.
+- Avoid adding persistent global state.
+
+LSP and fallback candidates should not be presented as two separate modes to the user; the feature presents one candidate list with source-specific metadata kept internal.
+
+## Applying Completions
+
+When accepting a completion:
+
+1. Prefer the LSP item's `textEdit` range and replacement text when present.
+2. Otherwise replace the detected prefix immediately before the caret with `insertText` or `label`.
+3. Apply non-overlapping `additionalTextEdits` in a stable order before the primary edit.
+4. Reject or skip additional edits that overlap the primary edit or each other.
+5. Perform edits through the editor's normal text mutation path so existing dirty tracking, undo, highlighting, hot-exit snapshots, and debounced LSP `didChange` continue to work.
+
+After acceptance, the completion UI closes. The editor's existing observer path handles downstream state updates.
+
+## Error Handling
+
+Autocomplete should fail closed:
+
+- If there is no LSP client, use buffer-word fallback.
+- If the LSP request fails or times out, use fallback when possible.
+- If a response arrives for an old request, old URI, old caret position, or unmounted view, discard it.
+- If candidate application cannot produce a safe edit range, dismiss without changing text.
+- If popup presentation cannot anchor to a visible caret, skip UI presentation.
+
+Failures should not surface blocking alerts. Diagnostics are not part of autocomplete error reporting.
+
+## Testing
+
+Swift Testing coverage should focus on non-UI logic:
+
+- Completion request encoding.
+- Completion result decoding for array and `CompletionList` shapes.
+- Completion item documentation/detail preservation.
+- Prefix detection.
+- Candidate filtering and ranking.
+- Buffer-word fallback extraction.
+- Snippet fallback stripping.
+- Replacement range computation.
+- `textEdit` and `additionalTextEdits` application ordering.
+- Rejection of overlapping edits.
+
+AppKit-focused tests should remain narrow:
+
+- `CodeTextView` routes `Tab`, `Return`, arrows, and `Esc` only while completion is active.
+- Completion dismisses on selection/caret states that invalidate the session.
+- Accepted completions mutate text through the same observer path used by normal edits.
+
+Manual verification should cover a real Swift project with `sourcekit-lsp`:
+
+- Automatic suggestions after typing.
+- Manual completion trigger.
+- Top suggestion acceptance with `Tab`.
+- Popup navigation and acceptance with `Return`.
+- Fallback behavior with no live LSP.
+- Stale responses do not flash old candidates.
+- Completion UI does not appear in external read-only tabs or multi-cursor mode.
+
+## Out Of Scope
+
+- Snippet placeholder expansion.
+- Signature help.
+- Completion item resolve.
+- Persistent ranking or telemetry.
+- Workspace-wide symbol fallback.
+- New language-server lifecycle management.
+- Changes to language-server installation UX.


### PR DESCRIPTION
## Summary

Adds IDE-style autocomplete to code editor panes using the existing LSP client, with a custom suggestion window and markdown-rendered completion documentation.

## Changes

- Add LSP completion request/response models and client support, including trigger characters from server capabilities.
- Wire autocomplete into `CodeEditorCoordinator` and `CodeTextView` with manual and automatic triggers.
- Add completion candidate normalization, prefix filtering, member-access trigger behavior, and buffer-symbol fallback for typed prefixes.
- Replace the animated popover with a VS Code-style child suggestion panel scoped to the editor window.
- Render completion documentation with the existing `MarkdownRenderer`, matching hover styling and code-fence highlighting.
- Add focused tests for completion engine behavior, LSP messages/client support, editor hooks, feature lifecycle, panel behavior, and markdown documentation rendering.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CompletionDocumentationRendererTests -quiet test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CompletionFeatureTests -quiet test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CompletionWindowControllerTests -quiet test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/CompletionEngineTests -quiet test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

Full local test suite was run earlier on this branch and still has unrelated pre-existing failures outside autocomplete.