### PR TITLE
feat: redesigned LSP hover with dwell trigger and shared overlay panel

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		065F01BB553C415040414D37 /* ImageDiffSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
+		08681BEDBD6D7232CC937704 /* HoverFeatureBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E853C6AAB6450A0845A7CD /* HoverFeatureBehaviorTests.swift */; };
 		08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */; };
 		095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
@@ -32,6 +33,7 @@
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
 		0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB91379591DA21D216A894 /* RelativeTime.swift */; };
 		0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */; };
+		0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */; };
 		0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */; };
 		0F560F9B2458B94C807E96A1 /* CodeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */; };
 		10557FBC430EEAB1196D9575 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */; };
@@ -75,6 +77,7 @@
 		214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98D0A96093087BF4C284053 /* AlasSlider.swift */; };
 		21D97FBF7356BC50400E0265 /* CommitContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */; };
 		21DDC95793C87C46FB46E3D6 /* ImageDiffSwipeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7018E992654E19345D8BD723 /* ImageDiffSwipeViewTests.swift */; };
+		2281077800674169E69C6C3B /* HoverWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */; };
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
 		23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
@@ -114,6 +117,7 @@
 		363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */; };
 		376A08C73011C5CA9E445C4B /* ImageDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */; };
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
+		395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */; };
 		3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */; };
 		3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */; };
 		3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E265B0C6F314FC80DB18053D /* RecommendedLanguageCatalog.swift */; };
@@ -257,6 +261,7 @@
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
 		8035C82C1C3F79801A0F2F39 /* ImageDiffPairKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */; };
 		8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */; };
+		81214C5FDACA47C2FFC15E9E /* HoverWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */; };
 		8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		82D3560952F0B800F56377D7 /* AgentHookInstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */; };
@@ -583,6 +588,7 @@
 		20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighterTests.swift; sourceTree = "<group>"; };
 		206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCheckerboardBackground.swift; sourceTree = "<group>"; };
 		2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
+		208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanelTests.swift; sourceTree = "<group>"; };
 		2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.App.swift; sourceTree = "<group>"; };
 		215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyHost.swift; sourceTree = "<group>"; };
 		220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModelTests.swift; sourceTree = "<group>"; };
@@ -648,6 +654,7 @@
 		3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilderTests.swift; sourceTree = "<group>"; };
 		3BF2F213480B30034B25B2B8 /* AgentRunError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunError.swift; sourceTree = "<group>"; };
 		3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfo.swift; sourceTree = "<group>"; };
+		3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverWindowControllerTests.swift; sourceTree = "<group>"; };
 		3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPicker.swift; sourceTree = "<group>"; };
 		3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardTests.swift; sourceTree = "<group>"; };
 		3D105CB2C185958ED23164D1 /* IndentationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationMode.swift; sourceTree = "<group>"; };
@@ -719,6 +726,7 @@
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
 		650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometry.swift; sourceTree = "<group>"; };
 		65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstaller.swift; sourceTree = "<group>"; };
+		65E853C6AAB6450A0845A7CD /* HoverFeatureBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeatureBehaviorTests.swift; sourceTree = "<group>"; };
 		6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateOverlayFocusTests.swift; sourceTree = "<group>"; };
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherFilterTests.swift; sourceTree = "<group>"; };
@@ -772,6 +780,7 @@
 		7FFC9539E615699AC90A7412 /* ProjectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManager.swift; sourceTree = "<group>"; };
 		802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeView.swift; sourceTree = "<group>"; };
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
+		8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverWindowController.swift; sourceTree = "<group>"; };
 		822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModel.swift; sourceTree = "<group>"; };
 		82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBehindStatusTests.swift; sourceTree = "<group>"; };
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
@@ -987,6 +996,7 @@
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
+		F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanel.swift; sourceTree = "<group>"; };
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
 		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
@@ -1120,6 +1130,7 @@
 				35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */,
 				C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */,
 				6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */,
+				208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */,
 				E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */,
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
 				25493E3B18A1AB94EA6985C3 /* EventHolder.swift */,
@@ -1150,7 +1161,9 @@
 				2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */,
 				23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */,
 				C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */,
+				65E853C6AAB6450A0845A7CD /* HoverFeatureBehaviorTests.swift */,
 				3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */,
+				3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */,
 				FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */,
 				9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */,
 				638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */,
@@ -1731,8 +1744,10 @@
 				781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */,
 				0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */,
 				932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */,
+				F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */,
 				0AF8152B18C9D6290724122F /* HoverFeature.swift */,
 				019A03B92542169A6595D432 /* HoverHighlightFeature.swift */,
+				8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */,
 				0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */,
 			);
 			path = Features;
@@ -2183,6 +2198,7 @@
 				DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */,
 				3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */,
 				25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */,
+				395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,
 				7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */,
@@ -2220,6 +2236,7 @@
 				B05BA1C6DD0BDA21E0932EE3 /* HookInstallNudgeResolver.swift in Sources */,
 				AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */,
 				E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */,
+				81214C5FDACA47C2FFC15E9E /* HoverWindowController.swift in Sources */,
 				EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */,
 				CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */,
 				A4AB930CA0EEA2CEF0302646 /* ImageCheckerboardBackground.swift in Sources */,
@@ -2446,6 +2463,7 @@
 				3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */,
 				C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */,
 				B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */,
+				0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */,
 				1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */,
 				C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */,
 				51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */,
@@ -2476,8 +2494,10 @@
 				3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */,
 				D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */,
 				1AE5FCAF7D44694876754813 /* HookInstallNudgeResolverTests.swift in Sources */,
+				08681BEDBD6D7232CC937704 /* HoverFeatureBehaviorTests.swift in Sources */,
 				C9DAC0F907752F6D3B955DD8 /* HoverFeatureRenderingTests.swift in Sources */,
 				D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */,
+				2281077800674169E69C6C3B /* HoverWindowControllerTests.swift in Sources */,
 				E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */,
 				3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */,
 				474DF7FE50CB6146644B2450 /* ImageDiffEndToEndTests.swift in Sources */,

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -41,6 +41,7 @@ final class CodeEditorCoordinator {
     let symbolsFeature = SymbolsFeature()
     private var pullDiagnosticsTask: Task<Void, Never>?
     private var hover: HoverFeature?
+    private var hoverObservers: [NSObjectProtocol] = []
     private var definition: DefinitionFeature?
     private var hoverHighlight: HoverHighlightFeature?
     private var completion: CompletionFeature?
@@ -126,6 +127,7 @@ final class CodeEditorCoordinator {
             getMonoFontFamily: { [weak self] in self?.currentFontFamily ?? self?.appState.config.code.fontFamily ?? "SF Mono" },
             getMonoFontSize: { [weak self] in self?.currentFontSize.map(Int.init) ?? self?.appState.config.code.fontSize ?? 13 }
         )
+        installHoverObservers(textView: textView)
         definition = DefinitionFeature(
             textView: textView,
             getClient: { [weak self] in
@@ -457,6 +459,8 @@ final class CodeEditorCoordinator {
             buffer.storage.removeLayoutManager(layoutManager)
         }
         layoutManager = nil
+        clearHoverObservers()
+        hover?.tearDown()
         hover = nil
         definition = nil
         hoverHighlight = nil
@@ -483,6 +487,63 @@ final class CodeEditorCoordinator {
             object: self,
             userInfo: ["tabId": tabId as Any]
         )
+    }
+
+    // MARK: - Hover observers
+
+    private func installHoverObservers(textView: CodeTextView) {
+        clearHoverObservers()
+        let nc = NotificationCenter.default
+
+        if let clipView = textView.enclosingScrollView?.contentView {
+            clipView.postsBoundsChangedNotifications = true
+            let token = nc.addObserver(
+                forName: NSView.boundsDidChangeNotification,
+                object: clipView,
+                queue: .main
+            ) { [weak self] _ in
+                self?.hover?.notifyScrolled()
+            }
+            hoverObservers.append(token)
+        }
+
+        let selectionToken = nc.addObserver(
+            forName: NSTextView.didChangeSelectionNotification,
+            object: textView,
+            queue: .main
+        ) { [weak self] _ in
+            self?.hover?.notifyCaretChanged()
+        }
+        hoverObservers.append(selectionToken)
+
+        // Subscribe with object: nil because attach(...) runs from
+        // makeNSView before the text view is inserted into a window, so
+        // textView.window is often nil here and never gets retried. The
+        // handler filters to the text view's current window at fire time.
+        let resizeToken = nc.addObserver(
+            forName: NSWindow.didResizeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self,
+                  let window = note.object as? NSWindow,
+                  window === self.textView?.window else { return }
+            self.hover?.notifyWindowResized()
+        }
+        hoverObservers.append(resizeToken)
+
+        textView.escapeHandler = { [weak self] in
+            self?.hover?.handleEscape() ?? false
+        }
+    }
+
+    private func clearHoverObservers() {
+        let nc = NotificationCenter.default
+        for token in hoverObservers {
+            nc.removeObserver(token)
+        }
+        hoverObservers.removeAll()
+        textView?.escapeHandler = nil
     }
 
     // MARK: - Edit propagation (highlight + didChange debouncer)

--- a/Alas/Sources/Code/Editor/CodeTextView.swift
+++ b/Alas/Sources/Code/Editor/CodeTextView.swift
@@ -31,6 +31,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     var completionManualTriggerHandler: (() -> Void)?
     var completionChangeHandler: (() -> Void)?
     var completionSelectionChangeHandler: (() -> Void)?
+    var escapeHandler: (() -> Bool)?
     var completionKeyHandler: ((CompletionKeyAction) -> Bool)?
     var indentationMode: IndentationMode = .plain
 
@@ -422,6 +423,7 @@ final class CodeTextView: NSTextView, FontSizeResponder {
     }
 
     override func cancelOperation(_ sender: Any?) {
+        if escapeHandler?() == true { return }
         if routeCompletionKey(.dismiss) { return }
         super.cancelOperation(sender)
     }
@@ -935,5 +937,56 @@ final class CodeTextView: NSTextView, FontSizeResponder {
             cursor -= 1
         }
         return backslashCount % 2 == 1
+    }
+}
+
+extension CodeTextView {
+    /// Returns the contiguous identifier-like range covering the character at
+    /// `point`, or nil if the point is outside the text or not over an
+    /// identifier character (`[A-Za-z0-9_]`). Used by hover and ⌘-underline.
+    func symbolRange(at point: NSPoint) -> NSRange? {
+        guard let layoutManager, let textContainer, let storage = textStorage else { return nil }
+        let containerPoint = NSPoint(
+            x: point.x - textContainerInset.width,
+            y: point.y - textContainerInset.height
+        )
+        let glyphIndex = layoutManager.glyphIndex(for: containerPoint, in: textContainer)
+        let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+        let nsString = storage.string as NSString
+        guard charIndex < nsString.length else { return nil }
+        let range = nsString.rangeOfWord(at: charIndex)
+        return range.length == 0 ? nil : range
+    }
+
+    /// Returns the bounding rect (in view coordinates, including
+    /// `textContainerInset`) of the first character of `range`. Used to anchor
+    /// the hover popover under a token.
+    func symbolAnchorRect(for range: NSRange) -> NSRect? {
+        guard range.length > 0, let layoutManager, let textContainer else { return nil }
+        let glyph = layoutManager.glyphIndexForCharacter(at: range.location)
+        let rect = layoutManager.boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: textContainer)
+        return rect.offsetBy(dx: textContainerInset.width, dy: textContainerInset.height)
+    }
+}
+
+extension NSString {
+    /// Returns the contiguous identifier-like range covering `index`, or an
+    /// empty range if the character at `index` is not part of an identifier.
+    func rangeOfWord(at index: Int) -> NSRange {
+        guard index < length else { return NSRange(location: index, length: 0) }
+        let isWordChar: (unichar) -> Bool = { c in
+            (c >= 0x41 && c <= 0x5A) ||           // A-Z
+            (c >= 0x61 && c <= 0x7A) ||           // a-z
+            (c >= 0x30 && c <= 0x39) ||           // 0-9
+             c == 0x5F                             // _
+        }
+        guard isWordChar(character(at: index)) else {
+            return NSRange(location: index, length: 0)
+        }
+        var start = index
+        while start > 0 && isWordChar(character(at: start - 1)) { start -= 1 }
+        var end = index
+        while end < length && isWordChar(character(at: end)) { end += 1 }
+        return NSRange(location: start, length: end - start)
     }
 }

--- a/Alas/Sources/Code/LSP/Features/CompletionWindowController.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionWindowController.swift
@@ -3,24 +3,13 @@ import SwiftUI
 
 @MainActor
 final class CompletionWindowController {
-    static let panelHidesOnDeactivate = true
-
-    private final class CompletionPanel: NSPanel {
-        override var canBecomeKey: Bool { false }
-        override var canBecomeMain: Bool { false }
-    }
-
     private let maxHeight: CGFloat = 260
     private let listWidth: CGFloat = 320
-    private let screenPadding: CGFloat = 6
-    private let caretGap: CGFloat = 4
 
-    private var panel: CompletionPanel?
+    private let overlay = EditorOverlayPanel()
     private var hostingController: NSHostingController<CompletionPopup>?
 
-    var isVisible: Bool {
-        panel?.isVisible == true
-    }
+    var isVisible: Bool { overlay.isVisible }
 
     func show(
         rows: [CompletionPopupRow],
@@ -33,92 +22,28 @@ final class CompletionWindowController {
     ) {
         let hasDocumentation = (documentation?.attributedString.length ?? 0) > 0
         let size = NSSize(width: hasDocumentation ? listWidth * 2 : listWidth, height: maxHeight)
-        let root = CompletionPopup(rows: rows, selection: selection, documentation: documentation, theme: theme, onChoose: onChoose)
-        let panel = ensurePanel(size: size)
-        hostingController?.rootView = root
-        panel.setFrame(frame(for: size, anchor: anchor, in: textView), display: true, animate: false)
-
-        attach(panel, to: textView.window)
-        if !panel.isVisible {
-            panel.orderFront(nil)
+        let root = CompletionPopup(
+            rows: rows,
+            selection: selection,
+            documentation: documentation,
+            theme: theme,
+            onChoose: onChoose
+        )
+        if let hostingController {
+            hostingController.rootView = root
+        } else {
+            hostingController = NSHostingController(rootView: root)
         }
+        guard let hostingController else { return }
+        overlay.show(
+            contentViewController: hostingController,
+            size: size,
+            anchor: anchor,
+            in: textView
+        )
     }
 
     func hide() {
-        if let panel {
-            panel.parent?.removeChildWindow(panel)
-        }
-        panel?.orderOut(nil)
-    }
-
-    private func ensurePanel(size: NSSize) -> CompletionPanel {
-        if let panel {
-            return panel
-        }
-
-        let hostingController = NSHostingController(
-            rootView: CompletionPopup(
-                rows: [],
-                selection: 0,
-                documentation: nil,
-                theme: (try? Theme.loadBundled(id: "cool-slate")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:]),
-                onChoose: { _ in }
-            )
-        )
-        let panel = CompletionPanel(
-            contentRect: NSRect(origin: .zero, size: size),
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
-        )
-        panel.contentViewController = hostingController
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.hasShadow = true
-        panel.level = .normal
-        panel.collectionBehavior = [.transient, .ignoresCycle]
-        panel.hidesOnDeactivate = Self.panelHidesOnDeactivate
-        self.hostingController = hostingController
-        self.panel = panel
-        return panel
-    }
-
-    func attach(_ panel: NSWindow, to parentWindow: NSWindow?) {
-        guard let parentWindow else { return }
-
-        if panel.parent !== parentWindow {
-            panel.parent?.removeChildWindow(panel)
-            parentWindow.addChildWindow(panel, ordered: .above)
-        }
-        panel.level = parentWindow.level
-    }
-
-    private func frame(for size: NSSize, anchor: NSRect, in textView: CodeTextView) -> NSRect {
-        guard let window = textView.window else {
-            return NSRect(origin: .zero, size: size)
-        }
-
-        let windowRect = textView.convert(anchor, to: nil)
-        let screenRect = window.convertToScreen(windowRect)
-        let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame ?? screenRect
-        let x = min(
-            max(screenRect.minX, visibleFrame.minX + screenPadding),
-            visibleFrame.maxX - size.width - screenPadding
-        )
-        let belowY = screenRect.minY - size.height - caretGap
-        let aboveY = screenRect.maxY + caretGap
-        let y: CGFloat
-        if belowY >= visibleFrame.minY + screenPadding {
-            y = belowY
-        } else {
-            y = min(aboveY, visibleFrame.maxY - size.height - screenPadding)
-        }
-
-        return NSRect(
-            x: x,
-            y: max(y, visibleFrame.minY + screenPadding),
-            width: size.width,
-            height: size.height
-        )
+        overlay.hide()
     }
 }

--- a/Alas/Sources/Code/LSP/Features/EditorOverlayPanel.swift
+++ b/Alas/Sources/Code/LSP/Features/EditorOverlayPanel.swift
@@ -1,0 +1,118 @@
+import AppKit
+
+@MainActor
+final class EditorOverlayPanel {
+    static let hidesOnDeactivate = true
+
+    private final class OverlayPanel: NSPanel {
+        override var canBecomeKey: Bool { false }
+        override var canBecomeMain: Bool { false }
+    }
+
+    private let screenPadding: CGFloat = 6
+    private let caretGap: CGFloat = 4
+
+    private var panel: OverlayPanel?
+
+    var isVisible: Bool {
+        panel?.isVisible == true
+    }
+
+    /// The panel's frame in screen coordinates, or nil if not visible.
+    /// Used by callers (e.g. HoverFeature) to perform their own
+    /// hit-testing against the overlay independent of any tracking area.
+    var screenFrame: NSRect? {
+        guard let panel, panel.isVisible else { return nil }
+        return panel.frame
+    }
+
+    func show(
+        contentViewController: NSViewController,
+        size: NSSize,
+        anchor: NSRect,
+        in textView: CodeTextView
+    ) {
+        let panel = ensurePanel(size: size)
+        panel.contentViewController = contentViewController
+        panel.setFrame(frame(for: size, anchor: anchor, in: textView), display: true, animate: false)
+        attach(panel, to: textView.window)
+        if !panel.isVisible {
+            panel.orderFront(nil)
+        }
+    }
+
+    func hide() {
+        if let panel {
+            panel.parent?.removeChildWindow(panel)
+        }
+        panel?.orderOut(nil)
+    }
+
+    private func ensurePanel(size: NSSize) -> OverlayPanel {
+        if let panel { return panel }
+        let panel = OverlayPanel(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.level = .normal
+        panel.collectionBehavior = [.transient, .ignoresCycle]
+        panel.hidesOnDeactivate = Self.hidesOnDeactivate
+        // Required so NSEvent.addLocalMonitorForEvents(.mouseMoved) fires
+        // for cursor motion over the panel. Without this AppKit suppresses
+        // mouseMoved delivery to non-key panels and the hover-over-panel
+        // detection breaks.
+        panel.acceptsMouseMovedEvents = true
+        self.panel = panel
+        return panel
+    }
+
+    private func attach(_ panel: NSWindow, to parentWindow: NSWindow?) {
+        guard let parentWindow else { return }
+        if panel.parent !== parentWindow {
+            panel.parent?.removeChildWindow(panel)
+            parentWindow.addChildWindow(panel, ordered: .above)
+        }
+        panel.level = parentWindow.level
+    }
+
+    func frame(for size: NSSize, anchor: NSRect, in textView: CodeTextView) -> NSRect {
+        guard let window = textView.window else {
+            return NSRect(origin: .zero, size: size)
+        }
+
+        let windowRect = textView.convert(anchor, to: nil)
+        let screenRect = window.convertToScreen(windowRect)
+        let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame ?? screenRect
+        let x = min(
+            max(screenRect.minX, visibleFrame.minX + screenPadding),
+            visibleFrame.maxX - size.width - screenPadding
+        )
+        let belowY = screenRect.minY - size.height - caretGap
+        let aboveY = screenRect.maxY + caretGap
+        let y: CGFloat
+        if belowY >= visibleFrame.minY + screenPadding {
+            y = belowY
+        } else {
+            y = min(aboveY, visibleFrame.maxY - size.height - screenPadding)
+        }
+
+        return NSRect(
+            x: x,
+            y: max(y, visibleFrame.minY + screenPadding),
+            width: size.width,
+            height: size.height
+        )
+    }
+}
+
+enum EditorOverlayPanelTesting {
+    @MainActor
+    static func frame(for panel: EditorOverlayPanel, size: NSSize, anchor: NSRect, in textView: CodeTextView) -> NSRect {
+        panel.frame(for: size, anchor: anchor, in: textView)
+    }
+}

--- a/Alas/Sources/Code/LSP/Features/HoverFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverFeature.swift
@@ -4,16 +4,37 @@ import SwiftUI
 
 @MainActor
 final class HoverFeature {
+    typealias RequestHover = (_ uri: String, _ position: LSPPosition) async throws -> LSPHoverResult?
+
     private weak var textView: CodeTextView?
     private let getClient: () -> LSPClient?
     private let getURI: () -> String?
     private let getTheme: () -> Theme
     private let getMonoFontFamily: () -> String
     private let getMonoFontSize: () -> Int
-    private var debounce: Task<Void, Never>?
-    private var popover: NSPopover?
-    private var lastPosition: NSPoint?
+    private let requestHover: RequestHover
+
+    private let windowController = HoverWindowController()
     private var requestID: UInt64 = 0
+    private var inFlight: Task<Void, Never>?
+    private var dwellTimer: Task<Void, Never>?
+    private var graceTimer: Task<Void, Never>?
+    private var mouseMonitor: Any?
+
+    private var optionHeld: Bool = false
+    private var lastMousePoint: NSPoint?
+    private var currentSymbolRange: NSRange?
+    private var shownSymbolRange: NSRange?
+    /// Last screen location we observed for the pointer. When the panel is
+    /// shown we install an NSEvent monitor that updates this on every
+    /// mouse-move; combined with the symbol's screen rect and the panel's
+    /// screen frame, we decide whether to keep the popover or dismiss.
+    private var lastScreenLocation: NSPoint?
+
+    private static let dwellNanos: UInt64 = 750_000_000 // 750 ms
+    /// Grace window for the pointer to bridge the gap between the symbol in
+    /// the editor and the overlay panel (and vice versa) before we dismiss.
+    private static let graceNanos: UInt64 = 500_000_000 // 500 ms
 
     init(
         textView: CodeTextView,
@@ -21,7 +42,8 @@ final class HoverFeature {
         getURI: @escaping () -> String?,
         getTheme: @escaping () -> Theme,
         getMonoFontFamily: @escaping () -> String,
-        getMonoFontSize: @escaping () -> Int
+        getMonoFontSize: @escaping () -> Int,
+        requestHover: RequestHover? = nil
     ) {
         self.textView = textView
         self.getClient = getClient
@@ -29,177 +51,387 @@ final class HoverFeature {
         self.getTheme = getTheme
         self.getMonoFontFamily = getMonoFontFamily
         self.getMonoFontSize = getMonoFontSize
-        textView.hoverHandler = { [weak self] p in self?.onMove(at: p) }
-    }
+        self.requestHover = requestHover ?? { uri, position in
+            guard let client = getClient() else { return nil }
+            return try await client.hover(uri: uri, position: position)
+        }
 
-    private func onMove(at point: NSPoint) {
-        // If the mouse moved by more than ~3px, restart the debounce window.
-        if let last = lastPosition, hypot(last.x - point.x, last.y - point.y) < 3 { return }
-        lastPosition = point
-        debounce?.cancel()
-        requestID += 1
-        let currentRequestID = requestID
-        let captured = point
-        debounce = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 250_000_000)
-            guard !Task.isCancelled else { return }
-            await self?.show(at: captured, requestID: currentRequestID)
+        let priorHover = textView.hoverHandler
+        textView.hoverHandler = { [weak self] p in
+            priorHover?(p)
+            self?.onMouseMoved(at: p)
         }
-    }
-
-    private func show(at point: NSPoint, requestID currentRequestID: UInt64) async {
-        guard let textView, let client = getClient(), let uri = getURI() else {
-            closePopover()
-            return
+        let priorFlags = textView.flagsChangedHandler
+        textView.flagsChangedHandler = { [weak self] event in
+            priorFlags?(event)
+            self?.onFlagsChanged(event)
         }
-        guard let position = textView.lspPosition(at: point) else {
-            closePopover()
-            return
-        }
-        let result: LSPHoverResult?
-        do {
-            result = try await client.hover(uri: uri, position: position)
-        } catch {
-            guard isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
-            closePopover()
-            return
-        }
-        guard isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
-        guard let result else {
-            closePopover()
-            return
-        }
-        let body: String
-        switch result.contents {
-        case .markupContent(_, let value): body = value
-        case .plain(let s):                body = s
-        }
-        guard !body.isEmpty else {
-            closePopover()
-            return
-        }
-        let textRect = textView.firstRect(for: position) ?? CGRect(origin: point, size: .zero)
-        await MainActor.run {
-            guard self.isCurrentRequest(currentRequestID, uri: uri, position: position, point: point) else { return }
-            self.presentPopover(text: body, anchor: textRect, in: textView)
+        let priorExit = textView.mouseExitedHandler
+        textView.mouseExitedHandler = { [weak self] in
+            priorExit?()
+            self?.onMouseExited()
         }
     }
 
-    private func isCurrentRequest(_ currentRequestID: UInt64, uri: String, position: LSPPosition, point: NSPoint) -> Bool {
-        guard !Task.isCancelled,
-              requestID == currentRequestID,
-              getURI() == uri,
-              textView?.lspPosition(at: point) == position
-        else { return false }
+    var isShowingPopover: Bool { windowController.isVisible }
+
+    func tearDown() {
+        dismiss()
+    }
+
+    // MARK: - Coordinator-facing notify entry points
+
+    func notifyScrolled() { dismiss() }
+    func notifyCaretChanged() { dismiss() }
+    func notifyWindowResized() { dismiss() }
+
+    /// Returns true if the popover was visible and consumed the Esc key.
+    func handleEscape() -> Bool {
+        guard isShowingPopover else { return false }
+        dismiss()
         return true
     }
 
-    private func presentPopover(text: String, anchor: NSRect, in view: NSView) {
+    // MARK: - Event entry points
+
+    private func onMouseMoved(at point: NSPoint) {
+        lastMousePoint = point
+        let newRange = textView?.symbolRange(at: point)
+        if newRange == currentSymbolRange { return }
+        currentSymbolRange = newRange
+
+        if let shownSymbolRange {
+            if newRange == shownSymbolRange {
+                // Back on the shown symbol — pre-empt any grace dismissal.
+                cancelGrace()
+                return
+            }
+            if let newRange {
+                // Cursor moved to a DIFFERENT identifier while a popover is
+                // up. Treat as intent to leave: dismiss the old immediately
+                // and start a fresh dwell for the new symbol.
+                cancelGrace()
+                inFlight?.cancel()
+                inFlight = nil
+                dwellTimer?.cancel()
+                dwellTimer = nil
+                uninstallMouseMonitor()
+                windowController.hide()
+                self.shownSymbolRange = nil
+                currentSymbolRange = newRange
+                if optionHeld {
+                    issueRequest(at: point)
+                } else {
+                    startDwellTimer(at: point)
+                }
+                return
+            }
+            // Cursor moved off the shown symbol into non-identifier
+            // territory (still inside the editor). Could be in transit to
+            // the panel — schedule a grace dismiss. The NSEvent monitor
+            // will cancel it if the pointer enters the panel's screen
+            // frame, and `onMouseMoved` will cancel it if the cursor
+            // returns to the shown symbol.
+            scheduleGraceDismiss()
+            return
+        }
+
+        // No popover shown yet — standard dwell / immediate logic.
+        inFlight?.cancel()
+        inFlight = nil
+        dwellTimer?.cancel()
+        dwellTimer = nil
+        guard newRange != nil else { return }
+        if optionHeld {
+            issueRequest(at: point)
+        } else {
+            startDwellTimer(at: point)
+        }
+    }
+
+    private func onMouseExited() {
+        // Mouse left the editor. Don't dismiss yet — the pointer may be on
+        // its way to the overlay panel. The NSEvent monitor installed when
+        // the popover is shown will decide based on screen-coord hit-testing.
+        scheduleGraceDismiss()
+    }
+
+    private func onFlagsChanged(_ event: NSEvent) {
+        let pressed = event.modifierFlags.contains(.option)
+        if pressed && !optionHeld {
+            optionHeld = true
+            if let point = lastMousePoint, currentSymbolRange != nil {
+                dwellTimer?.cancel()
+                issueRequest(at: point)
+            }
+        } else if !pressed && optionHeld {
+            optionHeld = false
+            // Releasing ⌥ does NOT dismiss — dismissal is governed by the
+            // symbol-tracking and forced-dismiss rules only.
+        }
+    }
+
+    // MARK: - Test seams
+
+    func simulateOptionPressed() {
+        guard !optionHeld else { return }
+        optionHeld = true
+        if let point = lastMousePoint, currentSymbolRange != nil {
+            dwellTimer?.cancel()
+            issueRequest(at: point)
+        }
+    }
+
+    func simulateOptionReleased() {
+        guard optionHeld else { return }
+        optionHeld = false
+    }
+
+    func simulateMouseMoved(at point: NSPoint) {
+        onMouseMoved(at: point)
+    }
+
+    /// Test seam: simulates an NSEvent mouseMoved at a global screen point
+    /// for the hit-test path used while the popover is shown.
+    func simulatePointerScreenLocation(_ location: NSPoint) {
+        lastScreenLocation = location
+        evaluatePointerLocation(location)
+    }
+
+    // MARK: - Dwell timer
+
+    private func startDwellTimer(at point: NSPoint) {
+        dwellTimer?.cancel()
+        let capturedRange = currentSymbolRange
+        dwellTimer = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.dwellNanos)
+            guard !Task.isCancelled else { return }
+            await MainActor.run { [weak self] in
+                guard let self,
+                      self.currentSymbolRange != nil,
+                      self.currentSymbolRange == capturedRange
+                else { return }
+                self.issueRequest(at: point)
+            }
+        }
+    }
+
+    private func dismiss() {
+        dwellTimer?.cancel()
+        dwellTimer = nil
+        inFlight?.cancel()
+        inFlight = nil
+        cancelGrace()
+        uninstallMouseMonitor()
+        windowController.hide()
+        shownSymbolRange = nil
+        currentSymbolRange = nil
+        lastScreenLocation = nil
+    }
+
+    private func scheduleGraceDismiss() {
+        // Nothing to dismiss if we never showed anything.
+        guard isShowingPopover || shownSymbolRange != nil else { return }
+        graceTimer?.cancel()
+        graceTimer = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.graceNanos)
+            guard !Task.isCancelled else { return }
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                // Re-check the cursor location at fire time. If by now it's
+                // over the symbol or the overlay panel, keep the popover up.
+                if let location = self.lastScreenLocation, self.pointerIsInSafeArea(location) {
+                    return
+                }
+                self.dismiss()
+            }
+        }
+    }
+
+    private func cancelGrace() {
+        graceTimer?.cancel()
+        graceTimer = nil
+    }
+
+    // MARK: - NSEvent monitor for pointer hit-testing while shown
+
+    private func installMouseMonitor() {
+        guard mouseMonitor == nil else { return }
+        // Seed the location so the first grace-timer fire has something to
+        // hit-test even if the cursor is stationary.
+        lastScreenLocation = NSEvent.mouseLocation
+        mouseMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
+            guard let self else { return event }
+            let location = NSEvent.mouseLocation
+            self.lastScreenLocation = location
+            self.evaluatePointerLocation(location)
+            return event
+        }
+    }
+
+    private func uninstallMouseMonitor() {
+        if let mouseMonitor {
+            NSEvent.removeMonitor(mouseMonitor)
+        }
+        mouseMonitor = nil
+    }
+
+    /// Returns true if the global screen point lies inside the symbol's
+    /// screen rect, the overlay panel's frame, or the corridor between
+    /// them. The corridor makes the symbol→panel transit forgiving against
+    /// slow movement and small lateral jitter; without it, anything off-
+    /// axis during transit immediately schedules a grace dismiss.
+    private func pointerIsInSafeArea(_ location: NSPoint) -> Bool {
+        let panelFrame = windowController.screenFrame
+        let symbolFrame = currentSymbolScreenRect()
+        if let panelFrame, panelFrame.contains(location) { return true }
+        if let symbolFrame, symbolFrame.contains(location) { return true }
+        if let panelFrame, let symbolFrame,
+           bridgeRect(symbolFrame: symbolFrame, panelFrame: panelFrame).contains(location) {
+            return true
+        }
+        return false
+    }
+
+    /// Returns the rectangular corridor between the symbol and the panel,
+    /// covering the gap that the cursor crosses during a normal mouse trip.
+    /// Width is the union of the symbol and panel widths so off-axis drift
+    /// stays inside; height is the vertical gap between them (zero if they
+    /// overlap or touch).
+    private func bridgeRect(symbolFrame: NSRect, panelFrame: NSRect) -> NSRect {
+        let leftX = min(symbolFrame.minX, panelFrame.minX)
+        let rightX = max(symbolFrame.maxX, panelFrame.maxX)
+        let bottomY: CGFloat
+        let topY: CGFloat
+        if panelFrame.maxY <= symbolFrame.minY {
+            // Panel sits below the symbol (default placement).
+            bottomY = panelFrame.maxY
+            topY = symbolFrame.minY
+        } else if panelFrame.minY >= symbolFrame.maxY {
+            // Panel was flipped above the symbol.
+            bottomY = symbolFrame.maxY
+            topY = panelFrame.minY
+        } else {
+            // Overlapping — no bridge strip.
+            return .zero
+        }
+        return NSRect(
+            x: leftX,
+            y: bottomY,
+            width: rightX - leftX,
+            height: max(0, topY - bottomY)
+        )
+    }
+
+    /// Translates the currently shown symbol's anchor rect into screen
+    /// coordinates so we can do hit-testing against the global cursor.
+    private func currentSymbolScreenRect() -> NSRect? {
+        guard let textView,
+              let window = textView.window,
+              let symbolRange = shownSymbolRange ?? currentSymbolRange,
+              let anchor = textView.symbolAnchorRect(for: symbolRange) else { return nil }
+        let windowRect = textView.convert(anchor, to: nil)
+        return window.convertToScreen(windowRect)
+    }
+
+    /// Called for every mouse-moved event while the popover is shown.
+    /// Cancels any pending grace dismiss if the cursor is on the symbol or
+    /// the overlay; schedules a grace dismiss if it's strayed off both.
+    private func evaluatePointerLocation(_ location: NSPoint) {
+        if pointerIsInSafeArea(location) {
+            cancelGrace()
+        } else if graceTimer == nil {
+            scheduleGraceDismiss()
+        }
+    }
+
+    // MARK: - Request dispatch
+
+    private func issueRequest(at point: NSPoint) {
+        guard let textView, let uri = getURI(),
+              let symbolRange = currentSymbolRange,
+              let position = textView.lspPosition(at: point) else {
+            return
+        }
+        requestID &+= 1
+        let currentRequestID = requestID
+        inFlight?.cancel()
+        let perform = requestHover
+        inFlight = Task { [weak self] in
+            let result: LSPHoverResult?
+            do {
+                result = try await perform(uri, position)
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self,
+                          self.isCurrentRequest(currentRequestID, uri: uri, symbolRange: symbolRange)
+                    else { return }
+                    self.windowController.hide()
+                    self.shownSymbolRange = nil
+                }
+                return
+            }
+            await MainActor.run { [weak self] in
+                guard let self,
+                      self.isCurrentRequest(currentRequestID, uri: uri, symbolRange: symbolRange)
+                else { return }
+                self.handleResult(result, symbolRange: symbolRange)
+            }
+        }
+    }
+
+    private func handleResult(_ result: LSPHoverResult?, symbolRange: NSRange) {
+        guard let result, let body = nonEmptyBody(result) else {
+            windowController.hide()
+            shownSymbolRange = nil
+            return
+        }
+        guard let textView else {
+            windowController.hide()
+            shownSymbolRange = nil
+            return
+        }
         let theme = getTheme()
         let family = getMonoFontFamily()
         let size = getMonoFontSize()
-
-        let document = Document(parsing: text)
-        let result = MarkdownRenderer().render(
+        let document = Document(parsing: body)
+        let renderResult = MarkdownRenderer().render(
             document: document,
             theme: theme,
             monospacedFontFamily: family,
             monospacedFontSize: size,
             baseDirectory: URL(fileURLWithPath: "/")
         )
-
-        popover?.close()
-        let popover = NSPopover()
-        popover.behavior = .transient
-        let host = NSHostingController(
-            rootView: HoverContentView(result: result, theme: theme)
+        let preferredSize = HoverFeatureTesting.computePreferredSize(for: renderResult)
+        let anchor = textView.symbolAnchorRect(for: symbolRange)
+            ?? CGRect(origin: lastMousePoint ?? .zero, size: .zero)
+        windowController.show(
+            result: renderResult,
+            size: preferredSize,
+            theme: theme,
+            anchor: anchor,
+            in: textView
         )
-        popover.contentViewController = host
-        popover.show(relativeTo: anchor, of: view, preferredEdge: .maxY)
-        self.popover = popover
-
-        applyPopoverSize(for: result)
+        shownSymbolRange = symbolRange
+        installMouseMonitor()
     }
 
-    private func applyPopoverSize(for result: MarkdownRenderResult) {
-        guard let popover else { return }
-        let layoutManager = NSLayoutManager()
-        let textContainer = NSTextContainer(containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude))
-        textContainer.widthTracksTextView = true
-        textContainer.lineFragmentPadding = 0
-        layoutManager.addTextContainer(textContainer)
-
-        let textStorage = NSTextStorage(attributedString: result.attributedString)
-        textStorage.addLayoutManager(layoutManager)
-        layoutManager.glyphRange(for: textContainer)
-
-        var usedRect = layoutManager.usedRect(for: textContainer)
-        usedRect.size.width += 16 + 20
-        usedRect.size.height += 16 + 20
-
-        let minSize = NSSize(width: 360, height: 220)
-        let maxSize = NSSize(width: 500, height: 400)
-        let clamped = NSSize(
-            width: max(minSize.width, min(usedRect.size.width, maxSize.width)),
-            height: max(minSize.height, min(usedRect.size.height, maxSize.height))
-        )
-        popover.contentSize = clamped
-    }
-
-    private func closePopover() {
-        popover?.close()
-        popover = nil
-    }
-}
-
-private struct HoverContentView: NSViewRepresentable {
-    let result: MarkdownRenderResult
-    let theme: Theme
-
-    func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSScrollView()
-        let textView = NSTextView()
-        textView.isEditable = false
-        textView.drawsBackground = false
-        textView.isSelectable = true
-        textView.textContainerInset = NSSize(width: 8, height: 8)
-        textView.isHorizontallyResizable = false
-        textView.autoresizingMask = [.width]
-        textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-
-        scrollView.documentView = textView
-        scrollView.drawsBackground = true
-        scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = false
-
-        context.coordinator.textView = textView
-        textView.textStorage?.setAttributedString(result.attributedString)
-        scrollView.backgroundColor = NSColor(theme.color("bg-1"))
-        return scrollView
-    }
-
-    func updateNSView(_ nsView: NSScrollView, context: Context) {
-        guard let textView = context.coordinator.textView else { return }
-        textView.textStorage?.setAttributedString(result.attributedString)
-        nsView.backgroundColor = NSColor(theme.color("bg-1"))
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator()
-    }
-
-    final class Coordinator: NSObject, NSTextViewDelegate {
-        weak var textView: NSTextView? {
-            didSet { textView?.delegate = self }
+    private func nonEmptyBody(_ result: LSPHoverResult) -> String? {
+        let body: String
+        switch result.contents {
+        case .markupContent(_, let value): body = value
+        case .plain(let s):                body = s
         }
+        return body.isEmpty ? nil : body
+    }
 
-        func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
-            if let url = link as? URL {
-                NSWorkspace.shared.open(url)
-            }
-            return true
-        }
+    private func isCurrentRequest(_ currentRequestID: UInt64, uri: String, symbolRange: NSRange) -> Bool {
+        guard !Task.isCancelled,
+              requestID == currentRequestID,
+              getURI() == uri,
+              currentSymbolRange == symbolRange
+        else { return false }
+        return true
     }
 }
 
@@ -242,11 +474,10 @@ enum HoverFeatureTesting {
         usedRect.size.width += 16 + 20
         usedRect.size.height += 16 + 20
 
-        let minSize = NSSize(width: 360, height: 220)
-        let maxSize = NSSize(width: 500, height: 400)
+        let maxSize = NSSize(width: 520, height: 400)
         return NSSize(
-            width: max(minSize.width, min(usedRect.size.width, maxSize.width)),
-            height: max(minSize.height, min(usedRect.size.height, maxSize.height))
+            width: min(usedRect.size.width, maxSize.width),
+            height: min(usedRect.size.height, maxSize.height)
         )
     }
 }
@@ -256,10 +487,6 @@ extension CodeTextView {
     /// view's coordinate space. Returns nil if outside the text area.
     func lspPosition(at point: NSPoint) -> LSPPosition? {
         guard let layoutManager, let textContainer, let storage = textStorage else { return nil }
-        // Mouse points arrive in text-view coordinates, but
-        // `glyphIndex(for:in:)` expects text-container coordinates. With a
-        // non-zero `textContainerInset` (we use 12, 8) the two differ — not
-        // converting shifts hover/Cmd-click onto a different column or line.
         let containerPoint = NSPoint(
             x: point.x - textContainerInset.width,
             y: point.y - textContainerInset.height
@@ -268,12 +495,11 @@ extension CodeTextView {
         let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
         let nsString = storage.string as NSString
         guard charIndex < nsString.length else { return nil }
-        // Walk to find line + UTF-16 column
         var line = 0
         var lineStart = 0
         var i = 0
         while i < charIndex {
-            if nsString.character(at: i) == 10 {  // \n
+            if nsString.character(at: i) == 10 {
                 line += 1
                 lineStart = i + 1
             }
@@ -287,7 +513,6 @@ extension CodeTextView {
     func firstRect(for position: LSPPosition) -> NSRect? {
         guard let storage = textStorage, let layoutManager else { return nil }
         let nsString = storage.string as NSString
-        // Find UTF-16 index for (line, character).
         var charIndex = 0
         var line = 0
         while line < position.line {
@@ -300,8 +525,6 @@ extension CodeTextView {
         guard charIndex < nsString.length else { return nil }
         let glyph = layoutManager.glyphIndexForCharacter(at: charIndex)
         let rect = layoutManager.boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: textContainer!)
-        // boundingRect is in container coords; the popover anchors against
-        // the view's bounds, so add the inset back.
         return rect.offsetBy(dx: textContainerInset.width, dy: textContainerInset.height)
     }
 }

--- a/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverHighlightFeature.swift
@@ -27,21 +27,25 @@ final class HoverHighlightFeature {
         self.textView = textView
         self.getClient = getClient
         self.getURI = getURI
+        // Chain all three handlers so coexisting features (HoverFeature's
+        // ⌥-peek) keep receiving their events. Coordinator constructs
+        // HoverFeature first, then this feature — without chaining we'd
+        // silently replace the prior closures.
+        let priorFlags = textView.flagsChangedHandler
         textView.flagsChangedHandler = { [weak self] event in
+            priorFlags?(event)
             self?.onFlagsChanged(event)
         }
+        let priorExit = textView.mouseExitedHandler
         textView.mouseExitedHandler = { [weak self] in
+            priorExit?()
             guard let self else { return }
             self.cancelInFlight()
             self.clearUnderline()
         }
-        // Reuse the existing hover handler — feature multiplexes hover and
-        // command-hover through the same closure. The popover-based
-        // `HoverFeature` already lives on `hoverHandler`, so install a
-        // chained closure that calls both.
-        let prior = textView.hoverHandler
+        let priorHover = textView.hoverHandler
         textView.hoverHandler = { [weak self] p in
-            prior?(p)
+            priorHover?(p)
             self?.onMove(at: p)
         }
     }
@@ -152,27 +156,5 @@ final class HoverHighlightFeature {
     private func cancelInFlight() {
         inFlight?.cancel()
         inFlight = nil
-    }
-}
-
-private extension NSString {
-    /// Returns the contiguous identifier-like range covering `index`, or an
-    /// empty range if the character at `index` is not part of an identifier.
-    func rangeOfWord(at index: Int) -> NSRange {
-        guard index < length else { return NSRange(location: index, length: 0) }
-        let isWordChar: (unichar) -> Bool = { c in
-            (c >= 0x41 && c <= 0x5A) ||           // A-Z
-            (c >= 0x61 && c <= 0x7A) ||           // a-z
-            (c >= 0x30 && c <= 0x39) ||           // 0-9
-             c == 0x5F                             // _
-        }
-        guard isWordChar(character(at: index)) else {
-            return NSRange(location: index, length: 0)
-        }
-        var start = index
-        while start > 0 && isWordChar(character(at: start - 1)) { start -= 1 }
-        var end = index
-        while end < length && isWordChar(character(at: end)) { end += 1 }
-        return NSRange(location: start, length: end - start)
     }
 }

--- a/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
+++ b/Alas/Sources/Code/LSP/Features/HoverWindowController.swift
@@ -1,0 +1,108 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class HoverWindowController {
+    private let overlay = EditorOverlayPanel()
+    private var hostingController: NSHostingController<HoverPopupView>?
+
+    var isVisible: Bool { overlay.isVisible }
+
+    var screenFrame: NSRect? { overlay.screenFrame }
+
+    func show(
+        result: MarkdownRenderResult,
+        size: NSSize,
+        theme: Theme,
+        anchor: NSRect,
+        in textView: CodeTextView
+    ) {
+        let root = HoverPopupView(result: result, theme: theme)
+        if let hostingController {
+            hostingController.rootView = root
+        } else {
+            hostingController = NSHostingController(rootView: root)
+        }
+        guard let hostingController else { return }
+        overlay.show(
+            contentViewController: hostingController,
+            size: size,
+            anchor: anchor,
+            in: textView
+        )
+    }
+
+    func hide() {
+        overlay.hide()
+    }
+}
+
+struct HoverPopupView: View {
+    let result: MarkdownRenderResult
+    let theme: Theme
+
+    var body: some View {
+        HoverPopupContent(result: result, theme: theme)
+            .background(Color(nsColor: NSColor(theme.color("bg-1"))))
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+private struct HoverPopupContent: NSViewRepresentable {
+    let result: MarkdownRenderResult
+    let theme: Theme
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.drawsBackground = false
+        textView.isSelectable = true
+        textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+
+        scrollView.documentView = textView
+        scrollView.drawsBackground = true
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.borderType = .noBorder
+
+        context.coordinator.textView = textView
+        textView.textStorage?.setAttributedString(result.attributedString)
+        scrollView.backgroundColor = NSColor(theme.color("bg-1"))
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let textView = context.coordinator.textView else { return }
+        textView.textStorage?.setAttributedString(result.attributedString)
+        nsView.backgroundColor = NSColor(theme.color("bg-1"))
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        weak var textView: NSTextView? {
+            didSet { textView?.delegate = self }
+        }
+
+        func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+            if let url = link as? URL {
+                NSWorkspace.shared.open(url)
+            } else if let string = link as? String, let url = URL(string: string) {
+                NSWorkspace.shared.open(url)
+            }
+            return true
+        }
+    }
+}

--- a/AlasTests/EditorOverlayPanelTests.swift
+++ b/AlasTests/EditorOverlayPanelTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct EditorOverlayPanelTests {
+    private func makeTextView(in window: NSWindow) -> CodeTextView {
+        let storage = NSTextStorage(string: "hello world")
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        window.contentView = textView
+        return textView
+    }
+
+    @Test func frameReturnsZeroSizedWhenViewHasNoWindow() {
+        let storage = NSTextStorage(string: "x")
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 100, height: 100))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: .zero, textContainer: container)
+        #expect(textView.window == nil)
+        let panel = EditorOverlayPanel()
+        let size = NSSize(width: 200, height: 120)
+
+        let frame = EditorOverlayPanelTesting.frame(
+            for: panel,
+            size: size,
+            anchor: NSRect(x: 50, y: 80, width: 20, height: 20),
+            in: textView
+        )
+
+        #expect(frame.size == size)
+        #expect(frame.origin == .zero)
+    }
+
+    @Test func framePlacesPanelBelowAnchorWhenSpaceAllows() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 200, y: 200, width: 800, height: 600),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: true
+        )
+        let textView = makeTextView(in: window)
+        let panel = EditorOverlayPanel()
+        let size = NSSize(width: 300, height: 100)
+        let anchor = NSRect(x: 50, y: 300, width: 40, height: 16)
+
+        let frame = EditorOverlayPanelTesting.frame(
+            for: panel,
+            size: size,
+            anchor: anchor,
+            in: textView
+        )
+
+        let anchorScreen = window.convertToScreen(textView.convert(anchor, to: nil))
+        #expect(frame.maxY < anchorScreen.minY)
+        #expect(frame.size == size)
+    }
+}

--- a/AlasTests/HoverFeatureBehaviorTests.swift
+++ b/AlasTests/HoverFeatureBehaviorTests.swift
@@ -1,0 +1,273 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct HoverFeatureBehaviorTests {
+    private func makeTextView() -> CodeTextView {
+        let storage = NSTextStorage(string: "let value = foo + bar\n")
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 800, height: 600))
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600), textContainer: container)
+        _ = layoutManager.glyphRange(for: container)
+        return textView
+    }
+
+    private func point(forCharacterAt index: Int, in textView: CodeTextView) -> NSPoint {
+        guard let layoutManager = textView.layoutManager,
+              let container = textView.textContainer else { return .zero }
+        let glyph = layoutManager.glyphIndexForCharacter(at: index)
+        let rect = layoutManager.boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: container)
+        return NSPoint(
+            x: rect.midX + textView.textContainerInset.width,
+            y: rect.midY + textView.textContainerInset.height
+        )
+    }
+
+    private func makeFeature(textView: CodeTextView, recorder: HoverRequestRecorder) -> HoverFeature {
+        let theme = (try? Theme.loadBundled(id: "cool-slate"))
+            ?? Theme(id: "fallback", name: "Fallback", tokens: [:])
+        return HoverFeature(
+            textView: textView,
+            getClient: { nil },
+            getURI: { "file:///tmp/example.swift" },
+            getTheme: { theme },
+            getMonoFontFamily: { "SF Mono" },
+            getMonoFontSize: { 13 },
+            requestHover: { uri, position in
+                await recorder.record(uri: uri, position: position)
+                return recorder.nextResponse()
+            }
+        )
+    }
+
+    @Test func mouseOverNonSymbolIssuesNoRequest() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: NSPoint(x: 600, y: 8))
+        try? await Task.sleep(nanoseconds: 900_000_000)
+
+        #expect(await recorder.calls.count == 0)
+        #expect(feature.isShowingPopover == false)
+    }
+
+    @Test func dwellOverSymbolFiresRequestAfterTimer() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.plainText("foo: Int"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        try? await Task.sleep(nanoseconds: 250_000_000)
+        #expect(await recorder.calls.count == 0)
+        #expect(feature.isShowingPopover == false)
+
+        try? await Task.sleep(nanoseconds: 700_000_000)
+        #expect(await recorder.calls.count == 1)
+        #expect(feature.isShowingPopover == true)
+    }
+
+    @Test func mouseExitsSymbolBeforeDwellCancelsTimer() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        feature.simulateMouseMoved(at: NSPoint(x: 600, y: 8))
+        try? await Task.sleep(nanoseconds: 900_000_000)
+
+        #expect(await recorder.calls.count == 0)
+        #expect(feature.isShowingPopover == false)
+    }
+
+    @Test func mouseMovesBetweenSymbolsResetsTimer() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.plainText("first"))
+        recorder.queueResponse(.plainText("second"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        feature.simulateMouseMoved(at: point(forCharacterAt: 18, in: textView))
+        try? await Task.sleep(nanoseconds: 900_000_000)
+
+        let calls = await recorder.calls
+        #expect(calls.count == 1)
+        #expect(feature.isShowingPopover == true)
+    }
+
+    @Test func optionAcceleratorFiresImmediately() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.plainText("Int"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        feature.simulateOptionPressed()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(await recorder.calls.count == 1)
+        #expect(feature.isShowingPopover == true)
+    }
+
+    @Test func optionWithoutSymbolDoesNothing() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: NSPoint(x: 600, y: 8))
+        feature.simulateOptionPressed()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        #expect(await recorder.calls.count == 0)
+        #expect(feature.isShowingPopover == false)
+    }
+
+    @Test func mouseMovementInsideShownSymbolDoesNotReRequest() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.plainText("foo: Int"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        try? await Task.sleep(nanoseconds: 900_000_000)
+        #expect(feature.isShowingPopover == true)
+        #expect(await recorder.calls.count == 1)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 13, in: textView))
+        feature.simulateMouseMoved(at: point(forCharacterAt: 14, in: textView))
+        try? await Task.sleep(nanoseconds: 300_000_000)
+
+        #expect(await recorder.calls.count == 1)
+        #expect(feature.isShowingPopover == true)
+    }
+
+    @Test func scrollNotificationDismisses() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.plainText("foo"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        feature.simulateOptionPressed()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        #expect(feature.isShowingPopover == true)
+
+        feature.notifyScrolled()
+        #expect(feature.isShowingPopover == false)
+    }
+
+    @Test func caretChangeNotificationDismisses() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.plainText("foo"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        feature.simulateOptionPressed()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        #expect(feature.isShowingPopover == true)
+
+        feature.notifyCaretChanged()
+        #expect(feature.isShowingPopover == false)
+    }
+
+    @Test func escapeKeyDismissesAndConsumesEvent() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.plainText("foo"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        feature.simulateOptionPressed()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        #expect(feature.isShowingPopover == true)
+
+        let consumed = feature.handleEscape()
+        #expect(consumed == true)
+        #expect(feature.isShowingPopover == false)
+    }
+
+    @Test func escapeKeyWhenNotShownDoesNotConsume() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        let consumed = feature.handleEscape()
+        #expect(consumed == false)
+    }
+
+    @Test func windowResizeNotificationDismisses() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.plainText("foo"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        feature.simulateOptionPressed()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        #expect(feature.isShowingPopover == true)
+
+        feature.notifyWindowResized()
+        #expect(feature.isShowingPopover == false)
+    }
+
+    @Test func mouseExitsEditorAfterGraceDismisses() async {
+        let textView = makeTextView()
+        let recorder = HoverRequestRecorder()
+        recorder.queueResponse(.plainText("foo"))
+        let feature = makeFeature(textView: textView, recorder: recorder)
+
+        feature.simulateMouseMoved(at: point(forCharacterAt: 12, in: textView))
+        feature.simulateOptionPressed()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        #expect(feature.isShowingPopover == true)
+
+        // Mouse left the editor: grace timer arms, popover stays for now.
+        textView.mouseExitedHandler?()
+        #expect(feature.isShowingPopover == true)
+
+        // After the grace window with no safe-area entry, popover dismisses.
+        // (In unit-test geometry the safe area is empty, so the grace timer
+        // will dismiss regardless.)
+        try? await Task.sleep(nanoseconds: 700_000_000)
+        #expect(feature.isShowingPopover == false)
+    }
+}
+
+@MainActor
+final class HoverRequestRecorder {
+    struct Call: Equatable {
+        let uri: String
+        let position: LSPPosition
+    }
+
+    private(set) var calls: [Call] = []
+    private var responses: [LSPHoverResult?] = []
+
+    func record(uri: String, position: LSPPosition) {
+        calls.append(Call(uri: uri, position: position))
+    }
+
+    func queueResponse(_ response: LSPHoverResult?) {
+        responses.append(response)
+    }
+
+    func nextResponse() -> LSPHoverResult? {
+        guard !responses.isEmpty else { return nil }
+        return responses.removeFirst()
+    }
+}
+
+private extension LSPHoverResult {
+    static func plainText(_ value: String) -> LSPHoverResult {
+        LSPHoverResult(contents: .plain(value), range: nil)
+    }
+}

--- a/AlasTests/HoverFeatureRenderingTests.swift
+++ b/AlasTests/HoverFeatureRenderingTests.swift
@@ -89,7 +89,7 @@ struct HoverFeatureRenderingTests {
         #expect(bgColor == expected)
     }
 
-    @Test func popoverSizeClampsToMinAndMax() throws {
+    @Test func popoverSizeShrinksToSmallContent() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")
         let tiny = Document(parsing: "x")
         let tinyResult = MarkdownRenderer().render(
@@ -98,9 +98,16 @@ struct HoverFeatureRenderingTests {
             baseDirectory: URL(fileURLWithPath: "/tmp")
         )
         let tinySize = HoverFeatureTesting.computePreferredSize(for: tinyResult)
-        #expect(tinySize.width >= 360)
-        #expect(tinySize.height >= 220)
+        // No 360 x 220 floor: a single character should not produce a giant box.
+        #expect(tinySize.width < 360)
+        #expect(tinySize.height < 220)
+        // AppKit padding gives a small natural minimum; just assert positive.
+        #expect(tinySize.width > 0)
+        #expect(tinySize.height > 0)
+    }
 
+    @Test func popoverSizeClampsLargeContent() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
         let huge = Document(parsing: String(repeating: "very long line of text that just keeps going on and on and on forever ", count: 30))
         let hugeResult = MarkdownRenderer().render(
             document: huge, theme: theme,
@@ -108,7 +115,7 @@ struct HoverFeatureRenderingTests {
             baseDirectory: URL(fileURLWithPath: "/tmp")
         )
         let hugeSize = HoverFeatureTesting.computePreferredSize(for: hugeResult)
-        #expect(hugeSize.width <= 500)
+        #expect(hugeSize.width <= 520)
         #expect(hugeSize.height <= 400)
     }
 }

--- a/AlasTests/HoverWindowControllerTests.swift
+++ b/AlasTests/HoverWindowControllerTests.swift
@@ -4,9 +4,9 @@ import Testing
 
 @MainActor
 @Suite(.serialized)
-struct CompletionWindowControllerTests {
+struct HoverWindowControllerTests {
     @Test func isVisibleStartsFalse() {
-        let controller = CompletionWindowController()
+        let controller = HoverWindowController()
         #expect(controller.isVisible == false)
     }
 }


### PR DESCRIPTION
## Summary

The previous LSP hover popped up on idle mouse motion in a stock `NSPopover` that was uninteractable and too eager. This PR rebuilds the trigger, persistence, anchoring, and chrome.

- **Trigger.** 750 ms idle dwell over an identifier; ⌥ accelerates to fire immediately. No popover from incidental motion or hovers over whitespace.
- **Anchor.** Pinned to the symbol's bounding rect (never the mouse), with below-or-above fallback and screen-clamped positioning.
- **Persistence.** Stays open as long as the cursor sits anywhere on the symbol, the panel, or the corridor between them. An `NSEvent` monitor drives the screen-coordinate hit-test, so the panel itself is interactive — mouse onto it to scroll long docs.
- **Dismiss.** A 500 ms grace timer covers transit and the small caret gap. Forced dismisses on scroll, caret movement, Esc, and window resize hide immediately.
- **Chrome.** New shared `EditorOverlayPanel` owns the borderless `NSPanel` lifecycle and positioning math; both `HoverWindowController` and the autocomplete `CompletionWindowController` delegate to it, guaranteeing identical look and behavior.

## Test plan

- [x] Swift Testing suites: hover behavior (state machine, dwell, ⌥, forced dismisses), hover rendering (sizing), positioning (`EditorOverlayPanelTests`).
- [x] Full `xcodebuild test` run.
- [x] Manual: dwell over symbols, ⌥ accelerator, mouse-onto-panel and scroll, typing/scroll/Esc/resize dismiss, tab switch, visual cohesion with autocomplete popup.