### PR TITLE
feat: expand conventional commit detector verbs

### DIFF
--- a/Alas/Sources/Git/CommitInfo.swift
+++ b/Alas/Sources/Git/CommitInfo.swift
@@ -17,6 +17,7 @@ struct CommitInfo: Identifiable, Hashable {
 extension CommitInfo {
     static let recognisedTypes: Set<String> = [
         "feat", "fix", "chore", "refactor", "perf", "docs", "test", "ci", "build",
+        "style", "revert", "tune",
     ]
 
     /// Splits a commit subject of the form

--- a/AlasTests/CommitInfoTests.swift
+++ b/AlasTests/CommitInfoTests.swift
@@ -41,10 +41,37 @@ struct CommitInfoTests {
     }
 
     @Test func recognisesAllExpectedTypes() {
-        for type in ["feat", "fix", "chore", "refactor", "perf", "docs", "test", "ci", "build"] {
+        for type in [
+            "feat", "fix", "chore", "refactor", "perf", "docs", "test", "ci", "build",
+            "style", "revert", "tune",
+        ] {
             let (tag, _) = CommitInfo.parseConventional(subject: "\(type): something")
             #expect(tag == type, "expected \(type) to be recognised")
         }
+    }
+
+    @Test func extractsTunePrefix() {
+        let (tag, stripped) = CommitInfo.parseConventional(subject: "tune: adjust animation timing")
+        #expect(tag == "tune")
+        #expect(stripped == "adjust animation timing")
+    }
+
+    @Test func extractsStylePrefix() {
+        let (tag, stripped) = CommitInfo.parseConventional(subject: "style: fix indentation")
+        #expect(tag == "style")
+        #expect(stripped == "fix indentation")
+    }
+
+    @Test func extractsRevertPrefix() {
+        let (tag, stripped) = CommitInfo.parseConventional(subject: "revert: undo feature flag")
+        #expect(tag == "revert")
+        #expect(stripped == "undo feature flag")
+    }
+
+    @Test func extractsScopedTunePrefix() {
+        let (tag, stripped) = CommitInfo.parseConventional(subject: "tune(sidebar): tweak row spacing")
+        #expect(tag == "tune")
+        #expect(stripped == "tweak row spacing")
     }
 
     @Test func initialsEmpty() {


### PR DESCRIPTION
## Summary
- add tune, style, and revert to the recognized conventional commit types
- cover the new verbs with focused CommitInfo tests, including scoped tune

## Validation
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test