### PR TITLE
refactor(settings): rename Advanced to Debug and move it last in sidebar

### DIFF
--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 enum SettingsSection: String, CaseIterable, Identifiable {
-    case advanced, agents, appearance, changes, code, shortcuts, terminal, worktrees
+    case agents, appearance, changes, code, shortcuts, terminal, worktrees, debug
     var id: String { rawValue }
     var label: String {
         switch self {
-        case .advanced:   return "Advanced"
+        case .debug:      return "Debug"
         case .agents:     return "Agents"
         case .appearance: return "Appearance"
         case .changes:    return "Changes"
@@ -17,7 +17,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     }
     var icon: String {
         switch self {
-        case .advanced:   return "wrench.and.screwdriver"
+        case .debug:      return "wrench.and.screwdriver"
         case .agents:     return "sparkle"
         case .appearance: return "palette"
         case .changes:    return "diff"
@@ -31,7 +31,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
 
 struct SettingsNavView: View {
     @Binding var selection: SettingsSection
-    var showsAdvanced: Bool
+    var showsDebug: Bool
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -67,8 +67,13 @@ struct SettingsNavView: View {
     }
 
     private var sections: [SettingsSection] {
-        SettingsSection.allCases
-            .filter { showsAdvanced || $0 != .advanced }
-            .sorted(by: { $0.label < $1.label })
+        let visible = SettingsSection.allCases
+            .filter { showsDebug || $0 != .debug }
+            .sorted(by: {
+                if $0 == .debug { return false }
+                if $1 == .debug { return true }
+                return $0.label < $1.label
+            })
+        return visible
     }
 }

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct SettingsWindow: View {
     @Bindable var state: AppState
     @State private var section: SettingsSection = .agents
-    @State private var showsAdvanced = AdvancedSettingsVisibility.isEnabled()
+    @State private var showsDebug = AdvancedSettingsVisibility.isEnabled()
 
     var body: some View {
         let theme = state.themeStore.current
@@ -27,10 +27,10 @@ struct SettingsWindow: View {
             .overlay(Divider().opacity(0.5), alignment: .bottom)
 
             HStack(spacing: 0) {
-                SettingsNavView(selection: $section, showsAdvanced: showsAdvanced)
+                SettingsNavView(selection: $section, showsDebug: showsDebug)
                 Group {
                     switch section {
-                    case .advanced:   AdvancedPane(state: state)
+                    case .debug:      AdvancedPane(state: state)
                     case .agents:     AgentsPane(state: state) { section = $0 }
                     case .appearance: AppearancePane(state: state)
                     case .changes:    ChangesPane(state: state)
@@ -63,8 +63,8 @@ struct SettingsWindow: View {
         .environment(\.theme, theme)
         .ignoresSafeArea()
         .onAppear {
-            showsAdvanced = AdvancedSettingsVisibility.isEnabled()
-            if !showsAdvanced, section == .advanced {
+            showsDebug = AdvancedSettingsVisibility.isEnabled()
+            if !showsDebug, section == .debug {
                 section = .agents
             }
             state.rescanAgents()

--- a/AlasTests/SettingsSectionTests.swift
+++ b/AlasTests/SettingsSectionTests.swift
@@ -10,8 +10,10 @@ struct SettingsSectionTests {
         #expect(labels.contains("Appearance"))
     }
 
-    @Test func sidebarSectionsAreSortedAlphabetically() {
+    @Test func sidebarSectionsAreSortedAlphabeticallyExceptDebugLast() {
         let labels = SettingsSection.allCases.map(\.label)
-        #expect(labels == labels.sorted())
+        let mainLabels = labels.filter { $0 != "Debug" }
+        #expect(mainLabels == mainLabels.sorted())
+        #expect(labels.last == "Debug")
     }
 }


### PR DESCRIPTION
## Summary

- Renames the hidden "Advanced" settings section to "Debug" to better reflect its purpose (developer/diagnostics toggles).
- Moves the Debug section from first to **last** in the settings sidebar, breaking strict alphabetical order intentionally so it sits at the end of the list.
- Keeps all other sections (Agents, Appearance, Changes, Code, Shortcuts, Terminal, Worktrees) sorted alphabetically.
- Updates `SettingsSectionTests` to assert the new ordering rule.

### What changed

- `SettingsNavView.swift`
  - Renames `.advanced` → `.debug`, label "Debug"
  - Replaces raw `allCases.sorted()` with a custom comparator that pins Debug to the end
- `SettingsWindow.swift`
  - Renames `showsAdvanced` → `showsDebug`, updates switch case and fallback logic
- `SettingsSectionTests.swift`
  - Renames test to `sidebarSectionsAreSortedAlphabeticallyExceptDebugLast` and asserts Debug is last

### Reviewer notes

- The `AdvancedSettingsVisibility` utility itself is intentionally unchanged; only the UI label and section ordering are affected.
- No functional changes to the pane contents (still maps to `AdvancedPane`).
