### PR TITLE
feat: hide left sidebar with ⌘B

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
+		BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */; };
 		BE4E46595AF10611CE0B1C6B /* TabActivityPulse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */; };
 		BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */; };
 		BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */; };
@@ -812,6 +813,7 @@
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
 		97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshotTests.swift; sourceTree = "<group>"; };
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
+		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
 		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
@@ -1211,6 +1213,7 @@
 				6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */,
 				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
 				F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */,
+				98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
 				9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */,
 				DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */,
@@ -2549,6 +2552,7 @@
 				CF2AD9C6F30BC02C040902A8 /* ShortcutResolverTests.swift in Sources */,
 				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
 				8FD71F989EFA5BF22B92B4CD /* SidebarMaterialChoiceTests.swift in Sources */,
+				BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,
 				771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */,
 				FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -74,6 +74,10 @@ struct AlasApp: App {
                 .disabled(!state.hasActiveCodeEditorTab)
             }
             CommandGroup(after: .toolbar) {
+                Button("Toggle Sidebar") {
+                    NotificationCenter.default.post(name: .alasToggleSidebar, object: nil)
+                }
+                .keyboardShortcut(state.shortcut(for: .toggleSidebar))
                 Button("Toggle Right Sidebar") {
                     NotificationCenter.default.post(name: .alasToggleRightPane, object: nil)
                 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -309,6 +309,11 @@ final class AppState {
         _ = saveConfig()
     }
 
+    func toggleSidebarVisibility() {
+        config.sidebarVisible.toggle()
+        _ = saveConfig()
+    }
+
     /// Tear down tabs, terminals, harness state, and editor buffers for any
     /// worktree IDs that existed in `beforeIds` but are absent after a refresh.
     /// Also re-points selection if the selected worktree was removed.

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -30,6 +30,7 @@ struct RootView: View {
                             get: { state.config.rightPaneWidth },
                             set: { state.config.rightPaneWidth = $0 }
                         ),
+                        sidebarVisible: state.config.sidebarVisible,
                         rightVisible: state.config.rightPaneVisible,
                         onWidthsChanged: { state.saveConfig() },
                         sidebar: {

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -311,7 +311,11 @@ private struct RootBaseHandlers: ViewModifier {
     let openSettings: () -> Void
 
     func body(content: Content) -> some View {
-        let a = content
+        let aSidebar = content
+            .onReceive(NotificationCenter.default.publisher(for: .alasToggleSidebar)) { _ in
+                state.toggleSidebarVisibility()
+            }
+        let a = aSidebar
             .onReceive(NotificationCenter.default.publisher(for: .alasToggleRightPane)) { _ in
                 state.toggleRightPaneVisibility()
             }
@@ -463,6 +467,7 @@ private struct RootPaneHandlers: ViewModifier {
 }
 
 extension Notification.Name {
+    static let alasToggleSidebar     = Notification.Name("AlasToggleSidebar")
     static let alasToggleRightPane   = Notification.Name("AlasToggleRightPane")
     static let alasCreateProject     = Notification.Name("AlasCreateProject")
     static let alasNewWorktree       = Notification.Name("AlasNewWorktree")

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -48,6 +48,10 @@ struct RootView: View {
                                 onNewWorktree: { projectId in
                                     newWorktreePresetProjectId = projectId
                                     showNewWorktree = true
+                                },
+                                onHideSidebar: {
+                                    state.config.sidebarVisible = false
+                                    state.saveConfig()
                                 }
                             )
                         },

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -63,6 +63,11 @@ struct CenterPaneView: View {
                     state.saveConfig()
                 },
                 rightSidebarHidden: !state.config.rightPaneVisible,
+                onRevealSidebar: {
+                    state.config.sidebarVisible = true
+                    state.saveConfig()
+                },
+                sidebarHidden: !state.config.sidebarVisible,
                 onMove: { draggedId, destinationId in
                     state.tabs.moveTab(worktreeId: worktree.id, fromId: draggedId, toId: destinationId)
                 }

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -107,6 +107,7 @@ struct TabBarView: View {
         .frame(height: 34)
         .background(theme.color("bg-2"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
+        .windowDragHandle()
     }
 }
 

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -20,6 +20,8 @@ struct TabBarView: View {
     let onLaunchAgent: (String) -> Void
     let onRevealRightSidebar: () -> Void
     let rightSidebarHidden: Bool
+    let onRevealSidebar: () -> Void
+    let sidebarHidden: Bool
     let onMove: (TabID, TabID) -> Void
     @Environment(\.theme) var theme
 
@@ -31,6 +33,13 @@ struct TabBarView: View {
 
     var body: some View {
         HStack(spacing: 0) {
+            if sidebarHidden {
+                TrafficLights()
+                    .padding(.leading, 12)
+                    .padding(.trailing, 10)
+                ToolbarIconButton(iconName: "sidebar.left", tooltip: "Show sidebar", action: onRevealSidebar)
+                    .padding(.trailing, 8)
+            }
             ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
                 TabButton(
                     tab: tab,

--- a/Alas/Sources/Layout/ThreePaneLayout.swift
+++ b/Alas/Sources/Layout/ThreePaneLayout.swift
@@ -22,6 +22,7 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                 availableWidth: Double(proxy.size.width),
                 preferredSidebarWidth: sidebarWidth,
                 preferredRightWidth: rightWidth,
+                sidebarPreferredVisible: true,
                 rightPreferredVisible: rightVisible,
                 configuration: ThreePaneSizing.Configuration(
                     sidebarMin: sidebarMin,

--- a/Alas/Sources/Layout/ThreePaneLayout.swift
+++ b/Alas/Sources/Layout/ThreePaneLayout.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
     @Binding var sidebarWidth: Double
     @Binding var rightWidth: Double
+    let sidebarVisible: Bool
     let rightVisible: Bool
     let onWidthsChanged: () -> Void
     @ViewBuilder let sidebar: () -> Sidebar
@@ -22,7 +23,7 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
                 availableWidth: Double(proxy.size.width),
                 preferredSidebarWidth: sidebarWidth,
                 preferredRightWidth: rightWidth,
-                sidebarPreferredVisible: true,
+                sidebarPreferredVisible: sidebarVisible,
                 rightPreferredVisible: rightVisible,
                 configuration: ThreePaneSizing.Configuration(
                     sidebarMin: sidebarMin,
@@ -35,15 +36,17 @@ struct ThreePaneLayout<Sidebar: View, Center: View, Right: View>: View {
             )
 
             HStack(spacing: 0) {
-                sidebar()
-                    .frame(width: CGFloat(sizing.sidebarWidth))
-                    .frame(maxHeight: .infinity)
-                DragHandle(axis: .horizontal) { delta in
-                    sidebarWidth = DragHandle.clamp(
-                        value: sidebarWidth + Double(delta),
-                        min: sidebarMin, max: sidebarMax
-                    )
-                    onWidthsChanged()
+                if sizing.sidebarVisible {
+                    sidebar()
+                        .frame(width: CGFloat(sizing.sidebarWidth))
+                        .frame(maxHeight: .infinity)
+                    DragHandle(axis: .horizontal) { delta in
+                        sidebarWidth = DragHandle.clamp(
+                            value: sidebarWidth + Double(delta),
+                            min: sidebarMin, max: sidebarMax
+                        )
+                        onWidthsChanged()
+                    }
                 }
                 center()
                     .frame(width: CGFloat(sizing.centerWidth))

--- a/Alas/Sources/Layout/ThreePaneSizing.swift
+++ b/Alas/Sources/Layout/ThreePaneSizing.swift
@@ -193,8 +193,8 @@ enum ThreePaneSizing {
 
         let usableWidth = max(0, availableWidth - dividerWidth)
 
-        // If center + right minimums cannot fit, collapse right entirely
-        // (mirroring how calculateTwoPane handles the sidebar+center case).
+        // Unlike calculateTwoPane, the right pane is optional: collapse it entirely
+        // rather than proportionally shrinking both panes below their minimums.
         guard usableWidth >= centerMin + rightMin else {
             return Result(
                 sidebarWidth: 0,

--- a/Alas/Sources/Layout/ThreePaneSizing.swift
+++ b/Alas/Sources/Layout/ThreePaneSizing.swift
@@ -14,6 +14,7 @@ enum ThreePaneSizing {
         var sidebarWidth: Double
         var centerWidth: Double
         var rightWidth: Double
+        var sidebarVisible: Bool
         var rightVisible: Bool
     }
 
@@ -21,6 +22,7 @@ enum ThreePaneSizing {
         availableWidth rawAvailableWidth: Double,
         preferredSidebarWidth rawPreferredSidebarWidth: Double,
         preferredRightWidth rawPreferredRightWidth: Double,
+        sidebarPreferredVisible: Bool,
         rightPreferredVisible: Bool,
         configuration: Configuration
     ) -> Result {
@@ -42,6 +44,17 @@ enum ThreePaneSizing {
             min: rightMin,
             max: rightMax
         )
+
+        guard sidebarPreferredVisible else {
+            return calculateCenterRight(
+                availableWidth: availableWidth,
+                preferredRightWidth: preferredRightWidth,
+                rightPreferredVisible: rightPreferredVisible,
+                rightMin: rightMin,
+                centerMin: centerMin,
+                dividerWidth: dividerWidth
+            )
+        }
 
         guard rightPreferredVisible else {
             return calculateTwoPane(
@@ -75,6 +88,7 @@ enum ThreePaneSizing {
                 sidebarWidth: preferredSidebarWidth,
                 centerWidth: max(0, preferredCenterWidth),
                 rightWidth: preferredRightWidth,
+                sidebarVisible: true,
                 rightVisible: true
             )
         }
@@ -119,6 +133,7 @@ enum ThreePaneSizing {
             sidebarWidth: sidebarWidth,
             centerWidth: centerWidth,
             rightWidth: rightWidth,
+            sidebarVisible: true,
             rightVisible: true
         )
     }
@@ -153,7 +168,56 @@ enum ThreePaneSizing {
             sidebarWidth: clampedSidebarWidth,
             centerWidth: max(0, usableWidth - clampedSidebarWidth),
             rightWidth: 0,
+            sidebarVisible: true,
             rightVisible: false
+        )
+    }
+
+    private static func calculateCenterRight(
+        availableWidth: Double,
+        preferredRightWidth: Double,
+        rightPreferredVisible: Bool,
+        rightMin: Double,
+        centerMin: Double,
+        dividerWidth: Double
+    ) -> Result {
+        guard rightPreferredVisible else {
+            return Result(
+                sidebarWidth: 0,
+                centerWidth: availableWidth,
+                rightWidth: 0,
+                sidebarVisible: false,
+                rightVisible: false
+            )
+        }
+
+        let usableWidth = max(0, availableWidth - dividerWidth)
+
+        // If center + right minimums cannot fit, collapse right entirely
+        // (mirroring how calculateTwoPane handles the sidebar+center case).
+        guard usableWidth >= centerMin + rightMin else {
+            return Result(
+                sidebarWidth: 0,
+                centerWidth: availableWidth,
+                rightWidth: 0,
+                sidebarVisible: false,
+                rightVisible: false
+            )
+        }
+
+        let rightWidth: Double
+        if usableWidth >= preferredRightWidth + centerMin {
+            rightWidth = preferredRightWidth
+        } else {
+            rightWidth = max(rightMin, usableWidth - centerMin)
+        }
+        let centerWidth = max(0, usableWidth - rightWidth)
+        return Result(
+            sidebarWidth: 0,
+            centerWidth: centerWidth,
+            rightWidth: rightWidth,
+            sidebarVisible: false,
+            rightVisible: true
         )
     }
 

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -21,6 +21,7 @@ struct AppConfig: Codable, Equatable {
     var sidebarWidth: Double
     var rightPaneWidth: Double
     var rightPaneVisible: Bool
+    var sidebarVisible: Bool
     var commitDetailSplitRatio: Double
     var general: General
     var worktrees: Worktrees
@@ -162,6 +163,7 @@ struct AppConfig: Codable, Equatable {
         sidebarWidth: 244,
         rightPaneWidth: 320,
         rightPaneVisible: true,
+        sidebarVisible: true,
         commitDetailSplitRatio: 0.32,
         general: General(
             launchAtLogin: false, closeToTray: true, confirmQuit: true,
@@ -245,7 +247,7 @@ extension AppConfig {
 extension AppConfig {
     enum CodingKeys: String, CodingKey {
         case themeId, accent, density, matchSystemTheme,
-             sidebarMaterial, sidebarWidth, rightPaneWidth, rightPaneVisible,
+             sidebarMaterial, sidebarWidth, rightPaneWidth, rightPaneVisible, sidebarVisible,
              commitDetailSplitRatio,
              general, worktrees, terminal, harness, code, markdown, changes,
              agents,
@@ -271,6 +273,7 @@ extension AppConfig {
         sidebarWidth = try c.decode(Double.self, forKey: .sidebarWidth)
         rightPaneWidth = try c.decode(Double.self, forKey: .rightPaneWidth)
         rightPaneVisible = try c.decode(Bool.self, forKey: .rightPaneVisible)
+        sidebarVisible = (try? c.decode(Bool.self, forKey: .sidebarVisible)) ?? true
         commitDetailSplitRatio = (try? c.decode(Double.self, forKey: .commitDetailSplitRatio)) ?? 0.32
         general = try c.decode(General.self, forKey: .general)
         worktrees = try c.decode(Worktrees.self, forKey: .worktrees)

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -13,7 +13,7 @@ enum ShortcutGroup: String, CaseIterable, Sendable {
 
 enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     // Global
-    case searchFiles, switchRepository, findAndReplace, toggleRightPane,
+    case searchFiles, switchRepository, findAndReplace, toggleSidebar, toggleRightPane,
          createProject, newWorktree, newTerminalTab, launchAgentTerminal,
          increaseFontSize, decreaseFontSize, resetFontSize
     // Code editor
@@ -25,7 +25,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
 
     var group: ShortcutGroup {
         switch self {
-        case .searchFiles, .switchRepository, .findAndReplace, .toggleRightPane,
+        case .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
              .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal,
              .increaseFontSize, .decreaseFontSize, .resetFontSize:
             return .global
@@ -43,6 +43,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .searchFiles:              return "Search Files"
         case .switchRepository:         return "Switch Repository"
         case .findAndReplace:           return "Find and Replace"
+        case .toggleSidebar:            return "Toggle Sidebar"
         case .toggleRightPane:          return "Toggle Right Sidebar"
         case .createProject:            return "Create Project"
         case .newWorktree:              return "New Worktree"
@@ -96,6 +97,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .searchFiles:              return .init(key: "p",          modifiers: [.command])
         case .switchRepository:         return .init(key: "k",          modifiers: [.command])
         case .findAndReplace:           return .init(key: "f",          modifiers: [.command, .option])
+        case .toggleSidebar:            return .init(key: "b",          modifiers: [.command])
         case .toggleRightPane:          return .init(key: "b",          modifiers: [.command, .option])
         case .createProject:            return .init(key: "n",          modifiers: [.command, .shift])
         case .newWorktree:              return .init(key: "n",          modifiers: [.command, .option])

--- a/Alas/Sources/Sidebar/SidebarHeaderView.swift
+++ b/Alas/Sources/Sidebar/SidebarHeaderView.swift
@@ -4,6 +4,7 @@ struct SidebarHeaderView: View {
     let onSettings: () -> Void
     let onAddProject: () -> Void
     let onSearch: () -> Void
+    let onHideSidebar: () -> Void
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
@@ -13,6 +14,7 @@ struct SidebarHeaderView: View {
                 ToolbarBtn(icon: "search", action: onSearch)
                 ToolbarBtn(icon: "folder-plus", action: onAddProject)
                 ToolbarBtn(icon: "gear", action: onSettings)
+                ToolbarBtn(icon: "sidebar.left", action: onHideSidebar)
             }
         }
         .padding(.horizontal, 12)

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -9,6 +9,7 @@ struct SidebarView: View {
     let onEditProject: (_ projectId: String) -> Void
     let onRemoveProject: (_ projectId: String) -> Void
     let onNewWorktree: (_ projectId: String?) -> Void
+    let onHideSidebar: () -> Void
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -24,7 +25,8 @@ struct SidebarView: View {
                     onAddProject: onAddProject,
                     onSearch: {
                         NotificationCenter.default.post(name: .alasOpenSearch, object: nil)
-                    }
+                    },
+                    onHideSidebar: onHideSidebar
                 )
                 ScrollView(.vertical, showsIndicators: true) {
                     VStack(alignment: .leading, spacing: 8) {

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -22,6 +22,7 @@ struct AppConfigTests {
         #expect(cfg.sidebarWidth == 244)
         #expect(cfg.rightPaneWidth == 320)
         #expect(cfg.rightPaneVisible == true)
+        #expect(cfg.sidebarVisible == true)
         #expect(cfg.terminal.shell == "/bin/zsh")
         #expect(cfg.harness.notifyOnFinish == true)
         #expect(cfg.harness.notifyOnAwaiting == true)
@@ -234,6 +235,42 @@ struct AppConfigTests {
         let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
         #expect(cfg.recentProjectIds == [])
         #expect(cfg.recentWorktreeIdsByProject == [:])
+    }
+
+    @Test func decodeOldConfigDefaultsSidebarVisibleTrue() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "density": "comfortable",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/code/.worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true, "notifyOnAwaiting": true}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.sidebarVisible == true)
     }
 
     @Test func repoSelectorRecentsRoundTrip() throws {

--- a/AlasTests/ShortcutActionTests.swift
+++ b/AlasTests/ShortcutActionTests.swift
@@ -23,6 +23,7 @@ struct ShortcutActionTests {
             (.searchFiles,          "p",          [.command]),
             (.switchRepository,     "k",          [.command]),
             (.findAndReplace,       "f",          [.command, .option]),
+            (.toggleSidebar,        "b",          [.command]),
             (.toggleRightPane,      "b",          [.command, .option]),
             (.createProject,        "n",          [.command, .shift]),
             (.newWorktree,          "n",          [.command, .option]),
@@ -54,7 +55,7 @@ struct ShortcutActionTests {
 
     @Test func groupAssignmentsMatchSpec() {
         let global: Set<ShortcutAction> = [
-            .searchFiles, .switchRepository, .findAndReplace, .toggleRightPane,
+            .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
             .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal,
             .increaseFontSize, .decreaseFontSize, .resetFontSize,
         ]

--- a/AlasTests/SidebarHeaderViewTests.swift
+++ b/AlasTests/SidebarHeaderViewTests.swift
@@ -15,7 +15,8 @@ struct SidebarHeaderViewTests {
         let view = SidebarHeaderView(
             onSettings: {},
             onAddProject: {},
-            onSearch: {}
+            onSearch: {},
+            onHideSidebar: {}
         )
         .environment(\.theme, currentTheme())
         let controller = NSHostingController(rootView: view)

--- a/AlasTests/SidebarVisibilityTests.swift
+++ b/AlasTests/SidebarVisibilityTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct SidebarVisibilityTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    @Test func toggleSidebarVisibilityHidesAndShowsAgain() {
+        let state = AppState(store: MemoryStore())
+        #expect(state.config.sidebarVisible)
+
+        state.toggleSidebarVisibility()
+        #expect(!state.config.sidebarVisible)
+
+        state.toggleSidebarVisibility()
+        #expect(state.config.sidebarVisible)
+    }
+}

--- a/AlasTests/TabActivityIconTintTests.swift
+++ b/AlasTests/TabActivityIconTintTests.swift
@@ -70,6 +70,8 @@ struct TabActivityIconTintTests {
             onLaunchAgent: { _ in },
             onRevealRightSidebar: { },
             rightSidebarHidden: false,
+            onRevealSidebar: { },
+            sidebarHidden: false,
             onMove: { _, _ in }
         )
         .environment(\.theme, currentTheme())

--- a/AlasTests/ThreePaneSizingTests.swift
+++ b/AlasTests/ThreePaneSizingTests.swift
@@ -20,6 +20,7 @@ struct ThreePaneSizingTests {
             availableWidth: 1_200,
             preferredSidebarWidth: 244,
             preferredRightWidth: 320,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: true,
             configuration: config
         )
@@ -44,6 +45,7 @@ struct ThreePaneSizingTests {
             availableWidth: 900,
             preferredSidebarWidth: preferredSidebarWidth,
             preferredRightWidth: preferredRightWidth,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: true,
             configuration: config
         )
@@ -64,6 +66,7 @@ struct ThreePaneSizingTests {
             availableWidth: 1_200,
             preferredSidebarWidth: 100,
             preferredRightWidth: 100,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: true,
             configuration: config
         )
@@ -80,6 +83,7 @@ struct ThreePaneSizingTests {
             availableWidth: availableWidth,
             preferredSidebarWidth: 200,
             preferredRightWidth: 240,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: true,
             configuration: config
         )
@@ -95,6 +99,7 @@ struct ThreePaneSizingTests {
             availableWidth: 840,
             preferredSidebarWidth: 244,
             preferredRightWidth: 320,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: true,
             configuration: config
         )
@@ -110,6 +115,7 @@ struct ThreePaneSizingTests {
             availableWidth: 1_200,
             preferredSidebarWidth: 244,
             preferredRightWidth: 320,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: false,
             configuration: config
         )
@@ -125,6 +131,7 @@ struct ThreePaneSizingTests {
             availableWidth: 580,
             preferredSidebarWidth: 244,
             preferredRightWidth: 320,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: false,
             configuration: config
         )
@@ -141,6 +148,7 @@ struct ThreePaneSizingTests {
             availableWidth: availableWidth,
             preferredSidebarWidth: 244,
             preferredRightWidth: 320,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: false,
             configuration: config
         )
@@ -158,6 +166,7 @@ struct ThreePaneSizingTests {
             availableWidth: availableWidth,
             preferredSidebarWidth: 244,
             preferredRightWidth: 320,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: false,
             configuration: config
         )
@@ -174,6 +183,7 @@ struct ThreePaneSizingTests {
             availableWidth: 120,
             preferredSidebarWidth: 244,
             preferredRightWidth: 320,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: true,
             configuration: config
         )
@@ -190,6 +200,7 @@ struct ThreePaneSizingTests {
             availableWidth: .nan,
             preferredSidebarWidth: .infinity,
             preferredRightWidth: -.infinity,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: true,
             configuration: config
         )
@@ -208,6 +219,7 @@ struct ThreePaneSizingTests {
             availableWidth: 1_800,
             preferredSidebarWidth: 900,
             preferredRightWidth: 900,
+            sidebarPreferredVisible: true,
             rightPreferredVisible: true,
             configuration: config
         )
@@ -215,5 +227,59 @@ struct ThreePaneSizingTests {
         #expect(isApproximatelyEqual(result.sidebarWidth, 420))
         #expect(isApproximatelyEqual(result.rightWidth, 560))
         #expect(isApproximatelyEqual(result.centerWidth, 808))
+    }
+
+    @Test func hiddenSidebarReducesToCenterRight() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 1_200,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            sidebarPreferredVisible: false,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(result.sidebarVisible == false)
+        #expect(isApproximatelyEqual(result.sidebarWidth, 0))
+        #expect(result.rightVisible == true)
+        #expect(isApproximatelyEqual(result.rightWidth, 320))
+        #expect(isApproximatelyEqual(result.centerWidth, 874))
+        // 1200 - 320 - 6 (single divider between center & right) = 874
+    }
+
+    @Test func hiddenSidebarAndHiddenRightYieldCenterOnly() {
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 1_000,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            sidebarPreferredVisible: false,
+            rightPreferredVisible: false,
+            configuration: config
+        )
+
+        #expect(result.sidebarVisible == false)
+        #expect(result.rightVisible == false)
+        #expect(isApproximatelyEqual(result.sidebarWidth, 0))
+        #expect(isApproximatelyEqual(result.rightWidth, 0))
+        #expect(isApproximatelyEqual(result.centerWidth, 1_000))
+    }
+
+    @Test func hiddenSidebarNarrowWindowCollapsesRight() {
+        // centerMin + rightMin + divider = 400 + 240 + 6 = 646.
+        // 600 < 646 — the right pane must collapse, center keeps remainder.
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 600,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            sidebarPreferredVisible: false,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(result.sidebarVisible == false)
+        #expect(result.rightVisible == false)
+        #expect(isApproximatelyEqual(result.sidebarWidth, 0))
+        #expect(isApproximatelyEqual(result.rightWidth, 0))
+        #expect(isApproximatelyEqual(result.centerWidth, 600))
     }
 }

--- a/AlasTests/ThreePaneSizingTests.swift
+++ b/AlasTests/ThreePaneSizingTests.swift
@@ -282,4 +282,23 @@ struct ThreePaneSizingTests {
         #expect(isApproximatelyEqual(result.rightWidth, 0))
         #expect(isApproximatelyEqual(result.centerWidth, 600))
     }
+
+    @Test func hiddenSidebarMediumWindowShrinksRightBelowPreferred() {
+        // centerMin + rightMin + divider = 400 + 240 + 6 = 646 ≤ 700 < 726 = preferredRight + centerMin + divider.
+        // Right is visible but shrunk below preferred to keep center at its min.
+        let result = ThreePaneSizing.calculate(
+            availableWidth: 700,
+            preferredSidebarWidth: 244,
+            preferredRightWidth: 320,
+            sidebarPreferredVisible: false,
+            rightPreferredVisible: true,
+            configuration: config
+        )
+
+        #expect(result.sidebarVisible == false)
+        #expect(result.rightVisible == true)
+        #expect(isApproximatelyEqual(result.sidebarWidth, 0))
+        #expect(isApproximatelyEqual(result.rightWidth, 294))   // 700 - 6 - 400 = 294
+        #expect(isApproximatelyEqual(result.centerWidth, 400))  // hits centerMin
+    }
 }

--- a/AlasTests/TouchTargetSmokeTests.swift
+++ b/AlasTests/TouchTargetSmokeTests.swift
@@ -143,6 +143,47 @@ struct TouchTargetSmokeTests {
         #expect(controller.view != nil)
     }
 
+    @Test func tabBarViewWithSidebarRevealRendersWithoutCrashing() {
+        let tab = Tab.editor(EditorTabState(
+            id: "t1",
+            title: "hello.swift",
+            relativePath: "hello.swift",
+            revealLine: nil,
+            revealCharacter: nil,
+            externalAbsolutePath: nil,
+            originatingRelativePath: nil,
+            markdownViewMode: nil,
+            markdownSplitFraction: nil
+        ))
+        let view = TabBarView(
+            tabs: [tab],
+            activeId: tab.id,
+            harnessLookup: { _ in nil },
+            dirtyLookup: { _ in false },
+            onActivate: { _ in },
+            onClose: { _ in },
+            onCloseOthers: { _ in },
+            onCloseAll: { },
+            onCloseToLeft: { _ in },
+            onCloseToRight: { _ in },
+            onCopyPath: { _ in },
+            onCopyRelativePath: { _ in },
+            onRenameTerminal: { _ in },
+            onNewTerminal: { },
+            enabledAgents: [],
+            onLaunchAgent: { _ in },
+            onRevealRightSidebar: { },
+            rightSidebarHidden: false,
+            onRevealSidebar: { },
+            sidebarHidden: true,
+            onMove: { _, _ in }
+        )
+        .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
     @Test func stageChipRendersWithoutCrashing() {
         let view = StageChip(staged: false, action: { })
             .environment(\.theme, currentTheme())

--- a/AlasTests/TouchTargetSmokeTests.swift
+++ b/AlasTests/TouchTargetSmokeTests.swift
@@ -61,6 +61,8 @@ struct TouchTargetSmokeTests {
             onLaunchAgent: { _ in },
             onRevealRightSidebar: { },
             rightSidebarHidden: false,
+            onRevealSidebar: { },
+            sidebarHidden: false,
             onMove: { _, _ in }
         )
         .environment(\.theme, currentTheme())
@@ -90,6 +92,8 @@ struct TouchTargetSmokeTests {
             onLaunchAgent: { _ in },
             onRevealRightSidebar: { },
             rightSidebarHidden: false,
+            onRevealSidebar: { },
+            sidebarHidden: false,
             onMove: { _, _ in }
         )
         .environment(\.theme, currentTheme())
@@ -129,6 +133,8 @@ struct TouchTargetSmokeTests {
             onLaunchAgent: { _ in },
             onRevealRightSidebar: { },
             rightSidebarHidden: true,
+            onRevealSidebar: { },
+            sidebarHidden: false,
             onMove: { _, _ in }
         )
         .environment(\.theme, currentTheme())


### PR DESCRIPTION
## Summary

- Adds a togglable left sidebar that mirrors the existing right-sidebar hide behavior. ⌘B toggles; ⌘⌥B continues to toggle the right sidebar.
- New `sidebar.left` hide button in the sidebar header, and when hidden the tab bar grows a leading section containing the macOS traffic lights and a reveal button (since the lights normally live in the sidebar header).
- Hidden state persists across launches via `AppConfig.sidebarVisible` (tolerant decode for older configs).

## Notes

- Per spec, the brief `DeletingWorktreeView` / `DeleteFailedWorktreeView` / `EmptyTabView` states don't show traffic lights when the sidebar is hidden — acceptable edge case for this iteration, the empty-state-with-no-projects view already has its own lights.
- Pre-existing test failures in `ImageFileTypeTests`, `InstallNudgeResolverTests`, and `LanguageServerRegistryTests` exist on `main` and are unrelated to this branch.

## Test plan

- [ ] ⌘B hides and shows the sidebar.
- [ ] Hide button in sidebar header hides it.
- [ ] When hidden, the tab bar shows traffic lights + a reveal button at its leading edge; clicking the reveal button restores the sidebar.
- [ ] Traffic lights (close / minimize / zoom) work in both states.
- [ ] ⌘⌥B continues to toggle the right sidebar independently.
- [ ] Hidden state persists across quit/relaunch.
- [ ] Window remains draggable from the tab bar's empty area when the sidebar is hidden.
- [ ] ⌘B in a focused terminal toggles the sidebar (reserved binding).