### PR TITLE
fix: show full bypass permissions description in Settings Agents

### DIFF
--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -68,7 +68,7 @@ struct AgentsPane: View {
                             Text("Configure harness notifications and install hooks.")
                                 .font(.system(size: 11.5))
                                 .foregroundColor(theme.color("fg-dim"))
-                                .lineLimit(2)
+                                .fixedSize(horizontal: false, vertical: true)
                         }
                         .frame(width: 240, alignment: .leading)
                         .padding(.top, 4)

--- a/Alas/Sources/Settings/SettingsRow.swift
+++ b/Alas/Sources/Settings/SettingsRow.swift
@@ -14,7 +14,7 @@ struct SettingsRow<Control: View>: View {
                 if let desc {
                     Text(desc).font(.system(size: 11.5))
                         .foregroundColor(theme.color("fg-dim"))
-                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .frame(width: 240, alignment: .leading)


### PR DESCRIPTION
## Summary
- Allow Settings row descriptions to expand vertically instead of truncating after two lines
- Apply the same wrapping behavior to the inline Harness description in Agents settings

## Tests
- Not run: build is blocked by pre-existing missing GhosttyKit.xcframework dependency