### PR TITLE
feat(sidebar): allow dropping projects to empty bottom area to reorder last

### DIFF
--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -78,6 +78,14 @@ final class ProjectsManager {
         reorderProject(fromIndex: fromIndex, toIndex: toIndex)
     }
 
+    func moveProjectToEnd(id: String) {
+        guard let fromIndex = projects.firstIndex(where: { $0.id == id }),
+              fromIndex != projects.count - 1
+        else { return }
+        let moving = projects.remove(at: fromIndex)
+        projects.append(moving)
+    }
+
     func worktrees(projectId: String) -> [Worktree] {
         worktreesByProject[projectId] ?? []
     }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -132,6 +132,15 @@ struct SidebarView: View {
                                 }
                             )
                         }
+                        Color.clear
+                            .frame(maxWidth: .infinity, minHeight: 40)
+                            .contentShape(Rectangle())
+                            .dropDestination(for: ProjectDragId.self) { items, _ in
+                                guard let draggedId = items.first?.id else { return false }
+                                state.projectsManager.moveProjectToEnd(id: draggedId)
+                                state.saveProjects()
+                                return true
+                            }
                     }
                     .padding(.top, 8)
                 }

--- a/AlasTests/ProjectsManagerProjectOrderingTests.swift
+++ b/AlasTests/ProjectsManagerProjectOrderingTests.swift
@@ -109,6 +109,40 @@ struct ProjectsManagerProjectOrderingTests {
         #expect(mgr.projects.map(\.id) == ["B", "C", "D", "A"])
     }
 
+    // MARK: - moveProjectToEnd(id:)
+
+    @Test func moveToEndMovesFirstProjectToEnd() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C"]))
+
+        mgr.moveProjectToEnd(id: "A")
+
+        #expect(mgr.projects.map(\.id) == ["B", "C", "A"])
+    }
+
+    @Test func moveToEndMovesMiddleProjectToEnd() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C", "D"]))
+
+        mgr.moveProjectToEnd(id: "B")
+
+        #expect(mgr.projects.map(\.id) == ["A", "C", "D", "B"])
+    }
+
+    @Test func moveToEndAlreadyLastIsNoOp() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B", "C"]))
+
+        mgr.moveProjectToEnd(id: "C")
+
+        #expect(mgr.projects.map(\.id) == ["A", "B", "C"])
+    }
+
+    @Test func moveToEndUnknownIdIsNoOp() {
+        let mgr = ProjectsManager(persistedProjects: makeProjects(["A", "B"]))
+
+        mgr.moveProjectToEnd(id: "Z")
+
+        #expect(mgr.projects.map(\.id) == ["A", "B"])
+    }
+
     // MARK: - persistence roundtrip
 
     @Test func projectOrderIsDeterminedByArrayPosition() {


### PR DESCRIPTION
Add a drop target below the project list so dragging a project to the empty space beneath the last item moves it to the end of the list.