### PR TITLE
Move prompt editor to separate window

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
 		395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */; };
 		3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */; };
+		39DE92AE4B12D2CD03655562 /* CommitPromptStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */; };
 		3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */; };
 		3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E265B0C6F314FC80DB18053D /* RecommendedLanguageCatalog.swift */; };
 		3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2498E56CBAF84CB67166C /* HarnessKind.swift */; };
@@ -345,6 +346,7 @@
 		AC905947E88C7A2BE39D9B00 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		ACD22D2C262833B77006E8BE /* DeleteFailedWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */; };
 		AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF8152B18C9D6290724122F /* HoverFeature.swift */; };
+		AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */; };
 		AF2263B61D95A8BFF0972E93 /* AgentHookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */; };
 		B05BA1C6DD0BDA21E0932EE3 /* HookInstallNudgeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */; };
 		B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7159EED1183F784104B4F /* FuzzyMatch.swift */; };
@@ -581,10 +583,12 @@
 		1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabFilterTests.swift; sourceTree = "<group>"; };
 		19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileTypeTests.swift; sourceTree = "<group>"; };
 		1A17A797374500E1FDD2382C /* PersistenceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStore.swift; sourceTree = "<group>"; };
+		1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatus.swift; sourceTree = "<group>"; };
 		1AFC62A30044F71F0F16C3FB /* TerminalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalService.swift; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
 		1DACC2D855F4316038CB40C7 /* CommitComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitComposerView.swift; sourceTree = "<group>"; };
+		1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatusTests.swift; sourceTree = "<group>"; };
 		1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouterTests.swift; sourceTree = "<group>"; };
 		20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighterTests.swift; sourceTree = "<group>"; };
 		206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCheckerboardBackground.swift; sourceTree = "<group>"; };
@@ -1116,6 +1120,7 @@
 				DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */,
 				E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */,
 				9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */,
+				1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */,
 				6D46BDE72E52818061452ECB /* CommitRowTests.swift */,
 				576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */,
 				8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */,
@@ -1463,6 +1468,7 @@
 				EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */,
 				A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */,
 				93CDC9895F48619E97461875 /* CodePane.swift */,
+				1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */,
 				12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */,
 				2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */,
 				0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */,
@@ -2171,6 +2177,7 @@
 				C55B79DC0AAE96CFA14BE76F /* CommitFilesListView.swift in Sources */,
 				4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */,
 				B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */,
+				39DE92AE4B12D2CD03655562 /* CommitPromptStatus.swift in Sources */,
 				11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */,
 				BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */,
 				CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */,
@@ -2444,6 +2451,7 @@
 				E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */,
 				06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */,
 				F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */,
+				AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */,
 				B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */,
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,
 				17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -392,6 +392,7 @@
 		C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */; };
 		C487C3AD43E7B5BBB45490DB /* CodexInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F0314E357190EF2A1F861B /* CodexInstaller.swift */; };
 		C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */; };
+		C4E0EADB37C91E54DCB897AB /* CommitPromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */; };
 		C512EC7827D3C46907DDB7A1 /* HighlightCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E50B0600EF60A0D9B09877 /* HighlightCapture.swift */; };
 		C51D65D3D40F801BC94ABBDD /* TabsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A218B5125FC963339E40605E /* TabsManager.swift */; };
 		C54DD220F01DC5BB858BB407 /* AgentInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B597B64DC2E72758FBE2A /* AgentInstaller.swift */; };
@@ -884,6 +885,7 @@
 		B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderView.swift; sourceTree = "<group>"; };
 		B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCacheTests.swift; sourceTree = "<group>"; };
 		B87F114EBEEACCC95B9EF8D5 /* ImageDiffOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffOverlayView.swift; sourceTree = "<group>"; };
+		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
 		BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerHeadUpdatesTests.swift; sourceTree = "<group>"; };
@@ -1468,6 +1470,7 @@
 				EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */,
 				A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */,
 				93CDC9895F48619E97461875 /* CodePane.swift */,
+				BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */,
 				1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */,
 				12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */,
 				2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */,
@@ -2177,6 +2180,7 @@
 				C55B79DC0AAE96CFA14BE76F /* CommitFilesListView.swift in Sources */,
 				4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */,
 				B79D01EECD92181B710D2648 /* CommitInfo.swift in Sources */,
+				C4E0EADB37C91E54DCB897AB /* CommitPromptEditorWindow.swift in Sources */,
 				39DE92AE4B12D2CD03655562 /* CommitPromptStatus.swift in Sources */,
 				11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */,
 				BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -223,5 +223,12 @@ struct AlasApp: App {
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)
         .defaultSize(width: 880, height: 580)
+
+        Window("Commit Prompt", id: "commit-prompt-editor") {
+            CommitPromptEditorWindow(state: state)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+        .defaultSize(width: 720, height: 560)
     }
 }

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -25,7 +25,9 @@ struct ChangesPane: View {
                                 openWindow(id: "commit-prompt-editor")
                             }
                             Spacer()
-                            PromptStatusChip(label: CommitPromptStatus.label(for: state.config.changes.prompt))
+                            if let chipLabel = CommitPromptStatus.chipLabel(for: state.config.changes.prompt) {
+                                PromptStatusChip(label: chipLabel)
+                            }
                         }
                         .frame(maxWidth: .infinity)
                     }

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -21,10 +21,10 @@ struct ChangesPane: View {
                     SettingsRow(name: "Prompt",
                                 desc: "Instructions sent to the CLI. The staged diff is appended on stdin.") {
                         HStack(spacing: 12) {
-                            Spacer()
                             AlasButton(title: "Edit", style: .normal) {
                                 openWindow(id: "commit-prompt-editor")
                             }
+                            Spacer()
                             PromptStatusChip(label: CommitPromptStatus.label(for: state.config.changes.prompt))
                         }
                         .frame(maxWidth: .infinity)

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -21,13 +21,13 @@ struct ChangesPane: View {
                     SettingsRow(name: "Prompt",
                                 desc: "Instructions sent to the CLI. The staged diff is appended on stdin.") {
                         HStack(spacing: 12) {
-                            Text(CommitPromptStatus.label(for: state.config.changes.prompt))
-                                .font(.system(size: 12.5))
-                                .foregroundColor(theme.color("fg-muted"))
-                            AlasButton(title: "Edit...", style: .subtle) {
+                            AlasButton(title: "Edit", style: .normal) {
                                 openWindow(id: "commit-prompt-editor")
                             }
+                            Spacer()
+                            PromptStatusChip(label: CommitPromptStatus.label(for: state.config.changes.prompt))
                         }
+                        .frame(maxWidth: .infinity)
                     }
                 }
             }
@@ -51,5 +51,24 @@ struct ChangesPane: View {
         }
         .pickerStyle(.menu)
         .frame(width: 240)
+    }
+}
+
+private struct PromptStatusChip: View {
+    let label: String
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        Text(label)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(theme.color("fg-muted"))
+            .padding(.horizontal, 8)
+            .frame(height: 22)
+            .background(theme.color("bg-2"))
+            .clipShape(RoundedRectangle(cornerRadius: 5))
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .strokeBorder(theme.color("line-soft"), lineWidth: 0.5)
+            )
     }
 }

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -21,10 +21,10 @@ struct ChangesPane: View {
                     SettingsRow(name: "Prompt",
                                 desc: "Instructions sent to the CLI. The staged diff is appended on stdin.") {
                         HStack(spacing: 12) {
+                            Spacer()
                             AlasButton(title: "Edit", style: .normal) {
                                 openWindow(id: "commit-prompt-editor")
                             }
-                            Spacer()
                             PromptStatusChip(label: CommitPromptStatus.label(for: state.config.changes.prompt))
                         }
                         .frame(maxWidth: .infinity)

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ChangesPane: View {
     @Bindable var state: AppState
     @Environment(\.theme) var theme
+    @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         ScrollView {
@@ -19,22 +20,12 @@ struct ChangesPane: View {
                     }
                     SettingsRow(name: "Prompt",
                                 desc: "Instructions sent to the CLI. The staged diff is appended on stdin.") {
-                        VStack(alignment: .leading, spacing: 8) {
-                            TextEditor(text: state.bind(\.changes.prompt))
-                                .font(.system(size: 12, design: .monospaced))
-                                .frame(minHeight: 200, maxHeight: 320)
-                                .scrollContentBackground(.hidden)
-                                .background(theme.color("bg-2"))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .stroke(theme.color("line-soft"), lineWidth: 0.5)
-                                )
-                            HStack {
-                                Spacer()
-                                AlasButton(title: "Reset to default", style: .subtle) {
-                                    state.config.changes.prompt = AppConfig.defaultCommitPrompt
-                                    state.saveConfig()
-                                }
+                        HStack(spacing: 12) {
+                            Text(CommitPromptStatus.label(for: state.config.changes.prompt))
+                                .font(.system(size: 12.5))
+                                .foregroundColor(theme.color("fg-muted"))
+                            AlasButton(title: "Edit...", style: .subtle) {
+                                openWindow(id: "commit-prompt-editor")
                             }
                         }
                     }

--- a/Alas/Sources/Settings/CommitPromptEditorWindow.swift
+++ b/Alas/Sources/Settings/CommitPromptEditorWindow.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct CommitPromptEditorWindow: View {
     @Bindable var state: AppState
-    @Environment(\.dismiss) private var dismiss
     @State private var draftPrompt = ""
 
     var body: some View {
@@ -58,12 +57,12 @@ struct CommitPromptEditorWindow: View {
             HStack(spacing: 8) {
                 Spacer()
                 AlasButton(title: "Cancel", style: .subtle) {
-                    dismiss()
+                    closeWindow()
                 }
                 AlasButton(title: "Save", style: .primary) {
                     state.config.changes.prompt = draftPrompt
                     state.saveConfig()
-                    dismiss()
+                    closeWindow()
                 }
             }
             .padding(.horizontal, 32)
@@ -71,7 +70,7 @@ struct CommitPromptEditorWindow: View {
             .background(theme.color("bg-2"))
             .overlay(Divider().opacity(0.5), alignment: .top)
         }
-        .frame(width: 720, height: 560)
+        .frame(minWidth: 720, minHeight: 560)
         .background(theme.color("bg-1"))
         .background(WindowConfigurator())
         .environment(\.theme, theme)
@@ -79,5 +78,9 @@ struct CommitPromptEditorWindow: View {
         .onAppear {
             draftPrompt = state.config.changes.prompt
         }
+    }
+
+    private func closeWindow() {
+        NSApp.keyWindow?.close()
     }
 }

--- a/Alas/Sources/Settings/CommitPromptEditorWindow.swift
+++ b/Alas/Sources/Settings/CommitPromptEditorWindow.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct CommitPromptEditorWindow: View {
+    @Bindable var state: AppState
+    @Environment(\.dismiss) private var dismiss
+    @State private var draftPrompt = ""
+
+    var body: some View {
+        let theme = state.themeStore.current
+
+        VStack(spacing: 0) {
+            ZStack {
+                LinearGradient(
+                    colors: [theme.color("bg-3"), theme.color("bg-2")],
+                    startPoint: .top, endPoint: .bottom
+                )
+                HStack {
+                    TrafficLights()
+                    Spacer()
+                }
+                .padding(.leading, 16)
+                Text("Commit Prompt")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(theme.color("fg-muted"))
+            }
+            .frame(height: 44)
+            .overlay(Divider().opacity(0.5), alignment: .bottom)
+
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .firstTextBaseline, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Commit message prompt")
+                            .font(.system(size: 18, weight: .semibold))
+                        Text("Instructions sent to the selected AI tool. The staged diff is appended on stdin.")
+                            .font(.system(size: 12.5))
+                            .foregroundColor(theme.color("fg-dim"))
+                    }
+                    Spacer()
+                    AlasButton(title: "Reset to Default", style: .subtle) {
+                        draftPrompt = AppConfig.defaultCommitPrompt
+                    }
+                }
+
+                TextEditor(text: $draftPrompt)
+                    .font(.system(size: 12, design: .monospaced))
+                    .scrollContentBackground(.hidden)
+                    .background(theme.color("bg-2"))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(theme.color("line-soft"), lineWidth: 0.5)
+                    )
+            }
+            .padding(.horizontal, 32)
+            .padding(.vertical, 24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(theme.color("bg-1"))
+
+            HStack(spacing: 8) {
+                Spacer()
+                AlasButton(title: "Cancel", style: .subtle) {
+                    dismiss()
+                }
+                AlasButton(title: "Save", style: .primary) {
+                    state.config.changes.prompt = draftPrompt
+                    state.saveConfig()
+                    dismiss()
+                }
+            }
+            .padding(.horizontal, 32)
+            .padding(.vertical, 12)
+            .background(theme.color("bg-2"))
+            .overlay(Divider().opacity(0.5), alignment: .top)
+        }
+        .frame(width: 720, height: 560)
+        .background(theme.color("bg-1"))
+        .background(WindowConfigurator())
+        .environment(\.theme, theme)
+        .ignoresSafeArea()
+        .onAppear {
+            draftPrompt = state.config.changes.prompt
+        }
+    }
+}

--- a/Alas/Sources/Settings/CommitPromptStatus.swift
+++ b/Alas/Sources/Settings/CommitPromptStatus.swift
@@ -1,5 +1,5 @@
 enum CommitPromptStatus {
-    static func label(for prompt: String) -> String {
-        prompt == AppConfig.defaultCommitPrompt ? "Default" : "Custom"
+    static func chipLabel(for prompt: String) -> String? {
+        prompt == AppConfig.defaultCommitPrompt ? nil : "Custom"
     }
 }

--- a/Alas/Sources/Settings/CommitPromptStatus.swift
+++ b/Alas/Sources/Settings/CommitPromptStatus.swift
@@ -1,0 +1,5 @@
+enum CommitPromptStatus {
+    static func label(for prompt: String) -> String {
+        prompt == AppConfig.defaultCommitPrompt ? "Default prompt" : "Custom prompt"
+    }
+}

--- a/Alas/Sources/Settings/CommitPromptStatus.swift
+++ b/Alas/Sources/Settings/CommitPromptStatus.swift
@@ -1,5 +1,5 @@
 enum CommitPromptStatus {
     static func label(for prompt: String) -> String {
-        prompt == AppConfig.defaultCommitPrompt ? "Default prompt" : "Custom prompt"
+        prompt == AppConfig.defaultCommitPrompt ? "Default" : "Custom"
     }
 }

--- a/AlasTests/CommitPromptStatusTests.swift
+++ b/AlasTests/CommitPromptStatusTests.swift
@@ -3,10 +3,10 @@ import Testing
 
 struct CommitPromptStatusTests {
     @Test func defaultPromptUsesDefaultStatus() {
-        #expect(CommitPromptStatus.label(for: AppConfig.defaultCommitPrompt) == "Default prompt")
+        #expect(CommitPromptStatus.label(for: AppConfig.defaultCommitPrompt) == "Default")
     }
 
     @Test func modifiedPromptUsesCustomStatus() {
-        #expect(CommitPromptStatus.label(for: AppConfig.defaultCommitPrompt + "\nExtra instruction.") == "Custom prompt")
+        #expect(CommitPromptStatus.label(for: AppConfig.defaultCommitPrompt + "\nExtra instruction.") == "Custom")
     }
 }

--- a/AlasTests/CommitPromptStatusTests.swift
+++ b/AlasTests/CommitPromptStatusTests.swift
@@ -2,11 +2,11 @@ import Testing
 @testable import Alas
 
 struct CommitPromptStatusTests {
-    @Test func defaultPromptUsesDefaultStatus() {
-        #expect(CommitPromptStatus.label(for: AppConfig.defaultCommitPrompt) == "Default")
+    @Test func defaultPromptHasNoStatusChip() {
+        #expect(CommitPromptStatus.chipLabel(for: AppConfig.defaultCommitPrompt) == nil)
     }
 
-    @Test func modifiedPromptUsesCustomStatus() {
-        #expect(CommitPromptStatus.label(for: AppConfig.defaultCommitPrompt + "\nExtra instruction.") == "Custom")
+    @Test func modifiedPromptUsesCustomStatusChip() {
+        #expect(CommitPromptStatus.chipLabel(for: AppConfig.defaultCommitPrompt + "\nExtra instruction.") == "Custom")
     }
 }

--- a/AlasTests/CommitPromptStatusTests.swift
+++ b/AlasTests/CommitPromptStatusTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import Alas
+
+struct CommitPromptStatusTests {
+    @Test func defaultPromptUsesDefaultStatus() {
+        #expect(CommitPromptStatus.label(for: AppConfig.defaultCommitPrompt) == "Default prompt")
+    }
+
+    @Test func modifiedPromptUsesCustomStatus() {
+        #expect(CommitPromptStatus.label(for: AppConfig.defaultCommitPrompt + "\nExtra instruction.") == "Custom prompt")
+    }
+}

--- a/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
+++ b/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
@@ -34,11 +34,11 @@ Settings -> Changes keeps the current Tool row. The Prompt row becomes compact:
 
 - Row title: `Prompt`
 - Description: `Instructions sent to the CLI. The staged diff is appended on stdin.`
-- Status text: `Default prompt` when the stored prompt equals
-  `AppConfig.defaultCommitPrompt`, otherwise `Custom prompt`
-- Action: `Edit...`
+- Action: `Edit`
+- Right-aligned status chip: `Default` when the stored prompt equals
+  `AppConfig.defaultCommitPrompt`, otherwise `Custom`
 
-Pressing `Edit...` opens a dedicated `Commit Prompt` window. The window uses the
+Pressing `Edit` opens a dedicated `Commit Prompt` window. The window uses the
 focused editor layout:
 
 - titlebar/chrome consistent with the Settings window
@@ -95,9 +95,8 @@ config and persists it.
   not manage prompt edit drafts.
 - `CommitPromptEditorWindow`: owns the prompt edit session, including draft,
   reset, save, cancel, and window close behavior.
-- Prompt status helper: if extracting the status label keeps `ChangesPane`
-  clearer, add a small pure helper that maps stored prompt text to
-  `Default prompt` or `Custom prompt`.
+- Prompt status helper: a small pure helper maps stored prompt text to `Default`
+  or `Custom` for the compact status chip.
 
 ## Error Handling
 
@@ -111,8 +110,8 @@ error surface is added, this window can adopt it.
 Use focused tests where they add value:
 
 - If a prompt status helper is extracted, add Swift Testing coverage for:
-  - default prompt -> `Default prompt`
-  - modified prompt -> `Custom prompt`
+  - default prompt -> `Default`
+  - modified prompt -> `Custom`
 - Existing `AppConfigChangesTests` already cover prompt persistence. Leave them
   unchanged because the data model is not changing.
 

--- a/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
+++ b/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
@@ -1,0 +1,130 @@
+# Prompt Editor Window Design
+
+## Context
+
+Settings -> Changes currently embeds the commit-message prompt editor directly in
+the settings pane. The prompt is a long monospaced text value stored in
+`AppConfig.changes.prompt` and used by the Changes sparkle action when generating
+commit messages.
+
+The inline editor consumes much of the Settings pane and auto-saves as the user
+types. Moving it into a dedicated window will make Settings easier to scan and
+make prompt editing feel like an intentional edit session.
+
+## Goals
+
+- Replace the inline prompt `TextEditor` in Settings -> Changes with a compact
+  status row and an Edit button.
+- Open a separate Commit Prompt window from that Edit button.
+- Use a local draft in the editor window so prompt edits are applied only on
+  Save.
+- Keep the implementation aligned with existing SwiftUI settings/window
+  patterns.
+
+## Non-Goals
+
+- No prompt preview panel.
+- No multi-section prompt editor navigation.
+- No prompt templates, validation rules, or commit-message test runner.
+- No changes to the AI tool picker behavior.
+
+## User Experience
+
+Settings -> Changes keeps the current Tool row. The Prompt row becomes compact:
+
+- Row title: `Prompt`
+- Description: `Instructions sent to the CLI. The staged diff is appended on stdin.`
+- Status text: `Default prompt` when the stored prompt equals
+  `AppConfig.defaultCommitPrompt`, otherwise `Custom prompt`
+- Action: `Edit...`
+
+Pressing `Edit...` opens a dedicated `Commit Prompt` window. The window uses the
+focused editor layout:
+
+- titlebar/chrome consistent with the Settings window
+- short heading and helper text
+- large monospaced editor
+- `Reset to Default`
+- footer actions: `Cancel` and `Save`
+
+The editor is draft-based. Opening the window copies
+`state.config.changes.prompt` into local view state. Typing changes only the
+draft. `Reset to Default` changes only the draft. `Cancel` closes the window
+without saving. `Save` writes the draft to `state.config.changes.prompt`, calls
+`state.saveConfig()`, and closes the window.
+
+## Architecture
+
+Add a new SwiftUI view under `Alas/Sources/Settings/` named
+`CommitPromptEditorWindow`.
+
+`AlasApp` adds a second settings-related scene:
+
+```swift
+Window("Commit Prompt", id: "commit-prompt-editor") {
+    CommitPromptEditorWindow(state: state)
+}
+.windowStyle(.hiddenTitleBar)
+.windowResizability(.contentSize)
+.defaultSize(width: 720, height: 560)
+```
+
+`ChangesPane` reads `@Environment(\.openWindow)` and calls:
+
+```swift
+openWindow(id: "commit-prompt-editor")
+```
+
+from the Prompt row's Edit button.
+
+`CommitPromptEditorWindow` receives `@Bindable var state: AppState`, reads the
+current theme from `state.themeStore.current`, applies it through the existing
+theme environment pattern, and uses `WindowConfigurator()` so the chrome matches
+the Settings window. It owns local draft state:
+
+```swift
+@State private var draftPrompt = ""
+```
+
+The draft is initialized from config in `onAppear`. Save assigns the draft to the
+config and persists it.
+
+## Component Boundaries
+
+- `ChangesPane`: owns the compact Settings row and window-launch action. It does
+  not manage prompt edit drafts.
+- `CommitPromptEditorWindow`: owns the prompt edit session, including draft,
+  reset, save, cancel, and window close behavior.
+- Prompt status helper: if extracting the status label keeps `ChangesPane`
+  clearer, add a small pure helper that maps stored prompt text to
+  `Default prompt` or `Custom prompt`.
+
+## Error Handling
+
+`state.saveConfig()` currently returns `Bool`, but the existing Settings UI does
+not expose save failures. This change will follow the current app behavior:
+attempt the save and close after assigning the config. If a future settings save
+error surface is added, this window can adopt it.
+
+## Testing
+
+Use focused tests where they add value:
+
+- If a prompt status helper is extracted, add Swift Testing coverage for:
+  - default prompt -> `Default prompt`
+  - modified prompt -> `Custom prompt`
+- Existing `AppConfigChangesTests` already cover prompt persistence. Leave them
+  unchanged because the data model is not changing.
+
+Full SwiftUI window behavior will be verified through the required project build
+and test commands rather than brittle UI tests.
+
+## Verification
+
+After implementation, run:
+
+```bash
+xcodegen
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```

--- a/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
+++ b/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
@@ -34,7 +34,8 @@ Settings -> Changes keeps the current Tool row. The Prompt row becomes compact:
 
 - Row title: `Prompt`
 - Description: `Instructions sent to the CLI. The staged diff is appended on stdin.`
-- Right-aligned controls: `Edit` button followed by a status chip.
+- Controls: `Edit` button aligned to the settings control column, with a
+  right-aligned status chip.
 - Status chip text: `Default` when the stored prompt equals
   `AppConfig.defaultCommitPrompt`, otherwise `Custom`.
 

--- a/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
+++ b/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
@@ -34,9 +34,9 @@ Settings -> Changes keeps the current Tool row. The Prompt row becomes compact:
 
 - Row title: `Prompt`
 - Description: `Instructions sent to the CLI. The staged diff is appended on stdin.`
-- Action: `Edit`
-- Right-aligned status chip: `Default` when the stored prompt equals
-  `AppConfig.defaultCommitPrompt`, otherwise `Custom`
+- Right-aligned controls: `Edit` button followed by a status chip.
+- Status chip text: `Default` when the stored prompt equals
+  `AppConfig.defaultCommitPrompt`, otherwise `Custom`.
 
 Pressing `Edit` opens a dedicated `Commit Prompt` window. The window uses the
 focused editor layout:

--- a/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
+++ b/docs/superpowers/specs/2026-05-24-prompt-editor-window-design.md
@@ -34,10 +34,9 @@ Settings -> Changes keeps the current Tool row. The Prompt row becomes compact:
 
 - Row title: `Prompt`
 - Description: `Instructions sent to the CLI. The staged diff is appended on stdin.`
-- Controls: `Edit` button aligned to the settings control column, with a
-  right-aligned status chip.
-- Status chip text: `Default` when the stored prompt equals
-  `AppConfig.defaultCommitPrompt`, otherwise `Custom`.
+- Controls: `Edit` button aligned to the settings control column.
+- Status chip: hidden when the stored prompt equals
+  `AppConfig.defaultCommitPrompt`; right-aligned with text `Custom` otherwise.
 
 Pressing `Edit` opens a dedicated `Commit Prompt` window. The window uses the
 focused editor layout:
@@ -96,8 +95,8 @@ config and persists it.
   not manage prompt edit drafts.
 - `CommitPromptEditorWindow`: owns the prompt edit session, including draft,
   reset, save, cancel, and window close behavior.
-- Prompt status helper: a small pure helper maps stored prompt text to `Default`
-  or `Custom` for the compact status chip.
+- Prompt status helper: a small pure helper maps stored prompt text to no chip
+  for the default prompt or `Custom` for custom prompts.
 
 ## Error Handling
 
@@ -111,7 +110,7 @@ error surface is added, this window can adopt it.
 Use focused tests where they add value:
 
 - If a prompt status helper is extracted, add Swift Testing coverage for:
-  - default prompt -> `Default`
+  - default prompt -> no status chip
   - modified prompt -> `Custom`
 - Existing `AppConfigChangesTests` already cover prompt persistence. Leave them
   unchanged because the data model is not changing.


### PR DESCRIPTION
## Summary

- Move the Changes commit prompt editor out of Settings into a dedicated Commit Prompt window.
- Replace the inline Settings editor with an Edit button and a Custom status chip only when the prompt differs from the default.
- Add focused prompt status tests and update the design spec.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/CommitPromptStatusTests`

## Note

A full local `xcodebuild ... test` run still fails in unrelated existing suites outside this change area, including image type, LSP install nudge/registry, commit row feedback, terminal CLI injection, hover timing, and worktree LFS tests.