### PR TITLE
fix: clamp agent logo icons in settings pickers to 14pt

### DIFF
--- a/Alas/Sources/Agents/AgentLogoView.swift
+++ b/Alas/Sources/Agents/AgentLogoView.swift
@@ -22,3 +22,23 @@ struct AgentLogoView: View {
         }
     }
 }
+
+extension AgentLogoView {
+    /// Returns an `NSImage` copy clamped to `size`.
+    /// SwiftUI `Menu` / `Picker` (`.menu` style) renders items as `NSMenuItem`s
+    /// and ignores SwiftUI frame sizing on custom icon views, drawing the
+    /// backing `NSImage` at its native pixel size. Pass this clamped copy
+    /// to `Image(nsImage:)` so the icon appears at the intended point size.
+    static func menuImage(for agent: AgentDefinition, size: CGFloat = 16) -> NSImage {
+        if let asset = agent.builtinLogoAssetName,
+           let source = NSImage(named: asset) {
+            let copy = source.copy() as? NSImage ?? source
+            copy.size = NSSize(width: size, height: size)
+            return copy
+        }
+        let fallback = NSImage(systemSymbolName: "sparkle", accessibilityDescription: nil)
+            ?? NSImage()
+        fallback.size = NSSize(width: size, height: size)
+        return fallback
+    }
+}

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 struct TabBarView: View {
@@ -232,7 +231,7 @@ private struct AgentSparkleMenu: View {
                             // SwiftUI frame sizing on custom icon views; it draws the
                             // backing NSImage at its native pixel size. Hand it an
                             // NSImage copy whose .size is clamped to 16pt.
-                            Image(nsImage: menuIconImage(for: agent))
+                            Image(nsImage: AgentLogoView.menuImage(for: agent))
                         }
                     }
                 }
@@ -246,18 +245,5 @@ private struct AgentSparkleMenu: View {
         .menuIndicator(.hidden)
         .fixedSize()
         .help(agents.isEmpty ? "No enabled agents" : "Launch agent")
-    }
-
-    private func menuIconImage(for agent: AgentDefinition) -> NSImage {
-        if let asset = agent.builtinLogoAssetName,
-           let source = NSImage(named: asset) {
-            let copy = source.copy() as? NSImage ?? source
-            copy.size = NSSize(width: 16, height: 16)
-            return copy
-        }
-        let fallback = NSImage(systemSymbolName: "sparkle", accessibilityDescription: nil)
-            ?? NSImage()
-        fallback.size = NSSize(width: 16, height: 16)
-        return fallback
     }
 }

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -108,7 +108,7 @@ struct AgentsPane: View {
                 Label {
                     Text(agent.displayName)
                 } icon: {
-                    AgentLogoView(agent: agent, size: 14)
+                    Image(nsImage: AgentLogoView.menuImage(for: agent, size: 14))
                 }
                 .tag(agent.id)
             }

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -52,7 +52,7 @@ struct ChangesPane: View {
                 Label {
                     Text(agent.displayName)
                 } icon: {
-                    AgentLogoView(agent: agent, size: 14)
+                    Image(nsImage: AgentLogoView.menuImage(for: agent, size: 14))
                 }
                 .tag(agent.id)
             }


### PR DESCRIPTION
SwiftUI Menu/Picker with .menu style renders items as NSMenuItems and ignores SwiftUI frame sizing on custom icon views, drawing the backing NSImage at its native pixel size. This caused the 256x256 logo PNGs to appear huge in pickers.

Apply the same NSImage-copy-with-clamped-size technique we use in the tab bar sparkle menu (#244) to the two new pickers added in PR #264:
- Settings > Agents > Default agent picker
- Settings > Changes > Agent picker

Extract the shared helper into  so TabBarView can also use it, deduplicating the icon clamping logic.