### PR TITLE
perf(diff): parse diffs off the main thread

### DIFF
--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -189,8 +189,23 @@ struct DiffTabView: View {
 
         do {
             let loadedDiff = try await git.diff(worktreePath: worktreePath, file: relativePath, staged: staged)
-            let loadedTotalAdd = loadedDiff.hunks.flatMap(\.lines).filter { $0.kind == .add }.count
-            let loadedTotalDel = loadedDiff.hunks.flatMap(\.lines).filter { $0.kind == .delete }.count
+            // Single off-main pass instead of two `.flatMap.filter.count`
+            // allocations on MainActor — for big diffs each pass copies the
+            // full line array, which would stall the UI right after parse.
+            let (loadedTotalAdd, loadedTotalDel) = await Task.detached(priority: .userInitiated) {
+                var add = 0
+                var del = 0
+                for hunk in loadedDiff.hunks {
+                    for line in hunk.lines {
+                        switch line.kind {
+                        case .add: add += 1
+                        case .delete: del += 1
+                        case .context: break
+                        }
+                    }
+                }
+                return (add, del)
+            }.value
             let tracked = (try? await Process.git(
                 ["ls-files", "--error-unmatch", "--", relativePath],
                 cwd: worktreePath

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -143,7 +143,7 @@ extension GitService {
             // — that's the normal case for an untracked file. Only treat exit
             // codes >= 2 as real failures.
             guard result.exitCode <= 1 else { return ParsedDiff(hunks: []) }
-            return DiffParser.parse(result.stdout)
+            return await Self.parseOffMain(result.stdout)
         }
 
         // Two distinct views, never combine HEAD and worktree:
@@ -165,7 +165,17 @@ extension GitService {
         args.append("--")
         args.append(file)
         let result = try await Process.git(args, cwd: worktreePath)
-        return DiffParser.parse(result.stdout)
+        return await Self.parseOffMain(result.stdout)
+    }
+
+    /// Parses diff stdout on a detached executor so callers awaited from the
+    /// MainActor (SwiftUI `.task`) don't resume on main for tens of thousands
+    /// of lines of synchronous string work — that's the freeze users see on
+    /// large generated files / lockfiles even though the pane shows a loader.
+    private static func parseOffMain(_ stdout: String) async -> ParsedDiff {
+        await Task.detached(priority: .userInitiated) {
+            DiffParser.parse(stdout)
+        }.value
     }
 
     func diff(worktreePath: URL, sha: String, file: String, originalPath: String? = nil) async throws -> ParsedDiff {
@@ -221,7 +231,10 @@ extension GitService {
                 userInfo: [NSLocalizedDescriptionKey: result.stderr]
             )
         }
-        return DiffParser.parse(Self.sliceDiffForFile(result.stdout, file: file))
+        let stdout = result.stdout
+        return await Task.detached(priority: .userInitiated) {
+            DiffParser.parse(Self.sliceDiffForFile(stdout, file: file))
+        }.value
     }
 
     /// Given a multi-file `git diff` output and a target path, return only


### PR DESCRIPTION
## Summary
- Large diffs froze the center panel because `DiffParser.parse` ran on the MainActor (resumption actor of `git.diff(...)` when called from SwiftUI `.task`). The existing `ProgressView` couldn't animate.
- `GitService.diff(...)`: all three parse sites now run inside `Task.detached(.userInitiated)`, so both the working-tree diff pane (`DiffTabView`) and the commit diff pane (`CommitTabView` → `CommitDiffView`) drop the heavy string work off-main.
- `DiffTabView.load()`: replace two `.flatMap.filter.count` allocations with a single off-main O(n) loop for the +/- totals.

## Test plan
- [x] Build (`xcodebuild ... build`) succeeds.
- [x] Manually verified on a real big diff: the loader spins, app stays responsive, no freeze while loading.
- [ ] If you see a render-time stutter *after* the loader disappears, that's a separate concern (non-lazy `VStack` + per-line tree-sitter highlighting on main) — flag it and we can switch to `LazyVStack`.