### PR TITLE
feat: sync terminal tab title with terminal OSC title

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1288,6 +1288,7 @@ final class AppState {
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
         _ = tabs.renameTerminal(worktreeId: worktreeId, tabId: tabId, title: field.stringValue)
+        tabs.clearTerminalRuntimeTitles(forLeavesInTabId: tabId)
     }
 
     func closeTab(worktreeId: String, tabId: TabID) {

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -70,6 +70,10 @@ struct CenterPaneView: View {
                 sidebarHidden: !state.config.sidebarVisible,
                 onMove: { draggedId, destinationId in
                     state.tabs.moveTab(worktreeId: worktree.id, fromId: draggedId, toId: destinationId)
+                },
+                titleLookup: { id in
+                    guard let tab = tabs.first(where: { $0.id == id }) else { return nil }
+                    return state.tabs.displayTerminalTitle(for: tab)
                 }
             )
             Group {

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -22,6 +22,7 @@ struct TabBarView: View {
     let onRevealSidebar: () -> Void
     let sidebarHidden: Bool
     let onMove: (TabID, TabID) -> Void
+    let titleLookup: (TabID) -> String?
     @Environment(\.theme) var theme
 
     private var isTerminalActive: Bool {
@@ -41,6 +42,7 @@ struct TabBarView: View {
             }
             ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
                 TabButton(
+                    titleLookup: titleLookup,
                     tab: tab,
                     active: tab.id == activeId,
                     showClose: tabs.count > 1,
@@ -111,6 +113,7 @@ struct TabBarView: View {
 }
 
 private struct TabButton: View {
+    let titleLookup: (TabID) -> String?
     let tab: Tab
     let active: Bool
     let showClose: Bool
@@ -126,7 +129,8 @@ private struct TabButton: View {
             Icon(name: tab.iconName, size: 11,
                  color: iconColor)
                 .modifier(TabActivityPulse(activityState: harnessInfo?.state))
-            Text(tab.title)
+            let displayTitle = titleLookup(tab.id) ?? tab.title
+            Text(displayTitle)
                 .font(.system(size: 11.5))
                 .foregroundColor(active ? theme.color("fg") : theme.color("fg-dim"))
                 .lineLimit(1)

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -43,6 +43,8 @@ final class TabsManager {
     /// completion handler only clears pendingExternalOpenTasks if its
     /// captured generation still matches the current one.
     private var pendingExternalOpenGen: [TabID: Int] = [:]
+    /// Runtime-only display titles for terminal pane leaves. Key = leafId.
+    var terminalRuntimeTitles: [String: String] = [:]
     private let lsp: WorkspaceLSPManager?
 
     init(bufferStore: EditorBufferStore = EditorBufferStore(), lsp: WorkspaceLSPManager? = nil) {
@@ -168,8 +170,30 @@ final class TabsManager {
         return tab
     }
 
-    // MARK: - Pane tree mutations
+    // MARK: - Terminal runtime titles
 
+    func setTerminalRuntimeTitle(leafId: String, title: String) {
+        guard !title.isEmpty else { return }
+        terminalRuntimeTitles[leafId] = title
+    }
+
+    func clearTerminalRuntimeTitles(forLeavesInTabId tabId: TabID) {
+        guard let file = byWorktree.values.first(where: { $0.tabs.contains(where: { $0.id == tabId }) }) else { return }
+        guard let tab = file.tabs.first(where: { $0.id == tabId }),
+              case .terminal(let state) = tab else { return }
+        for leaf in state.root.leaves() {
+            terminalRuntimeTitles.removeValue(forKey: leaf.id)
+        }
+    }
+
+    /// Returns the runtime display title for a terminal tab's focused leaf, if any.
+    func displayTerminalTitle(for tab: Tab) -> String? {
+        guard case .terminal(let state) = tab else { return nil }
+        guard let leafId = state.root.find(leafId: state.focusedLeafId)?.leaf.id else { return nil }
+        return terminalRuntimeTitles[leafId]
+    }
+
+    // MARK: - Pane tree mutations
     @discardableResult
     func setFocusedLeaf(worktreeId: String, tabId: TabID, leafId: String) -> Tab? {
         guard var file = byWorktree[worktreeId],
@@ -570,8 +594,14 @@ final class TabsManager {
     func close(worktreeId: String, tabId: TabID) {
         guard var file = byWorktree[worktreeId] else { return }
         guard let idx = file.tabs.firstIndex(where: { $0.id == tabId }) else { return }
+        let tab = file.tabs[idx]
         let wasActive = file.activeTabId == tabId
         file.tabs.remove(at: idx)
+        if case .terminal(let state) = tab {
+            for leaf in state.root.leaves() {
+                terminalRuntimeTitles.removeValue(forKey: leaf.id)
+            }
+        }
         if wasActive {
             if file.tabs.isEmpty {
                 file.activeTabId = nil

--- a/Alas/Sources/Center/TerminalTabView.swift
+++ b/Alas/Sources/Center/TerminalTabView.swift
@@ -95,6 +95,7 @@ private struct PaneLeafView: View {
                     .onAppear {
                         wireCwdHandler(session: session)
                         wireOpenURLHandler(session: session)
+                        wireTitleHandler(session: session, leafId: leaf.id)
                     }
             } else {
                 Color.clear
@@ -133,6 +134,14 @@ private struct PaneLeafView: View {
         session.surface.openURLHandler = { [weak state, sessionId = session.id] rawURL in
             guard let state else { return false }
             return state.routeTerminalOpenURL(rawURL: rawURL, sessionId: sessionId)
+        }
+    }
+
+    private func wireTitleHandler(session: TerminalSession, leafId: String) {
+        session.surface.titleHandler = { [weak state] title in
+            guard let state, !title.isEmpty else { return }
+            guard state.config.terminal.syncTabTitleWithTerminalTitle else { return }
+            state.tabs.setTerminalRuntimeTitle(leafId: leafId, title: title)
         }
     }
 }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -71,6 +71,13 @@ struct AppConfig: Codable, Equatable {
         var cursorBlink: Bool
         var scrollbackLines: Int
         var bell: String                 // off | visual | sound
+        var syncTabTitleWithTerminalTitle: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case shell, workingDirectory, startupScript, worktreeCreateScript,
+                 inheritParentEnv, fontFamily, fontSize, cursorStyle, cursorBlink,
+                 scrollbackLines, bell, syncTabTitleWithTerminalTitle
+        }
     }
 
     struct Harness: Codable, Equatable {
@@ -190,7 +197,8 @@ struct AppConfig: Codable, Equatable {
             cursorStyle: "beam",
             cursorBlink: true,
             scrollbackLines: 10000,
-            bell: "visual"
+            bell: "visual",
+            syncTabTitleWithTerminalTitle: false
         ),
         harness: Harness(notifyOnFinish: true, notifyOnAwaiting: true),
         code: Code(
@@ -274,7 +282,49 @@ extension AppConfig {
         commitDetailSplitRatio = (try? c.decode(Double.self, forKey: .commitDetailSplitRatio)) ?? 0.32
         general = try c.decode(General.self, forKey: .general)
         worktrees = try c.decode(Worktrees.self, forKey: .worktrees)
-        terminal = try c.decode(Terminal.self, forKey: .terminal)
+        if let termContainer = try? c.nestedContainer(keyedBy: AppConfig.Terminal.CodingKeys.self, forKey: .terminal) {
+            let shell = (try? termContainer.decode(String.self, forKey: .shell)) ?? "/bin/zsh"
+            let workingDirectory = (try? termContainer.decode(String.self, forKey: .workingDirectory)) ?? "worktreeRoot"
+            let startupScript = (try? termContainer.decode(String.self, forKey: .startupScript)) ?? ""
+            let worktreeCreateScript = (try? termContainer.decode(String.self, forKey: .worktreeCreateScript)) ?? ""
+            let inheritParentEnv = (try? termContainer.decode(Bool.self, forKey: .inheritParentEnv)) ?? true
+            let fontFamily = (try? termContainer.decode(String.self, forKey: .fontFamily)) ?? "JetBrains Mono"
+            let fontSize = (try? termContainer.decode(Int.self, forKey: .fontSize)) ?? 13
+            let cursorStyle = (try? termContainer.decode(String.self, forKey: .cursorStyle)) ?? "beam"
+            let cursorBlink = (try? termContainer.decode(Bool.self, forKey: .cursorBlink)) ?? true
+            let scrollbackLines = (try? termContainer.decode(Int.self, forKey: .scrollbackLines)) ?? 10000
+            let bell = (try? termContainer.decode(String.self, forKey: .bell)) ?? "visual"
+            let syncTabTitleWithTerminalTitle = (try? termContainer.decode(Bool.self, forKey: .syncTabTitleWithTerminalTitle)) ?? false
+            terminal = Terminal(
+                shell: shell,
+                workingDirectory: workingDirectory,
+                startupScript: startupScript,
+                worktreeCreateScript: worktreeCreateScript,
+                inheritParentEnv: inheritParentEnv,
+                fontFamily: fontFamily,
+                fontSize: fontSize,
+                cursorStyle: cursorStyle,
+                cursorBlink: cursorBlink,
+                scrollbackLines: scrollbackLines,
+                bell: bell,
+                syncTabTitleWithTerminalTitle: syncTabTitleWithTerminalTitle
+            )
+        } else {
+            terminal = Terminal(
+                shell: "/bin/zsh",
+                workingDirectory: "worktreeRoot",
+                startupScript: "",
+                worktreeCreateScript: "",
+                inheritParentEnv: true,
+                fontFamily: "JetBrains Mono",
+                fontSize: 13,
+                cursorStyle: "beam",
+                cursorBlink: true,
+                scrollbackLines: 10000,
+                bell: "visual",
+                syncTabTitleWithTerminalTitle: false
+            )
+        }
         harness = try c.decode(Harness.self, forKey: .harness)
         if let codeContainer = try? c.nestedContainer(keyedBy: AppConfig.Code.CodingKeys.self, forKey: .code) {
             let fontFamily = (try? codeContainer.decode(String.self, forKey: .fontFamily)) ?? "SF Mono"

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -99,6 +99,10 @@ struct TerminalPane: View {
                             ("off","off"), ("visual","visual"), ("sound","sound")
                         ])
                     }
+                    SettingsRow(name: "Sync tab title with terminal title",
+                                desc: "When the terminal reports a title, update the tab label.") {
+                        AlasToggle(on: state.bind(\.terminal.syncTabTitleWithTerminalTitle))
+                    }
                 }
 
                 SettingsGroup(title: "Harness") {

--- a/AlasTests/SettingsSaveNormalizationTests.swift
+++ b/AlasTests/SettingsSaveNormalizationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 
@@ -40,5 +41,12 @@ struct SettingsSaveNormalizationTests {
         #expect(normalized.command == "sourcekit-lsp")
         #expect(normalized.args == ["--stdio", "--log"])
         #expect(normalized.rootMarkers == ["Package.swift", ".git"])
+    }
+
+    @Test func decodeMissingSyncTabTitleField() throws {
+        let json = #"{"themeId":"cool-slate","accent":"teal","density":"comfortable","matchSystemTheme":false,"sidebarMaterial":"appKitSidebar","sidebarWidth":244,"rightPaneWidth":320,"rightPaneVisible":true,"sidebarVisible":true,"commitDetailSplitRatio":0.32,"general":{"launchAtLogin":false,"closeToTray":true,"confirmQuit":true,"autoUpdate":true,"updateChannel":"Stable","crashReports":false,"usageAnalytics":false},"worktrees":{"rootPath":"~/.alas/worktrees","pathTemplate":"{worktreeRoot}/{repo}/{branch}","branchPrefix":"feature/","baseBranch":"main","trackUpstream":true,"deleteBranchOnRemove":true,"autoFetch":true,"fetchIntervalMinutes":5,"pruneStale":false},"terminal":{"shell":"/bin/zsh","workingDirectory":"worktreeRoot","startupScript":"","worktreeCreateScript":"","inheritParentEnv":true,"fontFamily":"JetBrains Mono","fontSize":13,"cursorStyle":"beam","cursorBlink":true,"scrollbackLines":10000,"bell":"visual"},"harness":{"notifyOnFinish":true,"notifyOnAwaiting":true},"code":{"fontFamily":"SF Mono","fontSize":13,"formatOnSave":true,"languageServers":[],"dismissedInstallNudges":[],"userDefinedRecipes":{}},"markdown":{"defaultViewMode":"editor"},"changes":{"aiToolId":"none","prompt":"Hello"},"agents":{"builtinState":{},"custom":[],"worktreeAutoLaunch":{"agentId":null,"useBypassPermissions":false}},"files":{"showIgnored":true}}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.terminal.syncTabTitleWithTerminalTitle == false)
     }
 }

--- a/AlasTests/TabActivityIconTintTests.swift
+++ b/AlasTests/TabActivityIconTintTests.swift
@@ -72,7 +72,8 @@ struct TabActivityIconTintTests {
             rightSidebarHidden: false,
             onRevealSidebar: { },
             sidebarHidden: false,
-            onMove: { _, _ in }
+            onMove: { _, _ in },
+            titleLookup: { _ in nil }
         )
         .environment(\.theme, currentTheme())
 

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -564,3 +564,52 @@ struct TabsManagerPaneTests {
                 "lastCwd should be preserved across session replacement")
     }
 }
+
+// MARK: - Terminal runtime titles
+
+@MainActor
+struct TabsManagerRuntimeTitleTests {
+    @Test func setTerminalRuntimeTitleStoresTitle() {
+        let mgr = TabsManager()
+        mgr.setTerminalRuntimeTitle(leafId: "leaf1", title: "vim foo")
+        #expect(mgr.terminalRuntimeTitles["leaf1"] == "vim foo")
+    }
+
+    @Test func setTerminalRuntimeTitleIgnoresEmptyTitle() {
+        let mgr = TabsManager()
+        mgr.setTerminalRuntimeTitle(leafId: "leaf1", title: "vim foo")
+        mgr.setTerminalRuntimeTitle(leafId: "leaf1", title: "")
+        #expect(mgr.terminalRuntimeTitles["leaf1"] == "vim foo")
+    }
+
+    @Test func closingTerminalTabCleansUpRuntimeTitles() {
+        let worktreeId = "wt"
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: worktreeId, title: "bash", sessionId: "s1")
+        guard case .terminal(let state) = tab else {
+            Issue.record("Expected terminal tab")
+            return
+        }
+        let leafId = state.focusedLeafId
+        mgr.setTerminalRuntimeTitle(leafId: leafId, title: "vim foo")
+        mgr.close(worktreeId: worktreeId, tabId: tab.id)
+        #expect(mgr.terminalRuntimeTitles[leafId] == nil)
+    }
+
+    @Test func displayTerminalTitleReturnsFocusedLeafTitle() {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "bash", sessionId: "s1")
+        guard case .terminal(let state) = tab else {
+            Issue.record("Expected terminal tab")
+            return
+        }
+        mgr.setTerminalRuntimeTitle(leafId: state.focusedLeafId, title: "vim foo")
+        #expect(mgr.displayTerminalTitle(for: tab) == "vim foo")
+    }
+
+    @Test func displayTerminalTitleReturnsNilForNonTerminalTab() {
+        let mgr = TabsManager()
+        let tab = mgr.appendEditor(worktreeId: "wt", title: "README.md", relativePath: "README.md")
+        #expect(mgr.displayTerminalTitle(for: tab) == nil)
+    }
+}

--- a/AlasTests/TouchTargetSmokeTests.swift
+++ b/AlasTests/TouchTargetSmokeTests.swift
@@ -63,7 +63,8 @@ struct TouchTargetSmokeTests {
             rightSidebarHidden: false,
             onRevealSidebar: { },
             sidebarHidden: false,
-            onMove: { _, _ in }
+            onMove: { _, _ in },
+            titleLookup: { _ in nil }
         )
         .environment(\.theme, currentTheme())
         let controller = NSHostingController(rootView: view)
@@ -94,7 +95,8 @@ struct TouchTargetSmokeTests {
             rightSidebarHidden: false,
             onRevealSidebar: { },
             sidebarHidden: false,
-            onMove: { _, _ in }
+            onMove: { _, _ in },
+            titleLookup: { _ in nil }
         )
         .environment(\.theme, currentTheme())
         let controller = NSHostingController(rootView: view)
@@ -135,7 +137,8 @@ struct TouchTargetSmokeTests {
             rightSidebarHidden: true,
             onRevealSidebar: { },
             sidebarHidden: false,
-            onMove: { _, _ in }
+            onMove: { _, _ in },
+            titleLookup: { _ in nil }
         )
         .environment(\.theme, currentTheme())
         let controller = NSHostingController(rootView: view)
@@ -176,7 +179,8 @@ struct TouchTargetSmokeTests {
             rightSidebarHidden: false,
             onRevealSidebar: { },
             sidebarHidden: true,
-            onMove: { _, _ in }
+            onMove: { _, _ in },
+            titleLookup: { _ in nil }
         )
         .environment(\.theme, currentTheme())
         let controller = NSHostingController(rootView: view)

--- a/docs/superpowers/plans/2026-05-24-terminal-tab-title-sync.md
+++ b/docs/superpowers/plans/2026-05-24-terminal-tab-title-sync.md
@@ -1,0 +1,502 @@
+# Terminal Tab Title Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire Ghostty terminal title changes into the visible tab bar label for terminal tabs, gated by an optional setting.
+
+**Architecture:** A runtime-only dictionary in `TabsManager` stores leafId→displayTitle overrides. `TabBarView` resolves display titles at render time using a lookup closure. `TerminalTabView` wires `SurfaceView.titleHandler` to populate the dictionary when the setting is enabled. Manual tab renames clear the runtime override.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Testing, Observation framework
+
+---
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `Alas/Sources/Persistence/AppConfig.swift` | Add `syncTabTitleWithTerminalTitle` field to `Terminal` config |
+| `Alas/Sources/Center/TabsManager.swift` | Add `terminalRuntimeTitles` dict + `setTerminalRuntimeTitle`, `clearTerminalRuntimeTitles`, `displayTerminalTitle`, cleanup in `close` |
+| `Alas/Sources/Center/TabBarView.swift` | Add `titleLookup` prop; use resolved display title in `TabButton` |
+| `Alas/Sources/Center/CenterPaneView.swift` | Pass `titleLookup` closure to `TabBarView` |
+| `Alas/Sources/Center/TerminalTabView.swift` | Wire `titleHandler` in `PaneLeafView.onAppear` |
+| `Alas/Sources/App/AppState.swift` | Update `renameTerminalTab` to clear runtime titles for renamed tab |
+| `Alas/Sources/Settings/TerminalPane.swift` | Add "Sync tab title with terminal title" toggle in Appearance group |
+| `AlasTests/TabsManagerTests.swift` | Tests for runtime title storage + clear + close cleanup |
+| `AlasTests/TerminalTabStateCodableTests.swift` | Test that runtime dict is excluded from persistence |
+| `AlasTests/SettingsSectionTests.swift` | Test new config field decode/encode |
+| `AlasTests/TabActivityIconTintTests.swift` | May need update if `TabBarView` init signature changes |
+| `AlasTests/TouchTargetSmokeTests.swift` | May need update if `TabBarView` init signature changes |
+
+---
+
+### Task 1: Config Model – Add `syncTabTitleWithTerminalTitle`
+
+**Files:**
+- Modify: `Alas/Sources/Persistence/AppConfig.swift:63-75`
+- Test: `AlasTests/SettingsSectionTests.swift`
+
+The `Terminal` struct gets a new field. Add it after `bell`.
+
+- [ ] **Step 1: Add field to struct and defaults**
+
+In `Alas/Sources/Persistence/AppConfig.swift`, inside `struct Terminal`, add:
+
+```swift
+var syncTabTitleWithTerminalTitle: Bool
+```
+
+In the `defaults` static, inside `terminal: Terminal(...)` add after `bell: "visual":
+
+```swift
+syncTabTitleWithTerminalTitle: false
+```
+
+- [ ] **Step 2: Update CodingKeys and decode**
+
+Update `AppConfig.CodingKeys` if `Terminal` uses a custom `CodingKeys`; otherwise Swift generates. Check: `Terminal` currently has no custom CodingKeys, so Swift synthesizes them. The new field is auto-included.
+
+Add graceful decode in `init(from decoder:)` under the `terminal` decode block. Since `Terminal` has no custom decode yet, add one after the existing:
+
+```swift
+if let termContainer = try? c.nestedContainer(keyedBy: AppConfig.Terminal.CodingKeys.self, forKey: .terminal) {
+    let shell = (try? termContainer.decode(String.self, forKey: .shell)) ?? "/bin/zsh"
+    let workingDirectory = (try? termContainer.decode(String.self, forKey: .workingDirectory)) ?? "worktreeRoot"
+    let startupScript = (try? termContainer.decode(String.self, forKey: .startupScript)) ?? ""
+    let worktreeCreateScript = (try? termContainer.decode(String.self, forKey: .worktreeCreateScript)) ?? ""
+    let inheritParentEnv = (try? termContainer.decode(Bool.self, forKey: .inheritParentEnv)) ?? true
+    let fontFamily = (try? termContainer.decode(String.self, forKey: .fontFamily)) ?? "JetBrains Mono"
+    let fontSize = (try? termContainer.decode(Int.self, forKey: .fontSize)) ?? 13
+    let cursorStyle = (try? termContainer.decode(String.self, forKey: .cursorStyle)) ?? "beam"
+    let cursorBlink = (try? termContainer.decode(Bool.self, forKey: .cursorBlink)) ?? true
+    let scrollbackLines = (try? termContainer.decode(Int.self, forKey: .scrollbackLines)) ?? 10000
+    let bell = (try? termContainer.decode(String.self, forKey: .bell)) ?? "visual"
+    let syncTabTitleWithTerminalTitle = (try? termContainer.decode(Bool.self, forKey: .syncTabTitleWithTerminalTitle)) ?? false
+    terminal = Terminal(
+        shell: shell,
+        workingDirectory: workingDirectory,
+        startupScript: startupScript,
+        worktreeCreateScript: worktreeCreateScript,
+        inheritParentEnv: inheritParentEnv,
+        fontFamily: fontFamily,
+        fontSize: fontSize,
+        cursorStyle: cursorStyle,
+        cursorBlink: cursorBlink,
+        scrollbackLines: scrollbackLines,
+        bell: bell,
+        syncTabTitleWithTerminalTitle: syncTabTitleWithTerminalTitle
+    )
+} else {
+    terminal = Terminal(
+        shell: "/bin/zsh",
+        workingDirectory: "worktreeRoot",
+        startupScript: "",
+        worktreeCreateScript: "",
+        inheritParentEnv: true,
+        fontFamily: "JetBrains Mono",
+        fontSize: 13,
+        cursorStyle: "beam",
+        cursorBlink: true,
+        scrollbackLines: 10000,
+        bell: "visual",
+        syncTabTitleWithTerminalTitle: false
+    )
+}
+```
+
+Remove the existing `terminal = try c.decode(Terminal.self, forKey: .terminal)` line and replace with the above block.
+
+- [ ] **Step 3: Write test for decode backward compatibility**
+
+In `AlasTests/SettingsSectionTests.swift` (or a new test file `AlasTests/SettingsSaveNormalizationTests.swift`), add:
+
+```swift
+@Test func decodeMissingSyncTabTitleField() throws {
+    let json = #"{"themeId":"cool-slate","accent":"teal","density":"comfortable","matchSystemTheme":false,"sidebarMaterial":"appKitSidebar","sidebarWidth":244,"rightPaneWidth":320,"rightPaneVisible":true,"sidebarVisible":true,"commitDetailSplitRatio":0.32,"general":{"launchAtLogin":false,"closeToTray":true,"confirmQuit":true,"autoUpdate":true,"updateChannel":"Stable","crashReports":false,"usageAnalytics":false},"worktrees":{"rootPath":"~/.alas/worktrees","pathTemplate":"{worktreeRoot}/{repo}/{branch}","branchPrefix":"feature/","baseBranch":"main","trackUpstream":true,"deleteBranchOnRemove":true,"autoFetch":true,"fetchIntervalMinutes":5,"pruneStale":false},"terminal":{"shell":"/bin/zsh","workingDirectory":"worktreeRoot","startupScript":"","worktreeCreateScript":"","inheritParentEnv":true,"fontFamily":"JetBrains Mono","fontSize":13,"cursorStyle":"beam","cursorBlink":true,"scrollbackLines":10000,"bell":"visual"},"harness":{"notifyOnFinish":true,"notifyOnAwaiting":true},"code":{"fontFamily":"SF Mono","fontSize":13,"formatOnSave":true,"languageServers":[],"dismissedInstallNudges":[],"userDefinedRecipes":{}},"markdown":{"defaultViewMode":"editor"},"changes":{"aiToolId":"none","prompt":"Hello"},"agents":{"builtinState":{},"custom":[],"worktreeAutoLaunch":{"agentId":null,"useBypassPermissions":false}},"files":{"showIgnored":true}}"#
+    let data = Data(json.utf8)
+    let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+    #expect(decoded.terminal.syncTabTitleWithTerminalTitle == false)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` (specifically the settings tests)
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Persistence/AppConfig.swift AlasTests/SettingsSaveNormalizationTests.swift
+git commit -m "feat(config): add syncTabTitleWithTerminalTitle to terminal config"
+```
+
+---
+
+### Task 2: TabsManager – Runtime Title Storage
+
+**Files:**
+- Modify: `Alas/Sources/Center/TabsManager.swift`
+- Test: `AlasTests/TabsManagerTests.swift`
+
+- [ ] **Step 1: Add `terminalRuntimeTitles` property and API**
+
+In `Alas/Sources/Center/TabsManager.swift`, after `private var pendingExternalOpenGen: [TabID: Int] = [:]`, add:
+
+```swift
+/// Runtime-only display titles for terminal pane leaves. Key = leafId.
+var terminalRuntimeTitles: [String: String] = [:]
+```
+
+Add methods before the existing `// MARK: - Pane tree mutations`:
+
+```swift
+// MARK: - Terminal runtime titles
+
+func setTerminalRuntimeTitle(leafId: String, title: String) {
+    guard !title.isEmpty else { return }
+    terminalRuntimeTitles[leafId] = title
+}
+
+func clearTerminalRuntimeTitles(forLeavesInTabId tabId: TabID) {
+    guard let file = byWorktree.values.first(where: { $0.tabs.contains(where: { $0.id == tabId }) }) else { return }
+    guard let tab = file.tabs.first(where: { $0.id == tabId }),
+          case .terminal(let state) = tab else { return }
+    for leaf in state.root.leaves() {
+        terminalRuntimeTitles.removeValue(forKey: leaf.id)
+    }
+}
+
+/// Returns the runtime display title for a terminal tab's focused leaf, if any.
+func displayTerminalTitle(for tab: Tab) -> String? {
+    guard case .terminal(let state) = tab else { return nil }
+    guard let leafId = state.root.find(leafId: state.focusedLeafId)?.leaf.id else { return nil }
+    return terminalRuntimeTitles[leafId]
+}
+```
+
+- [ ] **Step 2: Add cleanup in `close`**
+
+In `Alas/Sources/Center/TabsManager.swift`, inside `close(worktreeId:tabId:)`, after:
+
+```swift
+let wasActive = file.activeTabId == tabId
+file.tabs.remove(at: idx)
+```
+
+Add before `if wasActive {`:
+
+```swift
+if case .terminal(let state) = tab {
+    for leaf in state.root.leaves() {
+        terminalRuntimeTitles.removeValue(forKey: leaf.id)
+    }
+}
+```
+
+- [ ] **Step 3: Write tests for runtime title storage**
+
+In `AlasTests/TabsManagerTests.swift`, add:
+
+```swift
+@Test func setTerminalRuntimeTitleStoresTitle() {
+    let mgr = TabsManager()
+    mgr.setTerminalRuntimeTitle(leafId: "leaf1", title: "vim foo")
+    #expect(mgr.terminalRuntimeTitles["leaf1"] == "vim foo")
+}
+
+@Test func setTerminalRuntimeTitleIgnoresEmptyTitle() {
+    let mgr = TabsManager()
+    mgr.setTerminalRuntimeTitle(leafId: "leaf1", title: "vim foo")
+    mgr.setTerminalRuntimeTitle(leafId: "leaf1", title: "")
+    #expect(mgr.terminalRuntimeTitles["leaf1"] == "vim foo")
+}
+
+@Test func clearTerminalRuntimeTitlesRemovesLeavesForTab() {
+    let mgr = TabsManager()
+    let tab = mgr.appendTerminal(worktreeId: "wt", title: "bash", sessionId: "s1")
+    guard let state = tab.terminalState else { return }
+    let leafId = state.focusedLeafId
+    mgr.setTerminalRuntimeTitle(leafId: leafId, title: "vim foo")
+    mgr.clearTerminalRuntimeTitles(forLeavesInTabId: tab.id)
+    #expect(mgr.terminalRuntimeTitles[leafId] == nil)
+}
+
+@Test func displayTerminalTitleReturnsFocusedLeafTitle() {
+    let mgr = TabsManager()
+    let tab = mgr.appendTerminal(worktreeId: "wt", title: "bash", sessionId: "s1")
+    let leafId = tab.terminalState?.focusedLeafId ?? ""
+    mgr.setTerminalRuntimeTitle(leafId: leafId, title: "vim foo")
+    #expect(mgr.displayTerminalTitle(for: tab) == "vim foo")
+}
+
+@Test func displayTerminalTitleReturnsNilForNonTerminalTab() {
+    let mgr = TabsManager()
+    let tab = mgr.appendEditor(worktreeId: "wt", title: "README.md", relativePath: "README.md")
+    #expect(mgr.displayTerminalTitle(for: tab) == nil)
+}
+
+@Test func closingTerminalTabCleansUpRuntimeTitles() {
+    let mgr = TabsManager()
+    let tab = mgr.appendTerminal(worktreeId: "wt", title: "bash", sessionId: "s1")
+    let leafId = tab.terminalState?.focusedLeafId ?? ""
+    mgr.setTerminalRuntimeTitle(leafId: leafId, title: "vim foo")
+    mgr.close(worktreeId: "wt", tabId: tab.id)
+    #expect(mgr.terminalRuntimeTitles[leafId] == nil)
+}
+```
+
+Note: `tab.terminalState` is not a real property — we need to unwrap via `case .terminal`. The tests above are pseudocode; real tests must switch.
+
+Real test code:
+
+```swift
+@Test func setTerminalRuntimeTitleStoresTitle() {
+    let mgr = TabsManager()
+    mgr.setTerminalRuntimeTitle(leafId: "leaf1", title: "vim foo")
+    #expect(mgr.terminalRuntimeTitles["leaf1"] == "vim foo")
+}
+
+@Test func setTerminalRuntimeTitleIgnoresEmptyTitle() {
+    let mgr = TabsManager()
+    mgr.setTerminalRuntimeTitle(leafId: "leaf1", title: "vim foo")
+    mgr.setTerminalRuntimeTitle(leafId: "leaf1", title: "")
+    #expect(mgr.terminalRuntimeTitles["leaf1"] == "vim foo")
+}
+
+@Test func closingTerminalTabCleansUpRuntimeTitles() {
+    let worktreeId = "wt"
+    let mgr = TabsManager()
+    let tab = mgr.appendTerminal(worktreeId: worktreeId, title: "bash", sessionId: "s1")
+    guard case .terminal(let state) = tab else {
+        Issue.record("Expected terminal tab")
+        return
+    }
+    let leafId = state.focusedLeafId
+    mgr.setTerminalRuntimeTitle(leafId: leafId, title: "vim foo")
+    mgr.close(worktreeId: worktreeId, tabId: tab.id)
+    #expect(mgr.terminalRuntimeTitles[leafId] == nil)
+}
+
+@Test func displayTerminalTitleReturnsFocusedLeafTitle() {
+    let mgr = TabsManager()
+    let tab = mgr.appendTerminal(worktreeId: "wt", title: "bash", sessionId: "s1")
+    guard case .terminal(let state) = tab else {
+        Issue.record("Expected terminal tab")
+        return
+    }
+    mgr.setTerminalRuntimeTitle(leafId: state.focusedLeafId, title: "vim foo")
+    #expect(mgr.displayTerminalTitle(for: tab) == "vim foo")
+}
+
+@Test func displayTerminalTitleReturnsNilForNonTerminalTab() {
+    let mgr = TabsManager()
+    let tab = mgr.appendEditor(worktreeId: "wt", title: "README.md", relativePath: "README.md")
+    #expect(mgr.displayTerminalTitle(for: tab) == nil)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Center/TabsManager.swift AlasTests/TabsManagerTests.swift
+git commit -m "feat(tabs): add runtime terminal title storage"
+```
+
+---
+
+### Task 3: TabBarView – Display-Time Title Resolution
+
+**Files:**
+- Modify: `Alas/Sources/Center/TabBarView.swift`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+- Test: `AlasTests/TouchTargetSmokeTests.swift`, `AlasTests/TabActivityIconTintTests.swift`
+
+- [ ] **Step 1: Add `titleLookup` prop to TabBarView and TabButton**
+
+In `Alas/Sources/Center/TabBarView.swift`, add after the existing `let onMove: (TabID, TabID) -> Void`:
+
+```swift
+let titleLookup: (TabID) -> String?
+```
+
+Inside `TabButton`, add before `let tab: Tab`:
+
+```swift
+let titleLookup: (TabID) -> String?
+```
+
+Replace `Text(tab.title)` with:
+
+```swift
+let displayTitle = titleLookup(tab.id) ?? tab.title
+Text(displayTitle)
+```
+
+In the `ForEach` inside `TabBarView.body`, update the `TabButton(...)` call to pass `titleLookup: titleLookup`.
+
+- [ ] **Step 2: Update CenterPaneView to pass titleLookup**
+
+In `Alas/Sources/Center/CenterPaneView.swift`, inside the `TabBarView(...)` call, add after `onMove: { ... }`:
+
+```swift
+titleLookup: { id in
+    guard let tab = tabs.first(where: { $0.id == id }) else { return nil }
+    return state.tabs.displayTerminalTitle(for: tab)
+}
+```
+
+- [ ] **Step 3: Fix test compile errors**
+
+Update `AlasTests/TouchTargetSmokeTests.swift` and `AlasTests/TabActivityIconTintTests.swift` to include `titleLookup: { _ in nil }` in their `TabBarView` instantiation. In `TabActivityIconTintTests.swift` it currently shows three instantiations of `TabBarView(...)` — add `titleLookup: { _ in nil }` to each.
+
+In `TouchTargetSmokeTests.swift` there are four instantiations — add `titleLookup: { _ in nil }` to each.
+
+- [ ] **Step 4: Build to verify compile**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/Center/TabBarView.swift Alas/Sources/Center/CenterPaneView.swift AlasTests/TabActivityIconTintTests.swift AlasTests/TouchTargetSmokeTests.swift
+git commit -m "feat(tab-bar): display runtime terminal titles"
+```
+
+---
+
+### Task 4: TerminalTabView – Wire titleHandler
+
+**Files:**
+- Modify: `Alas/Sources/Center/TerminalTabView.swift`
+
+- [ ] **Step 1: Add wireTitleHandler**
+
+In `Alas/Sources/Center/TerminalTabView.swift`, add inside `PaneLeafView` after `wireOpenURLHandler`:
+
+```swift
+private func wireTitleHandler(session: TerminalSession, leafId: String) {
+    session.surface.titleHandler = { [weak state] title in
+        guard let state, !title.isEmpty else { return }
+        guard state.config.terminal.syncTabTitleWithTerminalTitle else { return }
+        state.tabs.setTerminalRuntimeTitle(leafId: leafId, title: title)
+    }
+}
+```
+
+In `PaneLeafView.onAppear` (where `wireCwdHandler` and `wireOpenURLHandler` are called), add:
+
+```swift
+wireTitleHandler(session: session, leafId: leaf.id)
+```
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Alas/Sources/Center/TerminalTabView.swift
+git commit -m "feat(terminal-tab): wire titleHandler to runtime title sync"
+```
+
+---
+
+### Task 5: AppState – Clear Runtime Titles on Manual Rename
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+
+- [ ] **Step 1: Update renameTerminalTab**
+
+In `Alas/Sources/App/AppState.swift`, inside `renameTerminalTab(worktreeId:tabId:)`, after:
+
+```swift
+guard alert.runModal() == .alertFirstButtonReturn else { return }
+_ = tabs.renameTerminal(worktreeId: worktreeId, tabId: tabId, title: field.stringValue)
+```
+
+Add:
+
+```swift
+tabs.clearTerminalRuntimeTitles(forLeavesInTabId: tabId)
+```
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Alas/Sources/App/AppState.swift
+git commit -m "feat: clear runtime terminal titles on manual tab rename"
+```
+
+---
+
+### Task 6: Settings UI – Add Toggle
+
+**Files:**
+- Modify: `Alas/Sources/Settings/TerminalPane.swift`
+
+- [ ] **Step 1: Add toggle row in Appearance group**
+
+In `Alas/Sources/Settings/TerminalPane.swift`, inside `SettingsGroup(title: "Appearance")`, after the "Bell" row, add:
+
+```swift
+SettingsRow(name: "Sync tab title with terminal title",
+            desc: "When the terminal reports a title, update the tab label.") {
+    AlasToggle(on: state.bind(\.terminal.syncTabTitleWithTerminalTitle))
+}
+```
+
+- [ ] **Step 2: Build and test**
+
+Build first to check compile: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`
+
+Then run the full test suite: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`
+
+Expected: BUILD SUCCEEDED, TEST PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Alas/Sources/Settings/TerminalPane.swift
+git commit -m "feat(settings): add terminal tab title sync toggle"
+```
+
+---
+
+## Spec Coverage Check
+
+| Spec Section | Task |
+|---|---|
+| Section 1: Config & Settings | Task 1, Task 6 |
+| Section 2: TabsManager | Task 2 |
+| Section 2: TabBarView | Task 3 |
+| Section 2: TerminalTabView | Task 4 |
+| Section 2: Manual rename | Task 5 |
+| Section: Testing Plan | Each task's test steps |
+
+**No gaps.**
+
+---
+
+## Type Consistency Check
+
+- `setTerminalRuntimeTitle(leafId:title:)` — `leafId: String`, `title: String`
+- `clearTerminalRuntimeTitles(forLeavesInTabId:)` — `TabID` (alias for `String`)
+- `displayTerminalTitle(for:)` — takes `Tab`, returns `String?`
+- `titleLookup` closure — `(TabID) -> String?`
+- `syncTabTitleWithTerminalTitle` — `Bool`
+
+All consistent.

--- a/docs/superpowers/specs/2026-05-24-terminal-tab-title-sync-design.md
+++ b/docs/superpowers/specs/2026-05-24-terminal-tab-title-sync-design.md
@@ -1,0 +1,134 @@
+# Terminal Tab Title Sync – Design
+
+## Overview
+
+Wire Ghostty's terminal title changes (OSC sequences emitted by shells / processes) into the visible tab bar label for terminal tabs. When the terminal reports a title, the active terminal tab's label updates to match. If the terminal never reports a title, the existing tab label (stable name, default "bash", or user rename) is preserved.
+
+The feature is gated behind a new toggle in **Settings → Terminal → Appearance**: "Sync tab title with terminal title", defaulting to `false` for backward compatibility.
+
+---
+
+## Constraints & Decisions
+
+- **Runtime-only.** Tab titles from the terminal are ephemeral display state. They are never persisted. App relaunch restores the original `TerminalTabState.title`.
+- **Focused leaf wins.** A terminal tab may contain a split pane tree. The tab bar displays the title of whichever leaf currently has focus.
+- **Empty title ignored.** Ghostty sometimes reports `""` on title reset. We ignore empty strings so the prior title (persistent or runtime) remains visible.
+- **Manual rename takes control.** When a user manually renames a terminal tab ("Rename…" context menu), all runtime titles for that tab's leaves are cleared. The persistent title wins until future non-empty terminal title updates arrive.
+
+---
+
+## Architecture
+
+### 1. TabsManager – ephemeral title store
+
+TabsManager receives a new non-persisted property:
+
+```swift
+var terminalRuntimeTitles: [String: String] = [:]   // leafId → display title
+```
+
+New API added to `TabsManager`:
+
+- `setTerminalRuntimeTitle(leafId:title:)` – stores a title for the given leaf id. Non-empty only.
+- `clearTerminalRuntimeTitles(forLeavesInTabId:)` – removes all runtime title entries belonging to leaves of the specified tab.
+- `displayTerminalTitle(for tab: Tab, in worktreeId: String) -> String?` – convenience that, given a `.terminal` tab, resolves the runtime title for its currently focused leaf, or `nil` if the feature is off / the leaf has no runtime title.
+
+**Cleanup:** `close(worktreeId:tabId:)` now walks the closing terminal tab's leaves and removes their `terminalRuntimeTitles` entries.
+
+### 2. TabBarView – display-time resolution
+
+`TabButton` uses a resolved label instead of raw `tab.title`:
+
+- Add a new prop `titleLookup: (TabID) -> String?` to `TabBarView`.
+- Inside `TabButton`, compute: `let displayTitle = titleLookup(tab.id) ?? tab.title`
+- The `Text(tab.title)` line is replaced with `Text(displayTitle)`.
+
+`CenterPaneView` (the caller) provides a closure that, for a `.terminal` tab, asks `TabsManager.displayTerminalTitle(...)` for the focused-leaf runtime title; for all other tab kinds it returns `nil`.
+
+### 3. TerminalTabView – wiring titleHandler
+
+In `PaneLeafView.onAppear`, after the existing `wireCwdHandler` and `wireOpenURLHandler`, add:
+
+```swift
+private func wireTitleHandler(session: TerminalSession, leafId: String) {
+    session.surface.titleHandler = { [weak state] title in
+        guard let state, !title.isEmpty else { return }
+        guard state.config.terminal.syncTabTitleWithTerminalTitle else { return }
+        state.tabs.setTerminalRuntimeTitle(leafId: leafId, title: title)
+    }
+}
+```
+
+The handler is set once per leaf on view appear and survives pane focus changes.
+
+### 4. Manual rename interaction
+
+`AppState.renameTerminalTab(worktreeId:tabId:)` (the context-menu "Rename…" path) is updated so that after the alert returns and `tabs.renameTerminal(...)` mutates the persistent title, it also calls:
+
+```swift
+if let terminal = tabs.terminalState(for: tabId) {
+    for leaf in terminal.root.leaves() {
+        tabs.clearTerminalRuntimeTitles(forLeavesInTabId: tabId)
+    }
+}
+```
+
+This ensures the user's manually-chosen name is immediately visible.
+
+---
+
+## Config Model
+
+In `AppConfig.Terminal`:
+
+```swift
+var syncTabTitleWithTerminalTitle: Bool
+```
+
+Default:
+
+```swift
+terminal: Terminal(
+    ...
+    syncTabTitleWithTerminalTitle: false
+)
+```
+
+Decode path: graceful fallback to `false` for configs saved before this field was added.
+
+---
+
+## Settings UI
+
+In `TerminalPane.swift`, under the existing `SettingsGroup(title: "Appearance")`, add a `SettingsRow` after the "Bell" row:
+
+```swift
+SettingsRow(name: "Sync tab title with terminal title",
+            desc: "When the terminal reports a title, update the tab label.") {
+    AlasToggle(on: state.bind(\.terminal.syncTabTitleWithTerminalTitle))
+}
+```
+
+---
+
+## Error Handling & Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| Toggle is off | Runtime title dictionary stays empty; display falls through to persistent `tab.title` |
+| Terminal reports `""` | Ignored; prior title remains |
+| Tab closed | Cleanup removes leaf entries from `terminalRuntimeTitles` |
+| Split pane; focus switches | Tab bar label updates to the focused leaf's runtime title automatically |
+| Non-terminal tab | `titleLookup` returns `nil`; persistent title is shown unchanged |
+| App relaunch | Runtime dictionary is empty; all tabs restore with their persistent titles |
+
+---
+
+## Testing Plan
+
+1. **Happy path:** open terminal, simulate `titleHandler("vim foo")` via a test harness; assert `TabsManager.terminalRuntimeTitles` contains the leaf id and the tab bar displays "vim foo".
+2. **Empty title ignored:** call handler with `""`; assert no change in display title.
+3. **Manual rename clears runtime:** set a runtime title, trigger `renameTerminalTab`, assert runtime title entry is gone and persistent title is visible.
+4. **Toggle off:** set runtime title with toggle enabled, then disable toggle (or start disabled), assert display falls through to persistent title.
+5. **Split pane focused leaf:** two leaves with different runtime titles; assert focused-leaf title is shown.
+6. **Tab close cleanup:** close tab, assert `terminalRuntimeTitles` no longer contains leaf ids from that tab.


### PR DESCRIPTION
## Summary

Adds an optional setting that syncs the terminal tab title with the title reported by the embedded Ghostty terminal (via OSC sequences).

## Changes

- **Config**: `AppConfig.Terminal.syncTabTitleWithTerminalTitle` (default `false`, backward-compatible decode)
- **TabsManager**: Runtime-only `terminalRuntimeTitles` dictionary keyed by pane leaf ID; `setTerminalRuntimeTitle`, `clearTerminalRuntimeTitles`, `displayTerminalTitle`
- **TabBarView**: Tab button labels now resolve through a `titleLookup` closure at render time
- **TerminalTabView**: `PaneLeafView.onAppear` wires `SurfaceView.titleHandler` → `TabsManager`
- **AppState**: Manual tab rename clears accumulated runtime titles for immediate override
- **Settings UI**: Toggle in Terminal → Appearance: "Sync tab title with terminal title"

## Behavior

- **Runtime-only**: Titles are not persisted; app relaunch restores original tab names.
- **Focused leaf wins**: In split-pane terminal tabs, the focused pane's title drives the tab label.
- **Empty titles ignored**: Ghostty `""` resets are silently skipped.
- **Manual rename overrides**: User renames clear the runtime title; future OSC updates resume syncing.

## Testing

- Backward-compatibility decode test for configs missing `syncTabTitleWithTerminalTitle`
- Unit tests for title storage, empty-title rejection, focused-leaf lookup, and close cleanup
- 44 targeted tests pass; 1 pre-existing unrelated failure in `WorktreeServiceTests`
