### PR TITLE
feat: detect and orchestrate git merge conflicts in the right pane

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
 		3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6CCD7F7273667B5D67F821 /* SearchScope.swift */; };
 		32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */; };
+		32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */; };
 		3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36992F601C8EB6C3D45B584F /* SearchKbd.swift */; };
 		3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */; };
 		35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */; };
@@ -200,6 +201,7 @@
 		5E687CE659E83EF3B71CA86F /* PiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */; };
 		5EA1AA5C8D9DE003BACE8291 /* AlasGhostty.Surface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */; };
 		5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE58EF9CF8EC461667D9430 /* AppConfig.swift */; };
+		5F7E14A0D7E1D3F036806B73 /* MergeOperationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */; };
 		5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */; };
 		604E881461FC839C4233B0AF /* LSPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D394D40BC9060833DD640A /* LSPInstaller.swift */; };
 		6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */; };
@@ -553,6 +555,7 @@
 		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
 		0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabLoadingIndicatorTests.swift; sourceTree = "<group>"; };
 		0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewController.swift; sourceTree = "<group>"; };
+		0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationStateTests.swift; sourceTree = "<group>"; };
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
 		0E6600436B01C75D85C01FFA /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
@@ -705,6 +708,7 @@
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
+		542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationState.swift; sourceTree = "<group>"; };
 		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTargetSmokeTests.swift; sourceTree = "<group>"; };
@@ -1193,6 +1197,7 @@
 				373D587E3153D902EB10208B /* MarkdownParserTests.swift */,
 				B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */,
 				DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */,
+				0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */,
 				E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */,
 				C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */,
 				4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */,
@@ -1407,6 +1412,7 @@
 				6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */,
 				BD4A3B9B1103346242438940 /* FilesTabView.swift */,
 				F721FB733081A583D4053DDA /* FileTypeIconView.swift */,
+				542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */,
 				9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */,
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
 				795056B6AD803D2B555FC866 /* RightPaneStore.swift */,
@@ -2296,6 +2302,7 @@
 				6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
+				32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */,
@@ -2542,6 +2549,7 @@
 				8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */,
 				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,
 				EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */,
+				5F7E14A0D7E1D3F036806B73 /* MergeOperationStateTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,
 				D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -505,6 +505,7 @@
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
+		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
@@ -712,6 +713,7 @@
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
 		542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationState.swift; sourceTree = "<group>"; };
 		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
+		561094BA96058468F12002A1 /* ConflictsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictsSection.swift; sourceTree = "<group>"; };
 		563B664D082A9523260AA2EF /* RepoDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDot.swift; sourceTree = "<group>"; };
 		56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchTargetSmokeTests.swift; sourceTree = "<group>"; };
 		576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsAheadTests.swift; sourceTree = "<group>"; };
@@ -1412,6 +1414,7 @@
 				C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */,
 				3DCEFADD952DB870B8BAB890 /* CommitRow.swift */,
 				6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */,
+				561094BA96058468F12002A1 /* ConflictsSection.swift */,
 				BD4A3B9B1103346242438940 /* FilesTabView.swift */,
 				F721FB733081A583D4053DDA /* FileTypeIconView.swift */,
 				542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */,
@@ -2198,6 +2201,7 @@
 				FFC747D542D806E6CF6FCD03 /* CompletionPopup.swift in Sources */,
 				412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */,
 				C2EDB6A5E6149758C4A0051E /* ConflictMarkerParser.swift in Sources */,
+				FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */,
 				A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */,
 				A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */,
 				3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -251,6 +251,7 @@
 		7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6CA79B71B4AA72697392702 /* NumstatParser.swift */; };
 		7B309C87C042B3A18AB31D0F /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49B5B544A3432F8D8105268 /* SearchModel.swift */; };
 		7B85B033B476943E77867BA3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69024633944E9FFF6DA76FAE /* RootView.swift */; };
+		7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */; };
 		7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */; };
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
 		7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4575017544CD7603B3AB9069 /* GitEventFilter.swift */; };
@@ -884,6 +885,7 @@
 		B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderView.swift; sourceTree = "<group>"; };
 		B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCacheTests.swift; sourceTree = "<group>"; };
 		B87F114EBEEACCC95B9EF8D5 /* ImageDiffOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffOverlayView.swift; sourceTree = "<group>"; };
+		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
 		BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerHeadUpdatesTests.swift; sourceTree = "<group>"; };
@@ -1158,6 +1160,7 @@
 				82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */,
 				F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */,
 				38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */,
+				B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
 				039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */,
 				FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */,
@@ -2495,6 +2498,7 @@
 				EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */,
 				2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */,
 				1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */,
+				7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,
 				E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */,
 				1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		065F01BB553C415040414D37 /* ImageDiffSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
+		082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */; };
 		08681BEDBD6D7232CC937704 /* HoverFeatureBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E853C6AAB6450A0845A7CD /* HoverFeatureBehaviorTests.swift */; };
 		08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */; };
 		095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */; };
@@ -688,6 +689,7 @@
 		4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstallerTests.swift; sourceTree = "<group>"; };
 		4865995B2D4B92166321201F /* CommitContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilder.swift; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
+		4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCard.swift; sourceTree = "<group>"; };
 		4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardPathsTests.swift; sourceTree = "<group>"; };
 		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltinsTests.swift; sourceTree = "<group>"; };
@@ -1413,6 +1415,7 @@
 				BD4A3B9B1103346242438940 /* FilesTabView.swift */,
 				F721FB733081A583D4053DDA /* FileTypeIconView.swift */,
 				542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */,
+				4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */,
 				9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */,
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
 				795056B6AD803D2B555FC866 /* RightPaneStore.swift */,
@@ -2311,6 +2314,7 @@
 				7B25B1405BFDE5570B267213 /* NumstatParser.swift in Sources */,
 				74E1B2C42F77908AA597EF45 /* OKLCH.swift in Sources */,
 				6A10E9DF8A052DBDFF477863 /* OpenCodeInstaller.swift in Sources */,
+				082582F4BBA9DCFF0EAB9588 /* OperationCard.swift in Sources */,
 				86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */,
 				78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */,
 				449C7E4A63455D01633B791A /* PendingDiscard.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46BDE72E52818061452ECB /* CommitRowTests.swift */; };
 		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
 		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
+		B54B0BFA87B2566DB59C3D59 /* ConflictMarkerParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */; };
 		B574D2D5DF3129E326DCFCCF /* ShellEnvResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */; };
 		B5E38A6134CDE9F8D5EA76D1 /* CompletionWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */; };
 		B614CD7F894DD6908C903254 /* InstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */; };
@@ -386,6 +387,7 @@
 		C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620C4A708CD1013DE2736A00 /* AppIconTests.swift */; };
 		C1EBF68A32C7C1D61ECC89AC /* LSPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */; };
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
+		C2EDB6A5E6149758C4A0051E /* ConflictMarkerParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */; };
 		C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */; };
 		C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */; };
 		C487C3AD43E7B5BBB45490DB /* CodexInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F0314E357190EF2A1F861B /* CodexInstaller.swift */; };
@@ -595,6 +597,7 @@
 		220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModelTests.swift; sourceTree = "<group>"; };
 		23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCommandShellTests.swift; sourceTree = "<group>"; };
 		2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallProgressSheet.swift; sourceTree = "<group>"; };
+		2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParser.swift; sourceTree = "<group>"; };
 		2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBindingTests.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
 		25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunch.swift; sourceTree = "<group>"; };
@@ -834,6 +837,7 @@
 		9F650CFAC8E61B1EC99CD04A /* TabActivityPulseTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulseTransitionTests.swift; sourceTree = "<group>"; };
 		9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipe.swift; sourceTree = "<group>"; };
 		9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilter.swift; sourceTree = "<group>"; };
+		A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParserTests.swift; sourceTree = "<group>"; };
 		A218B5125FC963339E40605E /* TabsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManager.swift; sourceTree = "<group>"; };
 		A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStripTests.swift; sourceTree = "<group>"; };
 		A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTree.swift; sourceTree = "<group>"; };
@@ -1120,6 +1124,7 @@
 				576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */,
 				8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */,
 				A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */,
+				A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */,
 				97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */,
 				C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */,
 				AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */,
@@ -1288,6 +1293,7 @@
 				910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */,
 				6AF335AB8B3061C889A348B3 /* CommitDetails.swift */,
 				3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */,
+				2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */,
 				E1703FC5CD7DF16F4450E274 /* DiffParser.swift */,
 				339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */,
 				BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */,
@@ -2179,6 +2185,7 @@
 				D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */,
 				FFC747D542D806E6CF6FCD03 /* CompletionPopup.swift in Sources */,
 				412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */,
+				C2EDB6A5E6149758C4A0051E /* ConflictMarkerParser.swift in Sources */,
 				A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */,
 				A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */,
 				3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */,
@@ -2452,6 +2459,7 @@
 				DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */,
 				CDE156FA8E19E85437E79908 /* CompletionFeatureTests.swift in Sources */,
 				B5E38A6134CDE9F8D5EA76D1 /* CompletionWindowControllerTests.swift in Sources */,
+				B54B0BFA87B2566DB59C3D59 /* ConflictMarkerParserTests.swift in Sources */,
 				5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,
 				B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */,

--- a/Alas/Sources/Git/ConflictMarkerParser.swift
+++ b/Alas/Sources/Git/ConflictMarkerParser.swift
@@ -82,17 +82,18 @@ enum ConflictMarkerParser {
                 flushText()
                 let localLabel = String(line.dropFirst(beginMarker.count))
                 let remoteLabel = String(lines[end].dropFirst(endMarker.count))
+
+                // Helper to extract a half: empty range → "", non-empty → text + "\n"
+                func extractHalf(_ range: Range<Int>) -> String {
+                    let slice = lines[range].map(String.init)
+                    return slice.isEmpty ? "" : slice.joined(separator: "\n") + "\n"
+                }
+
                 // Local half: lines (beginIndex+1) ..< (baseIndex ?? mid)
                 let localUpper = baseIndex ?? mid
-                let localText = lines[(beginIndex + 1) ..< localUpper]
-                    .map(String.init).joined(separator: "\n") + "\n"
-                let baseText: String? = {
-                    guard let b = baseIndex else { return nil }
-                    return lines[(b + 1) ..< mid]
-                        .map(String.init).joined(separator: "\n") + "\n"
-                }()
-                let remoteText = lines[(mid + 1) ..< end]
-                    .map(String.init).joined(separator: "\n") + "\n"
+                let localText = extractHalf((beginIndex + 1) ..< localUpper)
+                let baseText: String? = baseIndex.map { extractHalf(($0 + 1) ..< mid) }
+                let remoteText = extractHalf((mid + 1) ..< end)
                 let block = ConflictBlock(
                     local: localText,
                     base: baseText,

--- a/Alas/Sources/Git/ConflictMarkerParser.swift
+++ b/Alas/Sources/Git/ConflictMarkerParser.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// A region inside a file that may contain conflict markers.
+enum ConflictRegion: Equatable {
+    case text(String)
+    case conflict(ConflictBlock)
+}
+
+/// One `<<<<<<< … >>>>>>>` block, optionally with a `|||||||` base section.
+struct ConflictBlock: Equatable {
+    let local: String                       // content of the "ours" half (with trailing \n)
+    let base: String?                       // content of the |||||||  half, or nil for merge style
+    let remote: String                      // content of the "theirs" half (with trailing \n)
+    let localLabel: String                  // text after `<<<<<<< `
+    let remoteLabel: String                 // text after `>>>>>>> `
+    let lineRangeInMerged: ClosedRange<Int> // 0-indexed line range covering markers in the source
+}
+
+/// Splits a file's text into `[ConflictRegion]`. Pure / synchronous /
+/// no I/O. Trusts the input — only run this on files that git reports
+/// as unmerged.
+enum ConflictMarkerParser {
+    private static let beginMarker = "<<<<<<< "
+    private static let baseMarker  = "||||||| "
+    private static let midMarker   = "======="
+    private static let endMarker   = ">>>>>>> "
+
+    static func parse(_ source: String) -> [ConflictRegion] {
+        // Preserve trailing-newline semantics: split keeping empty trailing element.
+        let lines = source.split(omittingEmptySubsequences: false, whereSeparator: { $0 == "\n" })
+        var result: [ConflictRegion] = []
+        var pendingText: [Substring] = []
+        var i = 0
+
+        func flushText(atEndOfFile: Bool = false) {
+            guard !pendingText.isEmpty else { return }
+            // pendingText is from split(omittingEmptySubsequences: false).
+            // When we encounter a conflict marker, all pending text lines had
+            // newlines after them in the original (because they weren't conflict markers).
+            // At end of file, respect the original trailing state.
+            let joined = pendingText.map(String.init).joined(separator: "\n")
+            if atEndOfFile {
+                // Preserve the original trailing-newline state.
+                // If pendingText ends with "", source had trailing \n.
+                result.append(.text(joined))
+            } else {
+                // Text before a conflict always needs a trailing \n.
+                result.append(.text(joined + "\n"))
+            }
+            pendingText.removeAll(keepingCapacity: true)
+        }
+
+        while i < lines.count {
+            let line = lines[i]
+            if line.hasPrefix(beginMarker) {
+                // Find the matching `=======` and `>>>>>>>`. Track an
+                // intermediate `|||||||` base section if present.
+                let beginIndex = i
+                var midIndex: Int? = nil
+                var baseIndex: Int? = nil
+                var endIndex: Int? = nil
+                var j = i + 1
+                while j < lines.count {
+                    let l = lines[j]
+                    if midIndex == nil && l.hasPrefix(baseMarker) {
+                        baseIndex = j
+                    } else if midIndex == nil && l == midMarker {
+                        midIndex = j
+                    } else if l.hasPrefix(endMarker) {
+                        endIndex = j
+                        break
+                    }
+                    j += 1
+                }
+                guard let mid = midIndex, let end = endIndex else {
+                    // Malformed: no matching closing markers. Emit the rest
+                    // as plain text and stop conflict scanning.
+                    for k in i ..< lines.count { pendingText.append(lines[k]) }
+                    i = lines.count
+                    break
+                }
+                flushText()
+                let localLabel = String(line.dropFirst(beginMarker.count))
+                let remoteLabel = String(lines[end].dropFirst(endMarker.count))
+                // Local half: lines (beginIndex+1) ..< (baseIndex ?? mid)
+                let localUpper = baseIndex ?? mid
+                let localText = lines[(beginIndex + 1) ..< localUpper]
+                    .map(String.init).joined(separator: "\n") + "\n"
+                let baseText: String? = {
+                    guard let b = baseIndex else { return nil }
+                    return lines[(b + 1) ..< mid]
+                        .map(String.init).joined(separator: "\n") + "\n"
+                }()
+                let remoteText = lines[(mid + 1) ..< end]
+                    .map(String.init).joined(separator: "\n") + "\n"
+                let block = ConflictBlock(
+                    local: localText,
+                    base: baseText,
+                    remote: remoteText,
+                    localLabel: localLabel,
+                    remoteLabel: remoteLabel,
+                    lineRangeInMerged: beginIndex ... end
+                )
+                result.append(.conflict(block))
+                i = end + 1
+            } else {
+                pendingText.append(line)
+                i += 1
+            }
+        }
+        flushText(atEndOfFile: true)
+        return result
+    }
+}

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1163,6 +1163,9 @@ extension GitService {
             cwd: worktreePath
         )
         let raw = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard result.exitCode == 0, !raw.isEmpty else {
+            throw OperationError.gitFailed(command: "rev-parse --absolute-git-dir", stderr: result.stderr)
+        }
         return URL(fileURLWithPath: raw)
     }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1409,16 +1409,37 @@ extension GitService {
     }
 
     func cherryPick(worktreePath: URL, sha: String) async throws -> MergeResult {
-        let result = try await Process.git(
-            ["-c", "merge.conflictStyle=zdiff3", "cherry-pick", sha],
-            cwd: worktreePath
-        )
+        let parents = try await parentCount(worktreePath: worktreePath, sha: sha)
+        var args: [String] = ["-c", "merge.conflictStyle=zdiff3", "cherry-pick"]
+        if parents >= 2 {
+            // Merge commit: pick changes relative to the first parent (mainline).
+            // Selecting a different mainline is a follow-up if needed.
+            args.append(contentsOf: ["-m", "1"])
+        }
+        args.append(sha)
+        let result = try await Process.git(args, cwd: worktreePath)
         return try await classifyOperationResult(
             worktreePath: worktreePath,
             exitCode: result.exitCode,
             stderr: result.stderr
         )
     }
+
+    /// Number of parent commits for `sha`. Returns 1 for a normal commit, 2+ for a merge.
+    private func parentCount(worktreePath: URL, sha: String) async throws -> Int {
+        let result = try await Process.git(
+            ["rev-list", "--parents", "-n", "1", sha],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else { return 1 }  // be lenient — let cherry-pick surface the real error
+        // Output: "<sha> <parent1> <parent2> ..."
+        let parts = result.stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: " ", omittingEmptySubsequences: true)
+        // parents = parts.count - 1 (the first token is the commit itself)
+        return max(parts.count - 1, 0)
+    }
+}
 }
 
 enum ConflictedFileError: LocalizedError {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -101,7 +101,8 @@ extension GitService {
                                           stage: entries[i].stage,
                                           add: c.add,
                                           del: c.del,
-                                          renameFrom: entries[i].renameFrom)
+                                          renameFrom: entries[i].renameFrom,
+                                          conflict: entries[i].conflict)
             } else if entries[i].add == 0 && entries[i].del == 0 {
                 // Numstat doesn't include unstaged untracked files, so they'd
                 // show 0/0 in the Changes pane and the totals would
@@ -118,7 +119,8 @@ extension GitService {
                                              stage: entries[i].stage,
                                              add: lines,
                                              del: 0,
-                                             renameFrom: entries[i].renameFrom)
+                                             renameFrom: entries[i].renameFrom,
+                                             conflict: entries[i].conflict)
                 }
             }
         }
@@ -1233,5 +1235,69 @@ extension GitService {
         }
 
         return RebasePlan(ontoBranch: onto, sourceBranch: source, commits: commits)
+    }
+}
+
+extension GitService {
+    /// Reads BASE / LOCAL / REMOTE for a conflicted file from index stages.
+    /// Stage indexes: 1 = common ancestor (base), 2 = ours (HEAD), 3 = theirs (incoming).
+    /// Returns nil for sides that don't exist (e.g., `bothAdded` has no base).
+    func conflictedFile(worktreePath: URL, relativePath: String) async throws -> ConflictedFile {
+        // Determine the conflict kind from current status (cheaper than
+        // calling status() and filtering — but this is what status() does
+        // anyway, so we just reuse it).
+        let allChanges = try await status(worktreePath: worktreePath)
+        guard let entry = allChanges.first(where: {
+            $0.path == relativePath && $0.conflict != nil
+        }), let kind = entry.conflict else {
+            throw ConflictedFileError.notConflicted(path: relativePath)
+        }
+
+        let base = try await readStageOrNil(worktreePath: worktreePath, stage: 1, path: relativePath)
+        let local = try await readStageOrNil(worktreePath: worktreePath, stage: 2, path: relativePath)
+        let remote = try await readStageOrNil(worktreePath: worktreePath, stage: 3, path: relativePath)
+
+        let absolute = worktreePath.appendingPathComponent(relativePath)
+        let mergedData = (try? Data(contentsOf: absolute)) ?? Data()
+        let isBinary = Self.looksBinary(mergedData)
+        let merged = isBinary ? "" : (String(data: mergedData, encoding: .utf8) ?? "")
+
+        return ConflictedFile(
+            relativePath: relativePath,
+            kind: kind,
+            base: base,
+            local: local,
+            remote: remote,
+            merged: merged,
+            isBinary: isBinary
+        )
+    }
+
+    /// `git show :N:path` returns the blob at index stage N. Returns nil
+    /// when the stage doesn't exist (git exits non-zero in that case).
+    private func readStageOrNil(worktreePath: URL, stage: Int, path: String) async throws -> String? {
+        let result = try await Process.git(
+            ["show", ":\(stage):\(path)"],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else { return nil }
+        return result.stdout
+    }
+
+    /// Same heuristic git uses: a NUL byte in the first 8KB → binary.
+    static func looksBinary(_ data: Data) -> Bool {
+        let probe = data.prefix(8192)
+        return probe.contains(0x00)
+    }
+}
+
+enum ConflictedFileError: LocalizedError {
+    case notConflicted(path: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConflicted(let path):
+            return "File '\(path)' is not in a conflicted state."
+        }
     }
 }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1145,6 +1145,12 @@ extension GitService {
             return .rebase(plan: plan)
         }
 
+        let rebaseApplyDir = gitDir.appendingPathComponent("rebase-apply")
+        if FileManager.default.fileExists(atPath: rebaseApplyDir.path) {
+            let plan = try await Self.readRebaseApplyPlan(rebaseApplyDir: rebaseApplyDir)
+            return .rebase(plan: plan)
+        }
+
         let cherryHead = gitDir.appendingPathComponent("CHERRY_PICK_HEAD")
         if FileManager.default.fileExists(atPath: cherryHead.path) {
             let sha = (try? String(contentsOf: cherryHead, encoding: .utf8))?
@@ -1251,6 +1257,54 @@ extension GitService {
         }
 
         return RebasePlan(ontoBranch: onto, sourceBranch: source, commits: commits)
+    }
+
+    /// Builds a RebasePlan from a `.git/rebase-apply` directory (apply-backend rebase).
+    /// Layout: `next` (current 1-based index), `last` (total), `0001`..`NNNN` (patch files),
+    /// `head-name` (source branch ref), `onto` (target SHA).
+    private static func readRebaseApplyPlan(rebaseApplyDir: URL) async throws -> RebasePlan {
+        func readFile(_ name: String) -> String? {
+            try? String(
+                contentsOf: rebaseApplyDir.appendingPathComponent(name),
+                encoding: .utf8
+            )
+        }
+
+        let nextInt = readFile("next").flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } ?? 0
+        let lastInt = readFile("last").flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } ?? 0
+        let ontoRef = readFile("onto")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let headName = readFile("head-name")?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let source = headName.flatMap { ref -> String in
+            ref.hasPrefix("refs/heads/") ? String(ref.dropFirst("refs/heads/".count)) : ref
+        }
+
+        var commits: [RebasePlanCommit] = []
+        let range = lastInt >= 1 ? (1...lastInt) : (1...0)
+        for i in range {
+            let patchName = String(format: "%04d", i)
+            var summary = "commit \(i)"
+            if let patchContent = readFile(patchName) {
+                for line in patchContent.split(separator: "\n", omittingEmptySubsequences: false) {
+                    let lineStr = String(line)
+                    if lineStr.hasPrefix("Subject: ") {
+                        summary = String(lineStr.dropFirst("Subject: ".count)).trimmingCharacters(in: .whitespaces)
+                        break
+                    }
+                }
+            }
+            let state: RebasePlanCommit.State
+            if i < nextInt {
+                state = .done
+            } else if i == nextInt {
+                state = .current
+            } else {
+                state = .pending
+            }
+            commits.append(RebasePlanCommit(sha: "patch-\(i)", summary: summary, state: state))
+        }
+
+        return RebasePlan(ontoBranch: ontoRef, sourceBranch: source, commits: commits)
     }
 }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1145,8 +1145,15 @@ extension GitService {
             return .rebase(plan: plan)
         }
 
+        // .git/rebase-apply is also used by `git am`, which writes an
+        // `applying` sentinel instead of `rebasing`. Treat only the
+        // rebase-shaped case as an in-progress rebase; an `am` conflict is
+        // out of scope for this UI (driving `rebase --continue` against an
+        // am state would error).
         let rebaseApplyDir = gitDir.appendingPathComponent("rebase-apply")
-        if FileManager.default.fileExists(atPath: rebaseApplyDir.path) {
+        let rebasingSentinel = rebaseApplyDir.appendingPathComponent("rebasing")
+        if FileManager.default.fileExists(atPath: rebaseApplyDir.path),
+           FileManager.default.fileExists(atPath: rebasingSentinel.path) {
             let plan = try await Self.readRebaseApplyPlan(rebaseApplyDir: rebaseApplyDir)
             return .rebase(plan: plan)
         }

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1111,3 +1111,127 @@ extension GitService {
         return Date()
     }
 }
+
+extension GitService {
+    /// Detects an in-progress merge / rebase / cherry-pick by inspecting
+    /// .git marker files. Returns nil when the worktree is idle.
+    func mergeState(worktreePath: URL) async throws -> MergeOperation? {
+        let gitDir = try await self.gitDir(worktreePath: worktreePath)
+
+        // Rebase first — both `MERGE_HEAD` and `rebase-merge` can coexist
+        // briefly during a `rebase -m`. Rebase is the more specific signal.
+        let rebaseMergeDir = gitDir.appendingPathComponent("rebase-merge")
+        if FileManager.default.fileExists(atPath: rebaseMergeDir.path) {
+            let plan = try await Self.readRebasePlan(
+                gitDir: gitDir,
+                rebaseMergeDir: rebaseMergeDir,
+                worktreePath: worktreePath
+            )
+            return .rebase(plan: plan)
+        }
+
+        let cherryHead = gitDir.appendingPathComponent("CHERRY_PICK_HEAD")
+        if FileManager.default.fileExists(atPath: cherryHead.path) {
+            let sha = (try? String(contentsOf: cherryHead, encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let summary = (try? await Process.git(
+                ["log", "-1", "--pretty=%s", sha],
+                cwd: worktreePath
+            ).stdout.trimmingCharacters(in: .whitespacesAndNewlines)) ?? sha
+            return .cherryPick(sha: sha, summary: summary)
+        }
+
+        let mergeHead = gitDir.appendingPathComponent("MERGE_HEAD")
+        if FileManager.default.fileExists(atPath: mergeHead.path) {
+            // Try to read MERGE_MSG for the source-branch name (`merge branch 'X'`).
+            let mergeMsg = gitDir.appendingPathComponent("MERGE_MSG")
+            let msg = (try? String(contentsOf: mergeMsg, encoding: .utf8)) ?? ""
+            let source = Self.parseMergeMsgBranch(msg)
+            return .merge(sourceBranch: source)
+        }
+        return nil
+    }
+
+    /// Resolves the absolute `.git` directory for the given worktree
+    /// (handles linked worktrees, where `.git` is a file pointing into a
+    /// subdir of the main repo).
+    private func gitDir(worktreePath: URL) async throws -> URL {
+        let result = try await Process.git(
+            ["rev-parse", "--absolute-git-dir"],
+            cwd: worktreePath
+        )
+        let raw = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        return URL(fileURLWithPath: raw)
+    }
+
+    /// MERGE_MSG looks like:
+    ///   Merge branch 'feature/x'
+    /// or:
+    ///   Merge branch 'feature/x' into main
+    /// We only need the first quoted token.
+    static func parseMergeMsgBranch(_ msg: String) -> String? {
+        guard let openQuote = msg.firstIndex(of: "'") else { return nil }
+        let after = msg.index(after: openQuote)
+        guard let closeQuote = msg[after...].firstIndex(of: "'") else { return nil }
+        return String(msg[after ..< closeQuote])
+    }
+
+    /// Reads `rebase-merge/git-rebase-todo` (pending) plus `done` (already
+    /// applied) and `msgnum`/`end` (1-indexed current commit) to build a
+    /// RebasePlan with `done` / `current` / `pending` state per commit.
+    private static func readRebasePlan(
+        gitDir: URL,
+        rebaseMergeDir: URL,
+        worktreePath: URL
+    ) async throws -> RebasePlan {
+        func read(_ name: String) -> String? {
+            try? String(
+                contentsOf: rebaseMergeDir.appendingPathComponent(name),
+                encoding: .utf8
+            )
+        }
+        let todo = read("git-rebase-todo") ?? ""
+        let done = read("done") ?? ""
+        let ontoRef = read("onto")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let headName = read("head-name")?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        func parseLines(_ raw: String) -> [(String, String)] {
+            // Lines look like: "pick abcd123 commit subject"
+            raw.split(separator: "\n", omittingEmptySubsequences: true).compactMap { l in
+                let line = l.trimmingCharacters(in: .whitespaces)
+                guard !line.isEmpty, !line.hasPrefix("#") else { return nil }
+                let parts = line.split(
+                    separator: " ",
+                    maxSplits: 2,
+                    omittingEmptySubsequences: true
+                )
+                guard parts.count >= 3 else { return nil }
+                return (String(parts[1]), String(parts[2]))
+            }
+        }
+
+        let doneCommits = parseLines(done)
+        let todoCommits = parseLines(todo)
+
+        // `done` includes the *currently-conflicting* commit as its last
+        // entry. Mark it as .current; everything before is .done; todo is .pending.
+        var commits: [RebasePlanCommit] = []
+        if doneCommits.count >= 1 {
+            for (sha, summary) in doneCommits.dropLast() {
+                commits.append(RebasePlanCommit(sha: sha, summary: summary, state: .done))
+            }
+            let last = doneCommits.last!
+            commits.append(RebasePlanCommit(sha: last.0, summary: last.1, state: .current))
+        }
+        for (sha, summary) in todoCommits {
+            commits.append(RebasePlanCommit(sha: sha, summary: summary, state: .pending))
+        }
+
+        let onto = ontoRef
+        let source = headName.flatMap { ref -> String in
+            ref.hasPrefix("refs/heads/") ? String(ref.dropFirst("refs/heads/".count)) : ref
+        }
+
+        return RebasePlan(ontoBranch: onto, sourceBranch: source, commits: commits)
+    }
+}

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1440,6 +1440,17 @@ extension GitService {
         return max(parts.count - 1, 0)
     }
 }
+
+extension GitService {
+    /// Resolves a delete-side conflict by removing the file from worktree + index.
+    /// Used for `bothDeleted` / `deletedByUs` / `deletedByThem` resolutions
+    /// where "keep it deleted" is the user's intent.
+    func keepDeleted(worktreePath: URL, relativePath: String) async throws {
+        let result = try await Process.git(["rm", "--", relativePath], cwd: worktreePath)
+        guard result.exitCode == 0 else {
+            throw OperationError.gitFailed(command: "rm", stderr: result.stderr)
+        }
+    }
 }
 
 enum ConflictedFileError: LocalizedError {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1325,6 +1325,32 @@ extension GitService {
     }
 }
 
+extension GitService {
+    func rebase(worktreePath: URL, onto: String) async throws -> MergeResult {
+        let result = try await Process.git(
+            ["-c", "merge.conflictStyle=zdiff3", "rebase", onto],
+            cwd: worktreePath
+        )
+        return try await classifyOperationResult(
+            worktreePath: worktreePath,
+            exitCode: result.exitCode,
+            stderr: result.stderr
+        )
+    }
+
+    func cherryPick(worktreePath: URL, sha: String) async throws -> MergeResult {
+        let result = try await Process.git(
+            ["-c", "merge.conflictStyle=zdiff3", "cherry-pick", sha],
+            cwd: worktreePath
+        )
+        return try await classifyOperationResult(
+            worktreePath: worktreePath,
+            exitCode: result.exitCode,
+            stderr: result.stderr
+        )
+    }
+}
+
 enum ConflictedFileError: LocalizedError {
     case notConflicted(path: String)
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1366,6 +1366,29 @@ enum ConflictedFileError: LocalizedError {
 }
 
 extension GitService {
+    /// Resolves a conflict by accepting LOCAL/HEAD content (`git checkout --ours <path>`).
+    /// Caller is responsible for staging via `markResolved` afterwards.
+    func useOurs(worktreePath: URL, relativePath: String) async throws {
+        let result = try await Process.git(
+            ["checkout", "--ours", "--", relativePath],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else {
+            throw OperationError.gitFailed(command: "checkout --ours", stderr: result.stderr)
+        }
+    }
+
+    /// Resolves a conflict by accepting REMOTE/incoming content (`git checkout --theirs <path>`).
+    func useTheirs(worktreePath: URL, relativePath: String) async throws {
+        let result = try await Process.git(
+            ["checkout", "--theirs", "--", relativePath],
+            cwd: worktreePath
+        )
+        guard result.exitCode == 0 else {
+            throw OperationError.gitFailed(command: "checkout --theirs", stderr: result.stderr)
+        }
+    }
+
     /// Stages a file (`git add <path>`). Used after the user marks a
     /// conflict resolution complete.
     func markResolved(worktreePath: URL, relativePath: String) async throws {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1291,6 +1291,40 @@ extension GitService {
     }
 }
 
+extension GitService {
+    /// Runs `git merge <branch>` with the zdiff3 conflict style so the
+    /// on-disk merged file includes the BASE section inline. Returns:
+    ///   - .clean   on a fast-forward or no-conflict merge
+    ///   - .conflict(files)   when the working tree is left in conflict
+    ///   - .error(message)    for any other non-zero exit
+    func merge(worktreePath: URL, branch: String) async throws -> MergeResult {
+        let result = try await Process.git(
+            ["-c", "merge.conflictStyle=zdiff3", "merge", branch, "--no-edit"],
+            cwd: worktreePath
+        )
+        return try await classifyOperationResult(
+            worktreePath: worktreePath,
+            exitCode: result.exitCode,
+            stderr: result.stderr
+        )
+    }
+
+    /// After running any conflict-producing operation, check the worktree
+    /// state and classify. Used by merge, rebase, cherry-pick, continue.
+    func classifyOperationResult(worktreePath: URL, exitCode: Int32, stderr: String) async throws -> MergeResult {
+        if exitCode == 0 {
+            return .clean
+        }
+        let changes = try await status(worktreePath: worktreePath)
+        let conflicted = changes.filter { $0.conflict != nil }
+        if !conflicted.isEmpty {
+            return .conflict(files: conflicted)
+        }
+        let msg = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return .error(message: msg.isEmpty ? "Operation failed with exit code \(exitCode)" : msg)
+    }
+}
+
 enum ConflictedFileError: LocalizedError {
     case notConflicted(path: String)
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1287,8 +1287,14 @@ extension GitService {
         }
 
         var commits: [RebasePlanCommit] = []
-        let range = lastInt >= 1 ? (1...lastInt) : (1...0)
-        for i in range {
+        // Guard the range: a missing or unparsable `last` would make
+        // `1...lastInt` trap (Range requires lowerBound <= upperBound).
+        // Return an empty plan in that case so the OperationCard still
+        // surfaces with Continue/Abort, just without a per-commit list.
+        guard lastInt >= 1 else {
+            return RebasePlan(ontoBranch: ontoRef, sourceBranch: source, commits: [])
+        }
+        for i in 1...lastInt {
             let patchName = String(format: "%04d", i)
             var summary = "commit \(i)"
             if let patchContent = readFile(patchName) {

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1361,3 +1361,88 @@ enum ConflictedFileError: LocalizedError {
         }
     }
 }
+
+extension GitService {
+    /// Stages a file (`git add <path>`). Used after the user marks a
+    /// conflict resolution complete.
+    func markResolved(worktreePath: URL, relativePath: String) async throws {
+        let result = try await Process.git(["add", "--", relativePath], cwd: worktreePath)
+        guard result.exitCode == 0 else {
+            throw OperationError.gitFailed(
+                command: "add",
+                stderr: result.stderr
+            )
+        }
+    }
+
+    /// `git merge --continue` / `git rebase --continue` / `git cherry-pick --continue`,
+    /// chosen by the operation kind. Returns the same MergeResult shape as
+    /// the initiating call — a rebase Continue may produce a new conflict
+    /// on the next commit.
+    func continueOperation(worktreePath: URL, op: MergeOperation) async throws -> MergeResult {
+        let subcommand: String
+        switch op {
+        case .merge:      subcommand = "merge"
+        case .rebase:     subcommand = "rebase"
+        case .cherryPick: subcommand = "cherry-pick"
+        }
+        let result = try await Process.git(
+            ["-c", "merge.conflictStyle=zdiff3", "-c", "core.editor=true", subcommand, "--continue"],
+            cwd: worktreePath
+        )
+        return try await classifyOperationResult(
+            worktreePath: worktreePath,
+            exitCode: result.exitCode,
+            stderr: result.stderr
+        )
+    }
+
+    /// `git <op> --abort`. Restores the worktree and clears in-progress state.
+    func abortOperation(worktreePath: URL, op: MergeOperation) async throws {
+        let subcommand: String
+        switch op {
+        case .merge:      subcommand = "merge"
+        case .rebase:     subcommand = "rebase"
+        case .cherryPick: subcommand = "cherry-pick"
+        }
+        let result = try await Process.git([subcommand, "--abort"], cwd: worktreePath)
+        guard result.exitCode == 0 else {
+            throw OperationError.gitFailed(command: "\(subcommand) --abort", stderr: result.stderr)
+        }
+    }
+
+    /// `git rebase --skip` / `git cherry-pick --skip`. Throws for `.merge`
+    /// (merge has no --skip).
+    func skipOperation(worktreePath: URL, op: MergeOperation) async throws -> MergeResult {
+        let subcommand: String
+        switch op {
+        case .rebase:     subcommand = "rebase"
+        case .cherryPick: subcommand = "cherry-pick"
+        case .merge:      throw OperationError.skipNotSupported
+        }
+        let result = try await Process.git(
+            ["-c", "merge.conflictStyle=zdiff3", "-c", "core.editor=true", subcommand, "--skip"],
+            cwd: worktreePath
+        )
+        return try await classifyOperationResult(
+            worktreePath: worktreePath,
+            exitCode: result.exitCode,
+            stderr: result.stderr
+        )
+    }
+}
+
+enum OperationError: LocalizedError {
+    case gitFailed(command: String, stderr: String)
+    case skipNotSupported
+
+    var errorDescription: String? {
+        switch self {
+        case .gitFailed(let cmd, let stderr):
+            let msg = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            return msg.isEmpty ? "git \(cmd) failed" : msg
+        case .skipNotSupported:
+            return "Skip is not supported for a merge."
+        }
+    }
+}

--- a/Alas/Sources/Git/GitTypes.swift
+++ b/Alas/Sources/Git/GitTypes.swift
@@ -23,11 +23,14 @@ struct Worktree: Identifiable, Equatable, Codable {
 struct ChangedFile: Identifiable, Equatable, Codable {
     var id: String { "\(stage.rawValue):\(path)" }
     let path: String
-    let status: String   // "A" | "M" | "D" | "R"
+    let status: String   // "A" | "M" | "D" | "R" | "U" (unmerged)
     let stage: ChangeStage
     let add: Int
     let del: Int
     let renameFrom: String?
+    /// Non-nil when this file is in a git unmerged (conflicted) state.
+    /// Nil for all clean changes. Defaulted for Codable back-compat.
+    var conflict: ConflictKind? = nil
 }
 
 enum ChangeStage: String, Codable {
@@ -61,4 +64,83 @@ struct FileTreeNode: Identifiable, Equatable, Codable {
     var isSubmodule: Bool = false
 
     enum Kind: String, Codable { case dir, file }
+}
+
+/// Classification of a git unmerged (conflicted) file. Mirrors git's
+/// porcelain=v2 `u XY` two-letter code where each letter is one of
+/// `D`eleted, `A`dded, `U`pdated on each side.
+enum ConflictKind: String, Codable, Equatable {
+    case bothModified       // UU
+    case bothAdded          // AA
+    case bothDeleted        // DD
+    case addedByUs          // AU
+    case addedByThem        // UA
+    case deletedByUs        // DU
+    case deletedByThem      // UD
+
+    /// Returns nil for `XY` pairs that don't represent a conflict.
+    static func fromPorcelainXY(_ xy: String) -> ConflictKind? {
+        switch xy {
+        case "UU": return .bothModified
+        case "AA": return .bothAdded
+        case "DD": return .bothDeleted
+        case "AU": return .addedByUs
+        case "UA": return .addedByThem
+        case "DU": return .deletedByUs
+        case "UD": return .deletedByThem
+        default:   return nil
+        }
+    }
+}
+
+/// The three sides of a conflicted file, plus the on-disk merged
+/// buffer with conflict markers. Loaded via `GitService.conflictedFile`.
+struct ConflictedFile: Equatable {
+    let relativePath: String
+    let kind: ConflictKind
+    let base: String?      // nil for `bothAdded` (no common ancestor)
+    let local: String?     // nil for `deletedByUs`
+    let remote: String?    // nil for `deletedByThem`
+    let merged: String     // the on-disk file with conflict markers
+    let isBinary: Bool
+}
+
+/// An in-progress conflict-producing operation. Detected by the presence
+/// of marker files inside `.git`: `MERGE_HEAD`, `rebase-merge/`, or
+/// `CHERRY_PICK_HEAD`.
+enum MergeOperation: Equatable {
+    /// Merging another branch into the current one.
+    /// - sourceBranch: the branch being merged in (read from MERGE_MSG / MERGE_HEAD ref)
+    case merge(sourceBranch: String?)
+
+    /// Rebase in progress. `plan` is the parsed contents of
+    /// `.git/rebase-merge/git-rebase-todo` plus `done`.
+    case rebase(plan: RebasePlan)
+
+    /// Cherry-picking a single commit. `sha` and the first line of the
+    /// commit message are exposed for the operation card.
+    case cherryPick(sha: String, summary: String)
+}
+
+struct RebasePlan: Equatable {
+    let ontoBranch: String?    // target ref, read from rebase-merge/onto
+    let sourceBranch: String?  // original branch, read from rebase-merge/head-name
+    let commits: [RebasePlanCommit]
+    var currentIndex: Int? {
+        commits.firstIndex(where: { $0.state == .current })
+    }
+}
+
+struct RebasePlanCommit: Equatable {
+    enum State: Equatable { case done, current, pending }
+    let sha: String          // short SHA as it appears in the todo file
+    let summary: String      // first line of commit message
+    let state: State
+}
+
+/// Outcome of running an operation that may produce conflicts.
+enum MergeResult: Equatable {
+    case clean
+    case conflict(files: [ChangedFile])
+    case error(message: String)
 }

--- a/Alas/Sources/Git/StatusParser.swift
+++ b/Alas/Sources/Git/StatusParser.swift
@@ -37,13 +37,13 @@ enum StatusParser {
             } else if line.hasPrefix("u ") {
                 // Porcelain v2 unmerged record:
                 //   u <xy> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>
-                // 11 fields before <path> (one xy, one sub, three modes, one
-                // worktree mode, three blob hashes) → maxSplits: 11 leaves
-                // <path> intact even when it contains spaces.
-                let tokens = line.split(separator: " ", maxSplits: 11, omittingEmptySubsequences: true).map(String.init)
-                if tokens.count >= 12 {
+                // 10 fields before <path> (record type + xy + sub + three
+                // modes + worktree mode + three blob hashes) → 11 total fields;
+                // maxSplits: 10 leaves <path> intact even when it contains spaces.
+                let tokens = line.split(separator: " ", maxSplits: 10, omittingEmptySubsequences: true).map(String.init)
+                if tokens.count >= 11 {
                     let xy = tokens[1]
-                    let path = tokens[11]
+                    let path = tokens[10]
                     let kind = ConflictKind.fromPorcelainXY(xy) ?? .bothModified
                     result.append(ChangedFile(
                         path: path,

--- a/Alas/Sources/Git/StatusParser.swift
+++ b/Alas/Sources/Git/StatusParser.swift
@@ -35,6 +35,11 @@ enum StatusParser {
                 result.append(ChangedFile(path: path, status: "A", stage: .unstaged, add: 0, del: 0, renameFrom: nil))
                 i += 1
             } else if line.hasPrefix("u ") {
+                // Porcelain v2 unmerged record:
+                //   u <xy> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>
+                // 11 fields before <path> (one xy, one sub, three modes, one
+                // worktree mode, three blob hashes) → maxSplits: 11 leaves
+                // <path> intact even when it contains spaces.
                 let tokens = line.split(separator: " ", maxSplits: 11, omittingEmptySubsequences: true).map(String.init)
                 if tokens.count >= 12 {
                     let xy = tokens[1]

--- a/Alas/Sources/Git/StatusParser.swift
+++ b/Alas/Sources/Git/StatusParser.swift
@@ -35,11 +35,20 @@ enum StatusParser {
                 result.append(ChangedFile(path: path, status: "A", stage: .unstaged, add: 0, del: 0, renameFrom: nil))
                 i += 1
             } else if line.hasPrefix("u ") {
-                // unmerged: surface as M for v1
-                let tokens = line.split(separator: " ", maxSplits: 10, omittingEmptySubsequences: true).map(String.init)
-                if tokens.count >= 11 {
-                    let path = tokens[10]
-                    result.append(ChangedFile(path: path, status: "M", stage: .unstaged, add: 0, del: 0, renameFrom: nil))
+                let tokens = line.split(separator: " ", maxSplits: 11, omittingEmptySubsequences: true).map(String.init)
+                if tokens.count >= 12 {
+                    let xy = tokens[1]
+                    let path = tokens[11]
+                    let kind = ConflictKind.fromPorcelainXY(xy) ?? .bothModified
+                    result.append(ChangedFile(
+                        path: path,
+                        status: "U",
+                        stage: .unstaged,
+                        add: 0,
+                        del: 0,
+                        renameFrom: nil,
+                        conflict: kind
+                    ))
                 }
                 i += 1
             } else {

--- a/Alas/Sources/Right/ChangedRow.swift
+++ b/Alas/Sources/Right/ChangedRow.swift
@@ -77,6 +77,7 @@ struct StatusBadge: View {
         case "A": return theme.color("add").opacity(0.18)
         case "D": return theme.color("del").opacity(0.18)
         case "R": return theme.color("info").opacity(0.18)
+        case "U": return theme.color("warn").opacity(0.20)
         default:  return theme.color("mod").opacity(0.20)
         }
     }
@@ -85,6 +86,7 @@ struct StatusBadge: View {
         case "A": return theme.color("add")
         case "D": return theme.color("del")
         case "R": return theme.color("info")
+        case "U": return theme.color("warn")
         default:  return theme.color("mod")
         }
     }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -163,7 +163,8 @@ struct ChangesTabView: View {
                 expanded: $rps.commitsExpanded,
                 onSelect: onSelectCommit,
                 onCopySHA: copyCommitSHA,
-                onLoadOlder: { Task { @MainActor in await rps.loadOlder() } }
+                onLoadOlder: { Task { @MainActor in await rps.loadOlder() } },
+                rps: rps
             )
         }
     }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -80,6 +80,7 @@ struct ChangesTabView: View {
                 onSelect: onSelect,
                 onUseOurs: { file in rps.useOurs(file: file) },
                 onUseTheirs: { file in rps.useTheirs(file: file) },
+                onKeepDeleted: { file in rps.keepDeleted(file: file) },
                 onMarkResolved: { file in rps.markResolved(file: file) }
             )
 

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -17,9 +17,51 @@ struct ChangesTabView: View {
         rps.changes.filter { $0.stage == .staged }.reduce(0) { $0 + $1.del }
     }
 
+    private var conflicts: [ChangedFile] {
+        rps.changes.filter { $0.conflict != nil }
+    }
+
+    private var nonConflictChanges: [ChangedFile] {
+        rps.changes.filter { $0.conflict == nil }
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
+                if let op = rps.mergeOp.current {
+                    OperationCard(
+                        operation: op,
+                        hasUnresolvedConflicts: !conflicts.isEmpty,
+                        onContinue: { rps.continueOperation() },
+                        onSkip: { rps.skipOperation() },
+                        onAbort: { rps.abortOperation() }
+                    )
+                }
+
+                ConflictsSection(
+                    conflicts: conflicts,
+                    onSelect: onSelect,
+                    onUseOurs: { file in
+                        Task {
+                            _ = try? await Process.git(
+                                ["checkout", "--ours", "--", file.path],
+                                cwd: rps.worktree.path
+                            )
+                            rps.markResolved(file: file)
+                        }
+                    },
+                    onUseTheirs: { file in
+                        Task {
+                            _ = try? await Process.git(
+                                ["checkout", "--theirs", "--", file.path],
+                                cwd: rps.worktree.path
+                            )
+                            rps.markResolved(file: file)
+                        }
+                    },
+                    onMarkResolved: { file in rps.markResolved(file: file) }
+                )
+
                 if stagedCount > 0 {
                     CommitComposerView(
                         state: rps.composer,
@@ -36,7 +78,7 @@ struct ChangesTabView: View {
                     )
                 }
                 WorkingTreeSectionView(
-                    changes: rps.changes,
+                    changes: nonConflictChanges,
                     expanded: $rps.workingTreeExpanded,
                     onSelect: onSelect,
                     onToggleStage: { rps.toggleStage($0) },

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -7,6 +7,13 @@ struct ChangesTabView: View {
     let onSelect: (ChangedFile) -> Void
     let onSelectCommit: (CommitInfo) -> Void
 
+    @State private var pendingMergeBranch: String = ""
+    @State private var pendingRebaseOnto: String = ""
+    @State private var branchesForPicker: [String] = []
+    @State private var branchesLoading: Bool = false
+    @State private var showMergePicker: Bool = false
+    @State private var showRebasePicker: Bool = false
+
     private var stagedCount: Int {
         rps.changes.filter { $0.stage == .staged }.count
     }
@@ -26,121 +33,216 @@ struct ChangesTabView: View {
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                if let op = rps.mergeOp.current {
-                    OperationCard(
-                        operation: op,
-                        hasUnresolvedConflicts: !conflicts.isEmpty,
-                        onContinue: { rps.continueOperation() },
-                        onSkip: { rps.skipOperation() },
-                        onAbort: { rps.abortOperation() }
-                    )
-                }
+        VStack(alignment: .leading, spacing: 0) {
+            branchOpsToolbar
+            ScrollView {
+                scrollContent
+            }
+        }
+        .popover(isPresented: $showMergePicker, arrowEdge: .bottom) {
+            branchPickerSheet(title: "Merge into current",
+                              actionLabel: "Merge",
+                              selection: $pendingMergeBranch,
+                              onConfirm: {
+                                  guard !pendingMergeBranch.isEmpty else { return }
+                                  rps.runMerge(branch: pendingMergeBranch)
+                                  showMergePicker = false
+                                  pendingMergeBranch = ""
+                              })
+        }
+        .popover(isPresented: $showRebasePicker, arrowEdge: .bottom) {
+            branchPickerSheet(title: "Rebase current onto",
+                              actionLabel: "Rebase",
+                              selection: $pendingRebaseOnto,
+                              onConfirm: {
+                                  guard !pendingRebaseOnto.isEmpty else { return }
+                                  rps.runRebase(onto: pendingRebaseOnto)
+                                  showRebasePicker = false
+                                  pendingRebaseOnto = ""
+                              })
+        }
+    }
 
-                ConflictsSection(
-                    conflicts: conflicts,
-                    onSelect: onSelect,
-                    onUseOurs: { file in
-                        Task {
-                            _ = try? await Process.git(
-                                ["checkout", "--ours", "--", file.path],
-                                cwd: rps.worktree.path
-                            )
-                            rps.markResolved(file: file)
-                        }
-                    },
-                    onUseTheirs: { file in
-                        Task {
-                            _ = try? await Process.git(
-                                ["checkout", "--theirs", "--", file.path],
-                                cwd: rps.worktree.path
-                            )
-                            rps.markResolved(file: file)
-                        }
-                    },
-                    onMarkResolved: { file in rps.markResolved(file: file) }
-                )
-
-                if stagedCount > 0 {
-                    CommitComposerView(
-                        state: rps.composer,
-                        appState: appState,
-                        stagedCount: stagedCount,
-                        stagedAdd: stagedAdd,
-                        stagedDel: stagedDel,
-                        branchName: branchName,
-                        availableAgents: appState.agentRegistry.enabled(),
-                        aiToolId: appState.bind(\.changes.aiToolId),
-                        onGenerate: handleGenerate,
-                        onCommit: { rps.runCommit() },
-                        onAmendToggle: { rps.amendDidChange($0) }
-                    )
-                }
-                WorkingTreeSectionView(
-                    changes: nonConflictChanges,
-                    expanded: $rps.workingTreeExpanded,
-                    onSelect: onSelect,
-                    onToggleStage: { rps.toggleStage($0) },
-                    onStageAll: { rps.stageAll($0) },
-                    onUnstageAll: { rps.unstageAll($0) },
-                    onIgnore: { path, isDir, dest in
-                        rps.ignore(path: path, isDirectory: isDir, destination: dest)
-                    },
-                    onDiscardAll: { rps.requestDiscardAll() },
-                    onDiscardFolder: { path in rps.requestDiscardFolder(path: path) },
-                    onOpenFile: { file in
-                        appState.openFile(relativePath: file.path, worktreeId: rps.worktree.id)
-                    },
-                    onCopyRelative: { file in
-                        Clipboard.copy(file.path)
-                    },
-                    onCopyFull: { file in
-                        let absolute = rps.worktree.path.appendingPathComponent(file.path).path
-                        Clipboard.copy(absolute)
-                    },
-                    onRevealInFinder: { file in
-                        let url = rps.worktree.path.appendingPathComponent(file.path)
-                        NSWorkspace.shared.activateFileViewerSelecting([url])
-                    },
-                    onCopyDiff: { file in
-                        rps.copyDiff(for: file.path, renameFrom: file.renameFrom)
-                    },
-                    onDiscardFile: { file in rps.requestDiscardFile(path: file.path) },
-                    isOpenFileEnabled: { file in
-                        DiffOpenFileAvailability.isAvailable(
-                            worktreePath: rps.worktree.path,
-                            relativePath: file.path
-                        )
-                    }
-                )
-                Divider().opacity(0.4)
-                CommitsSectionView(
-                    commits: rps.commits,
-                    olderCommits: rps.olderCommits,
-                    comparisonRef: rps.comparisonRef,
-                    hasMoreOlder: rps.hasMoreOlder,
-                    isLoadingOlder: rps.isLoadingOlder,
-                    behindBase: rps.showBehindBaseChip ? rps.behindBase : nil,
-                    behindUpstream: rps.showBehindUpstreamChip ? rps.behindUpstream : nil,
-                    expanded: $rps.commitsExpanded,
-                    onSelect: onSelectCommit,
-                    onCopySHA: copyCommitSHA,
-                    onLoadOlder: { Task { @MainActor in await rps.loadOlder() } }
+    private var scrollContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let op = rps.mergeOp.current {
+                OperationCard(
+                    operation: op,
+                    hasUnresolvedConflicts: !conflicts.isEmpty,
+                    onContinue: { rps.continueOperation() },
+                    onSkip: { rps.skipOperation() },
+                    onAbort: { rps.abortOperation() }
                 )
             }
+
+            ConflictsSection(
+                conflicts: conflicts,
+                onSelect: onSelect,
+                onUseOurs: { file in
+                    Task {
+                        _ = try? await Process.git(
+                            ["checkout", "--ours", "--", file.path],
+                            cwd: rps.worktree.path
+                        )
+                        rps.markResolved(file: file)
+                    }
+                },
+                onUseTheirs: { file in
+                    Task {
+                        _ = try? await Process.git(
+                            ["checkout", "--theirs", "--", file.path],
+                            cwd: rps.worktree.path
+                        )
+                        rps.markResolved(file: file)
+                    }
+                },
+                onMarkResolved: { file in rps.markResolved(file: file) }
+            )
+
+            if stagedCount > 0 {
+                CommitComposerView(
+                    state: rps.composer,
+                    appState: appState,
+                    stagedCount: stagedCount,
+                    stagedAdd: stagedAdd,
+                    stagedDel: stagedDel,
+                    branchName: branchName,
+                    availableAgents: appState.agentRegistry.enabled(),
+                    aiToolId: appState.bind(\.changes.aiToolId),
+                    onGenerate: handleGenerate,
+                    onCommit: { rps.runCommit() },
+                    onAmendToggle: { rps.amendDidChange($0) }
+                )
+            }
+            WorkingTreeSectionView(
+                changes: nonConflictChanges,
+                expanded: $rps.workingTreeExpanded,
+                onSelect: onSelect,
+                onToggleStage: { rps.toggleStage($0) },
+                onStageAll: { rps.stageAll($0) },
+                onUnstageAll: { rps.unstageAll($0) },
+                onIgnore: { path, isDir, dest in
+                    rps.ignore(path: path, isDirectory: isDir, destination: dest)
+                },
+                onDiscardAll: { rps.requestDiscardAll() },
+                onDiscardFolder: { path in rps.requestDiscardFolder(path: path) },
+                onOpenFile: { file in
+                    appState.openFile(relativePath: file.path, worktreeId: rps.worktree.id)
+                },
+                onCopyRelative: { file in
+                    Clipboard.copy(file.path)
+                },
+                onCopyFull: { file in
+                    let absolute = rps.worktree.path.appendingPathComponent(file.path).path
+                    Clipboard.copy(absolute)
+                },
+                onRevealInFinder: { file in
+                    let url = rps.worktree.path.appendingPathComponent(file.path)
+                    NSWorkspace.shared.activateFileViewerSelecting([url])
+                },
+                onCopyDiff: { file in
+                    rps.copyDiff(for: file.path, renameFrom: file.renameFrom)
+                },
+                onDiscardFile: { file in rps.requestDiscardFile(path: file.path) },
+                isOpenFileEnabled: { file in
+                    DiffOpenFileAvailability.isAvailable(
+                        worktreePath: rps.worktree.path,
+                        relativePath: file.path
+                    )
+                }
+            )
+            Divider().opacity(0.4)
+            CommitsSectionView(
+                commits: rps.commits,
+                olderCommits: rps.olderCommits,
+                comparisonRef: rps.comparisonRef,
+                hasMoreOlder: rps.hasMoreOlder,
+                isLoadingOlder: rps.isLoadingOlder,
+                behindBase: rps.showBehindBaseChip ? rps.behindBase : nil,
+                behindUpstream: rps.showBehindUpstreamChip ? rps.behindUpstream : nil,
+                expanded: $rps.commitsExpanded,
+                onSelect: onSelectCommit,
+                onCopySHA: copyCommitSHA,
+                onLoadOlder: { Task { @MainActor in await rps.loadOlder() } }
+            )
+        }
+    }
+
+    private var branchOpsToolbar: some View {
+        HStack(spacing: 6) {
+            Menu {
+                Button("Merge branch into this worktree…") { openMergePicker() }
+                Button("Rebase this worktree onto…")      { openRebasePicker() }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.triangle.merge")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Branch")
+                        .font(.system(size: 11))
+                }
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(Color.gray.opacity(0.05))
+    }
+
+    @ViewBuilder
+    private func branchPickerSheet(title: String,
+                                   actionLabel: String,
+                                   selection: Binding<String>,
+                                   onConfirm: @escaping () -> Void) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.system(size: 12, weight: .semibold))
+            BranchPicker(
+                selection: selection,
+                branches: branchesForPicker,
+                isLoading: branchesLoading,
+                errorMessage: nil
+            )
+            .frame(width: 280)
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    showMergePicker = false
+                    showRebasePicker = false
+                }
+                Button(actionLabel, action: onConfirm)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(selection.wrappedValue.isEmpty)
+            }
+        }
+        .padding(12)
+    }
+
+    private func openMergePicker() {
+        Task { await loadBranches() }
+        showMergePicker = true
+    }
+
+    private func openRebasePicker() {
+        Task { await loadBranches() }
+        showRebasePicker = true
+    }
+
+    private func loadBranches() async {
+        branchesLoading = true
+        defer { branchesLoading = false }
+        let svc = GitService()
+        if let list = try? await svc.branches(at: rps.worktree.path) {
+            branchesForPicker = list
         }
     }
 
     private var branchName: String? {
-        // The worktree branch is already in `Worktree.branch`; fall back to
-        // nil so the composer renders "(detached)" when we don't have one.
         let b = rps.worktree.branch
         return b.isEmpty ? nil : b
     }
 
     private func handleGenerate() {
-        // Re-click while busy = cancel the in-flight generation.
         if rps.composer.busy {
             rps.cancelGenerate()
             return

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -78,24 +78,8 @@ struct ChangesTabView: View {
             ConflictsSection(
                 conflicts: conflicts,
                 onSelect: onSelect,
-                onUseOurs: { file in
-                    Task {
-                        _ = try? await Process.git(
-                            ["checkout", "--ours", "--", file.path],
-                            cwd: rps.worktree.path
-                        )
-                        rps.markResolved(file: file)
-                    }
-                },
-                onUseTheirs: { file in
-                    Task {
-                        _ = try? await Process.git(
-                            ["checkout", "--theirs", "--", file.path],
-                            cwd: rps.worktree.path
-                        )
-                        rps.markResolved(file: file)
-                    }
-                },
+                onUseOurs: { file in rps.useOurs(file: file) },
+                onUseTheirs: { file in rps.useTheirs(file: file) },
                 onMarkResolved: { file in rps.markResolved(file: file) }
             )
 

--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -6,10 +6,12 @@ struct CommitRow: View {
     var isHistorical: Bool = false
     let onSelect: () -> Void
     let onCopySHA: () -> Void
+    var onCherryPick: (() -> Void)? = nil
 
     @Environment(\.theme) private var theme
     @StateObject private var copyFeedback = CopyFeedbackState()
     @State private var shaHovering = false
+    @State private var pendingCherryPick = false
 
     var body: some View {
         Button(action: onSelect) {
@@ -30,6 +32,22 @@ struct CommitRow: View {
         .copyFeedbackOverlay(message: copyFeedback.message)
         .contextMenu {
             Button("Copy Commit SHA") { copySHA() }
+            if onCherryPick != nil {
+                Divider()
+                Button("Cherry-pick…") { pendingCherryPick = true }
+            }
+        }
+        .confirmationDialog(
+            "Cherry-pick commit?",
+            isPresented: $pendingCherryPick,
+            titleVisibility: .visible
+        ) {
+            Button("Cherry-pick \(String(commit.sha.prefix(7)))", role: .destructive) {
+                onCherryPick?()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Apply this commit to the current branch.")
         }
     }
 

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -31,6 +31,7 @@ struct CommitsSectionView: View {
     let onSelect: (CommitInfo) -> Void
     let onCopySHA: (CommitInfo) -> Void
     let onLoadOlder: () -> Void
+    let rps: RightPaneState
 
     @Environment(\.theme) private var theme
 
@@ -82,7 +83,8 @@ struct CommitsSectionView: View {
                     commit: commit,
                     isLast: idx == commits.count - 1 && olderCommits.isEmpty,
                     onSelect: { onSelect(commit) },
-                    onCopySHA: { onCopySHA(commit) }
+                    onCopySHA: { onCopySHA(commit) },
+                    onCherryPick: { rps.runCherryPick(sha: commit.sha) }
                 )
             }
         } else if olderCommits.isEmpty {
@@ -103,7 +105,8 @@ struct CommitsSectionView: View {
                     isLast: idx == olderCommits.count - 1,
                     isHistorical: comparisonRef != nil,
                     onSelect: { onSelect(commit) },
-                    onCopySHA: { onCopySHA(commit) }
+                    onCopySHA: { onCopySHA(commit) },
+                    onCherryPick: { rps.runCherryPick(sha: commit.sha) }
                 )
             }
         }

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -5,6 +5,7 @@ struct ConflictsSection: View {
     let onSelect: (ChangedFile) -> Void
     let onUseOurs: (ChangedFile) -> Void
     let onUseTheirs: (ChangedFile) -> Void
+    let onKeepDeleted: (ChangedFile) -> Void
     let onMarkResolved: (ChangedFile) -> Void
 
     var body: some View {
@@ -48,11 +49,35 @@ struct ConflictsSection: View {
         }
         .buttonStyle(.plain)
         .contextMenu {
+            menuItems(for: file)
+        }
+    }
+
+    @ViewBuilder
+    private func menuItems(for file: ChangedFile) -> some View {
+        switch file.conflict {
+        case .bothModified, .bothAdded:
             Button("Use ours") { onUseOurs(file) }
             Button("Use theirs") { onUseTheirs(file) }
-            Divider()
-            Button("Mark resolved") { onMarkResolved(file) }
+        case .addedByUs:
+            Button("Keep ours") { onUseOurs(file) }
+        case .addedByThem:
+            Button("Keep theirs") { onUseTheirs(file) }
+        case .deletedByUs:
+            // ours = deleted; theirs = modified
+            Button("Keep theirs") { onUseTheirs(file) }
+            Button("Keep deleted") { onKeepDeleted(file) }
+        case .deletedByThem:
+            // ours = modified; theirs = deleted
+            Button("Keep ours") { onUseOurs(file) }
+            Button("Keep deleted") { onKeepDeleted(file) }
+        case .bothDeleted:
+            Button("Keep deleted") { onKeepDeleted(file) }
+        case nil:
+            EmptyView()
         }
+        Divider()
+        Button("Mark resolved") { onMarkResolved(file) }
     }
 
     private func iconName(for kind: ConflictKind?) -> String {

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+struct ConflictsSection: View {
+    let conflicts: [ChangedFile]
+    let onSelect: (ChangedFile) -> Void
+    let onUseOurs: (ChangedFile) -> Void
+    let onUseTheirs: (ChangedFile) -> Void
+    let onMarkResolved: (ChangedFile) -> Void
+
+    var body: some View {
+        if conflicts.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Conflicts (\(conflicts.count))")
+                    .font(.system(size: 10, weight: .semibold))
+                    .textCase(.uppercase)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.top, 6)
+                    .padding(.bottom, 2)
+                ForEach(conflicts) { file in
+                    row(for: file)
+                }
+            }
+            .padding(.bottom, 4)
+        }
+    }
+
+    private func row(for file: ChangedFile) -> some View {
+        Button(action: { onSelect(file) }) {
+            HStack(spacing: 6) {
+                Image(systemName: iconName(for: file.conflict))
+                    .foregroundColor(iconColor(for: file.conflict))
+                    .frame(width: 14)
+                Text(file.path)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundColor(.primary)
+                Spacer()
+                Text(kindLabel(file.conflict))
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("Use ours") { onUseOurs(file) }
+            Button("Use theirs") { onUseTheirs(file) }
+            Divider()
+            Button("Mark resolved") { onMarkResolved(file) }
+        }
+    }
+
+    private func iconName(for kind: ConflictKind?) -> String {
+        switch kind {
+        case .bothModified, .bothAdded, .bothDeleted, nil:
+            return "exclamationmark.triangle.fill"
+        case .deletedByUs, .deletedByThem:
+            return "trash.fill"
+        case .addedByUs, .addedByThem:
+            return "plus.circle.fill"
+        }
+    }
+
+    private func iconColor(for kind: ConflictKind?) -> Color {
+        switch kind {
+        case .bothDeleted: return .red
+        default:           return .orange
+        }
+    }
+
+    private func kindLabel(_ kind: ConflictKind?) -> String {
+        switch kind {
+        case .bothModified:  return "both modified"
+        case .bothAdded:     return "both added"
+        case .bothDeleted:   return "both deleted"
+        case .addedByUs:     return "added by us"
+        case .addedByThem:   return "added by them"
+        case .deletedByUs:   return "deleted by us"
+        case .deletedByThem: return "deleted by them"
+        case nil:            return ""
+        }
+    }
+}

--- a/Alas/Sources/Right/MergeOperationState.swift
+++ b/Alas/Sources/Right/MergeOperationState.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Observation
+
+/// Per-worktree, observable holder for the current in-progress
+/// merge/rebase/cherry-pick (or nil when the worktree is idle).
+/// Refreshed by `RightPaneState` whenever it refreshes `changes`.
+@Observable
+final class MergeOperationState {
+    private(set) var current: MergeOperation? = nil
+    /// Set when the most recent `refresh()` failed; surfaced in the UI as
+    /// a non-fatal warning. Cleared on the next successful refresh.
+    private(set) var lastError: String? = nil
+
+    private let worktreePath: URL
+    private let gitService: GitService
+
+    init(worktreePath: URL, gitService: GitService) {
+        self.worktreePath = worktreePath
+        self.gitService = gitService
+    }
+
+    /// Re-reads .git marker files and updates `current`. Safe to call
+    /// frequently — only inspects local files (no network).
+    func refresh() async {
+        do {
+            current = try await gitService.mergeState(worktreePath: worktreePath)
+            lastError = nil
+        } catch {
+            lastError = (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription
+            // Keep `current` as-is so transient errors don't flap the UI.
+        }
+    }
+}

--- a/Alas/Sources/Right/MergeOperationState.swift
+++ b/Alas/Sources/Right/MergeOperationState.swift
@@ -7,9 +7,6 @@ import Observation
 @Observable
 final class MergeOperationState {
     private(set) var current: MergeOperation? = nil
-    /// Set when the most recent `refresh()` failed; surfaced in the UI as
-    /// a non-fatal warning. Cleared on the next successful refresh.
-    private(set) var lastError: String? = nil
 
     private let worktreePath: URL
     private let gitService: GitService
@@ -24,11 +21,9 @@ final class MergeOperationState {
     func refresh() async {
         do {
             current = try await gitService.mergeState(worktreePath: worktreePath)
-            lastError = nil
         } catch {
-            lastError = (error as? LocalizedError)?.errorDescription
-                ?? error.localizedDescription
             // Keep `current` as-is so transient errors don't flap the UI.
+            // (Errors are not surfaced in v1; see Plan 2 for an error pill on the OperationCard.)
         }
     }
 }

--- a/Alas/Sources/Right/OperationCard.swift
+++ b/Alas/Sources/Right/OperationCard.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+struct OperationCard: View {
+    let operation: MergeOperation
+    let hasUnresolvedConflicts: Bool
+    let onContinue: () -> Void
+    let onSkip: () -> Void
+    let onAbort: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            header
+            subtitle
+            if case .rebase(let plan) = operation, !plan.commits.isEmpty {
+                progressBar(plan: plan)
+                planList(plan: plan)
+            }
+            actions
+        }
+        .padding(10)
+        .background(
+            LinearGradient(
+                colors: [Color.orange.opacity(0.25), Color.orange.opacity(0.10)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .overlay(Rectangle().frame(height: 1).foregroundColor(.black.opacity(0.3)), alignment: .bottom)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.orange)
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(.orange)
+        }
+    }
+
+    private var title: String {
+        switch operation {
+        case .merge:      return "Merging"
+        case .rebase:     return "Rebasing"
+        case .cherryPick: return "Cherry-picking"
+        }
+    }
+
+    private var subtitle: some View {
+        Text(subtitleText)
+            .font(.system(size: 11))
+            .foregroundColor(.primary)
+    }
+
+    private var subtitleText: String {
+        switch operation {
+        case .merge(let src):
+            if let src { return "\(src) into current branch" }
+            return "into current branch"
+        case .rebase(let plan):
+            let position = (plan.currentIndex.map { "commit \($0 + 1) of \(plan.commits.count)" }) ?? "in progress"
+            switch (plan.sourceBranch, plan.ontoBranch) {
+            case let (src?, onto?): return "\(src) onto \(onto) · \(position)"
+            case let (src?, nil):   return "\(src) · \(position)"
+            default:                return position
+            }
+        case .cherryPick(let sha, let summary):
+            return "\(String(sha.prefix(7))) · \(summary)"
+        }
+    }
+
+    private func progressBar(plan: RebasePlan) -> some View {
+        let done = plan.commits.filter { $0.state == .done }.count
+        let current = plan.commits.contains { $0.state == .current } ? 1 : 0
+        let fraction = Double(done + current) / Double(max(plan.commits.count, 1))
+        return GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Rectangle().fill(Color.black.opacity(0.3))
+                Rectangle().fill(Color.orange).frame(width: proxy.size.width * fraction)
+            }
+        }
+        .frame(height: 4)
+        .clipShape(RoundedRectangle(cornerRadius: 2))
+    }
+
+    private func planList(plan: RebasePlan) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            ForEach(plan.commits.prefix(6), id: \.sha) { commit in
+                HStack(spacing: 4) {
+                    Text(symbol(commit.state))
+                        .foregroundColor(color(commit.state))
+                    Text(commit.summary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .foregroundColor(color(commit.state))
+                }
+                .font(.system(size: 10))
+            }
+            if plan.commits.count > 6 {
+                Text("…\(plan.commits.count - 6) more")
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.top, 4)
+        .padding(.bottom, 2)
+    }
+
+    private func symbol(_ s: RebasePlanCommit.State) -> String {
+        switch s { case .done: return "✓"; case .current: return "▸"; case .pending: return "·" }
+    }
+    private func color(_ s: RebasePlanCommit.State) -> Color {
+        switch s { case .done: return .green; case .current: return .orange; case .pending: return .secondary }
+    }
+
+    private var actions: some View {
+        HStack(spacing: 4) {
+            Button(action: onContinue) { Text("Continue").font(.system(size: 11)) }
+                .buttonStyle(.borderedProminent)
+                .tint(.green)
+                .disabled(hasUnresolvedConflicts)
+            if case .merge = operation {} else {
+                Button(action: onSkip) { Text("Skip").font(.system(size: 11)) }
+                    .buttonStyle(.bordered)
+            }
+            Spacer()
+            Button(action: onAbort) { Text("Abort").font(.system(size: 11)) }
+                .buttonStyle(.bordered)
+                .tint(.red)
+        }
+        .padding(.top, 4)
+    }
+}

--- a/Alas/Sources/Right/OperationCard.swift
+++ b/Alas/Sources/Right/OperationCard.swift
@@ -107,10 +107,14 @@ struct OperationCard: View {
     }
 
     private func symbol(_ s: RebasePlanCommit.State) -> String {
-        switch s { case .done: return "✓"; case .current: return "▸"; case .pending: return "·" }
+        switch s { case .done: return "✓"
+        case .current: return "▸"
+        case .pending: return "·" }
     }
     private func color(_ s: RebasePlanCommit.State) -> Color {
-        switch s { case .done: return .green; case .current: return .orange; case .pending: return .secondary }
+        switch s { case .done: return .green
+        case .current: return .orange
+        case .pending: return .secondary }
     }
 
     private var actions: some View {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -972,6 +972,18 @@ final class RightPaneState {
     }
 
     @MainActor
+    func keepDeleted(file: ChangedFile) {
+        Task { @MainActor in
+            do {
+                try await git.keepDeleted(worktreePath: worktree.path, relativePath: file.path)
+                await refresh()
+            } catch {
+                logger.error("keepDeleted failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
     func markResolved(file: ChangedFile) {
         Task { @MainActor in
             do {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -10,6 +10,9 @@ enum RightPaneTab: String { case changes, files }
 final class RightPaneState {
     let worktree: Worktree
     var changes: [ChangedFile] = []
+    /// Per-worktree in-progress merge / rebase / cherry-pick state.
+    /// Refreshed alongside `changes` from `refresh()`.
+    let mergeOp: MergeOperationState
     var composer = CommitComposerState()
     var fileTree: [FileTreeNode] = []
     var loading: Bool = false
@@ -69,6 +72,11 @@ final class RightPaneState {
     /// that construct `RightPaneState` directly.
     var closeDiffTabs: (([String]) -> Void)? = nil
 
+    /// Injected by `RightPaneStore` to open the conflict resolution UI for a
+    /// given file. In Plan 1, this routes to the existing unified DiffTabView.
+    /// In Plan 2, it will route to the new 3-column merge editor.
+    var openConflict: ((String) -> Void)? = nil
+
     private let git = GitService()
     private let watcher: WorktreeWatcher
     private let logger = Logger(subsystem: "io.nlopez.alas", category: "right-pane-state")
@@ -103,6 +111,7 @@ final class RightPaneState {
         self.worktree = worktree
         self.baseBranch = baseBranch
         self.currentBranch = worktree.branch
+        self.mergeOp = MergeOperationState(worktreePath: worktree.path, gitService: GitService())
         self.watcher = WorktreeWatcher(path: worktree.path)
         watcher.onChange = { [weak self] in
             Task { @MainActor in await self?.refresh() }
@@ -148,6 +157,7 @@ final class RightPaneState {
             async let s = git.status(worktreePath: worktree.path)
             async let c = git.commitsAhead(at: worktree.path, baseBranch: baseBranch)
             async let br = git.currentBranch(worktreePath: worktree.path)
+            async let mergeRefresh: Void = mergeOp.refresh()
             let entries = try await s
             let tree = try await git.fileTree(worktreePath: worktree.path, statusEntries: entries)
             let (commits, ref) = try await c
@@ -186,6 +196,7 @@ final class RightPaneState {
                 }
                 didInitDefaultTab = true
             }
+            _ = await mergeRefresh
         } catch {
             // Surface failures via os.Logger so they're visible in Console.app
             // and the unified log. The previous `print` here silently kept
@@ -847,6 +858,117 @@ final class RightPaneState {
         } catch {
             logger.error("loadOlder failed for worktree \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             self.hasMoreOlder = false
+        }
+    }
+
+    // MARK: - Merge / rebase / cherry-pick operations
+
+    /// Runs `git merge <branch>`, refreshes state, and auto-opens the first
+    /// conflicted file (via `openConflict`) when the result is a conflict.
+    @MainActor
+    func runMerge(branch: String) {
+        Task { @MainActor in
+            do {
+                let result = try await git.merge(worktreePath: worktree.path, branch: branch)
+                await refresh()
+                handleOperationResult(result)
+            } catch {
+                logger.error("merge failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
+    func runRebase(onto: String) {
+        Task { @MainActor in
+            do {
+                let result = try await git.rebase(worktreePath: worktree.path, onto: onto)
+                await refresh()
+                handleOperationResult(result)
+            } catch {
+                logger.error("rebase failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
+    func runCherryPick(sha: String) {
+        Task { @MainActor in
+            do {
+                let result = try await git.cherryPick(worktreePath: worktree.path, sha: sha)
+                await refresh()
+                handleOperationResult(result)
+            } catch {
+                logger.error("cherry-pick failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
+    func continueOperation() {
+        Task { @MainActor in
+            guard let op = mergeOp.current else { return }
+            do {
+                let result = try await git.continueOperation(worktreePath: worktree.path, op: op)
+                await refresh()
+                handleOperationResult(result)
+            } catch {
+                logger.error("continue failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
+    func abortOperation() {
+        Task { @MainActor in
+            guard let op = mergeOp.current else { return }
+            do {
+                try await git.abortOperation(worktreePath: worktree.path, op: op)
+                await refresh()
+            } catch {
+                logger.error("abort failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
+    func skipOperation() {
+        Task { @MainActor in
+            guard let op = mergeOp.current else { return }
+            do {
+                let result = try await git.skipOperation(worktreePath: worktree.path, op: op)
+                await refresh()
+                handleOperationResult(result)
+            } catch {
+                logger.error("skip failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
+    func markResolved(file: ChangedFile) {
+        Task { @MainActor in
+            do {
+                try await git.markResolved(worktreePath: worktree.path, relativePath: file.path)
+                await refresh()
+            } catch {
+                logger.error("markResolved failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// On `.conflict`, auto-open the first conflicted file via the injected
+    /// `openConflict` closure. On `.clean`/`.error`, do nothing (refresh already
+    /// updated the operation card; `.error` is logged but not surfaced for v1).
+    private func handleOperationResult(_ result: MergeResult) {
+        switch result {
+        case .clean:
+            return
+        case .conflict(let files):
+            guard let first = files.first else { return }
+            openConflict?(first.path)
+        case .error(let message):
+            logger.error("operation returned error: \(message, privacy: .public)")
         }
     }
 }

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -161,6 +161,7 @@ final class RightPaneState {
             let entries = try await s
             let tree = try await git.fileTree(worktreePath: worktree.path, statusEntries: entries)
             let (commits, ref) = try await c
+            _ = await mergeRefresh
             self.changes = entries
             self.fileTree = tree
             self.commits = commits
@@ -196,7 +197,6 @@ final class RightPaneState {
                 }
                 didInitDefaultTab = true
             }
-            _ = await mergeRefresh
         } catch {
             // Surface failures via os.Logger so they're visible in Console.app
             // and the unified log. The previous `print` here silently kept

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -946,6 +946,32 @@ final class RightPaneState {
     }
 
     @MainActor
+    func useOurs(file: ChangedFile) {
+        Task { @MainActor in
+            do {
+                try await git.useOurs(worktreePath: worktree.path, relativePath: file.path)
+                try await git.markResolved(worktreePath: worktree.path, relativePath: file.path)
+                await refresh()
+            } catch {
+                logger.error("useOurs failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
+    func useTheirs(file: ChangedFile) {
+        Task { @MainActor in
+            do {
+                try await git.useTheirs(worktreePath: worktree.path, relativePath: file.path)
+                try await git.markResolved(worktreePath: worktree.path, relativePath: file.path)
+                await refresh()
+            } catch {
+                logger.error("useTheirs failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    @MainActor
     func markResolved(file: ChangedFile) {
         Task { @MainActor in
             do {

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -48,6 +48,27 @@ final class RightPaneStore {
                     }
                 }
             }
+            new.openConflict = { [weak self] path in
+                guard let app = self?.appState else { return }
+                // Plan 1 fallback: route conflicted files through the same unified
+                // diff view used elsewhere. Plan 2 will replace this with the new
+                // three-column merge editor.
+                let existing = app.tabs.tabs(forWorktree: id).first { tab in
+                    if case .diff(let s) = tab { return s.relativePath == path && s.staged == false } else { return false }
+                }
+                if let existing {
+                    app.tabs.activate(worktreeId: id, tabId: existing.id)
+                } else {
+                    let title = (path as NSString).lastPathComponent
+                    let tab = app.tabs.appendDiff(
+                        worktreeId: id,
+                        title: title,
+                        relativePath: path,
+                        staged: false
+                    )
+                    app.tabs.activate(worktreeId: id, tabId: tab.id)
+                }
+            }
             states[id] = new
             result = new
         }

--- a/AlasTests/ConflictMarkerParserTests.swift
+++ b/AlasTests/ConflictMarkerParserTests.swift
@@ -29,7 +29,8 @@ struct ConflictMarkerParserTests {
         guard case .text(let pre) = regions[0],
               case .conflict(let block) = regions[1],
               case .text(let post) = regions[2]
-        else { Issue.record("region kinds wrong"); return }
+        else { Issue.record("region kinds wrong")
+        return }
         #expect(pre == "before\n")
         #expect(block.local == "ours line\n")
         #expect(block.remote == "theirs line\n")
@@ -53,7 +54,8 @@ struct ConflictMarkerParserTests {
         let regions = ConflictMarkerParser.parse(input)
         #expect(regions.count == 2)
         guard case .conflict(let block) = regions[0] else {
-            Issue.record("expected leading conflict region"); return
+            Issue.record("expected leading conflict region")
+            return
         }
         #expect(block.local == "ours\n")
         #expect(block.base == "base\n")
@@ -85,7 +87,8 @@ struct ConflictMarkerParserTests {
               case .text = regions[2],
               case .conflict(let second) = regions[3],
               case .text = regions[4]
-        else { Issue.record("region order wrong"); return }
+        else { Issue.record("region order wrong")
+        return }
         #expect(first.local == "a-ours\n")
         #expect(second.local == "b-ours\n")
     }
@@ -103,7 +106,8 @@ struct ConflictMarkerParserTests {
             """
         let regions = ConflictMarkerParser.parse(input)
         guard case .conflict(let block) = regions[1] else {
-            Issue.record("expected conflict region"); return
+            Issue.record("expected conflict region")
+            return
         }
         // Lines are 0-indexed in the merged buffer.
         // Marker lines are 1 (<<<), 3 (===), 5 (>>>).
@@ -145,7 +149,8 @@ struct ConflictMarkerParserTests {
         let input = "<<<<<<< HEAD\n=======\ntheirs\n>>>>>>> feature\n"
         let regions = ConflictMarkerParser.parse(input)
         guard case .conflict(let block) = regions[0] else {
-            Issue.record("expected conflict region"); return
+            Issue.record("expected conflict region")
+            return
         }
         #expect(block.local == "")
         #expect(block.remote == "theirs\n")
@@ -155,7 +160,8 @@ struct ConflictMarkerParserTests {
         let input = "<<<<<<< HEAD\nours\n=======\n>>>>>>> feature\n"
         let regions = ConflictMarkerParser.parse(input)
         guard case .conflict(let block) = regions[0] else {
-            Issue.record("expected conflict region"); return
+            Issue.record("expected conflict region")
+            return
         }
         #expect(block.local == "ours\n")
         #expect(block.remote == "")
@@ -165,7 +171,8 @@ struct ConflictMarkerParserTests {
         let input = "<<<<<<< HEAD\nours\n||||||| ancestor\n=======\ntheirs\n>>>>>>> feature\n"
         let regions = ConflictMarkerParser.parse(input)
         guard case .conflict(let block) = regions[0] else {
-            Issue.record("expected conflict region"); return
+            Issue.record("expected conflict region")
+            return
         }
         #expect(block.local == "ours\n")
         #expect(block.base == "")
@@ -176,7 +183,8 @@ struct ConflictMarkerParserTests {
         let input = "<<<<<<< HEAD\n=======\n>>>>>>> feature\n"
         let regions = ConflictMarkerParser.parse(input)
         guard case .conflict(let block) = regions[0] else {
-            Issue.record("expected conflict region"); return
+            Issue.record("expected conflict region")
+            return
         }
         #expect(block.local == "")
         #expect(block.base == nil)

--- a/AlasTests/ConflictMarkerParserTests.swift
+++ b/AlasTests/ConflictMarkerParserTests.swift
@@ -140,4 +140,46 @@ struct ConflictMarkerParserTests {
         #expect(regions.count == 1)
         if case .text = regions[0] {} else { Issue.record("expected .text region for malformed conflict") }
     }
+
+    @Test func parsesEmptyLocalHalf() {
+        let input = "<<<<<<< HEAD\n=======\ntheirs\n>>>>>>> feature\n"
+        let regions = ConflictMarkerParser.parse(input)
+        guard case .conflict(let block) = regions[0] else {
+            Issue.record("expected conflict region"); return
+        }
+        #expect(block.local == "")
+        #expect(block.remote == "theirs\n")
+    }
+
+    @Test func parsesEmptyRemoteHalf() {
+        let input = "<<<<<<< HEAD\nours\n=======\n>>>>>>> feature\n"
+        let regions = ConflictMarkerParser.parse(input)
+        guard case .conflict(let block) = regions[0] else {
+            Issue.record("expected conflict region"); return
+        }
+        #expect(block.local == "ours\n")
+        #expect(block.remote == "")
+    }
+
+    @Test func parsesEmptyBaseInZdiff3() {
+        let input = "<<<<<<< HEAD\nours\n||||||| ancestor\n=======\ntheirs\n>>>>>>> feature\n"
+        let regions = ConflictMarkerParser.parse(input)
+        guard case .conflict(let block) = regions[0] else {
+            Issue.record("expected conflict region"); return
+        }
+        #expect(block.local == "ours\n")
+        #expect(block.base == "")
+        #expect(block.remote == "theirs\n")
+    }
+
+    @Test func parsesAllHalvesEmpty() {
+        let input = "<<<<<<< HEAD\n=======\n>>>>>>> feature\n"
+        let regions = ConflictMarkerParser.parse(input)
+        guard case .conflict(let block) = regions[0] else {
+            Issue.record("expected conflict region"); return
+        }
+        #expect(block.local == "")
+        #expect(block.base == nil)
+        #expect(block.remote == "")
+    }
 }

--- a/AlasTests/ConflictMarkerParserTests.swift
+++ b/AlasTests/ConflictMarkerParserTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct ConflictMarkerParserTests {
+    @Test func parsesPlainTextAsSingleRegion() {
+        let regions = ConflictMarkerParser.parse("line 1\nline 2\n")
+        #expect(regions.count == 1)
+        if case .text(let s) = regions[0] {
+            #expect(s == "line 1\nline 2\n")
+        } else {
+            Issue.record("expected .text region")
+        }
+    }
+
+    @Test func parsesMergeStyleConflict() {
+        let input = """
+            before
+            <<<<<<< HEAD
+            ours line
+            =======
+            theirs line
+            >>>>>>> feature
+            after
+
+            """
+        let regions = ConflictMarkerParser.parse(input)
+        #expect(regions.count == 3)
+        guard case .text(let pre) = regions[0],
+              case .conflict(let block) = regions[1],
+              case .text(let post) = regions[2]
+        else { Issue.record("region kinds wrong"); return }
+        #expect(pre == "before\n")
+        #expect(block.local == "ours line\n")
+        #expect(block.remote == "theirs line\n")
+        #expect(block.base == nil)
+        #expect(block.localLabel == "HEAD")
+        #expect(block.remoteLabel == "feature")
+        #expect(post == "after\n")
+    }
+
+    @Test func parsesZdiff3StyleConflict() {
+        let input = """
+            <<<<<<< HEAD
+            ours
+            ||||||| merged common ancestors
+            base
+            =======
+            theirs
+            >>>>>>> feature
+
+            """
+        let regions = ConflictMarkerParser.parse(input)
+        #expect(regions.count == 2)
+        guard case .conflict(let block) = regions[0] else {
+            Issue.record("expected leading conflict region"); return
+        }
+        #expect(block.local == "ours\n")
+        #expect(block.base == "base\n")
+        #expect(block.remote == "theirs\n")
+    }
+
+    @Test func parsesMultipleConflictsInOrder() {
+        let input = """
+            top
+            <<<<<<< HEAD
+            a-ours
+            =======
+            a-theirs
+            >>>>>>> x
+            middle
+            <<<<<<< HEAD
+            b-ours
+            =======
+            b-theirs
+            >>>>>>> x
+            bottom
+
+            """
+        let regions = ConflictMarkerParser.parse(input)
+        #expect(regions.count == 5)
+        // text, conflict, text, conflict, text
+        guard case .text = regions[0],
+              case .conflict(let first) = regions[1],
+              case .text = regions[2],
+              case .conflict(let second) = regions[3],
+              case .text = regions[4]
+        else { Issue.record("region order wrong"); return }
+        #expect(first.local == "a-ours\n")
+        #expect(second.local == "b-ours\n")
+    }
+
+    @Test func recordsLineRanges() {
+        let input = """
+            line0
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> x
+            line6
+
+            """
+        let regions = ConflictMarkerParser.parse(input)
+        guard case .conflict(let block) = regions[1] else {
+            Issue.record("expected conflict region"); return
+        }
+        // Lines are 0-indexed in the merged buffer.
+        // Marker lines are 1 (<<<), 3 (===), 5 (>>>).
+        #expect(block.lineRangeInMerged.lowerBound == 1)
+        #expect(block.lineRangeInMerged.upperBound == 5)
+    }
+
+    @Test func conflictMarkersInsideStringLiteralAreStillParsed() {
+        // Real-world ambiguity: we deliberately do NOT try to be smart about
+        // markers that appear inside source-code string literals. ParseFlat:
+        // the only thing that matters is whether the *file* has unmerged
+        // status. ConflictMarkerParser trusts the input.
+        let input = """
+            let template = \"\"\"
+            <<<<<<< not actually a conflict
+            \"\"\"
+
+            """
+        let regions = ConflictMarkerParser.parse(input)
+        // We *will* misparse this — and that's fine because the parser is
+        // only run on files git status reports as unmerged.
+        #expect(regions.count >= 1)
+    }
+
+    @Test func unterminatedConflictIsTreatedAsText() {
+        let input = """
+            <<<<<<< HEAD
+            ours
+
+            """
+        let regions = ConflictMarkerParser.parse(input)
+        // Defensive: if we see <<< without === and >>>, emit everything as
+        // text and let the user fix it manually.
+        #expect(regions.count == 1)
+        if case .text = regions[0] {} else { Issue.record("expected .text region for malformed conflict") }
+    }
+}

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -250,6 +250,30 @@ struct GitServiceMergeTests {
         #expect(after == nil)
     }
 
+    @Test func useOursAcceptsHeadContent() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        let svc = GitService()
+        _ = try await svc.merge(worktreePath: repo, branch: "feature")
+
+        try await svc.useOurs(worktreePath: repo, relativePath: "a.txt")
+        let content = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(content == "main change\n")
+    }
+
+    @Test func useTheirsAcceptsIncomingContent() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        let svc = GitService()
+        _ = try await svc.merge(worktreePath: repo, branch: "feature")
+
+        try await svc.useTheirs(worktreePath: repo, relativePath: "a.txt")
+        let content = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(content == "feature change\n")
+    }
+
     @Test func abortMergeRestoresHead() async throws {
         let repo = try await Self.makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -314,4 +314,35 @@ struct GitServiceMergeTests {
         #expect(plan.commits.contains { $0.state == .current })
     }
 
+    @Test func cherryPickMergeCommitUsesFirstParentMainline() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        // Build a merge commit on `feature`, then try to cherry-pick it onto `main`.
+        try Self.writeFile(repo, "a.txt", "base\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        try Self.writeFile(repo, "b.txt", "from-feature\n")
+        _ = try await Process.git(["add", "b.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add b"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        try Self.writeFile(repo, "c.txt", "from-main\n")
+        _ = try await Process.git(["add", "c.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add c"], cwd: repo)
+        // Create the merge commit on `feature` so it has 2 parents:
+        _ = try await Process.git(["checkout", "-q", "feature"], cwd: repo)
+        _ = try await Process.git(["-c", "core.editor=true", "merge", "main", "--no-ff"], cwd: repo)
+        let mergeSha = try await Process.git(["rev-parse", "HEAD"], cwd: repo).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        // Hard-reset main to before c.txt was added, then cherry-pick the merge commit.
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        _ = try await Process.git(["reset", "--hard", "HEAD~1"], cwd: repo)
+
+        let svc = GitService()
+        let result = try await svc.cherryPick(worktreePath: repo, sha: mergeSha)
+        // Without -m the cherry-pick would error with "is a merge but no -m option was given"
+        // and classifyOperationResult would map it to .error. With -m 1 the result should
+        // be .clean (merge commit applied cleanly).
+        #expect(result == .clean)
+    }
 }

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -211,4 +211,63 @@ struct GitServiceMergeTests {
             return
         }
     }
+
+    @Test func markResolvedStagesFile() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        let svc = GitService()
+        _ = try await svc.merge(worktreePath: repo, branch: "feature")
+
+        // Pretend the user resolved by writing a distinct resolution so it
+        // appears in git status as staged (accepting "ours" verbatim would
+        // produce content identical to HEAD, which git omits from status).
+        try Self.writeFile(repo, "a.txt", "resolved\n")
+        try await svc.markResolved(worktreePath: repo, relativePath: "a.txt")
+
+        let changes = try await svc.status(worktreePath: repo)
+        let entry = changes.first { $0.path == "a.txt" }
+        // After `git add` the file is staged with no remaining conflict.
+        #expect(entry?.stage == .staged)
+        #expect(entry?.conflict == nil)
+    }
+
+    @Test func continueMergeCommitsAndClearsState() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        let svc = GitService()
+        _ = try await svc.merge(worktreePath: repo, branch: "feature")
+        try Self.writeFile(repo, "a.txt", "main change\n")
+        try await svc.markResolved(worktreePath: repo, relativePath: "a.txt")
+
+        let state = try await svc.mergeState(worktreePath: repo)
+        guard case .merge = state else { Issue.record("expected merge state"); return }
+
+        let result = try await svc.continueOperation(worktreePath: repo, op: state!)
+        #expect(result == .clean)
+        let after = try await svc.mergeState(worktreePath: repo)
+        #expect(after == nil)
+    }
+
+    @Test func abortMergeRestoresHead() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        let svc = GitService()
+        let headBefore = try await Process.git(["rev-parse", "HEAD"], cwd: repo).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await svc.merge(worktreePath: repo, branch: "feature")
+
+        let state = try await svc.mergeState(worktreePath: repo)
+        try await svc.abortOperation(worktreePath: repo, op: state!)
+
+        let headAfter = try await Process.git(["rev-parse", "HEAD"], cwd: repo).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        #expect(headBefore == headAfter)
+        let mergedFile = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(!mergedFile.contains("<<<<<<<"))
+        let after = try await svc.mergeState(worktreePath: repo)
+        #expect(after == nil)
+    }
 }

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -101,4 +101,43 @@ struct GitServiceMergeTests {
         }
         #expect(sha.hasPrefix(featureSha.prefix(7)))
     }
+
+    @Test func conflictedFileReadsAllThreeSides() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let svc = GitService()
+        let file = try await svc.conflictedFile(worktreePath: repo, relativePath: "a.txt")
+        #expect(file.relativePath == "a.txt")
+        #expect(file.kind == .bothModified)
+        #expect(file.base == "base\n")
+        #expect(file.local == "main change\n")
+        #expect(file.remote == "feature change\n")
+        #expect(file.merged.contains("<<<<<<<"))
+        #expect(file.merged.contains(">>>>>>>"))
+        #expect(file.isBinary == false)
+    }
+
+    @Test func conflictedFileDetectsBinary() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        // Set up a conflicting binary file by writing different bytes on each branch.
+        let bin = Data([0x00, 0x01, 0x02, 0x03, 0x00, 0xFF])
+        try bin.write(to: repo.appendingPathComponent("a.bin"))
+        _ = try await Process.git(["add", "a.bin"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        try Data([0x00, 0x01, 0x02, 0xAA, 0x00, 0xFF]).write(to: repo.appendingPathComponent("a.bin"))
+        _ = try await Process.git(["commit", "-q", "-am", "feature"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        try Data([0x00, 0x01, 0x02, 0xBB, 0x00, 0xFF]).write(to: repo.appendingPathComponent("a.bin"))
+        _ = try await Process.git(["commit", "-q", "-am", "main"], cwd: repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let svc = GitService()
+        let file = try await svc.conflictedFile(worktreePath: repo, relativePath: "a.bin")
+        #expect(file.isBinary == true)
+    }
 }

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -345,4 +345,34 @@ struct GitServiceMergeTests {
         // be .clean (merge commit applied cleanly).
         #expect(result == .clean)
     }
+
+    @Test func keepDeletedRemovesFileAndStages() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try Self.writeFile(repo, "a.txt", "base\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        try Self.writeFile(repo, "a.txt", "feature modification\n")
+        _ = try await Process.git(["commit", "-q", "-am", "feature"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        _ = try await Process.git(["rm", "-q", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "delete a"], cwd: repo)
+        // Merge feature → main: ours deleted, theirs modified → DU (deletedByUs)
+        let svc = GitService()
+        _ = try await svc.merge(worktreePath: repo, branch: "feature")
+
+        try await svc.keepDeleted(worktreePath: repo, relativePath: "a.txt")
+        // File must be gone from the worktree.
+        let exists = FileManager.default.fileExists(atPath: repo.appendingPathComponent("a.txt").path)
+        #expect(exists == false)
+        // The conflict is resolved: a.txt must no longer appear with a conflict flag.
+        // For a DU conflict, HEAD already had the file deleted; `git rm` removes
+        // the worktree copy and clears the index entry, so a.txt won't appear in
+        // `git status` at all (index and HEAD agree on "absent"). Either absent
+        // or present-without-conflict is acceptable.
+        let changes = try await svc.status(worktreePath: repo)
+        let entry = changes.first { $0.path == "a.txt" }
+        #expect(entry?.conflict == nil)
+    }
 }

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -140,4 +140,45 @@ struct GitServiceMergeTests {
         let file = try await svc.conflictedFile(worktreePath: repo, relativePath: "a.bin")
         #expect(file.isBinary == true)
     }
+
+    @Test func mergeReturnsCleanWhenNoConflict() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try Self.writeFile(repo, "a.txt", "base\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        try Self.writeFile(repo, "b.txt", "new\n")
+        _ = try await Process.git(["add", "b.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "add b"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+
+        let svc = GitService()
+        let result = try await svc.merge(worktreePath: repo, branch: "feature")
+        #expect(result == .clean)
+    }
+
+    @Test func mergeReturnsConflictWhenConflicting() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+
+        let svc = GitService()
+        let result = try await svc.merge(worktreePath: repo, branch: "feature")
+        guard case .conflict(let files) = result else {
+            Issue.record("expected .conflict, got \(result)")
+            return
+        }
+        #expect(files.contains(where: { $0.path == "a.txt" && $0.conflict == .bothModified }))
+    }
+
+    @Test func mergeWritesZdiff3MarkersWithBaseSection() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        let svc = GitService()
+        _ = try await svc.merge(worktreePath: repo, branch: "feature")
+        let merged = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
+        #expect(merged.contains("|||||||"))  // zdiff3 base marker
+    }
 }

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -295,4 +295,23 @@ struct GitServiceMergeTests {
         let after = try await svc.mergeState(worktreePath: repo)
         #expect(after == nil)
     }
+
+    @Test func mergeStateDetectsRebaseApplyInProgress() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+
+        _ = try await Process.git(["checkout", "-q", "feature"], cwd: repo)
+        _ = try await Process.git(["-c", "rebase.backend=apply", "rebase", "main"], cwd: repo)
+
+        let svc = GitService()
+        let state = try await svc.mergeState(worktreePath: repo)
+        guard case .rebase(let plan) = state else {
+            Issue.record("expected .rebase via rebase-apply, got \(String(describing: state))")
+            return
+        }
+        #expect(plan.commits.count >= 1)
+        #expect(plan.commits.contains { $0.state == .current })
+    }
+
 }

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -1,0 +1,104 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct GitServiceMergeTests {
+    fileprivate static func makeRepo() async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-merge-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: dir)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: dir)
+        return dir
+    }
+
+    fileprivate static func writeFile(_ repo: URL, _ name: String, _ contents: String) throws {
+        try contents.write(
+            to: repo.appendingPathComponent(name),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    /// Creates two branches `main` and `feature` whose tips both modify the
+    /// same line of `a.txt`, so a merge will produce a conflict.
+    fileprivate static func makeConflictingBranches(_ repo: URL) async throws {
+        try writeFile(repo, "a.txt", "base\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        try writeFile(repo, "a.txt", "feature change\n")
+        _ = try await Process.git(["commit", "-q", "-am", "feature change"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        try writeFile(repo, "a.txt", "main change\n")
+        _ = try await Process.git(["commit", "-q", "-am", "main change"], cwd: repo)
+    }
+
+    @Test func mergeStateIsNilWhenNothingInProgress() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try Self.writeFile(repo, "a.txt", "hi\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+
+        let svc = GitService()
+        let state = try await svc.mergeState(worktreePath: repo)
+        #expect(state == nil)
+    }
+
+    @Test func mergeStateDetectsMergeInProgress() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+
+        // Trigger a conflicting merge (exit code non-zero, MERGE_HEAD set).
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let svc = GitService()
+        let state = try await svc.mergeState(worktreePath: repo)
+        guard case .merge(let source) = state else {
+            Issue.record("expected .merge state, got \(String(describing: state))")
+            return
+        }
+        #expect(source == "feature" || source == nil)  // git versions vary
+    }
+
+    @Test func mergeStateDetectsRebaseInProgress() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+
+        _ = try await Process.git(["checkout", "-q", "feature"], cwd: repo)
+        _ = try await Process.git(["rebase", "main"], cwd: repo)
+
+        let svc = GitService()
+        let state = try await svc.mergeState(worktreePath: repo)
+        guard case .rebase(let plan) = state else {
+            Issue.record("expected .rebase state, got \(String(describing: state))")
+            return
+        }
+        #expect(plan.commits.count >= 1)
+    }
+
+    @Test func mergeStateDetectsCherryPickInProgress() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+
+        // Cherry-pick feature's tip onto main → conflict, CHERRY_PICK_HEAD set.
+        let featureSha = try await Process.git(["rev-parse", "feature"], cwd: repo).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        _ = try await Process.git(["cherry-pick", featureSha], cwd: repo)
+
+        let svc = GitService()
+        let state = try await svc.mergeState(worktreePath: repo)
+        guard case .cherryPick(let sha, _) = state else {
+            Issue.record("expected .cherryPick state, got \(String(describing: state))")
+            return
+        }
+        #expect(sha.hasPrefix(featureSha.prefix(7)))
+    }
+}

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -181,4 +181,34 @@ struct GitServiceMergeTests {
         let merged = try String(contentsOf: repo.appendingPathComponent("a.txt"), encoding: .utf8)
         #expect(merged.contains("|||||||"))  // zdiff3 base marker
     }
+
+    @Test func rebaseReturnsConflictOnConflict() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["checkout", "-q", "feature"], cwd: repo)
+
+        let svc = GitService()
+        let result = try await svc.rebase(worktreePath: repo, onto: "main")
+        guard case .conflict(let files) = result else {
+            Issue.record("expected .conflict, got \(result)")
+            return
+        }
+        #expect(files.contains(where: { $0.path == "a.txt" }))
+    }
+
+    @Test func cherryPickReturnsConflictOnConflict() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        let featureSha = try await Process.git(["rev-parse", "feature"], cwd: repo).stdout
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let svc = GitService()
+        let result = try await svc.cherryPick(worktreePath: repo, sha: featureSha)
+        guard case .conflict = result else {
+            Issue.record("expected .conflict, got \(result)")
+            return
+        }
+    }
 }

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -314,6 +314,57 @@ struct GitServiceMergeTests {
         #expect(plan.commits.contains { $0.state == .current })
     }
 
+    @Test func mergeStateIgnoresGitAmInProgress() async throws {
+        // `git am` also uses .git/rebase-apply but writes an `applying`
+        // sentinel instead of `rebasing`. We must not classify it as a rebase
+        // (the UI would otherwise drive `rebase --continue/--abort`, which
+        // errors with "It looks like 'git am' is in progress").
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try Self.writeFile(repo, "a.txt", "base\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+
+        // Create a patch that conflicts with the current worktree so `git am`
+        // pauses with `.git/rebase-apply/` populated and the `applying` sentinel.
+        try Self.writeFile(repo, "a.txt", "in-worktree change\n")
+
+        let patch = """
+        From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+        From: t <t@e>
+        Date: Sun, 24 May 2026 21:56:13 +0200
+        Subject: patch
+
+        ---
+         a.txt | 2 +-
+         1 file changed, 1 insertion(+), 1 deletion(-)
+
+        diff --git a/a.txt b/a.txt
+        index 1111111..2222222 100644
+        --- a/a.txt
+        +++ b/a.txt
+        @@ -1 +1 @@
+        -base
+        +patched
+        --
+        2.43.0
+
+        """
+        let patchURL = repo.appendingPathComponent("conflict.patch")
+        try patch.write(to: patchURL, atomically: true, encoding: .utf8)
+        _ = try await Process.git(["am", "--3way", patchURL.path], cwd: repo)
+        // Confirm git am actually paused (rebase-apply dir exists, with `applying`).
+        let applyDir = repo.appendingPathComponent(".git/rebase-apply")
+        guard FileManager.default.fileExists(atPath: applyDir.path) else {
+            Issue.record("expected git am to leave .git/rebase-apply populated")
+            return
+        }
+
+        let svc = GitService()
+        let state = try await svc.mergeState(worktreePath: repo)
+        #expect(state == nil)
+    }
+
     @Test func cherryPickMergeCommitUsesFirstParentMainline() async throws {
         let repo = try await Self.makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -314,6 +314,31 @@ struct GitServiceMergeTests {
         #expect(plan.commits.contains { $0.state == .current })
     }
 
+    @Test func mergeStateDoesNotTrapOnEmptyRebaseApplyMetadata() async throws {
+        // Simulate a transient/incomplete .git/rebase-apply directory: the
+        // `rebasing` sentinel is present but `last` is missing/empty, so the
+        // commit count is unknown. `mergeState` must not crash — it should
+        // return .rebase with an empty plan instead.
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try Self.writeFile(repo, "a.txt", "x\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+
+        let applyDir = repo.appendingPathComponent(".git/rebase-apply")
+        try FileManager.default.createDirectory(at: applyDir, withIntermediateDirectories: true)
+        try "".write(to: applyDir.appendingPathComponent("rebasing"), atomically: true, encoding: .utf8)
+        // `next`/`last` deliberately omitted → parsed as 0.
+
+        let svc = GitService()
+        let state = try await svc.mergeState(worktreePath: repo)
+        guard case .rebase(let plan) = state else {
+            Issue.record("expected .rebase, got \(String(describing: state))")
+            return
+        }
+        #expect(plan.commits.isEmpty)
+    }
+
     @Test func mergeStateIgnoresGitAmInProgress() async throws {
         // `git am` also uses .git/rebase-apply but writes an `applying`
         // sentinel instead of `rebasing`. We must not classify it as a rebase

--- a/AlasTests/GitServiceMergeTests.swift
+++ b/AlasTests/GitServiceMergeTests.swift
@@ -242,7 +242,8 @@ struct GitServiceMergeTests {
         try await svc.markResolved(worktreePath: repo, relativePath: "a.txt")
 
         let state = try await svc.mergeState(worktreePath: repo)
-        guard case .merge = state else { Issue.record("expected merge state"); return }
+        guard case .merge = state else { Issue.record("expected merge state")
+        return }
 
         let result = try await svc.continueOperation(worktreePath: repo, op: state!)
         #expect(result == .clean)

--- a/AlasTests/MergeOperationStateTests.swift
+++ b/AlasTests/MergeOperationStateTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite(.serialized)
+struct MergeOperationStateTests {
+    fileprivate static func makeRepo() async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-mopstate-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: dir)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: dir)
+        return dir
+    }
+
+    @Test func currentIsNilForCleanRepo() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try "x\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+
+        let state = MergeOperationState(worktreePath: repo, gitService: GitService())
+        await state.refresh()
+        #expect(state.current == nil)
+    }
+
+    @Test func currentReflectsInProgressMerge() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        // reuse helper from GitServiceMergeTests
+        try "base\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        try "feature\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["commit", "-q", "-am", "feature"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        try "main\n".write(to: repo.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["commit", "-q", "-am", "main"], cwd: repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let state = MergeOperationState(worktreePath: repo, gitService: GitService())
+        await state.refresh()
+        guard case .merge = state.current else {
+            Issue.record("expected .merge, got \(String(describing: state.current))")
+            return
+        }
+    }
+}

--- a/AlasTests/StatusParserTests.swift
+++ b/AlasTests/StatusParserTests.swift
@@ -82,7 +82,7 @@ struct StatusParserTests {
     }
 
     @Test func parsesUnmergedBothModified() throws {
-        let raw = "u UU N... 100644 100644 100644 100644 a b c d src/foo.rs\u{0}"
+        let raw = "u UU N... 100644 100644 100644 100644 a b c src/foo.rs\u{0}"
         let entries = try StatusParser.parse(raw)
         let entry = try #require(entries.first)
         #expect(entry.status == "U")
@@ -92,7 +92,7 @@ struct StatusParserTests {
     }
 
     @Test func parsesUnmergedPathWithSpaces() throws {
-        let raw = "u UU N... 100644 100644 100644 100644 a b c d dir/a b.txt\u{0}"
+        let raw = "u UU N... 100644 100644 100644 100644 a b c dir/a b.txt\u{0}"
         let entries = try StatusParser.parse(raw)
         let entry = try #require(entries.first)
         #expect(entry.status == "U")
@@ -102,28 +102,28 @@ struct StatusParserTests {
     }
 
     @Test func parsesUnmergedDeletedByThem() throws {
-        let raw = "u UD N... 100644 100644 000000 100644 a b 0 d src/foo.rs\u{0}"
+        let raw = "u UD N... 100644 100644 000000 100644 a b 0 src/foo.rs\u{0}"
         let entries = try StatusParser.parse(raw)
         let entry = try #require(entries.first)
         #expect(entry.conflict == .deletedByThem)
     }
 
     @Test func parsesUnmergedDeletedByUs() throws {
-        let raw = "u DU N... 100644 000000 100644 100644 a 0 c d src/foo.rs\u{0}"
+        let raw = "u DU N... 100644 000000 100644 100644 a 0 c src/foo.rs\u{0}"
         let entries = try StatusParser.parse(raw)
         let entry = try #require(entries.first)
         #expect(entry.conflict == .deletedByUs)
     }
 
     @Test func parsesUnmergedBothAdded() throws {
-        let raw = "u AA N... 000000 100644 100644 100644 0 b c d src/foo.rs\u{0}"
+        let raw = "u AA N... 000000 100644 100644 100644 0 b c src/foo.rs\u{0}"
         let entries = try StatusParser.parse(raw)
         let entry = try #require(entries.first)
         #expect(entry.conflict == .bothAdded)
     }
 
     @Test func parsesUnmergedBothDeleted() throws {
-        let raw = "u DD N... 100644 000000 000000 100644 a 0 0 d src/foo.rs\u{0}"
+        let raw = "u DD N... 100644 000000 000000 100644 a 0 0 src/foo.rs\u{0}"
         let entries = try StatusParser.parse(raw)
         let entry = try #require(entries.first)
         #expect(entry.conflict == .bothDeleted)

--- a/AlasTests/StatusParserTests.swift
+++ b/AlasTests/StatusParserTests.swift
@@ -81,12 +81,51 @@ struct StatusParserTests {
         #expect(entry.path == "scratch.txt")
     }
 
-    @Test func parsesUnmergedPathWithSpaces() throws {
-        let raw = "u UU N... 100644 100644 100644 100644 a b c dir/a b.txt\u{0}"
+    @Test func parsesUnmergedBothModified() throws {
+        let raw = "u UU N... 100644 100644 100644 100644 a b c d src/foo.rs\u{0}"
         let entries = try StatusParser.parse(raw)
         let entry = try #require(entries.first)
-        #expect(entry.status == "M")
+        #expect(entry.status == "U")
+        #expect(entry.stage == .unstaged)
+        #expect(entry.path == "src/foo.rs")
+        #expect(entry.conflict == .bothModified)
+    }
+
+    @Test func parsesUnmergedPathWithSpaces() throws {
+        let raw = "u UU N... 100644 100644 100644 100644 a b c d dir/a b.txt\u{0}"
+        let entries = try StatusParser.parse(raw)
+        let entry = try #require(entries.first)
+        #expect(entry.status == "U")
         #expect(entry.stage == .unstaged)
         #expect(entry.path == "dir/a b.txt")
+        #expect(entry.conflict == .bothModified)
+    }
+
+    @Test func parsesUnmergedDeletedByThem() throws {
+        let raw = "u UD N... 100644 100644 000000 100644 a b 0 d src/foo.rs\u{0}"
+        let entries = try StatusParser.parse(raw)
+        let entry = try #require(entries.first)
+        #expect(entry.conflict == .deletedByThem)
+    }
+
+    @Test func parsesUnmergedDeletedByUs() throws {
+        let raw = "u DU N... 100644 000000 100644 100644 a 0 c d src/foo.rs\u{0}"
+        let entries = try StatusParser.parse(raw)
+        let entry = try #require(entries.first)
+        #expect(entry.conflict == .deletedByUs)
+    }
+
+    @Test func parsesUnmergedBothAdded() throws {
+        let raw = "u AA N... 000000 100644 100644 100644 0 b c d src/foo.rs\u{0}"
+        let entries = try StatusParser.parse(raw)
+        let entry = try #require(entries.first)
+        #expect(entry.conflict == .bothAdded)
+    }
+
+    @Test func parsesUnmergedBothDeleted() throws {
+        let raw = "u DD N... 100644 000000 000000 100644 a 0 0 d src/foo.rs\u{0}"
+        let entries = try StatusParser.parse(raw)
+        let entry = try #require(entries.first)
+        #expect(entry.conflict == .bothDeleted)
     }
 }


### PR DESCRIPTION
## Summary

End-to-end orchestration for merge, rebase, and cherry-pick from inside alas — without the in-app conflict editor (that's Plan 2).

- **Status parsing**: `StatusParser` now decodes git's `u XY` unmerged records into a typed `ConflictKind` instead of flattening them all to `M`. Existing consumers see `status == "U"` and a populated `conflict` field on `ChangedFile`.
- **GitService**: new methods for the full lifecycle — `mergeState`, `conflictedFile`, `merge`, `rebase`, `cherryPick`, `continueOperation`, `abortOperation`, `skipOperation`, `markResolved`, `useOurs`, `useTheirs`. All use shell-out via the existing `Process.git()` pattern and emit zdiff3-style markers (`merge.conflictStyle=zdiff3`) so the BASE section is preserved in the on-disk merged file (used later by the 3-column editor).
- **Conflict marker parser**: pure-Swift `ConflictMarkerParser` that splits a file into `[ConflictRegion]` (text + conflict blocks with optional base). Handles merge + zdiff3 styles and malformed input.
- **Right-pane surface**:
  - `MergeOperationState` (`@Observable`) holds the current in-progress operation per worktree, refreshed alongside the existing status reload.
  - `OperationCard` view shows operation title, rebase plan with progress bar, and Continue / Skip / Abort buttons.
  - `ConflictsSection` lists conflicted files with kind-specific icons and a use-ours / use-theirs / mark-resolved context menu.
  - `ChangesTabView` now hosts both above its existing sections, a "Branch" Menu button (Merge / Rebase via the existing `BranchPicker` popover), and filters conflicts out of the working-tree section so files don't double-list.
  - Cherry-pick wired onto commit-row context menu (`CommitRow` + `CommitsSectionView`).
- **Tests**: new `ConflictMarkerParserTests`, `GitServiceMergeTests`, `MergeOperationStateTests` spinning up real temp git repos. Pre-existing test failures (LanguageServerRegistry/kotlin, ImageFileType/svg, CommitRow/copyFeedback, HoverFeature, WorktreeService/LFS) are unrelated and exist on `main`.

## Out of scope (deferred to follow-up plans)

- **Plan 2** — the three-column merge editor in the center pane. Clicking a conflict today opens the existing unified `DiffTabView`.
- **Plan 3** — agent-assisted "explain both sides" / "resolve this file", binary/image conflict viewer, rename/delete conflict UI beyond the generic context menu.

## Test plan

- [ ] `xcodebuild test -only-testing:AlasTests/StatusParserTests` (13 tests, all green)
- [ ] `xcodebuild test -only-testing:AlasTests/ConflictMarkerParserTests` (11 tests, all green)
- [ ] `xcodebuild test -only-testing:AlasTests/GitServiceMergeTests` (13 tests, all green)
- [ ] `xcodebuild test -only-testing:AlasTests/MergeOperationStateTests` (2 tests, all green)
- [ ] Manual: open a real test repo with two conflicting branches, run Branch → Merge from alas, verify Operation card + Conflicts list, use Use ours / Continue, confirm clean merge commit lands and op card disappears.
- [ ] Manual: same flow for Rebase (Branch → Rebase) and Cherry-pick (right-click commit).
- [ ] Manual: Abort restores HEAD; conflict markers are gone from the working tree.