### PR TITLE
fix: strip trailing period from Ghostty file links when file not found

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1556,47 +1556,61 @@ final class AppState {
             return cwdRelative
         }
 
-        let target: TerminalOpenTarget
-        let resolved = resolve(path)
-        if FileManager.default.fileExists(atPath: resolved.path) {
-            target = TerminalOpenTarget(url: resolved, revealLine: nil, revealCharacter: nil)
-        } else if let parsed = Self.parseTerminalPathPosition(path) {
-            let resolvedParsed = resolve(parsed.path)
-            target = TerminalOpenTarget(
-                url: resolvedParsed,
-                revealLine: parsed.line - 1,
-                revealCharacter: (parsed.column ?? 1) - 1
+        func attemptOpen(_ candidatePath: String) -> Bool {
+            let target: TerminalOpenTarget
+            let resolved = resolve(candidatePath)
+            if FileManager.default.fileExists(atPath: resolved.path) {
+                target = TerminalOpenTarget(url: resolved, revealLine: nil, revealCharacter: nil)
+            } else if let parsed = Self.parseTerminalPathPosition(candidatePath) {
+                let resolvedParsed = resolve(parsed.path)
+                target = TerminalOpenTarget(
+                    url: resolvedParsed,
+                    revealLine: parsed.line - 1,
+                    revealCharacter: (parsed.column ?? 1) - 1
+                )
+            } else {
+                return false
+            }
+
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: target.url.path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue else { return false }
+
+            // Resolve symlinks on both sides before the containment check so that
+            // an in-tree symlink pointing outside the worktree (e.g.
+            // `worktree/escape -> /elsewhere`) doesn't get routed to the editor.
+            let resolvedTarget = target.url.resolvingSymlinksInPath().standardizedFileURL
+            let resolvedRoot = worktree.path.resolvingSymlinksInPath().standardizedFileURL
+            let rootComponents = resolvedRoot.pathComponents
+            let targetComponents = resolvedTarget.pathComponents
+            guard targetComponents.count > rootComponents.count,
+                  Array(targetComponents.prefix(rootComponents.count)) == rootComponents else {
+                return false
+            }
+            let relativePath = targetComponents.dropFirst(rootComponents.count).joined(separator: "/")
+            guard !relativePath.isEmpty else { return false }
+
+            openFile(
+                relativePath: relativePath,
+                worktreeId: worktree.id,
+                revealLine: target.revealLine,
+                revealCharacter: target.revealCharacter
             )
-        } else {
-            target = TerminalOpenTarget(url: resolved, revealLine: nil, revealCharacter: nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return true
         }
 
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: target.url.path, isDirectory: &isDirectory),
-              !isDirectory.boolValue else { return false }
+        if attemptOpen(path) { return true }
 
-        // Resolve symlinks on both sides before the containment check so that
-        // an in-tree symlink pointing outside the worktree (e.g.
-        // `worktree/escape -> /elsewhere`) doesn't get routed to the editor.
-        let resolvedTarget = target.url.resolvingSymlinksInPath().standardizedFileURL
-        let resolvedRoot = worktree.path.resolvingSymlinksInPath().standardizedFileURL
-        let rootComponents = resolvedRoot.pathComponents
-        let targetComponents = resolvedTarget.pathComponents
-        guard targetComponents.count > rootComponents.count,
-              Array(targetComponents.prefix(rootComponents.count)) == rootComponents else {
-            return false
+        // Trailing-period fallback: agents sometimes write paths like
+        // "src/foo.ts." where the final period is sentence punctuation that
+        // Ghostty includes in the link. Retry without it.
+        if path.hasSuffix(".") {
+            let trimmed = String(path.dropLast())
+            if !trimmed.isEmpty { return attemptOpen(trimmed) }
         }
-        let relativePath = targetComponents.dropFirst(rootComponents.count).joined(separator: "/")
-        guard !relativePath.isEmpty else { return false }
 
-        openFile(
-            relativePath: relativePath,
-            worktreeId: worktree.id,
-            revealLine: target.revealLine,
-            revealCharacter: target.revealCharacter
-        )
-        NSApp.activate(ignoringOtherApps: true)
-        return true
+        return false
     }
 
     private struct TerminalOpenTarget {

--- a/AlasTests/AppStateCLIRoutingTests.swift
+++ b/AlasTests/AppStateCLIRoutingTests.swift
@@ -300,6 +300,80 @@ struct AppStateCLIRoutingTests {
         #expect(handled == false)
     }
 
+    @Test func routeTerminalOpenURLStripsTrailingPeriodWhenFileIsMissing() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-trailing-dot")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let file = worktree.path.appendingPathComponent("hello.swift")
+        try "x\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        surface.setCurrentWorkingDirectory(worktree.path)
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: "hello.swift.", sessionId: "s1")
+
+        #expect(handled == true)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .editor(let s) = $0 { return s.relativePath == "hello.swift" }
+            return false
+        })
+    }
+
+    @Test func routeTerminalOpenURLStripsTrailingPeriodWithPosition() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-trailing-dot-pos")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        let file = worktree.path.appendingPathComponent("hello.swift")
+        try "first\nsecond\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        surface.setCurrentWorkingDirectory(worktree.path)
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: "hello.swift:2.", sessionId: "s1")
+
+        #expect(handled == true)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .editor(let s) = $0 {
+                return s.relativePath == "hello.swift"
+                    && s.revealLine == 1
+                    && s.revealCharacter == 0
+            }
+            return false
+        })
+    }
+
+    @Test func routeTerminalOpenURLPrefersExactPathEndingWithPeriod() async throws {
+        let (state, project, worktree) = try await makeStateWithWorktree(name: "ghostty-exact-dot")
+        defer { try? FileManager.default.removeItem(at: worktree.path) }
+        // Create a file whose name actually ends with a period.
+        let file = worktree.path.appendingPathComponent("Makefile.")
+        try "x\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        surface.setCurrentWorkingDirectory(worktree.path)
+        let session = TerminalSession(
+            id: "s1", worktreeId: worktree.id, projectId: project.id,
+            surface: surface, executable: "/bin/zsh", args: []
+        )
+        state.terminal.registry.register(session)
+
+        let handled = state.routeTerminalOpenURL(rawURL: "Makefile.", sessionId: "s1")
+
+        #expect(handled == true)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).contains {
+            if case .editor(let s) = $0 { return s.relativePath == "Makefile." }
+            return false
+        })
+    }
+
     @Test func makeCLICommandRouterOpensExternalFileOnOriginatingWorktreeAndSelectsIt() async throws {
         let (state, _, worktree) = try await makeStateWithWorktree(name: "external")
         defer { try? FileManager.default.removeItem(at: worktree.path) }


### PR DESCRIPTION
## Summary
- try Ghostty file links exactly first
- when the exact file is missing and the path ends with a period, retry after stripping that trailing period
- add routing tests for fallback behavior, line positions, and exact filenames ending in a period

## Tests
- Not run here; pre-existing GhosttyKit.xcframework build issue in this worktree prevents full build/test execution.