### PR TITLE
feat(right): clickable base branch selector in commits header

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */; };
 		376A08C73011C5CA9E445C4B /* ImageDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */; };
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
+		38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */; };
 		395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */; };
 		3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */; };
 		39DE92AE4B12D2CD03655562 /* CommitPromptStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */; };
@@ -764,6 +765,7 @@
 		6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateOverlayFocusTests.swift; sourceTree = "<group>"; };
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherFilterTests.swift; sourceTree = "<group>"; };
+		6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateBaseBranchTests.swift; sourceTree = "<group>"; };
 		674F70D8D27715223D10C582 /* MergeConflictResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResultView.swift; sourceTree = "<group>"; };
 		679E62B501E0490F48CCA830 /* EditorFindBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindBarView.swift; sourceTree = "<group>"; };
 		6821B71680094791995C4975 /* ShortcutsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsPane.swift; sourceTree = "<group>"; };
@@ -1258,6 +1260,7 @@
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
 				220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */,
 				784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */,
+				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
 				4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */,
 				3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */,
 				5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */,
@@ -2641,6 +2644,7 @@
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,
+				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
 				21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */,
 				8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */,
 				35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
 		41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */; };
 		41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */; };
+		4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */; };
 		422B560D70571FF42F0E78E6 /* ThreePaneSizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */; };
 		4239885256AB11FE8207D31E /* TextEditCoordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8062405A67C934905EE61D98 /* TextEditCoordinates.swift */; };
 		42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */; };
@@ -343,6 +344,7 @@
 		A2E0A755C2854FE489530FE3 /* ImageDiffDifferenceComputer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */; };
 		A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */; };
 		A4AB930CA0EEA2CEF0302646 /* ImageCheckerboardBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */; };
+		A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
 		A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563B664D082A9523260AA2EF /* RepoDot.swift */; };
 		A75289A4560BCA2DACA0760B /* AppStateCreateWorktreeSymlinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */; };
@@ -540,6 +542,7 @@
 
 /* Begin PBXFileReference section */
 		00057A43DD2D53F8F79FAC43 /* ShortcutActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutActionTests.swift; sourceTree = "<group>"; };
+		002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBranchSelector.swift; sourceTree = "<group>"; };
 		00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPickerTests.swift; sourceTree = "<group>"; };
 		008E982C8526670670425AB8 /* EmptyTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabView.swift; sourceTree = "<group>"; };
 		010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowConfigurator.swift; sourceTree = "<group>"; };
@@ -772,6 +775,7 @@
 		6B3F942D660C7ABA8542C77D /* ImageFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileType.swift; sourceTree = "<group>"; };
 		6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModelTests.swift; sourceTree = "<group>"; };
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
+		6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBranchSelectorTests.swift; sourceTree = "<group>"; };
 		6D46BDE72E52818061452ECB /* CommitRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRowTests.swift; sourceTree = "<group>"; };
 		6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagingTests.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1140,6 +1144,7 @@
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
+				6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */,
 				71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */,
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
@@ -1439,6 +1444,7 @@
 		413E432DDAAAE618029482C3 /* Right */ = {
 			isa = PBXGroup;
 			children = (
+				002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */,
 				3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */,
 				C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */,
 				3DCEFADD952DB870B8BAB890 /* CommitRow.swift */,
@@ -2204,6 +2210,7 @@
 				5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */,
 				8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */,
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
+				4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */,
 				9E302329243407946D47DC91 /* BranchPicker.swift in Sources */,
 				7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */,
 				139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */,
@@ -2502,6 +2509,7 @@
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
+				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1025,13 +1025,28 @@ extension GitService {
     }
 
     /// Resolves the base ref to compare against for a given worktree.
-    /// Returns nil when neither `origin/<base>` nor local `<base>` exists.
+    /// Returns nil when neither `origin/<base>`, `refs/remotes/<base>`, nor local `<base>` exists.
     /// `remote == nil` means "no fetch path; use the local ref as-is".
     func resolveBaseRef(
         worktreePath: URL,
         baseBranch: String
     ) async throws -> (remote: String?, baseRef: String)? {
         guard !baseBranch.isEmpty else { return nil }
+
+        // If baseBranch already contains a slash (e.g. "upstream/main"),
+        // try it as a direct remote-tracking ref first.
+        if baseBranch.contains("/") {
+            let directRef = "refs/remotes/\(baseBranch)"
+            let directCheck = try await Process.git(
+                ["show-ref", "--verify", "--quiet", directRef],
+                cwd: worktreePath
+            )
+            if directCheck.exitCode == 0 {
+                let parts = baseBranch.split(separator: "/", maxSplits: 1)
+                let remote = parts.count > 1 ? String(parts[0]) : nil
+                return (remote: remote, baseRef: baseBranch)
+            }
+        }
 
         // Prefer origin/<base>.
         let originRef = "refs/remotes/origin/\(baseBranch)"

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -775,19 +775,21 @@ extension GitService {
     ///
     /// One `git log` invocation parses subject + author + ISO date +
     /// per-commit numstat in a single pass to avoid N round-trips.
-    func commitsAhead(at worktree: URL, baseBranch: String? = nil) async throws -> (commits: [CommitInfo], comparisonRef: String?) {
+    func commitsAhead(at worktree: URL, baseBranch: String? = nil, ignoreUpstream: Bool = false) async throws -> (commits: [CommitInfo], comparisonRef: String?) {
         // Step 1: Resolve upstream first. `--symbolic-full-name @{u}` returns
         // `refs/remotes/origin/main`; `--abbrev-ref @{u}` returns
         // `origin/main`. Use the abbreviated form for display.
-        let up = try await Process.git(
-            ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
-            cwd: worktree
-        )
         var upstreamName: String? = nil
-        if up.exitCode == 0 {
-            let candidate = up.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !candidate.isEmpty && candidate != "@{u}" {
-                upstreamName = candidate
+        if !ignoreUpstream {
+            let up = try await Process.git(
+                ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+                cwd: worktree
+            )
+            if up.exitCode == 0 {
+                let candidate = up.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !candidate.isEmpty && candidate != "@{u}" {
+                    upstreamName = candidate
+                }
             }
         }
 

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -1030,7 +1030,7 @@ extension GitService {
     func resolveBaseRef(
         worktreePath: URL,
         baseBranch: String
-    ) async throws -> (remote: String?, baseRef: String)? {
+    ) async throws -> (remote: String?, baseRef: String, fetchBranch: String?)? {
         guard !baseBranch.isEmpty else { return nil }
 
         // If baseBranch already contains a slash (e.g. "upstream/main"),
@@ -1042,9 +1042,8 @@ extension GitService {
                 cwd: worktreePath
             )
             if directCheck.exitCode == 0 {
-                let parts = baseBranch.split(separator: "/", maxSplits: 1)
-                let remote = parts.count > 1 ? String(parts[0]) : nil
-                return (remote: remote, baseRef: baseBranch)
+                let remoteBranch = try await splitRemoteQualifiedRef(baseBranch, worktreePath: worktreePath)
+                return (remote: remoteBranch.remote, baseRef: baseBranch, fetchBranch: remoteBranch.branch)
             }
         }
 
@@ -1055,7 +1054,7 @@ extension GitService {
             cwd: worktreePath
         )
         if originCheck.exitCode == 0 {
-            return (remote: "origin", baseRef: "origin/\(baseBranch)")
+            return (remote: "origin", baseRef: "origin/\(baseBranch)", fetchBranch: baseBranch)
         }
 
         // Fall back to local <base>.
@@ -1064,10 +1063,29 @@ extension GitService {
             cwd: worktreePath
         )
         if localCheck.exitCode == 0 {
-            return (remote: nil, baseRef: baseBranch)
+            return (remote: nil, baseRef: baseBranch, fetchBranch: nil)
         }
 
         return nil
+    }
+
+    private func splitRemoteQualifiedRef(_ ref: String, worktreePath: URL) async throws -> (remote: String?, branch: String?) {
+        let remotesResult = try await Process.git(["remote"], cwd: worktreePath)
+        if remotesResult.exitCode == 0 {
+            let remotes = remotesResult.stdout
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map { String($0).trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            if let remote = remotes
+                .filter({ ref.hasPrefix($0 + "/") })
+                .max(by: { $0.count < $1.count }) {
+                return (remote: remote, branch: String(ref.dropFirst(remote.count + 1)))
+            }
+        }
+
+        let parts = ref.split(separator: "/", maxSplits: 1)
+        guard parts.count == 2 else { return (remote: nil, branch: nil) }
+        return (remote: String(parts[0]), branch: String(parts[1]))
     }
 
     /// Resolves the upstream tracking ref (e.g. `origin/my-feature`) of the

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -815,18 +815,27 @@ extension GitService {
                 }
             }
             if baseName == nil {
-                let origin = try await Process.git(
-                    ["show-ref", "--verify", "--quiet", "refs/remotes/origin/\(base)"],
-                    cwd: worktree
-                )
-                if origin.exitCode == 0 {
-                    baseName = "origin/\(base)"
-                } else {
+                if ignoreUpstream {
                     let local = try await Process.git(
                         ["show-ref", "--verify", "--quiet", "refs/heads/\(base)"],
                         cwd: worktree
                     )
                     if local.exitCode == 0 { baseName = base }
+                }
+                if baseName == nil {
+                    let origin = try await Process.git(
+                        ["show-ref", "--verify", "--quiet", "refs/remotes/origin/\(base)"],
+                        cwd: worktree
+                    )
+                    if origin.exitCode == 0 {
+                        baseName = "origin/\(base)"
+                    } else if !ignoreUpstream {
+                        let local = try await Process.git(
+                            ["show-ref", "--verify", "--quiet", "refs/heads/\(base)"],
+                            cwd: worktree
+                        )
+                        if local.exitCode == 0 { baseName = base }
+                    }
                 }
             }
         }
@@ -1030,7 +1039,8 @@ extension GitService {
     /// `remote == nil` means "no fetch path; use the local ref as-is".
     func resolveBaseRef(
         worktreePath: URL,
-        baseBranch: String
+        baseBranch: String,
+        preferLocal: Bool = false
     ) async throws -> (remote: String?, baseRef: String, fetchBranch: String?)? {
         guard !baseBranch.isEmpty else { return nil }
 
@@ -1054,7 +1064,17 @@ extension GitService {
             }
         }
 
-        // Prefer origin/<base>.
+        if preferLocal {
+            let localCheck = try await Process.git(
+                ["show-ref", "--verify", "--quiet", "refs/heads/\(baseBranch)"],
+                cwd: worktreePath
+            )
+            if localCheck.exitCode == 0 {
+                return (remote: nil, baseRef: baseBranch, fetchBranch: nil)
+            }
+        }
+
+        // Prefer origin/<base> for configured defaults.
         let originRef = "refs/remotes/origin/\(baseBranch)"
         let originCheck = try await Process.git(
             ["show-ref", "--verify", "--quiet", originRef],
@@ -1064,13 +1084,14 @@ extension GitService {
             return (remote: "origin", baseRef: "origin/\(baseBranch)", fetchBranch: baseBranch)
         }
 
-        // Fall back to local <base>.
-        let localCheck = try await Process.git(
-            ["show-ref", "--verify", "--quiet", "refs/heads/\(baseBranch)"],
-            cwd: worktreePath
-        )
-        if localCheck.exitCode == 0 {
-            return (remote: nil, baseRef: baseBranch, fetchBranch: nil)
+        if !preferLocal {
+            let localCheck = try await Process.git(
+                ["show-ref", "--verify", "--quiet", "refs/heads/\(baseBranch)"],
+                cwd: worktreePath
+            )
+            if localCheck.exitCode == 0 {
+                return (remote: nil, baseRef: baseBranch, fetchBranch: nil)
+            }
         }
 
         return nil

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -794,23 +794,24 @@ extension GitService {
         }
 
         // Step 2: If no upstream, try the base branch. Prefer `origin/<base>`
-        // over local `<base>` — the remote-tracking ref is usually current
-        // after a fetch, while the local branch can be stale (especially in
-        // worktrees that never check out the base branch directly). This also
-        // matches the ref the rebase affordance targets via `resolveBaseRef`,
-        // so the Commits section stays consistent with what the user just
-        // rebased onto.
+        // over local `<base>` for simple branch names. Slash-named bases are
+        // ambiguous, so resolve local refs first before treating them as
+        // remote-qualified refs.
         var baseName: String? = nil
         if upstreamName == nil, let base = baseBranch, !base.isEmpty {
-            // If base already contains a slash (e.g. "upstream/main"),
-            // try it as a direct remote-tracking ref first.
             if base.contains("/") {
-                let direct = try await Process.git(
-                    ["show-ref", "--verify", "--quiet", "refs/remotes/\(base)"],
+                let local = try await Process.git(
+                    ["show-ref", "--verify", "--quiet", "refs/heads/\(base)"],
                     cwd: worktree
                 )
-                if direct.exitCode == 0 {
+                if local.exitCode == 0 {
                     baseName = base
+                } else {
+                    let direct = try await Process.git(
+                        ["show-ref", "--verify", "--quiet", "refs/remotes/\(base)"],
+                        cwd: worktree
+                    )
+                    if direct.exitCode == 0 { baseName = base }
                 }
             }
             if baseName == nil {
@@ -1033,9 +1034,15 @@ extension GitService {
     ) async throws -> (remote: String?, baseRef: String, fetchBranch: String?)? {
         guard !baseBranch.isEmpty else { return nil }
 
-        // If baseBranch already contains a slash (e.g. "upstream/main"),
-        // try it as a direct remote-tracking ref first.
         if baseBranch.contains("/") {
+            let localCheck = try await Process.git(
+                ["show-ref", "--verify", "--quiet", "refs/heads/\(baseBranch)"],
+                cwd: worktreePath
+            )
+            if localCheck.exitCode == 0 {
+                return (remote: nil, baseRef: baseBranch, fetchBranch: nil)
+            }
+
             let directRef = "refs/remotes/\(baseBranch)"
             let directCheck = try await Process.git(
                 ["show-ref", "--verify", "--quiet", directRef],

--- a/Alas/Sources/Git/GitService.swift
+++ b/Alas/Sources/Git/GitService.swift
@@ -802,18 +802,31 @@ extension GitService {
         // rebased onto.
         var baseName: String? = nil
         if upstreamName == nil, let base = baseBranch, !base.isEmpty {
-            let origin = try await Process.git(
-                ["show-ref", "--verify", "--quiet", "refs/remotes/origin/\(base)"],
-                cwd: worktree
-            )
-            if origin.exitCode == 0 {
-                baseName = "origin/\(base)"
-            } else {
-                let local = try await Process.git(
-                    ["show-ref", "--verify", "--quiet", "refs/heads/\(base)"],
+            // If base already contains a slash (e.g. "upstream/main"),
+            // try it as a direct remote-tracking ref first.
+            if base.contains("/") {
+                let direct = try await Process.git(
+                    ["show-ref", "--verify", "--quiet", "refs/remotes/\(base)"],
                     cwd: worktree
                 )
-                if local.exitCode == 0 { baseName = base }
+                if direct.exitCode == 0 {
+                    baseName = base
+                }
+            }
+            if baseName == nil {
+                let origin = try await Process.git(
+                    ["show-ref", "--verify", "--quiet", "refs/remotes/origin/\(base)"],
+                    cwd: worktree
+                )
+                if origin.exitCode == 0 {
+                    baseName = "origin/\(base)"
+                } else {
+                    let local = try await Process.git(
+                        ["show-ref", "--verify", "--quiet", "refs/heads/\(base)"],
+                        cwd: worktree
+                    )
+                    if local.exitCode == 0 { baseName = base }
+                }
             }
         }
 

--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -13,7 +13,10 @@ struct BaseBranchSelector: View {
     @State private var hovering = false
 
     var body: some View {
-        Button(action: { onOpen(); open.toggle() }) {
+        Button(action: {
+            onOpen()
+            open.toggle()
+        }) {
             HStack(spacing: 4) {
                 Icon(name: "branch", size: 10, color: hovering ? theme.color("accent") : theme.color("fg-faint"))
                 Text(currentRef ?? baseBranch)

--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -109,7 +109,10 @@ extension BaseBranchSelector {
         for name in mainlineNames {
             if branches.contains(name) { append(name) }
             for branch in branches {
-                if branch.hasSuffix("/\(name)") && branch.contains("/") {
+                let parts = branch.split(separator: "/")
+                if parts.count == 2,
+                   parts[1] == name,
+                   !["feature", "release", "hotfix"].contains(parts[0]) {
                     append(branch)
                 }
             }

--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -123,6 +123,9 @@ extension BaseBranchSelector {
             append(name)
         }
 
+        // 4. Active comparison ref (so users can always re-select it)
+        if let currentRef { append(currentRef) }
+
         return out
     }
 }

--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -5,28 +5,84 @@ struct BaseBranchSelector: View {
     let branches: [String]
     let currentRef: String?
     let onSelect: (String) -> Void
+    let onOpen: () -> Void
 
     @Environment(\.theme) private var theme
     @State private var open = false
     @State private var search = ""
+    @State private var hovering = false
 
     var body: some View {
-        Button(action: { open.toggle() }) {
+        Button(action: { onOpen(); open.toggle() }) {
             HStack(spacing: 4) {
-                Icon(name: "branch", size: 10, color: theme.color("fg-faint"))
+                Icon(name: "branch", size: 10, color: hovering ? theme.color("accent") : theme.color("fg-faint"))
                 Text(currentRef ?? baseBranch)
                     .font(.system(size: 10.5, design: .monospaced))
-                    .foregroundColor(theme.color("fg-faint"))
+                    .foregroundColor(hovering ? theme.color("accent") : theme.color("fg-faint"))
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
         }
         .buttonStyle(.plain)
         .pointingHandCursor()
+        .onHover { hovering = $0 }
         .popover(isPresented: $open, arrowEdge: .bottom) {
-            // Placeholder for popover body (Task 3)
-            EmptyView()
+            popoverBody
         }
+    }
+
+    private var filteredBranches: [String] {
+        if search.isEmpty { return branches }
+        return branches.filter { $0.localizedCaseInsensitiveContains(search) }
+    }
+
+    @ViewBuilder
+    private var popoverBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            AlasField(text: $search, placeholder: "Search branches...")
+                .padding(8)
+            Divider().background(theme.color("line"))
+            if branches.isEmpty {
+                Text("No branches")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .padding(12)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(filteredBranches, id: \.self) { branch in
+                            row(name: branch)
+                        }
+                    }
+                }
+                .frame(maxHeight: 320)
+            }
+        }
+        .frame(width: 280)
+    }
+
+    private func row(name: String) -> some View {
+        Button(action: {
+            onSelect(name)
+            open = false
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                    .opacity(name == baseBranch ? 1 : 0)
+                Text(name)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -119,12 +119,17 @@ extension BaseBranchSelector {
         if let upstream { append(upstream) }
 
         // 3. Recent (max 3, newest first)
-        for name in recent.prefix(3) {
+        for name in recent.reversed().prefix(3) {
             append(name)
         }
 
         // 4. Active comparison ref (so users can always re-select it)
         if let currentRef { append(currentRef) }
+
+        // 5. Remaining branches, so search can reach refs outside the smart shortlist.
+        for branch in branches {
+            append(branch)
+        }
 
         return out
     }

--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -73,7 +73,7 @@ struct BaseBranchSelector: View {
                 Image(systemName: "checkmark")
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(theme.color("fg"))
-                    .opacity(name == baseBranch ? 1 : 0)
+                    .opacity(Self.isSelected(row: name, baseBranch: baseBranch, currentRef: currentRef) ? 1 : 0)
                 Text(name)
                     .font(.system(size: 12, design: .monospaced))
                     .foregroundColor(theme.color("fg"))
@@ -90,6 +90,10 @@ struct BaseBranchSelector: View {
 }
 
 extension BaseBranchSelector {
+    static func isSelected(row name: String, baseBranch: String, currentRef: String?) -> Bool {
+        name == (currentRef ?? baseBranch)
+    }
+
     static func smartList(
         branches: [String],
         currentRef: String?,

--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -33,7 +33,7 @@ struct BaseBranchSelector: View {
 extension BaseBranchSelector {
     static func smartList(
         branches: [String],
-        current: String?,
+        currentRef: String?,
         upstream: String?,
         recent: [String]
     ) -> [String] {

--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -105,11 +105,14 @@ extension BaseBranchSelector {
             out.append(name)
         }
 
-        // 1. Mainlines (local first, then its remote, in priority order)
+        // 1. Mainlines (local first, then every remote that carries it)
         for name in mainlineNames {
             if branches.contains(name) { append(name) }
-            let remote = "origin/\(name)"
-            if branches.contains(remote) { append(remote) }
+            for branch in branches {
+                if branch.hasSuffix("/\(name)") && branch.contains("/") {
+                    append(branch)
+                }
+            }
         }
 
         // 2. Upstream (if not already a mainline)

--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct BaseBranchSelector: View {
+    @Binding var baseBranch: String
+    let branches: [String]
+    let currentRef: String?
+    let onSelect: (String) -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var open = false
+    @State private var search = ""
+
+    var body: some View {
+        Button(action: { open.toggle() }) {
+            HStack(spacing: 4) {
+                Icon(name: "branch", size: 10, color: theme.color("fg-faint"))
+                Text(currentRef ?? baseBranch)
+                    .font(.system(size: 10.5, design: .monospaced))
+                    .foregroundColor(theme.color("fg-faint"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .buttonStyle(.plain)
+        .pointingHandCursor()
+        .popover(isPresented: $open, arrowEdge: .bottom) {
+            // Placeholder for popover body (Task 3)
+            EmptyView()
+        }
+    }
+}
+
+extension BaseBranchSelector {
+    static func smartList(
+        branches: [String],
+        current: String?,
+        upstream: String?,
+        recent: [String]
+    ) -> [String] {
+        let mainlineNames = ["main", "master", "develop", "trunk"]
+        var seen = Set<String>()
+        var out: [String] = []
+
+        func append(_ name: String) {
+            guard seen.insert(name).inserted else { return }
+            out.append(name)
+        }
+
+        // 1. Mainlines (local first, then its remote, in priority order)
+        for name in mainlineNames {
+            if branches.contains(name) { append(name) }
+            let remote = "origin/\(name)"
+            if branches.contains(remote) { append(remote) }
+        }
+
+        // 2. Upstream (if not already a mainline)
+        if let upstream { append(upstream) }
+
+        // 3. Recent (max 3, newest first)
+        for name in recent.prefix(3) {
+            append(name)
+        }
+
+        return out
+    }
+}

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -146,9 +146,13 @@ struct ChangesTabView: View {
                 behindBase: rps.showBehindBaseChip ? rps.behindBase : nil,
                 behindUpstream: rps.showBehindUpstreamChip ? rps.behindUpstream : nil,
                 expanded: $rps.commitsExpanded,
+                baseBranch: $rps.baseBranch,
+                branches: rps.availableBranches,
                 onSelect: onSelectCommit,
                 onCopySHA: copyCommitSHA,
                 onLoadOlder: { Task { @MainActor in await rps.loadOlder() } },
+                onSelectBaseBranch: { branch in rps.selectBaseBranch(branch) },
+                onOpenBaseBranchSelector: { Task { @MainActor in await rps.fetchBranches() } },
                 rps: rps
             )
         }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -157,8 +157,7 @@ struct ChangesTabView: View {
                 onCopySHA: copyCommitSHA,
                 onLoadOlder: { Task { @MainActor in await rps.loadOlder() } },
                 onSelectBaseBranch: { branch in
-                    let normalized = branch.hasPrefix("origin/") ? String(branch.dropFirst(7)) : branch
-                    rps.selectBaseBranch(normalized)
+                    rps.selectBaseBranch(branch)
                 },
                 onOpenBaseBranchSelector: { Task { @MainActor in await rps.fetchBranches() } },
                 rps: rps

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -147,7 +147,12 @@ struct ChangesTabView: View {
                 behindUpstream: rps.showBehindUpstreamChip ? rps.behindUpstream : nil,
                 expanded: $rps.commitsExpanded,
                 baseBranch: $rps.baseBranch,
-                branches: rps.availableBranches,
+                branches: BaseBranchSelector.smartList(
+                    branches: rps.availableBranches,
+                    currentRef: rps.comparisonRef,
+                    upstream: rps.upstreamRef,
+                    recent: rps.recentBaseBranches
+                ),
                 onSelect: onSelectCommit,
                 onCopySHA: copyCommitSHA,
                 onLoadOlder: { Task { @MainActor in await rps.loadOlder() } },

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -156,7 +156,10 @@ struct ChangesTabView: View {
                 onSelect: onSelectCommit,
                 onCopySHA: copyCommitSHA,
                 onLoadOlder: { Task { @MainActor in await rps.loadOlder() } },
-                onSelectBaseBranch: { branch in rps.selectBaseBranch(branch) },
+                onSelectBaseBranch: { branch in
+                    let normalized = branch.hasPrefix("origin/") ? String(branch.dropFirst(7)) : branch
+                    rps.selectBaseBranch(normalized)
+                },
                 onOpenBaseBranchSelector: { Task { @MainActor in await rps.fetchBranches() } },
                 rps: rps
             )

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -28,9 +28,13 @@ struct CommitsSectionView: View {
     let behindBase: GitService.BehindStatus?
     let behindUpstream: GitService.BehindStatus?
     @Binding var expanded: Bool
+    @Binding var baseBranch: String
+    let branches: [String]
     let onSelect: (CommitInfo) -> Void
     let onCopySHA: (CommitInfo) -> Void
     let onLoadOlder: () -> Void
+    let onSelectBaseBranch: (String) -> Void
+    let onOpenBaseBranchSelector: () -> Void
     let rps: RightPaneState
 
     @Environment(\.theme) private var theme
@@ -50,16 +54,13 @@ struct CommitsSectionView: View {
                     if let s = behindUpstream {
                         BehindChip(text: "\(s.count) behind \(s.ref)")
                     }
-                    if let comparisonRef {
-                        HStack(spacing: 4) {
-                            Icon(name: "branch", size: 10, color: theme.color("fg-faint"))
-                            Text(comparisonRef)
-                                .font(.system(size: 10.5, design: .monospaced))
-                                .foregroundColor(theme.color("fg-faint"))
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
-                    }
+                    BaseBranchSelector(
+                        baseBranch: $baseBranch,
+                        branches: branches,
+                        currentRef: comparisonRef,
+                        onSelect: onSelectBaseBranch,
+                        onOpen: onOpenBaseBranchSelector
+                    )
                 }
             }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -169,11 +169,10 @@ final class RightPaneState {
     func selectBaseBranch(_ branch: String) {
         baseBranch = branch
         userOverrodeBaseBranch = true
-        if !recentBaseBranches.contains(branch) {
-            recentBaseBranches.append(branch)
-            if recentBaseBranches.count > 3 {
-                recentBaseBranches = Array(recentBaseBranches.suffix(3))
-            }
+        recentBaseBranches.removeAll { $0 == branch }
+        recentBaseBranches.append(branch)
+        if recentBaseBranches.count > 3 {
+            recentBaseBranches = Array(recentBaseBranches.suffix(3))
         }
         Task { @MainActor in
             async let r = refresh()
@@ -821,7 +820,7 @@ final class RightPaneState {
                         try await git.fetchRef(
                             worktreePath: worktree.path,
                             remote: remote,
-                            branch: baseBranch
+                            branch: resolved.fetchBranch ?? baseBranch
                         )
                     } catch {
                         logger.error("base fetch failed for \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -169,6 +169,7 @@ final class RightPaneState {
     func selectBaseBranch(_ branch: String) {
         baseBranch = branch
         userOverrodeBaseBranch = true
+        behindBase = nil
         recentBaseBranches.removeAll { $0 == branch }
         recentBaseBranches.append(branch)
         if recentBaseBranches.count > 3 {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -203,7 +203,7 @@ final class RightPaneState {
             self.hasMoreOlder = true
             self.isLoadingOlder = false
             async let s = git.status(worktreePath: worktree.path)
-            async let c = git.commitsAhead(at: worktree.path, baseBranch: baseBranch, ignoreUpstream: true)
+            async let c = git.commitsAhead(at: worktree.path, baseBranch: baseBranch, ignoreUpstream: userOverrodeBaseBranch)
             async let br = git.currentBranch(worktreePath: worktree.path)
             async let mergeRefresh: Void = mergeOp.refresh()
             let entries = try await s

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -85,6 +85,11 @@ final class RightPaneState {
     /// `fetchBranches()`. Used by the base-branch picker.
     private(set) var availableBranches: [String] = []
 
+    /// Upstream tracking ref of the current branch (e.g. `origin/main`),
+    /// resolved during `refreshSyncStatus()`. Used by the base-branch
+    /// picker to include the upstream in the smart shortlist.
+    private(set) var upstreamRef: String? = nil
+
     private let git = GitService()
     private let watcher: WorktreeWatcher
     private let logger = Logger(subsystem: "io.nlopez.alas", category: "right-pane-state")
@@ -828,8 +833,10 @@ final class RightPaneState {
                 worktreePath: worktree.path
             ) else {
                 behindUpstream = nil
+                upstreamRef = nil
                 return
             }
+            upstreamRef = upstream.ref
             // Upstream ref looks like "origin/<branch>"; the local branch name
             // is what we fetch.
             let branchName = String(upstream.ref.dropFirst(upstream.remote.count + 1))

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -77,6 +77,14 @@ final class RightPaneState {
     /// In Plan 2, it will route to the new 3-column merge editor.
     var openConflict: ((String) -> Void)? = nil
 
+    /// In-memory ring buffer of recently selected base branches for this
+    /// worktree. Max 3 entries; newest at the end. Not persisted.
+    private(set) var recentBaseBranches: [String] = []
+
+    /// Branches available in this worktree, populated on-demand by
+    /// `fetchBranches()`. Used by the base-branch picker.
+    private(set) var availableBranches: [String] = []
+
     private let git = GitService()
     private let watcher: WorktreeWatcher
     private let logger = Logger(subsystem: "io.nlopez.alas", category: "right-pane-state")
@@ -140,6 +148,30 @@ final class RightPaneState {
         watcher.stop()
         syncStatusTimer?.cancel()
         syncStatusTimer = nil
+    }
+
+    /// Update the base branch, record it in the recent list, and refresh.
+    func selectBaseBranch(_ branch: String) {
+        baseBranch = branch
+        if !recentBaseBranches.contains(branch) {
+            recentBaseBranches.append(branch)
+            if recentBaseBranches.count > 3 {
+                recentBaseBranches.removeFirst(recentBaseBranches.count - 3)
+            }
+        }
+        Task { @MainActor in
+            await refresh()
+            await refreshSyncStatus()
+        }
+    }
+
+    /// Populate `availableBranches` from git. Best-effort; errors are logged.
+    func fetchBranches() async {
+        do {
+            availableBranches = try await git.branches(at: worktree.path)
+        } catch {
+            logger.error("branch list fetch failed for \(self.worktree.path.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     @MainActor

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -156,12 +156,13 @@ final class RightPaneState {
         if !recentBaseBranches.contains(branch) {
             recentBaseBranches.append(branch)
             if recentBaseBranches.count > 3 {
-                recentBaseBranches.removeFirst(recentBaseBranches.count - 3)
+                recentBaseBranches = Array(recentBaseBranches.suffix(3))
             }
         }
         Task { @MainActor in
-            await refresh()
-            await refreshSyncStatus()
+            async let r = refresh()
+            async let s = refreshSyncStatus()
+            _ = await (r, s)
         }
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -809,7 +809,8 @@ final class RightPaneState {
         do {
             guard let resolved = try await git.resolveBaseRef(
                 worktreePath: worktree.path,
-                baseBranch: baseBranch
+                baseBranch: baseBranch,
+                preferLocal: userOverrodeBaseBranch
             ) else {
                 behindBase = nil
                 return

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -65,6 +65,16 @@ final class RightPaneState {
     /// without throwing away the rest of the cached state.
     var baseBranch: String
 
+    /// `true` once the user has explicitly picked a base branch via the
+    /// selector. Prevents `RightPaneStore` from snapping the branch back to
+    /// the global config default on the next render.
+    var userOverrodeBaseBranch: Bool = false
+
+    /// The last base branch value that came from `AppConfig` (not from the
+    /// selector). Used by `RightPaneStore` to distinguish a Settings change
+    /// (new config value) from a normal render (same config value).
+    var lastConfigBaseBranch: String = ""
+
     var pendingDiscard: PendingDiscard? = nil
 
     /// Injected by `RightPaneStore` after creation so `confirmDiscard` can
@@ -158,6 +168,7 @@ final class RightPaneState {
     /// Update the base branch, record it in the recent list, and refresh.
     func selectBaseBranch(_ branch: String) {
         baseBranch = branch
+        userOverrodeBaseBranch = true
         if !recentBaseBranches.contains(branch) {
             recentBaseBranches.append(branch)
             if recentBaseBranches.count > 3 {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -188,7 +188,7 @@ final class RightPaneState {
             self.hasMoreOlder = true
             self.isLoadingOlder = false
             async let s = git.status(worktreePath: worktree.path)
-            async let c = git.commitsAhead(at: worktree.path, baseBranch: baseBranch)
+            async let c = git.commitsAhead(at: worktree.path, baseBranch: baseBranch, ignoreUpstream: true)
             async let br = git.currentBranch(worktreePath: worktree.path)
             async let mergeRefresh: Void = mergeOp.refresh()
             let entries = try await s

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -25,12 +25,16 @@ final class RightPaneStore {
             // change, leave the state's baseBranch alone so a user-picked
             // override survives across renders.
             if existing.lastConfigBaseBranch != baseBranch {
+                let clearedUserOverride = existing.userOverrodeBaseBranch
+                let baseChanged = existing.baseBranch != baseBranch
                 existing.lastConfigBaseBranch = baseBranch
                 existing.userOverrodeBaseBranch = false
-                if existing.baseBranch != baseBranch {
+                if baseChanged {
                     existing.baseBranch = baseBranch
+                }
+                if baseChanged || clearedUserOverride {
                     // Clear the prior probe so the chip doesn't show a stale
-                    // count against the OLD base while the new probe runs.
+                    // count while comparison semantics are changing.
                     existing.behindBase = nil
                     Task { @MainActor in
                         await existing.refresh()

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -20,25 +20,28 @@ final class RightPaneStore {
         let id = worktree.id
         let result: RightPaneState
         if let existing = states[id] {
-            // Keep the cached state in sync with the currently-configured
-            // base branch. If it changed (Settings → Worktrees → Base branch),
-            // update the field and trigger a refresh so commitsAhead runs
-            // against the new ref. We don't recreate the state because that
-            // would discard tab expansion / file-tree open-paths / the
-            // sticky activeTab choice.
-            if existing.baseBranch != baseBranch {
-                existing.baseBranch = baseBranch
-                // Clear the prior probe so the chip doesn't show a stale
-                // count against the OLD base while the new probe runs.
-                existing.behindBase = nil
-                Task { @MainActor in
-                    await existing.refresh()
-                    await existing.refreshSyncStatus()
+            // If the global config base branch changed (Settings → Worktrees),
+            // honor the new value and clear the user override. If it didn't
+            // change, leave the state's baseBranch alone so a user-picked
+            // override survives across renders.
+            if existing.lastConfigBaseBranch != baseBranch {
+                existing.lastConfigBaseBranch = baseBranch
+                existing.userOverrodeBaseBranch = false
+                if existing.baseBranch != baseBranch {
+                    existing.baseBranch = baseBranch
+                    // Clear the prior probe so the chip doesn't show a stale
+                    // count against the OLD base while the new probe runs.
+                    existing.behindBase = nil
+                    Task { @MainActor in
+                        await existing.refresh()
+                        await existing.refreshSyncStatus()
+                    }
                 }
             }
             result = existing
         } else {
             let new = RightPaneState(worktree: worktree, baseBranch: baseBranch)
+            new.lastConfigBaseBranch = baseBranch
             new.closeDiffTabs = { [weak self] paths in
                 guard let app = self?.appState else { return }
                 let pathSet = Set(paths)

--- a/AlasTests/BaseBranchSelectorTests.swift
+++ b/AlasTests/BaseBranchSelectorTests.swift
@@ -15,6 +15,16 @@ struct BaseBranchSelectorTests {
         #expect(result[2] == "develop")
     }
 
+    @Test func smartListDoesNotPromoteNestedBranchesNamedMain() {
+        let result = BaseBranchSelector.smartList(
+            branches: ["origin/release/main", "origin/main", "feature/main"],
+            currentRef: nil,
+            upstream: nil,
+            recent: []
+        )
+        #expect(result == ["origin/main", "origin/release/main", "feature/main"])
+    }
+
     @Test func smartListIncludesUpstreamWhenNotMainline() {
         let branches = ["main", "origin/feature-x"]
         let result = BaseBranchSelector.smartList(

--- a/AlasTests/BaseBranchSelectorTests.swift
+++ b/AlasTests/BaseBranchSelectorTests.swift
@@ -56,7 +56,7 @@ struct BaseBranchSelectorTests {
             upstream: nil,
             recent: ["a", "a", "b"]
         )
-        #expect(result == ["main", "a", "b"])
+        #expect(result == ["main", "b", "a"])
     }
 
     @Test func smartListSkipsAbsentMainlines() {
@@ -78,7 +78,17 @@ struct BaseBranchSelectorTests {
             upstream: nil,
             recent: ["a", "b", "c", "d"]
         )
-        #expect(result == ["main", "a", "b", "c"])
+        #expect(result == ["main", "d", "c", "b", "a"])
+    }
+
+    @Test func smartListOrdersRecentNewestFirst() {
+        let result = BaseBranchSelector.smartList(
+            branches: ["main", "release/old", "release/current", "release/new"],
+            currentRef: "main",
+            upstream: nil,
+            recent: ["release/old", "release/current", "release/new"]
+        )
+        #expect(result.prefix(4) == ["main", "release/new", "release/current", "release/old"])
     }
 
     @Test func smartListHandlesEmptyInput() {
@@ -99,5 +109,15 @@ struct BaseBranchSelectorTests {
             recent: []
         )
         #expect(result == ["main", "origin/main", "release/2026.1"])
+    }
+
+    @Test func smartListKeepsNonSmartBranchesSearchable() {
+        let result = BaseBranchSelector.smartList(
+            branches: ["main", "release/2026.1", "hotfix/payment"],
+            currentRef: "main",
+            upstream: nil,
+            recent: []
+        )
+        #expect(result == ["main", "release/2026.1", "hotfix/payment"])
     }
 }

--- a/AlasTests/BaseBranchSelectorTests.swift
+++ b/AlasTests/BaseBranchSelectorTests.swift
@@ -6,7 +6,7 @@ struct BaseBranchSelectorTests {
         let branches = ["feature/x", "main", "origin/main", "develop"]
         let result = BaseBranchSelector.smartList(
             branches: branches,
-            current: "origin/main",
+            currentRef: "origin/main",
             upstream: "origin/feature-x",
             recent: []
         )
@@ -19,7 +19,7 @@ struct BaseBranchSelectorTests {
         let branches = ["main", "origin/feature-x"]
         let result = BaseBranchSelector.smartList(
             branches: branches,
-            current: "origin/main",
+            currentRef: "origin/main",
             upstream: "origin/feature-x",
             recent: []
         )
@@ -30,29 +30,61 @@ struct BaseBranchSelectorTests {
         let branches = ["main", "origin/main"]
         let result = BaseBranchSelector.smartList(
             branches: branches,
-            current: "origin/main",
+            currentRef: "origin/main",
             upstream: "origin/main",
             recent: []
         )
-        #expect(result.filter { $0 == "origin/main" }.count == 1)
+        #expect(result == ["main", "origin/main"])
+    }
+
+    @Test func smartListDedupesRecentAgainstMainlines() {
+        let branches = ["main", "origin/main", "a"]
+        let result = BaseBranchSelector.smartList(
+            branches: branches,
+            currentRef: "origin/main",
+            upstream: "origin/main",
+            recent: ["main", "a"]
+        )
+        #expect(result == ["main", "origin/main", "a"])
+    }
+
+    @Test func smartListDedupesRecentInternally() {
+        let branches = ["main", "a"]
+        let result = BaseBranchSelector.smartList(
+            branches: branches,
+            currentRef: "main",
+            upstream: nil,
+            recent: ["a", "a", "b"]
+        )
+        #expect(result == ["main", "a", "b"])
+    }
+
+    @Test func smartListSkipsAbsentMainlines() {
+        let branches = ["main", "origin/main"]
+        let result = BaseBranchSelector.smartList(
+            branches: branches,
+            currentRef: "origin/main",
+            upstream: nil,
+            recent: []
+        )
+        #expect(result == ["main", "origin/main"])
     }
 
     @Test func smartListCapsRecentAtThree() {
         let branches = ["main", "a", "b", "c", "d"]
         let result = BaseBranchSelector.smartList(
             branches: branches,
-            current: "main",
+            currentRef: "main",
             upstream: nil,
             recent: ["a", "b", "c", "d"]
         )
-        let recentSection = result.drop(while: { $0 != "a" }).prefix(4)
-        #expect(recentSection.count == 3)
+        #expect(result == ["main", "a", "b", "c"])
     }
 
     @Test func smartListHandlesEmptyInput() {
         let result = BaseBranchSelector.smartList(
             branches: [],
-            current: nil,
+            currentRef: nil,
             upstream: nil,
             recent: []
         )

--- a/AlasTests/BaseBranchSelectorTests.swift
+++ b/AlasTests/BaseBranchSelectorTests.swift
@@ -90,4 +90,14 @@ struct BaseBranchSelectorTests {
         )
         #expect(result.isEmpty)
     }
+
+    @Test func smartListIncludesCurrentRefWhenAbsentFromShortlist() {
+        let result = BaseBranchSelector.smartList(
+            branches: ["main", "origin/main"],
+            currentRef: "release/2026.1",
+            upstream: nil,
+            recent: []
+        )
+        #expect(result == ["main", "origin/main", "release/2026.1"])
+    }
 }

--- a/AlasTests/BaseBranchSelectorTests.swift
+++ b/AlasTests/BaseBranchSelectorTests.swift
@@ -1,0 +1,61 @@
+import Testing
+@testable import Alas
+
+struct BaseBranchSelectorTests {
+    @Test func smartListOrdersMainlinesFirst() {
+        let branches = ["feature/x", "main", "origin/main", "develop"]
+        let result = BaseBranchSelector.smartList(
+            branches: branches,
+            current: "origin/main",
+            upstream: "origin/feature-x",
+            recent: []
+        )
+        #expect(result.first == "main")
+        #expect(result[1] == "origin/main")
+        #expect(result[2] == "develop")
+    }
+
+    @Test func smartListIncludesUpstreamWhenNotMainline() {
+        let branches = ["main", "origin/feature-x"]
+        let result = BaseBranchSelector.smartList(
+            branches: branches,
+            current: "origin/main",
+            upstream: "origin/feature-x",
+            recent: []
+        )
+        #expect(result.contains("origin/feature-x"))
+    }
+
+    @Test func smartListDedupesUpstreamThatIsAlsoMainline() {
+        let branches = ["main", "origin/main"]
+        let result = BaseBranchSelector.smartList(
+            branches: branches,
+            current: "origin/main",
+            upstream: "origin/main",
+            recent: []
+        )
+        #expect(result.filter { $0 == "origin/main" }.count == 1)
+    }
+
+    @Test func smartListCapsRecentAtThree() {
+        let branches = ["main", "a", "b", "c", "d"]
+        let result = BaseBranchSelector.smartList(
+            branches: branches,
+            current: "main",
+            upstream: nil,
+            recent: ["a", "b", "c", "d"]
+        )
+        let recentSection = result.drop(while: { $0 != "a" }).prefix(4)
+        #expect(recentSection.count == 3)
+    }
+
+    @Test func smartListHandlesEmptyInput() {
+        let result = BaseBranchSelector.smartList(
+            branches: [],
+            current: nil,
+            upstream: nil,
+            recent: []
+        )
+        #expect(result.isEmpty)
+    }
+}

--- a/AlasTests/BaseBranchSelectorTests.swift
+++ b/AlasTests/BaseBranchSelectorTests.swift
@@ -2,6 +2,16 @@ import Testing
 @testable import Alas
 
 struct BaseBranchSelectorTests {
+    @Test func isSelectedUsesCurrentRefWhenAvailable() {
+        #expect(BaseBranchSelector.isSelected(row: "origin/feature", baseBranch: "main", currentRef: "origin/feature"))
+        #expect(!BaseBranchSelector.isSelected(row: "main", baseBranch: "main", currentRef: "origin/feature"))
+    }
+
+    @Test func isSelectedFallsBackToBaseBranch() {
+        #expect(BaseBranchSelector.isSelected(row: "main", baseBranch: "main", currentRef: nil))
+        #expect(!BaseBranchSelector.isSelected(row: "origin/feature", baseBranch: "main", currentRef: nil))
+    }
+
     @Test func smartListOrdersMainlinesFirst() {
         let branches = ["feature/x", "main", "origin/main", "develop"]
         let result = BaseBranchSelector.smartList(

--- a/AlasTests/CommitsAheadTests.swift
+++ b/AlasTests/CommitsAheadTests.swift
@@ -202,4 +202,16 @@ struct CommitsAheadTests {
 
         #expect(comparisonRef == "team/main")
     }
+
+    @Test func explicitSimpleBasePrefersLocalBranchOverOrigin() async throws {
+        let (worktree, _) = try await makeRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: worktree.deletingLastPathComponent()) }
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: worktree)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat: feature work"], cwd: worktree)
+
+        let svc = GitService()
+        let (_, comparisonRef) = try await svc.commitsAhead(at: worktree, baseBranch: "main", ignoreUpstream: true)
+
+        #expect(comparisonRef == "main")
+    }
 }

--- a/AlasTests/CommitsAheadTests.swift
+++ b/AlasTests/CommitsAheadTests.swift
@@ -167,4 +167,20 @@ struct CommitsAheadTests {
         #expect(comparisonRef == "origin/main")
         #expect(commits.count == 1)
     }
+
+    @Test func ignoreUpstreamSkipsUpstreamResolution() async throws {
+        let (worktree, _) = try await makeRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: worktree.deletingLastPathComponent()) }
+        try "1\n".write(to: worktree.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["commit", "-q", "-am", "feat: ahead"], cwd: worktree)
+
+        let svc = GitService()
+        // With upstream resolution (default), upstream wins.
+        let (_, refDefault) = try await svc.commitsAhead(at: worktree, baseBranch: "nonexistent")
+        #expect(refDefault == "origin/main")
+
+        // With ignoreUpstream, upstream is skipped; nonexistent base returns nil.
+        let (_, refIgnored) = try await svc.commitsAhead(at: worktree, baseBranch: "nonexistent", ignoreUpstream: true)
+        #expect(refIgnored == nil)
+    }
 }

--- a/AlasTests/CommitsAheadTests.swift
+++ b/AlasTests/CommitsAheadTests.swift
@@ -183,4 +183,23 @@ struct CommitsAheadTests {
         let (_, refIgnored) = try await svc.commitsAhead(at: worktree, baseBranch: "nonexistent", ignoreUpstream: true)
         #expect(refIgnored == nil)
     }
+
+    @Test func slashNamedBasePrefersLocalBranchOverRemoteTrackingRef() async throws {
+        let (worktree, _) = try await makeRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: worktree.deletingLastPathComponent()) }
+        let otherRemote = worktree.deletingLastPathComponent().appendingPathComponent("team.git")
+        _ = try await Process.git(["init", "--bare", "-q", otherRemote.path], cwd: nil)
+        _ = try await Process.git(["remote", "add", "team", otherRemote.path], cwd: worktree)
+        _ = try await Process.git(["checkout", "-q", "-b", "team/main"], cwd: worktree)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "local slash base"], cwd: worktree)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: worktree)
+        _ = try await Process.git(["push", "-q", "team", "main"], cwd: worktree)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: worktree)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "feat: feature work"], cwd: worktree)
+
+        let svc = GitService()
+        let (_, comparisonRef) = try await svc.commitsAhead(at: worktree, baseBranch: "team/main", ignoreUpstream: true)
+
+        #expect(comparisonRef == "team/main")
+    }
 }

--- a/AlasTests/GitServiceBehindStatusTests.swift
+++ b/AlasTests/GitServiceBehindStatusTests.swift
@@ -46,6 +46,29 @@ struct GitServiceBehindStatusTests {
         #expect(resolved?.fetchBranch == "main")
     }
 
+    @Test func resolveBaseRefPrefersLocalSlashBranchOverRemoteTrackingRef() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let otherRemote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-behind-team-rmt-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: otherRemote) }
+        _ = try await Process.git(["init", "--bare", "-q", otherRemote.path], cwd: nil)
+        _ = try await Process.git(["remote", "add", "team", otherRemote.path], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "team/main"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "local slash branch"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        _ = try await Process.git(["push", "-q", "team", "main"], cwd: repo)
+
+        let svc = GitService()
+        let resolved = try await svc.resolveBaseRef(worktreePath: repo, baseBranch: "team/main")
+        #expect(resolved?.remote == nil)
+        #expect(resolved?.baseRef == "team/main")
+        #expect(resolved?.fetchBranch == nil)
+    }
+
     @Test func resolveBaseRefFallsBackToLocalBase() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-behind-loc-\(UUID().uuidString)")

--- a/AlasTests/GitServiceBehindStatusTests.swift
+++ b/AlasTests/GitServiceBehindStatusTests.swift
@@ -33,6 +33,19 @@ struct GitServiceBehindStatusTests {
         #expect(resolved?.fetchBranch == "main")
     }
 
+    @Test func resolveBaseRefCanPreferLocalSimpleBranch() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let svc = GitService()
+        let resolved = try await svc.resolveBaseRef(worktreePath: repo, baseBranch: "main", preferLocal: true)
+        #expect(resolved?.remote == nil)
+        #expect(resolved?.baseRef == "main")
+        #expect(resolved?.fetchBranch == nil)
+    }
+
     @Test func resolveBaseRefSplitsRemoteQualifiedBranchForFetch() async throws {
         let (repo, remote) = try await makeRepoWithRemote()
         defer {

--- a/AlasTests/GitServiceBehindStatusTests.swift
+++ b/AlasTests/GitServiceBehindStatusTests.swift
@@ -30,6 +30,20 @@ struct GitServiceBehindStatusTests {
         let resolved = try await svc.resolveBaseRef(worktreePath: repo, baseBranch: "main")
         #expect(resolved?.remote == "origin")
         #expect(resolved?.baseRef == "origin/main")
+        #expect(resolved?.fetchBranch == "main")
+    }
+
+    @Test func resolveBaseRefSplitsRemoteQualifiedBranchForFetch() async throws {
+        let (repo, remote) = try await makeRepoWithRemote()
+        defer {
+            try? FileManager.default.removeItem(at: repo)
+            try? FileManager.default.removeItem(at: remote)
+        }
+        let svc = GitService()
+        let resolved = try await svc.resolveBaseRef(worktreePath: repo, baseBranch: "origin/main")
+        #expect(resolved?.remote == "origin")
+        #expect(resolved?.baseRef == "origin/main")
+        #expect(resolved?.fetchBranch == "main")
     }
 
     @Test func resolveBaseRefFallsBackToLocalBase() async throws {
@@ -46,6 +60,7 @@ struct GitServiceBehindStatusTests {
         let resolved = try await svc.resolveBaseRef(worktreePath: dir, baseBranch: "main")
         #expect(resolved?.remote == nil)
         #expect(resolved?.baseRef == "main")
+        #expect(resolved?.fetchBranch == nil)
     }
 
     @Test func resolveBaseRefReturnsNilWhenNoBaseExists() async throws {

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -1,0 +1,82 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct RightPaneStateBaseBranchTests {
+    private func makeWorktree(at path: URL, branch: String) -> Worktree {
+        Worktree(
+            id: Worktree.makeId(path: path),
+            projectId: "test-project",
+            name: branch,
+            branch: branch,
+            path: path,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    private func createTestRepoWithBranches() async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-base-branch-branches-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: tmp)
+        try "main content\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", "main init"], cwd: tmp)
+        _ = try await Process.git(["checkout", "-q", "-b", "develop"], cwd: tmp)
+        try "develop content\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", "develop commit"], cwd: tmp)
+        _ = try await Process.git(["checkout", "-q", "-b", "trunk"], cwd: tmp)
+        try "trunk content\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", "trunk commit"], cwd: tmp)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: tmp)
+        return tmp
+    }
+
+    private func createTestRepoWithCommits() async throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-base-branch-commits-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: tmp)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: tmp)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: tmp)
+        for i in 1...3 {
+            try "\(i)\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+            _ = try await Process.git(["add", "."], cwd: tmp)
+            _ = try await Process.git(["commit", "-q", "-m", "commit \(i)"], cwd: tmp)
+        }
+        return tmp
+    }
+
+    @Test func selectBaseBranchAppendsToRecent() async throws {
+        let tmp = try await createTestRepoWithBranches()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let wt = makeWorktree(at: tmp, branch: "feature")
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        #expect(state.recentBaseBranches.isEmpty)
+        state.selectBaseBranch("develop")
+        #expect(state.recentBaseBranches == ["develop"])
+        state.selectBaseBranch("trunk")
+        #expect(state.recentBaseBranches == ["develop", "trunk"])
+    }
+
+    @Test func selectBaseBranchTriggersRefresh() async throws {
+        let tmp = try await createTestRepoWithCommits()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let wt = makeWorktree(at: tmp, branch: "feature")
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        await state.refresh()
+        let before = state.commits.count
+        state.selectBaseBranch("develop")
+        // After refresh, commits may differ; we just verify refresh was
+        // triggered by checking that loading eventually settles.
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        #expect(!state.loading)
+    }
+}

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -91,6 +91,18 @@ struct RightPaneStateBaseBranchTests {
         #expect(state.recentBaseBranches == ["develop", "trunk"])
     }
 
+    @Test func selectBaseBranchClearsBehindBase() async throws {
+        let tmp = try await createTestRepoWithBranches()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let wt = makeWorktree(at: tmp, branch: "feature")
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.behindBase = GitService.BehindStatus(ref: "origin/main", sha: "abc", count: 2, probedAt: Date())
+
+        state.selectBaseBranch("develop")
+
+        #expect(state.behindBase == nil)
+    }
+
     @Test func selectBaseBranchTriggersRefresh() async throws {
         let tmp = try await createTestRepoWithBranches()
         defer { try? FileManager.default.removeItem(at: tmp) }

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -58,6 +58,27 @@ struct RightPaneStateBaseBranchTests {
         return tmp
     }
 
+    private func createTestRepoWithUpstream() async throws -> (worktree: URL, root: URL) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-base-branch-upstream-\(UUID().uuidString)")
+        let remote = root.appendingPathComponent("remote.git")
+        let worktree = root.appendingPathComponent("clone")
+        try FileManager.default.createDirectory(at: remote, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "--bare", "-b", "master"], cwd: remote)
+        _ = try await Process.git(["clone", "-q", remote.path, worktree.path], cwd: nil)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: worktree)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: worktree)
+        try "base\n".write(to: worktree.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: worktree)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: worktree)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "master"], cwd: worktree)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: worktree)
+        try "feature\n".write(to: worktree.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["commit", "-q", "-am", "feature work"], cwd: worktree)
+        _ = try await Process.git(["push", "-q", "-u", "origin", "feature"], cwd: worktree)
+        return (worktree, root)
+    }
+
     @Test func selectBaseBranchAppendsToRecent() async throws {
         let tmp = try await createTestRepoWithBranches()
         defer { try? FileManager.default.removeItem(at: tmp) }
@@ -105,5 +126,16 @@ struct RightPaneStateBaseBranchTests {
         state.selectBaseBranch("staging")
         state.selectBaseBranch("main")
         #expect(state.recentBaseBranches == ["develop", "staging", "main"])
+    }
+
+    @Test func refreshUsesUpstreamWhenConfiguredBaseIsMissingAndNotOverridden() async throws {
+        let (repo, root) = try await createTestRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let wt = makeWorktree(at: repo, branch: "feature")
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+
+        await state.refresh()
+
+        #expect(state.comparisonRef == "origin/feature")
     }
 }

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -93,4 +93,17 @@ struct RightPaneStateBaseBranchTests {
         state.selectBaseBranch("main")
         #expect(state.recentBaseBranches == ["trunk", "staging", "main"])
     }
+
+    @Test func selectBaseBranchRefreshesExistingRecentRecency() async throws {
+        let tmp = try await createTestRepoWithBranches()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let wt = makeWorktree(at: tmp, branch: "feature")
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.selectBaseBranch("develop")
+        state.selectBaseBranch("trunk")
+        state.selectBaseBranch("develop")
+        state.selectBaseBranch("staging")
+        state.selectBaseBranch("main")
+        #expect(state.recentBaseBranches == ["develop", "staging", "main"])
+    }
 }

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -35,6 +35,10 @@ struct RightPaneStateBaseBranchTests {
         try "trunk content\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
         _ = try await Process.git(["add", "."], cwd: tmp)
         _ = try await Process.git(["commit", "-q", "-m", "trunk commit"], cwd: tmp)
+        _ = try await Process.git(["checkout", "-q", "-b", "staging"], cwd: tmp)
+        try "staging content\n".write(to: tmp.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: tmp)
+        _ = try await Process.git(["commit", "-q", "-m", "staging commit"], cwd: tmp)
         _ = try await Process.git(["checkout", "-q", "main"], cwd: tmp)
         return tmp
     }
@@ -67,16 +71,26 @@ struct RightPaneStateBaseBranchTests {
     }
 
     @Test func selectBaseBranchTriggersRefresh() async throws {
-        let tmp = try await createTestRepoWithCommits()
+        let tmp = try await createTestRepoWithBranches()
         defer { try? FileManager.default.removeItem(at: tmp) }
         let wt = makeWorktree(at: tmp, branch: "feature")
         let state = RightPaneState(worktree: wt, baseBranch: "main")
         await state.refresh()
-        let before = state.commits.count
-        state.selectBaseBranch("develop")
-        // After refresh, commits may differ; we just verify refresh was
-        // triggered by checking that loading eventually settles.
+        state.selectBaseBranch("trunk")
         try await Task.sleep(nanoseconds: 1_000_000_000)
         #expect(!state.loading)
+    }
+
+    @Test func selectBaseBranchCapsRecentAtThree() async throws {
+        let tmp = try await createTestRepoWithBranches()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let wt = makeWorktree(at: tmp, branch: "feature")
+        let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.selectBaseBranch("develop")
+        state.selectBaseBranch("trunk")
+        state.selectBaseBranch("staging")
+        #expect(state.recentBaseBranches == ["develop", "trunk", "staging"])
+        state.selectBaseBranch("main")
+        #expect(state.recentBaseBranches == ["trunk", "staging", "main"])
     }
 }

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -138,4 +138,23 @@ struct RightPaneStateBaseBranchTests {
 
         #expect(state.comparisonRef == "origin/feature")
     }
+
+    @Test func storeRefreshesWhenConfigMatchesClearedOverride() async throws {
+        let (repo, root) = try await createTestRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let wt = makeWorktree(at: repo, branch: "feature")
+        let store = RightPaneStore()
+        let state = store.state(for: wt, baseBranch: "main")
+
+        state.selectBaseBranch("develop")
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(state.baseBranch == "develop")
+        #expect(state.userOverrodeBaseBranch)
+
+        _ = store.state(for: wt, baseBranch: "develop")
+        try await Task.sleep(for: .milliseconds(600))
+
+        #expect(!state.userOverrodeBaseBranch)
+        #expect(state.comparisonRef == "origin/feature")
+    }
 }

--- a/docs/superpowers/specs/2026-05-24-base-branch-selector-design.md
+++ b/docs/superpowers/specs/2026-05-24-base-branch-selector-design.md
@@ -1,0 +1,81 @@
+# Base Branch Selector in Changes Panel
+
+## Summary
+
+Add a clickable base-branch chip to the Commits section header in the right pane. Tapping it opens a picker that lets the user choose which ref to compare HEAD against, changing the commits shown in the "Commits" list and the behind-base chip.
+
+## Motivation
+
+Currently the comparison ref (`origin/main`, `main`, or upstream) is shown as a static label in the Commits header. Users cannot change it without editing the global "Base branch" setting in Settings → Worktrees. For repos with multiple mainline branches (e.g., `main` and `develop`) or when reviewing a feature branch against a different trunk, users want to switch the comparison on the fly per worktree.
+
+## Design
+
+### UI
+
+- **Chip placement:** The existing `comparisonRef` row in `CommitsSectionView`’s header trailing slot becomes a tappable chip.
+- **Chip styling:** Same look as today — branch icon + monospace ref name in `fg-faint`. On hover, the text shifts to `accent` and the cursor becomes a pointing hand.
+- **Popover:** Opens below the chip. Contains:
+  1. A search field (filters the list).
+  2. A scrollable list of branches with a checkmark marking the current selection.
+  3. An "Other…" row at the bottom that opens a free-text field for arbitrary refs (or reuses the existing `BranchPicker` dialog).
+
+### Smart Shortlist
+
+The picker shows a smart shortlist of branches rather than every branch in the repo. The list is computed per-worktree when the popover opens.
+
+Priority / sections:
+1. **Mainline branches** — Any branch whose short name matches `main`, `master`, `develop`, or `trunk`. Both local and remote-tracking forms are included.
+2. **Current upstream** — If the active branch has an upstream tracking ref (e.g., `origin/feature-x`), include it.
+3. **Recently selected** — Up to 3 branches previously chosen for this worktree (kept in-memory on `RightPaneState`).
+4. **Deduplicated and sorted** — Local branches first, then remotes, alphabetically within each group.
+
+If a previously selected branch no longer exists (e.g., a stale remote branch), it still appears in the recent list with a "not found" note, but remains selectable so the user can see the empty state.
+
+### Data Flow
+
+```
+User taps chip
+  → popover opens with smart list
+User selects branch
+  → baseBranch on RightPaneState is updated
+  → RightPaneStore propagates change to cached state
+  → RightPaneState.refresh() triggered
+    → re-fetches commitsAhead(baseBranch:)
+    → re-fetches refreshSyncStatus()
+  → Commits list + behind-chips update reactively
+```
+
+### Component Architecture
+
+- **`BaseBranchSelector`** — New SwiftUI view. Owns the chip + popover.
+  - Inputs: `@Binding var baseBranch: String`, `worktree: Worktree`, `currentRef: String?`, `onSelect: (String) -> Void`.
+  - Internally computes the smart list when the popover opens.
+- **`CommitsSectionView`** — Replaces the inline `comparisonRef` HStack with `BaseBranchSelector` in the trailing slot.
+- **`RightPaneState`** — Gains a `recentBaseBranches: [String]` ring buffer (max 3) that is populated when the user selects a new base. The property is in-memory only (not persisted).
+
+### Error Handling
+
+- **Unresolvable branch:** If the selected branch does not resolve, `commitsAhead` returns empty commits and `nil` `comparisonRef`. The UI shows the "no comparison branch" empty state. No crash, no alert.
+- **Network fetch failure:** During `refreshSyncStatus`, fetch errors are logged via `os.Logger`. The UI keeps the last successful behind-chip state.
+
+## Testing Plan
+
+- Swift Testing unit tests for `BaseBranchSelector.smartList(branches:current:upstream:recent:)` covering:
+  - Ordering (mainlines → upstream → recent)
+  - Deduplication when upstream is also a mainline
+  - Capping recent list at 3
+  - Handling empty input gracefully
+- `RightPaneState` tests:
+  - Changing `baseBranch` triggers `refresh()` and updates `commits`/`comparisonRef`.
+  - Selecting a new base appends it to `recentBaseBranches`.
+  - An unresolvable branch results in empty commits and `nil` `comparisonRef`.
+
+## Out of Scope
+
+- Persisting the overridden base branch across app relaunches. This can be added later by writing per-worktree overrides into `AppConfig` without changing the component interface.
+- Changing the global Settings default from the picker. The picker is strictly a per-worktree override.
+
+## Risks / Open Questions
+
+- **Remote branch staleness:** If the user selects `origin/main` and later fetches, the comparison ref stays `origin/main`. This is the same behavior as today and is acceptable.
+- **Performance on huge repos:** The branch list is fetched with `git branch --list` + `git branch --remotes`, which is fast even on large repos. The smart list computation is in-memory string filtering.


### PR DESCRIPTION
Adds a clickable base-branch chip to the Commits section header that opens a picker and lets the user switch the comparison ref per worktree.

**Changes:**
- New `BaseBranchSelector` SwiftUI component with chip + popover
- Smart shortlist of branches (mainlines → upstream → recent selections)
- Per-worktree in-memory recent selections (ring buffer, max 3)
- On-demand branch fetching via `GitService.branches(at:)`
- Full wiring through `CommitsSectionView` → `ChangesTabView` → `RightPaneState`

**Tests:**
- 8 Swift Testing unit tests for smart-list ordering, dedup, capping, empty input
- 3 integration tests for `RightPaneState` mutation, refresh trigger, and cap-at-3 eviction

**Out of scope:**
- Persisting the override across app relaunches (can be added later via `AppConfig`)
- Changing the global Settings default from the picker