### PR TITLE
feat: three-column merge editor in the center pane

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
 		2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */; };
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
+		2EA0D9B6F711518ECBF14CF7 /* TabMergeConflictCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */; };
 		2ED636DD3A179B95C061A9E6 /* InlineErrorStripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */; };
 		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
@@ -165,6 +166,7 @@
 		45B3616A459480A78A5004E8 /* ImageDiffPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */; };
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
 		474DF7FE50CB6146644B2450 /* ImageDiffEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */; };
+		476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */; };
 		4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */; };
 		48E0B43B698544C1C4524242 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */; };
 		48EFAD2DE1F112D72B5F9FAC /* AgentPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37987D5884297401F95478D3 /* AgentPathTests.swift */; };
@@ -577,6 +579,7 @@
 		1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandleTests.swift; sourceTree = "<group>"; };
 		137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHookSettingsFile.swift; sourceTree = "<group>"; };
 		14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabView.swift; sourceTree = "<group>"; };
+		14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMergeConflictCodingTests.swift; sourceTree = "<group>"; };
 		155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessService.swift; sourceTree = "<group>"; };
 		159FE807399835B0821E1CAB /* EnvBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilder.swift; sourceTree = "<group>"; };
 		1688AB1B49758FAB5BF0AF2F /* light.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = light.json; sourceTree = "<group>"; };
@@ -623,6 +626,7 @@
 		29313DDC46A0CCA2FA42CDE9 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
 		295319DB8544C170DDD6328D /* PathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsTests.swift; sourceTree = "<group>"; };
 		2975A1465CA308E9766521F2 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabState.swift; sourceTree = "<group>"; };
 		2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRegistry.swift; sourceTree = "<group>"; };
 		2B9E3F080F847EF069137844 /* ShortcutBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBinding.swift; sourceTree = "<group>"; };
 		2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailabilityTests.swift; sourceTree = "<group>"; };
@@ -1259,6 +1263,7 @@
 				07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */,
 				C7DD2CA21EC45168D6E43564 /* TabActivityPulseTests.swift */,
 				9F650CFAC8E61B1EC99CD04A /* TabActivityPulseTransitionTests.swift */,
+				14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
 				4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */,
@@ -1523,6 +1528,7 @@
 				008E982C8526670670425AB8 /* EmptyTabView.swift */,
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
+				2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */,
 				B27595490B7D883CF5D9FFD5 /* Tab.swift */,
 				8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */,
 				BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */,
@@ -2320,6 +2326,7 @@
 				6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
+				476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */,
 				32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
@@ -2622,6 +2629,7 @@
 				6DDB5FC604A28D699350C3BD /* TabActivityIconTintTests.swift in Sources */,
 				6A639AFB741004AA32C9D81A /* TabActivityPulseTests.swift in Sources */,
 				90F619F67402DB675E2614CC /* TabActivityPulseTransitionTests.swift in Sources */,
+				2EA0D9B6F711518ECBF14CF7 /* TabMergeConflictCodingTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
 				BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -242,6 +242,7 @@
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
 		709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D105CB2C185958ED23164D1 /* IndentationMode.swift */; };
 		70FCC2B12AE446728EE7CF8D /* LSPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38499AFE31188908546EE222 /* LSPTransport.swift */; };
+		7146CECD7FE56140D7A7AF50 /* MergeConflictTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
 		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
@@ -739,6 +740,7 @@
 		5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModel.swift; sourceTree = "<group>"; };
 		5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateFileTreeTests.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
+		5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabView.swift; sourceTree = "<group>"; };
 		5BB6172AE118D2F9A40FD534 /* AgentsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPane.swift; sourceTree = "<group>"; };
 		5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackState.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
@@ -1548,6 +1550,7 @@
 				674F70D8D27715223D10C582 /* MergeConflictResultView.swift */,
 				CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */,
 				2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */,
+				5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */,
 				EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */,
 				91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */,
 				B27595490B7D883CF5D9FFD5 /* Tab.swift */,
@@ -2352,6 +2355,7 @@
 				B27F4047043A6FCE2E9C21A3 /* MergeConflictResultView.swift in Sources */,
 				906EE12924284FF21B9BDEFF /* MergeConflictTabModel.swift in Sources */,
 				476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */,
+				7146CECD7FE56140D7A7AF50 /* MergeConflictTabView.swift in Sources */,
 				B08F7ECC5E2612CC503E1BE0 /* MergeConflictTextStorage.swift in Sources */,
 				5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */,
 				32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
 		4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */; };
 		4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */; };
+		4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */; };
 		512A41C0AB75B8D35424EBCD /* DeletingWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */; };
@@ -361,6 +362,7 @@
 		B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7159EED1183F784104B4F /* FuzzyMatch.swift */; };
 		B06544FDB162DD8CDCD9EAF2 /* AlasHookCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57713D7143CFD53124E0523F /* AlasHookCommand.swift */; };
 		B0861243A465A06EDA290722 /* AgentHookSocketServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78C23951DE157A38A9ED899 /* AgentHookSocketServerTests.swift */; };
+		B08F7ECC5E2612CC503E1BE0 /* MergeConflictTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */; };
 		B092D71B3D727B89EAF5D753 /* SymbolsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
 		B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46BDE72E52818061452ECB /* CommitRowTests.swift */; };
@@ -818,6 +820,7 @@
 		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
+		8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictColumnView.swift; sourceTree = "<group>"; };
 		8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulse.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
@@ -1013,6 +1016,7 @@
 		EB52B59655B85764D85CFB7F /* LineEndingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEndingTests.swift; sourceTree = "<group>"; };
 		EBB8043A52927E5E935E2F9B /* ImageDiffPairLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairLoaderTests.swift; sourceTree = "<group>"; };
 		EBBBF87CC508451B2C0F3A66 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTextStorage.swift; sourceTree = "<group>"; };
 		EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigFilesTests.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
@@ -1535,8 +1539,10 @@
 				008E982C8526670670425AB8 /* EmptyTabView.swift */,
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
+				8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */,
 				CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */,
 				2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */,
+				EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */,
 				91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */,
 				B27595490B7D883CF5D9FFD5 /* Tab.swift */,
 				8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */,
@@ -2335,8 +2341,10 @@
 				6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
+				4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */,
 				906EE12924284FF21B9BDEFF /* MergeConflictTabModel.swift in Sources */,
 				476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */,
+				B08F7ECC5E2612CC503E1BE0 /* MergeConflictTextStorage.swift in Sources */,
 				5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */,
 				32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		B08F7ECC5E2612CC503E1BE0 /* MergeConflictTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */; };
 		B092D71B3D727B89EAF5D753 /* SymbolsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
+		B27F4047043A6FCE2E9C21A3 /* MergeConflictResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674F70D8D27715223D10C582 /* MergeConflictResultView.swift */; };
 		B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46BDE72E52818061452ECB /* CommitRowTests.swift */; };
 		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
 		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
@@ -757,6 +758,7 @@
 		6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateOverlayFocusTests.swift; sourceTree = "<group>"; };
 		66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Highlighted.swift; sourceTree = "<group>"; };
 		670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherFilterTests.swift; sourceTree = "<group>"; };
+		674F70D8D27715223D10C582 /* MergeConflictResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResultView.swift; sourceTree = "<group>"; };
 		679E62B501E0490F48CCA830 /* EditorFindBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindBarView.swift; sourceTree = "<group>"; };
 		6821B71680094791995C4975 /* ShortcutsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsPane.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
@@ -1540,6 +1542,7 @@
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
 				8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */,
+				674F70D8D27715223D10C582 /* MergeConflictResultView.swift */,
 				CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */,
 				2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */,
 				EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */,
@@ -2342,6 +2345,7 @@
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
 				4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */,
+				B27F4047043A6FCE2E9C21A3 /* MergeConflictResultView.swift in Sources */,
 				906EE12924284FF21B9BDEFF /* MergeConflictTabModel.swift in Sources */,
 				476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */,
 				B08F7ECC5E2612CC503E1BE0 /* MergeConflictTextStorage.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		B08F7ECC5E2612CC503E1BE0 /* MergeConflictTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */; };
 		B092D71B3D727B89EAF5D753 /* SymbolsFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15A32659EEBFA80F816CE31 /* SymbolsFeatureTests.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
+		B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */; };
 		B27F4047043A6FCE2E9C21A3 /* MergeConflictResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674F70D8D27715223D10C582 /* MergeConflictResultView.swift */; };
 		B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46BDE72E52818061452ECB /* CommitRowTests.swift */; };
 		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
@@ -1006,6 +1007,7 @@
 		E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderViewTests.swift; sourceTree = "<group>"; };
 		E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
 		E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibilityTests.swift; sourceTree = "<group>"; };
+		E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictMinimap.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilderTests.swift; sourceTree = "<group>"; };
@@ -1542,6 +1544,7 @@
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
 				8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */,
+				E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */,
 				674F70D8D27715223D10C582 /* MergeConflictResultView.swift */,
 				CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */,
 				2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */,
@@ -2345,6 +2348,7 @@
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
 				4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */,
+				B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */,
 				B27F4047043A6FCE2E9C21A3 /* MergeConflictResultView.swift in Sources */,
 				906EE12924284FF21B9BDEFF /* MergeConflictTabModel.swift in Sources */,
 				476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934BCC470703CF2DF2303357 /* SectionHeader.swift */; };
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
 		0407824F9DA8EEFC5B5EEA8A /* InstallerHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C506EF972D34E2F937D4FEEC /* InstallerHost.swift */; };
+		04C778DB96502CD36E4C031B /* MergeConflictTabModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */; };
 		04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */; };
 		0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */; };
 		065F01BB553C415040414D37 /* ImageDiffSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */; };
@@ -300,6 +301,7 @@
 		8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */; };
 		8FD71F989EFA5BF22B92B4CD /* SidebarMaterialChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */; };
 		8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2AC0F8B3A1B75239995AC /* AppState.swift */; };
+		906EE12924284FF21B9BDEFF /* MergeConflictTabModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */; };
 		90958414931FC96F766F0C46 /* DiagnosticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932F0FEE5330D5B4470C1874 /* DiagnosticsFeature.swift */; };
 		90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */; };
 		90BB0EFFD7E0EF8DE64296E6 /* ShortcutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */; };
@@ -950,6 +952,7 @@
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstaller.swift; sourceTree = "<group>"; };
 		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
+		CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModel.swift; sourceTree = "<group>"; };
 		CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRendererTests.swift; sourceTree = "<group>"; };
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
@@ -963,6 +966,7 @@
 		D49B5B544A3432F8D8105268 /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
 		D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeature.swift; sourceTree = "<group>"; };
 		D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolver.swift; sourceTree = "<group>"; };
+		D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModelTests.swift; sourceTree = "<group>"; };
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D64C0B7363363C77718B446C /* CopilotInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstaller.swift; sourceTree = "<group>"; };
 		D6A9977C979705A40595FD5E /* TabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerTests.swift; sourceTree = "<group>"; };
@@ -1212,6 +1216,7 @@
 				373D587E3153D902EB10208B /* MarkdownParserTests.swift */,
 				B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */,
 				DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */,
+				D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */,
 				0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */,
 				E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */,
 				C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */,
@@ -1528,6 +1533,7 @@
 				008E982C8526670670425AB8 /* EmptyTabView.swift */,
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
+				CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */,
 				2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */,
 				B27595490B7D883CF5D9FFD5 /* Tab.swift */,
 				8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */,
@@ -2326,6 +2332,7 @@
 				6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
+				906EE12924284FF21B9BDEFF /* MergeConflictTabModel.swift in Sources */,
 				476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */,
 				32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
@@ -2576,6 +2583,7 @@
 				8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */,
 				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,
 				EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */,
+				04C778DB96502CD36E4C031B /* MergeConflictTabModelTests.swift in Sources */,
 				5F7E14A0D7E1D3F036806B73 /* MergeOperationStateTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -179,6 +179,7 @@
 		4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */; };
 		4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
+		5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */; };
 		512A41C0AB75B8D35424EBCD /* DeletingWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */; };
 		51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25493E3B18A1AB94EA6985C3 /* EventHolder.swift */; };
 		513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */; };
@@ -827,6 +828,7 @@
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
+		91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictToolbar.swift; sourceTree = "<group>"; };
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
 		9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputerTests.swift; sourceTree = "<group>"; };
@@ -1535,6 +1537,7 @@
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
 				CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */,
 				2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */,
+				91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */,
 				B27595490B7D883CF5D9FFD5 /* Tab.swift */,
 				8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */,
 				BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */,
@@ -2334,6 +2337,7 @@
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
 				906EE12924284FF21B9BDEFF /* MergeConflictTabModel.swift in Sources */,
 				476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */,
+				5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */,
 				32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -143,6 +143,8 @@ struct CenterPaneView: View {
                     case .imagePreview(let s):
                         ImagePreviewTabView(worktreePath: worktree.path,
                                             relativePath: s.relativePath)
+                    case .mergeConflict:
+                        EmptyView()
                     }
                 }
             }

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -144,6 +144,8 @@ struct CenterPaneView: View {
                         ImagePreviewTabView(worktreePath: worktree.path,
                                             relativePath: s.relativePath)
                     case .mergeConflict:
+                        // Temporary placeholder — replaced by MergeConflictTabView
+                        // in the wiring task at the end of Plan 2.
                         EmptyView()
                     }
                 }

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -143,10 +143,12 @@ struct CenterPaneView: View {
                     case .imagePreview(let s):
                         ImagePreviewTabView(worktreePath: worktree.path,
                                             relativePath: s.relativePath)
-                    case .mergeConflict:
-                        // Temporary placeholder — replaced by MergeConflictTabView
-                        // in the wiring task at the end of Plan 2.
-                        EmptyView()
+                    case .mergeConflict(let s):
+                        MergeConflictTabView(
+                            state: state,
+                            worktree: worktree,
+                            tabState: s
+                        )
                     }
                 }
             }

--- a/Alas/Sources/Center/MergeConflictColumnView.swift
+++ b/Alas/Sources/Center/MergeConflictColumnView.swift
@@ -38,14 +38,20 @@ struct MergeConflictColumnView: NSViewRepresentable {
 
     func updateNSView(_ scroll: NSScrollView, context: Context) {
         guard let textView = scroll.documentView as? NSTextView else { return }
-        let attr = MergeConflictTextStorage.highlightedAttributedString(
-            text: text,
-            fileExtension: fileExtension,
-            fontFamily: codeFontFamily,
-            fontSize: codeFontSize,
-            theme: theme
-        )
-        textView.textStorage?.setAttributedString(attr)
+        // Avoid a full re-layout when the bound text hasn't changed (e.g., on
+        // theme/config-only updates). The background color is cheap to set
+        // unconditionally.
+        let current = textView.string
+        if current != text {
+            let attr = MergeConflictTextStorage.highlightedAttributedString(
+                text: text,
+                fileExtension: fileExtension,
+                fontFamily: codeFontFamily,
+                fontSize: codeFontSize,
+                theme: theme
+            )
+            textView.textStorage?.setAttributedString(attr)
+        }
         textView.backgroundColor = NSColor(theme.color("bg-1"))
     }
 }

--- a/Alas/Sources/Center/MergeConflictColumnView.swift
+++ b/Alas/Sources/Center/MergeConflictColumnView.swift
@@ -1,0 +1,51 @@
+import AppKit
+import SwiftUI
+
+/// Read-only column for LOCAL or REMOTE in the merge editor.
+/// NSTextView-backed for fast highlighting and native scrolling.
+struct MergeConflictColumnView: NSViewRepresentable {
+    let text: String
+    let fileExtension: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    @Environment(\.theme) var theme
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = true
+        scroll.autohidesScrollers = true
+        scroll.borderType = .noBorder
+
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = true
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.autoresizingMask = [.width]
+        textView.drawsBackground = true
+        textView.backgroundColor = NSColor(theme.color("bg-1"))
+        textView.textContainerInset = NSSize(width: 6, height: 6)
+
+        scroll.documentView = textView
+        return scroll
+    }
+
+    func updateNSView(_ scroll: NSScrollView, context: Context) {
+        guard let textView = scroll.documentView as? NSTextView else { return }
+        let attr = MergeConflictTextStorage.highlightedAttributedString(
+            text: text,
+            fileExtension: fileExtension,
+            fontFamily: codeFontFamily,
+            fontSize: codeFontSize,
+            theme: theme
+        )
+        textView.textStorage?.setAttributedString(attr)
+        textView.backgroundColor = NSColor(theme.color("bg-1"))
+    }
+}

--- a/Alas/Sources/Center/MergeConflictMinimap.swift
+++ b/Alas/Sources/Center/MergeConflictMinimap.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct MergeConflictMinimap: View {
+    let conflictCount: Int
+    let currentConflictIndex: Int?
+    let onJump: (Int) -> Void
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        VStack(spacing: 2) {
+            ForEach(0..<conflictCount, id: \.self) { i in
+                Button(action: { onJump(i) }) {
+                    Rectangle()
+                        .fill(tintFor(i))
+                        .frame(width: 6, height: 14)
+                        .cornerRadius(1)
+                }
+                .buttonStyle(.plain)
+                .help("Conflict \(i + 1)")
+            }
+            Spacer()
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 3)
+        .background(theme.color("bg-1"))
+        .overlay(Divider(), alignment: .leading)
+    }
+
+    private func tintFor(_ i: Int) -> Color {
+        if i == currentConflictIndex {
+            return theme.color("warn")
+        }
+        return theme.color("warn").opacity(0.55)
+    }
+}

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -1,0 +1,146 @@
+import AppKit
+import SwiftUI
+
+/// Editable RESULT column for the merge editor. Bound to the model's
+/// `resultText`. Reuses `MergeConflictTextStorage` for syntax highlighting
+/// and overlays yellow shading on conflict marker blocks so the user can
+/// see at a glance which regions still need resolution.
+struct MergeConflictResultView: NSViewRepresentable {
+    @Binding var text: String
+    let fileExtension: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    @Environment(\.theme) var theme
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = true
+        scroll.autohidesScrollers = true
+        scroll.borderType = .noBorder
+
+        let textView = NSTextView()
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = true
+        textView.allowsUndo = true
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.autoresizingMask = [.width]
+        textView.drawsBackground = true
+        textView.backgroundColor = NSColor(theme.color("bg-1"))
+        textView.textContainerInset = NSSize(width: 6, height: 6)
+        textView.delegate = context.coordinator
+        scroll.documentView = textView
+        context.coordinator.textView = textView
+        return scroll
+    }
+
+    func updateNSView(_ scroll: NSScrollView, context: Context) {
+        guard let textView = scroll.documentView as? NSTextView else { return }
+        // Only re-render the text storage when the bound text actually differs
+        // from what the user has typed. Otherwise we clobber the in-flight
+        // caret position on every external @State change.
+        let current = textView.string
+        if current != text {
+            let attr = MergeConflictTextStorage.highlightedAttributedString(
+                text: text,
+                fileExtension: fileExtension,
+                fontFamily: codeFontFamily,
+                fontSize: codeFontSize,
+                theme: theme
+            )
+            applyConflictShading(to: attr, text: text, theme: theme)
+            textView.textStorage?.setAttributedString(attr)
+        } else {
+            // Even when the string is unchanged, the conflict regions may have
+            // shifted (a typed edit can resolve a marker). Re-apply shading.
+            if let storage = textView.textStorage {
+                applyConflictShading(to: storage, text: text, theme: theme)
+            }
+        }
+        textView.backgroundColor = NSColor(theme.color("bg-1"))
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator($text)
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        weak var textView: NSTextView?
+        let text: Binding<String>
+        init(_ text: Binding<String>) { self.text = text }
+        func textDidChange(_ notification: Notification) {
+            guard let tv = notification.object as? NSTextView else { return }
+            text.wrappedValue = tv.string
+        }
+    }
+
+    /// Applies a yellow background to each line range that falls inside a
+    /// `<<<<<<< ... >>>>>>>` block in `text`.
+    private func applyConflictShading(
+        to storage: NSMutableAttributedString,
+        text: String,
+        theme: Theme
+    ) {
+        let regions = ConflictMarkerParser.parse(text)
+        let highlight = NSColor(theme.color("warn")).withAlphaComponent(0.18)
+        storage.removeAttribute(.backgroundColor, range: NSRange(location: 0, length: storage.length))
+        let lineRanges = Self.computeLineRanges(in: text as NSString)
+        for region in regions {
+            if case .conflict(let block) = region {
+                let lower = max(block.lineRangeInMerged.lowerBound, 0)
+                let upper = min(block.lineRangeInMerged.upperBound, lineRanges.count - 1)
+                guard upper >= lower, upper < lineRanges.count else { continue }
+                let start = lineRanges[lower].location
+                let end = NSMaxRange(lineRanges[upper])
+                let nsr = NSRange(location: start, length: end - start)
+                storage.addAttribute(.backgroundColor, value: highlight, range: nsr)
+            }
+        }
+    }
+
+    /// NSTextStorage variant — same algorithm, applied to a live storage.
+    private func applyConflictShading(
+        to storage: NSTextStorage,
+        text: String,
+        theme: Theme
+    ) {
+        let regions = ConflictMarkerParser.parse(text)
+        let highlight = NSColor(theme.color("warn")).withAlphaComponent(0.18)
+        storage.removeAttribute(.backgroundColor, range: NSRange(location: 0, length: storage.length))
+        let lineRanges = Self.computeLineRanges(in: text as NSString)
+        for region in regions {
+            if case .conflict(let block) = region {
+                let lower = max(block.lineRangeInMerged.lowerBound, 0)
+                let upper = min(block.lineRangeInMerged.upperBound, lineRanges.count - 1)
+                guard upper >= lower, upper < lineRanges.count else { continue }
+                let start = lineRanges[lower].location
+                let end = NSMaxRange(lineRanges[upper])
+                let nsr = NSRange(location: start, length: end - start)
+                storage.addAttribute(.backgroundColor, value: highlight, range: nsr)
+            }
+        }
+    }
+
+    /// NSRanges for each line (split on `\n`), preserving trailing-empty semantics.
+    private static func computeLineRanges(in nsString: NSString) -> [NSRange] {
+        var ranges: [NSRange] = []
+        var index = 0
+        while index <= nsString.length {
+            let lineRange = nsString.lineRange(for: NSRange(location: index, length: 0))
+            if lineRange.length == 0 {
+                ranges.append(NSRange(location: index, length: 0))
+                break
+            }
+            ranges.append(lineRange)
+            index = NSMaxRange(lineRange)
+            if index >= nsString.length { break }
+        }
+        return ranges
+    }
+}

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -81,32 +81,10 @@ struct MergeConflictResultView: NSViewRepresentable {
     }
 
     /// Applies a yellow background to each line range that falls inside a
-    /// `<<<<<<< ... >>>>>>>` block in `text`.
+    /// `<<<<<<< ... >>>>>>>` block in `text`. Accepts any `NSMutableAttributedString`
+    /// (including `NSTextStorage`, which IS-A `NSMutableAttributedString`).
     private func applyConflictShading(
         to storage: NSMutableAttributedString,
-        text: String,
-        theme: Theme
-    ) {
-        let regions = ConflictMarkerParser.parse(text)
-        let highlight = NSColor(theme.color("warn")).withAlphaComponent(0.18)
-        storage.removeAttribute(.backgroundColor, range: NSRange(location: 0, length: storage.length))
-        let lineRanges = Self.computeLineRanges(in: text as NSString)
-        for region in regions {
-            if case .conflict(let block) = region {
-                let lower = max(block.lineRangeInMerged.lowerBound, 0)
-                let upper = min(block.lineRangeInMerged.upperBound, lineRanges.count - 1)
-                guard upper >= lower, upper < lineRanges.count else { continue }
-                let start = lineRanges[lower].location
-                let end = NSMaxRange(lineRanges[upper])
-                let nsr = NSRange(location: start, length: end - start)
-                storage.addAttribute(.backgroundColor, value: highlight, range: nsr)
-            }
-        }
-    }
-
-    /// NSTextStorage variant — same algorithm, applied to a live storage.
-    private func applyConflictShading(
-        to storage: NSTextStorage,
         text: String,
         theme: Theme
     ) {

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -63,12 +63,19 @@ final class MergeConflictTabModel {
     /// Call after any mutation of `resultText` (typed by user or via accept actions).
     func reparse() {
         regions = ConflictMarkerParser.parse(resultText)
-        if let idx = currentConflictIndex, conflictRegionIndex(forConflictOrdinal: idx) == nil {
-            // The current conflict was resolved; move to the next unresolved one
-            // (or nil when none remain).
-            currentConflictIndex = firstConflictIndex()
-        } else if currentConflictIndex == nil {
-            currentConflictIndex = firstConflictIndex()
+        let total = conflictCount
+        guard total > 0 else {
+            currentConflictIndex = nil
+            return
+        }
+        if let idx = currentConflictIndex {
+            // Clamp: if the resolved conflict was the last in the list (or beyond),
+            // step the cursor back to the new last instead of snapping to 0.
+            // Otherwise the ordinal still points to a valid conflict because
+            // every later conflict shifts down by one when one is removed.
+            currentConflictIndex = min(idx, total - 1)
+        } else {
+            currentConflictIndex = 0
         }
     }
 
@@ -94,14 +101,9 @@ final class MergeConflictTabModel {
     }
 
     /// Returns the ordinal (0-based) of the first unresolved conflict, or nil.
-    /// Marked `internal` (default) so Task 4's extension can call it.
+    /// Marked `internal` (default) so callers in the same target can use it.
     func firstConflictIndex() -> Int? {
-        var ord = 0
-        for r in regions where isConflict(r) {
-            return ord
-        }
-        _ = ord
-        return nil
+        regions.contains(where: isConflict) ? 0 : nil
     }
 
     // MARK: - Accept actions

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -190,9 +190,17 @@ final class MergeConflictTabModel {
 
     /// Writes `resultText` to disk and stages the file via `GitService.markResolved`.
     /// Throws if either step fails.
+    ///
+    /// For binary conflicts `resultText` is intentionally empty (the editor
+    /// does not show binary bytes), so writing it would clobber whichever
+    /// side currently lives on disk. In that case we stage the file as-is
+    /// without writing — the on-disk file is whatever the user chose via
+    /// the Use ours / Use theirs context menu in the right pane.
     func markFileResolved() async throws {
-        let absolute = worktreePath.appendingPathComponent(relativePath)
-        try resultText.write(to: absolute, atomically: true, encoding: .utf8)
+        if conflictedFile?.isBinary != true {
+            let absolute = worktreePath.appendingPathComponent(relativePath)
+            try resultText.write(to: absolute, atomically: true, encoding: .utf8)
+        }
         try await gitService.markResolved(
             worktreePath: worktreePath,
             relativePath: relativePath

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -103,4 +103,97 @@ final class MergeConflictTabModel {
         _ = ord
         return nil
     }
+
+    // MARK: - Accept actions
+
+    /// Replaces the current conflict's marker block with LOCAL content.
+    func acceptLocal() {
+        guard let ordinal = currentConflictIndex,
+              let regionIdx = conflictRegionIndex(forConflictOrdinal: ordinal),
+              case .conflict(let block) = regions[regionIdx]
+        else { return }
+        replaceCurrentConflictBlock(with: block.local)
+    }
+
+    /// Replaces the current conflict's marker block with REMOTE content.
+    func acceptRemote() {
+        guard let ordinal = currentConflictIndex,
+              let regionIdx = conflictRegionIndex(forConflictOrdinal: ordinal),
+              case .conflict(let block) = regions[regionIdx]
+        else { return }
+        replaceCurrentConflictBlock(with: block.remote)
+    }
+
+    /// Replaces the current conflict's marker block with LOCAL followed by REMOTE.
+    func acceptBoth() {
+        guard let ordinal = currentConflictIndex,
+              let regionIdx = conflictRegionIndex(forConflictOrdinal: ordinal),
+              case .conflict(let block) = regions[regionIdx]
+        else { return }
+        replaceCurrentConflictBlock(with: block.local + block.remote)
+    }
+
+    /// Replaces the current conflict region in `resultText` with `replacement`
+    /// (which should already include any trailing newlines required). Updates
+    /// regions + currentConflictIndex.
+    private func replaceCurrentConflictBlock(with replacement: String) {
+        guard let ordinal = currentConflictIndex,
+              let regionIdx = conflictRegionIndex(forConflictOrdinal: ordinal),
+              case .conflict(let block) = regions[regionIdx]
+        else { return }
+
+        // Find the substring range of the marker block in resultText.
+        // We use the 0-indexed line range stored on the ConflictBlock:
+        //   lineRangeInMerged covers the `<<<<<<<` line through `>>>>>>>` line inclusive.
+        let lines = resultText.split(separator: "\n", omittingEmptySubsequences: false)
+        let lower = block.lineRangeInMerged.lowerBound
+        let upper = block.lineRangeInMerged.upperBound
+        guard upper < lines.count else { return }
+
+        // Rebuild resultText with the marker-block lines replaced by `replacement`.
+        var head = lines[0..<lower].map(String.init).joined(separator: "\n")
+        if !head.isEmpty { head += "\n" }
+        let tail = lines[(upper + 1)..<lines.count].map(String.init).joined(separator: "\n")
+        let trimmedReplacement = replacement.hasSuffix("\n") ? replacement : replacement + "\n"
+        resultText = head + trimmedReplacement + tail
+
+        reparse()
+    }
+
+    // MARK: - Navigation
+
+    /// Jumps to the next unresolved conflict, clamping at the last one.
+    func nextConflict() {
+        let total = conflictCount
+        guard total > 0 else {
+            currentConflictIndex = nil
+            return
+        }
+        let current = currentConflictIndex ?? -1
+        currentConflictIndex = min(current + 1, total - 1)
+    }
+
+    /// Jumps to the previous unresolved conflict, clamping at the first one.
+    func previousConflict() {
+        let total = conflictCount
+        guard total > 0 else {
+            currentConflictIndex = nil
+            return
+        }
+        let current = currentConflictIndex ?? total
+        currentConflictIndex = max(current - 1, 0)
+    }
+
+    // MARK: - Resolve
+
+    /// Writes `resultText` to disk and stages the file via `GitService.markResolved`.
+    /// Throws if either step fails.
+    func markFileResolved() async throws {
+        let absolute = worktreePath.appendingPathComponent(relativePath)
+        try resultText.write(to: absolute, atomically: true, encoding: .utf8)
+        try await gitService.markResolved(
+            worktreePath: worktreePath,
+            relativePath: relativePath
+        )
+    }
 }

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -191,14 +191,22 @@ final class MergeConflictTabModel {
     /// Writes `resultText` to disk and stages the file via `GitService.markResolved`.
     /// Throws if either step fails.
     ///
-    /// For binary conflicts `resultText` is intentionally empty (the editor
-    /// does not show binary bytes), so writing it would clobber whichever
-    /// side currently lives on disk. In that case we stage the file as-is
-    /// without writing — the on-disk file is whatever the user chose via
-    /// the Use ours / Use theirs context menu in the right pane.
+    /// The write step is skipped in two cases where `resultText` is
+    /// intentionally empty and writing would corrupt the resolution:
+    ///   - Binary conflicts: the editor does not show binary bytes. The
+    ///     on-disk file is whatever the user chose via the right-pane
+    ///     Use ours / Use theirs context menu.
+    ///   - Missing files: delete-side conflicts (e.g., `bothDeleted` from
+    ///     a rename/rename, or any path the user removed via Keep deleted)
+    ///     have no working-tree entry. Writing would recreate the file as
+    ///     a zero-byte addition and `git add` would stage it as an
+    ///     addition, undoing the deletion.
+    /// In both cases we simply stage whatever is currently in the index
+    /// (or the missing-file state) via `git add`.
     func markFileResolved() async throws {
-        if conflictedFile?.isBinary != true {
-            let absolute = worktreePath.appendingPathComponent(relativePath)
+        let absolute = worktreePath.appendingPathComponent(relativePath)
+        let exists = FileManager.default.fileExists(atPath: absolute.path)
+        if conflictedFile?.isBinary != true, exists {
             try resultText.write(to: absolute, atomically: true, encoding: .utf8)
         }
         try await gitService.markResolved(

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Observation
+import os
+
+/// Runtime view-model for a merge-conflict tab. Loads the three sides
+/// via `GitService.conflictedFile`, parses the on-disk merged buffer
+/// into regions, and exposes navigation / accept-side / resolve methods.
+@Observable
+@MainActor
+final class MergeConflictTabModel {
+    private(set) var conflictedFile: ConflictedFile?
+    private(set) var regions: [ConflictRegion] = []
+    /// 0-based index into the conflict subset of `regions`. nil when no
+    /// unresolved conflicts remain.
+    private(set) var currentConflictIndex: Int?
+    /// Mutable text of the on-disk merged buffer. Drives the RESULT column.
+    /// Updated by accept-side actions and by direct user edits.
+    var resultText: String = ""
+    /// Set when `load()` fails. Cleared on successful (re)load.
+    private(set) var loadError: String?
+
+    let worktreePath: URL
+    let relativePath: String
+    private let gitService: GitService
+    private let logger = Logger(subsystem: "io.nlopez.alas", category: "merge-conflict-tab")
+
+    init(worktreePath: URL, relativePath: String, gitService: GitService) {
+        self.worktreePath = worktreePath
+        self.relativePath = relativePath
+        self.gitService = gitService
+    }
+
+    /// Number of unresolved conflict regions currently in `resultText`.
+    var conflictCount: Int {
+        regions.reduce(0) { $0 + (isConflict($1) ? 1 : 0) }
+    }
+
+    /// Re-loads the conflicted file's three sides and re-parses the on-disk
+    /// merged buffer. Safe to call repeatedly.
+    func load() async {
+        do {
+            let file = try await gitService.conflictedFile(
+                worktreePath: worktreePath,
+                relativePath: relativePath
+            )
+            self.conflictedFile = file
+            self.resultText = file.merged
+            self.regions = ConflictMarkerParser.parse(file.merged)
+            self.currentConflictIndex = firstConflictIndex()
+            self.loadError = nil
+        } catch {
+            self.conflictedFile = nil
+            self.regions = []
+            self.resultText = ""
+            self.currentConflictIndex = nil
+            self.loadError = (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription
+            logger.error("merge-conflict load failed: \(self.loadError ?? "", privacy: .public)")
+        }
+    }
+
+    /// Re-parses `resultText` and updates `regions` + `currentConflictIndex`.
+    /// Call after any mutation of `resultText` (typed by user or via accept actions).
+    func reparse() {
+        regions = ConflictMarkerParser.parse(resultText)
+        if let idx = currentConflictIndex, conflictRegionIndex(forConflictOrdinal: idx) == nil {
+            // The current conflict was resolved; move to the next unresolved one
+            // (or nil when none remain).
+            currentConflictIndex = firstConflictIndex()
+        } else if currentConflictIndex == nil {
+            currentConflictIndex = firstConflictIndex()
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Marked `internal` (default) so Task 4's extension can call it.
+    func isConflict(_ region: ConflictRegion) -> Bool {
+        if case .conflict = region { return true }
+        return false
+    }
+
+    /// Returns the 0-based index into `regions` of the Nth conflict, or nil.
+    /// Marked `internal` (default) so Task 4's extension can call it.
+    func conflictRegionIndex(forConflictOrdinal ordinal: Int) -> Int? {
+        var seen = 0
+        for (i, r) in regions.enumerated() {
+            if isConflict(r) {
+                if seen == ordinal { return i }
+                seen += 1
+            }
+        }
+        return nil
+    }
+
+    /// Returns the ordinal (0-based) of the first unresolved conflict, or nil.
+    /// Marked `internal` (default) so Task 4's extension can call it.
+    func firstConflictIndex() -> Int? {
+        var ord = 0
+        for r in regions where isConflict(r) {
+            return ord
+        }
+        _ = ord
+        return nil
+    }
+}

--- a/Alas/Sources/Center/MergeConflictTabState.swift
+++ b/Alas/Sources/Center/MergeConflictTabState.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Persisted state for a merge-conflict resolution tab. The runtime
+/// model (current conflict index, edited buffer, parsed regions) lives
+/// in `MergeConflictTabModel` and is re-created on tab re-open.
+struct MergeConflictTabState: Codable, Equatable, Identifiable {
+    let id: TabID                 // "merge:<worktreeId>:<relativePath>"
+    let worktreeId: String
+    let relativePath: String
+    var title: String             // file's last path component
+    /// Whether the BASE section is rendered inline in the RESULT column.
+    /// Persists per-tab so the user's preference survives app restarts.
+    var showBase: Bool
+
+    init(worktreeId: String, relativePath: String, title: String, showBase: Bool = false) {
+        self.id = "merge:\(worktreeId):\(relativePath)"
+        self.worktreeId = worktreeId
+        self.relativePath = relativePath
+        self.title = title
+        self.showBase = showBase
+    }
+}

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -26,6 +26,7 @@ struct MergeConflictTabView: View {
             MergeConflictToolbar(
                 conflictCount: model.conflictCount,
                 currentConflictIndex: model.currentConflictIndex,
+                isLoaded: model.conflictedFile != nil,
                 showBase: showBaseBinding,
                 onPrevious: { model.previousConflict() },
                 onNext: { model.nextConflict() },
@@ -47,6 +48,11 @@ struct MergeConflictTabView: View {
                 }
             )
             content
+        }
+        // Trigger initial load from the always-rendered root so the first
+        // open (when content shows the spinner) still kicks off the work.
+        .task(id: tabState.relativePath) {
+            await model.load()
         }
     }
 
@@ -131,9 +137,6 @@ struct MergeConflictTabView: View {
                     while (model.currentConflictIndex ?? 0) > idx { model.previousConflict() }
                 }
             )
-        }
-        .task(id: tabState.relativePath) {
-            await model.load()
         }
     }
 

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+struct MergeConflictTabView: View {
+    @Bindable var state: AppState
+    let worktree: Worktree
+    let tabState: MergeConflictTabState
+
+    @State private var model: MergeConflictTabModel
+    @Environment(\.theme) var theme
+
+    init(state: AppState, worktree: Worktree, tabState: MergeConflictTabState) {
+        self.state = state
+        self.worktree = worktree
+        self.tabState = tabState
+        self._model = State(
+            initialValue: MergeConflictTabModel(
+                worktreePath: worktree.path,
+                relativePath: tabState.relativePath,
+                gitService: GitService()
+            )
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            MergeConflictToolbar(
+                conflictCount: model.conflictCount,
+                currentConflictIndex: model.currentConflictIndex,
+                showBase: showBaseBinding,
+                onPrevious: { model.previousConflict() },
+                onNext: { model.nextConflict() },
+                onAcceptLocal: { model.acceptLocal() },
+                onAcceptRemote: { model.acceptRemote() },
+                onAcceptBoth: { model.acceptBoth() },
+                onAcceptAndNext: {
+                    model.acceptLocal()
+                    model.nextConflict()
+                },
+                onMarkResolved: {
+                    Task {
+                        try? await model.markFileResolved()
+                        // The WorktreeWatcher on RightPaneState picks up the
+                        // .git/index change from `git add` and refreshes the
+                        // Conflicts section automatically — no explicit call
+                        // is needed here.
+                    }
+                }
+            )
+            content
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let loadError = model.loadError {
+            errorBanner(loadError)
+        } else if model.conflictedFile == nil {
+            ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            body3Columns
+        }
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.orange)
+            Text(message)
+                .font(.system(size: 12))
+            Spacer()
+            Button("Reload") {
+                Task { await model.load() }
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.color("bg-2"))
+    }
+
+    private var body3Columns: some View {
+        HStack(spacing: 0) {
+            // LOCAL
+            VStack(spacing: 0) {
+                columnHeader("LOCAL · ours")
+                MergeConflictColumnView(
+                    text: model.conflictedFile?.local ?? "",
+                    fileExtension: fileExtension,
+                    codeFontFamily: state.config.code.fontFamily,
+                    codeFontSize: CGFloat(state.config.code.fontSize)
+                )
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            // RESULT (editable)
+            VStack(spacing: 0) {
+                columnHeader("RESULT")
+                MergeConflictResultView(
+                    text: Binding(
+                        get: { model.resultText },
+                        set: { newValue in
+                            model.resultText = newValue
+                            model.reparse()
+                        }
+                    ),
+                    fileExtension: fileExtension,
+                    codeFontFamily: state.config.code.fontFamily,
+                    codeFontSize: CGFloat(state.config.code.fontSize)
+                )
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            // REMOTE
+            VStack(spacing: 0) {
+                columnHeader("REMOTE · theirs")
+                MergeConflictColumnView(
+                    text: model.conflictedFile?.remote ?? "",
+                    fileExtension: fileExtension,
+                    codeFontFamily: state.config.code.fontFamily,
+                    codeFontSize: CGFloat(state.config.code.fontSize)
+                )
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            MergeConflictMinimap(
+                conflictCount: model.conflictCount,
+                currentConflictIndex: model.currentConflictIndex,
+                onJump: { idx in
+                    // Clamp via repeated next/previous — the model's clamping
+                    // logic ensures we land exactly on `idx` when reachable.
+                    while (model.currentConflictIndex ?? 0) < idx { model.nextConflict() }
+                    while (model.currentConflictIndex ?? 0) > idx { model.previousConflict() }
+                }
+            )
+        }
+        .task(id: tabState.relativePath) {
+            await model.load()
+        }
+    }
+
+    private func columnHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .semibold))
+            .textCase(.uppercase)
+            .foregroundColor(theme.color("fg-dim"))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(theme.color("bg-2"))
+    }
+
+    private var fileExtension: String {
+        (tabState.relativePath as NSString).pathExtension
+    }
+
+    /// Writes the BASE-toggle back through TabsManager so the preference
+    /// persists per-tab across app restarts.
+    private var showBaseBinding: Binding<Bool> {
+        Binding(
+            get: { tabState.showBase },
+            set: { newValue in
+                state.tabs.updateMergeConflict(
+                    worktreeId: tabState.worktreeId,
+                    tabId: tabState.id
+                ) { mutableState in
+                    mutableState.showBase = newValue
+                }
+            }
+        )
+    }
+}

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -26,7 +26,10 @@ struct MergeConflictTabView: View {
             MergeConflictToolbar(
                 conflictCount: model.conflictCount,
                 currentConflictIndex: model.currentConflictIndex,
-                isLoaded: model.conflictedFile != nil,
+                // Binaries can't be resolved through the 3-column editor
+                // (they're handled via the right-pane Use ours / Use theirs
+                // context menu). Keep the resolve button disabled for them.
+                isLoaded: model.conflictedFile != nil && model.conflictedFile?.isBinary == false,
                 showBase: showBaseBinding,
                 onPrevious: { model.previousConflict() },
                 onNext: { model.nextConflict() },
@@ -49,9 +52,12 @@ struct MergeConflictTabView: View {
             )
             content
         }
-        // Trigger initial load from the always-rendered root so the first
-        // open (when content shows the spinner) still kicks off the work.
-        .task(id: tabState.relativePath) {
+        // Trigger a fresh load every time the view appears, not just on
+        // first mount. `TabsManager.openMergeConflict` re-uses an existing
+        // tab for the same path, so re-focusing after a second conflict on
+        // the same file must re-read the three sides to avoid showing stale
+        // resultText/regions from the prior conflict.
+        .task {
             await model.load()
         }
     }

--- a/Alas/Sources/Center/MergeConflictTextStorage.swift
+++ b/Alas/Sources/Center/MergeConflictTextStorage.swift
@@ -1,0 +1,37 @@
+import AppKit
+import SwiftUI
+
+/// Shared helpers for producing themed, syntax-highlighted
+/// `NSAttributedString`s for the merge editor columns. Pure functions
+/// — no state of their own. Uses `TreeSitterHighlighter` for highlighting,
+/// with regex fallback handled internally by the highlighter.
+enum MergeConflictTextStorage {
+    /// Produces a themed attributed string for `text` with syntax
+    /// highlighting based on `fileExtension`. Falls back to plain
+    /// monospaced text when no language is registered for the extension.
+    static func highlightedAttributedString(
+        text: String,
+        fileExtension: String,
+        fontFamily: String,
+        fontSize: CGFloat,
+        theme: Theme
+    ) -> NSMutableAttributedString {
+        let font = CenterTypography.resolveCodeFont(family: fontFamily, size: fontSize)
+        let editorTheme = EditorTheme(theme: theme)
+        let base = NSMutableAttributedString(
+            string: text,
+            attributes: [
+                .font: font,
+                .foregroundColor: editorTheme.defaultFG
+            ]
+        )
+
+        let spans = TreeSitterHighlighter.highlight(source: text, fileExtension: fileExtension)
+        for span in spans {
+            guard span.range.location + span.range.length <= base.length else { continue }
+            let attrs = editorTheme.attributes(for: span.capture)
+            base.addAttributes(attrs, range: span.range)
+        }
+        return base
+    }
+}

--- a/Alas/Sources/Center/MergeConflictToolbar.swift
+++ b/Alas/Sources/Center/MergeConflictToolbar.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct MergeConflictToolbar: View {
+    let conflictCount: Int
+    let currentConflictIndex: Int?
+    @Binding var showBase: Bool
+    let onPrevious: () -> Void
+    let onNext: () -> Void
+    let onAcceptLocal: () -> Void
+    let onAcceptRemote: () -> Void
+    let onAcceptBoth: () -> Void
+    let onAcceptAndNext: () -> Void
+    let onMarkResolved: () -> Void
+
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            counter
+            Divider().frame(height: 18)
+            navigationButtons
+            Divider().frame(height: 18)
+            acceptButtons
+            Spacer()
+            Toggle("Show BASE", isOn: $showBase)
+                .toggleStyle(.button)
+                .controlSize(.small)
+            Button(action: onMarkResolved) {
+                Text("Mark resolved")
+                    .font(.system(size: 11))
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.green)
+            .disabled(conflictCount > 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background(theme.color("bg-1"))
+        .overlay(Divider(), alignment: .bottom)
+    }
+
+    private var counter: some View {
+        Text(counterText)
+            .font(.system(size: 11))
+            .foregroundColor(theme.color("fg-dim"))
+    }
+
+    private var counterText: String {
+        if conflictCount == 0 {
+            return "All resolved"
+        }
+        if let idx = currentConflictIndex {
+            return "Conflict \(idx + 1) of \(conflictCount)"
+        }
+        return "\(conflictCount) conflict(s)"
+    }
+
+    private var navigationButtons: some View {
+        HStack(spacing: 2) {
+            Button(action: onPrevious) { Image(systemName: "chevron.up") }
+                .keyboardShortcut(.upArrow, modifiers: [.option])
+                .help("Previous conflict (⌥↑)")
+            Button(action: onNext) { Image(systemName: "chevron.down") }
+                .keyboardShortcut(.downArrow, modifiers: [.option])
+                .help("Next conflict (⌥↓)")
+            Button(action: onAcceptAndNext) {
+                HStack(spacing: 3) {
+                    Image(systemName: "checkmark")
+                    Image(systemName: "chevron.down")
+                }
+            }
+            .keyboardShortcut(.return, modifiers: [.option])
+            .help("Accept LOCAL and jump to next (⌥↵)")
+        }
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+        .disabled(conflictCount == 0)
+    }
+
+    private var acceptButtons: some View {
+        HStack(spacing: 4) {
+            Button("Use LOCAL", action: onAcceptLocal)
+                .keyboardShortcut("[", modifiers: [.command, .option])
+                .help("Accept LOCAL for current conflict (⌥⌘[)")
+            Button("Use REMOTE", action: onAcceptRemote)
+                .keyboardShortcut("]", modifiers: [.command, .option])
+                .help("Accept REMOTE for current conflict (⌥⌘])")
+            Button("Use BOTH", action: onAcceptBoth)
+                .help("Accept LOCAL then REMOTE")
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .disabled(conflictCount == 0)
+    }
+}

--- a/Alas/Sources/Center/MergeConflictToolbar.swift
+++ b/Alas/Sources/Center/MergeConflictToolbar.swift
@@ -25,6 +25,8 @@ struct MergeConflictToolbar: View {
             Toggle("Show BASE", isOn: $showBase)
                 .toggleStyle(.button)
                 .controlSize(.small)
+                .disabled(true)
+                .help("BASE inline rendering arrives in a follow-up — toggle is wired for persistence only")
             Button(action: onMarkResolved) {
                 Text("Mark resolved")
                     .font(.system(size: 11))

--- a/Alas/Sources/Center/MergeConflictToolbar.swift
+++ b/Alas/Sources/Center/MergeConflictToolbar.swift
@@ -3,6 +3,10 @@ import SwiftUI
 struct MergeConflictToolbar: View {
     let conflictCount: Int
     let currentConflictIndex: Int?
+    /// True only after the conflicted file has been loaded successfully.
+    /// Gates `Mark resolved` so it can't fire on an empty initial buffer
+    /// and clobber the on-disk file with empty contents.
+    let isLoaded: Bool
     @Binding var showBase: Bool
     let onPrevious: () -> Void
     let onNext: () -> Void
@@ -33,7 +37,7 @@ struct MergeConflictToolbar: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.green)
-            .disabled(conflictCount > 0)
+            .disabled(!isLoaded || conflictCount > 0)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 5)

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -8,6 +8,7 @@ enum Tab: Codable, Equatable, Identifiable {
     case diff(DiffTabState)
     case commit(CommitTabState)
     case imagePreview(ImagePreviewTabState)
+    case mergeConflict(MergeConflictTabState)
 
     var id: TabID {
         switch self {
@@ -16,6 +17,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .diff(let s):         return s.id
         case .commit(let s):       return s.id
         case .imagePreview(let s): return s.id
+        case .mergeConflict(let s): return s.id
         }
     }
 
@@ -26,6 +28,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .diff(let s):         return s.title
         case .commit(let s):       return s.title
         case .imagePreview(let s): return s.title
+        case .mergeConflict(let s): return s.title
         }
     }
 
@@ -36,6 +39,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .diff:         return "diff"
         case .commit:       return "commit"
         case .imagePreview: return "image"
+        case .mergeConflict: return "diff"
         }
     }
 
@@ -43,6 +47,7 @@ enum Tab: Codable, Equatable, Identifiable {
         switch self {
         case .editor(let s):       return s.isExternal ? nil : s.relativePath
         case .imagePreview(let s): return s.relativePath
+        case .mergeConflict(let s): return s.relativePath
         default:                   return nil
         }
     }

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -526,6 +526,7 @@ final class TabsManager {
             let existing = file.tabs[idx]
             file.activeTabId = existing.id
             byWorktree[worktreeId] = file
+            persist(worktreeId)
             return existing
         }
         let state = MergeConflictTabState(

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -539,6 +539,26 @@ final class TabsManager {
         return tab
     }
 
+    /// Mutate the `MergeConflictTabState` for `tabId` in `worktreeId`'s tab list,
+    /// in place. Used by the merge editor view to persist UI state like the
+    /// `showBase` toggle. Persists to disk.
+    @discardableResult
+    func updateMergeConflict(
+        worktreeId: String,
+        tabId: TabID,
+        _ transform: (inout MergeConflictTabState) -> Void
+    ) -> Bool {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .mergeConflict(var state) = file.tabs[idx]
+        else { return false }
+        transform(&state)
+        file.tabs[idx] = .mergeConflict(state)
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return true
+    }
+
     /// Open or focus an image preview tab for `relativePath`.
     @discardableResult
     func openImagePreview(worktreeId: String, relativePath: String) -> Tab {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -512,6 +512,32 @@ final class TabsManager {
         return tab
     }
 
+    /// Open a merge-conflict tab for `relativePath`, or activate the existing
+    /// one if it's already open. Returns the tab.
+    @discardableResult
+    func openMergeConflict(worktreeId: String, relativePath: String, title: String) -> Tab {
+        if var file = byWorktree[worktreeId],
+           let idx = file.tabs.firstIndex(where: {
+               if case .mergeConflict(let s) = $0 {
+                   return s.relativePath == relativePath
+               }
+               return false
+           }) {
+            let existing = file.tabs[idx]
+            file.activeTabId = existing.id
+            byWorktree[worktreeId] = file
+            return existing
+        }
+        let state = MergeConflictTabState(
+            worktreeId: worktreeId,
+            relativePath: relativePath,
+            title: title
+        )
+        let tab = Tab.mergeConflict(state)
+        append(tab, to: worktreeId)
+        return tab
+    }
+
     /// Open or focus an image preview tab for `relativePath`.
     @discardableResult
     func openImagePreview(worktreeId: String, relativePath: String) -> Tab {

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -77,7 +77,7 @@ struct ChangesTabView: View {
 
             ConflictsSection(
                 conflicts: conflicts,
-                onSelect: onSelect,
+                onSelect: { file in rps.openConflict?(file.path) },
                 onUseOurs: { file in rps.useOurs(file: file) },
                 onUseTheirs: { file in rps.useTheirs(file: file) },
                 onKeepDeleted: { file in rps.keepDeleted(file: file) },

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -50,24 +50,13 @@ final class RightPaneStore {
             }
             new.openConflict = { [weak self] path in
                 guard let app = self?.appState else { return }
-                // Plan 1 fallback: route conflicted files through the same unified
-                // diff view used elsewhere. Plan 2 will replace this with the new
-                // three-column merge editor.
-                let existing = app.tabs.tabs(forWorktree: id).first { tab in
-                    if case .diff(let s) = tab { return s.relativePath == path && s.staged == false } else { return false }
-                }
-                if let existing {
-                    app.tabs.activate(worktreeId: id, tabId: existing.id)
-                } else {
-                    let title = (path as NSString).lastPathComponent
-                    let tab = app.tabs.appendDiff(
-                        worktreeId: id,
-                        title: title,
-                        relativePath: path,
-                        staged: false
-                    )
-                    app.tabs.activate(worktreeId: id, tabId: tab.id)
-                }
+                let title = (path as NSString).lastPathComponent
+                let tab = app.tabs.openMergeConflict(
+                    worktreeId: id,
+                    relativePath: path,
+                    title: title
+                )
+                app.tabs.activate(worktreeId: id, tabId: tab.id)
             }
             states[id] = new
             result = new

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -76,4 +76,120 @@ struct MergeConflictTabModelTests {
         #expect(model.conflictedFile == nil)
         #expect(model.loadError != nil)
     }
+
+    @Test func acceptLocalReplacesMarkerBlockWithLocalContent() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        await model.load()
+
+        model.acceptLocal()
+        #expect(!model.resultText.contains("<<<<<<<"))
+        #expect(model.resultText.contains("main line"))
+        #expect(model.conflictCount == 0)
+        #expect(model.currentConflictIndex == nil)
+    }
+
+    @Test func acceptRemoteReplacesMarkerBlockWithRemoteContent() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        await model.load()
+
+        model.acceptRemote()
+        #expect(!model.resultText.contains("<<<<<<<"))
+        #expect(model.resultText.contains("feature line"))
+    }
+
+    @Test func acceptBothPreservesBothSides() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        await model.load()
+
+        model.acceptBoth()
+        #expect(!model.resultText.contains("<<<<<<<"))
+        #expect(model.resultText.contains("main line"))
+        #expect(model.resultText.contains("feature line"))
+    }
+
+    @Test func nextAndPreviousNavigateConflicts() {
+        let model = MergeConflictTabModel(
+            worktreePath: URL(fileURLWithPath: "/tmp/unused"),
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        // Bypass load() and inject a synthetic two-conflict resultText.
+        model.resultText = """
+        head
+        <<<<<<< HEAD
+        a-ours
+        =======
+        a-theirs
+        >>>>>>> feature
+        middle
+        <<<<<<< HEAD
+        b-ours
+        =======
+        b-theirs
+        >>>>>>> feature
+        tail
+
+        """
+        model.reparse()
+        #expect(model.conflictCount == 2)
+        #expect(model.currentConflictIndex == 0)
+
+        model.nextConflict()
+        #expect(model.currentConflictIndex == 1)
+        model.nextConflict()
+        #expect(model.currentConflictIndex == 1) // clamped at last
+
+        model.previousConflict()
+        #expect(model.currentConflictIndex == 0)
+        model.previousConflict()
+        #expect(model.currentConflictIndex == 0) // clamped at first
+    }
+
+    @Test func markFileResolvedStagesViaGitService() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        await model.load()
+        model.acceptLocal()
+        try await model.markFileResolved()
+
+        // After mark-resolved, status no longer lists a.txt as conflicted.
+        let changes = try await GitService().status(worktreePath: repo)
+        let entry = changes.first { $0.path == "a.txt" }
+        #expect(entry?.conflict == nil)
+    }
 }

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -1,0 +1,79 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct MergeConflictTabModelTests {
+    fileprivate static func makeRepo() async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-mctm-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["config", "user.email", "t@e"], cwd: dir)
+        _ = try await Process.git(["config", "user.name", "t"], cwd: dir)
+        _ = try await Process.git(["config", "commit.gpgsign", "false"], cwd: dir)
+        return dir
+    }
+
+    fileprivate static func writeFile(_ repo: URL, _ name: String, _ contents: String) throws {
+        try contents.write(
+            to: repo.appendingPathComponent(name),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    /// Same conflict-producing layout as Plan 1's GitServiceMergeTests:
+    /// base → feature edits a.txt; main edits a.txt differently.
+    fileprivate static func makeConflictingBranches(_ repo: URL) async throws {
+        try writeFile(repo, "a.txt", "base line\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        try writeFile(repo, "a.txt", "feature line\n")
+        _ = try await Process.git(["commit", "-q", "-am", "feature"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        try writeFile(repo, "a.txt", "main line\n")
+        _ = try await Process.git(["commit", "-q", "-am", "main"], cwd: repo)
+    }
+
+    @Test func loadPopulatesSidesAndRegions() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        await model.load()
+
+        #expect(model.conflictedFile?.local == "main line\n")
+        #expect(model.conflictedFile?.remote == "feature line\n")
+        #expect(model.conflictedFile?.base == "base line\n")
+        #expect(model.regions.count >= 1)
+        #expect(model.conflictCount == 1)
+        #expect(model.currentConflictIndex == 0)
+        #expect(model.resultText.contains("<<<<<<<"))
+    }
+
+    @Test func loadOnNonConflictedFileRecordsError() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try Self.writeFile(repo, "a.txt", "hi\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "init"], cwd: repo)
+
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        await model.load()
+        #expect(model.conflictedFile == nil)
+        #expect(model.loadError != nil)
+    }
+}

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -172,6 +172,47 @@ struct MergeConflictTabModelTests {
         #expect(model.currentConflictIndex == 0) // clamped at first
     }
 
+    @Test func acceptingLastConflictAnchorsCursorToPreviousNotZero() {
+        let model = MergeConflictTabModel(
+            worktreePath: URL(fileURLWithPath: "/tmp/unused"),
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        // Three conflicts. User is at the third (last). Accept it.
+        // Cursor should land on the new last (ordinal 1), NOT on ordinal 0.
+        model.resultText = """
+        head
+        <<<<<<< HEAD
+        a-ours
+        =======
+        a-theirs
+        >>>>>>> feature
+        middle1
+        <<<<<<< HEAD
+        b-ours
+        =======
+        b-theirs
+        >>>>>>> feature
+        middle2
+        <<<<<<< HEAD
+        c-ours
+        =======
+        c-theirs
+        >>>>>>> feature
+        tail
+
+        """
+        model.reparse()
+        #expect(model.conflictCount == 3)
+        model.nextConflict()   // 0 → 1
+        model.nextConflict()   // 1 → 2 (last)
+        #expect(model.currentConflictIndex == 2)
+
+        model.acceptLocal()    // resolves the last; reparse runs
+        #expect(model.conflictCount == 2)
+        #expect(model.currentConflictIndex == 1)   // anchored at new last, not 0
+    }
+
     @Test func markFileResolvedStagesViaGitService() async throws {
         let repo = try await Self.makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -233,4 +233,47 @@ struct MergeConflictTabModelTests {
         let entry = changes.first { $0.path == "a.txt" }
         #expect(entry?.conflict == nil)
     }
+
+    @Test func markFileResolvedDoesNotRecreateMissingFile() async throws {
+        // Build a deletedByUs (DU) conflict: feature modifies a.txt, main
+        // deletes it. After the merge, the working tree has a.txt (theirs'
+        // content). Then simulate the user choosing "Keep deleted" via the
+        // right-pane action (Plan 1) — which removes the file from disk
+        // BEFORE the user opens the merge editor. Now if Mark resolved
+        // writes resultText (empty for a non-existing file), it would
+        // recreate the file as a 0-byte addition. It must not.
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try Self.writeFile(repo, "a.txt", "base\n")
+        _ = try await Process.git(["add", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "base"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)
+        try Self.writeFile(repo, "a.txt", "feature modification\n")
+        _ = try await Process.git(["commit", "-q", "-am", "feature"], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "main"], cwd: repo)
+        _ = try await Process.git(["rm", "-q", "a.txt"], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "delete a"], cwd: repo)
+        // Merge feature → main: ours deleted, theirs modified → DU.
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        // Simulate the user picking "Keep deleted" from the right pane:
+        // remove the on-disk file.
+        try FileManager.default.removeItem(at: repo.appendingPathComponent("a.txt"))
+
+        // Now: open the merge editor for that path and click Mark resolved.
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        // load() will see the entry as still conflicted (until we stage).
+        await model.load()
+        try await model.markFileResolved()
+
+        // The file must NOT have been recreated.
+        let recreated = FileManager.default.fileExists(
+            atPath: repo.appendingPathComponent("a.txt").path
+        )
+        #expect(recreated == false)
+    }
 }

--- a/AlasTests/TabMergeConflictCodingTests.swift
+++ b/AlasTests/TabMergeConflictCodingTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct TabMergeConflictCodingTests {
+    @Test func roundTripsPreservingShowBase() throws {
+        let state = MergeConflictTabState(
+            worktreeId: "wt-abc",
+            relativePath: "src/foo.swift",
+            title: "foo.swift",
+            showBase: true
+        )
+        let tab = Tab.mergeConflict(state)
+        let data = try JSONEncoder().encode(tab)
+        let decoded = try JSONDecoder().decode(Tab.self, from: data)
+        guard case .mergeConflict(let s) = decoded else {
+            Issue.record("expected .mergeConflict case")
+            return
+        }
+        #expect(s.id == "merge:wt-abc:src/foo.swift")
+        #expect(s.worktreeId == "wt-abc")
+        #expect(s.relativePath == "src/foo.swift")
+        #expect(s.title == "foo.swift")
+        #expect(s.showBase == true)
+    }
+
+    @Test func idIsDerivedFromWorktreeAndPath() {
+        let state = MergeConflictTabState(
+            worktreeId: "wt",
+            relativePath: "a/b.txt",
+            title: "b.txt"
+        )
+        #expect(state.id == "merge:wt:a/b.txt")
+    }
+
+    @Test func defaultsShowBaseToFalse() {
+        let state = MergeConflictTabState(
+            worktreeId: "wt",
+            relativePath: "a.txt",
+            title: "a.txt"
+        )
+        #expect(state.showBase == false)
+    }
+}


### PR DESCRIPTION
## Summary

Plan 2 of merge-conflicts (Plan 1 = #273, merged): the IntelliJ-style three-column merge editor in the center pane. Clicking a conflicted file (from the right-pane Conflicts section or auto-opened after a merge) now opens a dedicated tab with LOCAL · ours / RESULT · editable / REMOTE · theirs side-by-side, a navigation toolbar, and a minimap.

- **New tab type** `Tab.mergeConflict(MergeConflictTabState)` with Codable persistence (carries a `showBase` per-tab preference)
- **`TabsManager`**: `openMergeConflict` (open-or-focus) + `updateMergeConflict` (mutator used by the BASE toggle's two-way binding)
- **`MergeConflictTabModel`** (`@Observable @MainActor`): loads the three sides via `GitService.conflictedFile` (Plan 1), parses the on-disk merged buffer via `ConflictMarkerParser` (Plan 1), exposes `acceptLocal/Remote/Both`, `nextConflict/previousConflict`, `markFileResolved`. Cursor anchoring keeps you near the resolved position instead of jumping back to conflict 1.
- **`MergeConflictToolbar`**: counter ("Conflict N of M"), prev/next/accept-and-next, Use LOCAL / REMOTE / BOTH, Show BASE toggle (disabled until inline rendering ships in Plan 3), Mark resolved (enabled only when all conflicts are resolved). Keyboard shortcuts: ⌥↑ ⌥↓ ⌥↵ ⌥⌘[ ⌥⌘]
- **Columns**: NSTextView-backed via `NSViewRepresentable`. Read-only `MergeConflictColumnView` for LOCAL/REMOTE (with redundant-re-render guard), editable `MergeConflictResultView` for RESULT (caret-preserving update guard, yellow shading over each `<<<<<<<...>>>>>>>` block). Both use `TreeSitterHighlighter` + `EditorTheme.attributes(for: span.capture)` via a shared `MergeConflictTextStorage` helper.
- **`MergeConflictMinimap`**: right-edge tick strip, current conflict full opacity, others 0.55
- **Routing swap**: `RightPaneStore.openConflict` now constructs a merge-conflict tab (Plan 1's `DiffTabView` fallback retired); `ConflictsSection` row taps route to the merge editor too

## Out of scope (Plan 3)

- BASE inline rendering inside RESULT when `showBase` is true (toggle is wired for persistence; visual treatment ships in Plan 3)
- Agent-assisted "explain both sides" / "resolve this file" buttons
- Binary/image conflict viewer
- Per-conflict agent annotations
- Resolved/unresolved tick distinction in the minimap (currently only unresolved conflicts are shown — resolved ones disappear as `regions` shrinks)

## Test plan

- [ ] `xcodebuild test -only-testing:AlasTests/TabMergeConflictCodingTests` (3 Codable round-trip tests, all green)
- [ ] `xcodebuild test -only-testing:AlasTests/MergeConflictTabModelTests` (8 tests: load, accept-local/remote/both, navigation, mark-resolved, cursor-anchoring-after-last-resolved)
- [ ] Manual: trigger a conflicting merge from inside alas, click a conflict in the Conflicts section, verify the 3-column editor opens. Use LOCAL → marker block disappears, counter shows "All resolved", Mark resolved button enables → click → file is staged. Continue commits the merge.
- [ ] Manual: confirm keyboard shortcuts ⌥↑ ⌥↓ ⌥↵ ⌥⌘[ ⌥⌘] work when the merge editor is focused.
- [ ] Manual: Show BASE toggle is visibly disabled with a tooltip explaining the deferral.