### PR TITLE
Improve diff text selection

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
 		23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
+		250F0E2CB26CC16D2FFDB9DD /* DiffSelectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */; };
 		25347EFEF1B5F7F4915DB120 /* DebounceTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 179A74F3A825DA1EC4C4E0FC /* DebounceTimerTests.swift */; };
 		255E9EAE89D521E08EB90918 /* JSONHookSettingsFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */; };
 		2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF2F213480B30034B25B2B8 /* AgentRunError.swift */; };
@@ -621,6 +622,7 @@
 		23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCommandShellTests.swift; sourceTree = "<group>"; };
 		2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallProgressSheet.swift; sourceTree = "<group>"; };
 		2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParser.swift; sourceTree = "<group>"; };
+		23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextView.swift; sourceTree = "<group>"; };
 		2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBindingTests.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
 		25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunch.swift; sourceTree = "<group>"; };
@@ -1543,6 +1545,7 @@
 				BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */,
 				D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */,
 				44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */,
+				23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */,
 				F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */,
 				6E8B52175A7F6144B4C52010 /* EditorTabView.swift */,
 				008E982C8526670670425AB8 /* EmptyTabView.swift */,
@@ -2262,6 +2265,7 @@
 				5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */,
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,
 				CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */,
+				250F0E2CB26CC16D2FFDB9DD /* DiffSelectableTextView.swift in Sources */,
 				AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */,
 				1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */,
 				A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -421,6 +421,7 @@
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
 		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
 		C9DAC0F907752F6D3B955DD8 /* HoverFeatureRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */; };
+		CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */; };
 		CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */; };
 		CAE7524F4289A256FF1069FC /* PaneTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C9E59E3987C1D3C9989D91 /* PaneTreeTests.swift */; };
 		CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */; };
@@ -701,6 +702,7 @@
 		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
+		44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextBuilder.swift; sourceTree = "<group>"; };
 		45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigShortcutsCodingTests.swift; sourceTree = "<group>"; };
 		4575017544CD7603B3AB9069 /* GitEventFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitEventFilter.swift; sourceTree = "<group>"; };
 		45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModelTests.swift; sourceTree = "<group>"; };
@@ -1540,6 +1542,7 @@
 				E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */,
 				BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */,
 				D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */,
+				44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */,
 				F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */,
 				6E8B52175A7F6144B4C52010 /* EditorTabView.swift */,
 				008E982C8526670670425AB8 /* EmptyTabView.swift */,
@@ -2258,6 +2261,7 @@
 				9FD539228216762192A02C69 /* DialogChrome.swift in Sources */,
 				5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */,
 				02425EBF61592A01B1FCC7D0 /* DiffParser.swift in Sources */,
+				CAD36BB3EBF8B31309B7BEFF /* DiffSelectableTextBuilder.swift in Sources */,
 				AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */,
 				1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */,
 				A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */,

--- a/Alas/Sources/Center/Commit/CommitDiffView.swift
+++ b/Alas/Sources/Center/Commit/CommitDiffView.swift
@@ -27,6 +27,7 @@ struct CommitDiffView: View {
                 header
                 content
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .background(theme.color("bg-1"))
         }
     }
@@ -117,7 +118,7 @@ struct CommitDiffView: View {
                 .foregroundColor(theme.color("fg-dim"))
                 .padding()
         } else {
-            ScrollView([.horizontal, .vertical]) {
+            ScrollView(.vertical) {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(diff.hunks.enumerated()), id: \.offset) { (_, hunk) in
                         HunkView(hunk: hunk, fileExtension: (path as NSString).pathExtension, codeFontFamily: codeFontFamily, codeFontSize: codeFontSize)
@@ -125,6 +126,7 @@ struct CommitDiffView: View {
                 }
                 .padding(.vertical, 8)
             }
+            .defaultScrollAnchor(.topLeading)
         }
     }
 

--- a/Alas/Sources/Center/Commit/CommitDiffView.swift
+++ b/Alas/Sources/Center/Commit/CommitDiffView.swift
@@ -117,7 +117,7 @@ struct CommitDiffView: View {
                 .foregroundColor(theme.color("fg-dim"))
                 .padding()
         } else {
-            ScrollView {
+            ScrollView([.horizontal, .vertical]) {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(diff.hunks.enumerated()), id: \.offset) { (_, hunk) in
                         HunkView(hunk: hunk, fileExtension: (path as NSString).pathExtension, codeFontFamily: codeFontFamily, codeFontSize: codeFontSize)

--- a/Alas/Sources/Center/DiffSelectableTextBuilder.swift
+++ b/Alas/Sources/Center/DiffSelectableTextBuilder.swift
@@ -1,0 +1,151 @@
+import AppKit
+import SwiftUI
+
+struct DiffSelectableTextBuilder {
+    struct LineMetadata: Equatable {
+        let kind: ParsedDiff.Hunk.Line.Kind
+        let marker: String
+        let range: NSRange
+    }
+
+    struct Result {
+        let attributedString: NSAttributedString
+        let lines: [LineMetadata]
+    }
+
+    static func plainString(for hunk: ParsedDiff.Hunk) -> String {
+        hunk.lines.map(\.text).joined(separator: "\n")
+    }
+
+    static func build(
+        hunk: ParsedDiff.Hunk,
+        fileExtension: String,
+        font: NSFont,
+        theme: Theme
+    ) -> Result {
+        let output = NSMutableAttributedString()
+        var metadata: [LineMetadata] = []
+        var location = 0
+
+        for (index, line) in hunk.lines.enumerated() {
+            if index > 0 {
+                output.append(NSAttributedString(string: "\n", attributes: baseAttributes(font: font, theme: theme)))
+                location += 1
+            }
+
+            let lineStart = location
+            let attributedLine = attributedLine(
+                line.text,
+                fileExtension: fileExtension,
+                font: font,
+                theme: theme
+            )
+            output.append(attributedLine)
+            let lineLength = (line.text as NSString).length
+            metadata.append(LineMetadata(
+                kind: line.kind,
+                marker: marker(for: line),
+                range: NSRange(location: lineStart, length: lineLength)
+            ))
+            location += lineLength
+        }
+
+        return Result(attributedString: output, lines: metadata)
+    }
+
+    private static func attributedLine(
+        _ line: String,
+        fileExtension: String,
+        font: NSFont,
+        theme: Theme
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        let ns = line as NSString
+        let total = ns.length
+        guard total > 0 else {
+            return NSAttributedString(string: "", attributes: baseAttributes(font: font, theme: theme))
+        }
+
+        let spans = TreeSitterHighlighter.tokenize(line: line, fileExtension: fileExtension)
+            .filter { $0.range.location >= 0 && NSMaxRange($0.range) <= total }
+            .sorted { $0.range.location < $1.range.location }
+
+        var cursor = 0
+        for span in spans {
+            if span.range.location < cursor { continue }
+            if span.range.location > cursor {
+                let plainRange = NSRange(location: cursor, length: span.range.location - cursor)
+                result.append(NSAttributedString(
+                    string: ns.substring(with: plainRange),
+                    attributes: baseAttributes(font: font, theme: theme)
+                ))
+            }
+            result.append(NSAttributedString(
+                string: ns.substring(with: span.range),
+                attributes: attributes(for: span.capture, font: font, theme: theme)
+            ))
+            cursor = NSMaxRange(span.range)
+        }
+
+        if cursor < total {
+            let tail = NSRange(location: cursor, length: total - cursor)
+            result.append(NSAttributedString(
+                string: ns.substring(with: tail),
+                attributes: baseAttributes(font: font, theme: theme)
+            ))
+        }
+
+        if result.length == 0 {
+            result.append(NSAttributedString(string: line, attributes: baseAttributes(font: font, theme: theme)))
+        }
+        return result
+    }
+
+    private static func marker(for line: ParsedDiff.Hunk.Line) -> String {
+        switch line.kind {
+        case .add:
+            return "+\(line.newNumber.map(String.init) ?? "")"
+        case .delete:
+            return "−\(line.oldNumber.map(String.init) ?? "")"
+        case .context:
+            return " \(line.oldNumber.map(String.init) ?? "")"
+        }
+    }
+
+    private static func baseAttributes(font: NSFont, theme: Theme) -> [NSAttributedString.Key: Any] {
+        [
+            .font: font,
+            .foregroundColor: NSColor(theme.color("fg")),
+            .paragraphStyle: CenterTypography.paragraphStyle(),
+        ]
+    }
+
+    private static func attributes(
+        for capture: HighlightCapture,
+        font: NSFont,
+        theme: Theme
+    ) -> [NSAttributedString.Key: Any] {
+        var attributes = baseAttributes(font: font, theme: theme)
+        attributes[.foregroundColor] = NSColor(color(for: capture, theme: theme))
+        return attributes
+    }
+
+    private static func color(for capture: HighlightCapture, theme: Theme) -> Color {
+        switch capture {
+        case .keyword:
+            return theme.color("syntax-keyword")
+        case .type:
+            return theme.color("syntax-type")
+        case .function:
+            return theme.color("syntax-function")
+        case .string:
+            return theme.color("add")
+        case .number:
+            return theme.color("mod")
+        case .comment:
+            return theme.color("fg-faint")
+        default:
+            return theme.color("fg")
+        }
+    }
+}

--- a/Alas/Sources/Center/DiffSelectableTextView.swift
+++ b/Alas/Sources/Center/DiffSelectableTextView.swift
@@ -169,18 +169,24 @@ final class DiffSelectableTextContainerView: NSView {
         )
         layoutManager.ensureLayout(for: textContainer)
 
-        let glyphRange = layoutManager.glyphRange(for: textContainer)
         var measuredRows: [NSRect] = []
-        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { lineFragmentRect, _, _, _, _ in
-            measuredRows.append(lineFragmentRect)
+        for line in lineMetadata {
+            var measuredRow = NSRect.null
+            if line.range.length > 0 {
+                let glyphRange = layoutManager.glyphRange(forCharacterRange: line.range, actualCharacterRange: nil)
+                layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { lineFragmentRect, _, _, _, _ in
+                    measuredRow = measuredRow.union(lineFragmentRect)
+                }
+            }
+            measuredRows.append(
+                measuredRow.isNull
+                    ? measuredTrailingRowRect(after: measuredRows, layoutManager: layoutManager)
+                    : measuredRow
+            )
         }
 
-        while measuredRows.count < lineMetadata.count {
-            measuredRows.append(measuredTrailingRowRect(after: measuredRows, layoutManager: layoutManager))
-        }
-
-        rowRects = Array(measuredRows.prefix(lineMetadata.count))
-        measuredTextHeight = rowRects.last?.maxY ?? 0
+        rowRects = measuredRows
+        measuredTextHeight = rowRects.map(\.maxY).max() ?? 0
         measuredTextWidth = ceil(layoutManager.usedRect(for: textContainer).width)
     }
 

--- a/Alas/Sources/Center/DiffSelectableTextView.swift
+++ b/Alas/Sources/Center/DiffSelectableTextView.swift
@@ -8,17 +8,70 @@ struct DiffSelectableTextView: NSViewRepresentable {
     let codeFontSize: CGFloat
     let theme: Theme
 
-    func makeNSView(context: Context) -> DiffSelectableTextContainerView {
-        DiffSelectableTextContainerView()
+    func makeNSView(context: Context) -> DiffSelectableTextScrollView {
+        DiffSelectableTextScrollView()
     }
 
-    func updateNSView(_ nsView: DiffSelectableTextContainerView, context: Context) {
+    func updateNSView(_ nsView: DiffSelectableTextScrollView, context: Context) {
         nsView.update(
             hunk: hunk,
             fileExtension: fileExtension,
             font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
             theme: theme
         )
+    }
+}
+
+final class DiffSelectableTextScrollView: NSScrollView {
+    let containerView = DiffSelectableTextContainerView()
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: containerView.intrinsicContentSize.height)
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        drawsBackground = false
+        borderType = .noBorder
+        hasHorizontalScroller = true
+        hasVerticalScroller = false
+        autohidesScrollers = true
+        scrollerStyle = .overlay
+        documentView = containerView
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("not used")
+    }
+
+    func update(
+        hunk: ParsedDiff.Hunk,
+        fileExtension: String,
+        font: NSFont,
+        theme: Theme
+    ) {
+        containerView.update(hunk: hunk, fileExtension: fileExtension, font: font, theme: theme)
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        let contentSize = containerView.intrinsicContentSize
+        containerView.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: max(contentSize.width, contentView.bounds.width),
+            height: contentSize.height
+        )
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        if abs(event.scrollingDeltaY) > abs(event.scrollingDeltaX) {
+            nextResponder?.scrollWheel(with: event)
+            return
+        }
+        super.scrollWheel(with: event)
     }
 }
 

--- a/Alas/Sources/Center/DiffSelectableTextView.swift
+++ b/Alas/Sources/Center/DiffSelectableTextView.swift
@@ -27,6 +27,8 @@ final class DiffSelectableTextContainerView: NSView {
 
     private let textView: NSTextView
     private var lineMetadata: [DiffSelectableTextBuilder.LineMetadata] = []
+    private var rowRects: [NSRect] = []
+    private var measuredTextHeight: CGFloat = 0
     private var theme: Theme?
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
 
@@ -99,6 +101,7 @@ final class DiffSelectableTextContainerView: NSView {
         )
         lineMetadata = result.lines
         textView.textStorage?.setAttributedString(result.attributedString)
+        updateMeasuredRowGeometry()
         needsDisplay = true
         invalidateIntrinsicContentSize()
         needsLayout = true
@@ -111,7 +114,7 @@ final class DiffSelectableTextContainerView: NSView {
             x: textX,
             y: verticalInset,
             width: max(0, bounds.width - textX - horizontalPadding),
-            height: max(0, CGFloat(lineMetadata.count) * rowHeight)
+            height: measuredTextHeight
         )
         textView.textContainer?.containerSize = NSSize(
             width: Self.unwrappedTextContainerWidth,
@@ -123,11 +126,13 @@ final class DiffSelectableTextContainerView: NSView {
         super.draw(dirtyRect)
         guard let theme else { return }
         for (index, line) in lineMetadata.enumerated() {
+            guard rowRects.indices.contains(index) else { continue }
+            let measuredRect = rowRects[index]
             let rect = NSRect(
                 x: 0,
-                y: verticalInset + CGFloat(index) * rowHeight,
+                y: verticalInset + measuredRect.minY,
                 width: bounds.width,
-                height: rowHeight
+                height: measuredRect.height
             )
             rowBackgroundColor(for: line.kind, theme: theme).setFill()
             rect.fill()
@@ -135,17 +140,64 @@ final class DiffSelectableTextContainerView: NSView {
         }
     }
 
-    private var lineHeight: CGFloat {
-        (font.ascender - font.descender + font.leading) * CenterTypography.lineHeightMultiple
-    }
-
-    private var rowHeight: CGFloat {
-        ceil(lineHeight)
-    }
-
     private var totalHeight: CGFloat {
         guard !lineMetadata.isEmpty else { return 0 }
-        return CGFloat(lineMetadata.count) * rowHeight + verticalInset * 2
+        return measuredTextHeight + verticalInset * 2
+    }
+
+    private func updateMeasuredRowGeometry() {
+        guard
+            !lineMetadata.isEmpty,
+            let layoutManager = textView.layoutManager,
+            let textContainer = textView.textContainer
+        else {
+            rowRects = []
+            measuredTextHeight = 0
+            return
+        }
+
+        textContainer.containerSize = NSSize(
+            width: Self.unwrappedTextContainerWidth,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        layoutManager.ensureLayout(for: textContainer)
+
+        let glyphRange = layoutManager.glyphRange(for: textContainer)
+        var measuredRows: [NSRect] = []
+        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { lineFragmentRect, _, _, _, _ in
+            measuredRows.append(lineFragmentRect)
+        }
+
+        while measuredRows.count < lineMetadata.count {
+            measuredRows.append(measuredTrailingRowRect(after: measuredRows, layoutManager: layoutManager))
+        }
+
+        rowRects = Array(measuredRows.prefix(lineMetadata.count))
+        measuredTextHeight = rowRects.last?.maxY ?? 0
+    }
+
+    private func measuredTrailingRowRect(after measuredRows: [NSRect], layoutManager: NSLayoutManager) -> NSRect {
+        let extraLineRect = layoutManager.extraLineFragmentRect
+        let rowHeight: CGFloat
+        let width: CGFloat
+
+        if extraLineRect.height > 0 {
+            rowHeight = extraLineRect.height
+            width = extraLineRect.width
+        } else if let previousRow = measuredRows.last {
+            rowHeight = previousRow.height
+            width = previousRow.width
+        } else {
+            rowHeight = layoutManager.defaultLineHeight(for: font)
+            width = Self.unwrappedTextContainerWidth
+        }
+
+        return NSRect(
+            x: 0,
+            y: measuredRows.last?.maxY ?? 0,
+            width: width,
+            height: rowHeight
+        )
     }
 
     private func drawMarker(
@@ -165,7 +217,7 @@ final class DiffSelectableTextContainerView: NSView {
             x: horizontalPadding,
             y: rowRect.minY,
             width: gutterWidth,
-            height: lineHeight
+            height: rowRect.height
         )
         (marker as NSString).draw(in: markerRect, withAttributes: attributes)
     }

--- a/Alas/Sources/Center/DiffSelectableTextView.swift
+++ b/Alas/Sources/Center/DiffSelectableTextView.swift
@@ -1,0 +1,184 @@
+import AppKit
+import SwiftUI
+
+struct DiffSelectableTextView: NSViewRepresentable {
+    let hunk: ParsedDiff.Hunk
+    let fileExtension: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let theme: Theme
+
+    func makeNSView(context: Context) -> DiffSelectableTextContainerView {
+        DiffSelectableTextContainerView()
+    }
+
+    func updateNSView(_ nsView: DiffSelectableTextContainerView, context: Context) {
+        nsView.update(
+            hunk: hunk,
+            fileExtension: fileExtension,
+            font: CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize),
+            theme: theme
+        )
+    }
+}
+
+final class DiffSelectableTextContainerView: NSView {
+    private let textView: NSTextView
+    private var lineMetadata: [DiffSelectableTextBuilder.LineMetadata] = []
+    private var theme: Theme?
+    private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
+
+    private let gutterWidth: CGFloat = 58
+    private let horizontalPadding: CGFloat = 14
+    private let rowVerticalPadding = CenterTypography.rowVerticalPadding
+
+    override var isFlipped: Bool { true }
+
+    override init(frame frameRect: NSRect) {
+        let storage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(size: NSSize(width: 10, height: CGFloat.greatestFiniteMagnitude))
+        container.widthTracksTextView = true
+        container.heightTracksTextView = false
+        container.lineFragmentPadding = 0
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+
+        textView = NSTextView(frame: .zero, textContainer: container)
+        super.init(frame: frameRect)
+
+        wantsLayer = true
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.drawsBackground = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.allowsUndo = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isContinuousSpellCheckingEnabled = false
+        textView.isGrammarCheckingEnabled = false
+        textView.smartInsertDeleteEnabled = false
+        addSubview(textView)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("not used")
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: totalHeight)
+    }
+
+    func update(
+        hunk: ParsedDiff.Hunk,
+        fileExtension: String,
+        font: NSFont,
+        theme: Theme
+    ) {
+        self.font = font
+        self.theme = theme
+        let result = DiffSelectableTextBuilder.build(
+            hunk: hunk,
+            fileExtension: fileExtension,
+            font: font,
+            theme: theme
+        )
+        lineMetadata = result.lines
+        textView.textStorage?.setAttributedString(result.attributedString)
+        needsDisplay = true
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        let textX = horizontalPadding + gutterWidth + 16
+        textView.frame = NSRect(
+            x: textX,
+            y: rowVerticalPadding,
+            width: max(0, bounds.width - textX - horizontalPadding),
+            height: max(0, totalHeight - rowVerticalPadding * 2)
+        )
+        textView.textContainer?.containerSize = NSSize(
+            width: textView.bounds.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard let theme else { return }
+        for (index, line) in lineMetadata.enumerated() {
+            let rect = NSRect(
+                x: 0,
+                y: CGFloat(index) * rowHeight,
+                width: bounds.width,
+                height: rowHeight
+            )
+            rowBackgroundColor(for: line.kind, theme: theme).setFill()
+            rect.fill()
+            drawMarker(line.marker, in: rect, kind: line.kind, theme: theme)
+        }
+    }
+
+    private var lineHeight: CGFloat {
+        (font.ascender - font.descender + font.leading) * CenterTypography.lineHeightMultiple
+    }
+
+    private var rowHeight: CGFloat {
+        ceil(lineHeight + rowVerticalPadding * 2)
+    }
+
+    private var totalHeight: CGFloat {
+        guard !lineMetadata.isEmpty else { return 0 }
+        return CGFloat(lineMetadata.count) * rowHeight
+    }
+
+    private func drawMarker(
+        _ marker: String,
+        in rowRect: NSRect,
+        kind: ParsedDiff.Hunk.Line.Kind,
+        theme: Theme
+    ) {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .right
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: markerColor(for: kind, theme: theme),
+            .paragraphStyle: paragraph,
+        ]
+        let markerRect = NSRect(
+            x: horizontalPadding,
+            y: rowRect.minY + rowVerticalPadding,
+            width: gutterWidth,
+            height: lineHeight
+        )
+        (marker as NSString).draw(in: markerRect, withAttributes: attributes)
+    }
+
+    private func rowBackgroundColor(for kind: ParsedDiff.Hunk.Line.Kind, theme: Theme) -> NSColor {
+        switch kind {
+        case .add:
+            return NSColor(theme.color("add").opacity(0.10))
+        case .delete:
+            return NSColor(theme.color("del").opacity(0.10))
+        case .context:
+            return .clear
+        }
+    }
+
+    private func markerColor(for kind: ParsedDiff.Hunk.Line.Kind, theme: Theme) -> NSColor {
+        switch kind {
+        case .add:
+            return NSColor(theme.color("add"))
+        case .delete:
+            return NSColor(theme.color("del"))
+        case .context:
+            return NSColor(theme.color("fg-faint"))
+        }
+    }
+}

--- a/Alas/Sources/Center/DiffSelectableTextView.swift
+++ b/Alas/Sources/Center/DiffSelectableTextView.swift
@@ -29,6 +29,7 @@ final class DiffSelectableTextContainerView: NSView {
     private var lineMetadata: [DiffSelectableTextBuilder.LineMetadata] = []
     private var rowRects: [NSRect] = []
     private var measuredTextHeight: CGFloat = 0
+    private var measuredTextWidth: CGFloat = 0
     private var theme: Theme?
     private var font: NSFont = .monospacedSystemFont(ofSize: 13, weight: .regular)
 
@@ -82,7 +83,7 @@ final class DiffSelectableTextContainerView: NSView {
     }
 
     override var intrinsicContentSize: NSSize {
-        NSSize(width: NSView.noIntrinsicMetric, height: totalHeight)
+        NSSize(width: totalWidth, height: totalHeight)
     }
 
     func update(
@@ -113,7 +114,7 @@ final class DiffSelectableTextContainerView: NSView {
         textView.frame = NSRect(
             x: textX,
             y: verticalInset,
-            width: max(0, bounds.width - textX - horizontalPadding),
+            width: max(measuredTextWidth, bounds.width - textX - horizontalPadding),
             height: measuredTextHeight
         )
         textView.textContainer?.containerSize = NSSize(
@@ -131,7 +132,7 @@ final class DiffSelectableTextContainerView: NSView {
             let rect = NSRect(
                 x: 0,
                 y: verticalInset + measuredRect.minY,
-                width: bounds.width,
+                width: max(bounds.width, totalWidth),
                 height: measuredRect.height
             )
             rowBackgroundColor(for: line.kind, theme: theme).setFill()
@@ -145,6 +146,11 @@ final class DiffSelectableTextContainerView: NSView {
         return measuredTextHeight + verticalInset * 2
     }
 
+    private var totalWidth: CGFloat {
+        let textX = horizontalPadding + gutterWidth + 16
+        return textX + measuredTextWidth + horizontalPadding
+    }
+
     private func updateMeasuredRowGeometry() {
         guard
             !lineMetadata.isEmpty,
@@ -153,6 +159,7 @@ final class DiffSelectableTextContainerView: NSView {
         else {
             rowRects = []
             measuredTextHeight = 0
+            measuredTextWidth = 0
             return
         }
 
@@ -174,6 +181,7 @@ final class DiffSelectableTextContainerView: NSView {
 
         rowRects = Array(measuredRows.prefix(lineMetadata.count))
         measuredTextHeight = rowRects.last?.maxY ?? 0
+        measuredTextWidth = ceil(layoutManager.usedRect(for: textContainer).width)
     }
 
     private func measuredTrailingRowRect(after measuredRows: [NSRect], layoutManager: NSLayoutManager) -> NSRect {

--- a/Alas/Sources/Center/DiffSelectableTextView.swift
+++ b/Alas/Sources/Center/DiffSelectableTextView.swift
@@ -135,6 +135,7 @@ final class DiffSelectableTextContainerView: NSView {
                 width: max(bounds.width, totalWidth),
                 height: measuredRect.height
             )
+            guard rect.intersects(dirtyRect) else { continue }
             rowBackgroundColor(for: line.kind, theme: theme).setFill()
             rect.fill()
             drawMarker(line.marker, in: rect, kind: line.kind, theme: theme)

--- a/Alas/Sources/Center/DiffSelectableTextView.swift
+++ b/Alas/Sources/Center/DiffSelectableTextView.swift
@@ -23,6 +23,8 @@ struct DiffSelectableTextView: NSViewRepresentable {
 }
 
 final class DiffSelectableTextContainerView: NSView {
+    private static let unwrappedTextContainerWidth: CGFloat = 1_000_000
+
     private let textView: NSTextView
     private var lineMetadata: [DiffSelectableTextBuilder.LineMetadata] = []
     private var theme: Theme?
@@ -30,15 +32,18 @@ final class DiffSelectableTextContainerView: NSView {
 
     private let gutterWidth: CGFloat = 58
     private let horizontalPadding: CGFloat = 14
-    private let rowVerticalPadding = CenterTypography.rowVerticalPadding
+    private let verticalInset = CenterTypography.rowVerticalPadding
 
     override var isFlipped: Bool { true }
 
     override init(frame frameRect: NSRect) {
         let storage = NSTextStorage()
         let layoutManager = NSLayoutManager()
-        let container = NSTextContainer(size: NSSize(width: 10, height: CGFloat.greatestFiniteMagnitude))
-        container.widthTracksTextView = true
+        let container = NSTextContainer(size: NSSize(
+            width: Self.unwrappedTextContainerWidth,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
+        container.widthTracksTextView = false
         container.heightTracksTextView = false
         container.lineFragmentPadding = 0
         layoutManager.addTextContainer(container)
@@ -54,6 +59,11 @@ final class DiffSelectableTextContainerView: NSView {
         textView.drawsBackground = false
         textView.backgroundColor = .clear
         textView.textContainerInset = .zero
+        textView.isHorizontallyResizable = true
+        textView.maxSize = NSSize(
+            width: Self.unwrappedTextContainerWidth,
+            height: CGFloat.greatestFiniteMagnitude
+        )
         textView.allowsUndo = false
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
@@ -99,12 +109,12 @@ final class DiffSelectableTextContainerView: NSView {
         let textX = horizontalPadding + gutterWidth + 16
         textView.frame = NSRect(
             x: textX,
-            y: rowVerticalPadding,
+            y: verticalInset,
             width: max(0, bounds.width - textX - horizontalPadding),
-            height: max(0, totalHeight - rowVerticalPadding * 2)
+            height: max(0, CGFloat(lineMetadata.count) * rowHeight)
         )
         textView.textContainer?.containerSize = NSSize(
-            width: textView.bounds.width,
+            width: Self.unwrappedTextContainerWidth,
             height: CGFloat.greatestFiniteMagnitude
         )
     }
@@ -115,7 +125,7 @@ final class DiffSelectableTextContainerView: NSView {
         for (index, line) in lineMetadata.enumerated() {
             let rect = NSRect(
                 x: 0,
-                y: CGFloat(index) * rowHeight,
+                y: verticalInset + CGFloat(index) * rowHeight,
                 width: bounds.width,
                 height: rowHeight
             )
@@ -130,12 +140,12 @@ final class DiffSelectableTextContainerView: NSView {
     }
 
     private var rowHeight: CGFloat {
-        ceil(lineHeight + rowVerticalPadding * 2)
+        ceil(lineHeight)
     }
 
     private var totalHeight: CGFloat {
         guard !lineMetadata.isEmpty else { return 0 }
-        return CGFloat(lineMetadata.count) * rowHeight
+        return CGFloat(lineMetadata.count) * rowHeight + verticalInset * 2
     }
 
     private func drawMarker(
@@ -153,7 +163,7 @@ final class DiffSelectableTextContainerView: NSView {
         ]
         let markerRect = NSRect(
             x: horizontalPadding,
-            y: rowRect.minY + rowVerticalPadding,
+            y: rowRect.minY,
             width: gutterWidth,
             height: lineHeight
         )

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -344,106 +344,16 @@ struct HunkView: View {
             .background(theme.color("bg-2"))
             .overlay(Divider().opacity(0.5), alignment: .top)
             .overlay(Divider().opacity(0.5), alignment: .bottom)
-            ForEach(Array(hunk.lines.enumerated()), id: \.offset) { (_, line) in
-                HStack(alignment: .top, spacing: 16) {
-                    Text(lineMarker(line))
-                        .frame(width: 44, alignment: .trailing)
-                        .foregroundColor(markerColor(line))
-                    Text(highlightedLine(line.text, ext: fileExtension))
-                    Spacer(minLength: 0)
-                }
-                .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize))
-                .padding(.horizontal, 14)
-                .centerPanelRowSpacing()
-                .background(rowBg(line))
-            }
-        }
-        .textSelection(.enabled)
-    }
-
-    /// Compose a single `AttributedString` for `line` with per-token
-    /// foreground colors. Rendering as a single SwiftUI `Text` (rather
-    /// than an HStack of per-token Texts) lets SwiftUI lay the line out
-    /// as one run of text — without it, long lines collapse into a
-    /// vertical stack of one-token columns under width pressure.
-    private func highlightedLine(_ line: String, ext: String) -> AttributedString {
-        var attr = AttributedString()
-        for (text, capture) in renderedSpans(line, ext: ext) {
-            var part = AttributedString(text)
-            part.foregroundColor = color(for: capture)
-            attr.append(part)
-        }
-        return attr
-    }
-
-    /// Build a sequence of `(text, capture)` pairs covering the entire
-    /// `line`, using `TreeSitterHighlighter`'s per-line spans. Plain
-    /// segments between captured ranges keep their text (capture = .plain).
-    private func renderedSpans(_ line: String, ext: String) -> [(String, HighlightCapture)] {
-        let ns = line as NSString
-        let total = ns.length
-        guard total > 0 else { return [] }
-        let spans = TreeSitterHighlighter.tokenize(line: line, fileExtension: ext)
-            .filter { $0.range.location >= 0 && NSMaxRange($0.range) <= total }
-            .sorted { $0.range.location < $1.range.location }
-
-        var result: [(String, HighlightCapture)] = []
-        var cursor = 0
-        for span in spans {
-            if span.range.location < cursor { continue } // skip overlapping
-            if span.range.location > cursor {
-                let plainRange = NSRange(location: cursor, length: span.range.location - cursor)
-                result.append((ns.substring(with: plainRange), .plain))
-            }
-            result.append((ns.substring(with: span.range), span.capture))
-            cursor = NSMaxRange(span.range)
-        }
-        if cursor < total {
-            let tail = NSRange(location: cursor, length: total - cursor)
-            result.append((ns.substring(with: tail), .plain))
-        }
-        if result.isEmpty {
-            result.append((line, .plain))
-        }
-        return result
-    }
-
-    private func color(for capture: HighlightCapture) -> Color {
-        switch capture {
-        case .keyword:  return theme.color("syntax-keyword")
-        case .type:     return theme.color("syntax-type")
-        case .function: return theme.color("syntax-function")
-        case .string:   return theme.color("add")
-        case .number:   return theme.color("mod")
-        case .comment:  return theme.color("fg-faint")
-        default:        return theme.color("fg")
-        }
-    }
-
-    private func lineMarker(_ l: ParsedDiff.Hunk.Line) -> String {
-        switch l.kind {
-        case .add:     return "+\(l.newNumber.map(String.init) ?? "")"
-        case .delete:  return "−\(l.oldNumber.map(String.init) ?? "")"
-        case .context: return " \(l.oldNumber.map(String.init) ?? "")"
-        }
-    }
-
-    private func rowBg(_ l: ParsedDiff.Hunk.Line) -> Color {
-        switch l.kind {
-        case .add:    return theme.color("add").opacity(0.10)
-        case .delete: return theme.color("del").opacity(0.10)
-        case .context: return .clear
+            DiffSelectableTextView(
+                hunk: hunk,
+                fileExtension: fileExtension,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                theme: theme
+            )
         }
     }
 
     /// The hunk header (@@…@@) is rendered slightly smaller than diff content.
     private var headerFontSize: CGFloat { (codeFontSize * 0.85).rounded() }
-
-    private func markerColor(_ l: ParsedDiff.Hunk.Line) -> Color {
-        switch l.kind {
-        case .add:    return theme.color("add")
-        case .delete: return theme.color("del")
-        case .context: return theme.color("fg-faint")
-        }
-    }
 }

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -89,7 +89,7 @@ struct DiffTabView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(theme.color("bg-2"))
             }
-            ScrollView([.horizontal, .vertical]) {
+            ScrollView(.vertical) {
                 if !loaded {
                     ProgressView().padding()
                 } else if diff.hunks.isEmpty {
@@ -111,7 +111,9 @@ struct DiffTabView: View {
                     .padding(.vertical, 8)
                 }
             }
+            .defaultScrollAnchor(.topLeading)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(theme.color("bg-1"))
         .task(id: loadKey) { await load() }
         .alert(
@@ -325,6 +327,7 @@ struct HunkView: View {
     var onStage:   (() -> Void)? = nil
     var onDiscard: (() -> Void)? = nil
     @Environment(\.theme) var theme
+    @State private var bodyViewportWidth: CGFloat = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -341,19 +344,42 @@ struct HunkView: View {
                 }
             }
             .padding(.horizontal, 14).padding(.vertical, 4)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(theme.color("bg-2"))
             .overlay(Divider().opacity(0.5), alignment: .top)
             .overlay(Divider().opacity(0.5), alignment: .bottom)
-            DiffSelectableTextView(
-                hunk: hunk,
-                fileExtension: fileExtension,
-                codeFontFamily: codeFontFamily,
-                codeFontSize: codeFontSize,
-                theme: theme
+            ScrollView(.horizontal) {
+                DiffSelectableTextView(
+                    hunk: hunk,
+                    fileExtension: fileExtension,
+                    codeFontFamily: codeFontFamily,
+                    codeFontSize: codeFontSize,
+                    theme: theme
+                )
+                .frame(minWidth: bodyViewportWidth, alignment: .leading)
+            }
+            .defaultScrollAnchor(.topLeading)
+            .fixedSize(horizontal: false, vertical: true)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear.preference(key: HunkBodyViewportWidthPreferenceKey.self, value: proxy.size.width)
+                }
             )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onPreferenceChange(HunkBodyViewportWidthPreferenceKey.self) { width in
+            bodyViewportWidth = width
         }
     }
 
     /// The hunk header (@@…@@) is rendered slightly smaller than diff content.
     private var headerFontSize: CGFloat { (codeFontSize * 0.85).rounded() }
+}
+
+private struct HunkBodyViewportWidthPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
 }

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -335,6 +335,7 @@ struct HunkView: View {
                 Text(hunk.header)
                     .font(CenterTypography.codeFont(family: codeFontFamily, size: headerFontSize))
                     .foregroundColor(theme.color("fg-dim"))
+                    .textSelection(.enabled)
                 Spacer(minLength: 8)
                 if onStage != nil {
                     AlasButton(title: "Stage hunk", style: .subtle, action: { onStage?() })

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -327,7 +327,6 @@ struct HunkView: View {
     var onStage:   (() -> Void)? = nil
     var onDiscard: (() -> Void)? = nil
     @Environment(\.theme) var theme
-    @State private var bodyViewportWidth: CGFloat = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -349,38 +348,18 @@ struct HunkView: View {
             .background(theme.color("bg-2"))
             .overlay(Divider().opacity(0.5), alignment: .top)
             .overlay(Divider().opacity(0.5), alignment: .bottom)
-            ScrollView(.horizontal) {
-                DiffSelectableTextView(
-                    hunk: hunk,
-                    fileExtension: fileExtension,
-                    codeFontFamily: codeFontFamily,
-                    codeFontSize: codeFontSize,
-                    theme: theme
-                )
-                .frame(minWidth: bodyViewportWidth, alignment: .leading)
-            }
-            .defaultScrollAnchor(.topLeading)
-            .fixedSize(horizontal: false, vertical: true)
-            .background(
-                GeometryReader { proxy in
-                    Color.clear.preference(key: HunkBodyViewportWidthPreferenceKey.self, value: proxy.size.width)
-                }
+            DiffSelectableTextView(
+                hunk: hunk,
+                fileExtension: fileExtension,
+                codeFontFamily: codeFontFamily,
+                codeFontSize: codeFontSize,
+                theme: theme
             )
+            .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .onPreferenceChange(HunkBodyViewportWidthPreferenceKey.self) { width in
-            bodyViewportWidth = width
-        }
     }
 
     /// The hunk header (@@…@@) is rendered slightly smaller than diff content.
     private var headerFontSize: CGFloat { (codeFontSize * 0.85).rounded() }
-}
-
-private struct HunkBodyViewportWidthPreferenceKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
 }

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -89,7 +89,7 @@ struct DiffTabView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(theme.color("bg-2"))
             }
-            ScrollView {
+            ScrollView([.horizontal, .vertical]) {
                 if !loaded {
                     ProgressView().padding()
                 } else if diff.hunks.isEmpty {

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -4,9 +4,8 @@ import AppKit
 @testable import Alas
 
 /// Smoke tests for the shared diff hunk renderer used by working-tree and
-/// commit diff panes. Text selection is exercised at runtime via
-/// `.textSelection(.enabled)` and is not inspectable in an `NSHostingController`;
-/// these tests guard rendering crashes with varied hunk shapes.
+/// commit diff panes. The native hunk body is inspectable in hosted views, while
+/// these tests also guard rendering crashes with varied hunk shapes.
 @Suite(.serialized)
 @MainActor
 struct DiffSelectableTextTests {
@@ -139,7 +138,9 @@ struct Foo {
         let textView = try #require(textViews.first)
         #expect(textView.isHorizontallyResizable)
         #expect(textView.textContainer?.widthTracksTextView == false)
-        #expect((textView.textContainer?.containerSize.width ?? 0) > textView.bounds.width * 100)
+        #expect((textView.textContainer?.containerSize.width ?? 0) > textView.bounds.width)
+        #expect(container.intrinsicContentSize.width > container.frame.width)
+        #expect(textView.frame.width > container.frame.width)
     }
 
     private func allSubviews(of view: NSView) -> [NSView] {

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -143,6 +143,39 @@ struct Foo {
         #expect(textView.frame.width > container.frame.width)
     }
 
+    @Test func diffSelectableTextViewPreservesWrappedFragmentHeightForHugeLine() throws {
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -1,1 +1,1 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: [
+                .init(
+                    kind: .add,
+                    text: String(repeating: "x", count: 160_000),
+                    oldNumber: nil,
+                    newNumber: 1
+                ),
+            ]
+        )
+        let container = DiffSelectableTextContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.update(
+            hunk: hunk,
+            fileExtension: "txt",
+            font: font,
+            theme: currentTheme()
+        )
+        container.layoutSubtreeIfNeeded()
+
+        let textView = try #require(allSubviews(of: container).compactMap { $0 as? NSTextView }.first)
+        let measuredTextHeight = try measuredLineFragmentHeight(in: textView)
+        let expectedHeight = measuredTextHeight + CenterTypography.rowVerticalPadding * 2
+
+        #expect(measuredTextHeight > layoutManagerLineHeight(font: font))
+        #expect(abs(textView.frame.height - measuredTextHeight) < 0.001)
+        #expect(abs(container.intrinsicContentSize.height - expectedHeight) < 0.001)
+    }
+
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
     }
@@ -170,6 +203,10 @@ struct Foo {
 
         #expect(!measuredRect.isNull)
         return measuredRect.height
+    }
+
+    private func layoutManagerLineHeight(font: NSFont) -> CGFloat {
+        NSLayoutManager().defaultLineHeight(for: font)
     }
 
     // MARK: HunkView standalone

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -71,7 +71,7 @@ struct Foo {
         #expect(result.lines.last?.range.location == (result.attributedString.string as NSString).length - 1)
     }
 
-    @Test func diffSelectableTextViewHostsCodeOnlyNativeTextView() {
+    @Test func diffSelectableTextViewHostsCodeOnlyNativeTextView() throws {
         let view = DiffSelectableTextView(
             hunk: sampleHunk(),
             fileExtension: "swift",
@@ -85,11 +85,57 @@ struct Foo {
         controller.view.layoutSubtreeIfNeeded()
 
         let textViews = allSubviews(of: controller.view).compactMap { $0 as? NSTextView }
-        #expect(textViews.contains(where: { textView in
-            textView.isSelectable &&
-            !textView.isEditable &&
-            textView.string == DiffSelectableTextBuilder.plainString(for: sampleHunk())
-        }))
+        #expect(textViews.count == 1)
+        let textView = try #require(textViews.first)
+        #expect(textView.isSelectable)
+        #expect(!textView.isEditable)
+        #expect(textView.string == DiffSelectableTextBuilder.plainString(for: sampleHunk()))
+    }
+
+    @Test func diffSelectableTextViewUsesNativeLineHeightForRows() {
+        let font = CenterTypography.resolveCodeFont(family: "", size: 13)
+        let container = DiffSelectableTextContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.update(
+            hunk: sampleHunk(),
+            fileExtension: "swift",
+            font: font,
+            theme: currentTheme()
+        )
+
+        let lineHeight = ceil((font.ascender - font.descender + font.leading) * CenterTypography.lineHeightMultiple)
+        let expectedHeight = CGFloat(sampleHunk().lines.count) * lineHeight + CenterTypography.rowVerticalPadding * 2
+        #expect(container.intrinsicContentSize.height == expectedHeight)
+    }
+
+    @Test func diffSelectableTextViewDisablesLongLineWrapping() throws {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -1,1 +1,1 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: [
+                .init(
+                    kind: .add,
+                    text: String(repeating: "let value = veryLongExpression + ", count: 80),
+                    oldNumber: nil,
+                    newNumber: 1
+                ),
+            ]
+        )
+        let container = DiffSelectableTextContainerView(frame: NSRect(x: 0, y: 0, width: 160, height: 200))
+        container.update(
+            hunk: hunk,
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            theme: currentTheme()
+        )
+        container.layoutSubtreeIfNeeded()
+
+        let textViews = allSubviews(of: container).compactMap { $0 as? NSTextView }
+        #expect(textViews.count == 1)
+        let textView = try #require(textViews.first)
+        #expect(textView.isHorizontallyResizable)
+        #expect(textView.textContainer?.widthTracksTextView == false)
+        #expect((textView.textContainer?.containerSize.width ?? 0) > textView.bounds.width * 100)
     }
 
     private func allSubviews(of view: NSView) -> [NSView] {

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -71,6 +71,31 @@ struct Foo {
         #expect(result.lines.last?.range.location == (result.attributedString.string as NSString).length - 1)
     }
 
+    @Test func diffSelectableTextViewHostsCodeOnlyNativeTextView() {
+        let view = DiffSelectableTextView(
+            hunk: sampleHunk(),
+            fileExtension: "swift",
+            codeFontFamily: "",
+            codeFontSize: 13,
+            theme: currentTheme()
+        )
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let textViews = allSubviews(of: controller.view).compactMap { $0 as? NSTextView }
+        #expect(textViews.contains(where: { textView in
+            textView.isSelectable &&
+            !textView.isEditable &&
+            textView.string == DiffSelectableTextBuilder.plainString(for: sampleHunk())
+        }))
+    }
+
+    private func allSubviews(of view: NSView) -> [NSView] {
+        view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
+    }
+
     // MARK: HunkView standalone
 
     @Test func hunkViewRendersWithoutCrashing() {

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -171,19 +171,23 @@ struct Foo {
         #expect(controller.view != nil)
     }
 
-    @Test func hunkViewHostsNativeSelectableTextView() {
+    @Test func hunkViewHostsNativeSelectableTextView() throws {
         let view = HunkView(hunk: sampleHunk(), fileExtension: "swift")
             .environment(\.theme, currentTheme())
         let controller = NSHostingController(rootView: view)
         controller.view.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
         controller.view.layoutSubtreeIfNeeded()
 
-        let textViews = allSubviews(of: controller.view).compactMap { $0 as? NSTextView }
-        #expect(textViews.contains(where: { textView in
-            textView.isSelectable &&
-            !textView.isEditable &&
-            textView.string == DiffSelectableTextBuilder.plainString(for: sampleHunk())
-        }))
+        let containerViews = allSubviews(of: controller.view).compactMap { $0 as? DiffSelectableTextContainerView }
+        #expect(containerViews.count == 1)
+        let containerView = try #require(containerViews.first)
+
+        let textViews = allSubviews(of: containerView).compactMap { $0 as? NSTextView }
+        #expect(textViews.count == 1)
+        let textView = try #require(textViews.first)
+        #expect(textView.isSelectable)
+        #expect(!textView.isEditable)
+        #expect(textView.string == DiffSelectableTextBuilder.plainString(for: sampleHunk()))
     }
 
     @Test func hunkViewWithActionsRendersWithoutCrashing() {

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -171,6 +171,21 @@ struct Foo {
         #expect(controller.view != nil)
     }
 
+    @Test func hunkViewHostsNativeSelectableTextView() {
+        let view = HunkView(hunk: sampleHunk(), fileExtension: "swift")
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let textViews = allSubviews(of: controller.view).compactMap { $0 as? NSTextView }
+        #expect(textViews.contains(where: { textView in
+            textView.isSelectable &&
+            !textView.isEditable &&
+            textView.string == DiffSelectableTextBuilder.plainString(for: sampleHunk())
+        }))
+    }
+
     @Test func hunkViewWithActionsRendersWithoutCrashing() {
         let view = HunkView(
             hunk: sampleHunk(),

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -28,6 +28,49 @@ struct DiffSelectableTextTests {
         )
     }
 
+    @Test func diffSelectableTextBuilderPlainStringExcludesGutters() {
+        let text = DiffSelectableTextBuilder.plainString(for: sampleHunk())
+        #expect(text == """
+struct Foo {
+    let bar: Int
+    let bar: String
+}
+""")
+        #expect(!text.contains("+11"))
+        #expect(!text.contains("−11"))
+        #expect(!text.contains("@@"))
+    }
+
+    @Test func diffSelectableTextBuilderPreservesEmptyLines() {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -1,3 +1,3 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: [
+                .init(kind: .context, text: "alpha", oldNumber: 1, newNumber: 1),
+                .init(kind: .delete, text: "", oldNumber: 2, newNumber: nil),
+                .init(kind: .add, text: "omega", oldNumber: nil, newNumber: 2),
+            ]
+        )
+
+        #expect(DiffSelectableTextBuilder.plainString(for: hunk) == "alpha\n\nomega")
+    }
+
+    @Test func diffSelectableTextBuilderReturnsLineMetadataForEveryLine() {
+        let result = DiffSelectableTextBuilder.build(
+            hunk: sampleHunk(),
+            fileExtension: "swift",
+            font: CenterTypography.resolveCodeFont(family: "", size: 13),
+            theme: currentTheme()
+        )
+
+        #expect(result.attributedString.string == DiffSelectableTextBuilder.plainString(for: sampleHunk()))
+        #expect(result.lines.map(\.kind) == [.context, .delete, .add, .context])
+        #expect(result.lines.map(\.marker) == [" 10", "−11", "+11", " 12"])
+        #expect(result.lines.first?.range == NSRange(location: 0, length: 12))
+        #expect(result.lines.last?.range.location == (result.attributedString.string as NSString).length - 1)
+    }
+
     // MARK: HunkView standalone
 
     @Test func hunkViewRendersWithoutCrashing() {

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -92,7 +92,7 @@ struct Foo {
         #expect(textView.string == DiffSelectableTextBuilder.plainString(for: sampleHunk()))
     }
 
-    @Test func diffSelectableTextViewUsesNativeLineHeightForRows() {
+    @Test func diffSelectableTextViewUsesMeasuredAppKitLineFragmentsForRows() throws {
         let font = CenterTypography.resolveCodeFont(family: "", size: 13)
         let container = DiffSelectableTextContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         container.update(
@@ -101,10 +101,14 @@ struct Foo {
             font: font,
             theme: currentTheme()
         )
+        container.layoutSubtreeIfNeeded()
 
-        let lineHeight = ceil((font.ascender - font.descender + font.leading) * CenterTypography.lineHeightMultiple)
-        let expectedHeight = CGFloat(sampleHunk().lines.count) * lineHeight + CenterTypography.rowVerticalPadding * 2
-        #expect(container.intrinsicContentSize.height == expectedHeight)
+        let textView = try #require(allSubviews(of: container).compactMap { $0 as? NSTextView }.first)
+        let measuredTextHeight = try measuredLineFragmentHeight(in: textView)
+        let expectedHeight = measuredTextHeight + CenterTypography.rowVerticalPadding * 2
+
+        #expect(abs(textView.frame.height - measuredTextHeight) < 0.001)
+        #expect(abs(container.intrinsicContentSize.height - expectedHeight) < 0.001)
     }
 
     @Test func diffSelectableTextViewDisablesLongLineWrapping() throws {
@@ -140,6 +144,21 @@ struct Foo {
 
     private func allSubviews(of view: NSView) -> [NSView] {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
+    }
+
+    private func measuredLineFragmentHeight(in textView: NSTextView) throws -> CGFloat {
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        layoutManager.ensureLayout(for: textContainer)
+
+        let glyphRange = layoutManager.glyphRange(for: textContainer)
+        var measuredRect = NSRect.null
+        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { lineFragmentRect, _, _, _, _ in
+            measuredRect = measuredRect.union(lineFragmentRect)
+        }
+
+        #expect(!measuredRect.isNull)
+        return measuredRect.height
     }
 
     // MARK: HunkView standalone

--- a/AlasTests/DiffSelectableTextTests.swift
+++ b/AlasTests/DiffSelectableTextTests.swift
@@ -147,6 +147,16 @@ struct Foo {
         view.subviews + view.subviews.flatMap { allSubviews(of: $0) }
     }
 
+    private func ancestorSubviews(of view: NSView) -> [NSView] {
+        var result: [NSView] = []
+        var current = view.superview
+        while let view = current {
+            result.append(view)
+            current = view.superview
+        }
+        return result
+    }
+
     private func measuredLineFragmentHeight(in textView: NSTextView) throws -> CGFloat {
         let layoutManager = try #require(textView.layoutManager)
         let textContainer = try #require(textView.textContainer)
@@ -189,6 +199,52 @@ struct Foo {
         #expect(textView.isSelectable)
         #expect(!textView.isEditable)
         #expect(textView.string == DiffSelectableTextBuilder.plainString(for: sampleHunk()))
+    }
+
+    @Test func hunkHeaderActionsRemainInViewportForLongLines() throws {
+        let hunk = ParsedDiff.Hunk(
+            header: "@@ -1,1 +1,1 @@",
+            oldStart: 1,
+            newStart: 1,
+            lines: [
+                .init(
+                    kind: .add,
+                    text: String(repeating: "let value = veryLongExpression + ", count: 80),
+                    oldNumber: nil,
+                    newNumber: 1
+                ),
+            ]
+        )
+        let view = HunkView(
+            hunk: hunk,
+            fileExtension: "swift",
+            onStage: {},
+            onDiscard: {}
+        )
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 500, height: 180)
+        controller.view.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+        controller.view.layoutSubtreeIfNeeded()
+
+        let container = try #require(
+            allSubviews(of: controller.view).compactMap { $0 as? DiffSelectableTextContainerView }.first
+        )
+        #expect(ancestorSubviews(of: container).contains { $0 is NSScrollView })
+    }
+
+    @Test func hunkBodyFillsViewportForShortLines() throws {
+        let view = HunkView(hunk: sampleHunk(), fileExtension: "swift")
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 500, height: 180)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let container = try #require(
+            allSubviews(of: controller.view).compactMap { $0 as? DiffSelectableTextContainerView }.first
+        )
+        #expect(container.bounds.width >= 490)
     }
 
     @Test func hunkViewWithActionsRendersWithoutCrashing() {
@@ -240,6 +296,34 @@ struct Foo {
         let controller = NSHostingController(rootView: view)
         controller.view.layoutSubtreeIfNeeded()
         #expect(controller.view != nil)
+    }
+
+    @Test func commitDiffViewPinsShortDiffToTopOfViewport() throws {
+        let diff = ParsedDiff(hunks: [sampleHunk()])
+        let view = CommitDiffView(
+            worktreePath: URL(fileURLWithPath: "/tmp"),
+            sha: "abc1234",
+            file: sampleFile(),
+            path: "Sources/App.swift",
+            diff: diff,
+            loading: false,
+            error: nil,
+            onOpenFile: nil
+        )
+            .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 900, height: 600)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let container = try #require(
+            allSubviews(of: controller.view).compactMap { $0 as? DiffSelectableTextContainerView }.first
+        )
+        let containerRect = container.convert(container.bounds, to: controller.view)
+        let distanceFromTop = controller.view.isFlipped
+            ? containerRect.minY
+            : controller.view.bounds.maxY - containerRect.maxY
+
+        #expect(distanceFromTop < 140)
     }
 
     @Test func commitDiffViewEmptyHunksRendersWithoutCrashing() {

--- a/docs/superpowers/specs/2026-05-24-diff-text-selection-design.md
+++ b/docs/superpowers/specs/2026-05-24-diff-text-selection-design.md
@@ -1,0 +1,150 @@
+# Diff Text Selection Design
+
+## Context
+
+The central diff pane renders parsed git hunks through `HunkView`, shared by
+working-tree diffs and commit diffs. Each diff row is currently built from
+separate SwiftUI `Text` values inside row `HStack`s, with
+`.textSelection(.enabled)` applied to the hunk container.
+
+That structure allows selecting text within a row, but does not provide a
+single continuous native text surface for drag selection across multiple diff
+lines. Users should be able to select and copy multiple lines from the central
+diff pane.
+
+## Goals
+
+- Allow native multi-line text selection in central text diff panes.
+- Copy selected diff content without visual gutters: no old/new line numbers,
+  no change markers, and no hunk header text unless the user explicitly selects
+  header text outside the diff body.
+- Preserve the current diff readability: hunk headers, stage/discard actions,
+  code font settings, syntax colors, and add/delete/context row treatments.
+- Apply the behavior to both working-tree diffs and commit diffs through the
+  shared hunk renderer.
+
+## Non-Goals
+
+- Do not change image diff behavior.
+- Do not add custom selection semantics such as rectangular selection.
+- Do not include diff gutters in copied text.
+- Do not redesign the central pane layout beyond what is needed for selection.
+
+## Recommended Approach
+
+Replace the selectable SwiftUI diff body rows with a small read-only AppKit text
+surface, exposed to SwiftUI through `NSViewRepresentable`. The hunk chrome
+remains SwiftUI: hunk header, stage/discard buttons, spacing, and surrounding
+layout stay in `HunkView`.
+
+The text surface builds one continuous attributed string from `ParsedDiff.Hunk`
+line content:
+
+- Each storage line contains only `ParsedDiff.Hunk.Line.text`.
+- Lines are joined with newline characters so AppKit can select across them
+  natively.
+- The text view is selectable but not editable.
+- The text view uses the same code font resolution as the editor and current
+  SwiftUI diff rows.
+- Syntax highlighting is applied to the attributed string with the existing
+  `TreeSitterHighlighter` tokenization.
+
+Because gutters are not part of the text storage, normal copy operations produce
+only the selected code content.
+
+## Visual Gutters And Row State
+
+The visible line-number/change-marker gutter should remain non-selectable UI.
+There are two acceptable implementation shapes:
+
+1. Keep gutters in SwiftUI beside the AppKit text surface if alignment can be
+   kept stable with fixed line metrics.
+2. Draw gutters and row backgrounds as non-text decoration in the AppKit-backed
+   view if that produces better alignment.
+
+The implementation should choose the smaller, more reliable option after a
+short prototype pass. In both cases, copied text must come from code-only text
+storage.
+
+Row background colors should continue to distinguish added, deleted, and context
+lines. If drawing full-width AppKit line backgrounds proves too invasive, a
+first implementation may keep the existing SwiftUI row background treatment as
+long as selection remains continuous and visually understandable.
+
+## Components
+
+### `DiffSelectableTextView`
+
+An `NSViewRepresentable` wrapper that owns a read-only `NSTextView` inside an
+`NSScrollView`-free AppKit container. The surrounding SwiftUI `ScrollView`
+continues to own scrolling for the whole diff pane.
+
+Responsibilities:
+
+- Configure selectable, non-editable plain text behavior.
+- Disable unwanted rich text editing features.
+- Apply font, paragraph style, syntax colors, and theme colors.
+- Size vertically to fit all hunk body lines.
+- Update text storage when the hunk, theme, file extension, font family, or font
+  size changes.
+
+### `DiffAttributedTextBuilder`
+
+A small pure helper for building attributed code-only hunk text. It should be
+testable without hosting SwiftUI or AppKit views.
+
+Responsibilities:
+
+- Join hunk line text with newlines.
+- Preserve empty lines.
+- Apply per-token syntax attributes.
+- Map hunk line kinds to any line-level metadata needed by the view.
+
+### `HunkView`
+
+`HunkView` keeps hunk header and hunk action buttons. Its body delegates the
+selectable code content to `DiffSelectableTextView` instead of rendering each
+line as independent selectable SwiftUI text.
+
+## Data Flow
+
+1. `DiffTabView` and `CommitDiffView` load a `ParsedDiff`.
+2. Each `ParsedDiff.Hunk` is passed into shared `HunkView`.
+3. `HunkView` renders non-selectable header/actions and creates the selectable
+   diff body.
+4. `DiffAttributedTextBuilder` converts hunk lines into code-only attributed
+   text.
+5. `DiffSelectableTextView` displays the attributed text in one native text
+   surface, enabling multi-line selection and code-only copying.
+
+## Error Handling
+
+This feature does not introduce new recoverable runtime errors. If syntax
+highlighting fails to produce spans, the builder should fall back to plain
+foreground styling for the affected line, matching the current defensive
+behavior.
+
+Invalid or unavailable configured font families should continue to fall back
+through `CenterTypography.resolveCodeFont`.
+
+## Testing
+
+Add focused tests for the pure builder:
+
+- Multi-line hunk text joins only `line.text` values.
+- Added/deleted/context markers and line numbers are excluded from produced
+  string content.
+- Empty diff lines are preserved.
+- Plain text file extensions render without crashing.
+
+Keep or update the existing `DiffSelectableTextTests` smoke tests so `HunkView`
+and `CommitDiffView` still render without crashing for hunks, empty hunks, and
+custom code font settings.
+
+Manual verification should include selecting multiple lines in:
+
+- A working-tree diff.
+- A commit diff.
+- A hunk containing add, delete, context, and empty lines.
+
+The copied clipboard text should contain only selected code content.


### PR DESCRIPTION
## Summary
- Render diff hunk bodies with a native selectable text view so multi-line selection works.
- Keep copied text code-only by drawing gutters and backgrounds outside text storage.
- Keep hunk controls fixed while long diff bodies scroll horizontally and short-line row backgrounds fill the viewport.

## Test Plan
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/DiffSelectableTextTests test`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` *(fails on existing unrelated tests: InstallNudgeResolver/LanguageServerRegistry/ImageFileType timing and environment-sensitive cases, HoverFeatureBehavior, TabsManagerBuffer, WorktreeService git-lfs setup)*