### PR TITLE
feat: agent assist + special conflict kinds for merge editor

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */; };
 		4B2031FB61782327D5279F98 /* FileTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339EA6ACAF180AADEC12841F /* FileTreeBuilder.swift */; };
 		4B8A7F326E4DBD17C9D95E1E /* CommitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02E429B37288215EBC89571 /* CommitHeaderView.swift */; };
+		4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */; };
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
 		4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */; };
 		4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */; };
@@ -280,6 +281,7 @@
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
 		859AD39BA8D5A9FCC905648D /* ImageDiffViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */; };
+		85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */; };
 		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
 		873535DE3342024BD7AA057E /* ShortcutReservations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */; };
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
@@ -834,6 +836,7 @@
 		8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidatorTests.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
 		90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Discard.swift"; sourceTree = "<group>"; };
+		90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeAgent.swift; sourceTree = "<group>"; };
 		910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesTreeBuilder.swift; sourceTree = "<group>"; };
 		9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMonoNerdFont-Regular.ttf"; sourceTree = "<group>"; };
 		91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictToolbar.swift; sourceTree = "<group>"; };
@@ -930,6 +933,7 @@
 		BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstallerTests.swift; sourceTree = "<group>"; };
 		BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequest.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
+		C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeAgentTests.swift; sourceTree = "<group>"; };
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
 		C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
 		C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextTests.swift; sourceTree = "<group>"; };
@@ -1228,6 +1232,7 @@
 				373D587E3153D902EB10208B /* MarkdownParserTests.swift */,
 				B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */,
 				DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */,
+				C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */,
 				D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */,
 				0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */,
 				E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */,
@@ -1545,6 +1550,7 @@
 				008E982C8526670670425AB8 /* EmptyTabView.swift */,
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
+				90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */,
 				8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */,
 				E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */,
 				674F70D8D27715223D10C582 /* MergeConflictResultView.swift */,
@@ -2350,6 +2356,7 @@
 				6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
+				4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */,
 				4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */,
 				B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */,
 				B27F4047043A6FCE2E9C21A3 /* MergeConflictResultView.swift in Sources */,
@@ -2607,6 +2614,7 @@
 				8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */,
 				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,
 				EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */,
+				85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */,
 				04C778DB96502CD36E4C031B /* MergeConflictTabModelTests.swift in Sources */,
 				5F7E14A0D7E1D3F036806B73 /* MergeOperationStateTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
 		98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */; };
 		98CCFEFD7D0E8C27C6B373F6 /* ShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */; };
+		98ED89EA20255EBB9D186AD5 /* MergeConflictBinaryDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */; };
 		9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
@@ -437,6 +438,7 @@
 		CDEE1CFA85DF21346B05C2E2 /* Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29313DDC46A0CCA2FA42CDE9 /* Icon.swift */; };
 		CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */; };
 		CE43461FCD815780370E90D8 /* SearchKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */; };
+		CF105C488C01331534C65D88 /* MergeConflictBinaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */; };
 		CF12433D8F30CEA05088FFB0 /* CodeTextViewIndentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */; };
 		CF2AD9C6F30BC02C040902A8 /* ShortcutResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */; };
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
@@ -650,6 +652,7 @@
 		2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstallerTests.swift; sourceTree = "<group>"; };
 		2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReaderTests.swift; sourceTree = "<group>"; };
 		30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorCoordinator.swift; sourceTree = "<group>"; };
+		31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryDetectionTests.swift; sourceTree = "<group>"; };
 		31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowController.swift; sourceTree = "<group>"; };
 		321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcherTests.swift; sourceTree = "<group>"; };
 		328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageRegistry.swift; sourceTree = "<group>"; };
@@ -768,6 +771,7 @@
 		679E62B501E0490F48CCA830 /* EditorFindBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindBarView.swift; sourceTree = "<group>"; };
 		6821B71680094791995C4975 /* ShortcutsPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsPane.swift; sourceTree = "<group>"; };
 		69024633944E9FFF6DA76FAE /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictBinaryView.swift; sourceTree = "<group>"; };
 		69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhosttySmokeTests.swift; sourceTree = "<group>"; };
 		69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateOverlayTests.swift; sourceTree = "<group>"; };
 		6A190D4B29B35C457AA9829F /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
@@ -1235,6 +1239,7 @@
 				B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */,
 				DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */,
 				C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */,
+				31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */,
 				D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */,
 				0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */,
 				E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */,
@@ -1554,6 +1559,7 @@
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
 				90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */,
 				EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */,
+				69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */,
 				8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */,
 				E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */,
 				674F70D8D27715223D10C582 /* MergeConflictResultView.swift */,
@@ -2361,6 +2367,7 @@
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
 				4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */,
 				0575E49BE44BEB8AB9D4977F /* MergeConflictAgentProposalView.swift in Sources */,
+				CF105C488C01331534C65D88 /* MergeConflictBinaryView.swift in Sources */,
 				4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */,
 				B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */,
 				B27F4047043A6FCE2E9C21A3 /* MergeConflictResultView.swift in Sources */,
@@ -2619,6 +2626,7 @@
 				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,
 				EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */,
 				85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */,
+				98ED89EA20255EBB9D186AD5 /* MergeConflictBinaryDetectionTests.swift in Sources */,
 				04C778DB96502CD36E4C031B /* MergeConflictTabModelTests.swift in Sources */,
 				5F7E14A0D7E1D3F036806B73 /* MergeOperationStateTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		04C778DB96502CD36E4C031B /* MergeConflictTabModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */; };
 		04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */; };
 		0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */; };
+		0575E49BE44BEB8AB9D4977F /* MergeConflictAgentProposalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */; };
 		065F01BB553C415040414D37 /* ImageDiffSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
@@ -1035,6 +1036,7 @@
 		EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParserTests.swift; sourceTree = "<group>"; };
 		EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
 		EECB91379591DA21D216A894 /* RelativeTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTime.swift; sourceTree = "<group>"; };
+		EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAgentProposalView.swift; sourceTree = "<group>"; };
 		F0D567F7F894902AD192D220 /* mason-lsps.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "mason-lsps.json"; sourceTree = "<group>"; };
 		F12340A649892955245BECB7 /* DefinitionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionFeature.swift; sourceTree = "<group>"; };
 		F15E14D45EC3926768DE5BD1 /* DiffTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffTabView.swift; sourceTree = "<group>"; };
@@ -1551,6 +1553,7 @@
 				6B3F942D660C7ABA8542C77D /* ImageFileType.swift */,
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
 				90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */,
+				EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */,
 				8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */,
 				E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */,
 				674F70D8D27715223D10C582 /* MergeConflictResultView.swift */,
@@ -2357,6 +2360,7 @@
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
 				4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */,
+				0575E49BE44BEB8AB9D4977F /* MergeConflictAgentProposalView.swift in Sources */,
 				4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */,
 				B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */,
 				B27F4047043A6FCE2E9C21A3 /* MergeConflictResultView.swift in Sources */,

--- a/Alas/Sources/Center/MergeAgent.swift
+++ b/Alas/Sources/Center/MergeAgent.swift
@@ -115,17 +115,26 @@ enum MergeAgent {
     }
 
     static func parseResolveOutput(_ raw: String) -> String {
-        // Many agents wrap output in ```lang ... ``` fences. Strip them.
-        var text = raw
-        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        if let first = lines.first, first.trimmingCharacters(in: .whitespaces).hasPrefix("```"),
-           let lastIdx = lines.lastIndex(where: { $0.trimmingCharacters(in: .whitespaces).hasPrefix("```") }),
-           lastIdx > 0 {
-            let inner = lines[(lines.index(after: lines.startIndex)) ..< lastIdx]
-            text = inner.joined(separator: "\n")
-            if !text.isEmpty, !text.hasSuffix("\n") { text += "\n" }
-            return text
+        // Many agents wrap output in ```lang ... ``` fences. Strip them only
+        // when they're the entire wrapper — i.e., the FIRST and LAST non-empty
+        // lines are both fence markers. A file whose own content starts with
+        // a fence (e.g., a markdown source file that opens with ```swift) must
+        // pass through unchanged.
+        let allLines = raw.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let nonEmptyIndices = allLines.indices.filter {
+            !allLines[$0].trimmingCharacters(in: .whitespaces).isEmpty
         }
+        guard let firstNonEmpty = nonEmptyIndices.first,
+              let lastNonEmpty = nonEmptyIndices.last,
+              firstNonEmpty < lastNonEmpty,
+              allLines[firstNonEmpty].trimmingCharacters(in: .whitespaces).hasPrefix("```"),
+              allLines[lastNonEmpty].trimmingCharacters(in: .whitespaces).hasPrefix("```")
+        else {
+            return raw
+        }
+        let inner = allLines[(firstNonEmpty + 1) ..< lastNonEmpty]
+        var text = inner.joined(separator: "\n")
+        if !text.isEmpty, !text.hasSuffix("\n") { text += "\n" }
         return text
     }
 }

--- a/Alas/Sources/Center/MergeAgent.swift
+++ b/Alas/Sources/Center/MergeAgent.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Thin domain-facing wrapper over `AgentRunner.runPrompt` for the merge
+/// editor. Owns the prompt templates and the post-parsing of agent output.
+/// Stateless — every call is independent.
+enum MergeAgent {
+    /// One-line summary of a single conflict block. Returns an empty string
+    /// on agent failure (the caller surfaces this as "no annotation").
+    static func explainConflict(
+        agent: AgentDefinition,
+        block: ConflictBlock,
+        language: String?,
+        timeout: TimeInterval = 30
+    ) async throws -> String {
+        let prompt = explainPrompt(block: block, language: language)
+        let result = try await AgentRunner.runPrompt(
+            agent: agent,
+            input: "",
+            prompt: prompt,
+            timeout: timeout
+        )
+        return parseExplainOutput(result.body.isEmpty ? result.subject : result.body)
+    }
+
+    /// Full-file resolution proposal. Returns the proposed file contents
+    /// (without conflict markers). Caller is responsible for presenting
+    /// a diff against the current `resultText` before applying.
+    static func resolveFile(
+        agent: AgentDefinition,
+        filePath: String,
+        local: String,
+        base: String?,
+        remote: String,
+        mergedWithMarkers: String,
+        language: String?,
+        timeout: TimeInterval = 90
+    ) async throws -> String {
+        let prompt = resolvePrompt(
+            filePath: filePath,
+            local: local,
+            base: base,
+            remote: remote,
+            mergedWithMarkers: mergedWithMarkers,
+            language: language
+        )
+        let result = try await AgentRunner.runPrompt(
+            agent: agent,
+            input: "",
+            prompt: prompt,
+            timeout: timeout
+        )
+        return parseResolveOutput(result.body.isEmpty ? result.subject : result.body)
+    }
+
+    // MARK: - Prompts (pulled out for testability)
+
+    static func explainPrompt(block: ConflictBlock, language: String?) -> String {
+        var lines: [String] = []
+        lines.append("Summarize in one sentence what changed on each side of this Git merge conflict.")
+        lines.append("Output ONLY the sentence in the form: 'LOCAL <verb> X; REMOTE <verb> Y.'")
+        lines.append("No preamble, no markdown, no quotes, no code fences.")
+        if let language, !language.isEmpty {
+            lines.append("Language: \(language)")
+        }
+        lines.append("")
+        lines.append("LOCAL (\(block.localLabel)):")
+        lines.append(block.local)
+        if let base = block.base, !base.isEmpty {
+            lines.append("BASE:")
+            lines.append(base)
+        }
+        lines.append("REMOTE (\(block.remoteLabel)):")
+        lines.append(block.remote)
+        return lines.joined(separator: "\n")
+    }
+
+    static func resolvePrompt(
+        filePath: String,
+        local: String,
+        base: String?,
+        remote: String,
+        mergedWithMarkers: String,
+        language: String?
+    ) -> String {
+        var lines: [String] = []
+        lines.append("You are resolving a Git merge conflict in \(filePath).")
+        if let language, !language.isEmpty {
+            lines.append("Language: \(language)")
+        }
+        lines.append("Reconcile LOCAL and REMOTE intent into the smallest correct merged file.")
+        lines.append("Output ONLY the resolved file contents — no conflict markers, no prose,")
+        lines.append("no markdown fences, no commentary.")
+        lines.append("")
+        lines.append("=== LOCAL ===")
+        lines.append(local)
+        if let base, !base.isEmpty {
+            lines.append("=== BASE ===")
+            lines.append(base)
+        }
+        lines.append("=== REMOTE ===")
+        lines.append(remote)
+        lines.append("=== MERGED (with markers) ===")
+        lines.append(mergedWithMarkers)
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Output parsing (pulled out for testability)
+
+    static func parseExplainOutput(_ raw: String) -> String {
+        let firstLine = raw
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .first
+            .map(String.init) ?? ""
+        return firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func parseResolveOutput(_ raw: String) -> String {
+        // Many agents wrap output in ```lang ... ``` fences. Strip them.
+        var text = raw
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        if let first = lines.first, first.trimmingCharacters(in: .whitespaces).hasPrefix("```"),
+           let lastIdx = lines.lastIndex(where: { $0.trimmingCharacters(in: .whitespaces).hasPrefix("```") }),
+           lastIdx > 0 {
+            let inner = lines[(lines.index(after: lines.startIndex)) ..< lastIdx]
+            text = inner.joined(separator: "\n")
+            if !text.isEmpty, !text.hasSuffix("\n") { text += "\n" }
+            return text
+        }
+        return text
+    }
+}

--- a/Alas/Sources/Center/MergeConflictAgentProposalView.swift
+++ b/Alas/Sources/Center/MergeConflictAgentProposalView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct MergeConflictAgentProposalView: View {
+    let currentText: String
+    let proposedText: String
+    let fileExtension: String
+    let codeFontFamily: String
+    let codeFontSize: CGFloat
+    let onApply: () -> Void
+    let onCancel: () -> Void
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            HStack(spacing: 0) {
+                VStack(spacing: 0) {
+                    columnLabel("CURRENT")
+                    MergeConflictColumnView(
+                        text: currentText,
+                        fileExtension: fileExtension,
+                        codeFontFamily: codeFontFamily,
+                        codeFontSize: codeFontSize
+                    )
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                Divider()
+                VStack(spacing: 0) {
+                    columnLabel("AGENT PROPOSAL")
+                    MergeConflictColumnView(
+                        text: proposedText,
+                        fileExtension: fileExtension,
+                        codeFontFamily: codeFontFamily,
+                        codeFontSize: codeFontSize
+                    )
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            actions
+        }
+        .background(theme.color("bg-1"))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(theme.color("line"), lineWidth: 1)
+        )
+        .padding(20)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "sparkles")
+                .foregroundColor(theme.color("accent"))
+            Text("Review proposed resolution")
+                .font(.system(size: 13, weight: .semibold))
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-2"))
+        .overlay(Divider(), alignment: .bottom)
+    }
+
+    private func columnLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .semibold))
+            .textCase(.uppercase)
+            .foregroundColor(theme.color("fg-dim"))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(theme.color("bg-2"))
+    }
+
+    private var actions: some View {
+        HStack(spacing: 8) {
+            Spacer()
+            Button("Cancel", action: onCancel)
+                .keyboardShortcut(.cancelAction)
+            Button("Apply", action: onApply)
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .tint(theme.color("accent"))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-2"))
+        .overlay(Divider(), alignment: .top)
+    }
+}

--- a/Alas/Sources/Center/MergeConflictBinaryView.swift
+++ b/Alas/Sources/Center/MergeConflictBinaryView.swift
@@ -4,6 +4,7 @@ import AppKit
 struct MergeConflictBinaryView: View {
     let conflictedFile: ConflictedFile
     let worktreePath: URL
+    let loadGeneration: Int
     @Environment(\.theme) var theme
 
     private var isImage: Bool {
@@ -40,7 +41,8 @@ struct MergeConflictBinaryView: View {
             ImageStageView(
                 worktreePath: worktreePath,
                 relativePath: conflictedFile.relativePath,
-                stage: stage
+                stage: stage,
+                loadGeneration: loadGeneration
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
@@ -71,6 +73,7 @@ private struct ImageStageView: NSViewRepresentable {
     let worktreePath: URL
     let relativePath: String
     let stage: Int
+    let loadGeneration: Int
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -91,7 +94,7 @@ private struct ImageStageView: NSViewRepresentable {
     }
 
     private func loadIfNeeded(into view: NSImageView, context: Context) {
-        let key = "\(worktreePath.path)\n\(relativePath)\n\(stage)"
+        let key = "\(worktreePath.path)\n\(relativePath)\n\(stage)\n\(loadGeneration)"
         guard context.coordinator.lastKey != key else { return }
         context.coordinator.lastKey = key
         Task {

--- a/Alas/Sources/Center/MergeConflictBinaryView.swift
+++ b/Alas/Sources/Center/MergeConflictBinaryView.swift
@@ -97,9 +97,25 @@ private struct ImageStageView: NSViewRepresentable {
         let key = "\(worktreePath.path)\n\(relativePath)\n\(stage)\n\(loadGeneration)"
         guard context.coordinator.lastKey != key else { return }
         context.coordinator.lastKey = key
-        Task {
-            let data = await readStageData(stage: stage, path: relativePath, cwd: worktreePath)
+
+        // Cancel any in-flight load — its result, if it arrives now, would be
+        // for a stale key and would overwrite the just-requested image.
+        context.coordinator.loadTask?.cancel()
+
+        let coordinator = context.coordinator
+        let capturedKey = key
+        let capturedStage = stage
+        let capturedPath = relativePath
+        let capturedCwd = worktreePath
+        coordinator.loadTask = Task {
+            let data = await Self.readStageData(stage: capturedStage, path: capturedPath, cwd: capturedCwd)
+            if Task.isCancelled { return }
             await MainActor.run {
+                // Defensive: only apply if the coordinator's key still matches
+                // what this Task was started for. If the user switched again
+                // mid-await, the new task already updated lastKey and we'd be
+                // setting an image for an outdated request.
+                guard coordinator.lastKey == capturedKey else { return }
                 if let data, let image = NSImage(data: data) {
                     view.image = image
                 } else {
@@ -109,7 +125,7 @@ private struct ImageStageView: NSViewRepresentable {
         }
     }
 
-    private func readStageData(stage: Int, path: String, cwd: URL) async -> Data? {
+    private static func readStageData(stage: Int, path: String, cwd: URL) async -> Data? {
         let result = try? await Process.gitData(
             ["show", ":\(stage):\(path)"],
             cwd: cwd
@@ -120,5 +136,10 @@ private struct ImageStageView: NSViewRepresentable {
 
     final class Coordinator {
         var lastKey: String?
+        var loadTask: Task<Void, Never>?
+
+        deinit {
+            loadTask?.cancel()
+        }
     }
 }

--- a/Alas/Sources/Center/MergeConflictBinaryView.swift
+++ b/Alas/Sources/Center/MergeConflictBinaryView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import AppKit
+
+struct MergeConflictBinaryView: View {
+    let conflictedFile: ConflictedFile
+    let worktreePath: URL
+    @Environment(\.theme) var theme
+
+    private var isImage: Bool {
+        ImageFileType.isSupported(relativePath: conflictedFile.relativePath)
+    }
+
+    var body: some View {
+        if isImage {
+            imageSideBySide
+        } else {
+            nonImageBanner
+        }
+    }
+
+    @ViewBuilder
+    private var imageSideBySide: some View {
+        HStack(spacing: 0) {
+            imageColumn(title: "LOCAL · ours", stage: 2)
+            Divider()
+            imageColumn(title: "REMOTE · theirs", stage: 3)
+        }
+    }
+
+    private func imageColumn(title: String, stage: Int) -> some View {
+        VStack(spacing: 0) {
+            Text(title)
+                .font(.system(size: 10, weight: .semibold))
+                .textCase(.uppercase)
+                .foregroundColor(theme.color("fg-dim"))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(theme.color("bg-2"))
+            ImageStageView(
+                worktreePath: worktreePath,
+                relativePath: conflictedFile.relativePath,
+                stage: stage
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var nonImageBanner: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "doc.questionmark")
+                .font(.system(size: 36))
+                .foregroundColor(theme.color("fg-dim"))
+            Text("Binary conflict")
+                .font(.system(size: 14, weight: .semibold))
+            Text("This file's contents can't be merged in the text editor.\nUse the right-pane Conflicts section to pick a side via Use ours / Use theirs, then Mark resolved here.")
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg-dim"))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.color("bg-1"))
+    }
+}
+
+/// Loads an image from a specific git index stage (`:N:<path>`) and renders
+/// it via `NSImageView`. Uses `Process.gitData` (raw bytes, not UTF-8) so
+/// binary payloads aren't corrupted.
+private struct ImageStageView: NSViewRepresentable {
+    let worktreePath: URL
+    let relativePath: String
+    let stage: Int
+
+    func makeNSView(context: Context) -> NSImageView {
+        let view = NSImageView()
+        view.imageScaling = .scaleProportionallyUpOrDown
+        view.imageAlignment = .alignCenter
+        view.imageFrameStyle = .none
+        view.animates = false
+        loadImage(into: view)
+        return view
+    }
+
+    func updateNSView(_ view: NSImageView, context: Context) {
+        loadImage(into: view)
+    }
+
+    private func loadImage(into view: NSImageView) {
+        let path = relativePath
+        let stage = stage
+        let cwd = worktreePath
+        Task {
+            let data = await readStageData(stage: stage, path: path, cwd: cwd)
+            await MainActor.run {
+                if let data, let image = NSImage(data: data) {
+                    view.image = image
+                } else {
+                    view.image = nil
+                }
+            }
+        }
+    }
+
+    private func readStageData(stage: Int, path: String, cwd: URL) async -> Data? {
+        let result = try? await Process.gitData(
+            ["show", ":\(stage):\(path)"],
+            cwd: cwd
+        )
+        guard let result, result.exitCode == 0 else { return nil }
+        return result.stdout
+    }
+}

--- a/Alas/Sources/Center/MergeConflictBinaryView.swift
+++ b/Alas/Sources/Center/MergeConflictBinaryView.swift
@@ -72,26 +72,30 @@ private struct ImageStageView: NSViewRepresentable {
     let relativePath: String
     let stage: Int
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
     func makeNSView(context: Context) -> NSImageView {
         let view = NSImageView()
         view.imageScaling = .scaleProportionallyUpOrDown
         view.imageAlignment = .alignCenter
         view.imageFrameStyle = .none
         view.animates = false
-        loadImage(into: view)
+        loadIfNeeded(into: view, context: context)
         return view
     }
 
     func updateNSView(_ view: NSImageView, context: Context) {
-        loadImage(into: view)
+        loadIfNeeded(into: view, context: context)
     }
 
-    private func loadImage(into view: NSImageView) {
-        let path = relativePath
-        let stage = stage
-        let cwd = worktreePath
+    private func loadIfNeeded(into view: NSImageView, context: Context) {
+        let key = "\(worktreePath.path)\n\(relativePath)\n\(stage)"
+        guard context.coordinator.lastKey != key else { return }
+        context.coordinator.lastKey = key
         Task {
-            let data = await readStageData(stage: stage, path: path, cwd: cwd)
+            let data = await readStageData(stage: stage, path: relativePath, cwd: worktreePath)
             await MainActor.run {
                 if let data, let image = NSImage(data: data) {
                     view.image = image
@@ -109,5 +113,9 @@ private struct ImageStageView: NSViewRepresentable {
         )
         guard let result, result.exitCode == 0 else { return nil }
         return result.stdout
+    }
+
+    final class Coordinator {
+        var lastKey: String?
     }
 }

--- a/Alas/Sources/Center/MergeConflictMinimap.swift
+++ b/Alas/Sources/Center/MergeConflictMinimap.swift
@@ -1,13 +1,23 @@
 import SwiftUI
 
 struct MergeConflictMinimap: View {
-    let conflictCount: Int
+    let conflictCount: Int          // unresolved
+    let resolvedCount: Int          // initialConflictCount - conflictCount
     let currentConflictIndex: Int?
     let onJump: (Int) -> Void
     @Environment(\.theme) var theme
 
     var body: some View {
         VStack(spacing: 2) {
+            // Resolved ticks (green, not clickable)
+            ForEach(0..<resolvedCount, id: \.self) { _ in
+                Rectangle()
+                    .fill(theme.color("add"))
+                    .opacity(0.65)
+                    .frame(width: 6, height: 14)
+                    .cornerRadius(1)
+            }
+            // Unresolved ticks (yellow, clickable to jump)
             ForEach(0..<conflictCount, id: \.self) { i in
                 Button(action: { onJump(i) }) {
                     Rectangle()

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -97,25 +97,14 @@ struct MergeConflictResultView: NSViewRepresentable {
     ) {
         let regions = ConflictMarkerParser.parse(text)
         let highlight = NSColor(theme.color("warn")).withAlphaComponent(0.18)
+        // We deliberately do NOT clear .font / .foregroundColor here. Clearing
+        // them over conflict regions would strip the TreeSitter syntax styling
+        // from LOCAL/REMOTE lines. The Coordinator's `lastShowBase` tracking in
+        // `updateNSView` forces a full re-render whenever `showBase` toggles,
+        // which is when stale BASE styling actually matters in practice.
         storage.removeAttribute(.backgroundColor, range: NSRange(location: 0, length: storage.length))
         let nsString = text as NSString
         let lineRanges = Self.computeLineRanges(in: nsString)
-        // Clear ALL conflict-region-only styling that this function may have
-        // added in a prior pass: background, plus the italic + muted attributes
-        // applied to BASE lines (which can persist on lines that no longer
-        // belong to the BASE segment after an edit shifts line numbering).
-        for region in regions {
-            if case .conflict(let block) = region {
-                let lower = max(block.lineRangeInMerged.lowerBound, 0)
-                let upper = min(block.lineRangeInMerged.upperBound, lineRanges.count - 1)
-                guard upper >= lower, upper < lineRanges.count else { continue }
-                let start = lineRanges[lower].location
-                let end = NSMaxRange(lineRanges[upper])
-                let regionRange = NSRange(location: start, length: end - start)
-                storage.removeAttribute(.font, range: regionRange)
-                storage.removeAttribute(.foregroundColor, range: regionRange)
-            }
-        }
         for region in regions {
             if case .conflict(let block) = region {
                 let lower = max(block.lineRangeInMerged.lowerBound, 0)

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -100,6 +100,22 @@ struct MergeConflictResultView: NSViewRepresentable {
         storage.removeAttribute(.backgroundColor, range: NSRange(location: 0, length: storage.length))
         let nsString = text as NSString
         let lineRanges = Self.computeLineRanges(in: nsString)
+        // Clear ALL conflict-region-only styling that this function may have
+        // added in a prior pass: background, plus the italic + muted attributes
+        // applied to BASE lines (which can persist on lines that no longer
+        // belong to the BASE segment after an edit shifts line numbering).
+        for region in regions {
+            if case .conflict(let block) = region {
+                let lower = max(block.lineRangeInMerged.lowerBound, 0)
+                let upper = min(block.lineRangeInMerged.upperBound, lineRanges.count - 1)
+                guard upper >= lower, upper < lineRanges.count else { continue }
+                let start = lineRanges[lower].location
+                let end = NSMaxRange(lineRanges[upper])
+                let regionRange = NSRange(location: start, length: end - start)
+                storage.removeAttribute(.font, range: regionRange)
+                storage.removeAttribute(.foregroundColor, range: regionRange)
+            }
+        }
         for region in regions {
             if case .conflict(let block) = region {
                 let lower = max(block.lineRangeInMerged.lowerBound, 0)

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -43,11 +43,11 @@ struct MergeConflictResultView: NSViewRepresentable {
 
     func updateNSView(_ scroll: NSScrollView, context: Context) {
         guard let textView = scroll.documentView as? NSTextView else { return }
-        // Only re-render the text storage when the bound text actually differs
-        // from what the user has typed. Otherwise we clobber the in-flight
-        // caret position on every external @State change.
+        // Re-render whenever text changed OR the showBase toggle changed since
+        // last render (italic/muted attrs would otherwise persist after toggle-off).
         let current = textView.string
-        if current != text {
+        let needsFullRender = current != text || context.coordinator.lastShowBase != showBase
+        if needsFullRender {
             let attr = MergeConflictTextStorage.highlightedAttributedString(
                 text: text,
                 fileExtension: fileExtension,
@@ -57,6 +57,7 @@ struct MergeConflictResultView: NSViewRepresentable {
             )
             applyConflictShading(to: attr, text: text, theme: theme)
             textView.textStorage?.setAttributedString(attr)
+            context.coordinator.lastShowBase = showBase
         } else {
             // Even when the string is unchanged, the conflict regions may have
             // shifted (a typed edit can resolve a marker). Re-apply shading.
@@ -74,6 +75,9 @@ struct MergeConflictResultView: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         weak var textView: NSTextView?
         let text: Binding<String>
+        /// Tracks the `showBase` value from the last full re-render so we can
+        /// detect toggle changes and force a fresh attributed string build.
+        var lastShowBase: Bool = false
         init(_ text: Binding<String>) { self.text = text }
         func textDidChange(_ notification: Notification) {
             guard let tv = notification.object as? NSTextView else { return }

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -10,6 +10,7 @@ struct MergeConflictResultView: NSViewRepresentable {
     let fileExtension: String
     let codeFontFamily: String
     let codeFontSize: CGFloat
+    let showBase: Bool
     @Environment(\.theme) var theme
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -81,8 +82,10 @@ struct MergeConflictResultView: NSViewRepresentable {
     }
 
     /// Applies a yellow background to each line range that falls inside a
-    /// `<<<<<<< ... >>>>>>>` block in `text`. Accepts any `NSMutableAttributedString`
-    /// (including `NSTextStorage`, which IS-A `NSMutableAttributedString`).
+    /// `<<<<<<< ... >>>>>>>` block in `text`. Also applies italic + muted
+    /// attributes to BASE lines when `showBase` is true.
+    /// Accepts any `NSMutableAttributedString` (including `NSTextStorage`,
+    /// which IS-A `NSMutableAttributedString`).
     private func applyConflictShading(
         to storage: NSMutableAttributedString,
         text: String,
@@ -91,7 +94,8 @@ struct MergeConflictResultView: NSViewRepresentable {
         let regions = ConflictMarkerParser.parse(text)
         let highlight = NSColor(theme.color("warn")).withAlphaComponent(0.18)
         storage.removeAttribute(.backgroundColor, range: NSRange(location: 0, length: storage.length))
-        let lineRanges = Self.computeLineRanges(in: text as NSString)
+        let nsString = text as NSString
+        let lineRanges = Self.computeLineRanges(in: nsString)
         for region in regions {
             if case .conflict(let block) = region {
                 let lower = max(block.lineRangeInMerged.lowerBound, 0)
@@ -99,8 +103,48 @@ struct MergeConflictResultView: NSViewRepresentable {
                 guard upper >= lower, upper < lineRanges.count else { continue }
                 let start = lineRanges[lower].location
                 let end = NSMaxRange(lineRanges[upper])
-                let nsr = NSRange(location: start, length: end - start)
-                storage.addAttribute(.backgroundColor, value: highlight, range: nsr)
+                storage.addAttribute(.backgroundColor, value: highlight,
+                                     range: NSRange(location: start, length: end - start))
+
+                if showBase, block.base != nil {
+                    applyBaseStyling(in: storage,
+                                     fullText: nsString,
+                                     lineRanges: lineRanges,
+                                     conflictRange: lower ... upper,
+                                     theme: theme)
+                }
+            }
+        }
+    }
+
+    /// Walks the lines inside a conflict marker block and applies italic +
+    /// muted-color attributes to the lines that fall between `||||||| ` and
+    /// `=======` markers. Called only when `showBase == true`.
+    private func applyBaseStyling(
+        in storage: NSMutableAttributedString,
+        fullText: NSString,
+        lineRanges: [NSRange],
+        conflictRange: ClosedRange<Int>,
+        theme: Theme
+    ) {
+        var inBase = false
+        let italic = CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize)
+            .italicVariant()
+        let muted = NSColor(theme.color("fg-dim"))
+        for lineIdx in conflictRange {
+            let lineRange = lineRanges[lineIdx]
+            let lineText = fullText.substring(with: lineRange)
+            if lineText.hasPrefix("||||||| ") {
+                inBase = true
+                continue
+            }
+            if lineText.hasPrefix("=======") {
+                inBase = false
+                continue
+            }
+            if inBase {
+                storage.addAttribute(.font, value: italic, range: lineRange)
+                storage.addAttribute(.foregroundColor, value: muted, range: lineRange)
             }
         }
     }
@@ -120,5 +164,16 @@ struct MergeConflictResultView: NSViewRepresentable {
             if index >= nsString.length { break }
         }
         return ranges
+    }
+}
+
+private extension NSFont {
+    /// Returns the italic version of this font, falling back to self if the
+    /// font has no italic face.
+    func italicVariant() -> NSFont {
+        let descriptor = fontDescriptor.withSymbolicTraits(
+            fontDescriptor.symbolicTraits.union(.italic)
+        )
+        return NSFont(descriptor: descriptor, size: pointSize) ?? self
     }
 }

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -18,6 +18,13 @@ final class MergeConflictTabModel {
     var resultText: String = ""
     /// Set when `load()` fails. Cleared on successful (re)load.
     private(set) var loadError: String?
+    /// Per-conflict-ordinal one-line annotation populated by the agent.
+    /// Cached for the lifetime of the model (cleared on `load()`).
+    private(set) var annotations: [Int: String] = [:]
+    /// Conflict count at the moment `load()` last succeeded. Used by the
+    /// minimap to show progress (resolved vs total). Cleared (set to 0)
+    /// on `load()` failure.
+    private(set) var initialConflictCount: Int = 0
 
     let worktreePath: URL
     let relativePath: String
@@ -47,12 +54,16 @@ final class MergeConflictTabModel {
             self.resultText = file.merged
             self.regions = ConflictMarkerParser.parse(file.merged)
             self.currentConflictIndex = firstConflictIndex()
+            self.initialConflictCount = self.conflictCount
+            self.annotations = [:]
             self.loadError = nil
         } catch {
             self.conflictedFile = nil
             self.regions = []
             self.resultText = ""
             self.currentConflictIndex = nil
+            self.initialConflictCount = 0
+            self.annotations = [:]
             self.loadError = (error as? LocalizedError)?.errorDescription
                 ?? error.localizedDescription
             logger.error("merge-conflict load failed: \(self.loadError ?? "", privacy: .public)")
@@ -213,5 +224,11 @@ final class MergeConflictTabModel {
             worktreePath: worktreePath,
             relativePath: relativePath
         )
+    }
+
+    /// Records a one-line agent annotation for the conflict at `ordinal`.
+    /// Called by `MergeConflictTabView` after a successful `MergeAgent.explainConflict` round-trip.
+    func setAnnotation(_ text: String, forConflictOrdinal ordinal: Int) {
+        annotations[ordinal] = text
     }
 }

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -33,6 +33,13 @@ final class MergeConflictTabModel {
     /// re-focused for a fresh conflict on the same path.
     private(set) var loadGeneration: Int = 0
 
+    /// Block keys for which an `explainCurrentConflict` request is currently
+    /// in flight. Prevents duplicate agent dispatches when both an
+    /// `onChange(currentConflictIndex)` and an `onChange(loadGeneration)`
+    /// view-hook fire for the same conflict in the same render cycle.
+    @ObservationIgnored
+    private var explainInFlight: Set<String> = []
+
     /// Set while a `MergeAgent` request is in flight. Drives toolbar disabled-state.
     private(set) var agentBusy: Bool = false
 
@@ -67,6 +74,7 @@ final class MergeConflictTabModel {
     /// into the model after we've cleared everything.
     func load() async {
         loadGeneration += 1
+        explainInFlight.removeAll()
         do {
             let file = try await gitService.conflictedFile(
                 worktreePath: worktreePath,
@@ -274,13 +282,20 @@ final class MergeConflictTabModel {
     // MARK: - Agent assist
 
     /// Asks the agent to summarize the current conflict in one sentence and
-    /// caches the result in `annotations[currentConflictIndex]`. No-op if
-    /// there's no current conflict or no agent. Errors are silent (no UI).
+    /// caches the result in `annotations`, keyed by block content. No-op if
+    /// there's no current conflict, no agent, the annotation is already
+    /// cached, or a request for the same block is already in flight.
+    /// Errors are silent (no UI).
     func explainCurrentConflict(using agent: AgentDefinition, language: String?) async {
         guard let ordinal = currentConflictIndex,
               let regionIdx = conflictRegionIndex(forConflictOrdinal: ordinal),
               case .conflict(let block) = regions[regionIdx]
         else { return }
+        let key = Self.annotationKey(for: block)
+        // De-dupe: cache hit or already-in-flight for the same block → bail.
+        guard annotations[key] == nil, !explainInFlight.contains(key) else { return }
+        explainInFlight.insert(key)
+        defer { explainInFlight.remove(key) }
         do {
             let sentence = try await MergeAgent.explainConflict(
                 agent: agent,

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -18,9 +18,11 @@ final class MergeConflictTabModel {
     var resultText: String = ""
     /// Set when `load()` fails. Cleared on successful (re)load.
     private(set) var loadError: String?
-    /// Per-conflict-ordinal one-line annotation populated by the agent.
-    /// Cached for the lifetime of the model (cleared on `load()`).
-    private(set) var annotations: [Int: String] = [:]
+    /// Per-conflict-block one-line annotation populated by the agent.
+    /// Keyed by a stable identity derived from the conflict's three sides
+    /// (NOT by ordinal — ordinals shift when prior conflicts are resolved).
+    /// Cleared on `load()`.
+    private(set) var annotations: [String: String] = [:]
     /// Conflict count at the moment `load()` last succeeded. Used by the
     /// minimap to show progress (resolved vs total). Cleared (set to 0)
     /// on `load()` failure.
@@ -234,10 +236,23 @@ final class MergeConflictTabModel {
         )
     }
 
-    /// Records a one-line agent annotation for the conflict at `ordinal`.
-    /// Called by `MergeConflictTabView` after a successful `MergeAgent.explainConflict` round-trip.
-    func setAnnotation(_ text: String, forConflictOrdinal ordinal: Int) {
-        annotations[ordinal] = text
+    /// Deterministic stable identity for a `ConflictBlock`. Used as the key
+    /// for `annotations` so cached explanations follow the block when other
+    /// conflicts get resolved and the ordinal numbering shifts.
+    static func annotationKey(for block: ConflictBlock) -> String {
+        "\(block.local)\n<<<<<<<<\n\(block.base ?? "")\n========\n\(block.remote)"
+    }
+
+    /// Records a one-line agent annotation for `block`. Called by
+    /// `MergeConflictTabView` after a successful `MergeAgent.explainConflict`
+    /// round-trip.
+    func setAnnotation(_ text: String, for block: ConflictBlock) {
+        annotations[Self.annotationKey(for: block)] = text
+    }
+
+    /// Returns the cached annotation for `block`, or nil if not cached.
+    func annotation(for block: ConflictBlock) -> String? {
+        annotations[Self.annotationKey(for: block)]
     }
 
     // MARK: - Agent assist
@@ -257,7 +272,7 @@ final class MergeConflictTabModel {
                 language: language
             )
             if !sentence.isEmpty {
-                setAnnotation(sentence, forConflictOrdinal: ordinal)
+                setAnnotation(sentence, for: block)
             }
         } catch {
             logger.error("explain failed: \(error.localizedDescription, privacy: .public)")

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -292,10 +292,20 @@ final class MergeConflictTabModel {
     /// Asks the agent to propose a full-file resolution. On success, stashes
     /// the proposal in `agentProposal` for the view to render as a diff
     /// overlay. Errors leave `agentProposal` nil.
+    ///
+    /// If `load()` runs while this request is in flight (e.g. tab re-focused
+    /// for a fresh conflict on the same path), the late response is dropped:
+    /// applying it would clobber the freshly loaded buffer with stale content.
+    /// We detect that via the `loadGeneration` token captured at request start.
     func requestAgentResolveFile(using agent: AgentDefinition, language: String?) async {
         guard let file = conflictedFile else { return }
+        let startGeneration = loadGeneration
         agentBusy = true
-        defer { agentBusy = false }
+        defer {
+            if loadGeneration == startGeneration {
+                agentBusy = false
+            }
+        }
         do {
             let proposal = try await MergeAgent.resolveFile(
                 agent: agent,
@@ -306,8 +316,10 @@ final class MergeConflictTabModel {
                 mergedWithMarkers: resultText,
                 language: language
             )
+            guard loadGeneration == startGeneration else { return }
             agentProposal = proposal
         } catch {
+            guard loadGeneration == startGeneration else { return }
             agentProposal = nil
             logger.error("resolveFile failed: \(error.localizedDescription, privacy: .public)")
         }

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -26,6 +26,14 @@ final class MergeConflictTabModel {
     /// on `load()` failure.
     private(set) var initialConflictCount: Int = 0
 
+    /// Set while a `MergeAgent` request is in flight. Drives toolbar disabled-state.
+    private(set) var agentBusy: Bool = false
+
+    /// Agent's proposed full-file resolution, awaiting user Apply/Cancel.
+    /// Nil when no proposal is pending. Cleared by `applyAgentProposal` /
+    /// `discardAgentProposal`.
+    private(set) var agentProposal: String?
+
     let worktreePath: URL
     let relativePath: String
     private let gitService: GitService
@@ -230,5 +238,74 @@ final class MergeConflictTabModel {
     /// Called by `MergeConflictTabView` after a successful `MergeAgent.explainConflict` round-trip.
     func setAnnotation(_ text: String, forConflictOrdinal ordinal: Int) {
         annotations[ordinal] = text
+    }
+
+    // MARK: - Agent assist
+
+    /// Asks the agent to summarize the current conflict in one sentence and
+    /// caches the result in `annotations[currentConflictIndex]`. No-op if
+    /// there's no current conflict or no agent. Errors are silent (no UI).
+    func explainCurrentConflict(using agent: AgentDefinition, language: String?) async {
+        guard let ordinal = currentConflictIndex,
+              let regionIdx = conflictRegionIndex(forConflictOrdinal: ordinal),
+              case .conflict(let block) = regions[regionIdx]
+        else { return }
+        do {
+            let sentence = try await MergeAgent.explainConflict(
+                agent: agent,
+                block: block,
+                language: language
+            )
+            if !sentence.isEmpty {
+                setAnnotation(sentence, forConflictOrdinal: ordinal)
+            }
+        } catch {
+            logger.error("explain failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Asks the agent to propose a full-file resolution. On success, stashes
+    /// the proposal in `agentProposal` for the view to render as a diff
+    /// overlay. Errors leave `agentProposal` nil.
+    func requestAgentResolveFile(using agent: AgentDefinition, language: String?) async {
+        guard let file = conflictedFile else { return }
+        agentBusy = true
+        defer { agentBusy = false }
+        do {
+            let proposal = try await MergeAgent.resolveFile(
+                agent: agent,
+                filePath: relativePath,
+                local: file.local ?? "",
+                base: file.base,
+                remote: file.remote ?? "",
+                mergedWithMarkers: resultText,
+                language: language
+            )
+            agentProposal = proposal
+        } catch {
+            agentProposal = nil
+            logger.error("resolveFile failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Replaces `resultText` with the pending `agentProposal` and clears it.
+    /// No-op when there's no proposal.
+    func applyAgentProposal() {
+        guard let proposal = agentProposal else { return }
+        resultText = proposal
+        agentProposal = nil
+        reparse()
+    }
+
+    /// Discards the pending agent proposal without changing `resultText`.
+    func discardAgentProposal() {
+        agentProposal = nil
+    }
+
+    /// Test-only setter so unit tests can stage a proposal without invoking
+    /// a real agent. Marked `internal` (default) and named to make its
+    /// test-only intent obvious.
+    func setAgentProposalForTesting(_ proposal: String) {
+        agentProposal = proposal
     }
 }

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -28,6 +28,11 @@ final class MergeConflictTabModel {
     /// on `load()` failure.
     private(set) var initialConflictCount: Int = 0
 
+    /// Increments on every successful `load()`. Consumers (binary preview)
+    /// include this in their cache keys so they invalidate when the tab is
+    /// re-focused for a fresh conflict on the same path.
+    private(set) var loadGeneration: Int = 0
+
     /// Set while a `MergeAgent` request is in flight. Drives toolbar disabled-state.
     private(set) var agentBusy: Bool = false
 
@@ -67,6 +72,7 @@ final class MergeConflictTabModel {
             self.initialConflictCount = self.conflictCount
             self.annotations = [:]
             self.loadError = nil
+            self.loadGeneration += 1
         } catch {
             self.conflictedFile = nil
             self.regions = []

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -28,10 +28,20 @@ final class MergeConflictTabModel {
     /// on `load()` failure.
     private(set) var initialConflictCount: Int = 0
 
-    /// Increments on every successful `load()`. Consumers (binary preview)
-    /// include this in their cache keys so they invalidate when the tab is
-    /// re-focused for a fresh conflict on the same path.
+    /// Increments at the *start* of every `load()` attempt. Used by
+    /// stale-async guards (binary image cache, `requestAgentResolveFile`)
+    /// to detect that a load has begun mid-await and drop their results.
+    /// Bumping at start (rather than completion) means an in-flight request
+    /// is invalidated as soon as a new load kicks off — even if it never
+    /// finishes (e.g. file no longer conflicted).
     private(set) var loadGeneration: Int = 0
+
+    /// Increments after `load()` has committed its new state to the model
+    /// (success OR failure). Used by view-side reload triggers that need
+    /// to read the post-load `regions` / `currentConflictIndex` to dispatch
+    /// further work (e.g. auto-explain). Distinct from `loadGeneration`
+    /// because firing on the start-of-load value would read stale state.
+    private(set) var loadCompletionGeneration: Int = 0
 
     /// Block keys for which an `explainCurrentConflict` request is currently
     /// in flight. Prevents duplicate agent dispatches when both an
@@ -102,6 +112,9 @@ final class MergeConflictTabModel {
                 ?? error.localizedDescription
             logger.error("merge-conflict load failed: \(self.loadError ?? "", privacy: .public)")
         }
+        // Bump AFTER state is committed so view-side reload triggers read
+        // post-load `regions` / `currentConflictIndex` (not stale values).
+        loadCompletionGeneration += 1
     }
 
     /// Re-parses `resultText` and updates `regions` + `currentConflictIndex`.

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -59,7 +59,14 @@ final class MergeConflictTabModel {
 
     /// Re-loads the conflicted file's three sides and re-parses the on-disk
     /// merged buffer. Safe to call repeatedly.
+    ///
+    /// `loadGeneration` is incremented on EVERY attempt (success or failure)
+    /// so stale-async guards (`requestAgentResolveFile`, binary image cache)
+    /// invalidate even when a reload fails — otherwise an in-flight agent
+    /// resolve from before a failed reload could still write its proposal
+    /// into the model after we've cleared everything.
     func load() async {
+        loadGeneration += 1
         do {
             let file = try await gitService.conflictedFile(
                 worktreePath: worktreePath,
@@ -74,7 +81,6 @@ final class MergeConflictTabModel {
             self.agentProposal = nil
             self.agentBusy = false
             self.loadError = nil
-            self.loadGeneration += 1
         } catch {
             self.conflictedFile = nil
             self.regions = []

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -71,6 +71,8 @@ final class MergeConflictTabModel {
             self.currentConflictIndex = firstConflictIndex()
             self.initialConflictCount = self.conflictCount
             self.annotations = [:]
+            self.agentProposal = nil
+            self.agentBusy = false
             self.loadError = nil
             self.loadGeneration += 1
         } catch {
@@ -80,6 +82,8 @@ final class MergeConflictTabModel {
             self.currentConflictIndex = nil
             self.initialConflictCount = 0
             self.annotations = [:]
+            self.agentProposal = nil
+            self.agentBusy = false
             self.loadError = (error as? LocalizedError)?.errorDescription
                 ?? error.localizedDescription
             logger.error("merge-conflict load failed: \(self.loadError ?? "", privacy: .public)")

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -28,10 +28,8 @@ struct MergeConflictTabView: View {
                     conflictCount: model.conflictCount,
                     currentConflictIndex: model.currentConflictIndex,
                     currentAnnotation: currentBlockAnnotation,
-                    // Binaries can't be resolved through the 3-column editor
-                    // (they're handled via the right-pane Use ours / Use theirs
-                    // context menu). Keep the resolve button disabled for them.
-                    isLoaded: model.conflictedFile != nil && model.conflictedFile?.isBinary == false,
+                    isLoaded: model.conflictedFile != nil,
+                    canRunAgent: model.conflictedFile != nil && model.conflictedFile?.isBinary == false,
                     agentBusy: model.agentBusy,
                     hasAgent: resolvedAgent != nil,
                     hasPendingProposal: model.agentProposal != nil,

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -34,6 +34,7 @@ struct MergeConflictTabView: View {
                     isLoaded: model.conflictedFile != nil && model.conflictedFile?.isBinary == false,
                     agentBusy: model.agentBusy,
                     hasAgent: resolvedAgent != nil,
+                    hasPendingProposal: model.agentProposal != nil,
                     showBase: showBaseBinding,
                     onPrevious: { model.previousConflict() },
                     onNext: { model.nextConflict() },

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -91,6 +91,11 @@ struct MergeConflictTabView: View {
             errorBanner(loadError)
         } else if model.conflictedFile == nil {
             ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if model.conflictedFile?.isBinary == true {
+            MergeConflictBinaryView(
+                conflictedFile: model.conflictedFile!,
+                worktreePath: worktree.path
+            )
         } else {
             body3Columns
         }

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -27,6 +27,7 @@ struct MergeConflictTabView: View {
                 MergeConflictToolbar(
                     conflictCount: model.conflictCount,
                     currentConflictIndex: model.currentConflictIndex,
+                    currentAnnotation: model.annotations[model.currentConflictIndex ?? -1],
                     // Binaries can't be resolved through the 3-column editor
                     // (they're handled via the right-pane Use ours / Use theirs
                     // context menu). Keep the resolve button disabled for them.
@@ -165,6 +166,24 @@ struct MergeConflictTabView: View {
                     while (model.currentConflictIndex ?? 0) > idx { model.previousConflict() }
                 }
             )
+        }
+        .onChange(of: model.currentConflictIndex) { _, newIndex in
+            guard let agent = resolvedAgent,
+                  let ord = newIndex,
+                  model.annotations[ord] == nil
+            else { return }
+            Task {
+                await model.explainCurrentConflict(using: agent, language: fileLanguage)
+            }
+        }
+        .onChange(of: model.conflictedFile?.relativePath) { _, _ in
+            guard let agent = resolvedAgent,
+                  let ord = model.currentConflictIndex,
+                  model.annotations[ord] == nil
+            else { return }
+            Task {
+                await model.explainCurrentConflict(using: agent, language: fileLanguage)
+            }
         }
     }
 

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -27,7 +27,7 @@ struct MergeConflictTabView: View {
                 MergeConflictToolbar(
                     conflictCount: model.conflictCount,
                     currentConflictIndex: model.currentConflictIndex,
-                    currentAnnotation: model.annotations[model.currentConflictIndex ?? -1],
+                    currentAnnotation: currentBlockAnnotation,
                     // Binaries can't be resolved through the 3-column editor
                     // (they're handled via the right-pane Use ours / Use theirs
                     // context menu). Keep the resolve button disabled for them.
@@ -178,7 +178,8 @@ struct MergeConflictTabView: View {
         .onChange(of: model.currentConflictIndex) { _, newIndex in
             guard let agent = resolvedAgent,
                   let ord = newIndex,
-                  model.annotations[ord] == nil
+                  let block = currentConflictBlock(at: ord),
+                  model.annotation(for: block) == nil
             else { return }
             Task {
                 await model.explainCurrentConflict(using: agent, language: fileLanguage)
@@ -187,7 +188,8 @@ struct MergeConflictTabView: View {
         .onChange(of: model.conflictedFile?.relativePath) { _, _ in
             guard let agent = resolvedAgent,
                   let ord = model.currentConflictIndex,
-                  model.annotations[ord] == nil
+                  let block = currentConflictBlock(at: ord),
+                  model.annotation(for: block) == nil
             else { return }
             Task {
                 await model.explainCurrentConflict(using: agent, language: fileLanguage)
@@ -226,6 +228,28 @@ struct MergeConflictTabView: View {
     private var fileLanguage: String? {
         let ext = fileExtension
         return ext.isEmpty ? nil : ext
+    }
+
+    /// Annotation for the conflict the cursor is currently on, looked up by
+    /// block-content identity (not ordinal) so it survives resolutions that
+    /// renumber later conflicts.
+    private var currentBlockAnnotation: String? {
+        guard let ord = model.currentConflictIndex,
+              let block = currentConflictBlock(at: ord)
+        else { return nil }
+        return model.annotation(for: block)
+    }
+
+    /// Returns the `ConflictBlock` for the Nth unresolved conflict, or nil.
+    private func currentConflictBlock(at ordinal: Int) -> ConflictBlock? {
+        var seen = 0
+        for region in model.regions {
+            if case .conflict(let block) = region {
+                if seen == ordinal { return block }
+                seen += 1
+            }
+        }
+        return nil
     }
 
     /// Writes the BASE-toggle back through TabsManager so the preference

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -140,7 +140,8 @@ struct MergeConflictTabView: View {
                     ),
                     fileExtension: fileExtension,
                     codeFontFamily: state.config.code.fontFamily,
-                    codeFontSize: CGFloat(state.config.code.fontSize)
+                    codeFontSize: CGFloat(state.config.code.fontSize),
+                    showBase: tabState.showBase
                 )
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -22,38 +22,57 @@ struct MergeConflictTabView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            MergeConflictToolbar(
-                conflictCount: model.conflictCount,
-                currentConflictIndex: model.currentConflictIndex,
-                // Binaries can't be resolved through the 3-column editor
-                // (they're handled via the right-pane Use ours / Use theirs
-                // context menu). Keep the resolve button disabled for them.
-                isLoaded: model.conflictedFile != nil && model.conflictedFile?.isBinary == false,
-                agentBusy: model.agentBusy,
-                hasAgent: false,                 // wired in Task 6
-                showBase: showBaseBinding,
-                onPrevious: { model.previousConflict() },
-                onNext: { model.nextConflict() },
-                onAcceptLocal: { model.acceptLocal() },
-                onAcceptRemote: { model.acceptRemote() },
-                onAcceptBoth: { model.acceptBoth() },
-                onAcceptAndNext: {
-                    model.acceptLocal()
-                    model.nextConflict()
-                },
-                onAskAgentResolve: {},           // wired in Task 6
-                onMarkResolved: {
-                    Task {
-                        try? await model.markFileResolved()
-                        // The WorktreeWatcher on RightPaneState picks up the
-                        // .git/index change from `git add` and refreshes the
-                        // Conflicts section automatically — no explicit call
-                        // is needed here.
+        ZStack {
+            VStack(spacing: 0) {
+                MergeConflictToolbar(
+                    conflictCount: model.conflictCount,
+                    currentConflictIndex: model.currentConflictIndex,
+                    // Binaries can't be resolved through the 3-column editor
+                    // (they're handled via the right-pane Use ours / Use theirs
+                    // context menu). Keep the resolve button disabled for them.
+                    isLoaded: model.conflictedFile != nil && model.conflictedFile?.isBinary == false,
+                    agentBusy: model.agentBusy,
+                    hasAgent: resolvedAgent != nil,
+                    showBase: showBaseBinding,
+                    onPrevious: { model.previousConflict() },
+                    onNext: { model.nextConflict() },
+                    onAcceptLocal: { model.acceptLocal() },
+                    onAcceptRemote: { model.acceptRemote() },
+                    onAcceptBoth: { model.acceptBoth() },
+                    onAcceptAndNext: {
+                        model.acceptLocal()
+                        model.nextConflict()
+                    },
+                    onAskAgentResolve: {
+                        guard let agent = resolvedAgent else { return }
+                        Task {
+                            await model.requestAgentResolveFile(using: agent, language: fileLanguage)
+                        }
+                    },
+                    onMarkResolved: {
+                        Task {
+                            try? await model.markFileResolved()
+                            // The WorktreeWatcher on RightPaneState picks up the
+                            // .git/index change from `git add` and refreshes the
+                            // Conflicts section automatically — no explicit call
+                            // is needed here.
+                        }
                     }
-                }
-            )
-            content
+                )
+                content
+            }
+            if let proposal = model.agentProposal {
+                MergeConflictAgentProposalView(
+                    currentText: model.resultText,
+                    proposedText: proposal,
+                    fileExtension: fileExtension,
+                    codeFontFamily: state.config.code.fontFamily,
+                    codeFontSize: CGFloat(state.config.code.fontSize),
+                    onApply: { model.applyAgentProposal() },
+                    onCancel: { model.discardAgentProposal() }
+                )
+                .transition(.opacity)
+            }
         }
         // Trigger a fresh load every time the view appears, not just on
         // first mount. `TabsManager.openMergeConflict` re-uses an existing
@@ -162,6 +181,24 @@ struct MergeConflictTabView: View {
 
     private var fileExtension: String {
         (tabState.relativePath as NSString).pathExtension
+    }
+
+    /// Resolves the agent to use for merge-conflict assistance. Prefers the
+    /// user's pinned tool from Settings → Changes → AI tool, then falls back
+    /// to any enabled agent. Returns nil only when no agents are configured.
+    private var resolvedAgent: AgentDefinition? {
+        let id = state.config.changes.aiToolId
+        if !id.isEmpty, id != "none", let agent = state.agent(id: id) {
+            return agent
+        }
+        return state.agentRegistry.enabled().first
+    }
+
+    /// Best-effort language label for the agent prompts. Returns nil for
+    /// extension-less paths so the prompts omit the language hint.
+    private var fileLanguage: String? {
+        let ext = fileExtension
+        return ext.isEmpty ? nil : ext
     }
 
     /// Writes the BASE-toggle back through TabsManager so the preference

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -81,6 +81,12 @@ struct MergeConflictTabView: View {
         // resultText/regions from the prior conflict.
         .task {
             await model.load()
+            // Kick off the first annotation fetch directly after load. The
+            // `.onChange` hooks on `body3Columns` don't fire on initial
+            // insertion, so without this call a single-conflict file
+            // (where currentConflictIndex stays at 0 forever) would never
+            // get auto-explained.
+            triggerExplainIfNeeded()
         }
     }
 

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -93,7 +93,8 @@ struct MergeConflictTabView: View {
         } else if model.conflictedFile?.isBinary == true {
             MergeConflictBinaryView(
                 conflictedFile: model.conflictedFile!,
-                worktreePath: worktree.path
+                worktreePath: worktree.path,
+                loadGeneration: model.loadGeneration
             )
         } else {
             body3Columns
@@ -176,16 +177,6 @@ struct MergeConflictTabView: View {
         .onChange(of: model.currentConflictIndex) { _, newIndex in
             guard let agent = resolvedAgent,
                   let ord = newIndex,
-                  let block = currentConflictBlock(at: ord),
-                  model.annotation(for: block) == nil
-            else { return }
-            Task {
-                await model.explainCurrentConflict(using: agent, language: fileLanguage)
-            }
-        }
-        .onChange(of: model.conflictedFile?.relativePath) { _, _ in
-            guard let agent = resolvedAgent,
-                  let ord = model.currentConflictIndex,
                   let block = currentConflictBlock(at: ord),
                   model.annotation(for: block) == nil
             else { return }

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -203,10 +203,14 @@ struct MergeConflictTabView: View {
 
     /// Resolves the agent to use for merge-conflict assistance. Prefers the
     /// user's pinned tool from Settings → Changes → AI tool, then falls back
-    /// to any enabled agent. Returns nil only when no agents are configured.
+    /// to any enabled agent. Returns nil when the user explicitly chose
+    /// "none" (AI disabled) or when no agents are configured.
     private var resolvedAgent: AgentDefinition? {
         let id = state.config.changes.aiToolId
-        if !id.isEmpty, id != "none", let agent = state.agent(id: id) {
+        // Explicit "none" means the user disabled AI: respect that and never
+        // auto-fire agent calls (auto-explain on conflict change, etc.).
+        if id == "none" { return nil }
+        if !id.isEmpty, let agent = state.agent(id: id) {
             return agent
         }
         return state.agentRegistry.enabled().first

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -174,15 +174,32 @@ struct MergeConflictTabView: View {
                 }
             )
         }
-        .onChange(of: model.currentConflictIndex) { _, newIndex in
-            guard let agent = resolvedAgent,
-                  let ord = newIndex,
-                  let block = currentConflictBlock(at: ord),
-                  model.annotation(for: block) == nil
-            else { return }
-            Task {
-                await model.explainCurrentConflict(using: agent, language: fileLanguage)
-            }
+        .onChange(of: model.currentConflictIndex) { _, _ in
+            triggerExplainIfNeeded()
+        }
+        // Also re-trigger on every load attempt — covers the case where a
+        // reload (e.g. tab re-focused for a fresh conflict on the same path)
+        // lands on the same currentConflictIndex as before and the index
+        // hook wouldn't fire. Annotations are cleared on load(), so this
+        // request gets through the cache check, and the model's in-flight
+        // dedup ensures we don't double-dispatch with the index hook.
+        .onChange(of: model.loadGeneration) { _, _ in
+            triggerExplainIfNeeded()
+        }
+    }
+
+    /// Fires `explainCurrentConflict` for the current conflict if there's
+    /// an agent configured, a current conflict, and no cached annotation.
+    /// The model dedupes against in-flight requests for the same block, so
+    /// repeated calls from multiple `.onChange` hooks are safe.
+    private func triggerExplainIfNeeded() {
+        guard let agent = resolvedAgent,
+              let ord = model.currentConflictIndex,
+              let block = currentConflictBlock(at: ord),
+              model.annotation(for: block) == nil
+        else { return }
+        Task {
+            await model.explainCurrentConflict(using: agent, language: fileLanguage)
         }
     }
 

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -177,13 +177,17 @@ struct MergeConflictTabView: View {
         .onChange(of: model.currentConflictIndex) { _, _ in
             triggerExplainIfNeeded()
         }
-        // Also re-trigger on every load attempt — covers the case where a
-        // reload (e.g. tab re-focused for a fresh conflict on the same path)
-        // lands on the same currentConflictIndex as before and the index
-        // hook wouldn't fire. Annotations are cleared on load(), so this
-        // request gets through the cache check, and the model's in-flight
-        // dedup ensures we don't double-dispatch with the index hook.
-        .onChange(of: model.loadGeneration) { _, _ in
+        // Also re-trigger after every load completes — covers the case
+        // where a reload (e.g. tab re-focused for a fresh conflict on the
+        // same path) lands on the same currentConflictIndex as before and
+        // the index hook wouldn't fire. We watch `loadCompletionGeneration`
+        // rather than `loadGeneration` so the trigger reads the POST-load
+        // `regions` / `currentConflictIndex` (loadGeneration bumps at the
+        // start of load, before state is committed). Annotations are
+        // cleared on load(), so this request gets through the cache check;
+        // the model's in-flight dedup makes the overlap with the index
+        // hook safe.
+        .onChange(of: model.loadCompletionGeneration) { _, _ in
             triggerExplainIfNeeded()
         }
     }

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -30,6 +30,8 @@ struct MergeConflictTabView: View {
                 // (they're handled via the right-pane Use ours / Use theirs
                 // context menu). Keep the resolve button disabled for them.
                 isLoaded: model.conflictedFile != nil && model.conflictedFile?.isBinary == false,
+                agentBusy: model.agentBusy,
+                hasAgent: false,                 // wired in Task 6
                 showBase: showBaseBinding,
                 onPrevious: { model.previousConflict() },
                 onNext: { model.nextConflict() },
@@ -40,6 +42,7 @@ struct MergeConflictTabView: View {
                     model.acceptLocal()
                     model.nextConflict()
                 },
+                onAskAgentResolve: {},           // wired in Task 6
                 onMarkResolved: {
                     Task {
                         try? await model.markFileResolved()

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -164,6 +164,7 @@ struct MergeConflictTabView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             MergeConflictMinimap(
                 conflictCount: model.conflictCount,
+                resolvedCount: max(model.initialConflictCount - model.conflictCount, 0),
                 currentConflictIndex: model.currentConflictIndex,
                 onJump: { idx in
                     // Clamp via repeated next/previous — the model's clamping

--- a/Alas/Sources/Center/MergeConflictToolbar.swift
+++ b/Alas/Sources/Center/MergeConflictToolbar.swift
@@ -4,10 +4,14 @@ struct MergeConflictToolbar: View {
     let conflictCount: Int
     let currentConflictIndex: Int?
     let currentAnnotation: String?
-    /// True only after the conflicted file has been loaded successfully.
-    /// Gates `Mark resolved` so it can't fire on an empty initial buffer
-    /// and clobber the on-disk file with empty contents.
+    /// True once the conflicted file has been loaded successfully (binary
+    /// or text). Gates `Mark resolved` so it can't fire on an empty initial
+    /// buffer. Stays true for binaries — the user resolves them via the
+    /// right-pane Use ours/theirs context menu, then clicks Mark resolved here.
     let isLoaded: Bool
+    /// True only when a loaded file is text-based (non-binary). Gates the
+    /// agent + 3-column-only actions (prev/next, accept LOCAL/REMOTE/BOTH).
+    let canRunAgent: Bool
     let agentBusy: Bool
     let hasAgent: Bool
     /// True while an unreviewed agent proposal is on screen. The toolbar
@@ -48,7 +52,7 @@ struct MergeConflictToolbar: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .disabled(!isLoaded || !hasAgent || agentBusy || hasPendingProposal)
+            .disabled(!canRunAgent || !hasAgent || agentBusy || hasPendingProposal)
             .help(hasAgent
                 ? "Run the configured agent on the whole file and preview its proposal"
                 : "Configure an agent in Settings to enable this")

--- a/Alas/Sources/Center/MergeConflictToolbar.swift
+++ b/Alas/Sources/Center/MergeConflictToolbar.swift
@@ -7,6 +7,8 @@ struct MergeConflictToolbar: View {
     /// Gates `Mark resolved` so it can't fire on an empty initial buffer
     /// and clobber the on-disk file with empty contents.
     let isLoaded: Bool
+    let agentBusy: Bool
+    let hasAgent: Bool
     @Binding var showBase: Bool
     let onPrevious: () -> Void
     let onNext: () -> Void
@@ -14,6 +16,7 @@ struct MergeConflictToolbar: View {
     let onAcceptRemote: () -> Void
     let onAcceptBoth: () -> Void
     let onAcceptAndNext: () -> Void
+    let onAskAgentResolve: () -> Void
     let onMarkResolved: () -> Void
 
     @Environment(\.theme) var theme
@@ -26,11 +29,27 @@ struct MergeConflictToolbar: View {
             Divider().frame(height: 18)
             acceptButtons
             Spacer()
+            Button(action: onAskAgentResolve) {
+                HStack(spacing: 4) {
+                    if agentBusy {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Image(systemName: "sparkles")
+                    }
+                    Text("Ask agent to resolve")
+                        .font(.system(size: 11))
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(!isLoaded || !hasAgent || agentBusy)
+            .help(hasAgent
+                ? "Run the configured agent on the whole file and preview its proposal"
+                : "Configure an agent in Settings to enable this")
             Toggle("Show BASE", isOn: $showBase)
                 .toggleStyle(.button)
                 .controlSize(.small)
-                .disabled(true)
-                .help("BASE inline rendering arrives in a follow-up — toggle is wired for persistence only")
+                .help("Show the common-ancestor BASE lines inside each conflict region")
             Button(action: onMarkResolved) {
                 Text("Mark resolved")
                     .font(.system(size: 11))

--- a/Alas/Sources/Center/MergeConflictToolbar.swift
+++ b/Alas/Sources/Center/MergeConflictToolbar.swift
@@ -10,6 +10,11 @@ struct MergeConflictToolbar: View {
     let isLoaded: Bool
     let agentBusy: Bool
     let hasAgent: Bool
+    /// True while an unreviewed agent proposal is on screen. The toolbar
+    /// stays interactive at the edges of the overlay; this gate prevents
+    /// the user from kicking off a second agent run that would silently
+    /// clobber the pending proposal.
+    let hasPendingProposal: Bool
     @Binding var showBase: Bool
     let onPrevious: () -> Void
     let onNext: () -> Void
@@ -43,7 +48,7 @@ struct MergeConflictToolbar: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
-            .disabled(!isLoaded || !hasAgent || agentBusy)
+            .disabled(!isLoaded || !hasAgent || agentBusy || hasPendingProposal)
             .help(hasAgent
                 ? "Run the configured agent on the whole file and preview its proposal"
                 : "Configure an agent in Settings to enable this")

--- a/Alas/Sources/Center/MergeConflictToolbar.swift
+++ b/Alas/Sources/Center/MergeConflictToolbar.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MergeConflictToolbar: View {
     let conflictCount: Int
     let currentConflictIndex: Int?
+    let currentAnnotation: String?
     /// True only after the conflicted file has been loaded successfully.
     /// Gates `Mark resolved` so it can't fire on an empty initial buffer
     /// and clobber the on-disk file with empty contents.
@@ -65,9 +66,18 @@ struct MergeConflictToolbar: View {
     }
 
     private var counter: some View {
-        Text(counterText)
-            .font(.system(size: 11))
-            .foregroundColor(theme.color("fg-dim"))
+        VStack(alignment: .leading, spacing: 1) {
+            Text(counterText)
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-dim"))
+            if let annotation = currentAnnotation, !annotation.isEmpty {
+                Text("✦ \(annotation)")
+                    .font(.system(size: 10).italic())
+                    .foregroundColor(theme.color("fg-subtle"))
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+            }
+        }
     }
 
     private var counterText: String {

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -138,6 +138,8 @@ struct ConflictsSection: View {
         }
     }
 
+    /// Context menu for `textConflictRow` only. Delete-side and bothDeleted
+    /// rows render their own dedicated rows + menus and never reach here.
     @ViewBuilder
     private func menuItems(for file: ChangedFile) -> some View {
         switch file.conflict {
@@ -148,17 +150,7 @@ struct ConflictsSection: View {
             Button("Keep ours") { onUseOurs(file) }
         case .addedByThem:
             Button("Keep theirs") { onUseTheirs(file) }
-        case .deletedByUs:
-            // ours = deleted; theirs = modified
-            Button("Keep theirs") { onUseTheirs(file) }
-            Button("Keep deleted") { onKeepDeleted(file) }
-        case .deletedByThem:
-            // ours = modified; theirs = deleted
-            Button("Keep ours") { onUseOurs(file) }
-            Button("Keep deleted") { onKeepDeleted(file) }
-        case .bothDeleted:
-            Button("Keep deleted") { onKeepDeleted(file) }
-        case nil:
+        case .deletedByUs, .deletedByThem, .bothDeleted, nil:
             EmptyView()
         }
         Divider()

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -106,14 +106,20 @@ struct ConflictsSection: View {
     private func deleteSideRow(_ file: ChangedFile) -> some View {
         let isOursDeleted = file.conflict == .deletedByUs
         return HStack(spacing: 6) {
-            Image(systemName: "trash.fill")
-                .foregroundColor(.orange)
-                .frame(width: 14)
-            Text(file.path)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .foregroundColor(.primary)
-            Spacer()
+            Button(action: { onSelect(file) }) {
+                HStack(spacing: 6) {
+                    Image(systemName: "trash.fill")
+                        .foregroundColor(.orange)
+                        .frame(width: 14)
+                    Text(file.path)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .foregroundColor(.primary)
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
             Button(isOursDeleted ? "Keep theirs" : "Keep ours") {
                 if isOursDeleted { onUseTheirs(file) } else { onUseOurs(file) }
             }

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -8,6 +8,8 @@ struct ConflictsSection: View {
     let onKeepDeleted: (ChangedFile) -> Void
     let onMarkResolved: (ChangedFile) -> Void
 
+    @State private var pendingBothDeletedConfirm: ChangedFile?
+
     var body: some View {
         if conflicts.isEmpty {
             EmptyView()
@@ -28,7 +30,19 @@ struct ConflictsSection: View {
         }
     }
 
+    @ViewBuilder
     private func row(for file: ChangedFile) -> some View {
+        switch file.conflict {
+        case .bothDeleted:
+            bothDeletedRow(file)
+        case .deletedByUs, .deletedByThem:
+            deleteSideRow(file)
+        default:
+            textConflictRow(for: file)
+        }
+    }
+
+    private func textConflictRow(for file: ChangedFile) -> some View {
         Button(action: { onSelect(file) }) {
             HStack(spacing: 6) {
                 Image(systemName: iconName(for: file.conflict))
@@ -50,6 +64,77 @@ struct ConflictsSection: View {
         .buttonStyle(.plain)
         .contextMenu {
             menuItems(for: file)
+        }
+    }
+
+    private func bothDeletedRow(_ file: ChangedFile) -> some View {
+        Button(action: { pendingBothDeletedConfirm = file }) {
+            HStack(spacing: 6) {
+                Image(systemName: "trash.fill")
+                    .foregroundColor(.red)
+                    .frame(width: 14)
+                Text(file.path)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundColor(.primary)
+                Spacer()
+                Text("both deleted")
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .confirmationDialog(
+            "Both sides deleted this file. Stage the deletion?",
+            isPresented: Binding(
+                get: { pendingBothDeletedConfirm?.id == file.id },
+                set: { if !$0 { pendingBothDeletedConfirm = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Keep deleted", role: .destructive) {
+                onKeepDeleted(file)
+                pendingBothDeletedConfirm = nil
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+    }
+
+    private func deleteSideRow(_ file: ChangedFile) -> some View {
+        let isOursDeleted = file.conflict == .deletedByUs
+        return HStack(spacing: 6) {
+            Image(systemName: "trash.fill")
+                .foregroundColor(.orange)
+                .frame(width: 14)
+            Text(file.path)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundColor(.primary)
+            Spacer()
+            Button(isOursDeleted ? "Keep theirs" : "Keep ours") {
+                if isOursDeleted { onUseTheirs(file) } else { onUseOurs(file) }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+            Button("Keep deleted") { onKeepDeleted(file) }
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+                .tint(.red)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 3)
+        .contextMenu {
+            if isOursDeleted {
+                Button("Keep theirs") { onUseTheirs(file) }
+            } else {
+                Button("Keep ours") { onUseOurs(file) }
+            }
+            Button("Keep deleted") { onKeepDeleted(file) }
+            Divider()
+            Button("Mark resolved") { onMarkResolved(file) }
         }
     }
 

--- a/AlasTests/MergeAgentTests.swift
+++ b/AlasTests/MergeAgentTests.swift
@@ -80,4 +80,28 @@ struct MergeAgentTests {
         let out = "let a = 1\nlet b = 2\n"
         #expect(MergeAgent.parseResolveOutput(out) == out)
     }
+
+    @Test func parseResolveOutputPreservesLegitFileStartingWithFence() {
+        // A markdown source file that starts with a code fence and never
+        // closes the WHOLE document with a fence. Current behavior was to
+        // strip; correct behavior is to pass through unchanged.
+        let out = """
+        ```swift
+        let a = 1
+        ```
+        Some prose after the code block.
+        """
+        let parsed = MergeAgent.parseResolveOutput(out)
+        #expect(parsed == out)
+    }
+
+    @Test func parseResolveOutputStripsOnlyWhenFencesAreFullWrappers() {
+        let out = """
+        ```swift
+        let a = 1
+        ```
+        """
+        let parsed = MergeAgent.parseResolveOutput(out)
+        #expect(parsed == "let a = 1\n")
+    }
 }

--- a/AlasTests/MergeAgentTests.swift
+++ b/AlasTests/MergeAgentTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct MergeAgentTests {
+    @Test func explainPromptIncludesAllThreeSidesAndAsksForOneLine() {
+        let block = ConflictBlock(
+            local: "let host = \"localhost\"\n",
+            base: "let host = \"127.0.0.1\"\n",
+            remote: "let host = \"0.0.0.0\"\n",
+            localLabel: "HEAD",
+            remoteLabel: "feature",
+            lineRangeInMerged: 12 ... 18
+        )
+        let prompt = MergeAgent.explainPrompt(block: block, language: "swift")
+        #expect(prompt.contains("LOCAL"))
+        #expect(prompt.contains("REMOTE"))
+        #expect(prompt.contains("BASE"))
+        #expect(prompt.contains("let host = \"localhost\""))
+        #expect(prompt.contains("let host = \"127.0.0.1\""))
+        #expect(prompt.contains("let host = \"0.0.0.0\""))
+        #expect(prompt.contains("one sentence"))
+    }
+
+    @Test func explainPromptOmitsBaseWhenNil() {
+        let block = ConflictBlock(
+            local: "a\n",
+            base: nil,
+            remote: "b\n",
+            localLabel: "HEAD",
+            remoteLabel: "feature",
+            lineRangeInMerged: 0 ... 4
+        )
+        let prompt = MergeAgent.explainPrompt(block: block, language: nil)
+        #expect(prompt.contains("LOCAL"))
+        #expect(prompt.contains("REMOTE"))
+        #expect(!prompt.contains("BASE:"))
+    }
+
+    @Test func resolvePromptIncludesPathAndAllThreeSides() {
+        let prompt = MergeAgent.resolvePrompt(
+            filePath: "Sources/Foo.swift",
+            local: "let a = 1\n",
+            base: "let a = 0\n",
+            remote: "let a = 2\n",
+            mergedWithMarkers: "<<<<<<< HEAD\nlet a = 1\n=======\nlet a = 2\n>>>>>>> feature\n",
+            language: "swift"
+        )
+        #expect(prompt.contains("Sources/Foo.swift"))
+        #expect(prompt.contains("LOCAL"))
+        #expect(prompt.contains("REMOTE"))
+        #expect(prompt.contains("BASE"))
+        #expect(prompt.contains("Output ONLY the resolved file"))
+        #expect(prompt.contains("swift"))
+    }
+
+    @Test func parseExplainOutputTakesFirstLineAndTrims() {
+        let out = "  LOCAL renamed host; REMOTE changed default.   \n\nignored prose\n"
+        let parsed = MergeAgent.parseExplainOutput(out)
+        #expect(parsed == "LOCAL renamed host; REMOTE changed default.")
+    }
+
+    @Test func parseExplainOutputEmpty() {
+        #expect(MergeAgent.parseExplainOutput("") == "")
+        #expect(MergeAgent.parseExplainOutput("\n\n") == "")
+    }
+
+    @Test func parseResolveOutputStripsLeadingTrailingFencesAndWhitespace() {
+        let out = """
+        ```swift
+        let a = 1
+        ```
+
+        """
+        let parsed = MergeAgent.parseResolveOutput(out)
+        #expect(parsed == "let a = 1\n")
+    }
+
+    @Test func parseResolveOutputPassesThroughPlainContent() {
+        let out = "let a = 1\nlet b = 2\n"
+        #expect(MergeAgent.parseResolveOutput(out) == out)
+    }
+}

--- a/AlasTests/MergeConflictBinaryDetectionTests.swift
+++ b/AlasTests/MergeConflictBinaryDetectionTests.swift
@@ -1,0 +1,17 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct MergeConflictBinaryDetectionTests {
+    @Test func imageExtensionsAreImages() {
+        #expect(ImageFileType.isSupported(relativePath: "assets/cat.png"))
+        #expect(ImageFileType.isSupported(relativePath: "logo.jpg"))
+        #expect(ImageFileType.isSupported(relativePath: "icon.WEBP"))
+    }
+
+    @Test func nonImageBinariesAreNotImages() {
+        #expect(!ImageFileType.isSupported(relativePath: "compiled/program"))
+        #expect(!ImageFileType.isSupported(relativePath: "asset.bin"))
+        #expect(!ImageFileType.isSupported(relativePath: "lib.so"))
+    }
+}

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -303,8 +303,63 @@ struct MergeConflictTabModelTests {
             gitService: GitService()
         )
         #expect(model.annotations.isEmpty)
-        model.setAnnotation("LOCAL renamed; REMOTE changed default.", forConflictOrdinal: 0)
-        #expect(model.annotations[0] == "LOCAL renamed; REMOTE changed default.")
+        let block = ConflictBlock(
+            local: "ours\n", base: nil, remote: "theirs\n",
+            localLabel: "HEAD", remoteLabel: "feature",
+            lineRangeInMerged: 0 ... 4
+        )
+        model.setAnnotation("LOCAL renamed; REMOTE changed default.", for: block)
+        #expect(model.annotation(for: block) == "LOCAL renamed; REMOTE changed default.")
+    }
+
+    @Test func annotationKeyedByBlockContentSurvivesResolution() {
+        let model = MergeConflictTabModel(
+            worktreePath: URL(fileURLWithPath: "/tmp/unused"),
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        // Two conflicts with distinguishable sides.
+        model.resultText = """
+        head
+        <<<<<<< HEAD
+        a-ours
+        =======
+        a-theirs
+        >>>>>>> feature
+        middle
+        <<<<<<< HEAD
+        b-ours
+        =======
+        b-theirs
+        >>>>>>> feature
+        tail
+
+        """
+        model.reparse()
+        #expect(model.conflictCount == 2)
+
+        // Manually cache an annotation for the SECOND conflict (block "b").
+        let blocks = model.regions.compactMap { (r: ConflictRegion) -> ConflictBlock? in
+            if case .conflict(let b) = r { return b } else { return nil }
+        }
+        #expect(blocks.count == 2)
+        model.setAnnotation("about b", for: blocks[1])
+        #expect(model.annotation(for: blocks[1]) == "about b")
+
+        // Now resolve the FIRST conflict. After reparse the only remaining
+        // conflict is the "b" block, now at ordinal 0. Its annotation must
+        // still resolve to "about b" — not the empty string the OLD ordinal 1
+        // index would have produced under the old [Int: String] scheme.
+        // (Navigate to ordinal 0 via previousConflict from reparse's default.)
+        model.previousConflict() // ensure we're at ordinal 0
+        model.acceptLocal()
+        #expect(model.conflictCount == 1)
+
+        let remaining = model.regions.compactMap { (r: ConflictRegion) -> ConflictBlock? in
+            if case .conflict(let b) = r { return b } else { return nil }
+        }
+        #expect(remaining.count == 1)
+        #expect(model.annotation(for: remaining[0]) == "about b")
     }
 
     @Test func applyAgentProposalReplacesResultTextAndReparses() {

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -276,4 +276,34 @@ struct MergeConflictTabModelTests {
         )
         #expect(recreated == false)
     }
+
+    @Test func loadSnapshotsInitialConflictCount() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        await model.load()
+        #expect(model.initialConflictCount == 1)
+        model.acceptLocal()
+        // After resolution, the snapshot survives:
+        #expect(model.initialConflictCount == 1)
+        #expect(model.conflictCount == 0)
+    }
+
+    @Test func annotationsStartEmptyAndCanBeSet() {
+        let model = MergeConflictTabModel(
+            worktreePath: URL(fileURLWithPath: "/tmp/unused"),
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        #expect(model.annotations.isEmpty)
+        model.setAnnotation("LOCAL renamed; REMOTE changed default.", forConflictOrdinal: 0)
+        #expect(model.annotations[0] == "LOCAL renamed; REMOTE changed default.")
+    }
 }

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -306,4 +306,41 @@ struct MergeConflictTabModelTests {
         model.setAnnotation("LOCAL renamed; REMOTE changed default.", forConflictOrdinal: 0)
         #expect(model.annotations[0] == "LOCAL renamed; REMOTE changed default.")
     }
+
+    @Test func applyAgentProposalReplacesResultTextAndReparses() {
+        let model = MergeConflictTabModel(
+            worktreePath: URL(fileURLWithPath: "/tmp/unused"),
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        model.resultText = """
+        <<<<<<< HEAD
+        ours
+        =======
+        theirs
+        >>>>>>> feature
+
+        """
+        model.reparse()
+        #expect(model.conflictCount == 1)
+        model.setAgentProposalForTesting("merged content\n")
+        #expect(model.agentProposal == "merged content\n")
+        model.applyAgentProposal()
+        #expect(model.resultText == "merged content\n")
+        #expect(model.conflictCount == 0)
+        #expect(model.agentProposal == nil)
+    }
+
+    @Test func discardAgentProposalClearsProposalAndKeepsResultText() {
+        let model = MergeConflictTabModel(
+            worktreePath: URL(fileURLWithPath: "/tmp/unused"),
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        model.resultText = "before\n"
+        model.setAgentProposalForTesting("after\n")
+        model.discardAgentProposal()
+        #expect(model.agentProposal == nil)
+        #expect(model.resultText == "before\n")
+    }
 }

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -386,6 +386,29 @@ struct MergeConflictTabModelTests {
         #expect(model.agentProposal == nil)
     }
 
+    @Test func loadClearsAnyPendingAgentProposal() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        await model.load()
+        // Simulate a pending agent proposal from a prior session/conflict.
+        model.setAgentProposalForTesting("stale proposal\n")
+        #expect(model.agentProposal != nil)
+
+        // Reloading the tab (e.g. re-focused for a fresh conflict) must
+        // clear the stale proposal so the user can't accidentally Apply
+        // it onto the newly loaded conflict.
+        await model.load()
+        #expect(model.agentProposal == nil)
+    }
+
     @Test func discardAgentProposalClearsProposalAndKeepsResultText() {
         let model = MergeConflictTabModel(
             worktreePath: URL(fileURLWithPath: "/tmp/unused"),

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -409,7 +409,10 @@ struct MergeConflictTabModelTests {
         #expect(model.agentProposal == nil)
     }
 
-    @Test func loadGenerationIncrementsOnEverySuccessfulLoad() async throws {
+    @Test func loadGenerationIncrementsOnEveryLoadAttempt() async throws {
+        // Both successful and failed loads must bump the generation — stale
+        // async guards (binary cache, requestAgentResolveFile) rely on it
+        // changing even when a reload fails.
         let repo = try await Self.makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
         try await Self.makeConflictingBranches(repo)
@@ -425,9 +428,15 @@ struct MergeConflictTabModelTests {
         let first = model.loadGeneration
         #expect(first > 0)
         await model.load()
-        // The token must change on every reload — that's what stale-async
-        // guards (binary cache, requestAgentResolveFile) key off of.
         #expect(model.loadGeneration > first)
+
+        // Now make load() fail by abort'ing the merge so a.txt is no longer
+        // conflicted. The generation must still bump.
+        _ = try await Process.git(["merge", "--abort"], cwd: repo)
+        let beforeFailedLoad = model.loadGeneration
+        await model.load()
+        #expect(model.loadError != nil)
+        #expect(model.loadGeneration > beforeFailedLoad)
     }
 
     @Test func discardAgentProposalClearsProposalAndKeepsResultText() {

--- a/AlasTests/MergeConflictTabModelTests.swift
+++ b/AlasTests/MergeConflictTabModelTests.swift
@@ -409,6 +409,27 @@ struct MergeConflictTabModelTests {
         #expect(model.agentProposal == nil)
     }
 
+    @Test func loadGenerationIncrementsOnEverySuccessfulLoad() async throws {
+        let repo = try await Self.makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try await Self.makeConflictingBranches(repo)
+        _ = try await Process.git(["merge", "feature", "--no-edit"], cwd: repo)
+
+        let model = MergeConflictTabModel(
+            worktreePath: repo,
+            relativePath: "a.txt",
+            gitService: GitService()
+        )
+        #expect(model.loadGeneration == 0)
+        await model.load()
+        let first = model.loadGeneration
+        #expect(first > 0)
+        await model.load()
+        // The token must change on every reload — that's what stale-async
+        // guards (binary cache, requestAgentResolveFile) key off of.
+        #expect(model.loadGeneration > first)
+    }
+
     @Test func discardAgentProposalClearsProposalAndKeepsResultText() {
         let model = MergeConflictTabModel(
             worktreePath: URL(fileURLWithPath: "/tmp/unused"),


### PR DESCRIPTION
## Summary

Plan 3 of merge-conflicts (Plan 1 = #273, Plan 2 = #276 — both merged): rounds out the merge editor with agent assistance, binary/image conflict viewer, BASE inline rendering, minimap progress, and polished rename/delete UX.

- **MergeAgent** — wraps `AgentRunner.runPrompt` with `explainConflict` + `resolveFile`. Prompt templates pulled out for unit testing (7 tests).
- **Model agent state** — `MergeConflictTabModel` gains `annotations: [Int: String]` (per-conflict cache), `initialConflictCount` (minimap snapshot), `agentBusy`, `agentProposal`, plus methods `explainCurrentConflict`, `requestAgentResolveFile`, `applyAgentProposal`, `discardAgentProposal`.
- **Toolbar** — new `✦ Ask agent to resolve` button (disabled when no agent / busy / not loaded / proposal pending). BASE toggle re-enabled (Plan 2 had it disabled pending visual). Counter line gains a 2-line layout where line 2 shows the `✦ annotation` italic + muted.
- **`MergeConflictAgentProposalView`** — modal overlay (ZStack on top of editor) showing current vs proposed text side-by-side. Apply replaces `resultText`; Cancel discards.
- **Auto-explain** — `.onChange(currentConflictIndex)` and `.onChange(conflictedFile.relativePath)` fire `explainCurrentConflict` when there's no cached annotation. Silent on agent failure.
- **BASE inline styling** — when `showBase=true`, base content lines (between `||||||| ` and `=======` markers) render italic in `fg-dim` on top of the existing yellow conflict shading.
- **`MergeConflictBinaryView`** — when `conflictedFile.isBinary`, the 3-column body is replaced with side-by-side `NSImage` previews for image extensions (raw bytes via `Process.gitData("show", ":N:<path>")`) or an instructional banner for non-images pointing to right-pane Use ours / Use theirs.
- **Minimap progress** — gains `resolvedCount`; renders that many green ticks before the existing yellow unresolved ticks. Total = `initialConflictCount` snapshot.
- **`ConflictsSection` polish** — `bothDeleted` rows tap → confirmation dialog ("Stage the deletion?") instead of opening the merge editor. `deletedByUs`/`deletedByThem` rows get inline trailing buttons (`Keep ours/theirs` + `Keep deleted`) so common actions don't require right-click.

## Out of scope (could be Plan 4 polish)

- Multi-mainline cherry-pick UI (Plan 1 auto-picks `-m 1`)
- Agent multi-turn refinement (the proposal is one-shot)
- Per-conflict agent resolve (vs. full-file)
- Tree-conflict / submodule-conflict UX

## Test plan

- [ ] `xcodebuild test -only-testing:AlasTests/MergeAgentTests` (7 prompt + parse tests)
- [ ] `xcodebuild test -only-testing:AlasTests/MergeConflictTabModelTests` (13 model tests — agent state, annotation cache, proposal apply/discard, cursor anchoring)
- [ ] `xcodebuild test -only-testing:AlasTests/MergeConflictBinaryDetectionTests` (2 routing tests)
- [ ] Manual: open a real conflict with an agent configured. Confirm the `✦ annotation` line appears under the counter after ~1s. Click `✦ Ask agent to resolve` → overlay appears with current vs proposed. Apply → resultText replaces; Cancel → unchanged.
- [ ] Manual: toggle Show BASE — `|||||||` lines become italic + muted.
- [ ] Manual: resolve conflicts one by one — minimap shows green ticks accumulating before remaining yellow ones.
- [ ] Manual: set up a binary (e.g. PNG) conflict; merge editor opens side-by-side image preview. Right-pane Use ours / Use theirs picks a side; Mark resolved works.
- [ ] Manual: set up a `bothDeleted` (rename/rename) conflict; tap row in Conflicts section → confirmation dialog appears. Click Keep deleted → file stays gone.
- [ ] Manual: `deletedByUs` row shows inline `Keep theirs` + `Keep deleted` buttons.