### PR TITLE
fix: align conventional commit verb chip to first-line baseline

### DIFF
--- a/Alas/Sources/Right/CommitRow.swift
+++ b/Alas/Sources/Right/CommitRow.swift
@@ -71,7 +71,7 @@ struct CommitRow: View {
     }
 
     private var subjectLine: some View {
-        HStack(spacing: 6) {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
             if let tag = commit.conventionalTag {
                 Text(tag)
                     .font(.system(size: 9.5, weight: .bold, design: .monospaced))


### PR DESCRIPTION
Use .firstTextBaseline alignment on the subject line HStack so the verb chip stays aligned with the first line of text when commit messages wrap to multiple lines.