### PR TITLE
feat(right): use Nerd Font icons for special folders in files sidebar

### DIFF
--- a/Alas/Sources/Right/FileTypeIconView.swift
+++ b/Alas/Sources/Right/FileTypeIconView.swift
@@ -290,6 +290,7 @@ struct FolderIconView: View {
                 .frame(width: size, height: size)
         } else {
             Icon(name: "folder", size: 11, color: fallbackColor)
+                .frame(width: size, height: size)
         }
     }
 }

--- a/Alas/Sources/Right/FileTypeIconView.swift
+++ b/Alas/Sources/Right/FileTypeIconView.swift
@@ -10,7 +10,7 @@ enum FileTypeIcon {
         let hex: String       // 6-char RGB hex, no leading "#"
         let kind: Kind
         let style: Style
-        enum Kind { case filename, ext, fallbackExt, generic }
+        enum Kind { case filename, ext, fallbackExt, generic, folderExact, folderSuffix, folderPath }
         enum Style { case nerdFont, text }
     }
 
@@ -176,6 +176,62 @@ enum FileTypeIcon {
         "makefile":            ("\u{E673}", "7A6A5A"),
         "cmakelists.txt":      ("\u{E673}", "7A6A5A"),
     ]
+
+    // MARK: - Folder icon lookup
+
+    /// Returns icon info for semantically meaningful folders, or `nil` for
+    /// generic folders that should keep the default folder icon.
+    static func folderInfo(name: String, path: String? = nil) -> Info? {
+        // 1. Path-aware matches (folder name alone is too ambiguous).
+        if let path = path?.lowercased() {
+            for entry in folderPathSuffixes {
+                if path.hasSuffix(entry.pathSuffix) {
+                    return Info(symbol: entry.symbol, hex: entry.hex, kind: .folderPath, style: .nerdFont)
+                }
+            }
+        }
+
+        let lower = name.lowercased()
+
+        // 2. Exact folder-name match.
+        if let hit = folderTable[lower] {
+            return Info(symbol: hit.symbol, hex: hit.hex, kind: .folderExact, style: .nerdFont)
+        }
+
+        // 3. Suffix-pattern match (e.g. *.xcodeproj).
+        for entry in folderSuffixes {
+            if lower.hasSuffix(entry.suffix) {
+                return Info(symbol: entry.symbol, hex: entry.hex, kind: .folderSuffix, style: .nerdFont)
+            }
+        }
+
+        return nil
+    }
+
+    private static let folderTable: [String: (symbol: String, hex: String)] = [
+        ".github":      ("\u{EA84}", "7A8089"),  // GitHub
+        ".gitlab":      ("\u{F296}",  "FC6D26"),  // GitLab
+        ".git":         ("\u{E65D}", "F05033"),  // Git
+        ".vscode":      ("\u{E70C}", "007ACC"),  // VS Code
+        ".idea":        ("\u{E7B5}", "A97BF3"),  // JetBrains
+        "node_modules": ("\u{E718}", "68A063"),  // Node.js
+        ".gradle":      ("\u{E660}", "02303A"),  // Gradle
+        ".docker":      ("\u{E650}", "2496ED"),  // Docker
+        "docker":       ("\u{E650}", "2496ED"),  // Docker assets
+        ".circleci":    ("\u{E63E}", "343434"),  // CircleCI
+    ]
+
+    private static let folderSuffixes: [(suffix: String, symbol: String, hex: String)] = [
+        (".xcodeproj",   "\u{E711}", "A2AAAD"),  // Xcode project
+        (".xcworkspace", "\u{E711}", "A2AAAD"),  // Xcode workspace
+        (".framework",   "\u{E711}", "A2AAAD"),  // Apple framework
+        (".app",         "\u{E711}", "A2AAAD"),  // macOS app bundle
+    ]
+
+    private static let folderPathSuffixes: [(pathSuffix: String, symbol: String, hex: String)] = [
+        ("src/main/resources", "\u{E256}", "E76F00"),  // Java resources
+        ("src/test/resources", "\u{E256}", "E76F00"),  // Java test resources
+    ]
 }
 
 /// Square tile with the file-type glyph.
@@ -216,6 +272,25 @@ struct FileTypeIconView: View {
         default: scale = 0.48  // 3+
         }
         return max(8, (size * scale).rounded())
+    }
+}
+
+/// Renders a Nerd Font glyph for semantically meaningful folders,
+/// falling back to the standard SF Symbol folder icon for generic ones.
+struct FolderIconView: View {
+    let name: String
+    let path: String
+    let open: Bool
+    let fallbackColor: Color
+    var size: CGFloat = 18
+
+    var body: some View {
+        if let info = FileTypeIcon.folderInfo(name: name, path: path) {
+            NerdFontGlyphView(symbol: info.symbol, hex: info.hex)
+                .frame(width: size, height: size)
+        } else {
+            Icon(name: "folder", size: 11, color: fallbackColor)
+        }
     }
 }
 

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -44,7 +44,12 @@ struct FilesTabView: View {
                             } else {
                                 Color.clear.frame(width: 14, height: 14)
                             }
-                            Icon(name: "folder", size: 11, color: folderColor(for: node, open: open))
+                            FolderIconView(
+                                name: node.name,
+                                path: node.path,
+                                open: open,
+                                fallbackColor: folderColor(for: node, open: open)
+                            )
                             Text(node.name)
                                 .font(.system(size: 11.5, design: .monospaced))
                                 .foregroundColor(rowForeground(for: node))

--- a/Alas/Sources/Right/WorkingTreeSectionView.swift
+++ b/Alas/Sources/Right/WorkingTreeSectionView.swift
@@ -183,7 +183,12 @@ struct WorkingTreeSectionView: View {
                         HStack(spacing: 6) {
                             Icon(name: open ? "chev-down" : "chev-right", size: 10, color: theme.color("fg-faint"))
                                 .frame(width: 14, height: 14)
-                            Icon(name: "folder", size: 11, color: open ? theme.color("accent") : theme.color("fg-dim"))
+                            FolderIconView(
+                                name: node.name,
+                                path: node.path,
+                                open: open,
+                                fallbackColor: open ? theme.color("accent") : theme.color("fg-dim")
+                            )
                             Text(node.name)
                                 .font(.system(size: 11.5, design: .monospaced))
                                 .foregroundColor(theme.color("fg"))

--- a/AlasTests/FileTypeIconTests.swift
+++ b/AlasTests/FileTypeIconTests.swift
@@ -84,4 +84,63 @@ struct FileTypeIconTests {
         #expect(FileTypeIcon.info(for: "widget.cpp").symbol == "\u{E646}")
         #expect(FileTypeIcon.info(for: "view.hpp").symbol == "\u{E646}")
     }
+
+    // MARK: - Folder icon lookup
+
+    @Test func exactFolderNameMatchesResolve() {
+        #expect(FileTypeIcon.folderInfo(name: ".github")?.symbol == "\u{EA84}")
+        #expect(FileTypeIcon.folderInfo(name: ".vscode")?.symbol == "\u{E70C}")
+        #expect(FileTypeIcon.folderInfo(name: "node_modules")?.symbol == "\u{E718}")
+        #expect(FileTypeIcon.folderInfo(name: ".gradle")?.symbol == "\u{E660}")
+        #expect(FileTypeIcon.folderInfo(name: ".git")?.symbol == "\u{E65D}")
+        #expect(FileTypeIcon.folderInfo(name: ".gitlab")?.symbol == "\u{F296}")
+        #expect(FileTypeIcon.folderInfo(name: ".docker")?.symbol == "\u{E650}")
+        #expect(FileTypeIcon.folderInfo(name: "docker")?.symbol == "\u{E650}")
+        #expect(FileTypeIcon.folderInfo(name: ".circleci")?.symbol == "\u{E63E}")
+    }
+
+    @Test func folderLookupIsCaseInsensitive() {
+        #expect(FileTypeIcon.folderInfo(name: ".GitHub")?.symbol == "\u{EA84}")
+        #expect(FileTypeIcon.folderInfo(name: ".GITHUB")?.symbol == "\u{EA84}")
+        #expect(FileTypeIcon.folderInfo(name: "Node_Modules")?.symbol == "\u{E718}")
+    }
+
+    @Test func folderSuffixMatchesResolve() {
+        #expect(FileTypeIcon.folderInfo(name: "Bleh.xcodeproj")?.symbol == "\u{E711}")
+        #expect(FileTypeIcon.folderInfo(name: "Alas.xcworkspace")?.symbol == "\u{E711}")
+        #expect(FileTypeIcon.folderInfo(name: "GhosttyKit.framework")?.symbol == "\u{E711}")
+        #expect(FileTypeIcon.folderInfo(name: "My.app")?.symbol == "\u{E711}")
+    }
+
+    @Test func folderSuffixMatchesAreCaseInsensitive() {
+        #expect(FileTypeIcon.folderInfo(name: "Foo.XCODEPROJ")?.symbol == "\u{E711}")
+    }
+
+    @Test func pathAwareFolderMatchesResolve() {
+        #expect(FileTypeIcon.folderInfo(name: "resources", path: "src/main/resources")?.symbol == "\u{E256}")
+        #expect(FileTypeIcon.folderInfo(name: "resources", path: "src/test/resources")?.symbol == "\u{E256}")
+    }
+
+    @Test func plainResourcesFolderReturnsNil() {
+        #expect(FileTypeIcon.folderInfo(name: "resources", path: "resources") == nil)
+        #expect(FileTypeIcon.folderInfo(name: "resources") == nil)
+    }
+
+    @Test func genericFoldersReturnNil() {
+        for name in ["src", "lib", "test", "tests", "__tests__", "build", "dist",
+                     "public", "assets", "docs", "config", "scripts", "bin"] {
+            #expect(FileTypeIcon.folderInfo(name: name) == nil, "Expected nil for \(name)")
+        }
+    }
+
+    @Test func unsupportedFoldersReturnNil() {
+        #expect(FileTypeIcon.folderInfo(name: ".husky") == nil)
+        #expect(FileTypeIcon.folderInfo(name: "vendor") == nil)
+    }
+
+    @Test func folderInfoKindsAreCorrect() {
+        #expect(FileTypeIcon.folderInfo(name: ".github")?.kind == .folderExact)
+        #expect(FileTypeIcon.folderInfo(name: "Foo.xcodeproj")?.kind == .folderSuffix)
+        #expect(FileTypeIcon.folderInfo(name: "resources", path: "src/main/resources")?.kind == .folderPath)
+    }
 }


### PR DESCRIPTION
## Summary
- add a conservative special-folder Nerd Font icon mapping for the right sidebar file tree
- render matched folders with semantic Nerd Font glyphs while preserving generic folder fallback
- cover exact, suffix, path-aware, and unsupported folder lookup behavior in tests

## Tests
- not run: xcodebuild cannot complete in this worktree because .build/ghostty/GhosttyKit.xcframework is missing