### PR TITLE
feat(center): merge-conflicts UX followups

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */; };
 		0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */; };
 		0575E49BE44BEB8AB9D4977F /* MergeConflictAgentProposalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */; };
+		0585FDF4437997020A1D1579 /* MergeConflictAnnotationStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */; };
 		065F01BB553C415040414D37 /* ImageDiffSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */; };
 		065F1A7FCF81FF29BAEF5A86 /* ScopeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */; };
 		06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */; };
@@ -895,6 +896,7 @@
 		A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChevronStabilityTests.swift; sourceTree = "<group>"; };
 		A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDirectionTests.swift; sourceTree = "<group>"; };
 		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
+		A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAnnotationStrip.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimer.swift; sourceTree = "<group>"; };
 		A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailView.swift; sourceTree = "<group>"; };
@@ -1574,6 +1576,7 @@
 				12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */,
 				90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */,
 				EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */,
+				A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */,
 				69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */,
 				8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */,
 				E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */,
@@ -2385,6 +2388,7 @@
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
 				4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */,
 				0575E49BE44BEB8AB9D4977F /* MergeConflictAgentProposalView.swift in Sources */,
+				0585FDF4437997020A1D1579 /* MergeConflictAnnotationStrip.swift in Sources */,
 				CF105C488C01331534C65D88 /* MergeConflictBinaryView.swift in Sources */,
 				4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */,
 				B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */,

--- a/Alas/Sources/Center/MergeConflictAnnotationStrip.swift
+++ b/Alas/Sources/Center/MergeConflictAnnotationStrip.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// One-line strip below the merge-conflict toolbar that surfaces the AI
+/// explanation for the current conflict. Collapsed by default to a single
+/// truncated line; tapping anywhere expands to the full wrapped text, and
+/// the `×` button hides the strip entirely for the lifetime of the current
+/// annotation (it reappears when the annotation changes — e.g. user
+/// navigates to the next conflict).
+struct MergeConflictAnnotationStrip: View {
+    let annotation: String
+
+    @State private var isExpanded = false
+    @State private var dismissedAnnotation: String?
+
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        if dismissedAnnotation == annotation {
+            EmptyView()
+        } else {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: "sparkles")
+                    .foregroundColor(theme.color("fg-subtle"))
+                    .font(.system(size: 10))
+                    .padding(.top, 2)
+                Button(action: { isExpanded.toggle() }) {
+                    Text(annotation)
+                        .font(.system(size: 11))
+                        .italic()
+                        .foregroundColor(theme.color("fg-dim"))
+                        .lineLimit(isExpanded ? nil : 1)
+                        .truncationMode(.tail)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                        .textSelection(.enabled)
+                }
+                .buttonStyle(.plain)
+                .help(isExpanded ? "Collapse" : "Click to expand")
+                Button(action: { dismissedAnnotation = annotation }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(theme.color("fg-subtle"))
+                        .padding(.top, 2)
+                }
+                .buttonStyle(.plain)
+                .help("Dismiss this annotation")
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(theme.color("bg-2"))
+            .overlay(Divider(), alignment: .bottom)
+            .onChange(of: annotation) { _, _ in
+                // New annotation arrived (e.g., user navigated to another
+                // conflict). Collapse back to the teaser so the user
+                // doesn't get a wall of text without asking for it.
+                isExpanded = false
+            }
+        }
+    }
+}

--- a/Alas/Sources/Center/MergeConflictAnnotationStrip.swift
+++ b/Alas/Sources/Center/MergeConflictAnnotationStrip.swift
@@ -13,12 +13,17 @@ import SwiftUI
 struct MergeConflictAnnotationStrip: View {
     let annotation: String
     /// Stable identity for the current conflict block — typically
-    /// `MergeConflictTabModel.annotationKey(for:)`. Used as the dismissal
-    /// key so dismissals follow the conflict, not the rendered sentence.
+    /// `MergeConflictTabModel.annotationKey(for:)` combined with the
+    /// block's line range. Used as the dismissal key so dismissals
+    /// follow the conflict, not the rendered sentence.
     let conflictKey: String
+    /// Set of dismissed conflict keys, owned by the parent view so the
+    /// dismissal survives this strip being unmounted between
+    /// navigations (e.g., visiting a conflict that has no cached
+    /// annotation yet would otherwise destroy local @State).
+    @Binding var dismissedKeys: Set<String>
 
     @State private var isExpanded = false
-    @State private var dismissedKeys: Set<String> = []
 
     @Environment(\.theme) var theme
 

--- a/Alas/Sources/Center/MergeConflictAnnotationStrip.swift
+++ b/Alas/Sources/Center/MergeConflictAnnotationStrip.swift
@@ -3,19 +3,27 @@ import SwiftUI
 /// One-line strip below the merge-conflict toolbar that surfaces the AI
 /// explanation for the current conflict. Collapsed by default to a single
 /// truncated line; tapping anywhere expands to the full wrapped text, and
-/// the `×` button hides the strip entirely for the lifetime of the current
-/// annotation (it reappears when the annotation changes — e.g. user
-/// navigates to the next conflict).
+/// the `×` button hides the strip for this specific conflict (it reappears
+/// for any other conflict the user navigates to).
+///
+/// Dismissal is keyed by `conflictKey` rather than `annotation` text so two
+/// distinct conflicts that happen to produce identical one-line summaries
+/// (common with repetitive import/order conflicts) don't share dismissal
+/// state.
 struct MergeConflictAnnotationStrip: View {
     let annotation: String
+    /// Stable identity for the current conflict block — typically
+    /// `MergeConflictTabModel.annotationKey(for:)`. Used as the dismissal
+    /// key so dismissals follow the conflict, not the rendered sentence.
+    let conflictKey: String
 
     @State private var isExpanded = false
-    @State private var dismissedAnnotation: String?
+    @State private var dismissedKeys: Set<String> = []
 
     @Environment(\.theme) var theme
 
     var body: some View {
-        if dismissedAnnotation == annotation {
+        if dismissedKeys.contains(conflictKey) {
             EmptyView()
         } else {
             HStack(alignment: .top, spacing: 6) {
@@ -37,7 +45,7 @@ struct MergeConflictAnnotationStrip: View {
                 }
                 .buttonStyle(.plain)
                 .help(isExpanded ? "Collapse" : "Click to expand")
-                Button(action: { dismissedAnnotation = annotation }) {
+                Button(action: { dismissedKeys.insert(conflictKey) }) {
                     Image(systemName: "xmark")
                         .font(.system(size: 9, weight: .medium))
                         .foregroundColor(theme.color("fg-subtle"))
@@ -50,10 +58,10 @@ struct MergeConflictAnnotationStrip: View {
             .padding(.vertical, 5)
             .background(theme.color("bg-2"))
             .overlay(Divider(), alignment: .bottom)
-            .onChange(of: annotation) { _, _ in
-                // New annotation arrived (e.g., user navigated to another
-                // conflict). Collapse back to the teaser so the user
-                // doesn't get a wall of text without asking for it.
+            .onChange(of: conflictKey) { _, _ in
+                // User navigated to another conflict. Collapse back to
+                // the teaser so they don't get a wall of text without
+                // asking for it.
                 isExpanded = false
             }
         }

--- a/Alas/Sources/Center/MergeConflictAnnotationStrip.swift
+++ b/Alas/Sources/Center/MergeConflictAnnotationStrip.swift
@@ -45,7 +45,16 @@ struct MergeConflictAnnotationStrip: View {
                 }
                 .buttonStyle(.plain)
                 .help(isExpanded ? "Collapse" : "Click to expand")
-                Button(action: { dismissedKeys.insert(conflictKey) }) {
+                Button(action: {
+                    dismissedKeys.insert(conflictKey)
+                    // Also collapse so a future re-show (different conflict
+                    // whose strip is not dismissed) starts on the teaser.
+                    // The `.onChange(of: conflictKey)` below only fires
+                    // while the visible branch is mounted; resetting here
+                    // covers the dismiss-then-navigate path where the
+                    // strip is unmounted before the key change.
+                    isExpanded = false
+                }) {
                     Image(systemName: "xmark")
                         .font(.system(size: 9, weight: .medium))
                         .foregroundColor(theme.color("fg-subtle"))

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -16,6 +16,13 @@ struct MergeConflictResultView: NSViewRepresentable {
     /// line range on every change so the navigation actually moves the
     /// cursor in the editor.
     let currentConflictIndex: Int?
+    /// Structural-change signal. Paired with `currentConflictIndex` in
+    /// the reselection guard so an accept that removes a conflict block
+    /// (which leaves the index numerically the same while the underlying
+    /// block at that ordinal changes) still triggers a reselect. Plain
+    /// text edits inside the buffer don't change this count, so we
+    /// don't scroll-jack the user mid-typing.
+    let conflictCount: Int
     @Environment(\.theme) var theme
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -72,20 +79,27 @@ struct MergeConflictResultView: NSViewRepresentable {
         }
         textView.backgroundColor = NSColor(theme.color("bg-1"))
 
-        // Scroll + select the current conflict whenever the index changes.
-        // Done AFTER any storage update so the layout manager has the
-        // refreshed text. Guarded against running on every keystroke by
-        // tracking the last applied index on the coordinator.
-        if let index = currentConflictIndex,
-           index != context.coordinator.lastAppliedConflictIndex {
-            if let range = Self.conflictRange(in: text, at: index) {
+        // Scroll + select the current conflict when navigation lands on
+        // a new ordinal OR when an accept removes a block and renumbers
+        // (same ordinal points at a different block). The guard tuple
+        // is (index, count); plain text edits don't change `count`, so
+        // typing won't yank the user's cursor.
+        let trigger = ReselectTrigger(index: currentConflictIndex, count: conflictCount)
+        if trigger != context.coordinator.lastReselectTrigger {
+            if let index = currentConflictIndex,
+               let range = Self.conflictRange(in: text, at: index) {
                 textView.setSelectedRange(range)
                 textView.scrollRangeToVisible(range)
             }
-            context.coordinator.lastAppliedConflictIndex = index
-        } else if currentConflictIndex == nil {
-            context.coordinator.lastAppliedConflictIndex = nil
+            context.coordinator.lastReselectTrigger = trigger
         }
+    }
+
+    /// Pair tracked across `updateNSView` invocations to decide whether
+    /// to re-select the current conflict's range. See the call site.
+    struct ReselectTrigger: Equatable {
+        let index: Int?
+        let count: Int
     }
 
     func makeCoordinator() -> Coordinator {
@@ -98,9 +112,10 @@ struct MergeConflictResultView: NSViewRepresentable {
         /// Tracks the `showBase` value from the last full re-render so we can
         /// detect toggle changes and force a fresh attributed string build.
         var lastShowBase: Bool = false
-        /// Tracks the index we already scrolled to so updateNSView doesn't
-        /// re-select on every keystroke or text update.
-        var lastAppliedConflictIndex: Int?
+        /// Pair we last reselected for, so we only re-scroll when the
+        /// user actually navigates or a structural change (accept, agent
+        /// apply) renumbers conflicts.
+        var lastReselectTrigger: ReselectTrigger?
         init(_ text: Binding<String>) { self.text = text }
         func textDidChange(_ notification: Notification) {
             guard let tv = notification.object as? NSTextView else { return }

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -11,6 +11,11 @@ struct MergeConflictResultView: NSViewRepresentable {
     let codeFontFamily: String
     let codeFontSize: CGFloat
     let showBase: Bool
+    /// Index of the conflict the user has navigated to (prev/next), or
+    /// nil when none. The view scrolls to and selects that conflict's
+    /// line range on every change so the navigation actually moves the
+    /// cursor in the editor.
+    let currentConflictIndex: Int?
     @Environment(\.theme) var theme
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -66,6 +71,21 @@ struct MergeConflictResultView: NSViewRepresentable {
             }
         }
         textView.backgroundColor = NSColor(theme.color("bg-1"))
+
+        // Scroll + select the current conflict whenever the index changes.
+        // Done AFTER any storage update so the layout manager has the
+        // refreshed text. Guarded against running on every keystroke by
+        // tracking the last applied index on the coordinator.
+        if let index = currentConflictIndex,
+           index != context.coordinator.lastAppliedConflictIndex {
+            if let range = Self.conflictRange(in: text, at: index) {
+                textView.setSelectedRange(range)
+                textView.scrollRangeToVisible(range)
+            }
+            context.coordinator.lastAppliedConflictIndex = index
+        } else if currentConflictIndex == nil {
+            context.coordinator.lastAppliedConflictIndex = nil
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -78,11 +98,36 @@ struct MergeConflictResultView: NSViewRepresentable {
         /// Tracks the `showBase` value from the last full re-render so we can
         /// detect toggle changes and force a fresh attributed string build.
         var lastShowBase: Bool = false
+        /// Tracks the index we already scrolled to so updateNSView doesn't
+        /// re-select on every keystroke or text update.
+        var lastAppliedConflictIndex: Int?
         init(_ text: Binding<String>) { self.text = text }
         func textDidChange(_ notification: Notification) {
             guard let tv = notification.object as? NSTextView else { return }
             text.wrappedValue = tv.string
         }
+    }
+
+    /// Returns the NSRange covering the Nth conflict block's lines in
+    /// `text`, or nil when the index is out of bounds.
+    private static func conflictRange(in text: String, at ordinal: Int) -> NSRange? {
+        let regions = ConflictMarkerParser.parse(text)
+        var seen = 0
+        let nsString = text as NSString
+        let lineRanges = computeLineRanges(in: nsString)
+        for region in regions {
+            guard case .conflict(let block) = region else { continue }
+            if seen == ordinal {
+                let lower = max(block.lineRangeInMerged.lowerBound, 0)
+                let upper = min(block.lineRangeInMerged.upperBound, lineRanges.count - 1)
+                guard upper >= lower, upper < lineRanges.count else { return nil }
+                let start = lineRanges[lower].location
+                let end = NSMaxRange(lineRanges[upper])
+                return NSRange(location: start, length: end - start)
+            }
+            seen += 1
+        }
+        return nil
     }
 
     /// Applies a yellow background to each line range that falls inside a

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -74,6 +74,18 @@ final class MergeConflictTabModel {
         regions.reduce(0) { $0 + (isConflict($1) ? 1 : 0) }
     }
 
+    /// True when any conflict region carries a BASE side. Used by the
+    /// toolbar to disable the Show BASE toggle for merges driven without
+    /// `merge.conflictStyle=zdiff3`, where toggling would be a no-op.
+    var hasBase: Bool {
+        for region in regions {
+            if case .conflict(let block) = region, block.base != nil {
+                return true
+            }
+        }
+        return false
+    }
+
     /// Re-loads the conflicted file's three sides and re-parses the on-disk
     /// merged buffer. Safe to call repeatedly.
     ///

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -64,8 +64,13 @@ struct MergeConflictTabView: View {
                         }
                     }
                 )
-                if let annotation = currentBlockAnnotation, !annotation.isEmpty {
-                    MergeConflictAnnotationStrip(annotation: annotation)
+                if let annotation = currentBlockAnnotation,
+                   !annotation.isEmpty,
+                   let key = currentBlockKey {
+                    MergeConflictAnnotationStrip(
+                        annotation: annotation,
+                        conflictKey: key
+                    )
                 }
                 content
             }
@@ -267,6 +272,16 @@ struct MergeConflictTabView: View {
               let block = currentConflictBlock(at: ord)
         else { return nil }
         return model.annotation(for: block)
+    }
+
+    /// Content-stable identity for the current conflict block. Passed to
+    /// `MergeConflictAnnotationStrip` as the dismissal key so dismissals
+    /// follow the conflict and not the rendered annotation text.
+    private var currentBlockKey: String? {
+        guard let ord = model.currentConflictIndex,
+              let block = currentConflictBlock(at: ord)
+        else { return nil }
+        return MergeConflictTabModel.annotationKey(for: block)
     }
 
     /// Returns the `ConflictBlock` for the Nth unresolved conflict, or nil.

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -166,7 +166,8 @@ struct MergeConflictTabView: View {
                     codeFontFamily: state.config.code.fontFamily,
                     codeFontSize: CGFloat(state.config.code.fontSize),
                     showBase: tabState.showBase,
-                    currentConflictIndex: model.currentConflictIndex
+                    currentConflictIndex: model.currentConflictIndex,
+                    conflictCount: model.conflictCount
                 )
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -274,14 +275,17 @@ struct MergeConflictTabView: View {
         return model.annotation(for: block)
     }
 
-    /// Content-stable identity for the current conflict block. Passed to
-    /// `MergeConflictAnnotationStrip` as the dismissal key so dismissals
-    /// follow the conflict and not the rendered annotation text.
+    /// Per-instance identity for the current conflict block, used as the
+    /// strip's dismissal key. Combines line-range position with the
+    /// content hash so two blocks with identical LOCAL/BASE/REMOTE
+    /// content (the model's content-only `annotationKey` would alias
+    /// them) still dismiss independently.
     private var currentBlockKey: String? {
         guard let ord = model.currentConflictIndex,
               let block = currentConflictBlock(at: ord)
         else { return nil }
-        return MergeConflictTabModel.annotationKey(for: block)
+        let range = block.lineRangeInMerged
+        return "\(range.lowerBound)-\(range.upperBound):\(MergeConflictTabModel.annotationKey(for: block))"
     }
 
     /// Returns the `ConflictBlock` for the Nth unresolved conflict, or nil.

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -281,17 +281,20 @@ struct MergeConflictTabView: View {
         return model.annotation(for: block)
     }
 
-    /// Per-instance identity for the current conflict block, used as the
-    /// strip's dismissal key. Combines line-range position with the
-    /// content hash so two blocks with identical LOCAL/BASE/REMOTE
-    /// content (the model's content-only `annotationKey` would alias
-    /// them) still dismiss independently.
+    /// Identity for the current conflict block, used as the strip's
+    /// dismissal key. Matches the content-hash key the model uses for
+    /// caching annotations (`MergeConflictTabModel.annotationKey(for:)`)
+    /// so dismissals survive positional shifts — edits above the block,
+    /// resolving earlier conflicts — the same way the cached annotation
+    /// itself does. Two blocks with byte-identical LOCAL/BASE/REMOTE
+    /// in the same file share both the cached explanation and the
+    /// dismissal state, which is consistent: the annotation cache is
+    /// already aliased, so the dismissal aliases too.
     private var currentBlockKey: String? {
         guard let ord = model.currentConflictIndex,
               let block = currentConflictBlock(at: ord)
         else { return nil }
-        let range = block.lineRangeInMerged
-        return "\(range.lowerBound)-\(range.upperBound):\(MergeConflictTabModel.annotationKey(for: block))"
+        return MergeConflictTabModel.annotationKey(for: block)
     }
 
     /// Returns the `ConflictBlock` for the Nth unresolved conflict, or nil.

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -6,6 +6,11 @@ struct MergeConflictTabView: View {
     let tabState: MergeConflictTabState
 
     @State private var model: MergeConflictTabModel
+    /// Conflict keys dismissed from the annotation strip. Lifted out of
+    /// `MergeConflictAnnotationStrip` so dismissal survives navigating
+    /// to a conflict that has no cached annotation (which would unmount
+    /// the strip and otherwise reset its local @State).
+    @State private var dismissedAnnotationKeys: Set<String> = []
     @Environment(\.theme) var theme
 
     init(state: AppState, worktree: Worktree, tabState: MergeConflictTabState) {
@@ -69,7 +74,8 @@ struct MergeConflictTabView: View {
                    let key = currentBlockKey {
                     MergeConflictAnnotationStrip(
                         annotation: annotation,
-                        conflictKey: key
+                        conflictKey: key,
+                        dismissedKeys: $dismissedAnnotationKeys
                     )
                 }
                 content

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -27,22 +27,18 @@ struct MergeConflictTabView: View {
                 MergeConflictToolbar(
                     conflictCount: model.conflictCount,
                     currentConflictIndex: model.currentConflictIndex,
-                    currentAnnotation: currentBlockAnnotation,
                     isLoaded: model.conflictedFile != nil,
                     canRunAgent: model.conflictedFile != nil && model.conflictedFile?.isBinary == false,
                     agentBusy: model.agentBusy,
                     hasAgent: resolvedAgent != nil,
                     hasPendingProposal: model.agentProposal != nil,
                     showBase: showBaseBinding,
+                    baseAvailable: model.hasBase,
                     onPrevious: { model.previousConflict() },
                     onNext: { model.nextConflict() },
                     onAcceptLocal: { model.acceptLocal() },
                     onAcceptRemote: { model.acceptRemote() },
                     onAcceptBoth: { model.acceptBoth() },
-                    onAcceptAndNext: {
-                        model.acceptLocal()
-                        model.nextConflict()
-                    },
                     onAskAgentResolve: {
                         guard let agent = resolvedAgent else { return }
                         Task {
@@ -51,14 +47,26 @@ struct MergeConflictTabView: View {
                     },
                     onMarkResolved: {
                         Task {
-                            try? await model.markFileResolved()
-                            // The WorktreeWatcher on RightPaneState picks up the
-                            // .git/index change from `git add` and refreshes the
-                            // Conflicts section automatically — no explicit call
-                            // is needed here.
+                            do {
+                                try await model.markFileResolved()
+                                // Explicit refresh + tab close so the user
+                                // gets immediate feedback that the file
+                                // moved out of Conflicts. The FSEvents
+                                // watcher would catch up eventually, but
+                                // the debouncer + watcher latency made the
+                                // change feel sticky.
+                                await state.rightPaneStore.refresh(worktreeId: worktree.id)
+                                state.closeTab(worktreeId: worktree.id, tabId: tabState.id)
+                            } catch {
+                                // markResolved is best-effort; the gitService
+                                // logs the underlying error.
+                            }
                         }
                     }
                 )
+                if let annotation = currentBlockAnnotation, !annotation.isEmpty {
+                    MergeConflictAnnotationStrip(annotation: annotation)
+                }
                 content
             }
             if let proposal = model.agentProposal {
@@ -152,7 +160,8 @@ struct MergeConflictTabView: View {
                     fileExtension: fileExtension,
                     codeFontFamily: state.config.code.fontFamily,
                     codeFontSize: CGFloat(state.config.code.fontSize),
-                    showBase: tabState.showBase
+                    showBase: tabState.showBase,
+                    currentConflictIndex: model.currentConflictIndex
                 )
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Alas/Sources/Center/MergeConflictToolbar.swift
+++ b/Alas/Sources/Center/MergeConflictToolbar.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct MergeConflictToolbar: View {
     let conflictCount: Int
     let currentConflictIndex: Int?
-    let currentAnnotation: String?
     /// True once the conflicted file has been loaded successfully (binary
     /// or text). Gates `Mark resolved` so it can't fire on an empty initial
     /// buffer. Stays true for binaries — the user resolves them via the
@@ -20,12 +19,15 @@ struct MergeConflictToolbar: View {
     /// clobber the pending proposal.
     let hasPendingProposal: Bool
     @Binding var showBase: Bool
+    /// True only when the merged file actually contains zdiff3 `|||||||`
+    /// markers. Off for merges driven from outside alas without
+    /// `merge.conflictStyle=zdiff3`, where the toggle would do nothing.
+    let baseAvailable: Bool
     let onPrevious: () -> Void
     let onNext: () -> Void
     let onAcceptLocal: () -> Void
     let onAcceptRemote: () -> Void
     let onAcceptBoth: () -> Void
-    let onAcceptAndNext: () -> Void
     let onAskAgentResolve: () -> Void
     let onMarkResolved: () -> Void
 
@@ -59,7 +61,10 @@ struct MergeConflictToolbar: View {
             Toggle("Show BASE", isOn: $showBase)
                 .toggleStyle(.button)
                 .controlSize(.small)
-                .help("Show the common-ancestor BASE lines inside each conflict region")
+                .disabled(!baseAvailable)
+                .help(baseAvailable
+                    ? "Show the common-ancestor BASE lines inside each conflict region"
+                    : "This file has no BASE markers. Run the merge with merge.conflictStyle=zdiff3 to enable BASE.")
             Button(action: onMarkResolved) {
                 Text("Mark resolved")
                     .font(.system(size: 11))
@@ -75,18 +80,9 @@ struct MergeConflictToolbar: View {
     }
 
     private var counter: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            Text(counterText)
-                .font(.system(size: 11))
-                .foregroundColor(theme.color("fg-dim"))
-            if let annotation = currentAnnotation, !annotation.isEmpty {
-                Text("✦ \(annotation)")
-                    .font(.system(size: 10).italic())
-                    .foregroundColor(theme.color("fg-subtle"))
-                    .lineLimit(2)
-                    .truncationMode(.tail)
-            }
-        }
+        Text(counterText)
+            .font(.system(size: 11))
+            .foregroundColor(theme.color("fg-dim"))
     }
 
     private var counterText: String {
@@ -100,25 +96,22 @@ struct MergeConflictToolbar: View {
     }
 
     private var navigationButtons: some View {
-        HStack(spacing: 2) {
-            Button(action: onPrevious) { Image(systemName: "chevron.up") }
-                .keyboardShortcut(.upArrow, modifiers: [.option])
-                .help("Previous conflict (⌥↑)")
-            Button(action: onNext) { Image(systemName: "chevron.down") }
-                .keyboardShortcut(.downArrow, modifiers: [.option])
-                .help("Next conflict (⌥↓)")
-            Button(action: onAcceptAndNext) {
-                HStack(spacing: 3) {
-                    Image(systemName: "checkmark")
-                    Image(systemName: "chevron.down")
-                }
-            }
-            .keyboardShortcut(.return, modifiers: [.option])
-            .help("Accept LOCAL and jump to next (⌥↵)")
+        HStack(spacing: 4) {
+            ChevronNavButton(
+                systemName: "chevron.up",
+                tooltip: "Previous conflict (⌥↑)",
+                shortcut: .upArrow,
+                disabled: conflictCount == 0,
+                action: onPrevious
+            )
+            ChevronNavButton(
+                systemName: "chevron.down",
+                tooltip: "Next conflict (⌥↓)",
+                shortcut: .downArrow,
+                disabled: conflictCount == 0,
+                action: onNext
+            )
         }
-        .buttonStyle(.borderless)
-        .controlSize(.small)
-        .disabled(conflictCount == 0)
     }
 
     private var acceptButtons: some View {
@@ -135,5 +128,38 @@ struct MergeConflictToolbar: View {
         .buttonStyle(.bordered)
         .controlSize(.small)
         .disabled(conflictCount == 0)
+    }
+}
+
+/// Icon-only chevron button matching the worktree `+` button styling: a
+/// fixed-size hit area with a hover background and tinted icon. Plain
+/// borderless buttons in a toolbar read as text, which is what the user
+/// flagged — this gives prev/next a real affordance.
+private struct ChevronNavButton: View {
+    let systemName: String
+    let tooltip: String
+    let shortcut: KeyEquivalent
+    let disabled: Bool
+    let action: () -> Void
+
+    @State private var hovering = false
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(disabled
+                    ? theme.color("fg-faint")
+                    : (hovering ? theme.color("fg") : theme.color("fg-muted")))
+                .frame(width: 20, height: 20)
+                .background(hovering && !disabled ? theme.color("bg-4") : .clear)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .buttonStyle(.plain)
+        .keyboardShortcut(shortcut, modifiers: [.option])
+        .help(tooltip)
+        .disabled(disabled)
+        .onHover { hovering = $0 }
     }
 }

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -84,6 +84,16 @@ final class RightPaneStore {
         activeId = id
     }
 
+    /// Refreshes the cached `RightPaneState` for `worktreeId` if one exists.
+    /// No-op when the worktree hasn't been activated yet. Called from the
+    /// merge-conflict editor after `Mark resolved` so the Conflicts section
+    /// reflects the staged resolution immediately without waiting for the
+    /// FSEvents debouncer.
+    func refresh(worktreeId: String) async {
+        guard let state = states[worktreeId] else { return }
+        await state.refresh()
+    }
+
     /// Stops the currently-active state's background work. Call when the
     /// right pane is hidden or no worktree is selected, so the FSEvents
     /// watcher and the 5-min sync timer don't keep running with no


### PR DESCRIPTION
## Summary

Polish pass on the merge-conflict editor after dogfooding the merged feature (PR #278).

- **Mark resolved → refresh + close**: now explicitly refreshes the right pane and closes the tab so the user gets immediate feedback that the file moved out of Conflicts. The FSEvents watcher debouncer made the change feel sticky.
- **Annotation strip below toolbar**: moves the AI explanation out of the cramped toolbar into a dedicated collapsible strip — 1-line teaser by default, tap to expand to full text, × to dismiss.
- **Remove unclear ✓ button**: the "Accept LOCAL and jump to next" composite duplicated Use LOCAL + ↓; dropped.
- **Restyle nav chevrons**: prev/next now use a hover background matching the worktree `+` button pattern so they read as real controls.
- **Disable Show BASE when no `|||||||` markers**: the toggle silently did nothing for merges driven without `merge.conflictStyle=zdiff3`. Now disabled with a tooltip.
- **Scroll + select on prev/next**: RESULT view now scrolls to and selects the current conflict's line range when the user navigates.

## Test plan

- [x] Build green (Debug)
- [x] `MergeConflictTabModelTests` passing (16/16)
- [x] `swiftformat --lint` clean
- [ ] Manual smoke (user dogfooded earlier rounds; PR #278 in main)