### PR TITLE
fix(files): folder icon review feedback

### DIFF
--- a/Alas/Sources/Right/FileTypeIconView.swift
+++ b/Alas/Sources/Right/FileTypeIconView.swift
@@ -185,7 +185,7 @@ enum FileTypeIcon {
         // 1. Path-aware matches (folder name alone is too ambiguous).
         if let path = path?.lowercased() {
             for entry in folderPathSuffixes {
-                if path.hasSuffix(entry.pathSuffix) {
+                if pathMatchesSegmentSuffix(path, entry.pathSuffix) {
                     return Info(symbol: entry.symbol, hex: entry.hex, kind: .folderPath, style: .nerdFont)
                 }
             }
@@ -232,6 +232,15 @@ enum FileTypeIcon {
         ("src/main/resources", "\u{E256}", "E76F00"),  // Java resources
         ("src/test/resources", "\u{E256}", "E76F00"),  // Java test resources
     ]
+
+    private static func pathMatchesSegmentSuffix(_ path: String, _ suffix: String) -> Bool {
+        let normalizedPath = path.replacingOccurrences(of: "\\", with: "/")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let normalizedSuffix = suffix.replacingOccurrences(of: "\\", with: "/")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+        return normalizedPath == normalizedSuffix || normalizedPath.hasSuffix("/" + normalizedSuffix)
+    }
 }
 
 /// Square tile with the file-type glyph.
@@ -285,13 +294,14 @@ struct FolderIconView: View {
     var size: CGFloat = 18
 
     var body: some View {
-        if let info = FileTypeIcon.folderInfo(name: name, path: path) {
-            NerdFontGlyphView(symbol: info.symbol, hex: info.hex)
-                .frame(width: size, height: size)
-        } else {
-            Icon(name: "folder", size: 11, color: fallbackColor)
-                .frame(width: size, height: size)
+        Group {
+            if let info = FileTypeIcon.folderInfo(name: name, path: path) {
+                NerdFontGlyphView(symbol: info.symbol, hex: info.hex)
+            } else {
+                Icon(name: "folder", size: 11, color: fallbackColor)
+            }
         }
+        .frame(width: size, height: size)
     }
 }
 

--- a/AlasTests/FileTypeIconTests.swift
+++ b/AlasTests/FileTypeIconTests.swift
@@ -119,6 +119,14 @@ struct FileTypeIconTests {
     @Test func pathAwareFolderMatchesResolve() {
         #expect(FileTypeIcon.folderInfo(name: "resources", path: "src/main/resources")?.symbol == "\u{E256}")
         #expect(FileTypeIcon.folderInfo(name: "resources", path: "src/test/resources")?.symbol == "\u{E256}")
+        #expect(FileTypeIcon.folderInfo(name: "resources", path: "server/src/main/resources")?.symbol == "\u{E256}")
+        #expect(FileTypeIcon.folderInfo(name: "resources", path: "server\\src\\test\\resources")?.symbol == "\u{E256}")
+    }
+
+    @Test func pathAwareFolderMatchesRequireSegmentBoundary() {
+        #expect(FileTypeIcon.folderInfo(name: "resources", path: "mysrc/main/resources") == nil)
+        #expect(FileTypeIcon.folderInfo(name: "resources", path: "src/main/myresources") == nil)
+        #expect(FileTypeIcon.folderInfo(name: "resources", path: "app/mysrc/test/resources") == nil)
     }
 
     @Test func plainResourcesFolderReturnsNil() {


### PR DESCRIPTION
## Summary
- keep folder rows aligned by applying the fixed icon frame to the whole `FolderIconView`
- restrict Java resources folder detection to exact path-segment suffixes
- add regression coverage for nested resources paths and false-positive suffix matches

## Validation
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing AlasTests/FileTypeIconTests`