### PR TITLE
feat(center): bulk agent resolve + editable prompts + tab polish

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		2ED636DD3A179B95C061A9E6 /* InlineErrorStripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */; };
 		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
+		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
 		3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6CCD7F7273667B5D67F821 /* SearchScope.swift */; };
 		32A11F8AF508AA2A7D3EF788 /* ThemeEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6F2D792F7DFAE3DA8E597 /* ThemeEnvironment.swift */; };
@@ -187,6 +188,7 @@
 		4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
 		5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */; };
+		50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B42244BDE33A69EDE16562 /* PromptEditorBody.swift */; };
 		512A41C0AB75B8D35424EBCD /* DeletingWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */; };
 		51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25493E3B18A1AB94EA6985C3 /* EventHolder.swift */; };
 		513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */; };
@@ -246,9 +248,11 @@
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */; };
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
+		7028C08DE3F176175CA1FC20 /* MergeConflictResolvedEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */; };
 		709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D105CB2C185958ED23164D1 /* IndentationMode.swift */; };
 		70FCC2B12AE446728EE7CF8D /* LSPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38499AFE31188908546EE222 /* LSPTransport.swift */; };
 		7146CECD7FE56140D7A7AF50 /* MergeConflictTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */; };
+		71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
 		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
@@ -293,6 +297,7 @@
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
 		87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CA995EE43C73449EBF79A7 /* ClaudeInstaller.swift */; };
 		881EB8E37CE9D947A2C74564 /* GitRefNameInputFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D6BBD77A210BB378E217FC /* GitRefNameInputFilterTests.swift */; };
+		8824EFBA6EA3673F13244C6D /* MergeSingleResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */; };
 		884F7EB87029E537B923191E /* DefinitionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */; };
 		8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */; };
 		8950201500394191D7D981D2 /* MarkdownRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */; };
@@ -558,6 +563,7 @@
 		013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjection.swift; sourceTree = "<group>"; };
 		01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupViewLayoutTests.swift; sourceTree = "<group>"; };
 		019A03B92542169A6595D432 /* HoverHighlightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeature.swift; sourceTree = "<group>"; };
+		01B42244BDE33A69EDE16562 /* PromptEditorBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptEditorBody.swift; sourceTree = "<group>"; };
 		01F0314E357190EF2A1F861B /* CodexInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstaller.swift; sourceTree = "<group>"; };
 		02161104BA524379A359CB2D /* SidebarChromeTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarChromeTheme.swift; sourceTree = "<group>"; };
 		028348C468E45161F567110A /* LSPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallerTests.swift; sourceTree = "<group>"; };
@@ -573,6 +579,7 @@
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
 		09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffMode.swift; sourceTree = "<group>"; };
+		0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResolvedEmptyView.swift; sourceTree = "<group>"; };
 		09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolverTests.swift; sourceTree = "<group>"; };
 		0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPair.swift; sourceTree = "<group>"; };
 		09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistry.swift; sourceTree = "<group>"; };
@@ -806,8 +813,10 @@
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
 		73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapper.swift; sourceTree = "<group>"; };
 		743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolver.swift; sourceTree = "<group>"; };
+		749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSingleResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		74D394D40BC9060833DD640A /* LSPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstaller.swift; sourceTree = "<group>"; };
 		7544FD20BC61E587CAFAC099 /* AgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistry.swift; sourceTree = "<group>"; };
+		7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkConflictResolveReport.swift; sourceTree = "<group>"; };
 		768D12909DD5233659AC4E03 /* RepoGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupView.swift; sourceTree = "<group>"; };
 		76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolverTests.swift; sourceTree = "<group>"; };
 		76F2498E56CBAF84CB67166C /* HarnessKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessKind.swift; sourceTree = "<group>"; };
@@ -1060,6 +1069,7 @@
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
+		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanel.swift; sourceTree = "<group>"; };
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
 		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
@@ -1466,6 +1476,7 @@
 			isa = PBXGroup;
 			children = (
 				002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */,
+				7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */,
 				3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */,
 				C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */,
 				3DCEFADD952DB870B8BAB890 /* CommitRow.swift */,
@@ -1544,7 +1555,10 @@
 				1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */,
 				12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */,
 				2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */,
+				F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */,
+				749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */,
 				0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */,
+				01B42244BDE33A69EDE16562 /* PromptEditorBody.swift */,
 				6A190D4B29B35C457AA9829F /* SettingsBinding.swift */,
 				F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */,
 				515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */,
@@ -1580,6 +1594,7 @@
 				69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */,
 				8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */,
 				E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */,
+				0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */,
 				674F70D8D27715223D10C582 /* MergeConflictResultView.swift */,
 				CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */,
 				2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */,
@@ -2239,6 +2254,7 @@
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
 				4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */,
 				9E302329243407946D47DC91 /* BranchPicker.swift in Sources */,
+				71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */,
 				7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */,
 				139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */,
 				FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */,
@@ -2387,11 +2403,13 @@
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
 				4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */,
+				2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */,
 				0575E49BE44BEB8AB9D4977F /* MergeConflictAgentProposalView.swift in Sources */,
 				0585FDF4437997020A1D1579 /* MergeConflictAnnotationStrip.swift in Sources */,
 				CF105C488C01331534C65D88 /* MergeConflictBinaryView.swift in Sources */,
 				4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */,
 				B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */,
+				7028C08DE3F176175CA1FC20 /* MergeConflictResolvedEmptyView.swift in Sources */,
 				B27F4047043A6FCE2E9C21A3 /* MergeConflictResultView.swift in Sources */,
 				906EE12924284FF21B9BDEFF /* MergeConflictTabModel.swift in Sources */,
 				476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */,
@@ -2399,6 +2417,7 @@
 				B08F7ECC5E2612CC503E1BE0 /* MergeConflictTextStorage.swift in Sources */,
 				5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */,
 				32A4E1C6A5A43C8B9C47C3C9 /* MergeOperationState.swift in Sources */,
+				8824EFBA6EA3673F13244C6D /* MergeSingleResolvePromptEditorWindow.swift in Sources */,
 				82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */,
 				02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */,
 				11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */,
@@ -2419,6 +2438,7 @@
 				F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */,
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
+				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,
 				3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,

--- a/Alas/Sources/Agents/AgentRunner.swift
+++ b/Alas/Sources/Agents/AgentRunner.swift
@@ -237,8 +237,14 @@ private struct AgentPromptInvocation {
             )
         }
 
+        // Put bypass BEFORE `promptModeArgs` (not between args + prompt)
+        // so a custom agent whose `promptModeArgs` ends with an
+        // option-taking-value (e.g. `["chat", "--prompt"]`) keeps
+        // that option adjacent to its value. Inserting bypass in the
+        // middle would make the option swallow the bypass flag as its
+        // value and misparse the prompt.
         return AgentPromptInvocation(
-            arguments: agent.promptModeArgs + bypass + [prompt],
+            arguments: bypass + agent.promptModeArgs + [prompt],
             stdin: input
         )
     }

--- a/Alas/Sources/Agents/AgentRunner.swift
+++ b/Alas/Sources/Agents/AgentRunner.swift
@@ -39,13 +39,15 @@ enum AgentRunner {
         prompt: String,
         workingDirectory: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        timeout: TimeInterval = 120
+        timeout: TimeInterval = 120,
+        bypassPermissions: Bool = false
     ) async throws -> GeneratedMessage {
         let binary = agent.resolvedBinary
         let invocation = AgentPromptInvocation.make(
             agent: agent,
             input: input,
-            prompt: prompt
+            prompt: prompt,
+            bypassPermissions: bypassPermissions
         )
         let pipe = Pipe()
         // We can't use Process.run directly because it doesn't accept
@@ -209,21 +211,34 @@ private struct AgentPromptInvocation {
     static func make(
         agent: AgentDefinition,
         input: String,
-        prompt: String
+        prompt: String,
+        bypassPermissions: Bool = false
     ) -> AgentPromptInvocation {
+        // Insert the agent-specific bypass-permissions flag (e.g.
+        // `--dangerously-skip-permissions`, `--yolo`,
+        // `--dangerously-bypass-approvals-and-sandbox`) between the
+        // prompt-mode args and the prompt itself when the caller opted
+        // in. Callers that don't need file-write capability (e.g.
+        // read-only summary calls) leave this off.
+        let bypass: [String] = {
+            guard bypassPermissions, let flag = agent.bypassPermissionsFlag else {
+                return []
+            }
+            return [flag]
+        }()
         if isCodexExec(agent) {
             // `--skip-git-repo-check` is required because codex refuses to
             // start in a directory it hasn't been told to trust (and there
             // is no interactive prompt to satisfy in non-interactive exec).
             // The trailing `-` makes codex read the prompt from stdin.
             return AgentPromptInvocation(
-                arguments: agent.promptModeArgs + ["--skip-git-repo-check", "-"],
+                arguments: agent.promptModeArgs + bypass + ["--skip-git-repo-check", "-"],
                 stdin: combinedPrompt(prompt: prompt, input: input)
             )
         }
 
         return AgentPromptInvocation(
-            arguments: agent.promptModeArgs + [prompt],
+            arguments: agent.promptModeArgs + bypass + [prompt],
             stdin: input
         )
     }

--- a/Alas/Sources/Agents/AgentRunner.swift
+++ b/Alas/Sources/Agents/AgentRunner.swift
@@ -33,6 +33,12 @@ enum AgentMessageParser {
 /// `Process+Git.swift`; the commentary there explains why each fd is closed
 /// when it is.
 enum AgentRunner {
+    /// Convenience wrapper for callers that want the parsed
+    /// `subject`/`body` shape (commit-message generator, etc.). The
+    /// bulk merge-conflict resolve uses `runPromptRaw` instead because
+    /// `AgentMessageParser` drops every line after the first in the
+    /// initial paragraph, which collapses "one line per file"
+    /// summaries to a single line.
     static func runPrompt(
         agent: AgentDefinition,
         input: String,
@@ -42,6 +48,31 @@ enum AgentRunner {
         timeout: TimeInterval = 120,
         bypassPermissions: Bool = false
     ) async throws -> GeneratedMessage {
+        let stdout = try await runPromptRaw(
+            agent: agent,
+            input: input,
+            prompt: prompt,
+            workingDirectory: workingDirectory,
+            environment: environment,
+            timeout: timeout,
+            bypassPermissions: bypassPermissions
+        )
+        return AgentMessageParser.parse(stdout)
+    }
+
+    /// Returns the agent's raw stdout, lossless. Use this when the
+    /// caller wants the full output structure (e.g. a multi-line
+    /// per-file summary) instead of the heuristic
+    /// subject/body split.
+    static func runPromptRaw(
+        agent: AgentDefinition,
+        input: String,
+        prompt: String,
+        workingDirectory: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        timeout: TimeInterval = 120,
+        bypassPermissions: Bool = false
+    ) async throws -> String {
         let binary = agent.resolvedBinary
         let invocation = AgentPromptInvocation.make(
             agent: agent,
@@ -200,7 +231,7 @@ enum AgentRunner {
             }
             throw AgentRunError.nonZeroExit(stderr: stderr, exitCode: process.terminationStatus)
         }
-        return AgentMessageParser.parse(stdout)
+        return stdout
     }
 }
 

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -230,5 +230,19 @@ struct AlasApp: App {
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)
         .defaultSize(width: 720, height: 560)
+
+        Window("Merge: Resolve All Prompt", id: "merge-bulk-prompt-editor") {
+            MergeBulkResolvePromptEditorWindow(state: state)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+        .defaultSize(width: 720, height: 560)
+
+        Window("Merge: Single-File Prompt", id: "merge-single-prompt-editor") {
+            MergeSingleResolvePromptEditorWindow(state: state)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+        .defaultSize(width: 720, height: 560)
     }
 }

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -149,6 +149,7 @@ struct CenterPaneView: View {
                             worktree: worktree,
                             tabState: s
                         )
+                        .id(s.id)
                     }
                 }
             }

--- a/Alas/Sources/Center/MergeAgent.swift
+++ b/Alas/Sources/Center/MergeAgent.swift
@@ -1,11 +1,15 @@
 import Foundation
 
 /// Thin domain-facing wrapper over `AgentRunner.runPrompt` for the merge
-/// editor. Owns the prompt templates and the post-parsing of agent output.
-/// Stateless — every call is independent.
+/// editor. Owns the prompt assembly + post-parsing of agent output.
+/// Stateless — every call is independent. Prompt templates come from
+/// the caller (typically `AppConfig.changes.merge*Prompt`) so the user
+/// can customize them in Settings without having to redeploy.
 enum MergeAgent {
     /// One-line summary of a single conflict block. Returns an empty string
     /// on agent failure (the caller surfaces this as "no annotation").
+    /// Not user-customizable — the format is consumed by the annotation
+    /// strip and the prompt is tuned for that exact output shape.
     static func explainConflict(
         agent: AgentDefinition,
         block: ConflictBlock,
@@ -25,8 +29,14 @@ enum MergeAgent {
     /// Full-file resolution proposal. Returns the proposed file contents
     /// (without conflict markers). Caller is responsible for presenting
     /// a diff against the current `resultText` before applying.
+    ///
+    /// `template` is the user-customizable instructions portion. The
+    /// three-side dump (LOCAL/BASE/REMOTE/MERGED) is appended verbatim
+    /// because its format is consumed by the parsing step below — the
+    /// user only controls the instructions, not the data layout.
     static func resolveFile(
         agent: AgentDefinition,
+        template: String,
         filePath: String,
         local: String,
         base: String?,
@@ -35,7 +45,8 @@ enum MergeAgent {
         language: String?,
         timeout: TimeInterval = 90
     ) async throws -> String {
-        let prompt = resolvePrompt(
+        let prompt = resolveFilePrompt(
+            template: template,
             filePath: filePath,
             local: local,
             base: base,
@@ -47,9 +58,40 @@ enum MergeAgent {
             agent: agent,
             input: "",
             prompt: prompt,
-            timeout: timeout
+            timeout: timeout,
+            bypassPermissions: true
         )
         return parseResolveOutput(result.body.isEmpty ? result.subject : result.body)
+    }
+
+    /// Single workspace-level resolve. Hands the agent CWD'd at the
+    /// worktree and asks it to find every conflicted file (via `git
+    /// status`), reconcile each in-place, and stage the result.
+    /// Returns whatever the agent prints — surfaced as a summary in
+    /// the Conflicts section banner. Caller is responsible for
+    /// refreshing afterwards; we don't try to enumerate touched paths
+    /// from the prompt response because the agent's output format
+    /// isn't pinned.
+    ///
+    /// Passes `bypassPermissions: true` because the whole point of the
+    /// bulk action is to let the agent write files + run `git add`
+    /// non-interactively. Without the bypass flag, claude/cursor/etc.
+    /// stop on the first write and ask for approval the user can't
+    /// answer (we're not running the agent in a TTY).
+    static func resolveAllInWorkspace(
+        agent: AgentDefinition,
+        prompt: String,
+        worktreePath: URL,
+        timeout: TimeInterval = 600
+    ) async throws -> GeneratedMessage {
+        return try await AgentRunner.runPrompt(
+            agent: agent,
+            input: "",
+            prompt: prompt,
+            workingDirectory: worktreePath.path,
+            timeout: timeout,
+            bypassPermissions: true
+        )
     }
 
     // MARK: - Prompts (pulled out for testability)
@@ -74,7 +116,13 @@ enum MergeAgent {
         return lines.joined(separator: "\n")
     }
 
-    static func resolvePrompt(
+    /// Builds the full prompt by substituting `{filePath}` /
+    /// `{language}` placeholders in `template` and appending the
+    /// three-side dump. Unknown `{x}` placeholders pass through
+    /// untouched so a user's custom template that uses other tokens
+    /// (e.g. for their own bookkeeping) isn't silently mangled.
+    static func resolveFilePrompt(
+        template: String,
         filePath: String,
         local: String,
         base: String?,
@@ -82,15 +130,10 @@ enum MergeAgent {
         mergedWithMarkers: String,
         language: String?
     ) -> String {
-        var lines: [String] = []
-        lines.append("You are resolving a Git merge conflict in \(filePath).")
-        if let language, !language.isEmpty {
-            lines.append("Language: \(language)")
-        }
-        lines.append("Reconcile LOCAL and REMOTE intent into the smallest correct merged file.")
-        lines.append("Output ONLY the resolved file contents — no conflict markers, no prose,")
-        lines.append("no markdown fences, no commentary.")
-        lines.append("")
+        var prompt = template
+        prompt = prompt.replacingOccurrences(of: "{filePath}", with: filePath)
+        prompt = prompt.replacingOccurrences(of: "{language}", with: language ?? "")
+        var lines: [String] = [prompt, ""]
         lines.append("=== LOCAL ===")
         lines.append(local)
         if let base, !base.isEmpty {

--- a/Alas/Sources/Center/MergeAgent.swift
+++ b/Alas/Sources/Center/MergeAgent.swift
@@ -34,6 +34,13 @@ enum MergeAgent {
     /// three-side dump (LOCAL/BASE/REMOTE/MERGED) is appended verbatim
     /// because its format is consumed by the parsing step below — the
     /// user only controls the instructions, not the data layout.
+    ///
+    /// Intentionally does NOT pass `bypassPermissions`. This is a
+    /// proposal-only call: the agent should produce text on stdout that
+    /// alas previews to the user (Apply/Cancel overlay) before any
+    /// workspace mutation. Giving the agent skip-permissions would let
+    /// it write/stage files behind the user's back, breaking the
+    /// review boundary that the proposal overlay exists to enforce.
     static func resolveFile(
         agent: AgentDefinition,
         template: String,
@@ -58,8 +65,7 @@ enum MergeAgent {
             agent: agent,
             input: "",
             prompt: prompt,
-            timeout: timeout,
-            bypassPermissions: true
+            timeout: timeout
         )
         return parseResolveOutput(result.body.isEmpty ? result.subject : result.body)
     }

--- a/Alas/Sources/Center/MergeAgent.swift
+++ b/Alas/Sources/Center/MergeAgent.swift
@@ -89,8 +89,14 @@ enum MergeAgent {
         prompt: String,
         worktreePath: URL,
         timeout: TimeInterval = 600
-    ) async throws -> GeneratedMessage {
-        return try await AgentRunner.runPrompt(
+    ) async throws -> String {
+        // Use the raw-stdout variant: `AgentMessageParser` collapses
+        // any subsequent same-paragraph lines after the first into the
+        // body, so a typical "one line per file" summary would have
+        // every line after the first dropped from `subject` and the
+        // banner tooltip would only show the first file. The raw
+        // output preserves the full per-file breakdown.
+        return try await AgentRunner.runPromptRaw(
             agent: agent,
             input: "",
             prompt: prompt,

--- a/Alas/Sources/Center/MergeConflictResolvedEmptyView.swift
+++ b/Alas/Sources/Center/MergeConflictResolvedEmptyView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// Shown in a merge-conflict tab when the underlying file is no longer
+/// in a conflicted state (resolved or staged from elsewhere while the
+/// tab stayed open). Matches the centered-empty-state pattern used by
+/// `EmptyTabView` so the user gets a clear "nothing to do here" signal
+/// instead of a mid-pane error banner.
+struct MergeConflictResolvedEmptyView: View {
+    let relativePath: String
+    let onOpenFile: () -> Void
+    let onCloseTab: () -> Void
+
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        VStack(spacing: 14) {
+            ZStack {
+                LinearGradient(
+                    colors: [theme.color("bg-3"), theme.color("bg-2")],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .frame(width: 80, height: 80)
+                .clipShape(RoundedRectangle(cornerRadius: 22))
+                Image(systemName: "checkmark.seal.fill")
+                    .font(.system(size: 30))
+                    .foregroundColor(.green)
+            }
+            Text("No conflict here")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            Text("\(relativePath) is no longer in a conflicted state.")
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg-dim"))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 400)
+            HStack(spacing: 8) {
+                AlasButton(title: "Open file", icon: "code", style: .primary, action: onOpenFile)
+                AlasButton(title: "Close tab", icon: "x", style: .normal, action: onCloseTab)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.color("bg-1"))
+    }
+}

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -155,9 +155,16 @@ struct MergeConflictResultView: NSViewRepresentable {
                     ? NSRange(location: marker.location, length: marker.length - 1)
                     : marker
                 if affectedCharRange.length == 0 {
-                    // Insertion: block only when the cursor is strictly
-                    // inside the marker body (not at its start or end).
-                    if affectedCharRange.location > body.location,
+                    // Insertion: block when the cursor is anywhere from
+                    // the start of the marker body up to (but not
+                    // including) its end. We can't distinguish a
+                    // newline-only insert (safe — pushes the marker
+                    // down) from a text insert (unsafe — prepends to
+                    // the marker characters) without inspecting the
+                    // replacement string, so just block all of them.
+                    // Users can insert content on the line ABOVE the
+                    // marker instead.
+                    if affectedCharRange.location >= body.location,
                        affectedCharRange.location < NSMaxRange(body) {
                         return false
                     }

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -413,7 +413,15 @@ private struct HunkClassification {
                 markerLineRanges.append(range)
                 continue
             }
-            if line.hasPrefix(">>>>>>> ") {
+            // End marker only valid in REMOTE. `ConflictMarkerParser`
+            // technically scans for end-prefix earlier in its else-if
+            // chain, but if a separator was never seen it bails out
+            // and emits the whole "block" as plain text — so the
+            // effective end-marker semantics ARE remote-only. Mirror
+            // that here so a `>>>>>>> ` line inside LOCAL/BASE content
+            // (docs/test fixtures showing markers) doesn't prematurely
+            // close the block in the classifier.
+            if state == .remote, line.hasPrefix(">>>>>>> ") {
                 lines.append(Line(range: range, kind: .markerEnd))
                 markerLineRanges.append(range)
                 let start = lineRanges[blockStartLineIdx].location

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -173,23 +173,31 @@ struct MergeConflictResultView: NSViewRepresentable {
                     // upper bound, typing at end-of-marker-line would
                     // append text directly to the marker (e.g.
                     // `>>>>>>> feature` + 'x' → `>>>>>>> featurex`),
-                    // corrupting it. Positions on adjacent lines stay
-                    // editable because they're outside this range.
+                    // corrupting it. Inserting at NSMaxRange(marker)
+                    // (start of the next line) stays allowed.
                     if affectedCharRange.location >= body.location,
                        affectedCharRange.location <= NSMaxRange(body) {
                         return false
                     }
-                } else if NSIntersectionRange(body, affectedCharRange).length > 0 {
-                    return false
-                }
-                // Backspace into the marker line (selection at marker
-                // start, deleting the previous newline) is also rejected
-                // because deleting the newline would merge a content
-                // line into the marker line.
-                if affectedCharRange.length > 0,
-                   affectedCharRange.location < marker.location,
-                   NSMaxRange(affectedCharRange) > marker.location {
-                    return false
+                } else {
+                    // Deletion/replacement: protect the FULL marker
+                    // range (including the trailing newline). Forward-
+                    // delete at end of marker line or backspace at
+                    // start of the line below both remove the trailing
+                    // `\n` and merge the next content line into the
+                    // marker — same corruption mode as editing the
+                    // marker text itself.
+                    if NSIntersectionRange(marker, affectedCharRange).length > 0 {
+                        return false
+                    }
+                    // Backspace at start of marker line (selection
+                    // ending exactly at marker.location) deletes the
+                    // previous line's newline and merges the previous
+                    // content line into the marker line. Same problem,
+                    // different boundary.
+                    if NSMaxRange(affectedCharRange) == marker.location {
+                        return false
+                    }
                 }
             }
             return true

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -155,17 +155,17 @@ struct MergeConflictResultView: NSViewRepresentable {
                     ? NSRange(location: marker.location, length: marker.length - 1)
                     : marker
                 if affectedCharRange.length == 0 {
-                    // Insertion: block when the cursor is anywhere from
-                    // the start of the marker body up to (but not
-                    // including) its end. We can't distinguish a
-                    // newline-only insert (safe — pushes the marker
-                    // down) from a text insert (unsafe — prepends to
-                    // the marker characters) without inspecting the
-                    // replacement string, so just block all of them.
-                    // Users can insert content on the line ABOVE the
-                    // marker instead.
+                    // Insertion: block the entire closed range
+                    // [body.location, NSMaxRange(body)] — anywhere on
+                    // the marker line including the position right
+                    // before its trailing newline. Without the inclusive
+                    // upper bound, typing at end-of-marker-line would
+                    // append text directly to the marker (e.g.
+                    // `>>>>>>> feature` + 'x' → `>>>>>>> featurex`),
+                    // corrupting it. Positions on adjacent lines stay
+                    // editable because they're outside this range.
                     if affectedCharRange.location >= body.location,
-                       affectedCharRange.location < NSMaxRange(body) {
+                       affectedCharRange.location <= NSMaxRange(body) {
                         return false
                     }
                 } else if NSIntersectionRange(body, affectedCharRange).length > 0 {

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -145,13 +145,24 @@ struct MergeConflictResultView: NSViewRepresentable {
             shouldChangeTextIn affectedCharRange: NSRange,
             replacementString: String?
         ) -> Bool {
+            let storage = textView.string as NSString
             for marker in markerLineRanges {
-                // `marker` includes the trailing newline; we don't want
-                // to block an insertion at the exact end of the marker
-                // line (which would push the marker down by inserting
-                // before it on the next line). Strip the newline for
-                // the intersection check.
-                let body = marker.length > 0
+                // `marker` includes the trailing newline when one
+                // exists. We strip the newline so an insertion at the
+                // exact end of the marker line (which would push the
+                // marker down by inserting before it on the next line)
+                // stays allowed. But when the buffer ends without a
+                // trailing newline — common for files that never had
+                // one — the final marker line has no newline to strip,
+                // so we use the full range unchanged. Without this
+                // check the last visible character of that final
+                // marker (e.g. the last `>`) would fall outside the
+                // protected range and could be edited or appended.
+                let endsWithNewline =
+                    marker.length > 0 &&
+                    NSMaxRange(marker) <= storage.length &&
+                    storage.character(at: NSMaxRange(marker) - 1) == 0x0A
+                let body = endsWithNewline
                     ? NSRange(location: marker.location, length: marker.length - 1)
                     : marker
                 if affectedCharRange.length == 0 {

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -354,7 +354,13 @@ private struct HunkClassification {
         var blockStartLineIdx = 0
         for (idx, range) in lineRanges.enumerated() {
             let line = nsString.substring(with: range)
-            if line.hasPrefix("<<<<<<<") {
+            // Match `ConflictMarkerParser` exactly: begin/base/end have
+            // a trailing space + label; mid is the literal `=======`
+            // (so a content line like "======= Section" doesn't get
+            // misclassified as a separator). Strip the trailing newline
+            // for the mid exact match because `line` includes it.
+            let trimmed = line.hasSuffix("\n") ? String(line.dropLast()) : line
+            if line.hasPrefix("<<<<<<< ") {
                 state = .local
                 blockStartLineIdx = idx
                 lines.append(Line(range: range, kind: .markerBegin))
@@ -368,13 +374,13 @@ private struct HunkClassification {
                 markerLineRanges.append(range)
                 continue
             }
-            if line.hasPrefix("=======") {
+            if trimmed == "=======" {
                 state = .remote
                 lines.append(Line(range: range, kind: .markerSeparator))
                 markerLineRanges.append(range)
                 continue
             }
-            if line.hasPrefix(">>>>>>>") {
+            if line.hasPrefix(">>>>>>> ") {
                 lines.append(Line(range: range, kind: .markerEnd))
                 markerLineRanges.append(range)
                 let start = lineRanges[blockStartLineIdx].location

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -379,7 +379,14 @@ private struct HunkClassification {
             // misclassified as a separator). Strip the trailing newline
             // for the mid exact match because `line` includes it.
             let trimmed = line.hasSuffix("\n") ? String(line.dropLast()) : line
-            if line.hasPrefix("<<<<<<< ") {
+            // Only treat `<<<<<<< ` as a marker when we're OUTSIDE a
+            // conflict. `ConflictMarkerParser` doesn't recurse, so a
+            // line with that prefix appearing inside LOCAL/BASE/REMOTE
+            // content (e.g. a docstring or test fixture about merge
+            // markers) is content, not a marker. Recursing here would
+            // misclassify those lines as non-editable AND corrupt
+            // navigation by overwriting `blockStartLineIdx` mid-block.
+            if state == .outside, line.hasPrefix("<<<<<<< ") {
                 state = .local
                 blockStartLineIdx = idx
                 lines.append(Line(range: range, kind: .markerBegin))

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -394,13 +394,20 @@ private struct HunkClassification {
                 continue
             }
             if state == .outside { continue }
-            if line.hasPrefix("||||||| ") {
+            // Match `ConflictMarkerParser`'s state restrictions:
+            //  - baseMarker is only valid before the separator (i.e.
+            //    while still in LOCAL). A `||||||| ` line that appears
+            //    in REMOTE content is content, not a marker.
+            //  - midMarker is only valid before REMOTE starts (in
+            //    LOCAL or BASE). A `=======` line that appears in
+            //    REMOTE content is content, not a marker.
+            if state == .local, line.hasPrefix("||||||| ") {
                 state = .base
                 lines.append(Line(range: range, kind: .markerBase))
                 markerLineRanges.append(range)
                 continue
             }
-            if trimmed == "=======" {
+            if (state == .local || state == .base), trimmed == "=======" {
                 state = .remote
                 lines.append(Line(range: range, kind: .markerSeparator))
                 markerLineRanges.append(range)

--- a/Alas/Sources/Center/MergeConflictResultView.swift
+++ b/Alas/Sources/Center/MergeConflictResultView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 
 /// Editable RESULT column for the merge editor. Bound to the model's
 /// `resultText`. Reuses `MergeConflictTextStorage` for syntax highlighting
-/// and overlays yellow shading on conflict marker blocks so the user can
-/// see at a glance which regions still need resolution.
+/// and overlays per-hunk shading on conflict marker blocks so the user
+/// can see at a glance which side each line belongs to (LOCAL / BASE /
+/// REMOTE), and which lines are the markers themselves (non-editable).
 struct MergeConflictResultView: NSViewRepresentable {
     @Binding var text: String
     let fileExtension: String
@@ -32,7 +33,7 @@ struct MergeConflictResultView: NSViewRepresentable {
         scroll.autohidesScrollers = true
         scroll.borderType = .noBorder
 
-        let textView = NSTextView()
+        let textView = MergeConflictResultTextView()
         textView.isEditable = true
         textView.isSelectable = true
         textView.isVerticallyResizable = true
@@ -46,7 +47,7 @@ struct MergeConflictResultView: NSViewRepresentable {
         textView.autoresizingMask = [.width]
         textView.drawsBackground = true
         textView.backgroundColor = NSColor(theme.color("bg-1"))
-        textView.textContainerInset = NSSize(width: 6, height: 6)
+        textView.textContainerInset = NSSize(width: 10, height: 6)
         textView.delegate = context.coordinator
         scroll.documentView = textView
         context.coordinator.textView = textView
@@ -54,11 +55,12 @@ struct MergeConflictResultView: NSViewRepresentable {
     }
 
     func updateNSView(_ scroll: NSScrollView, context: Context) {
-        guard let textView = scroll.documentView as? NSTextView else { return }
+        guard let textView = scroll.documentView as? MergeConflictResultTextView else { return }
         // Re-render whenever text changed OR the showBase toggle changed since
         // last render (italic/muted attrs would otherwise persist after toggle-off).
         let current = textView.string
         let needsFullRender = current != text || context.coordinator.lastShowBase != showBase
+        let classification = HunkClassification.compute(in: text)
         if needsFullRender {
             let attr = MergeConflictTextStorage.highlightedAttributedString(
                 text: text,
@@ -67,17 +69,21 @@ struct MergeConflictResultView: NSViewRepresentable {
                 fontSize: codeFontSize,
                 theme: theme
             )
-            applyConflictShading(to: attr, text: text, theme: theme)
+            applyHunkShading(to: attr, classification: classification, theme: theme)
             textView.textStorage?.setAttributedString(attr)
             context.coordinator.lastShowBase = showBase
         } else {
             // Even when the string is unchanged, the conflict regions may have
             // shifted (a typed edit can resolve a marker). Re-apply shading.
             if let storage = textView.textStorage {
-                applyConflictShading(to: storage, text: text, theme: theme)
+                applyHunkShading(to: storage, classification: classification, theme: theme)
             }
         }
         textView.backgroundColor = NSColor(theme.color("bg-1"))
+        textView.hunkBars = sideBars(for: classification, theme: theme)
+        textView.markerLineRanges = classification.markerLineRanges
+        context.coordinator.markerLineRanges = classification.markerLineRanges
+        textView.needsDisplay = true
 
         // Scroll + select the current conflict when navigation lands on
         // a new ordinal OR when an accept removes a block and renumbers
@@ -87,7 +93,7 @@ struct MergeConflictResultView: NSViewRepresentable {
         let trigger = ReselectTrigger(index: currentConflictIndex, count: conflictCount)
         if trigger != context.coordinator.lastReselectTrigger {
             if let index = currentConflictIndex,
-               let range = Self.conflictRange(in: text, at: index) {
+               let range = classification.conflictRange(at: index) {
                 textView.setSelectedRange(range)
                 textView.scrollRangeToVisible(range)
             }
@@ -116,106 +122,272 @@ struct MergeConflictResultView: NSViewRepresentable {
         /// user actually navigates or a structural change (accept, agent
         /// apply) renumbers conflicts.
         var lastReselectTrigger: ReselectTrigger?
+        /// Marker line ranges from the most recent classification. Used by
+        /// `shouldChangeTextIn:` to block edits that would touch a
+        /// marker line.
+        var markerLineRanges: [NSRange] = []
+
         init(_ text: Binding<String>) { self.text = text }
+
         func textDidChange(_ notification: Notification) {
             guard let tv = notification.object as? NSTextView else { return }
             text.wrappedValue = tv.string
         }
-    }
 
-    /// Returns the NSRange covering the Nth conflict block's lines in
-    /// `text`, or nil when the index is out of bounds.
-    private static func conflictRange(in text: String, at ordinal: Int) -> NSRange? {
-        let regions = ConflictMarkerParser.parse(text)
-        var seen = 0
-        let nsString = text as NSString
-        let lineRanges = computeLineRanges(in: nsString)
-        for region in regions {
-            guard case .conflict(let block) = region else { continue }
-            if seen == ordinal {
-                let lower = max(block.lineRangeInMerged.lowerBound, 0)
-                let upper = min(block.lineRangeInMerged.upperBound, lineRanges.count - 1)
-                guard upper >= lower, upper < lineRanges.count else { return nil }
-                let start = lineRanges[lower].location
-                let end = NSMaxRange(lineRanges[upper])
-                return NSRange(location: start, length: end - start)
-            }
-            seen += 1
-        }
-        return nil
-    }
-
-    /// Applies a yellow background to each line range that falls inside a
-    /// `<<<<<<< ... >>>>>>>` block in `text`. Also applies italic + muted
-    /// attributes to BASE lines when `showBase` is true.
-    /// Accepts any `NSMutableAttributedString` (including `NSTextStorage`,
-    /// which IS-A `NSMutableAttributedString`).
-    private func applyConflictShading(
-        to storage: NSMutableAttributedString,
-        text: String,
-        theme: Theme
-    ) {
-        let regions = ConflictMarkerParser.parse(text)
-        let highlight = NSColor(theme.color("warn")).withAlphaComponent(0.18)
-        // We deliberately do NOT clear .font / .foregroundColor here. Clearing
-        // them over conflict regions would strip the TreeSitter syntax styling
-        // from LOCAL/REMOTE lines. The Coordinator's `lastShowBase` tracking in
-        // `updateNSView` forces a full re-render whenever `showBase` toggles,
-        // which is when stale BASE styling actually matters in practice.
-        storage.removeAttribute(.backgroundColor, range: NSRange(location: 0, length: storage.length))
-        let nsString = text as NSString
-        let lineRanges = Self.computeLineRanges(in: nsString)
-        for region in regions {
-            if case .conflict(let block) = region {
-                let lower = max(block.lineRangeInMerged.lowerBound, 0)
-                let upper = min(block.lineRangeInMerged.upperBound, lineRanges.count - 1)
-                guard upper >= lower, upper < lineRanges.count else { continue }
-                let start = lineRanges[lower].location
-                let end = NSMaxRange(lineRanges[upper])
-                storage.addAttribute(.backgroundColor, value: highlight,
-                                     range: NSRange(location: start, length: end - start))
-
-                if showBase, block.base != nil {
-                    applyBaseStyling(in: storage,
-                                     fullText: nsString,
-                                     lineRanges: lineRanges,
-                                     conflictRange: lower ... upper,
-                                     theme: theme)
+        /// Blocks edits that would mutate a conflict marker line. The
+        /// hunk content lines (between markers) stay fully editable —
+        /// this is the user's working buffer. Marker lines themselves
+        /// (`<<<<<<<`, `|||||||`, `=======`, `>>>>>>>`) are structural;
+        /// stray edits there silently break conflict-state parsing for
+        /// Use LOCAL/REMOTE/BOTH and Mark resolved.
+        func textView(
+            _ textView: NSTextView,
+            shouldChangeTextIn affectedCharRange: NSRange,
+            replacementString: String?
+        ) -> Bool {
+            for marker in markerLineRanges {
+                // `marker` includes the trailing newline; we don't want
+                // to block an insertion at the exact end of the marker
+                // line (which would push the marker down by inserting
+                // before it on the next line). Strip the newline for
+                // the intersection check.
+                let body = marker.length > 0
+                    ? NSRange(location: marker.location, length: marker.length - 1)
+                    : marker
+                if affectedCharRange.length == 0 {
+                    // Insertion: block only when the cursor is strictly
+                    // inside the marker body (not at its start or end).
+                    if affectedCharRange.location > body.location,
+                       affectedCharRange.location < NSMaxRange(body) {
+                        return false
+                    }
+                } else if NSIntersectionRange(body, affectedCharRange).length > 0 {
+                    return false
+                }
+                // Backspace into the marker line (selection at marker
+                // start, deleting the previous newline) is also rejected
+                // because deleting the newline would merge a content
+                // line into the marker line.
+                if affectedCharRange.length > 0,
+                   affectedCharRange.location < marker.location,
+                   NSMaxRange(affectedCharRange) > marker.location {
+                    return false
                 }
             }
+            return true
         }
     }
 
-    /// Walks the lines inside a conflict marker block and applies italic +
-    /// muted-color attributes to the lines that fall between `||||||| ` and
-    /// `=======` markers. Called only when `showBase == true`.
-    private func applyBaseStyling(
-        in storage: NSMutableAttributedString,
-        fullText: NSString,
-        lineRanges: [NSRange],
-        conflictRange: ClosedRange<Int>,
+    /// Walks the marker classification and applies per-hunk background
+    /// tints + italic/muted styling for BASE lines (when `showBase`).
+    /// Does NOT clear .font / .foregroundColor outside of BASE lines so
+    /// TreeSitter syntax styling on LOCAL/REMOTE content stays intact.
+    private func applyHunkShading(
+        to storage: NSMutableAttributedString,
+        classification: HunkClassification,
         theme: Theme
     ) {
-        var inBase = false
-        let italic = CenterTypography.resolveCodeFont(family: codeFontFamily, size: codeFontSize)
-            .italicVariant()
-        let muted = NSColor(theme.color("fg-dim"))
-        for lineIdx in conflictRange {
-            let lineRange = lineRanges[lineIdx]
-            let lineText = fullText.substring(with: lineRange)
-            if lineText.hasPrefix("||||||| ") {
-                inBase = true
-                continue
+        storage.removeAttribute(.backgroundColor,
+                                range: NSRange(location: 0, length: storage.length))
+        let localTint = NSColor.systemGreen.withAlphaComponent(0.12)
+        let remoteTint = NSColor.systemBlue.withAlphaComponent(0.12)
+        let baseTint = NSColor(theme.color("fg-dim")).withAlphaComponent(0.10)
+        let markerTint = NSColor(theme.color("warn")).withAlphaComponent(0.20)
+        for line in classification.lines {
+            let color: NSColor
+            switch line.kind {
+            case .markerBegin, .markerBase, .markerSeparator, .markerEnd:
+                color = markerTint
+            case .contentLocal:
+                color = localTint
+            case .contentBase:
+                color = baseTint
+            case .contentRemote:
+                color = remoteTint
             }
-            if lineText.hasPrefix("=======") {
-                inBase = false
-                continue
-            }
-            if inBase {
-                storage.addAttribute(.font, value: italic, range: lineRange)
-                storage.addAttribute(.foregroundColor, value: muted, range: lineRange)
+            storage.addAttribute(.backgroundColor, value: color, range: line.range)
+        }
+        if showBase {
+            let italic = CenterTypography
+                .resolveCodeFont(family: codeFontFamily, size: codeFontSize)
+                .italicVariant()
+            let muted = NSColor(theme.color("fg-dim"))
+            for line in classification.lines where line.kind == .contentBase {
+                storage.addAttribute(.font, value: italic, range: line.range)
+                storage.addAttribute(.foregroundColor, value: muted, range: line.range)
             }
         }
+    }
+
+    /// Pairs the line range of each hunk content line with the color of
+    /// the side bar to draw alongside it. The NSTextView subclass uses
+    /// these in `drawBackground(in:)` to paint a vertical stripe in the
+    /// gutter so the side is identifiable even when the user scrolls
+    /// past the markers.
+    private func sideBars(
+        for classification: HunkClassification,
+        theme: Theme
+    ) -> [MergeConflictResultTextView.HunkBar] {
+        let localColor = NSColor.systemGreen.withAlphaComponent(0.85)
+        let remoteColor = NSColor.systemBlue.withAlphaComponent(0.85)
+        let baseColor = NSColor(theme.color("fg-dim")).withAlphaComponent(0.7)
+        var bars: [MergeConflictResultTextView.HunkBar] = []
+        for line in classification.lines {
+            let color: NSColor?
+            switch line.kind {
+            case .contentLocal:        color = localColor
+            case .contentRemote:       color = remoteColor
+            case .contentBase:         color = showBase ? baseColor : nil
+            case .markerBegin, .markerBase, .markerSeparator, .markerEnd:
+                color = nil
+            }
+            if let color {
+                bars.append(.init(range: line.range, color: color))
+            }
+        }
+        return bars
+    }
+}
+
+/// NSTextView subclass that paints a vertical color bar in the gutter
+/// for each conflict-hunk line range, so the user can see which side
+/// (LOCAL / BASE / REMOTE) a given line belongs to even when scrolled
+/// past the markers themselves.
+final class MergeConflictResultTextView: NSTextView {
+    struct HunkBar {
+        let range: NSRange
+        let color: NSColor
+    }
+
+    var hunkBars: [HunkBar] = []
+    /// Mirror of `Coordinator.markerLineRanges`, also stored on the
+    /// view so `drawBackground` can flag the marker rows visually
+    /// (subtle left indicator) without having to ask the delegate.
+    var markerLineRanges: [NSRange] = []
+
+    /// Width of the side bar in points. Fits inside the
+    /// `textContainerInset.width` so it doesn't visually clip glyphs.
+    private let barWidth: CGFloat = 3
+    /// Inset from the view's left edge to the bar's left edge.
+    private let barLeftInset: CGFloat = 3
+
+    override func drawBackground(in rect: NSRect) {
+        super.drawBackground(in: rect)
+        guard let layoutManager,
+              let textContainer
+        else { return }
+        let origin = textContainerOrigin
+        for bar in hunkBars {
+            let glyphRange = layoutManager.glyphRange(
+                forCharacterRange: bar.range,
+                actualCharacterRange: nil
+            )
+            var boundingRect = layoutManager.boundingRect(
+                forGlyphRange: glyphRange,
+                in: textContainer
+            )
+            boundingRect = boundingRect.offsetBy(dx: origin.x, dy: origin.y)
+            let barRect = NSRect(
+                x: barLeftInset,
+                y: boundingRect.minY,
+                width: barWidth,
+                height: boundingRect.height
+            )
+            bar.color.setFill()
+            barRect.fill()
+        }
+    }
+}
+
+/// Per-line classification of every line in the buffer relative to the
+/// conflict-marker grammar. The view uses this to know where to apply
+/// background tints, where to draw side bars, and which line ranges to
+/// block from editing.
+private struct HunkClassification {
+    enum Kind {
+        case markerBegin
+        case markerBase
+        case markerSeparator
+        case markerEnd
+        case contentLocal
+        case contentBase
+        case contentRemote
+    }
+
+    struct Line {
+        let range: NSRange
+        let kind: Kind
+    }
+
+    let lines: [Line]
+    /// NSRanges for the conflict-block lines (markers + content) per
+    /// unresolved conflict, in document order. Used by `conflictRange`
+    /// to support prev/next navigation.
+    let conflictBlocks: [NSRange]
+    /// Just the marker-line NSRanges, used to block edits on those
+    /// lines via `shouldChangeTextIn`.
+    let markerLineRanges: [NSRange]
+
+    func conflictRange(at ordinal: Int) -> NSRange? {
+        guard ordinal >= 0, ordinal < conflictBlocks.count else { return nil }
+        return conflictBlocks[ordinal]
+    }
+
+    static func compute(in text: String) -> HunkClassification {
+        let nsString = text as NSString
+        let lineRanges = computeLineRanges(in: nsString)
+        var lines: [Line] = []
+        var conflictBlocks: [NSRange] = []
+        var markerLineRanges: [NSRange] = []
+        // State machine across lines: scan for begin → optional base → separator → end.
+        // When inside, every line is classified; outside, we don't emit a Line
+        // (those lines have no tint).
+        enum State { case outside, local, base, remote }
+        var state = State.outside
+        var blockStartLineIdx = 0
+        for (idx, range) in lineRanges.enumerated() {
+            let line = nsString.substring(with: range)
+            if line.hasPrefix("<<<<<<<") {
+                state = .local
+                blockStartLineIdx = idx
+                lines.append(Line(range: range, kind: .markerBegin))
+                markerLineRanges.append(range)
+                continue
+            }
+            if state == .outside { continue }
+            if line.hasPrefix("||||||| ") {
+                state = .base
+                lines.append(Line(range: range, kind: .markerBase))
+                markerLineRanges.append(range)
+                continue
+            }
+            if line.hasPrefix("=======") {
+                state = .remote
+                lines.append(Line(range: range, kind: .markerSeparator))
+                markerLineRanges.append(range)
+                continue
+            }
+            if line.hasPrefix(">>>>>>>") {
+                lines.append(Line(range: range, kind: .markerEnd))
+                markerLineRanges.append(range)
+                let start = lineRanges[blockStartLineIdx].location
+                let end = NSMaxRange(range)
+                conflictBlocks.append(NSRange(location: start, length: end - start))
+                state = .outside
+                continue
+            }
+            switch state {
+            case .local:   lines.append(Line(range: range, kind: .contentLocal))
+            case .base:    lines.append(Line(range: range, kind: .contentBase))
+            case .remote:  lines.append(Line(range: range, kind: .contentRemote))
+            case .outside: break // unreachable — guarded above
+            }
+        }
+        return HunkClassification(
+            lines: lines,
+            conflictBlocks: conflictBlocks,
+            markerLineRanges: markerLineRanges
+        )
     }
 
     /// NSRanges for each line (split on `\n`), preserving trailing-empty semantics.

--- a/Alas/Sources/Center/MergeConflictTabModel.swift
+++ b/Alas/Sources/Center/MergeConflictTabModel.swift
@@ -18,6 +18,11 @@ final class MergeConflictTabModel {
     var resultText: String = ""
     /// Set when `load()` fails. Cleared on successful (re)load.
     private(set) var loadError: String?
+    /// `true` when the most recent load failed specifically because the
+    /// file is no longer in a conflicted state (resolved or staged from
+    /// elsewhere while this tab stayed open). Drives the empty-state
+    /// pane rendering — distinct from a generic load failure.
+    private(set) var notInConflictedState: Bool = false
     /// Per-conflict-block one-line annotation populated by the agent.
     /// Keyed by a stable identity derived from the conflict's three sides
     /// (NOT by ordinal — ordinals shift when prior conflicts are resolved).
@@ -111,6 +116,7 @@ final class MergeConflictTabModel {
             self.agentProposal = nil
             self.agentBusy = false
             self.loadError = nil
+            self.notInConflictedState = false
         } catch {
             self.conflictedFile = nil
             self.regions = []
@@ -122,6 +128,11 @@ final class MergeConflictTabModel {
             self.agentBusy = false
             self.loadError = (error as? LocalizedError)?.errorDescription
                 ?? error.localizedDescription
+            if case ConflictedFileError.notConflicted = error {
+                self.notInConflictedState = true
+            } else {
+                self.notInConflictedState = false
+            }
             logger.error("merge-conflict load failed: \(self.loadError ?? "", privacy: .public)")
         }
         // Bump AFTER state is committed so view-side reload triggers read
@@ -343,7 +354,11 @@ final class MergeConflictTabModel {
     /// for a fresh conflict on the same path), the late response is dropped:
     /// applying it would clobber the freshly loaded buffer with stale content.
     /// We detect that via the `loadGeneration` token captured at request start.
-    func requestAgentResolveFile(using agent: AgentDefinition, language: String?) async {
+    func requestAgentResolveFile(
+        using agent: AgentDefinition,
+        template: String,
+        language: String?
+    ) async {
         guard let file = conflictedFile else { return }
         let startGeneration = loadGeneration
         agentBusy = true
@@ -355,6 +370,7 @@ final class MergeConflictTabModel {
         do {
             let proposal = try await MergeAgent.resolveFile(
                 agent: agent,
+                template: template,
                 filePath: relativePath,
                 local: file.local ?? "",
                 base: file.base,

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -28,6 +28,23 @@ struct MergeConflictTabView: View {
 
     var body: some View {
         ZStack {
+            if model.notInConflictedState {
+                MergeConflictResolvedEmptyView(
+                    relativePath: tabState.relativePath,
+                    onOpenFile: {
+                        state.openFile(
+                            relativePath: tabState.relativePath,
+                            worktreeId: worktree.id
+                        )
+                    },
+                    onCloseTab: {
+                        state.closeTab(
+                            worktreeId: worktree.id,
+                            tabId: tabState.id
+                        )
+                    }
+                )
+            } else {
             VStack(spacing: 0) {
                 MergeConflictToolbar(
                     conflictCount: model.conflictCount,
@@ -46,8 +63,13 @@ struct MergeConflictTabView: View {
                     onAcceptBoth: { model.acceptBoth() },
                     onAskAgentResolve: {
                         guard let agent = resolvedAgent else { return }
+                        let template = state.config.changes.mergeSingleResolvePrompt
                         Task {
-                            await model.requestAgentResolveFile(using: agent, language: fileLanguage)
+                            await model.requestAgentResolveFile(
+                                using: agent,
+                                template: template,
+                                language: fileLanguage
+                            )
                         }
                     },
                     onMarkResolved: {
@@ -79,6 +101,7 @@ struct MergeConflictTabView: View {
                     )
                 }
                 content
+            }
             }
             if let proposal = model.agentProposal {
                 MergeConflictAgentProposalView(

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -127,9 +127,18 @@ struct AppConfig: Codable, Equatable {
     struct Changes: Codable, Equatable {
         var aiToolId: String   // "claude" | "codex" | "cursor-agent" | "pi" | "none"
         var prompt: String
+        /// Workspace-level "fix every merge conflict in this repo"
+        /// prompt fed to the agent CWD'd at the worktree. The agent
+        /// uses its own filesystem tools to enumerate + reconcile.
+        var mergeBulkResolvePrompt: String
+        /// Single-file resolve template — the instructions portion
+        /// only. The three sides (LOCAL/BASE/REMOTE/MERGED) are
+        /// appended verbatim by `MergeAgent`. `{filePath}` and
+        /// `{language}` are substituted; anything else passes through.
+        var mergeSingleResolvePrompt: String
 
         enum CodingKeys: String, CodingKey {
-            case aiToolId, prompt
+            case aiToolId, prompt, mergeBulkResolvePrompt, mergeSingleResolvePrompt
         }
     }
 
@@ -210,7 +219,12 @@ struct AppConfig: Codable, Equatable {
             userDefinedRecipes: [:]
         ),
         markdown: Markdown(defaultViewMode: .editor),
-        changes: Changes(aiToolId: "none", prompt: AppConfig.defaultCommitPrompt),
+        changes: Changes(
+            aiToolId: "none",
+            prompt: AppConfig.defaultCommitPrompt,
+            mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
+            mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt
+        ),
         agents: Agents(
             builtinState: [:],
             custom: [],
@@ -247,6 +261,40 @@ extension AppConfig {
     When amending, the previous commit's message is provided — prefer
     refining it over starting from scratch unless the diff has materially
     changed.
+    """
+
+    static let defaultMergeBulkResolvePrompt = """
+    You are resolving every Git merge conflict in this workspace.
+
+    Procedure:
+    1. Run `git status` to list conflicted files (entries marked UU, AA, AU, UA).
+    2. For each text conflict, read the file. Use the surrounding code,
+       tests, and related files for context — that's the whole point of
+       doing this in-workspace rather than file-by-file in isolation.
+    3. Reconcile LOCAL and REMOTE intent into the smallest correct merged
+       file. Remove ALL conflict markers (<<<<<<<, |||||||, =======,
+       >>>>>>>) and any zdiff3 BASE blocks. Write the resolved file back.
+    4. For binary files, assume LOCAL (ours) is the source of truth: run
+       `git checkout --ours -- <path>` to drop the remote side.
+    5. Stage each resolved file with `git add <path>`.
+
+    Skip:
+    - Delete-side conflicts (deleted by us / deleted by them / both deleted)
+      — the user picks Keep ours / theirs / deleted in the UI.
+
+    Do NOT commit. Do NOT abort or continue the in-progress merge / rebase
+    / cherry-pick — the user drives those from the UI after reviewing.
+
+    When done, print a short summary: which files you resolved and which
+    you skipped or couldn't reconcile, with one line per file.
+    """
+
+    static let defaultMergeSingleResolvePrompt = """
+    You are resolving a Git merge conflict in {filePath}.
+    Language: {language}
+    Reconcile LOCAL and REMOTE intent into the smallest correct merged file.
+    Output ONLY the resolved file contents — no conflict markers, no prose,
+    no markdown fences, no commentary.
     """
 }
 
@@ -362,9 +410,23 @@ extension AppConfig {
         if let changesContainer = try? c.nestedContainer(keyedBy: AppConfig.Changes.CodingKeys.self, forKey: .changes) {
             let toolId = (try? changesContainer.decode(String.self, forKey: .aiToolId)) ?? "none"
             let prompt = (try? changesContainer.decode(String.self, forKey: .prompt)) ?? AppConfig.defaultCommitPrompt
-            changes = Changes(aiToolId: toolId, prompt: prompt)
+            let bulkResolve = (try? changesContainer.decode(String.self, forKey: .mergeBulkResolvePrompt))
+                ?? AppConfig.defaultMergeBulkResolvePrompt
+            let singleResolve = (try? changesContainer.decode(String.self, forKey: .mergeSingleResolvePrompt))
+                ?? AppConfig.defaultMergeSingleResolvePrompt
+            changes = Changes(
+                aiToolId: toolId,
+                prompt: prompt,
+                mergeBulkResolvePrompt: bulkResolve,
+                mergeSingleResolvePrompt: singleResolve
+            )
         } else {
-            changes = Changes(aiToolId: "none", prompt: AppConfig.defaultCommitPrompt)
+            changes = Changes(
+                aiToolId: "none",
+                prompt: AppConfig.defaultCommitPrompt,
+                mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
+                mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt
+            )
         }
         if let agentsContainer = try? c.nestedContainer(
             keyedBy: AppConfig.Agents.CodingKeys.self, forKey: .agents

--- a/Alas/Sources/Right/BulkConflictResolveReport.swift
+++ b/Alas/Sources/Right/BulkConflictResolveReport.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Result of `RightPaneState.resolveAllConflicts(using:)`. Surfaced in
+/// the Conflicts section as a transient banner after the agent's
+/// workspace-level run finishes. The actual "did it work?" signal is
+/// the post-refresh conflict count — this banner just lets the user
+/// see the agent's narrative for what it did.
+struct BulkConflictResolveReport: Equatable {
+    /// True when the agent invocation itself succeeded (process exit 0,
+    /// no Swift-side error). False on launch failure, timeout, or
+    /// cancellation. Doesn't speak to whether every conflict actually
+    /// got resolved — check the refreshed conflict count for that.
+    let success: Bool
+    /// Conflicts remaining after the refresh that followed the run.
+    /// Zero means the agent reconciled everything.
+    let remainingConflicts: Int
+    /// Subject line from the agent's stdout, surfaced as the banner
+    /// headline. Empty when the agent produced no usable output.
+    let summary: String
+    /// Optional full body, shown in the banner tooltip.
+    let details: String
+}

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -278,13 +278,17 @@ struct ChangesTabView: View {
     private var resolvedBulkAgent: AgentDefinition? {
         let id = appState.config.changes.aiToolId
         if id == "none" { return nil }
-        let candidate: AgentDefinition?
         if !id.isEmpty, let agent = appState.agent(id: id) {
-            candidate = agent
-        } else {
-            candidate = appState.agentRegistry.enabled().first
+            return agent.bypassPermissionsFlag != nil ? agent : nil
         }
-        guard let candidate, candidate.bypassPermissionsFlag != nil else { return nil }
-        return candidate
+        // Fallback: pick the first ENABLED agent that also supports
+        // bypass. Filtering before .first matters when the registry's
+        // enabled list begins with an agent that has no bypass flag
+        // (e.g. Pi) but a later one does (e.g. Claude / Codex /
+        // Cursor) — without this we'd reject the first match and
+        // leave bulk resolve disabled despite a usable tool being
+        // available.
+        return appState.agentRegistry.enabled()
+            .first(where: { $0.bypassPermissionsFlag != nil })
     }
 }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -77,11 +77,23 @@ struct ChangesTabView: View {
 
             ConflictsSection(
                 conflicts: conflicts,
+                bulkInFlight: rps.bulkResolveInFlight,
+                bulkReport: rps.bulkResolveReport,
+                hasAgent: resolvedBulkAgent != nil,
                 onSelect: { file in rps.openConflict?(file.path) },
                 onUseOurs: { file in rps.useOurs(file: file) },
                 onUseTheirs: { file in rps.useTheirs(file: file) },
                 onKeepDeleted: { file in rps.keepDeleted(file: file) },
-                onMarkResolved: { file in rps.markResolved(file: file) }
+                onMarkResolved: { file in rps.markResolved(file: file) },
+                onResolveAllWithAgent: {
+                    guard let agent = resolvedBulkAgent else { return }
+                    rps.resolveAllConflicts(
+                        using: agent,
+                        prompt: appState.config.changes.mergeBulkResolvePrompt
+                    )
+                },
+                onCancelBulkResolve: { rps.cancelBulkResolve() },
+                onDismissBulkReport: { rps.dismissBulkResolveReport() }
             )
 
             if stagedCount > 0 {
@@ -250,5 +262,18 @@ struct ChangesTabView: View {
 
     private func copyCommitSHA(_ commit: CommitInfo) {
         Clipboard.copy(commit.sha)
+    }
+
+    /// Agent to use for the Conflicts section's bulk resolve. Mirrors the
+    /// `MergeConflictTabView.resolvedAgent` precedence: respect explicit
+    /// "none", prefer the user's pinned tool from Settings, fall back to
+    /// any enabled agent.
+    private var resolvedBulkAgent: AgentDefinition? {
+        let id = appState.config.changes.aiToolId
+        if id == "none" { return nil }
+        if !id.isEmpty, let agent = appState.agent(id: id) {
+            return agent
+        }
+        return appState.agentRegistry.enabled().first
     }
 }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -268,12 +268,23 @@ struct ChangesTabView: View {
     /// `MergeConflictTabView.resolvedAgent` precedence: respect explicit
     /// "none", prefer the user's pinned tool from Settings, fall back to
     /// any enabled agent.
+    ///
+    /// Filters out agents without a `bypassPermissionsFlag` because the
+    /// bulk action runs the agent non-interactively (no TTY to answer
+    /// write-approval prompts). Without bypass support, the agent would
+    /// stall on the first file write and the run would hang until the
+    /// 10-minute timeout fires. The bulk button is disabled in that
+    /// case with a tooltip explaining why.
     private var resolvedBulkAgent: AgentDefinition? {
         let id = appState.config.changes.aiToolId
         if id == "none" { return nil }
+        let candidate: AgentDefinition?
         if !id.isEmpty, let agent = appState.agent(id: id) {
-            return agent
+            candidate = agent
+        } else {
+            candidate = appState.agentRegistry.enabled().first
         }
-        return appState.agentRegistry.enabled().first
+        guard let candidate, candidate.bypassPermissionsFlag != nil else { return nil }
+        return candidate
     }
 }

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -29,7 +29,11 @@ struct ConflictsSection: View {
     @State private var pendingBothDeletedConfirm: ChangedFile?
 
     var body: some View {
-        if conflicts.isEmpty, bulkReport == nil {
+        // Keep the section mounted while a bulk run is in flight too,
+        // so the spinner + Cancel stay visible even if conflicts drop
+        // to zero mid-run (e.g. an intermediate refresh after the
+        // agent stages a file).
+        if conflicts.isEmpty, bulkReport == nil, !bulkInFlight {
             EmptyView()
         } else {
             VStack(alignment: .leading, spacing: 2) {

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -2,32 +2,144 @@ import SwiftUI
 
 struct ConflictsSection: View {
     let conflicts: [ChangedFile]
+    /// True while the workspace-level agent invocation is running. The
+    /// resolve button flips into Cancel and a spinner row appears below
+    /// the header.
+    let bulkInFlight: Bool
+    /// Final outcome of the last bulk-resolve run. Surfaced as a
+    /// transient banner the user can dismiss.
+    let bulkReport: BulkConflictResolveReport?
+    /// True when at least one enabled AI tool is configured for the
+    /// Changes section. Gates the bulk action — disabled with a tooltip
+    /// otherwise.
+    let hasAgent: Bool
     let onSelect: (ChangedFile) -> Void
     let onUseOurs: (ChangedFile) -> Void
     let onUseTheirs: (ChangedFile) -> Void
     let onKeepDeleted: (ChangedFile) -> Void
     let onMarkResolved: (ChangedFile) -> Void
+    /// Triggered by the section-header bulk-resolve button.
+    let onResolveAllWithAgent: () -> Void
+    /// Triggered while a bulk resolve is in flight; the same button
+    /// flips into a cancel action.
+    let onCancelBulkResolve: () -> Void
+    /// Triggered when the user closes the post-run banner.
+    let onDismissBulkReport: () -> Void
 
     @State private var pendingBothDeletedConfirm: ChangedFile?
 
     var body: some View {
-        if conflicts.isEmpty {
+        if conflicts.isEmpty, bulkReport == nil {
             EmptyView()
         } else {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Conflicts (\(conflicts.count))")
-                    .font(.system(size: 10, weight: .semibold))
-                    .textCase(.uppercase)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 10)
-                    .padding(.top, 6)
-                    .padding(.bottom, 2)
+                header
+                if bulkInFlight {
+                    progressRow
+                }
+                if let report = bulkReport {
+                    reportRow(report)
+                }
                 ForEach(conflicts) { file in
                     row(for: file)
                 }
             }
             .padding(.bottom, 4)
         }
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Text("Conflicts (\(conflicts.count))")
+                .font(.system(size: 10, weight: .semibold))
+                .textCase(.uppercase)
+                .foregroundColor(.secondary)
+            Spacer()
+            bulkResolveButton
+        }
+        .padding(.horizontal, 10)
+        .padding(.top, 6)
+        .padding(.bottom, 2)
+    }
+
+    @ViewBuilder
+    private var bulkResolveButton: some View {
+        if bulkInFlight {
+            Button(action: onCancelBulkResolve) {
+                HStack(spacing: 4) {
+                    Image(systemName: "stop.circle")
+                    Text("Cancel")
+                }
+                .font(.system(size: 10))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+            .tint(.red)
+        } else if !conflicts.isEmpty {
+            Button(action: onResolveAllWithAgent) {
+                HStack(spacing: 4) {
+                    Image(systemName: "sparkles")
+                    Text("Resolve all with agent")
+                }
+                .font(.system(size: 10))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+            .disabled(!hasAgent)
+            .help(hasAgent
+                ? "Run the configured agent across every text conflict and stage the results"
+                : "Configure an agent in Settings → Changes to enable this")
+        }
+    }
+
+    private var progressRow: some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.mini)
+            Text("Agent resolving conflicts…")
+                .font(.system(size: 10))
+                .foregroundColor(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 3)
+    }
+
+    private func reportRow(_ report: BulkConflictResolveReport) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: reportIcon(for: report))
+                .foregroundColor(reportColor(for: report))
+                .font(.system(size: 10))
+                .padding(.top, 1)
+            Text(report.summary)
+                .font(.system(size: 10))
+                .foregroundColor(.secondary)
+                .lineLimit(3)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button(action: onDismissBulkReport) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .medium))
+                    .foregroundColor(.secondary)
+                    .padding(.top, 1)
+            }
+            .buttonStyle(.plain)
+            .help("Dismiss")
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 3)
+        .help(report.details.isEmpty ? report.summary : report.details)
+    }
+
+    private func reportIcon(for report: BulkConflictResolveReport) -> String {
+        if !report.success { return "exclamationmark.triangle.fill" }
+        return report.remainingConflicts == 0
+            ? "checkmark.circle.fill"
+            : "exclamationmark.circle.fill"
+    }
+
+    private func reportColor(for report: BulkConflictResolveReport) -> Color {
+        if !report.success { return .red }
+        return report.remainingConflicts == 0 ? .green : .orange
     }
 
     @ViewBuilder

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -92,7 +92,7 @@ struct ConflictsSection: View {
             .disabled(!hasAgent)
             .help(hasAgent
                 ? "Run the configured agent across every text conflict and stage the results"
-                : "Configure an agent in Settings → Changes to enable this")
+                : "Pick an agent in Settings → Changes that supports non-interactive permission bypass (e.g. Claude, Codex, Cursor)")
         }
     }
 

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1079,22 +1079,13 @@ final class RightPaneState {
             guard let self else { return }
             var report: BulkConflictResolveReport
             do {
-                let result = try await MergeAgent.resolveAllInWorkspace(
+                let agentOutput = try await MergeAgent.resolveAllInWorkspace(
                     agent: agent,
                     prompt: prompt,
                     worktreePath: self.worktree.path
                 )
                 await self.refresh()
                 let remaining = self.changes.filter { $0.conflict != nil }.count
-                // Build a short status headline ourselves; stash the
-                // full agent output (subject + body, joined) in details.
-                // We can't use `result.subject` alone — the parser puts
-                // only the first line in subject, so a per-file
-                // breakdown collapses to the first file and the rest
-                // gets buried.
-                let agentOutput = [result.subject, result.body]
-                    .filter { !$0.isEmpty }
-                    .joined(separator: "\n")
                 let headline: String = {
                     if remaining == 0 {
                         return "All conflicts resolved."
@@ -1105,7 +1096,7 @@ final class RightPaneState {
                     success: true,
                     remainingConflicts: remaining,
                     summary: headline,
-                    details: agentOutput
+                    details: agentOutput.trimmingCharacters(in: .whitespacesAndNewlines)
                 )
             } catch {
                 await self.refresh()

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -1086,13 +1086,26 @@ final class RightPaneState {
                 )
                 await self.refresh()
                 let remaining = self.changes.filter { $0.conflict != nil }.count
+                // Build a short status headline ourselves; stash the
+                // full agent output (subject + body, joined) in details.
+                // We can't use `result.subject` alone — the parser puts
+                // only the first line in subject, so a per-file
+                // breakdown collapses to the first file and the rest
+                // gets buried.
+                let agentOutput = [result.subject, result.body]
+                    .filter { !$0.isEmpty }
+                    .joined(separator: "\n")
+                let headline: String = {
+                    if remaining == 0 {
+                        return "All conflicts resolved."
+                    }
+                    return "Agent finished — \(remaining) conflict(s) still need attention."
+                }()
                 report = BulkConflictResolveReport(
                     success: true,
                     remainingConflicts: remaining,
-                    summary: result.subject.isEmpty
-                        ? (remaining == 0 ? "All conflicts resolved." : "Agent finished with \(remaining) conflict(s) remaining.")
-                        : result.subject,
-                    details: result.body
+                    summary: headline,
+                    details: agentOutput
                 )
             } catch {
                 await self.refresh()

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -77,6 +77,21 @@ final class RightPaneState {
 
     var pendingDiscard: PendingDiscard? = nil
 
+    /// True while the workspace-level agent invocation is running.
+    /// Surfaced in the Conflicts section header as a spinner; the
+    /// resolve button flips into Cancel.
+    var bulkResolveInFlight: Bool = false
+
+    /// Last completed bulk-resolve outcome, or nil when none has run
+    /// since this state was created (or since the user dismissed the
+    /// banner). Cleared by `dismissBulkResolveReport`.
+    var bulkResolveReport: BulkConflictResolveReport? = nil
+
+    /// Task handle for the in-flight bulk resolve so the user can
+    /// cancel the agent (SIGTERM via Process cancellation).
+    @ObservationIgnored
+    private var bulkResolveTask: Task<Void, Never>? = nil
+
     /// Injected by `RightPaneStore` after creation so `confirmDiscard` can
     /// close any open diff tabs whose path was just discarded. Nil in tests
     /// that construct `RightPaneState` directly.
@@ -1045,6 +1060,68 @@ final class RightPaneState {
                 logger.error("markResolved failed: \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
+
+    /// Hands the configured agent the whole worktree (CWD'd at
+    /// `worktree.path`) with a single "fix every merge conflict" prompt.
+    /// The agent uses its own tools to enumerate conflicted files, read
+    /// surrounding code for context, write reconciled output, and stage.
+    /// One call instead of N gives the agent cross-file context (which
+    /// is the entire point of resolving merges with a coding agent) and
+    /// avoids paying CLI startup cost per file.
+    @MainActor
+    func resolveAllConflicts(using agent: AgentDefinition, prompt: String) {
+        guard bulkResolveTask == nil else { return }
+        guard changes.contains(where: { $0.conflict != nil }) else { return }
+        bulkResolveReport = nil
+        bulkResolveInFlight = true
+        bulkResolveTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            var report: BulkConflictResolveReport
+            do {
+                let result = try await MergeAgent.resolveAllInWorkspace(
+                    agent: agent,
+                    prompt: prompt,
+                    worktreePath: self.worktree.path
+                )
+                await self.refresh()
+                let remaining = self.changes.filter { $0.conflict != nil }.count
+                report = BulkConflictResolveReport(
+                    success: true,
+                    remainingConflicts: remaining,
+                    summary: result.subject.isEmpty
+                        ? (remaining == 0 ? "All conflicts resolved." : "Agent finished with \(remaining) conflict(s) remaining.")
+                        : result.subject,
+                    details: result.body
+                )
+            } catch {
+                await self.refresh()
+                let remaining = self.changes.filter { $0.conflict != nil }.count
+                report = BulkConflictResolveReport(
+                    success: false,
+                    remainingConflicts: remaining,
+                    summary: "Agent failed: \(error.localizedDescription)",
+                    details: ""
+                )
+            }
+            self.bulkResolveInFlight = false
+            self.bulkResolveReport = report
+            self.bulkResolveTask = nil
+        }
+    }
+
+    /// Cancels an in-flight bulk resolve by tearing down the agent
+    /// process via Task cancellation (AgentRunner forwards as SIGTERM).
+    @MainActor
+    func cancelBulkResolve() {
+        bulkResolveTask?.cancel()
+    }
+
+    /// Clears the post-run banner so it doesn't linger after the user
+    /// has acknowledged the outcome.
+    @MainActor
+    func dismissBulkResolveReport() {
+        bulkResolveReport = nil
     }
 
     /// On `.conflict`, auto-open the first conflicted file via the injected

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -9,7 +9,7 @@ struct ChangesPane: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Text("Changes").font(.system(size: 18, weight: .semibold))
-                Text("AI-generated commit messages and related defaults.")
+                Text("AI-generated commit messages and merge-conflict resolution.")
                     .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
                     .padding(.bottom, 12)
 
@@ -20,20 +20,52 @@ struct ChangesPane: View {
                     }
                     SettingsRow(name: "Prompt",
                                 desc: "Instructions sent to the CLI. The staged diff is appended on stdin.") {
-                        HStack(spacing: 12) {
-                            AlasButton(title: "Edit", style: .normal) {
-                                openWindow(id: "commit-prompt-editor")
-                            }
-                            Spacer()
-                            if let chipLabel = CommitPromptStatus.chipLabel(for: state.config.changes.prompt) {
-                                PromptStatusChip(label: chipLabel)
-                            }
-                        }
-                        .frame(maxWidth: .infinity)
+                        promptEditorRow(
+                            windowId: "commit-prompt-editor",
+                            currentValue: state.config.changes.prompt,
+                            defaultValue: AppConfig.defaultCommitPrompt
+                        )
+                    }
+                }
+
+                SettingsGroup(title: "Merge conflicts") {
+                    SettingsRow(name: "Bulk resolve prompt",
+                                desc: "Sent to the agent CWD'd at the worktree when the user clicks 'Resolve all with agent'. The agent uses its own tools to enumerate, reconcile, and stage every conflicted file.") {
+                        promptEditorRow(
+                            windowId: "merge-bulk-prompt-editor",
+                            currentValue: state.config.changes.mergeBulkResolvePrompt,
+                            defaultValue: AppConfig.defaultMergeBulkResolvePrompt
+                        )
+                    }
+                    SettingsRow(name: "Single-file prompt",
+                                desc: "Used by 'Ask agent to resolve' in the merge editor toolbar. The three sides are appended automatically.") {
+                        promptEditorRow(
+                            windowId: "merge-single-prompt-editor",
+                            currentValue: state.config.changes.mergeSingleResolvePrompt,
+                            defaultValue: AppConfig.defaultMergeSingleResolvePrompt
+                        )
                     }
                 }
             }
             .padding(.horizontal, 32).padding(.vertical, 24)
+        }
+    }
+
+    /// Edit button + Custom chip, grouped together. Previously this row
+    /// used a `Spacer()` between the two, which left them visually
+    /// disconnected — flagged as "awful and unaligned" during dogfooding.
+    private func promptEditorRow(
+        windowId: String,
+        currentValue: String,
+        defaultValue: String
+    ) -> some View {
+        HStack(spacing: 8) {
+            AlasButton(title: "Edit", style: .normal) {
+                openWindow(id: windowId)
+            }
+            if currentValue != defaultValue {
+                PromptStatusChip(label: "Custom")
+            }
         }
     }
 

--- a/Alas/Sources/Settings/CommitPromptEditorWindow.swift
+++ b/Alas/Sources/Settings/CommitPromptEditorWindow.swift
@@ -5,79 +5,21 @@ struct CommitPromptEditorWindow: View {
     @State private var draftPrompt = ""
 
     var body: some View {
-        let theme = state.themeStore.current
-
-        VStack(spacing: 0) {
-            ZStack {
-                LinearGradient(
-                    colors: [theme.color("bg-3"), theme.color("bg-2")],
-                    startPoint: .top, endPoint: .bottom
-                )
-                HStack {
-                    TrafficLights()
-                    Spacer()
-                }
-                .padding(.leading, 16)
-                Text("Commit Prompt")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(theme.color("fg-muted"))
-            }
-            .frame(height: 44)
-            .overlay(Divider().opacity(0.5), alignment: .bottom)
-
-            VStack(alignment: .leading, spacing: 12) {
-                HStack(alignment: .firstTextBaseline, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Commit message prompt")
-                            .font(.system(size: 18, weight: .semibold))
-                        Text("Instructions sent to the selected AI tool. The staged diff is appended on stdin.")
-                            .font(.system(size: 12.5))
-                            .foregroundColor(theme.color("fg-dim"))
-                    }
-                    Spacer()
-                    AlasButton(title: "Reset to Default", style: .subtle) {
-                        draftPrompt = AppConfig.defaultCommitPrompt
-                    }
-                }
-
-                TextEditor(text: $draftPrompt)
-                    .font(.system(size: 12, design: .monospaced))
-                    .scrollContentBackground(.hidden)
-                    .background(theme.color("bg-2"))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 6)
-                            .stroke(theme.color("line-soft"), lineWidth: 0.5)
-                    )
-            }
-            .padding(.horizontal, 32)
-            .padding(.vertical, 24)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(theme.color("bg-1"))
-
-            HStack(spacing: 8) {
-                Spacer()
-                AlasButton(title: "Cancel", style: .subtle) {
-                    closeWindow()
-                }
-                AlasButton(title: "Save", style: .primary) {
-                    state.config.changes.prompt = draftPrompt
-                    state.saveConfig()
-                    closeWindow()
-                }
-            }
-            .padding(.horizontal, 32)
-            .padding(.vertical, 12)
-            .background(theme.color("bg-2"))
-            .overlay(Divider().opacity(0.5), alignment: .top)
-        }
-        .frame(minWidth: 720, minHeight: 560)
-        .background(theme.color("bg-1"))
-        .background(WindowConfigurator())
-        .environment(\.theme, theme)
-        .ignoresSafeArea()
-        .onAppear {
-            draftPrompt = state.config.changes.prompt
-        }
+        PromptEditorBody(
+            windowTitle: "Commit Prompt",
+            title: "Commit message prompt",
+            description: "Instructions sent to the selected AI tool. The staged diff is appended on stdin.",
+            draftPrompt: $draftPrompt,
+            onReset: { draftPrompt = AppConfig.defaultCommitPrompt },
+            onCancel: { closeWindow() },
+            onSave: {
+                state.config.changes.prompt = draftPrompt
+                state.saveConfig()
+                closeWindow()
+            },
+            theme: state.themeStore.current
+        )
+        .onAppear { draftPrompt = state.config.changes.prompt }
     }
 
     private func closeWindow() {

--- a/Alas/Sources/Settings/MergeBulkResolvePromptEditorWindow.swift
+++ b/Alas/Sources/Settings/MergeBulkResolvePromptEditorWindow.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct MergeBulkResolvePromptEditorWindow: View {
+    @Bindable var state: AppState
+    @State private var draftPrompt = ""
+
+    var body: some View {
+        PromptEditorBody(
+            windowTitle: "Merge: Resolve All Prompt",
+            title: "Bulk merge-conflict resolution prompt",
+            description: "Sent to the agent CWD'd at the worktree when the user clicks 'Resolve all with agent' in the Conflicts section. The agent uses its own tools to enumerate, reconcile, and stage every conflicted file.",
+            draftPrompt: $draftPrompt,
+            onReset: { draftPrompt = AppConfig.defaultMergeBulkResolvePrompt },
+            onCancel: { closeWindow() },
+            onSave: {
+                state.config.changes.mergeBulkResolvePrompt = draftPrompt
+                state.saveConfig()
+                closeWindow()
+            },
+            theme: state.themeStore.current
+        )
+        .onAppear { draftPrompt = state.config.changes.mergeBulkResolvePrompt }
+    }
+
+    private func closeWindow() {
+        NSApp.keyWindow?.close()
+    }
+}

--- a/Alas/Sources/Settings/MergeSingleResolvePromptEditorWindow.swift
+++ b/Alas/Sources/Settings/MergeSingleResolvePromptEditorWindow.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct MergeSingleResolvePromptEditorWindow: View {
+    @Bindable var state: AppState
+    @State private var draftPrompt = ""
+
+    var body: some View {
+        PromptEditorBody(
+            windowTitle: "Merge: Single-File Prompt",
+            title: "Per-file merge-conflict resolution prompt",
+            description: "Used by 'Ask agent to resolve' in the merge editor toolbar. The three sides (LOCAL / BASE / REMOTE / MERGED) are appended automatically. Placeholders: {filePath}, {language}.",
+            draftPrompt: $draftPrompt,
+            onReset: { draftPrompt = AppConfig.defaultMergeSingleResolvePrompt },
+            onCancel: { closeWindow() },
+            onSave: {
+                state.config.changes.mergeSingleResolvePrompt = draftPrompt
+                state.saveConfig()
+                closeWindow()
+            },
+            theme: state.themeStore.current
+        )
+        .onAppear { draftPrompt = state.config.changes.mergeSingleResolvePrompt }
+    }
+
+    private func closeWindow() {
+        NSApp.keyWindow?.close()
+    }
+}

--- a/Alas/Sources/Settings/PromptEditorBody.swift
+++ b/Alas/Sources/Settings/PromptEditorBody.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+/// Shared layout for prompt-editor windows (Commit, Merge Resolve all,
+/// Merge Resolve file). Pulls out the title + textarea + footer
+/// structure so each prompt type only has to declare its title,
+/// description, draft binding, and the actions.
+struct PromptEditorBody: View {
+    let windowTitle: String
+    let title: String
+    let description: String
+    @Binding var draftPrompt: String
+    let onReset: () -> Void
+    let onCancel: () -> Void
+    let onSave: () -> Void
+    let theme: Theme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.system(size: 18, weight: .semibold))
+                    Text(description)
+                        .font(.system(size: 12.5))
+                        .foregroundColor(theme.color("fg-dim"))
+                }
+                TextEditor(text: $draftPrompt)
+                    .font(.system(size: 12, design: .monospaced))
+                    .scrollContentBackground(.hidden)
+                    .background(theme.color("bg-2"))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(theme.color("line-soft"), lineWidth: 0.5)
+                    )
+            }
+            .padding(.horizontal, 32)
+            .padding(.vertical, 24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(theme.color("bg-1"))
+            footer
+        }
+        .frame(minWidth: 720, minHeight: 560)
+        .background(theme.color("bg-1"))
+        .background(WindowConfigurator())
+        .environment(\.theme, theme)
+        .ignoresSafeArea()
+    }
+
+    private var header: some View {
+        ZStack {
+            LinearGradient(
+                colors: [theme.color("bg-3"), theme.color("bg-2")],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            HStack {
+                TrafficLights()
+                Spacer()
+            }
+            .padding(.leading, 16)
+            Text(windowTitle)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+        }
+        .frame(height: 44)
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    /// Footer mirrors the AgentEditView pattern: subtle destructive /
+    /// reset action on the left, Cancel + primary save on the right.
+    /// Keeps the alignment consistent across settings dialogs.
+    private var footer: some View {
+        HStack(spacing: 8) {
+            AlasButton(title: "Reset to Default", style: .subtle, action: onReset)
+            Spacer()
+            AlasButton(title: "Cancel", style: .subtle, action: onCancel)
+            AlasButton(title: "Save", style: .primary, action: onSave)
+        }
+        .padding(.horizontal, 32)
+        .padding(.vertical, 12)
+        .background(theme.color("bg-2"))
+        .overlay(Divider().opacity(0.5), alignment: .top)
+    }
+}

--- a/AlasTests/MergeAgentTests.swift
+++ b/AlasTests/MergeAgentTests.swift
@@ -37,8 +37,9 @@ struct MergeAgentTests {
         #expect(!prompt.contains("BASE:"))
     }
 
-    @Test func resolvePromptIncludesPathAndAllThreeSides() {
-        let prompt = MergeAgent.resolvePrompt(
+    @Test func resolvePromptSubstitutesPlaceholdersAndAppendsSides() {
+        let prompt = MergeAgent.resolveFilePrompt(
+            template: AppConfig.defaultMergeSingleResolvePrompt,
             filePath: "Sources/Foo.swift",
             local: "let a = 1\n",
             base: "let a = 0\n",
@@ -52,6 +53,22 @@ struct MergeAgentTests {
         #expect(prompt.contains("BASE"))
         #expect(prompt.contains("Output ONLY the resolved file"))
         #expect(prompt.contains("swift"))
+        #expect(!prompt.contains("{filePath}"))
+        #expect(!prompt.contains("{language}"))
+    }
+
+    @Test func resolvePromptPreservesUnknownPlaceholders() {
+        let template = "Custom prompt for {filePath} in {language}, ticket {ticketId}."
+        let prompt = MergeAgent.resolveFilePrompt(
+            template: template,
+            filePath: "a.swift",
+            local: "x",
+            base: nil,
+            remote: "y",
+            mergedWithMarkers: "z",
+            language: "swift"
+        )
+        #expect(prompt.contains("Custom prompt for a.swift in swift, ticket {ticketId}."))
     }
 
     @Test func parseExplainOutputTakesFirstLineAndTrims() {


### PR DESCRIPTION
## Summary

Second dogfooding pass on the merge-conflict feature after #281.

### Bulk resolve
- **Single workspace-level agent call** instead of per-file fan-out. The agent gets CWD'd at the worktree and uses its own tools to enumerate conflicts and reconcile with full cross-file context. Faster + better reconciliations.
- **Bypass-permissions plumbing**: `AgentRunner.runPrompt` takes a `bypassPermissions` flag; the bulk + per-file resolve calls set it so file writes + `git add` go through non-interactively (no TTY to answer prompts).
- **Default prompt** now tells the agent to handle binary conflicts by assuming LOCAL is the source of truth (`git checkout --ours`).

### Editable prompts (Settings → Changes)
- New `AppConfig.Changes` fields: `mergeBulkResolvePrompt` + `mergeSingleResolvePrompt` with defaults migrated from `MergeAgent` constants. Single-file template uses `{filePath}` / `{language}` placeholders.
- Two new editor windows (`merge-bulk-prompt-editor`, `merge-single-prompt-editor`) sharing a `PromptEditorBody` view with the existing commit editor.
- Editor footer matches `AgentEditView`: Reset on the left, Cancel + Save on the right.
- Prompt rows in Settings now group the Edit button with the Custom chip directly (no more Spacer between them).

### Merge-conflict tab polish
- **Tab identity bug fixed**: `.id(s.id)` on the `mergeConflict` case in `CenterPaneView`. Two open merge tabs were sharing the same view + @State, showing identical content.
- **Resolved-empty state**: replaces the mid-pane "not in a conflicted state" banner with a centered `EmptyTabView`-style empty state (green seal, Open file + Close tab buttons). Generic load failures still get the banner.

## Test plan

- [x] Build green (Debug)
- [x] `MergeAgentTests` + `MergeConflictTabModelTests` passing (26/26)
- [x] `swiftformat --lint` clean
- [x] Manual: bulk resolve works against a multi-file conflict; single-file resolve overlay still works
- [x] Manual: opening multiple merge tabs now shows distinct content
- [x] Manual: resolving a file externally renders the empty state, Open file + Close tab work