### PR TITLE
Move merge/rebase menu into Commits section header

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */; };
 		41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */; };
 		4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */; };
+		A49C0ADC45E541E78E9049E3 /* BranchOpsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41679CEF6904DF2AED24120 /* BranchOpsMenu.swift */; };
 		422B560D70571FF42F0E78E6 /* ThreePaneSizingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60A6B7CB83D842FEE2D801C /* ThreePaneSizingTests.swift */; };
 		4239885256AB11FE8207D31E /* TextEditCoordinates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8062405A67C934905EE61D98 /* TextEditCoordinates.swift */; };
 		42502D6356225A4304C93818 /* TerminalTabStateCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */; };
@@ -796,6 +797,7 @@
 		6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolverTests.swift; sourceTree = "<group>"; };
 		6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreServiceTests.swift; sourceTree = "<group>"; };
 		6FFE12732C0D83715FC990A9 /* CommitsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsSectionView.swift; sourceTree = "<group>"; };
+		C41679CEF6904DF2AED24120 /* BranchOpsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchOpsMenu.swift; sourceTree = "<group>"; };
 		7018E992654E19345D8BD723 /* ImageDiffSwipeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeViewTests.swift; sourceTree = "<group>"; };
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigSidebarChromeOverridesTests.swift; sourceTree = "<group>"; };
@@ -1464,6 +1466,7 @@
 			isa = PBXGroup;
 			children = (
 				002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */,
+				C41679CEF6904DF2AED24120 /* BranchOpsMenu.swift */,
 				3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */,
 				C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */,
 				3DCEFADD952DB870B8BAB890 /* CommitRow.swift */,
@@ -2267,6 +2270,7 @@
 				11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */,
 				BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */,
 				CE24C8CA495726CD294FD223 /* CommitsSectionView.swift in Sources */,
+				A49C0ADC45E541E78E9049E3 /* BranchOpsMenu.swift in Sources */,
 				8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */,
 				C7A839C87B7C9F70F5BD6631 /* CompletionEngine.swift in Sources */,
 				D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */,

--- a/Alas/Sources/Right/BranchOpsMenu.swift
+++ b/Alas/Sources/Right/BranchOpsMenu.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+/// Icon-only menu exposing branch operations (merge / rebase) for the
+/// current worktree. Lives in the Commits section header next to
+/// `BaseBranchSelector`. Owns its own popover state for the branch
+/// pickers so callers don't need to thread state through.
+struct BranchOpsMenu: View {
+    let rps: RightPaneState
+
+    @State private var pendingMergeBranch: String = ""
+    @State private var pendingRebaseOnto: String = ""
+    @State private var branchesForPicker: [String] = []
+    @State private var branchesLoading: Bool = false
+    @State private var showMergePicker: Bool = false
+    @State private var showRebasePicker: Bool = false
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Menu {
+            Button("Merge branch into this worktree…") { openMergePicker() }
+            Button("Rebase this worktree onto…")      { openRebasePicker() }
+        } label: {
+            Image(systemName: "arrow.triangle.merge")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(theme.color("fg-muted"))
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Branch operations")
+        .popover(isPresented: $showMergePicker, arrowEdge: .bottom) {
+            pickerSheet(title: "Merge into current",
+                        actionLabel: "Merge",
+                        selection: $pendingMergeBranch,
+                        onConfirm: {
+                            guard !pendingMergeBranch.isEmpty else { return }
+                            rps.runMerge(branch: pendingMergeBranch)
+                            showMergePicker = false
+                            pendingMergeBranch = ""
+                        })
+        }
+        .popover(isPresented: $showRebasePicker, arrowEdge: .bottom) {
+            pickerSheet(title: "Rebase current onto",
+                        actionLabel: "Rebase",
+                        selection: $pendingRebaseOnto,
+                        onConfirm: {
+                            guard !pendingRebaseOnto.isEmpty else { return }
+                            rps.runRebase(onto: pendingRebaseOnto)
+                            showRebasePicker = false
+                            pendingRebaseOnto = ""
+                        })
+        }
+    }
+
+    @ViewBuilder
+    private func pickerSheet(title: String,
+                             actionLabel: String,
+                             selection: Binding<String>,
+                             onConfirm: @escaping () -> Void) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.system(size: 12, weight: .semibold))
+            BranchPicker(
+                selection: selection,
+                branches: branchesForPicker,
+                isLoading: branchesLoading,
+                errorMessage: nil
+            )
+            .frame(width: 280)
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    showMergePicker = false
+                    showRebasePicker = false
+                }
+                Button(actionLabel, action: onConfirm)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(selection.wrappedValue.isEmpty)
+            }
+        }
+        .padding(12)
+    }
+
+    private func openMergePicker() {
+        Task { await loadBranches() }
+        showMergePicker = true
+    }
+
+    private func openRebasePicker() {
+        Task { await loadBranches() }
+        showRebasePicker = true
+    }
+
+    private func loadBranches() async {
+        branchesLoading = true
+        defer { branchesLoading = false }
+        let svc = GitService()
+        if let list = try? await svc.branches(at: rps.worktree.path) {
+            branchesForPicker = list
+        }
+    }
+}

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -7,13 +7,6 @@ struct ChangesTabView: View {
     let onSelect: (ChangedFile) -> Void
     let onSelectCommit: (CommitInfo) -> Void
 
-    @State private var pendingMergeBranch: String = ""
-    @State private var pendingRebaseOnto: String = ""
-    @State private var branchesForPicker: [String] = []
-    @State private var branchesLoading: Bool = false
-    @State private var showMergePicker: Bool = false
-    @State private var showRebasePicker: Bool = false
-
     private var stagedCount: Int {
         rps.changes.filter { $0.stage == .staged }.count
     }
@@ -33,33 +26,8 @@ struct ChangesTabView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            branchOpsToolbar
-            ScrollView {
-                scrollContent
-            }
-        }
-        .popover(isPresented: $showMergePicker, arrowEdge: .bottom) {
-            branchPickerSheet(title: "Merge into current",
-                              actionLabel: "Merge",
-                              selection: $pendingMergeBranch,
-                              onConfirm: {
-                                  guard !pendingMergeBranch.isEmpty else { return }
-                                  rps.runMerge(branch: pendingMergeBranch)
-                                  showMergePicker = false
-                                  pendingMergeBranch = ""
-                              })
-        }
-        .popover(isPresented: $showRebasePicker, arrowEdge: .bottom) {
-            branchPickerSheet(title: "Rebase current onto",
-                              actionLabel: "Rebase",
-                              selection: $pendingRebaseOnto,
-                              onConfirm: {
-                                  guard !pendingRebaseOnto.isEmpty else { return }
-                                  rps.runRebase(onto: pendingRebaseOnto)
-                                  showRebasePicker = false
-                                  pendingRebaseOnto = ""
-                              })
+        ScrollView {
+            scrollContent
         }
     }
 
@@ -162,75 +130,6 @@ struct ChangesTabView: View {
                 onOpenBaseBranchSelector: { Task { @MainActor in await rps.fetchBranches() } },
                 rps: rps
             )
-        }
-    }
-
-    private var branchOpsToolbar: some View {
-        HStack(spacing: 6) {
-            Menu {
-                Button("Merge branch into this worktree…") { openMergePicker() }
-                Button("Rebase this worktree onto…")      { openRebasePicker() }
-            } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "arrow.triangle.merge")
-                        .font(.system(size: 11, weight: .semibold))
-                    Text("Branch")
-                        .font(.system(size: 11))
-                }
-            }
-            .menuStyle(.borderlessButton)
-            .fixedSize()
-            Spacer()
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 4)
-        .background(Color.gray.opacity(0.05))
-    }
-
-    @ViewBuilder
-    private func branchPickerSheet(title: String,
-                                   actionLabel: String,
-                                   selection: Binding<String>,
-                                   onConfirm: @escaping () -> Void) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title).font(.system(size: 12, weight: .semibold))
-            BranchPicker(
-                selection: selection,
-                branches: branchesForPicker,
-                isLoading: branchesLoading,
-                errorMessage: nil
-            )
-            .frame(width: 280)
-            HStack {
-                Spacer()
-                Button("Cancel") {
-                    showMergePicker = false
-                    showRebasePicker = false
-                }
-                Button(actionLabel, action: onConfirm)
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(selection.wrappedValue.isEmpty)
-            }
-        }
-        .padding(12)
-    }
-
-    private func openMergePicker() {
-        Task { await loadBranches() }
-        showMergePicker = true
-    }
-
-    private func openRebasePicker() {
-        Task { await loadBranches() }
-        showRebasePicker = true
-    }
-
-    private func loadBranches() async {
-        branchesLoading = true
-        defer { branchesLoading = false }
-        let svc = GitService()
-        if let list = try? await svc.branches(at: rps.worktree.path) {
-            branchesForPicker = list
         }
     }
 

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -61,6 +61,7 @@ struct CommitsSectionView: View {
                         onSelect: onSelectBaseBranch,
                         onOpen: onOpenBaseBranchSelector
                     )
+                    BranchOpsMenu(rps: rps)
                 }
             }
 

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -49,10 +49,12 @@ struct CommitsSectionView: View {
             ) {
                 HStack(spacing: 6) {
                     if let s = behindBase {
-                        BehindChip(text: "\(s.count) behind \(s.ref)")
+                        BehindChip(text: "\(s.count) behind")
+                            .help("\(s.count) behind \(s.ref)")
                     }
                     if let s = behindUpstream {
-                        BehindChip(text: "\(s.count) behind \(s.ref)")
+                        BehindChip(text: "\(s.count) behind")
+                            .help("\(s.count) behind \(s.ref)")
                     }
                     BaseBranchSelector(
                         baseBranch: $baseBranch,


### PR DESCRIPTION
## Summary

- Replace the disjointed gray "Branch" strip at the top of the Changes tab with a small `arrow.triangle.merge` icon-menu tucked into the Commits section header, next to the existing `BaseBranchSelector` chip.
- Extract the merge/rebase trigger, popovers, picker state, and branch loading into a new self-contained `BranchOpsMenu` view; `ChangesTabView` no longer owns any of that state.
- Shorten the "behind" chip to just `N behind` (full `N behind <ref>` kept as a hover tooltip) since the base ref already appears in the adjacent chip — saves horizontal width.

Before: a second horizontal strip below the Changes/Files tab bar with one tiny "Branch" button and a gray background.
After: no extra strip; merge/rebase live as an icon menu in the Commits header, visible whether the section is collapsed or expanded.

## Test plan
- [ ] Changes tab no longer shows the gray strip below the Changes/Files segments
- [ ] In the Commits section header, the merge-arrow icon appears to the right of the base-branch chip
- [ ] Collapsing the Commits section keeps the icon visible and operable
- [ ] Clicking the icon shows the merge/rebase items; each opens its picker popover
- [ ] Selecting a branch and confirming runs the same merge/rebase the old button did
- [ ] Behind chip reads "N behind" with the full ref in the hover tooltip
- [ ] Clicking the base-branch chip or merge-arrow does not collapse/expand the Commits section