### PR TITLE
fix(tabs): always show close button on terminal tabs

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		7B309C87C042B3A18AB31D0F /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49B5B544A3432F8D8105268 /* SearchModel.swift */; };
 		7B85B033B476943E77867BA3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69024633944E9FFF6DA76FAE /* RootView.swift */; };
 		7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */; };
+		7C7C3B2EA1DBB7CB35C9F00D /* TabIsTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F7F9EE594C8011DE15F08 /* TabIsTerminalTests.swift */; };
 		7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */; };
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
 		7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4575017544CD7603B3AB9069 /* GitEventFilter.swift */; };
@@ -1070,6 +1071,7 @@
 		F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessDetectorTests.swift; sourceTree = "<group>"; };
 		F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarMaterialChoiceTests.swift; sourceTree = "<group>"; };
 		F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsGroup.swift; sourceTree = "<group>"; };
+		F49F7F9EE594C8011DE15F08 /* TabIsTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabIsTerminalTests.swift; sourceTree = "<group>"; };
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanel.swift; sourceTree = "<group>"; };
@@ -1318,6 +1320,7 @@
 				07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */,
 				C7DD2CA21EC45168D6E43564 /* TabActivityPulseTests.swift */,
 				9F650CFAC8E61B1EC99CD04A /* TabActivityPulseTransitionTests.swift */,
+				F49F7F9EE594C8011DE15F08 /* TabIsTerminalTests.swift */,
 				14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
@@ -2729,6 +2732,7 @@
 				6DDB5FC604A28D699350C3BD /* TabActivityIconTintTests.swift in Sources */,
 				6A639AFB741004AA32C9D81A /* TabActivityPulseTests.swift in Sources */,
 				90F619F67402DB675E2614CC /* TabActivityPulseTransitionTests.swift in Sources */,
+				7C7C3B2EA1DBB7CB35C9F00D /* TabIsTerminalTests.swift in Sources */,
 				2EA0D9B6F711518ECBF14CF7 /* TabMergeConflictCodingTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -43,6 +43,11 @@ enum Tab: Codable, Equatable, Identifiable {
         }
     }
 
+    var isTerminal: Bool {
+        if case .terminal = self { return true }
+        return false
+    }
+
     var relativeFilePath: String? {
         switch self {
         case .editor(let s):       return s.isExternal ? nil : s.relativePath

--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -45,7 +45,7 @@ struct TabBarView: View {
                     titleLookup: titleLookup,
                     tab: tab,
                     active: tab.id == activeId,
-                    showClose: tabs.count > 1,
+                    showClose: tab.isTerminal || tabs.count > 1,
                     harnessInfo: harnessLookup(tab.id),
                     dirty: dirtyLookup(tab.id),
                     onActivate: { onActivate(tab.id) },

--- a/AlasTests/TabIsTerminalTests.swift
+++ b/AlasTests/TabIsTerminalTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import Alas
+
+struct TabIsTerminalTests {
+    @Test func terminalTabReportsIsTerminal() {
+        let tab = Tab.terminal(TerminalTabState(id: "t1", title: "bash", sessionId: "s1"))
+        #expect(tab.isTerminal)
+    }
+
+    @Test func editorTabDoesNotReportIsTerminal() {
+        let tab = Tab.editor(EditorTabState(
+            id: "e1",
+            title: "hello.swift",
+            relativePath: "hello.swift",
+            revealLine: nil,
+            revealCharacter: nil,
+            externalAbsolutePath: nil,
+            originatingRelativePath: nil,
+            markdownViewMode: nil,
+            markdownSplitFraction: nil
+        ))
+        #expect(!tab.isTerminal)
+    }
+
+    @Test func commitTabDoesNotReportIsTerminal() {
+        let tab = Tab.commit(CommitTabState(worktreeId: "wt", sha: "abc", title: "fix"))
+        #expect(!tab.isTerminal)
+    }
+}


### PR DESCRIPTION
## Summary\n- show the existing close control on terminal tabs even when they are the only tab\n- keep existing close-button behavior for non-terminal tabs\n- add Swift Testing coverage for terminal tab detection\n\n## Verification\n- xcodegen\n- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build