### PR TITLE
feat(highlight): JSON syntax highlighting via tree-sitter

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
+		7377F6BACEEA621425E54FBC /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
 		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
 		7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */; };
 		74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 77EF95AD63DDA8DB0504087B /* TreeSitterSwift */; };
@@ -348,7 +349,7 @@
 		98ED89EA20255EBB9D186AD5 /* MergeConflictBinaryDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31CE012ED93AA22C257FEB8A /* MergeConflictBinaryDetectionTests.swift */; };
 		9927E3934D3CAA9055EF5E44 /* DiffOpenFileAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */; };
 		9A3EB3ACA3AB366431C904EB /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */; };
-		9B2B055195430A5A40BC7659 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
+		9B2B055195430A5A40BC7659 /* TreeSitterJSON in Frameworks */ = {isa = PBXBuildFile; productRef = 5130D28B6980AF12D2256A6D /* TreeSitterJSON */; };
 		9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */; };
 		9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */; };
 		9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */; };
@@ -1138,7 +1139,8 @@
 				1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */,
 				74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */,
 				92EEAFAEFB3E637FB72174A8 /* TreeSitterYAML in Frameworks */,
-				9B2B055195430A5A40BC7659 /* Markdown in Frameworks */,
+				9B2B055195430A5A40BC7659 /* TreeSitterJSON in Frameworks */,
+				7377F6BACEEA621425E54FBC /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2171,6 +2173,7 @@
 				F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */,
 				77EF95AD63DDA8DB0504087B /* TreeSitterSwift */,
 				2B4C3DD473FF121828FD3CA5 /* TreeSitterYAML */,
+				5130D28B6980AF12D2256A6D /* TreeSitterJSON */,
 				B69450B224F0C82A52D00662 /* Markdown */,
 			);
 			productName = Alas;
@@ -2203,6 +2206,7 @@
 			packageReferences = (
 				B9008B8C0F5A7E880C250FE4 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 				CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */,
+				FC44B93BBD7A9BE00A7FADD2 /* XCRemoteSwiftPackageReference "tree-sitter-json" */,
 				7019D0C134F78A3B7F4CF4BB /* XCRemoteSwiftPackageReference "tree-sitter-swift" */,
 				C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterYAML" */,
 			);
@@ -3111,12 +3115,25 @@
 				minimumVersion = 0.25.0;
 			};
 		};
+		FC44B93BBD7A9BE00A7FADD2 /* XCRemoteSwiftPackageReference "tree-sitter-json" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tree-sitter/tree-sitter-json";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.24.8;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		2B4C3DD473FF121828FD3CA5 /* TreeSitterYAML */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TreeSitterYAML;
+		};
+		5130D28B6980AF12D2256A6D /* TreeSitterJSON */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FC44B93BBD7A9BE00A7FADD2 /* XCRemoteSwiftPackageReference "tree-sitter-json" */;
+			productName = TreeSitterJSON;
 		};
 		77EF95AD63DDA8DB0504087B /* TreeSitterSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "tree-sitter-json",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-json",
+      "state" : {
+        "revision" : "ee35a6ebefcef0c5c416c0d1ccec7370cfca5a24",
+        "version" : "0.24.8"
+      }
+    },
+    {
       "identity" : "tree-sitter-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/alex-pinkus/tree-sitter-swift",

--- a/Alas/Sources/Code/Highlight/LanguageRegistry.swift
+++ b/Alas/Sources/Code/Highlight/LanguageRegistry.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftTreeSitter
+import TreeSitterJSON
 import TreeSitterSwift
 import TreeSitterYAML
 
@@ -23,6 +24,7 @@ enum LanguageRegistry {
         switch key {
         case "swift":         lang = Language(language: tree_sitter_swift())
         case "yaml", "yml":   lang = Language(language: tree_sitter_yaml())
+        case "json":          lang = Language(language: tree_sitter_json())
         default:              lang = nil
         }
         if let lang { languageCache[key] = lang }
@@ -49,6 +51,10 @@ enum LanguageRegistry {
         case "yaml", "yml":
             query = loadQuery(named: "highlights",
                               bundleNameContains: "TreeSitterYAML",
+                              language: lang)
+        case "json":
+            query = loadQuery(named: "highlights",
+                              bundleNameContains: "TreeSitterJSON",
                               language: lang)
         default:
             query = nil

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -16,11 +16,16 @@ struct TreeSitterHighlighterTests {
     @Test("fallback highlighter preserves non-Swift spans")
     func fallbackHighlighterForKnownExtensions() throws {
         let rust = TreeSitterHighlighter.highlight(source: #"fn main() { println!("hi") }"#, fileExtension: "rs")
-        let json = TreeSitterHighlighter.highlight(source: #"{"ok": true, "n": 1}"#, fileExtension: "json")
         #expect(rust.contains(where: { $0.capture == .keyword }))
         #expect(rust.contains(where: { $0.capture == .string }))
-        #expect(json.contains(where: { $0.capture == .string }))
-        #expect(json.contains(where: { $0.capture == .number }))
+    }
+
+    @Test("JSON strings and numbers are captured")
+    func jsonBasics() throws {
+        let spans = TreeSitterHighlighter.highlight(source: #"{"ok": true, "n": 1, "name": "alas"}"#, fileExtension: "json")
+        #expect(!spans.isEmpty)
+        #expect(spans.contains(where: { $0.capture == .string }))
+        #expect(spans.contains(where: { $0.capture == .number }))
     }
 
     @Test("unknown extension returns no spans")

--- a/project.yml
+++ b/project.yml
@@ -31,6 +31,9 @@ packages:
     # check that returns false during SPM resolution, dropping the
     # external scanner and breaking the link.
     path: ThirdParty/TreeSitterYAML
+  TreeSitterJSON:
+    url: https://github.com/tree-sitter/tree-sitter-json
+    from: 0.24.8
   Markdown:
     url: https://github.com/apple/swift-markdown
     from: 0.4.0
@@ -75,6 +78,8 @@ targets:
         product: TreeSitterSwift
       - package: TreeSitterYAML
         product: TreeSitterYAML
+      - package: TreeSitterJSON
+        product: TreeSitterJSON
       - package: Markdown
         product: Markdown
     settings:


### PR DESCRIPTION
<!-- gg:managed:start -->
Wires tree-sitter-json v0.24.8 into LanguageRegistry so `.json` files
render with tree-sitter coloring (strings, numbers, booleans, null)
instead of the regex fallback. Upstream Package.swift is SPM-clean so we
consume it remotely — no vendoring required.
<!-- gg:managed:end -->