### PR TITLE
feat(highlight): TOML syntax highlighting via tree-sitter

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -266,7 +266,7 @@
 		71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
-		7377F6BACEEA621425E54FBC /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
+		7377F6BACEEA621425E54FBC /* TreeSitterTOML in Frameworks */ = {isa = PBXBuildFile; productRef = 69EF3147FDD8F28F8D65D4FC /* TreeSitterTOML */; };
 		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
 		7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */; };
 		74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 77EF95AD63DDA8DB0504087B /* TreeSitterSwift */; };
@@ -300,6 +300,7 @@
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		82D3560952F0B800F56377D7 /* AgentHookInstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */; };
 		82E9F713C1BFF433E540314C /* AgentLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F6E707551671670D8CBA38 /* AgentLogoView.swift */; };
+		8352A6C0D7AE371907E50217 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
 		859AD39BA8D5A9FCC905648D /* ImageDiffViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */; };
@@ -1140,7 +1141,8 @@
 				74CCD3B95116C51EB43F5CFA /* TreeSitterSwift in Frameworks */,
 				92EEAFAEFB3E637FB72174A8 /* TreeSitterYAML in Frameworks */,
 				9B2B055195430A5A40BC7659 /* TreeSitterJSON in Frameworks */,
-				7377F6BACEEA621425E54FBC /* Markdown in Frameworks */,
+				7377F6BACEEA621425E54FBC /* TreeSitterTOML in Frameworks */,
+				8352A6C0D7AE371907E50217 /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2174,6 +2176,7 @@
 				77EF95AD63DDA8DB0504087B /* TreeSitterSwift */,
 				2B4C3DD473FF121828FD3CA5 /* TreeSitterYAML */,
 				5130D28B6980AF12D2256A6D /* TreeSitterJSON */,
+				69EF3147FDD8F28F8D65D4FC /* TreeSitterTOML */,
 				B69450B224F0C82A52D00662 /* Markdown */,
 			);
 			productName = Alas;
@@ -2208,6 +2211,7 @@
 				CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */,
 				FC44B93BBD7A9BE00A7FADD2 /* XCRemoteSwiftPackageReference "tree-sitter-json" */,
 				7019D0C134F78A3B7F4CF4BB /* XCRemoteSwiftPackageReference "tree-sitter-swift" */,
+				A38DA0B05C2E29601ED4C8A9 /* XCRemoteSwiftPackageReference "tree-sitter-toml" */,
 				C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterYAML" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -3099,6 +3103,14 @@
 				revision = 7b7909f2f6b9414be0958275f4c8e5d69c3bca43;
 			};
 		};
+		A38DA0B05C2E29601ED4C8A9 /* XCRemoteSwiftPackageReference "tree-sitter-toml" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tree-sitter-grammars/tree-sitter-toml";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.0;
+			};
+		};
 		B9008B8C0F5A7E880C250FE4 /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-markdown";
@@ -3134,6 +3146,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = FC44B93BBD7A9BE00A7FADD2 /* XCRemoteSwiftPackageReference "tree-sitter-json" */;
 			productName = TreeSitterJSON;
+		};
+		69EF3147FDD8F28F8D65D4FC /* TreeSitterTOML */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A38DA0B05C2E29601ED4C8A9 /* XCRemoteSwiftPackageReference "tree-sitter-toml" */;
+			productName = TreeSitterTOML;
 		};
 		77EF95AD63DDA8DB0504087B /* TreeSitterSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -52,6 +52,15 @@
       "state" : {
         "revision" : "7b7909f2f6b9414be0958275f4c8e5d69c3bca43"
       }
+    },
+    {
+      "identity" : "tree-sitter-toml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter-grammars/tree-sitter-toml",
+      "state" : {
+        "revision" : "64b56832c2cffe41758f28e05c756a3a98d16f41",
+        "version" : "0.7.0"
+      }
     }
   ],
   "version" : 2

--- a/Alas/Sources/Code/Highlight/LanguageRegistry.swift
+++ b/Alas/Sources/Code/Highlight/LanguageRegistry.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftTreeSitter
 import TreeSitterJSON
 import TreeSitterSwift
+import TreeSitterTOML
 import TreeSitterYAML
 
 /// Maps a file extension to a `SwiftTreeSitter.Language` and the
@@ -25,6 +26,7 @@ enum LanguageRegistry {
         case "swift":         lang = Language(language: tree_sitter_swift())
         case "yaml", "yml":   lang = Language(language: tree_sitter_yaml())
         case "json":          lang = Language(language: tree_sitter_json())
+        case "toml":          lang = Language(language: tree_sitter_toml())
         default:              lang = nil
         }
         if let lang { languageCache[key] = lang }
@@ -55,6 +57,10 @@ enum LanguageRegistry {
         case "json":
             query = loadQuery(named: "highlights",
                               bundleNameContains: "TreeSitterJSON",
+                              language: lang)
+        case "toml":
+            query = loadQuery(named: "highlights",
+                              bundleNameContains: "TreeSitterTOML",
                               language: lang)
         default:
             query = nil

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -28,6 +28,20 @@ struct TreeSitterHighlighterTests {
         #expect(spans.contains(where: { $0.capture == .number }))
     }
 
+    @Test("TOML keys, strings, and numbers are captured")
+    func tomlBasics() throws {
+        let src = """
+        name = "alas"
+        port = 8080
+        [server]
+        host = "localhost"
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "toml")
+        #expect(!spans.isEmpty)
+        #expect(spans.contains(where: { $0.capture == .string }))
+        #expect(spans.contains(where: { $0.capture == .number }))
+    }
+
     @Test("unknown extension returns no spans")
     func unknownExtension() throws {
         let spans = TreeSitterHighlighter.highlight(source: "print()", fileExtension: "abc")

--- a/project.yml
+++ b/project.yml
@@ -34,6 +34,9 @@ packages:
   TreeSitterJSON:
     url: https://github.com/tree-sitter/tree-sitter-json
     from: 0.24.8
+  TreeSitterTOML:
+    url: https://github.com/tree-sitter-grammars/tree-sitter-toml
+    from: 0.7.0
   Markdown:
     url: https://github.com/apple/swift-markdown
     from: 0.4.0
@@ -80,6 +83,8 @@ targets:
         product: TreeSitterYAML
       - package: TreeSitterJSON
         product: TreeSitterJSON
+      - package: TreeSitterTOML
+        product: TreeSitterTOML
       - package: Markdown
         product: Markdown
     settings:


### PR DESCRIPTION
<!-- gg:managed:start -->
Wires tree-sitter-toml v0.7.0 into LanguageRegistry so `.toml` files
render with tree-sitter coloring (table headers, keys, strings, numbers,
dates). Upstream Package.swift is SPM-clean — consumed remotely, no
vendoring required.
<!-- gg:managed:end -->