### PR TITLE
feat(highlight): Rust syntax highlighting via tree-sitter

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -73,7 +73,7 @@
 		1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
 		1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */; };
-		1D66F354E7488D0CDAC39BE2 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
+		1D66F354E7488D0CDAC39BE2 /* TreeSitterRust in Frameworks */ = {isa = PBXBuildFile; productRef = 8007CCE96A65B912CE519EF0 /* TreeSitterRust */; };
 		1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */; };
 		1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */; };
 		1E775E7F3C9F47C676C61B09 /* SwiftTreeSitter in Frameworks */ = {isa = PBXBuildFile; productRef = F1A519F1F3F2B01C1D2E13A7 /* SwiftTreeSitter */; };
@@ -286,6 +286,7 @@
 		7B85B033B476943E77867BA3 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69024633944E9FFF6DA76FAE /* RootView.swift */; };
 		7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */; };
 		7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */; };
+		7C9B1B7376FE5F651D9127D1 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = B69450B224F0C82A52D00662 /* Markdown */; };
 		7CA34C93E31EA98047AF6D81 /* MergeScrollCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883981BBADF9816718091CE1 /* MergeScrollCoordinatorTests.swift */; };
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
 		7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4575017544CD7603B3AB9069 /* GitEventFilter.swift */; };
@@ -1145,7 +1146,8 @@
 				9B2B055195430A5A40BC7659 /* TreeSitterJSON in Frameworks */,
 				7377F6BACEEA621425E54FBC /* TreeSitterTOML in Frameworks */,
 				8352A6C0D7AE371907E50217 /* TreeSitterPython in Frameworks */,
-				1D66F354E7488D0CDAC39BE2 /* Markdown in Frameworks */,
+				1D66F354E7488D0CDAC39BE2 /* TreeSitterRust in Frameworks */,
+				7C9B1B7376FE5F651D9127D1 /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2182,6 +2184,7 @@
 				5130D28B6980AF12D2256A6D /* TreeSitterJSON */,
 				69EF3147FDD8F28F8D65D4FC /* TreeSitterTOML */,
 				7D55FFC5D9F65DAD0178FB0E /* TreeSitterPython */,
+				8007CCE96A65B912CE519EF0 /* TreeSitterRust */,
 				B69450B224F0C82A52D00662 /* Markdown */,
 			);
 			productName = Alas;
@@ -2215,6 +2218,7 @@
 				B9008B8C0F5A7E880C250FE4 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 				CF72A36467D20A160E653761 /* XCRemoteSwiftPackageReference "swift-tree-sitter" */,
 				FC44B93BBD7A9BE00A7FADD2 /* XCRemoteSwiftPackageReference "tree-sitter-json" */,
+				AFDA8006DAB856320603269E /* XCRemoteSwiftPackageReference "tree-sitter-rust" */,
 				7019D0C134F78A3B7F4CF4BB /* XCRemoteSwiftPackageReference "tree-sitter-swift" */,
 				A38DA0B05C2E29601ED4C8A9 /* XCRemoteSwiftPackageReference "tree-sitter-toml" */,
 				5844843C71BA73C8F5B45D8A /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterPython" */,
@@ -3121,6 +3125,14 @@
 				minimumVersion = 0.7.0;
 			};
 		};
+		AFDA8006DAB856320603269E /* XCRemoteSwiftPackageReference "tree-sitter-rust" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tree-sitter/tree-sitter-rust";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.24.2;
+			};
+		};
 		B9008B8C0F5A7E880C250FE4 /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-markdown";
@@ -3170,6 +3182,11 @@
 		7D55FFC5D9F65DAD0178FB0E /* TreeSitterPython */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TreeSitterPython;
+		};
+		8007CCE96A65B912CE519EF0 /* TreeSitterRust */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AFDA8006DAB856320603269E /* XCRemoteSwiftPackageReference "tree-sitter-rust" */;
+			productName = TreeSitterRust;
 		};
 		B69450B224F0C82A52D00662 /* Markdown */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -46,6 +46,15 @@
       }
     },
     {
+      "identity" : "tree-sitter-rust",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter-rust",
+      "state" : {
+        "revision" : "77a3747266f4d621d0757825e6b11edcbf991ca5",
+        "version" : "0.24.2"
+      }
+    },
+    {
       "identity" : "tree-sitter-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/alex-pinkus/tree-sitter-swift",

--- a/Alas/Sources/Code/Highlight/LanguageRegistry.swift
+++ b/Alas/Sources/Code/Highlight/LanguageRegistry.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftTreeSitter
 import TreeSitterJSON
 import TreeSitterPython
+import TreeSitterRust
 import TreeSitterSwift
 import TreeSitterTOML
 import TreeSitterYAML
@@ -29,6 +30,7 @@ enum LanguageRegistry {
         case "json":          lang = Language(language: tree_sitter_json())
         case "toml":          lang = Language(language: tree_sitter_toml())
         case "py":            lang = Language(language: tree_sitter_python())
+        case "rs":            lang = Language(language: tree_sitter_rust())
         default:              lang = nil
         }
         if let lang { languageCache[key] = lang }
@@ -67,6 +69,10 @@ enum LanguageRegistry {
         case "py":
             query = loadQuery(named: "highlights",
                               bundleNameContains: "TreeSitterPython",
+                              language: lang)
+        case "rs":
+            query = loadQuery(named: "highlights",
+                              bundleNameContains: "TreeSitterRust",
                               language: lang)
         default:
             query = nil

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -13,11 +13,13 @@ struct TreeSitterHighlighterTests {
         #expect(captures.contains(.function))
     }
 
-    @Test("fallback highlighter preserves non-Swift spans")
-    func fallbackHighlighterForKnownExtensions() throws {
-        let rust = TreeSitterHighlighter.highlight(source: #"fn main() { println!("hi") }"#, fileExtension: "rs")
-        #expect(rust.contains(where: { $0.capture == .keyword }))
-        #expect(rust.contains(where: { $0.capture == .string }))
+    @Test("Rust `fn main()` is captured as keyword + function")
+    func rustFunction() throws {
+        let spans = TreeSitterHighlighter.highlight(source: #"fn main() { println!("hi") }"#, fileExtension: "rs")
+        let captures = Set(spans.map { $0.capture })
+        #expect(captures.contains(.keyword))
+        #expect(captures.contains(.function))
+        #expect(captures.contains(.string))
     }
 
     @Test("JSON strings and numbers are captured")

--- a/project.yml
+++ b/project.yml
@@ -42,6 +42,9 @@ packages:
     # has the same broken `FileManager.fileExists` scanner conditional
     # as tree-sitter-yaml.
     path: ThirdParty/TreeSitterPython
+  TreeSitterRust:
+    url: https://github.com/tree-sitter/tree-sitter-rust
+    from: 0.24.2
   Markdown:
     url: https://github.com/apple/swift-markdown
     from: 0.4.0
@@ -92,6 +95,8 @@ targets:
         product: TreeSitterTOML
       - package: TreeSitterPython
         product: TreeSitterPython
+      - package: TreeSitterRust
+        product: TreeSitterRust
       - package: Markdown
         product: Markdown
     settings:


### PR DESCRIPTION
<!-- gg:managed:start -->
Wires tree-sitter-rust v0.24.2 into LanguageRegistry so `.rs` files
render with tree-sitter coloring (keywords, fn definitions, lifetimes,
macros, strings). Upstream Package.swift is SPM-clean — consumed
remotely, no vendoring required.
<!-- gg:managed:end -->