### PR TITLE
feat(code): LSP status badge in editor breadcrumb

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 		BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */; };
 		BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88379ACE40F42BE4A3257659 /* ThemeTests.swift */; };
 		BFADE15EC5D60235EF2ACBE1 /* ImageDiffPairLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB8043A52927E5E935E2F9B /* ImageDiffPairLoaderTests.swift */; };
+		BFB0E1885389D75F93C98BCF /* EditorLSPStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */; };
 		BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */; };
 		BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */; };
 		C02EB84F4343BD78984791EB /* CommitComposerStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCC5576ACD7C49EB6915992 /* CommitComposerStateTests.swift */; };
@@ -1060,6 +1061,7 @@
 		D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigCodeInstallTests.swift; sourceTree = "<group>"; };
 		D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
 		D97EF761C70A3AF83C00879A /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
+		D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatus.swift; sourceTree = "<group>"; };
 		D9E6D61B213F3378243B4A26 /* AlasField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasField.swift; sourceTree = "<group>"; };
 		DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRow.swift; sourceTree = "<group>"; };
 		DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetailsTests.swift; sourceTree = "<group>"; };
@@ -1911,6 +1913,7 @@
 				BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */,
 				679E62B501E0490F48CCA830 /* EditorFindBarView.swift */,
 				55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */,
+				D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
 				35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */,
 				3D105CB2C185958ED23164D1 /* IndentationMode.swift */,
@@ -2439,6 +2442,7 @@
 				DEBA25FCF25D26395BD04F73 /* EditorConflictBanner.swift in Sources */,
 				3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */,
 				25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */,
+				BFB0E1885389D75F93C98BCF /* EditorLSPStatus.swift in Sources */,
 				395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */; };
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
 		8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */; };
+		8FA22790805C973E9EF64477 /* EditorLSPStatusResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */; };
 		8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */; };
 		8FD71F989EFA5BF22B92B4CD /* SidebarMaterialChoiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */; };
 		8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2AC0F8B3A1B75239995AC /* AppState.swift */; };
@@ -375,6 +376,7 @@
 		A0F1E46BC1A9E2CC21805EE7 /* FilesTabFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1977C85C3DFD1F232A2755AD /* FilesTabFilterTests.swift */; };
 		A15C8E0D7A942160A74BD68E /* ImageDiffPairResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */; };
 		A19649A790595DF4F48C3824 /* TerminalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFC62A30044F71F0F16C3FB /* TerminalService.swift */; };
+		A19D418808D8CCCE04242E07 /* EditorLSPStatusResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B2EDBA4EB4BF7A854FF96 /* EditorLSPStatusResolverTests.swift */; };
 		A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */; };
 		A240E6FE68F27C04D32A270A /* AlasApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */; };
 		A2B0E4C1D80EB12F7BECE7FC /* RepoSelectorDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */; };
@@ -663,6 +665,7 @@
 		206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCheckerboardBackground.swift; sourceTree = "<group>"; };
 		2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
 		208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanelTests.swift; sourceTree = "<group>"; };
+		209B2EDBA4EB4BF7A854FF96 /* EditorLSPStatusResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusResolverTests.swift; sourceTree = "<group>"; };
 		2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.App.swift; sourceTree = "<group>"; };
 		215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyHost.swift; sourceTree = "<group>"; };
 		220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModelTests.swift; sourceTree = "<group>"; };
@@ -723,6 +726,7 @@
 		37987D5884297401F95478D3 /* AgentPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPathTests.swift; sourceTree = "<group>"; };
 		379D90AD620EAF6E84A04902 /* ImageDiffSideBySideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSideBySideView.swift; sourceTree = "<group>"; };
 		37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorEnvironment.swift; sourceTree = "<group>"; };
+		37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusResolver.swift; sourceTree = "<group>"; };
 		38499AFE31188908546EE222 /* LSPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransport.swift; sourceTree = "<group>"; };
 		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
 		38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairKind.swift; sourceTree = "<group>"; };
@@ -1283,6 +1287,7 @@
 				35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */,
 				C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */,
 				6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */,
+				209B2EDBA4EB4BF7A854FF96 /* EditorLSPStatusResolverTests.swift */,
 				208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */,
 				E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */,
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
@@ -1914,6 +1919,7 @@
 				679E62B501E0490F48CCA830 /* EditorFindBarView.swift */,
 				55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */,
 				D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */,
+				37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
 				35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */,
 				3D105CB2C185958ED23164D1 /* IndentationMode.swift */,
@@ -2443,6 +2449,7 @@
 				3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */,
 				25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */,
 				BFB0E1885389D75F93C98BCF /* EditorLSPStatus.swift in Sources */,
+				8FA22790805C973E9EF64477 /* EditorLSPStatusResolver.swift in Sources */,
 				395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,
 				41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */,
@@ -2737,6 +2744,7 @@
 				3B7D77B9E71C66ACB1E007D7 /* EditorBufferStoreTests.swift in Sources */,
 				C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */,
 				B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */,
+				A19D418808D8CCCE04242E07 /* EditorLSPStatusResolverTests.swift in Sources */,
 				0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */,
 				1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */,
 				C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */; };
 		3961F6003185B2FC9DFE7E14 /* ImageDiffDifferenceComputerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */; };
 		39DE92AE4B12D2CD03655562 /* CommitPromptStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */; };
+		3A108152BB33EF9B00FC2F1B /* EditorLSPStatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDABED76CD2A552B1781D3F4 /* EditorLSPStatusBadge.swift */; };
 		3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */; };
 		3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E265B0C6F314FC80DB18053D /* RecommendedLanguageCatalog.swift */; };
 		3AF04FB045CE3D9CAC066B27 /* HarnessKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F2498E56CBAF84CB67166C /* HarnessKind.swift */; };
@@ -564,6 +565,7 @@
 		F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */; };
 		F855DEEEE005795EC6B13544 /* AlasFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 169FC38D03727F34855EB521 /* AlasFieldTests.swift */; };
 		F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */; };
+		F92535799AE74C9BF1DC3D88 /* EditorLSPStatusOverridePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */; };
 		F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */; };
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
 		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
@@ -855,6 +857,7 @@
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
 		72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWordDiffTests.swift; sourceTree = "<group>"; };
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
+		73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusOverridePicker.swift; sourceTree = "<group>"; };
 		73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLifecycleEventMapper.swift; sourceTree = "<group>"; };
 		743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptResolver.swift; sourceTree = "<group>"; };
 		749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSingleResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
@@ -998,6 +1001,7 @@
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
 		BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerHeadUpdatesTests.swift; sourceTree = "<group>"; };
 		BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfig.swift; sourceTree = "<group>"; };
+		BDABED76CD2A552B1781D3F4 /* EditorLSPStatusBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusBadge.swift; sourceTree = "<group>"; };
 		BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletingWorktreeView.swift; sourceTree = "<group>"; };
 		BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitIgnoreService.swift; sourceTree = "<group>"; };
 		BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentSearcher.swift; sourceTree = "<group>"; };
@@ -1922,6 +1926,8 @@
 				679E62B501E0490F48CCA830 /* EditorFindBarView.swift */,
 				55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */,
 				D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */,
+				BDABED76CD2A552B1781D3F4 /* EditorLSPStatusBadge.swift */,
+				73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */,
 				37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */,
 				C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */,
 				35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */,
@@ -2452,6 +2458,8 @@
 				3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */,
 				25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */,
 				BFB0E1885389D75F93C98BCF /* EditorLSPStatus.swift in Sources */,
+				3A108152BB33EF9B00FC2F1B /* EditorLSPStatusBadge.swift in Sources */,
+				F92535799AE74C9BF1DC3D88 /* EditorLSPStatusOverridePicker.swift in Sources */,
 				8FA22790805C973E9EF64477 /* EditorLSPStatusResolver.swift in Sources */,
 				395BC74AF07FD44D67DBE579 /* EditorOverlayPanel.swift in Sources */,
 				1066AF44E2FCA9B1B2DDE9D7 /* EditorTabView.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -435,6 +435,7 @@
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
 		BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */; };
 		BE4E46595AF10611CE0B1C6B /* TabActivityPulse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */; };
+		BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */; };
 		BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */; };
 		BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */; };
 		BF9C16C33DF0BBAF2946AFC3 /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88379ACE40F42BE4A3257659 /* ThemeTests.swift */; };
@@ -965,6 +966,7 @@
 		A98D0A96093087BF4C284053 /* AlasSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasSlider.swift; sourceTree = "<group>"; };
 		AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstallerTests.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
+		AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManagerStatusTests.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometryTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
@@ -1415,6 +1417,7 @@
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
+				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
 				C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
@@ -2886,6 +2889,7 @@
 				9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
+				BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */,
 				E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
 				E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */,

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -206,30 +206,19 @@ struct EditorTabView: View {
     }
 
     private var statusBadge: some View {
-        // External editor tabs (SDK files, opened via cmd-click) have an
-        // absolute path and an empty `relativePath` — fetching them via
-        // `tabs.buffer(...)` would create a parallel in-worktree buffer
-        // and watcher alongside the real external buffer, leaking state.
-        let buffer: EditorBuffer
-        if let abs = externalAbsolutePath {
-            let absoluteURL = URL(fileURLWithPath: abs)
-            let ext = (abs as NSString).pathExtension
-            let language = appState.lsp.language(forFileExtension: ext)
-            let originatingFileURL: URL? = originatingRelativePath.map { worktreePath.appendingPathComponent($0) }
-            buffer = appState.tabs.externalBuffer(
-                worktreeId: worktreeId,
-                tabId: tabId,
-                absoluteURL: absoluteURL,
-                worktreeRoot: worktreePath,
-                originatingFileURL: originatingFileURL,
-                language: language
-            )
-        } else {
-            buffer = appState.tabs.buffer(
-                worktreeId: worktreeId, tabId: tabId,
-                worktreeRoot: worktreePath, relativePath: relativePath
-            )
-        }
+        // External editor tabs (SDK files, opened via cmd-click) don't
+        // support runtime override: `EditorBuffer.applyEffectiveLanguageToLSP`
+        // bails for `isExternal == true`, so the override wouldn't actually
+        // re-route LSP traffic. We also avoid calling `tabs.externalBuffer`
+        // here because it has side effects (startWatching, ensureExternalLSPOpen)
+        // that would refire on every breadcrumb re-render. The override
+        // picker is hidden via `supportsOverride: false` so the user isn't
+        // offered a no-op action.
+        let isExternal = externalAbsolutePath != nil
+        let buffer: EditorBuffer? = isExternal ? nil : appState.tabs.buffer(
+            worktreeId: worktreeId, tabId: tabId,
+            worktreeRoot: worktreePath, relativePath: relativePath
+        )
         let absolutePath = externalAbsolutePath ?? worktreePath.appendingPathComponent(relativePath).path
         let registry = appState.lsp.activeRegistry
         let resolver = EditorLSPStatusResolver(
@@ -243,7 +232,7 @@ struct EditorTabView: View {
 
         let status = resolver.resolve(
             absolutePath: absolutePath,
-            override: buffer.languageOverride,
+            override: buffer?.languageOverride,
             worktreeRoot: worktreePath
         )
 
@@ -269,6 +258,7 @@ struct EditorTabView: View {
 
         return EditorLSPStatusBadge(
             status: status,
+            supportsOverride: !isExternal,
             availableLanguages: availableLanguagesProvider,
             openFilesUsingLanguage: openFilesUsingLanguage,
             onRestart: {
@@ -283,7 +273,7 @@ struct EditorTabView: View {
                 }
             },
             onOverride: { newLanguage in
-                buffer.languageOverride = newLanguage
+                buffer?.languageOverride = newLanguage
             },
             onOpenSettings: {
                 openWindow(id: "settings")

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -249,12 +249,9 @@ struct EditorTabView: View {
                 .sorted { $0.displayName < $1.displayName }
         }
 
-        let openFilesUsingLanguage: Int
-        if let lang = status.language {
-            openFilesUsingLanguage = appState.lsp.openFilesUsing(language: lang, rootURL: worktreePath)
-        } else {
-            openFilesUsingLanguage = 0
-        }
+        let openFilesUsingLanguage: Int = status.language == nil
+            ? 0
+            : appState.lsp.openFilesUsing(forFile: URL(fileURLWithPath: absolutePath), worktreeRoot: worktreePath)
 
         return EditorLSPStatusBadge(
             status: status,

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -254,8 +254,13 @@ struct EditorTabView: View {
             openFilesUsingLanguage: openFilesUsingLanguage,
             onRestart: {
                 guard let lang = status.language else { return }
+                let fileURL = URL(fileURLWithPath: absolutePath)
                 Task { @MainActor in
-                    await appState.lsp.restartHolder(forLanguage: lang, rootURL: worktreePath)
+                    await appState.lsp.restartHolder(
+                        forFile: fileURL,
+                        worktreeRoot: worktreePath,
+                        languageId: lang
+                    )
                 }
             },
             onOverride: { newLanguage in
@@ -263,16 +268,6 @@ struct EditorTabView: View {
             },
             onOpenSettings: {
                 openWindow(id: "settings")
-            },
-            onCancel: {
-                guard let lang = status.language else { return }
-                Task { @MainActor in
-                    await appState.lsp.closeDocument(
-                        worktreeRoot: worktreePath,
-                        fileURL: URL(fileURLWithPath: absolutePath),
-                        languageId: lang
-                    )
-                }
             },
             onInstall: {
                 // The existing InstallNudgeBanner below the breadcrumb already

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -206,10 +206,30 @@ struct EditorTabView: View {
     }
 
     private var statusBadge: some View {
-        let buffer = appState.tabs.buffer(
-            worktreeId: worktreeId, tabId: tabId,
-            worktreeRoot: worktreePath, relativePath: relativePath
-        )
+        // External editor tabs (SDK files, opened via cmd-click) have an
+        // absolute path and an empty `relativePath` — fetching them via
+        // `tabs.buffer(...)` would create a parallel in-worktree buffer
+        // and watcher alongside the real external buffer, leaking state.
+        let buffer: EditorBuffer
+        if let abs = externalAbsolutePath {
+            let absoluteURL = URL(fileURLWithPath: abs)
+            let ext = (abs as NSString).pathExtension
+            let language = appState.lsp.language(forFileExtension: ext)
+            let originatingFileURL: URL? = originatingRelativePath.map { worktreePath.appendingPathComponent($0) }
+            buffer = appState.tabs.externalBuffer(
+                worktreeId: worktreeId,
+                tabId: tabId,
+                absoluteURL: absoluteURL,
+                worktreeRoot: worktreePath,
+                originatingFileURL: originatingFileURL,
+                language: language
+            )
+        } else {
+            buffer = appState.tabs.buffer(
+                worktreeId: worktreeId, tabId: tabId,
+                worktreeRoot: worktreePath, relativePath: relativePath
+            )
+        }
         let absolutePath = externalAbsolutePath ?? worktreePath.appendingPathComponent(relativePath).path
         let registry = appState.lsp.activeRegistry
         let resolver = EditorLSPStatusResolver(

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -1,6 +1,35 @@
 import SwiftUI
 import AppKit
 
+private struct LSPStatusProbes {
+    struct Manager: EditorLSPStatusResolver.ManagerProbe {
+        let inner: WorkspaceLSPManager
+        @MainActor
+        func documentStatus(forFile fileURL: URL, worktreeRoot: URL) -> WorkspaceLSPManager.DocumentStatus {
+            inner.documentStatus(forFile: fileURL, worktreeRoot: worktreeRoot)
+        }
+    }
+
+    struct Availability: EditorLSPStatusResolver.AvailabilityProbe {
+        let registry: LanguageServerRegistry
+        let availability: LanguageServerAvailability
+        func status(forLanguage language: String) -> LanguageServerAvailability.Status? {
+            guard let entry = registry.allEntries().first(where: { $0.language == language }) else { return nil }
+            return availability.status(for: entry)
+        }
+        func command(forLanguage language: String) -> String? {
+            registry.allEntries().first(where: { $0.language == language })?.command
+        }
+    }
+
+    struct Registry: EditorLSPStatusResolver.RegistryProbe {
+        let inner: LanguageServerRegistry
+        func language(forFileExtension ext: String) -> String? {
+            inner.language(forFileExtension: ext)
+        }
+    }
+}
+
 struct EditorTabView: View {
     let worktreePath: URL
     let relativePath: String
@@ -13,6 +42,7 @@ struct EditorTabView: View {
     let originatingRelativePath: String?
     let onRevealInFiles: (String) -> Void
     @Environment(\.theme) var theme
+    @Environment(\.openWindow) private var openWindow
 
     @State private var findBarVisible: Bool = false
     @State private var findController = EditorFindController()
@@ -168,9 +198,81 @@ struct EditorTabView: View {
                 }
             }
             Spacer()
+            statusBadge
         }
         .padding(.horizontal, 12).frame(height: 28)
         .background(theme.color("bg-1"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    private var statusBadge: some View {
+        let buffer = appState.tabs.buffer(
+            worktreeId: worktreeId, tabId: tabId,
+            worktreeRoot: worktreePath, relativePath: relativePath
+        )
+        let absolutePath = externalAbsolutePath ?? worktreePath.appendingPathComponent(relativePath).path
+        let registry = appState.lsp.activeRegistry
+        let availability = LanguageServerAvailability()
+        let resolver = EditorLSPStatusResolver(
+            manager: LSPStatusProbes.Manager(inner: appState.lsp),
+            availability: LSPStatusProbes.Availability(registry: registry, availability: availability),
+            registry: LSPStatusProbes.Registry(inner: registry)
+        )
+        // Touch `stateTick` so SwiftUI re-renders on holder transitions even
+        // when the buffer-side state hasn't changed.
+        _ = appState.lsp.stateTick
+
+        let status = resolver.resolve(
+            absolutePath: absolutePath,
+            override: buffer.languageOverride,
+            worktreeRoot: worktreePath
+        )
+
+        let availableLanguages: [(language: String, displayName: String)] =
+            registry.allEntries()
+                .filter { availability.status(for: $0) == .available }
+                .map { ($0.language, RecommendedLanguageCatalog.entry(forLanguage: $0.language)?.displayName ?? $0.language) }
+                .sorted { $0.displayName < $1.displayName }
+
+        let openFilesUsingLanguage: Int
+        if let lang = status.language {
+            openFilesUsingLanguage = appState.lsp.openFilesUsing(language: lang, rootURL: worktreePath)
+        } else {
+            openFilesUsingLanguage = 0
+        }
+
+        return EditorLSPStatusBadge(
+            status: status,
+            availableLanguages: availableLanguages,
+            openFilesUsingLanguage: openFilesUsingLanguage,
+            onRestart: {
+                guard let lang = status.language else { return }
+                Task { @MainActor in
+                    await appState.lsp.restartHolder(forLanguage: lang, rootURL: worktreePath)
+                }
+            },
+            onOverride: { newLanguage in
+                buffer.languageOverride = newLanguage
+            },
+            onOpenSettings: {
+                openWindow(id: "settings")
+            },
+            onCancel: {
+                guard let lang = status.language else { return }
+                Task { @MainActor in
+                    await appState.lsp.closeDocument(
+                        worktreeRoot: worktreePath,
+                        fileURL: URL(fileURLWithPath: absolutePath),
+                        languageId: lang
+                    )
+                }
+            },
+            onInstall: {
+                // The existing InstallNudgeBanner below the breadcrumb already
+                // handles inline install flows; from the badge popover we
+                // surface the install entry via Settings → Code.
+                openWindow(id: "settings")
+            }
+        )
     }
 }

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -11,11 +11,11 @@ private struct LSPStatusProbes {
     }
 
     struct Availability: EditorLSPStatusResolver.AvailabilityProbe {
+        let manager: WorkspaceLSPManager
         let registry: LanguageServerRegistry
-        let availability: LanguageServerAvailability
+        @MainActor
         func status(forLanguage language: String) -> LanguageServerAvailability.Status? {
-            guard let entry = registry.allEntries().first(where: { $0.language == language }) else { return nil }
-            return availability.status(for: entry)
+            manager.availabilityStatus(forLanguage: language)
         }
         func command(forLanguage language: String) -> String? {
             registry.allEntries().first(where: { $0.language == language })?.command
@@ -212,10 +212,9 @@ struct EditorTabView: View {
         )
         let absolutePath = externalAbsolutePath ?? worktreePath.appendingPathComponent(relativePath).path
         let registry = appState.lsp.activeRegistry
-        let availability = LanguageServerAvailability()
         let resolver = EditorLSPStatusResolver(
             manager: LSPStatusProbes.Manager(inner: appState.lsp),
-            availability: LSPStatusProbes.Availability(registry: registry, availability: availability),
+            availability: LSPStatusProbes.Availability(manager: appState.lsp, registry: registry),
             registry: LSPStatusProbes.Registry(inner: registry)
         )
         // Touch `stateTick` so SwiftUI re-renders on holder transitions even
@@ -233,10 +232,10 @@ struct EditorTabView: View {
         // languages involves PATH walks and (for sourcekit-lsp) an `xcrun`
         // subprocess — too expensive for a view body that runs many times
         // per second.
-        let availableLanguagesProvider: () -> [(language: String, displayName: String)] = {
-            let availability = LanguageServerAvailability()
-            return registry.allEntries()
-                .filter { availability.status(for: $0) == .available }
+        let manager = appState.lsp
+        let availableLanguagesProvider: @MainActor () -> [(language: String, displayName: String)] = {
+            registry.allEntries()
+                .filter { manager.availabilityStatus(forLanguage: $0.language) == .available }
                 .map { ($0.language, RecommendedLanguageCatalog.entry(forLanguage: $0.language)?.displayName ?? $0.language) }
                 .sorted { $0.displayName < $1.displayName }
         }

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -228,11 +228,18 @@ struct EditorTabView: View {
             worktreeRoot: worktreePath
         )
 
-        let availableLanguages: [(language: String, displayName: String)] =
-            registry.allEntries()
+        // Compute the override picker's language list only when the popover
+        // opens, not on every breadcrumb re-render. Filtering installed
+        // languages involves PATH walks and (for sourcekit-lsp) an `xcrun`
+        // subprocess — too expensive for a view body that runs many times
+        // per second.
+        let availableLanguagesProvider: () -> [(language: String, displayName: String)] = {
+            let availability = LanguageServerAvailability()
+            return registry.allEntries()
                 .filter { availability.status(for: $0) == .available }
                 .map { ($0.language, RecommendedLanguageCatalog.entry(forLanguage: $0.language)?.displayName ?? $0.language) }
                 .sorted { $0.displayName < $1.displayName }
+        }
 
         let openFilesUsingLanguage: Int
         if let lang = status.language {
@@ -243,7 +250,7 @@ struct EditorTabView: View {
 
         return EditorLSPStatusBadge(
             status: status,
-            availableLanguages: availableLanguages,
+            availableLanguages: availableLanguagesProvider,
             openFilesUsingLanguage: openFilesUsingLanguage,
             onRestart: {
                 guard let lang = status.language else { return }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -1,6 +1,5 @@
 import AppKit
 import Foundation
-import Observation
 
 /// Lifecycle adapter between a `CodeTextView` (per-mount, recreated by
 /// SwiftUI) and an `EditorBuffer` (per-tab, owned by `TabsManager`). The
@@ -428,71 +427,6 @@ final class CodeEditorCoordinator {
         subscribeIfPossible(theme: theme)
         editObserverToken = buffer.onTextEdit { [weak self] edit in
             self?.scheduleEditPropagation(edit: edit)
-        }
-        observeEffectiveLanguage(buffer)
-        // Reconcile any preexisting override on the newly bound buffer.
-        // `withObservationTracking` only fires when the tracked value changes
-        // *after* registration, so a buffer that already has a
-        // `languageOverride` set (e.g. user is switching back to a tab they
-        // previously overrode) would otherwise be silently ignored.
-        handleLanguageChange(for: buffer)
-    }
-
-    private func observeEffectiveLanguage(_ buffer: EditorBuffer) {
-        // One-shot `withObservationTracking` re-arms itself from inside
-        // `onChange`, so each change drives at most one close+reopen cycle.
-        // The identity guard inside the inner Task prevents a stale
-        // observation (left over from a previous bindBuffer) from firing on
-        // the coordinator after it has rebound to a different buffer.
-        _ = withObservationTracking {
-            buffer.effectiveLanguage
-        } onChange: { [weak self, weak buffer] in
-            Task { @MainActor [weak self, weak buffer] in
-                guard let self, let buffer, self.buffer === buffer else { return }
-                self.handleLanguageChange(for: buffer)
-                self.observeEffectiveLanguage(buffer)
-            }
-        }
-    }
-
-    private func handleLanguageChange(for buffer: EditorBuffer) {
-        // Identity guard: a stale observation from a prior bindBuffer could
-        // fire here against the previous buffer; ignore it so we don't mutate
-        // LSP routing for the currently-bound tab using the old buffer's
-        // effectiveLanguage.
-        guard self.buffer === buffer else { return }
-        // External buffers route LSP through a separate worktree-anchored
-        // holder owned by TabsManager. Routing them through openDocument here
-        // would leak a new worktree-keyed document; for v1 we don't support
-        // overriding language on external buffers.
-        guard !buffer.isExternal else { return }
-        let newLanguage = buffer.effectiveLanguage
-        let previous = currentLanguage
-        guard newLanguage != previous else { return }
-        let rootCapture = currentRoot
-        let relCapture = currentRelativePath
-        currentLanguage = newLanguage
-        Task { @MainActor [weak self, weak buffer] in
-            guard let self, let buffer, self.buffer === buffer else { return }
-            if let previous, let root = rootCapture, let rel = relCapture {
-                await self.appState.lsp.closeDocument(
-                    worktreeRoot: root,
-                    fileURL: root.appendingPathComponent(rel),
-                    languageId: previous
-                )
-            }
-            if let newLanguage, let root = rootCapture, let rel = relCapture {
-                // Recapture text inside the Task so edits the user made
-                // between override toggle and Task execution aren't clobbered
-                // by a stale snapshot.
-                let text = buffer.storage.string
-                _ = await self.appState.lsp.openDocument(
-                    worktreeRoot: root,
-                    fileURL: root.appendingPathComponent(rel),
-                    languageId: newLanguage,
-                    text: text
-                )
-            }
         }
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import Observation
 
 /// Lifecycle adapter between a `CodeTextView` (per-mount, recreated by
 /// SwiftUI) and an `EditorBuffer` (per-tab, owned by `TabsManager`). The
@@ -390,6 +391,24 @@ final class CodeEditorCoordinator {
     /// Wire the coordinator and the text view to `buffer`. If a previous
     /// buffer is already bound, its layout manager and edit observer are torn
     /// down first so the text view stops rendering the old storage.
+    private func observeEffectiveLanguage(_ buffer: EditorBuffer) {
+        // One-shot `withObservationTracking` re-arms itself from `onChange`.
+        // This observer only mirrors `buffer.effectiveLanguage` into
+        // `currentLanguage` — LSP open/close lives in `EditorBuffer`.
+        // Keeping `currentLanguage` accurate is critical because hover,
+        // definition, completion, diagnostics, didChange, and indentation
+        // all route through it.
+        _ = withObservationTracking {
+            _ = buffer.effectiveLanguage
+        } onChange: { [weak self, weak buffer] in
+            Task { @MainActor [weak self, weak buffer] in
+                guard let self, let buffer, self.buffer === buffer else { return }
+                self.currentLanguage = buffer.effectiveLanguage
+                self.observeEffectiveLanguage(buffer)
+            }
+        }
+    }
+
     private func bindBuffer(_ buffer: EditorBuffer, theme: Theme) {
         pullDiagnosticsTask?.cancel()
         pullDiagnosticsTask = nil
@@ -408,6 +427,10 @@ final class CodeEditorCoordinator {
         self.currentRelativePath = buffer.relativePath
         let ext = (buffer.relativePath as NSString).pathExtension
         currentLanguage = appState.lsp.language(forFileExtension: ext)
+        // Reconcile against any pre-existing override before arming the
+        // observer (the observer only fires on subsequent changes).
+        currentLanguage = buffer.effectiveLanguage
+        observeEffectiveLanguage(buffer)
         applyIndentationMode()
         if let layoutManager {
             buffer.storage.addLayoutManager(layoutManager)

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -404,6 +404,7 @@ final class CodeEditorCoordinator {
             Task { @MainActor [weak self, weak buffer] in
                 guard let self, let buffer, self.buffer === buffer else { return }
                 self.currentLanguage = buffer.effectiveLanguage
+                self.applyIndentationMode()
                 self.observeEffectiveLanguage(buffer)
             }
         }

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -430,35 +430,50 @@ final class CodeEditorCoordinator {
             self?.scheduleEditPropagation(edit: edit)
         }
         observeEffectiveLanguage(buffer)
+        // Reconcile any preexisting override on the newly bound buffer.
+        // `withObservationTracking` only fires when the tracked value changes
+        // *after* registration, so a buffer that already has a
+        // `languageOverride` set (e.g. user is switching back to a tab they
+        // previously overrode) would otherwise be silently ignored.
+        handleLanguageChange(for: buffer)
     }
-
-    private var languageObservationArmed = false
 
     private func observeEffectiveLanguage(_ buffer: EditorBuffer) {
         // One-shot `withObservationTracking` re-arms itself from inside
         // `onChange`, so each change drives at most one close+reopen cycle.
+        // The identity guard inside the inner Task prevents a stale
+        // observation (left over from a previous bindBuffer) from firing on
+        // the coordinator after it has rebound to a different buffer.
         _ = withObservationTracking {
             buffer.effectiveLanguage
         } onChange: { [weak self, weak buffer] in
             Task { @MainActor [weak self, weak buffer] in
-                guard let self, let buffer else { return }
+                guard let self, let buffer, self.buffer === buffer else { return }
                 self.handleLanguageChange(for: buffer)
                 self.observeEffectiveLanguage(buffer)
             }
         }
-        languageObservationArmed = true
     }
 
     private func handleLanguageChange(for buffer: EditorBuffer) {
+        // Identity guard: a stale observation from a prior bindBuffer could
+        // fire here against the previous buffer; ignore it so we don't mutate
+        // LSP routing for the currently-bound tab using the old buffer's
+        // effectiveLanguage.
+        guard self.buffer === buffer else { return }
+        // External buffers route LSP through a separate worktree-anchored
+        // holder owned by TabsManager. Routing them through openDocument here
+        // would leak a new worktree-keyed document; for v1 we don't support
+        // overriding language on external buffers.
+        guard !buffer.isExternal else { return }
         let newLanguage = buffer.effectiveLanguage
         let previous = currentLanguage
         guard newLanguage != previous else { return }
         let rootCapture = currentRoot
         let relCapture = currentRelativePath
-        let text = buffer.storage.string
         currentLanguage = newLanguage
-        Task { @MainActor [weak self] in
-            guard let self else { return }
+        Task { @MainActor [weak self, weak buffer] in
+            guard let self, let buffer, self.buffer === buffer else { return }
             if let previous, let root = rootCapture, let rel = relCapture {
                 await self.appState.lsp.closeDocument(
                     worktreeRoot: root,
@@ -467,6 +482,10 @@ final class CodeEditorCoordinator {
                 )
             }
             if let newLanguage, let root = rootCapture, let rel = relCapture {
+                // Recapture text inside the Task so edits the user made
+                // between override toggle and Task execution aren't clobbered
+                // by a stale snapshot.
+                let text = buffer.storage.string
                 _ = await self.appState.lsp.openDocument(
                     worktreeRoot: root,
                     fileURL: root.appendingPathComponent(rel),

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import Observation
 
 /// Lifecycle adapter between a `CodeTextView` (per-mount, recreated by
 /// SwiftUI) and an `EditorBuffer` (per-tab, owned by `TabsManager`). The
@@ -427,6 +428,52 @@ final class CodeEditorCoordinator {
         subscribeIfPossible(theme: theme)
         editObserverToken = buffer.onTextEdit { [weak self] edit in
             self?.scheduleEditPropagation(edit: edit)
+        }
+        observeEffectiveLanguage(buffer)
+    }
+
+    private var languageObservationArmed = false
+
+    private func observeEffectiveLanguage(_ buffer: EditorBuffer) {
+        // One-shot `withObservationTracking` re-arms itself from inside
+        // `onChange`, so each change drives at most one close+reopen cycle.
+        _ = withObservationTracking {
+            buffer.effectiveLanguage
+        } onChange: { [weak self, weak buffer] in
+            Task { @MainActor [weak self, weak buffer] in
+                guard let self, let buffer else { return }
+                self.handleLanguageChange(for: buffer)
+                self.observeEffectiveLanguage(buffer)
+            }
+        }
+        languageObservationArmed = true
+    }
+
+    private func handleLanguageChange(for buffer: EditorBuffer) {
+        let newLanguage = buffer.effectiveLanguage
+        let previous = currentLanguage
+        guard newLanguage != previous else { return }
+        let rootCapture = currentRoot
+        let relCapture = currentRelativePath
+        let text = buffer.storage.string
+        currentLanguage = newLanguage
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if let previous, let root = rootCapture, let rel = relCapture {
+                await self.appState.lsp.closeDocument(
+                    worktreeRoot: root,
+                    fileURL: root.appendingPathComponent(rel),
+                    languageId: previous
+                )
+            }
+            if let newLanguage, let root = rootCapture, let rel = relCapture {
+                _ = await self.appState.lsp.openDocument(
+                    worktreeRoot: root,
+                    fileURL: root.appendingPathComponent(rel),
+                    languageId: newLanguage,
+                    text: text
+                )
+            }
         }
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -273,11 +273,24 @@ final class CodeEditorCoordinator {
     }
 
     func updateIfNeeded(worktreeId: String, worktreeRoot: URL, relativePath: String, tabId: TabID, revealLine: Int?, revealCharacter: Int?, theme: Theme, externalAbsolutePath: String? = nil, originatingRelativePath: String? = nil) {
-        let nextLanguage: String?
+        // Re-query the registry every time so a registry change (e.g. a
+        // server gets installed) still flips this comparison and triggers a
+        // rebind. When the same tab is being re-evaluated and has an
+        // override set, layer the override on top — otherwise the path
+        // identity check would see `currentLanguage = override` vs.
+        // `nextLanguage = inferred` permanently and rebind on every update,
+        // churning undo/selection state.
+        let inferred: String?
         if let abs = externalAbsolutePath {
-            nextLanguage = appState.lsp.language(forFileExtension: (abs as NSString).pathExtension)
+            inferred = appState.lsp.language(forFileExtension: (abs as NSString).pathExtension)
         } else {
-            nextLanguage = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+            inferred = appState.lsp.language(forFileExtension: (relativePath as NSString).pathExtension)
+        }
+        let nextLanguage: String?
+        if let buf = self.buffer, currentWorktreeId == worktreeId, currentTabId == tabId {
+            nextLanguage = buf.languageOverride ?? inferred
+        } else {
+            nextLanguage = inferred
         }
 
         let pathChanged: Bool
@@ -427,10 +440,14 @@ final class CodeEditorCoordinator {
         self.currentRoot = buffer.worktreeRoot
         self.currentRelativePath = buffer.relativePath
         let ext = (buffer.relativePath as NSString).pathExtension
-        currentLanguage = appState.lsp.language(forFileExtension: ext)
-        // Reconcile against any pre-existing override before arming the
-        // observer (the observer only fires on subsequent changes).
-        currentLanguage = buffer.effectiveLanguage
+        let freshlyInferred = appState.lsp.language(forFileExtension: ext)
+        // Layer a pre-existing override on top of the freshly inferred
+        // language. We don't read `buffer.effectiveLanguage` directly
+        // because `buffer.language` is captured at buffer-init time and
+        // can be stale after a registry change (e.g. a server gets
+        // installed) — using the fresh registry lookup keeps that
+        // transition working while still honoring override.
+        currentLanguage = buffer.languageOverride ?? freshlyInferred
         observeEffectiveLanguage(buffer)
         applyIndentationMode()
         if let layoutManager {

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -625,6 +625,12 @@ final class EditorBuffer {
     private func applyEffectiveLanguageToLSP() {
         guard !isExternal, lsp != nil else { return }
         let prior = languageReopenTask
+        // Cancel the prior queued transition before we await it — this
+        // propagates cancellation through the chain. `close()` only cancels
+        // the latest `languageReopenTask`, but since each new task cancels
+        // its predecessor at start, an older queued task gets cancelled too
+        // and never reaches its LSP hops post-teardown.
+        prior?.cancel()
         // `openedLanguage` is intentionally NOT mutated synchronously here.
         // If we did, a concurrent `close()` (e.g. tab closed immediately
         // after the override flip) would read the *new* languageId from

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -630,9 +630,8 @@ final class EditorBuffer {
         let previous = openedLanguage
         openedLanguage = new
         let worktreeRootCapture = worktreeRoot
-        let text = storage.string
         let prior = languageReopenTask
-        languageReopenTask = Task {
+        languageReopenTask = Task { [weak self] in
             await prior?.value
             if Task.isCancelled { return }
             if let previous {
@@ -640,6 +639,11 @@ final class EditorBuffer {
             }
             if Task.isCancelled { return }
             if let new {
+                // Snapshot text right before the open call so edits made
+                // during the prior-task / close await aren't dropped.
+                // `EditorBuffer` is `@MainActor`-isolated, so this read is
+                // serialized against incoming edits.
+                let text = await MainActor.run { self?.storage.string ?? "" }
                 await lsp.openDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: new, text: text)
             }
         }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -74,11 +74,26 @@ final class EditorBuffer {
     @ObservationIgnored
     private(set) var language: String?
 
+    /// Language identifier the buffer last instructed the LSP server to
+    /// open this document under. Tracks what the *server* knows, which
+    /// can lag `effectiveLanguage` across the async close/open hop on
+    /// override change. Initialized when the buffer's init-time `didOpen`
+    /// is scheduled; updated synchronously when an override transition
+    /// fires. Used by every LSP path (didClose, didSave, close()) so
+    /// notifications always reference the holder that's actually open.
+    @ObservationIgnored
+    private var openedLanguage: String?
+
     /// Per-tab, per-session override of the inferred language. Setting this
-    /// triggers `CodeEditorCoordinator` to close the document on the current
-    /// holder and re-open it under the new language. Cleared automatically
-    /// when the buffer is torn down at tab close.
-    var languageOverride: String?
+    /// drives the buffer to close the document on the previous language
+    /// holder and reopen it under the new effective language. Cleared
+    /// automatically when the buffer is torn down at tab close.
+    var languageOverride: String? {
+        didSet {
+            guard languageOverride != oldValue else { return }
+            applyEffectiveLanguageToLSP()
+        }
+    }
 
     /// Language used for LSP routing, syntax highlighting, and the status
     /// badge. `languageOverride` (set by the badge popover) wins; otherwise
@@ -176,6 +191,7 @@ final class EditorBuffer {
         if !isExternal, let lsp, let language {
             let url = worktreeRoot.appendingPathComponent(self.relativePath)
             let text = storage.string
+            openedLanguage = language
             Task { await lsp.openDocument(worktreeRoot: worktreeRoot, fileURL: url, languageId: language, text: text) }
         }
     }
@@ -195,6 +211,7 @@ final class EditorBuffer {
         let url = worktreeRoot.appendingPathComponent(relativePath)
         guard !lsp.isDocumentOpen(fileURL: url, worktreeRoot: worktreeRoot) else { return }
         let text = storage.string
+        openedLanguage = language
         Task { await lsp.openDocument(worktreeRoot: worktreeRoot, fileURL: url, languageId: language, text: text) }
     }
 
@@ -594,21 +611,43 @@ final class EditorBuffer {
         relativePath(for: url) ?? relativePath
     }
 
+    /// Reconcile `openedLanguage` with `effectiveLanguage`. Closes the
+    /// document on the previous holder (if any) and reopens it on the new
+    /// language (if any). Skipped for external buffers — those route via a
+    /// different external-document API.
+    private func applyEffectiveLanguageToLSP() {
+        guard !isExternal, let lsp else { return }
+        let new = effectiveLanguage
+        guard new != openedLanguage else { return }
+        let url = worktreeRoot.appendingPathComponent(relativePath)
+        let previous = openedLanguage
+        openedLanguage = new
+        if let previous {
+            Task { await lsp.closeDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: previous) }
+        }
+        if let new {
+            let text = storage.string
+            Task { await lsp.openDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: new, text: text) }
+        }
+    }
+
     private func notifyDidSave(url: URL) {
-        if let lsp, let language {
-            Task { await lsp.didSave(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: language) }
+        if let lsp, let opened = openedLanguage {
+            Task { await lsp.didSave(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: opened) }
         }
     }
 
     private func notifyDidClose(url: URL, language: String?) {
-        if let lsp, let language {
-            Task { await lsp.closeDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: language) }
+        if let lsp, let opened = openedLanguage {
+            Task { await lsp.closeDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: opened) }
+            openedLanguage = nil
         }
     }
 
     private func notifyDidOpen(url: URL, text: String) {
-        if let lsp, let language {
-            Task { await lsp.openDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: language, text: text) }
+        if let lsp, let effective = effectiveLanguage {
+            openedLanguage = effective
+            Task { await lsp.openDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: effective, text: text) }
         }
     }
 
@@ -821,9 +860,10 @@ final class EditorBuffer {
             discardSnapshot()
         }
         stopWatching()
-        if let lsp, let language {
+        if let lsp, let opened = openedLanguage {
             let url = worktreeRoot.appendingPathComponent(relativePath)
-            Task { await lsp.closeDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: language) }
+            Task { await lsp.closeDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: opened) }
+            openedLanguage = nil
         }
     }
 

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -343,6 +343,11 @@ final class EditorBuffer {
             return
         }
         stopWatching()
+        // Cancel any in-flight language-override transition so its captured
+        // URL (the pre-rename path) can't fire a stale didOpen at the old
+        // URI after we've already moved on.
+        languageReopenTask?.cancel()
+        languageReopenTask = nil
         relativePath = newRelativePath
         language = lsp?.language(forFileExtension: (newRelativePath as NSString).pathExtension)
         if wasDirty {
@@ -410,6 +415,8 @@ final class EditorBuffer {
         let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
         let canonical = storage.string
         stopWatching()
+        languageReopenTask?.cancel()
+        languageReopenTask = nil
         do {
             try write(canonical: canonical, to: newURL, createDirectories: true)
             relativePath = newRelativePath
@@ -438,6 +445,8 @@ final class EditorBuffer {
         let oldURL = worktreeRoot.appendingPathComponent(relativePath)
         let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
         stopWatching()
+        languageReopenTask?.cancel()
+        languageReopenTask = nil
         do {
             try FileManager.default.createDirectory(at: newURL.deletingLastPathComponent(), withIntermediateDirectories: true)
             if FileManager.default.fileExists(atPath: newURL.path) {
@@ -647,6 +656,10 @@ final class EditorBuffer {
             let previous = self.openedLanguage
             let target = self.effectiveLanguage
             guard target != previous else { return }
+            // Re-read the URL inside the Task so a rename/move that landed
+            // during the prior-task / close await still targets the current
+            // path. Snapshotting outside the Task would leave the reopen
+            // attached to the pre-rename URI, leaking refs.
             let url = self.worktreeRoot.appendingPathComponent(self.relativePath)
             let worktreeRootCapture = self.worktreeRoot
             if let previous {

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -623,28 +623,36 @@ final class EditorBuffer {
     /// language (if any). Skipped for external buffers — those route via a
     /// different external-document API.
     private func applyEffectiveLanguageToLSP() {
-        guard !isExternal, let lsp else { return }
-        let new = effectiveLanguage
-        guard new != openedLanguage else { return }
-        let url = worktreeRoot.appendingPathComponent(relativePath)
-        let previous = openedLanguage
-        openedLanguage = new
-        let worktreeRootCapture = worktreeRoot
+        guard !isExternal, lsp != nil else { return }
         let prior = languageReopenTask
+        // `openedLanguage` is intentionally NOT mutated synchronously here.
+        // If we did, a concurrent `close()` (e.g. tab closed immediately
+        // after the override flip) would read the *new* languageId from
+        // `openedLanguage` and try to didClose it on a holder that never
+        // received didOpen — leaving the old holder's refcount unbalanced.
+        // The Task body below updates `openedLanguage` only after each LSP
+        // hop actually completes, and re-reads `effectiveLanguage` and
+        // `previous` at execution time so chained transitions observe the
+        // real post-prior-task state.
         languageReopenTask = Task { [weak self] in
             await prior?.value
             if Task.isCancelled { return }
+            guard let self, let lsp = self.lsp else { return }
+            let previous = self.openedLanguage
+            let target = self.effectiveLanguage
+            guard target != previous else { return }
+            let url = self.worktreeRoot.appendingPathComponent(self.relativePath)
+            let worktreeRootCapture = self.worktreeRoot
             if let previous {
                 await lsp.closeDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: previous)
+                if Task.isCancelled { return }
+                self.openedLanguage = nil
             }
-            if Task.isCancelled { return }
-            if let new {
-                // Snapshot text right before the open call so edits made
-                // during the prior-task / close await aren't dropped.
-                // `EditorBuffer` is `@MainActor`-isolated, so this read is
-                // serialized against incoming edits.
-                let text = await MainActor.run { self?.storage.string ?? "" }
-                await lsp.openDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: new, text: text)
+            if let target {
+                let text = self.storage.string
+                await lsp.openDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: target, text: text)
+                if Task.isCancelled { return }
+                self.openedLanguage = target
             }
         }
     }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -657,7 +657,16 @@ final class EditorBuffer {
             if let target {
                 let text = self.storage.string
                 await lsp.openDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: target, text: text)
-                if Task.isCancelled { return }
+                if Task.isCancelled {
+                    // openDocument has already bumped refs on the server
+                    // (the ref bump happens synchronously inside the
+                    // manager before its first await). `close()` would
+                    // have read `openedLanguage == nil` and skipped its
+                    // didClose, so without this compensation the doc
+                    // would be left referenced with no owning buffer.
+                    await lsp.closeDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: target)
+                    return
+                }
                 self.openedLanguage = target
             }
         }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -84,6 +84,16 @@ final class EditorBuffer {
     @ObservationIgnored
     private var openedLanguage: String?
 
+    /// Serializes the async close+open hop fired by `applyEffectiveLanguageToLSP`
+    /// across rapid override changes. Without this, a chain like
+    /// swift→typescript→python could land its tasks out of order — an older
+    /// task reopens the stale language *after* the newer one, leaving the
+    /// document attached to the wrong holder and unbalancing future close/ref
+    /// bookkeeping. Each new override change awaits the previous chain
+    /// before issuing its own close+open.
+    @ObservationIgnored
+    private var languageReopenTask: Task<Void, Never>?
+
     /// Per-tab, per-session override of the inferred language. Setting this
     /// drives the buffer to close the document on the previous language
     /// holder and reopen it under the new effective language. Cleared
@@ -621,7 +631,9 @@ final class EditorBuffer {
         openedLanguage = new
         let worktreeRootCapture = worktreeRoot
         let text = storage.string
-        Task {
+        let prior = languageReopenTask
+        languageReopenTask = Task {
+            await prior?.value
             if let previous {
                 await lsp.closeDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: previous)
             }

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -73,6 +73,24 @@ final class EditorBuffer {
     private let lsp: WorkspaceLSPManager?
     @ObservationIgnored
     private(set) var language: String?
+
+    /// Per-tab, per-session override of the inferred language. Setting this
+    /// triggers `CodeEditorCoordinator` to close the document on the current
+    /// holder and re-open it under the new language. Cleared automatically
+    /// when the buffer is torn down at tab close.
+    var languageOverride: String?
+
+    /// Language used for LSP routing, syntax highlighting, and the status
+    /// badge. `languageOverride` (set by the badge popover) wins; otherwise
+    /// the inferred `language` from the file extension is used.
+    var effectiveLanguage: String? { languageOverride ?? language }
+
+    #if DEBUG
+    /// Test-only setter so unit tests can simulate a buffer whose
+    /// inferred language has already been computed.
+    func setLanguageForTest(_ value: String?) { language = value }
+    #endif
+
     @ObservationIgnored
     var shouldFollowPathChange: ((String, String) -> Bool)?
     @ObservationIgnored

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -634,9 +634,11 @@ final class EditorBuffer {
         let prior = languageReopenTask
         languageReopenTask = Task {
             await prior?.value
+            if Task.isCancelled { return }
             if let previous {
                 await lsp.closeDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: previous)
             }
+            if Task.isCancelled { return }
             if let new {
                 await lsp.openDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: new, text: text)
             }
@@ -866,6 +868,11 @@ final class EditorBuffer {
     /// for hot-exit restore; explicit tab removal discards it.
     func close(persistDirtySnapshot: Bool = true) {
         snapshotTask?.cancel()
+        // Cancel any in-flight language-override reopen so it can't run
+        // `openDocument` after close() has already torn down the buffer —
+        // that would leak an LSP holder ref nobody owns.
+        languageReopenTask?.cancel()
+        languageReopenTask = nil
         if persistDirtySnapshot {
             if dirty { snapshotNow() }
         } else {

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -207,12 +207,12 @@ final class EditorBuffer {
     /// document would leave a dangling ref the next `didClose` couldn't
     /// balance.
     func reopenLSPDocument() {
-        guard !isExternal, let lsp, let language else { return }
+        guard !isExternal, let lsp, let effective = effectiveLanguage else { return }
         let url = worktreeRoot.appendingPathComponent(relativePath)
         guard !lsp.isDocumentOpen(fileURL: url, worktreeRoot: worktreeRoot) else { return }
         let text = storage.string
-        openedLanguage = language
-        Task { await lsp.openDocument(worktreeRoot: worktreeRoot, fileURL: url, languageId: language, text: text) }
+        openedLanguage = effective
+        Task { await lsp.openDocument(worktreeRoot: worktreeRoot, fileURL: url, languageId: effective, text: text) }
     }
 
     func reopenLSPDocument(afterRegistering language: String, forFileExtensions extensions: Set<String>) {
@@ -325,7 +325,6 @@ final class EditorBuffer {
         let oldURL = worktreeRoot.appendingPathComponent(relativePath)
         let oldRelativePath = relativePath
         let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
-        let oldLanguage = language
         let wasDirty = dirty
         guard shouldFollowPathChange?(oldRelativePath, newRelativePath) ?? true else {
             if wasDirty {
@@ -345,7 +344,7 @@ final class EditorBuffer {
             discardSnapshot()
             handleEdit(edit: nil)
         }
-        notifyDidClose(url: oldURL, language: oldLanguage)
+        notifyDidClose(url: oldURL)
         notifyDidOpen(url: newURL, text: storage.string)
         onPathChanged?(oldRelativePath, newRelativePath)
         startWatching()
@@ -399,7 +398,6 @@ final class EditorBuffer {
         }
         let oldURL = worktreeRoot.appendingPathComponent(relativePath)
         let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
-        let oldLanguage = language
         let canonical = storage.string
         stopWatching()
         do {
@@ -410,7 +408,7 @@ final class EditorBuffer {
             updateOriginalMtime(from: newURL)
             updateOriginalFileIdentity(from: newURL)
             discardSnapshot()
-            notifyDidClose(url: oldURL, language: oldLanguage)
+            notifyDidClose(url: oldURL)
             notifyDidOpen(url: newURL, text: canonical)
             notifyDidSave(url: newURL)
             onPathChanged?(oldURLRelativePath(from: oldURL), newRelativePath)
@@ -429,7 +427,6 @@ final class EditorBuffer {
         }
         let oldURL = worktreeRoot.appendingPathComponent(relativePath)
         let newURL = worktreeRoot.appendingPathComponent(newRelativePath)
-        let oldLanguage = language
         stopWatching()
         do {
             try FileManager.default.createDirectory(at: newURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -450,7 +447,7 @@ final class EditorBuffer {
             } else {
                 discardSnapshot()
             }
-            notifyDidClose(url: oldURL, language: oldLanguage)
+            notifyDidClose(url: oldURL)
             notifyDidOpen(url: newURL, text: storage.string)
             onPathChanged?(oldURLRelativePath(from: oldURL), newRelativePath)
             startWatching()
@@ -622,12 +619,15 @@ final class EditorBuffer {
         let url = worktreeRoot.appendingPathComponent(relativePath)
         let previous = openedLanguage
         openedLanguage = new
-        if let previous {
-            Task { await lsp.closeDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: previous) }
-        }
-        if let new {
-            let text = storage.string
-            Task { await lsp.openDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: new, text: text) }
+        let worktreeRootCapture = worktreeRoot
+        let text = storage.string
+        Task {
+            if let previous {
+                await lsp.closeDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: previous)
+            }
+            if let new {
+                await lsp.openDocument(worktreeRoot: worktreeRootCapture, fileURL: url, languageId: new, text: text)
+            }
         }
     }
 
@@ -637,7 +637,7 @@ final class EditorBuffer {
         }
     }
 
-    private func notifyDidClose(url: URL, language: String?) {
+    private func notifyDidClose(url: URL) {
         if let lsp, let opened = openedLanguage {
             Task { await lsp.closeDocument(worktreeRoot: self.worktreeRoot, fileURL: url, languageId: opened) }
             openedLanguage = nil

--- a/Alas/Sources/Code/Editor/EditorBuffer.swift
+++ b/Alas/Sources/Code/Editor/EditorBuffer.swift
@@ -697,7 +697,16 @@ final class EditorBuffer {
             try save()
             return
         }
-        let resolvedLanguage = language ?? lsp.language(forFileExtension: ((relativePath as NSString).pathExtension))
+        // Prefer the user's runtime override, then whatever the server
+        // currently has open (which already accounts for override and
+        // post-init transitions), then fall back to the inferred language
+        // or a fresh registry lookup. Without this, an overridden tab
+        // would silently format against the original language's server
+        // (or no server at all for unknown-extension overrides).
+        let resolvedLanguage = languageOverride
+            ?? openedLanguage
+            ?? language
+            ?? lsp.language(forFileExtension: ((relativePath as NSString).pathExtension))
         guard let resolvedLanguage else {
             try save()
             return

--- a/Alas/Sources/Code/Editor/EditorLSPStatus.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatus.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Bucketed LSP status surfaced to the editor breadcrumb badge. Derivation
+/// from live manager / registry / availability state lives in
+/// `EditorLSPStatusResolver`; this file is a pure value type.
+enum EditorLSPStatus: Equatable {
+    case ready(language: String, command: String)
+    case loading(language: String)
+    case problem(language: String, kind: ProblemKind, command: String?)
+    case noLanguage(fileExtension: String)
+}
+
+enum ProblemKind: Equatable {
+    case notInstalled
+    case dead
+    case disabled
+}

--- a/Alas/Sources/Code/Editor/EditorLSPStatus.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatus.swift
@@ -15,3 +15,14 @@ enum ProblemKind: Equatable {
     case dead
     case disabled
 }
+
+extension EditorLSPStatus {
+    /// Language id for this status, if any. `.noLanguage` returns nil.
+    var language: String? {
+        switch self {
+        case .ready(let lang, _), .loading(let lang), .problem(let lang, _, _):
+            return lang
+        case .noLanguage: return nil
+        }
+    }
+}

--- a/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
@@ -7,7 +7,6 @@ struct EditorLSPStatusBadge: View {
     let onRestart: () -> Void
     let onOverride: (String) -> Void
     let onOpenSettings: () -> Void
-    let onCancel: () -> Void
     let onInstall: () -> Void
 
     @State private var popoverOpen: Bool = false
@@ -134,11 +133,9 @@ struct EditorLSPStatusBadge: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(language).font(.system(size: 11, weight: .semibold))
             Text("Starting…").font(.system(size: 11))
-            HStack {
-                Button("Cancel") { onCancel()
-                popoverOpen = false }
-                Button("Open settings") { onOpenSettings()
-                popoverOpen = false }
+            Button("Open settings") {
+                onOpenSettings()
+                popoverOpen = false
             }
         }
     }

--- a/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+struct EditorLSPStatusBadge: View {
+    let status: EditorLSPStatus
+    let availableLanguages: [(language: String, displayName: String)]
+    let openFilesUsingLanguage: Int
+    let onRestart: () -> Void
+    let onOverride: (String) -> Void
+    let onOpenSettings: () -> Void
+    let onCancel: () -> Void
+    let onInstall: () -> Void
+
+    @State private var popoverOpen: Bool = false
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        Button { popoverOpen.toggle() } label: { pill }
+            .buttonStyle(.plain)
+            .help(tooltip)
+            .popover(isPresented: $popoverOpen, arrowEdge: .top) {
+                popoverBody.padding(10).frame(width: 280)
+            }
+    }
+
+    private var pill: some View {
+        HStack(spacing: 6) {
+            glyph
+            Text(label)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(theme.color("fg-muted"))
+            if case .problem = status {
+                Text("!")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(theme.color("warn"))
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(theme.color("bg-2").opacity(popoverOpen ? 1 : 0))
+        .clipShape(Capsule())
+        .contentShape(Capsule())
+    }
+
+    @ViewBuilder
+    private var glyph: some View {
+        switch status {
+        case .ready:
+            Circle().fill(theme.color("add")).frame(width: 7, height: 7)
+        case .loading:
+            ProgressView().controlSize(.mini).frame(width: 9, height: 9)
+        case .problem:
+            Circle().fill(theme.color("warn")).frame(width: 7, height: 7)
+        case .noLanguage:
+            Circle().stroke(theme.color("fg-faint"), lineWidth: 1).frame(width: 7, height: 7)
+        }
+    }
+
+    private var label: String {
+        switch status {
+        case .ready(let language, _),
+             .loading(let language),
+             .problem(let language, _, _):
+            return language
+        case .noLanguage(let ext):
+            return ext.isEmpty ? "Plain text" : ".\(ext)"
+        }
+    }
+
+    private var tooltip: String {
+        switch status {
+        case .ready(let lang, let cmd): return "\(lang) · \(cmd)"
+        case .loading(let lang): return "\(lang) · starting…"
+        case .problem(let lang, let kind, _):
+            let reason: String
+            switch kind {
+            case .notInstalled: reason = "not installed"
+            case .dead:         reason = "crashed"
+            case .disabled:     reason = "disabled"
+            }
+            return "\(lang) · \(reason)"
+        case .noLanguage: return "No language server"
+        }
+    }
+
+    @ViewBuilder
+    private var popoverBody: some View {
+        switch status {
+        case .ready(let lang, let cmd):
+            readyBody(language: lang, command: cmd)
+        case .loading(let lang):
+            loadingBody(language: lang)
+        case .problem(let lang, let kind, let cmd):
+            problemBody(language: lang, kind: kind, command: cmd)
+        case .noLanguage(let ext):
+            noLanguageBody(fileExtension: ext)
+        }
+    }
+
+    private func readyBody(language: String, command: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("\(language) · \(command)").font(.system(size: 11, weight: .semibold))
+            Text("Connected. Document is open and synced.").font(.system(size: 11))
+            HStack(spacing: 8) {
+                Button(restartLabel(language: language)) { onRestart(); popoverOpen = false }
+                Button("Open settings") { onOpenSettings(); popoverOpen = false }
+            }
+            Divider()
+            EditorLSPStatusOverridePicker(
+                availableLanguages: availableLanguages,
+                onPick: { onOverride($0); popoverOpen = false },
+                onOpenSettings: { onOpenSettings(); popoverOpen = false }
+            )
+        }
+    }
+
+    private func loadingBody(language: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(language).font(.system(size: 11, weight: .semibold))
+            Text("Starting…").font(.system(size: 11))
+            HStack {
+                Button("Cancel") { onCancel(); popoverOpen = false }
+                Button("Open settings") { onOpenSettings(); popoverOpen = false }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func problemBody(language: String, kind: ProblemKind, command: String?) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(language).font(.system(size: 11, weight: .semibold))
+            switch kind {
+            case .notInstalled:
+                Text("Language server not installed.").font(.system(size: 11))
+                HStack {
+                    Button("Install…") { onInstall(); popoverOpen = false }
+                    Button("Open settings") { onOpenSettings(); popoverOpen = false }
+                }
+                Divider()
+                EditorLSPStatusOverridePicker(
+                    availableLanguages: availableLanguages,
+                    onPick: { onOverride($0); popoverOpen = false },
+                    onOpenSettings: { onOpenSettings(); popoverOpen = false }
+                )
+            case .dead:
+                Text("Server crashed.").font(.system(size: 11))
+                HStack {
+                    Button(restartLabel(language: language)) { onRestart(); popoverOpen = false }
+                    Button("Open settings") { onOpenSettings(); popoverOpen = false }
+                }
+                Divider()
+                EditorLSPStatusOverridePicker(
+                    availableLanguages: availableLanguages,
+                    onPick: { onOverride($0); popoverOpen = false },
+                    onOpenSettings: { onOpenSettings(); popoverOpen = false }
+                )
+            case .disabled:
+                Text("Disabled in settings.").font(.system(size: 11))
+                Button("Open settings") { onOpenSettings(); popoverOpen = false }
+            }
+        }
+    }
+
+    private func noLanguageBody(fileExtension ext: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(ext.isEmpty ? "Plain text" : ".\(ext)")
+                .font(.system(size: 11, weight: .semibold))
+            Text("No language server for this file. Treat as another language?")
+                .font(.system(size: 11))
+            EditorLSPStatusOverridePicker(
+                availableLanguages: availableLanguages,
+                onPick: { onOverride($0); popoverOpen = false },
+                onOpenSettings: { onOpenSettings(); popoverOpen = false }
+            )
+        }
+    }
+
+    private func restartLabel(language: String) -> String {
+        if openFilesUsingLanguage > 1 {
+            return "Restart \(language) (affects \(openFilesUsingLanguage) open files)"
+        }
+        return "Restart server"
+    }
+}

--- a/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
@@ -17,9 +17,20 @@ struct EditorLSPStatusBadge: View {
         Button { popoverOpen.toggle() } label: { pill }
             .buttonStyle(.plain)
             .help(tooltip)
+            .accessibilityLabel(Text("Language server status: \(tooltip)"))
+            .accessibilityHint(Text("Shows actions for this file's language server"))
+            .accessibilityAddTraits(.isButton)
             .popover(isPresented: $popoverOpen, arrowEdge: .top) {
                 popoverBody.padding(10).frame(width: 280)
             }
+    }
+
+    private var overridePicker: some View {
+        EditorLSPStatusOverridePicker(
+            availableLanguages: availableLanguages,
+            onPick: { onOverride($0); popoverOpen = false },
+            onOpenSettings: { onOpenSettings(); popoverOpen = false }
+        )
     }
 
     private var pill: some View {
@@ -45,13 +56,13 @@ struct EditorLSPStatusBadge: View {
     private var glyph: some View {
         switch status {
         case .ready:
-            Circle().fill(theme.color("add")).frame(width: 7, height: 7)
+            Circle().fill(theme.color("add")).frame(width: 7, height: 7).accessibilityHidden(true)
         case .loading:
-            ProgressView().controlSize(.mini).frame(width: 9, height: 9)
+            ProgressView().controlSize(.mini).frame(width: 9, height: 9).accessibilityHidden(true)
         case .problem:
-            Circle().fill(theme.color("warn")).frame(width: 7, height: 7)
+            Circle().fill(theme.color("warn")).frame(width: 7, height: 7).accessibilityHidden(true)
         case .noLanguage:
-            Circle().stroke(theme.color("fg-faint"), lineWidth: 1).frame(width: 7, height: 7)
+            Circle().stroke(theme.color("fg-faint"), lineWidth: 1).frame(width: 7, height: 7).accessibilityHidden(true)
         }
     }
 
@@ -105,11 +116,7 @@ struct EditorLSPStatusBadge: View {
                 Button("Open settings") { onOpenSettings(); popoverOpen = false }
             }
             Divider()
-            EditorLSPStatusOverridePicker(
-                availableLanguages: availableLanguages,
-                onPick: { onOverride($0); popoverOpen = false },
-                onOpenSettings: { onOpenSettings(); popoverOpen = false }
-            )
+            overridePicker
         }
     }
 
@@ -136,11 +143,7 @@ struct EditorLSPStatusBadge: View {
                     Button("Open settings") { onOpenSettings(); popoverOpen = false }
                 }
                 Divider()
-                EditorLSPStatusOverridePicker(
-                    availableLanguages: availableLanguages,
-                    onPick: { onOverride($0); popoverOpen = false },
-                    onOpenSettings: { onOpenSettings(); popoverOpen = false }
-                )
+                overridePicker
             case .dead:
                 Text("Server crashed.").font(.system(size: 11))
                 HStack {
@@ -148,11 +151,7 @@ struct EditorLSPStatusBadge: View {
                     Button("Open settings") { onOpenSettings(); popoverOpen = false }
                 }
                 Divider()
-                EditorLSPStatusOverridePicker(
-                    availableLanguages: availableLanguages,
-                    onPick: { onOverride($0); popoverOpen = false },
-                    onOpenSettings: { onOpenSettings(); popoverOpen = false }
-                )
+                overridePicker
             case .disabled:
                 Text("Disabled in settings.").font(.system(size: 11))
                 Button("Open settings") { onOpenSettings(); popoverOpen = false }
@@ -166,11 +165,7 @@ struct EditorLSPStatusBadge: View {
                 .font(.system(size: 11, weight: .semibold))
             Text("No language server for this file. Treat as another language?")
                 .font(.system(size: 11))
-            EditorLSPStatusOverridePicker(
-                availableLanguages: availableLanguages,
-                onPick: { onOverride($0); popoverOpen = false },
-                onOpenSettings: { onOpenSettings(); popoverOpen = false }
-            )
+            overridePicker
         }
     }
 

--- a/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct EditorLSPStatusBadge: View {
     let status: EditorLSPStatus
-    let availableLanguages: [(language: String, displayName: String)]
+    let availableLanguages: () -> [(language: String, displayName: String)]
     let openFilesUsingLanguage: Int
     let onRestart: () -> Void
     let onOverride: (String) -> Void
@@ -11,6 +11,7 @@ struct EditorLSPStatusBadge: View {
     let onInstall: () -> Void
 
     @State private var popoverOpen: Bool = false
+    @State private var resolvedLanguages: [(language: String, displayName: String)] = []
     @Environment(\.theme) var theme
 
     var body: some View {
@@ -27,10 +28,15 @@ struct EditorLSPStatusBadge: View {
 
     private var overridePicker: some View {
         EditorLSPStatusOverridePicker(
-            availableLanguages: availableLanguages,
+            availableLanguages: resolvedLanguages,
             onPick: { onOverride($0); popoverOpen = false },
             onOpenSettings: { onOpenSettings(); popoverOpen = false }
         )
+        .onAppear {
+            if resolvedLanguages.isEmpty {
+                resolvedLanguages = availableLanguages()
+            }
+        }
     }
 
     private var pill: some View {

--- a/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
@@ -34,9 +34,11 @@ struct EditorLSPStatusBadge: View {
             popoverOpen = false }
         )
         .onAppear {
-            if resolvedLanguages.isEmpty {
-                resolvedLanguages = availableLanguages()
-            }
+            // Recompute on each popover open so settings changes (server
+            // installed/enabled/disabled) show up without recreating the
+            // tab. The manager memoizes the underlying availability probe,
+            // so this is cheap.
+            resolvedLanguages = availableLanguages()
         }
     }
 

--- a/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
@@ -2,6 +2,12 @@ import SwiftUI
 
 struct EditorLSPStatusBadge: View {
     let status: EditorLSPStatus
+    /// When `false`, the override picker is hidden everywhere in the popover.
+    /// External editor tabs (SDK files opened via cmd-click) pass `false`
+    /// because `EditorBuffer.applyEffectiveLanguageToLSP` bails for
+    /// `isExternal == true`, so an override pick wouldn't actually re-route
+    /// LSP — better to hide the no-op action than to mislead.
+    var supportsOverride: Bool = true
     let availableLanguages: () -> [(language: String, displayName: String)]
     let openFilesUsingLanguage: Int
     let onRestart: () -> Void
@@ -25,20 +31,23 @@ struct EditorLSPStatusBadge: View {
             }
     }
 
+    @ViewBuilder
     private var overridePicker: some View {
-        EditorLSPStatusOverridePicker(
-            availableLanguages: resolvedLanguages,
-            onPick: { onOverride($0)
-            popoverOpen = false },
-            onOpenSettings: { onOpenSettings()
-            popoverOpen = false }
-        )
-        .onAppear {
-            // Recompute on each popover open so settings changes (server
-            // installed/enabled/disabled) show up without recreating the
-            // tab. The manager memoizes the underlying availability probe,
-            // so this is cheap.
-            resolvedLanguages = availableLanguages()
+        if supportsOverride {
+            EditorLSPStatusOverridePicker(
+                availableLanguages: resolvedLanguages,
+                onPick: { onOverride($0)
+                popoverOpen = false },
+                onOpenSettings: { onOpenSettings()
+                popoverOpen = false }
+            )
+            .onAppear {
+                // Recompute on each popover open so settings changes (server
+                // installed/enabled/disabled) show up without recreating the
+                // tab. The manager memoizes the underlying availability probe,
+                // so this is cheap.
+                resolvedLanguages = availableLanguages()
+            }
         }
     }
 

--- a/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
@@ -29,8 +29,10 @@ struct EditorLSPStatusBadge: View {
     private var overridePicker: some View {
         EditorLSPStatusOverridePicker(
             availableLanguages: resolvedLanguages,
-            onPick: { onOverride($0); popoverOpen = false },
-            onOpenSettings: { onOpenSettings(); popoverOpen = false }
+            onPick: { onOverride($0)
+            popoverOpen = false },
+            onOpenSettings: { onOpenSettings()
+            popoverOpen = false }
         )
         .onAppear {
             if resolvedLanguages.isEmpty {
@@ -118,8 +120,10 @@ struct EditorLSPStatusBadge: View {
             Text("\(language) · \(command)").font(.system(size: 11, weight: .semibold))
             Text("Connected. Document is open and synced.").font(.system(size: 11))
             HStack(spacing: 8) {
-                Button(restartLabel(language: language)) { onRestart(); popoverOpen = false }
-                Button("Open settings") { onOpenSettings(); popoverOpen = false }
+                Button(restartLabel(language: language)) { onRestart()
+                popoverOpen = false }
+                Button("Open settings") { onOpenSettings()
+                popoverOpen = false }
             }
             Divider()
             overridePicker
@@ -131,8 +135,10 @@ struct EditorLSPStatusBadge: View {
             Text(language).font(.system(size: 11, weight: .semibold))
             Text("Starting…").font(.system(size: 11))
             HStack {
-                Button("Cancel") { onCancel(); popoverOpen = false }
-                Button("Open settings") { onOpenSettings(); popoverOpen = false }
+                Button("Cancel") { onCancel()
+                popoverOpen = false }
+                Button("Open settings") { onOpenSettings()
+                popoverOpen = false }
             }
         }
     }
@@ -145,22 +151,27 @@ struct EditorLSPStatusBadge: View {
             case .notInstalled:
                 Text("Language server not installed.").font(.system(size: 11))
                 HStack {
-                    Button("Install…") { onInstall(); popoverOpen = false }
-                    Button("Open settings") { onOpenSettings(); popoverOpen = false }
+                    Button("Install…") { onInstall()
+                    popoverOpen = false }
+                    Button("Open settings") { onOpenSettings()
+                    popoverOpen = false }
                 }
                 Divider()
                 overridePicker
             case .dead:
                 Text("Server crashed.").font(.system(size: 11))
                 HStack {
-                    Button(restartLabel(language: language)) { onRestart(); popoverOpen = false }
-                    Button("Open settings") { onOpenSettings(); popoverOpen = false }
+                    Button(restartLabel(language: language)) { onRestart()
+                    popoverOpen = false }
+                    Button("Open settings") { onOpenSettings()
+                    popoverOpen = false }
                 }
                 Divider()
                 overridePicker
             case .disabled:
                 Text("Disabled in settings.").font(.system(size: 11))
-                Button("Open settings") { onOpenSettings(); popoverOpen = false }
+                Button("Open settings") { onOpenSettings()
+                popoverOpen = false }
             }
         }
     }

--- a/Alas/Sources/Code/Editor/EditorLSPStatusOverridePicker.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusOverridePicker.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct EditorLSPStatusOverridePicker: View {
+    let availableLanguages: [(language: String, displayName: String)]
+    let onPick: (String) -> Void
+    let onOpenSettings: () -> Void
+    @State private var query: String = ""
+    @Environment(\.theme) var theme
+
+    private var filtered: [(language: String, displayName: String)] {
+        let q = query.lowercased()
+        guard !q.isEmpty else { return availableLanguages }
+        return availableLanguages.filter {
+            $0.language.lowercased().contains(q) ||
+            $0.displayName.lowercased().contains(q)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextField("Search…", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 11))
+            ScrollView {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(filtered, id: \.language) { entry in
+                        Button {
+                            onPick(entry.language)
+                        } label: {
+                            HStack {
+                                Text(entry.displayName)
+                                    .font(.system(size: 11))
+                                Spacer()
+                                Text(entry.language)
+                                    .font(.system(size: 10, design: .monospaced))
+                                    .foregroundColor(theme.color("fg-muted"))
+                            }
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .frame(maxHeight: 180)
+            Divider()
+            Button("Configure more servers in Settings…", action: onOpenSettings)
+                .buttonStyle(.link)
+                .font(.system(size: 11))
+        }
+        .padding(8)
+        .frame(width: 260)
+    }
+}

--- a/Alas/Sources/Code/Editor/EditorLSPStatusResolver.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusResolver.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Pure derivation from `(absolutePath, override?, worktreeRoot)` plus
+/// injected probes to an `EditorLSPStatus`. No I/O, easy to unit-test by
+/// passing fakes. The probes mirror the surface the resolver needs from
+/// `WorkspaceLSPManager`, `LanguageServerAvailability`, and
+/// `LanguageServerRegistry` so production code wires the real types and
+/// tests wire fakes.
+@MainActor
+struct EditorLSPStatusResolver {
+    protocol ManagerProbe {
+        func documentStatus(forFile fileURL: URL, worktreeRoot: URL) -> WorkspaceLSPManager.DocumentStatus
+    }
+
+    protocol AvailabilityProbe {
+        func status(forLanguage language: String) -> LanguageServerAvailability.Status?
+        func command(forLanguage language: String) -> String?
+    }
+
+    protocol RegistryProbe {
+        func language(forFileExtension ext: String) -> String?
+    }
+
+    let manager: ManagerProbe
+    let availability: AvailabilityProbe
+    let registry: RegistryProbe
+
+    func resolve(absolutePath: String, override: String?, worktreeRoot: URL) -> EditorLSPStatus {
+        let ext = (absolutePath as NSString).pathExtension.lowercased()
+        let inferred = registry.language(forFileExtension: ext)
+        guard let language = override ?? inferred else {
+            return .noLanguage(fileExtension: ext)
+        }
+
+        let command = availability.command(forLanguage: language)
+        switch availability.status(forLanguage: language) {
+        case .disabled:
+            return .problem(language: language, kind: .disabled, command: command)
+        case .notInstalled:
+            return .problem(language: language, kind: .notInstalled, command: command)
+        case .available:
+            let fileURL = URL(fileURLWithPath: absolutePath)
+            switch manager.documentStatus(forFile: fileURL, worktreeRoot: worktreeRoot) {
+            case .none, .loading:
+                return .loading(language: language)
+            case .ready:
+                return .ready(language: language, command: command ?? "")
+            case .dead:
+                return .problem(language: language, kind: .dead, command: command)
+            }
+        case nil:
+            // Language is mentioned somewhere (override) but the registry has
+            // no entry for it. Treat as "no language server configured" → a
+            // disabled-looking problem. Resolver tests don't currently
+            // exercise this; the override picker only surfaces languages
+            // that have a registry entry.
+            return .problem(language: language, kind: .disabled, command: nil)
+        }
+    }
+}

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -49,6 +49,8 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// `ready` is a one-shot Task that returns `true` when initialize
     /// succeeded and `false` on failure; both open and close await it
     /// before sending notifications.
+    private enum HolderLifeState { case starting, ready, dead }
+
     private struct Holder {
         let client: LSPClient
         let ready: Task<Bool, Never>
@@ -57,6 +59,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
         var versions: [String: Int]   // last didChange version per URI
         var pendingOpenText: [String: String]  // latest text supplied to a not-yet-sent didOpen
         var texts: [String: String]  // last text version sent to the server per URI
+        var lifeState: HolderLifeState
     }
 
     /// Coarse status of a document's serving holder. The resolver folds this
@@ -70,6 +73,14 @@ final class WorkspaceLSPManager: DocumentFormatter {
     }
 
     private var holders: [Key: Holder] = [:]
+
+    /// Bumping counter that lets `@Observable` consumers (the status badge)
+    /// re-run derivations when a holder transitions starting → ready → dead.
+    /// Incremented under `@MainActor` so SwiftUI sees changes without a hop.
+    private(set) var stateTick: Int = 0
+
+    private func bumpStateTick() { stateTick &+= 1 }
+
     private var registry: LanguageServerRegistry
 
     init(registry: LanguageServerRegistry) {
@@ -104,6 +115,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
             let dead = await existing.client.state == .dead
             if dead, let cur = holders[key], cur.client === existing.client {
                 holders.removeValue(forKey: key)
+                bumpStateTick()
             }
         }
         let client: LSPClient
@@ -119,7 +131,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
             // content while the server was still initializing.)
             var pending = existing.pendingOpenText
             if !existing.openedURIs.contains(uri) { pending[uri] = text }
-            holders[key] = Holder(client: existing.client, ready: existing.ready, refsByURI: refs, openedURIs: existing.openedURIs, versions: existing.versions, pendingOpenText: pending, texts: existing.texts)
+            holders[key] = Holder(client: existing.client, ready: existing.ready, refsByURI: refs, openedURIs: existing.openedURIs, versions: existing.versions, pendingOpenText: pending, texts: existing.texts, lifeState: existing.lifeState)
             client = existing.client
             ready = existing.ready
             isFirstOpener = false
@@ -131,13 +143,19 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 do { try await newClient.initialize()
                 return true } catch { return false }
             }
-            holders[key] = Holder(client: newClient, ready: task, refsByURI: [uri: 1], openedURIs: [], versions: [:], pendingOpenText: [uri: text], texts: [:])
+            holders[key] = Holder(client: newClient, ready: task, refsByURI: [uri: 1], openedURIs: [], versions: [:], pendingOpenText: [uri: text], texts: [:], lifeState: .starting)
+            bumpStateTick()
             client = newClient
             ready = task
             isFirstOpener = true
         }
 
         let initOk = await ready.value
+        if var h = holders[key], h.client === client {
+            h.lifeState = initOk ? .ready : .dead
+            holders[key] = h
+            bumpStateTick()
+        }
         if !initOk {
             // Init failed. The opener that spawned the client owns its
             // teardown — if `shutdown()` only ran on `.ready` the failed
@@ -263,6 +281,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
         if let c = holders[key], c.refsByURI.isEmpty {
             await c.client.shutdown()
             holders.removeValue(forKey: key)
+            bumpStateTick()
         }
     }
 
@@ -321,6 +340,24 @@ final class WorkspaceLSPManager: DocumentFormatter {
         let uri = fileURL.lspURI
         guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot) else { return nil }
         return holders[key]?.client
+    }
+
+    /// Coarse holder lifecycle for the file's serving holder, suitable for
+    /// the editor status badge. Collapses "no holder yet" and "holder still
+    /// initializing" into `.loading` because the user-visible reading is
+    /// identical.
+    func documentStatus(forFile fileURL: URL, worktreeRoot: URL) -> DocumentStatus {
+        let uri = fileURL.lspURI
+        guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot),
+              let holder = holders[key] else {
+            return .none
+        }
+        switch holder.lifeState {
+        case .starting: return .loading
+        case .ready:
+            return holder.openedURIs.contains(uri) ? .ready : .loading
+        case .dead: return .dead
+        }
     }
 
     /// Returns the client only after the specific file has completed the

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -632,6 +632,10 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 h.versions[uri] = 1
                 h.pendingOpenText.removeValue(forKey: uri)
                 h.texts[uri] = openText
+                // Record the languageId so `restartHolder` can reopen
+                // this URI under the right language on shared servers
+                // (typescript-language-server, etc).
+                h.languagesByURI[uri] = language
                 holders[key] = h
             }
             try? await cur.client.didOpen(

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -463,25 +463,6 @@ final class WorkspaceLSPManager: DocumentFormatter {
     }
 
     private func restartHolder(key: Key, existing: Holder, language: String) async {
-        // Reopen every URI a tab is still referencing — not just `openedURIs`.
-        // A holder that died during initialize never delivered `didOpen` for
-        // anything, but the user's tab intent is recorded in `refsByURI`. We
-        // want restart to bring those tabs back up.
-        //
-        // Preserve refcount multiplicity: a URI held by two tabs has
-        // refsByURI[uri] = 2, and `openDocument` increments refs by 1 per
-        // call. We call `openDocument` once per reference so the post-restart
-        // holder ends with the same refcount, otherwise the next `closeDocument`
-        // from one of the holders would tear the document down while the
-        // other still expects it open.
-        let refsToReopen = existing.refsByURI
-        let textsByURI = existing.texts.merging(existing.pendingOpenText) { current, _ in current }
-        // One holder can serve multiple languageIds (typescript-language-server
-        // serves typescript/typescriptreact/javascript/javascriptreact). Reopen
-        // each URI under the languageId it was originally opened with;
-        // fall back to the caller-provided `language` for never-opened URIs.
-        let languagesByURI = existing.languagesByURI
-
         // Mark the holder dead synchronously so the badge transitions through
         // `.dead` and concurrent `openDocument` calls see a dying holder
         // rather than bumping refs on the one we're about to shut down.
@@ -493,9 +474,35 @@ final class WorkspaceLSPManager: DocumentFormatter {
 
         await existing.client.shutdown()
 
+        // Reopen state is sampled AFTER shutdown completes. This @MainActor
+        // method is reentrant across the await, so other open/close calls
+        // can have mutated `refsByURI`, `texts`, `languagesByURI`, etc. We
+        // want to base the reopen on the latest snapshot — otherwise a tab
+        // closed during the shutdown await would still get its document
+        // reopened, and a tab opened during the await would get dropped.
+        //
+        // Refcount multiplicity is preserved: a URI held by two tabs has
+        // refsByURI[uri] = 2, and `openDocument` increments refs by 1 per
+        // call. We call `openDocument` once per reference so the post-
+        // restart holder ends with the same refcount.
+        //
+        // Per-URI languageId is honored on shared servers
+        // (typescript-language-server serves typescript / typescriptreact /
+        // javascript / javascriptreact under one binary).
+        let refsToReopen: [String: Int]
+        let textsByURI: [String: String]
+        let languagesByURI: [String: String]
         if let cur = holders[key], cur.client === existing.client {
+            refsToReopen = cur.refsByURI
+            textsByURI = cur.texts.merging(cur.pendingOpenText) { current, _ in current }
+            languagesByURI = cur.languagesByURI
             holders.removeValue(forKey: key)
             bumpStateTick()
+        } else {
+            // The holder was already replaced (e.g. by the dead-client
+            // detection path in a concurrent `openDocument`). Nothing for
+            // us to reopen — the live holder owns its own state.
+            return
         }
 
         let reopenRoot = URL(fileURLWithPath: key.root)

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -296,6 +296,17 @@ final class WorkspaceLSPManager: DocumentFormatter {
         holder.refsByURI = refs
         holders[key] = holder
 
+        // If the holder never reached `.ready` (init failed), it lingers
+        // in the dict so the badge can show `.problem(.dead)` and offer
+        // restart. Once the last user-intent ref is released, sweep the
+        // dead entry — otherwise repeated open-then-close attempts on a
+        // misconfigured server would accumulate stale holders.
+        if holder.lifeState == .dead, refs.isEmpty {
+            holders.removeValue(forKey: key)
+            bumpStateTick()
+            return
+        }
+
         let initOk = await holder.ready.value
         guard let cur = holders[key] else { return }
         if !initOk { return }

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -456,7 +456,14 @@ final class WorkspaceLSPManager: DocumentFormatter {
         // A holder that died during initialize never delivered `didOpen` for
         // anything, but the user's tab intent is recorded in `refsByURI`. We
         // want restart to bring those tabs back up.
-        let urisToReopen = Set(existing.refsByURI.keys)
+        //
+        // Preserve refcount multiplicity: a URI held by two tabs has
+        // refsByURI[uri] = 2, and `openDocument` increments refs by 1 per
+        // call. We call `openDocument` once per reference so the post-restart
+        // holder ends with the same refcount, otherwise the next `closeDocument`
+        // from one of the holders would tear the document down while the
+        // other still expects it open.
+        let refsToReopen = existing.refsByURI
         let textsByURI = existing.texts.merging(existing.pendingOpenText) { current, _ in current }
         // One holder can serve multiple languageIds (typescript-language-server
         // serves typescript/typescriptreact/javascript/javascriptreact). Reopen
@@ -481,11 +488,13 @@ final class WorkspaceLSPManager: DocumentFormatter {
         }
 
         let reopenRoot = URL(fileURLWithPath: key.root)
-        for uri in urisToReopen {
-            guard let fileURL = URL(string: uri) else { continue }
+        for (uri, refCount) in refsToReopen {
+            guard refCount > 0, let fileURL = URL(string: uri) else { continue }
             let text = textsByURI[uri] ?? ""
             let reopenLanguage = languagesByURI[uri] ?? language
-            _ = await openDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: reopenLanguage, text: text)
+            for _ in 0 ..< refCount {
+                _ = await openDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: reopenLanguage, text: text)
+            }
         }
     }
 

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -157,17 +157,14 @@ final class WorkspaceLSPManager: DocumentFormatter {
             bumpStateTick()
         }
         if !initOk {
-            // Init failed. The opener that spawned the client owns its
-            // teardown — if `shutdown()` only ran on `.ready` the failed
-            // `Process` would be left behind. Identity-guard the dictionary
-            // entry too, so a fresh holder swapped in by a later opener
-            // isn't removed alongside.
+            // Init failed. The opener that spawned the client owns the
+            // shutdown call to release the failed `Process`. Leave the
+            // holder entry in place with `lifeState = .dead` so the badge
+            // can show "problem" and offer "Restart" — removing the holder
+            // here would make `documentStatus` report `.none`, indistinguishable
+            // from "never opened". `restartHolder` is the proper cleanup path.
             if isFirstOpener {
                 await client.shutdown()
-                if let cur = holders[key], cur.client === client {
-                    holders.removeValue(forKey: key)
-                    bumpStateTick()
-                }
             }
             return nil
         }
@@ -374,6 +371,37 @@ final class WorkspaceLSPManager: DocumentFormatter {
             return nil
         }
         return holder.client
+    }
+
+    /// Tear down the holder serving `language` under `rootURL` and re-open
+    /// every URI it had open. Holder-scoped (not tab-scoped) so all tabs
+    /// sharing the holder benefit from one restart — which matches the user
+    /// intuition "restart the Swift server".
+    ///
+    /// No-op when no matching holder exists.
+    func restartHolder(forLanguage language: String, rootURL: URL) async {
+        guard let entry = registry.entry(forLanguage: language) else { return }
+        let lspRoot = Self.resolveLSPRoot(fileURL: rootURL, worktreeRoot: rootURL, markers: entry.rootMarkers)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
+        guard let existing = holders[key] else { return }
+
+        // Reopen every URI a tab is still referencing — not just `openedURIs`.
+        // A holder that died during initialize never delivered `didOpen` for
+        // anything, but the user's tab intent is recorded in `refsByURI`. We
+        // want restart to bring those tabs back up.
+        let urisToReopen = Set(existing.refsByURI.keys)
+        let textsByURI = existing.texts.merging(existing.pendingOpenText) { current, _ in current }
+        await existing.client.shutdown()
+        if let cur = holders[key], cur.client === existing.client {
+            holders.removeValue(forKey: key)
+            bumpStateTick()
+        }
+
+        for uri in urisToReopen {
+            guard let fileURL = URL(string: uri) else { continue }
+            let text = textsByURI[uri] ?? ""
+            _ = await openDocument(worktreeRoot: rootURL, fileURL: fileURL, languageId: language, text: text)
+        }
     }
 
     /// True when `fileURL` has already been delivered to a live (non-dead)

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -337,8 +337,10 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// the worktree root.
     func client(forFile fileURL: URL, worktreeRoot: URL, language: String) -> LSPClient? {
         let uri = fileURL.lspURI
-        guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot) else { return nil }
-        return holders[key]?.client
+        guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot),
+              let holder = holders[key],
+              holder.lifeState != .dead else { return nil }
+        return holder.client
     }
 
     /// Coarse holder lifecycle for the file's serving holder, suitable for
@@ -379,6 +381,10 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// intuition "restart the Swift server".
     ///
     /// No-op when no matching holder exists.
+    ///
+    /// `rootURL` must be the LSP root the holder is keyed under (typically
+    /// resolved via `holderKey` or by passing the worktree root for a simple
+    /// workspace). For nested packages, pass the package directory.
     func restartHolder(forLanguage language: String, rootURL: URL) async {
         guard let entry = registry.entry(forLanguage: language) else { return }
         let lspRoot = Self.resolveLSPRoot(fileURL: rootURL, worktreeRoot: rootURL, markers: entry.rootMarkers)
@@ -391,7 +397,18 @@ final class WorkspaceLSPManager: DocumentFormatter {
         // want restart to bring those tabs back up.
         let urisToReopen = Set(existing.refsByURI.keys)
         let textsByURI = existing.texts.merging(existing.pendingOpenText) { current, _ in current }
+
+        // Mark the holder dead synchronously so the badge transitions through
+        // `.dead` and concurrent `openDocument` calls see a dying holder
+        // rather than bumping refs on the one we're about to shut down.
+        if var h = holders[key], h.client === existing.client {
+            h.lifeState = .dead
+            holders[key] = h
+            bumpStateTick()
+        }
+
         await existing.client.shutdown()
+
         if let cur = holders[key], cur.client === existing.client {
             holders.removeValue(forKey: key)
             bumpStateTick()

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -361,6 +361,19 @@ final class WorkspaceLSPManager: DocumentFormatter {
         }
     }
 
+    /// Read-only access to the active registry for derivation by views.
+    var activeRegistry: LanguageServerRegistry { registry }
+
+    /// Number of open file URIs currently served by the holder matching
+    /// `language` and `rootURL`. Used by the badge to warn when restarting
+    /// would affect multiple tabs.
+    func openFilesUsing(language: String, rootURL: URL) -> Int {
+        guard let entry = registry.entry(forLanguage: language) else { return 0 }
+        let lspRoot = Self.resolveLSPRoot(fileURL: rootURL, worktreeRoot: rootURL, markers: entry.rootMarkers)
+        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
+        return holders[key]?.openedURIs.count ?? 0
+    }
+
     /// Returns the client only after the specific file has completed the
     /// initialize + didOpen path. Request/notification features should use
     /// this instead of `client(forFile:)` so they never talk to a server that

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -59,6 +59,16 @@ final class WorkspaceLSPManager: DocumentFormatter {
         var texts: [String: String]  // last text version sent to the server per URI
     }
 
+    /// Coarse status of a document's serving holder. The resolver folds this
+    /// into `EditorLSPStatus.loading` (.none and .loading), `.ready`, or
+    /// `.problem(.dead)`.
+    enum DocumentStatus: Equatable {
+        case none
+        case loading
+        case ready
+        case dead
+    }
+
     private var holders: [Key: Holder] = [:]
     private var registry: LanguageServerRegistry
 

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -405,13 +405,14 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// Read-only access to the active registry for derivation by views.
     var activeRegistry: LanguageServerRegistry { registry }
 
-    /// Number of open file URIs currently served by the holder matching
-    /// `language` and `rootURL`. Used by the badge to warn when restarting
-    /// would affect multiple tabs.
-    func openFilesUsing(language: String, rootURL: URL) -> Int {
-        guard let entry = registry.entry(forLanguage: language) else { return 0 }
-        let lspRoot = Self.resolveLSPRoot(fileURL: rootURL, worktreeRoot: rootURL, markers: entry.rootMarkers)
-        let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
+    /// Number of open file URIs currently served by the holder serving
+    /// `fileURL`. Used by the badge to warn when restarting would affect
+    /// multiple tabs. Looks up the holder via the file URI (not the
+    /// worktree root) so nested-package holders are matched correctly —
+    /// pre-resolving the LSP root from `worktreeRoot` would miss them.
+    func openFilesUsing(forFile fileURL: URL, worktreeRoot: URL) -> Int {
+        let uri = fileURL.lspURI
+        guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot) else { return 0 }
         return holders[key]?.openedURIs.count ?? 0
     }
 

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -388,22 +388,39 @@ final class WorkspaceLSPManager: DocumentFormatter {
         return holder.client
     }
 
-    /// Tear down the holder serving `language` under `rootURL` and re-open
-    /// every URI it had open. Holder-scoped (not tab-scoped) so all tabs
-    /// sharing the holder benefit from one restart — which matches the user
-    /// intuition "restart the Swift server".
+    /// Tear down the holder currently serving `fileURL` under `worktreeRoot`
+    /// and re-open every URI it had open. Holder-scoped (not tab-scoped) so
+    /// all tabs sharing the holder benefit from one restart — which matches
+    /// the user intuition "restart the Swift server".
+    ///
+    /// Looks the holder up via `holderKey(forURI:withinWorktreeRoot:)` so a
+    /// nested-package holder keyed under a sub-directory of `worktreeRoot`
+    /// is found correctly — pre-resolving the LSP root from `worktreeRoot`
+    /// would miss nested-package holders.
     ///
     /// No-op when no matching holder exists.
+    func restartHolder(forFile fileURL: URL, worktreeRoot: URL, languageId: String) async {
+        let uri = fileURL.lspURI
+        guard let key = holderKey(forURI: uri, withinWorktreeRoot: worktreeRoot),
+              let existing = holders[key] else { return }
+        await restartHolder(key: key, existing: existing, language: languageId)
+    }
+
+    /// Tear down the holder serving `language` under `rootURL` and re-open
+    /// every URI it had open. `rootURL` must be the LSP root the holder is
+    /// keyed under; for nested packages, prefer `restartHolder(forFile:worktreeRoot:languageId:)`
+    /// which resolves the key via the file URI.
     ///
-    /// `rootURL` must be the LSP root the holder is keyed under (typically
-    /// resolved via `holderKey` or by passing the worktree root for a simple
-    /// workspace). For nested packages, pass the package directory.
+    /// No-op when no matching holder exists.
     func restartHolder(forLanguage language: String, rootURL: URL) async {
         guard let entry = registry.entry(forLanguage: language) else { return }
         let lspRoot = Self.resolveLSPRoot(fileURL: rootURL, worktreeRoot: rootURL, markers: entry.rootMarkers)
         let key = Key(root: lspRoot.path, command: entry.command, args: entry.args, env: entry.env)
         guard let existing = holders[key] else { return }
+        await restartHolder(key: key, existing: existing, language: language)
+    }
 
+    private func restartHolder(key: Key, existing: Holder, language: String) async {
         // Reopen every URI a tab is still referencing — not just `openedURIs`.
         // A holder that died during initialize never delivered `didOpen` for
         // anything, but the user's tab intent is recorded in `refsByURI`. We
@@ -427,10 +444,11 @@ final class WorkspaceLSPManager: DocumentFormatter {
             bumpStateTick()
         }
 
+        let reopenRoot = URL(fileURLWithPath: key.root)
         for uri in urisToReopen {
             guard let fileURL = URL(string: uri) else { continue }
             let text = textsByURI[uri] ?? ""
-            _ = await openDocument(worktreeRoot: rootURL, fileURL: fileURL, languageId: language, text: text)
+            _ = await openDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: language, text: text)
         }
     }
 

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -639,6 +639,13 @@ final class WorkspaceLSPManager: DocumentFormatter {
         }
         guard let key, var holder = holders[key] else { return false }
 
+        // Skip dead holders so an external-tab reopen/retry loop doesn't
+        // accumulate refs on a server that's never going to answer. The
+        // caller treats `false` as "retry later"; the in-worktree
+        // `openDocument` path will respawn a fresh holder when a real tab
+        // opens, and the badge can offer Restart in the meantime.
+        guard holder.lifeState != .dead else { return false }
+
         // Bump refcount and record pending text in case the server is still
         // initializing — the same approach used by openDocument for in-worktree
         // files.

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -59,6 +59,13 @@ final class WorkspaceLSPManager: DocumentFormatter {
         var versions: [String: Int]   // last didChange version per URI
         var pendingOpenText: [String: String]  // latest text supplied to a not-yet-sent didOpen
         var texts: [String: String]  // last text version sent to the server per URI
+        // One holder can serve multiple LSP languageIds (typescript-language-server
+        // serves typescript/typescriptreact/javascript/javascriptreact under a
+        // single binary). Per-URI tracking lets `restartHolder` reopen each
+        // file with the languageId it was originally opened under, instead
+        // of forcing every file onto the languageId of the tab that
+        // triggered the restart.
+        var languagesByURI: [String: String]
         var lifeState: HolderLifeState
     }
 
@@ -83,12 +90,34 @@ final class WorkspaceLSPManager: DocumentFormatter {
 
     private var registry: LanguageServerRegistry
 
+    /// Cached per-language availability so the status badge doesn't re-run
+    /// `LanguageServerAvailability.status(for:)` — which can spawn
+    /// `xcrun --find sourcekit-lsp` synchronously on the main actor — on
+    /// every SwiftUI breadcrumb re-render. Cleared whenever the registry
+    /// changes (the only thing that can change the answer).
+    private var cachedAvailability = LanguageServerAvailability()
+    private var availabilityCache: [String: LanguageServerAvailability.Status] = [:]
+
     init(registry: LanguageServerRegistry) {
         self.registry = registry
     }
 
     func updateRegistry(_ registry: LanguageServerRegistry) {
         self.registry = registry
+        cachedAvailability = LanguageServerAvailability()
+        availabilityCache.removeAll()
+    }
+
+    /// Returns the cached availability status for `language`, falling back
+    /// to a single `LanguageServerAvailability.status(for:)` probe and
+    /// caching the result. Designed for hot-path callers like the status
+    /// badge resolver.
+    func availabilityStatus(forLanguage language: String) -> LanguageServerAvailability.Status? {
+        if let cached = availabilityCache[language] { return cached }
+        guard let entry = registry.allEntries().first(where: { $0.language == language }) else { return nil }
+        let status = cachedAvailability.status(for: entry)
+        availabilityCache[language] = status
+        return status
     }
 
     /// Register an open editor tab for `(worktreeRoot, fileURL)`. Spawns
@@ -131,7 +160,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
             // content while the server was still initializing.)
             var pending = existing.pendingOpenText
             if !existing.openedURIs.contains(uri) { pending[uri] = text }
-            holders[key] = Holder(client: existing.client, ready: existing.ready, refsByURI: refs, openedURIs: existing.openedURIs, versions: existing.versions, pendingOpenText: pending, texts: existing.texts, lifeState: existing.lifeState)
+            holders[key] = Holder(client: existing.client, ready: existing.ready, refsByURI: refs, openedURIs: existing.openedURIs, versions: existing.versions, pendingOpenText: pending, texts: existing.texts, languagesByURI: existing.languagesByURI, lifeState: existing.lifeState)
             client = existing.client
             ready = existing.ready
             isFirstOpener = false
@@ -143,7 +172,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 do { try await newClient.initialize()
                 return true } catch { return false }
             }
-            holders[key] = Holder(client: newClient, ready: task, refsByURI: [uri: 1], openedURIs: [], versions: [:], pendingOpenText: [uri: text], texts: [:], lifeState: .starting)
+            holders[key] = Holder(client: newClient, ready: task, refsByURI: [uri: 1], openedURIs: [], versions: [:], pendingOpenText: [uri: text], texts: [:], languagesByURI: [:], lifeState: .starting)
             bumpStateTick()
             client = newClient
             ready = task
@@ -196,6 +225,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 holder.versions[uri] = 1
                 holder.pendingOpenText.removeValue(forKey: uri)
                 holder.texts[uri] = openText
+                holder.languagesByURI[uri] = languageId
                 holders[key] = holder
                 bumpStateTick()
             }
@@ -272,6 +302,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 c.versions.removeValue(forKey: uri)
                 c.pendingOpenText.removeValue(forKey: uri)
                 c.texts.removeValue(forKey: uri)
+                c.languagesByURI.removeValue(forKey: uri)
                 holders[key] = c
             }
         }
@@ -427,6 +458,11 @@ final class WorkspaceLSPManager: DocumentFormatter {
         // want restart to bring those tabs back up.
         let urisToReopen = Set(existing.refsByURI.keys)
         let textsByURI = existing.texts.merging(existing.pendingOpenText) { current, _ in current }
+        // One holder can serve multiple languageIds (typescript-language-server
+        // serves typescript/typescriptreact/javascript/javascriptreact). Reopen
+        // each URI under the languageId it was originally opened with;
+        // fall back to the caller-provided `language` for never-opened URIs.
+        let languagesByURI = existing.languagesByURI
 
         // Mark the holder dead synchronously so the badge transitions through
         // `.dead` and concurrent `openDocument` calls see a dying holder
@@ -448,7 +484,8 @@ final class WorkspaceLSPManager: DocumentFormatter {
         for uri in urisToReopen {
             guard let fileURL = URL(string: uri) else { continue }
             let text = textsByURI[uri] ?? ""
-            _ = await openDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: language, text: text)
+            let reopenLanguage = languagesByURI[uri] ?? language
+            _ = await openDocument(worktreeRoot: reopenRoot, fileURL: fileURL, languageId: reopenLanguage, text: text)
         }
     }
 
@@ -659,6 +696,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 c.versions.removeValue(forKey: uri)
                 c.pendingOpenText.removeValue(forKey: uri)
                 c.texts.removeValue(forKey: uri)
+                c.languagesByURI.removeValue(forKey: uri)
                 holders[key] = c
             }
         }

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -166,6 +166,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 await client.shutdown()
                 if let cur = holders[key], cur.client === client {
                     holders.removeValue(forKey: key)
+                    bumpStateTick()
                 }
             }
             return nil
@@ -199,6 +200,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 holder.pendingOpenText.removeValue(forKey: uri)
                 holder.texts[uri] = openText
                 holders[key] = holder
+                bumpStateTick()
             }
             try? await client.didOpen(
                 uri: uri,
@@ -592,6 +594,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
         if let c = holders[key], c.refsByURI.isEmpty {
             await c.client.shutdown()
             holders.removeValue(forKey: key)
+            bumpStateTick()
         }
     }
 

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -673,6 +673,11 @@ final class WorkspaceLSPManager: DocumentFormatter {
                 // (typescript-language-server, etc).
                 h.languagesByURI[uri] = language
                 holders[key] = h
+                // Match in-worktree `openDocument`: bump the tick so the
+                // badge transitions from `.loading` to `.ready` (and the
+                // restart-impact count refreshes) without waiting for an
+                // unrelated UI change.
+                bumpStateTick()
             }
             try? await cur.client.didOpen(
                 uri: uri,

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -112,11 +112,21 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// to a single `LanguageServerAvailability.status(for:)` probe and
     /// caching the result. Designed for hot-path callers like the status
     /// badge resolver.
+    ///
+    /// Only stable results (`.available`, `.disabled`) are cached — those
+    /// don't change without a registry update. `.notInstalled` is re-probed
+    /// on every call so a runtime install (e.g. the install nudge flow) is
+    /// picked up without an explicit cache invalidation hook. The fast-path
+    /// PATH walk is cheap; the `xcrun --find` fallback for `sourcekit-lsp`
+    /// only fires when the binary isn't on PATH, which is uncommon on dev
+    /// machines.
     func availabilityStatus(forLanguage language: String) -> LanguageServerAvailability.Status? {
         if let cached = availabilityCache[language] { return cached }
         guard let entry = registry.allEntries().first(where: { $0.language == language }) else { return nil }
         let status = cachedAvailability.status(for: entry)
-        availabilityCache[language] = status
+        if status != .notInstalled {
+            availabilityCache[language] = status
+        }
         return status
     }
 

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -938,4 +938,54 @@ struct EditorBufferLanguageOverrideTests {
         buf.languageOverride = nil
         #expect(buf.effectiveLanguage == "swift")
     }
+
+    /// Verifies the reactive plumbing in `CodeEditorCoordinator`: when a tab
+    /// flips its `languageOverride`, the coordinator's `observeEffectiveLanguage`
+    /// observer should fire, update `currentLanguage`, and reapply the
+    /// indentation mode. Checking `textView.indentationMode` is the cheapest
+    /// visible side-effect to assert on (currentLanguage itself is private).
+    @Test func coordinatorObserverRefreshesIndentationOnLanguageOverride() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-lsp-override-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let fileURL = root.appendingPathComponent("scratch.unknown")
+        try "x\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let appState = AppState()
+        let buffer = appState.tabs.buffer(
+            worktreeId: "wt-override", tabId: "tab-override",
+            worktreeRoot: root, relativePath: "scratch.unknown"
+        )
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 400, height: 300))
+        layoutManager.addTextContainer(textContainer)
+        let textView = CodeTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 300), textContainer: textContainer)
+        let coordinator = CodeEditorCoordinator(appState: appState)
+        let theme = try ThemeStore().current
+
+        coordinator.attach(
+            textView: textView,
+            buffer: buffer,
+            layoutManager: layoutManager,
+            worktreeId: "wt-override",
+            worktreeRoot: root,
+            tabId: "tab-override",
+            revealLine: nil,
+            revealCharacter: nil,
+            theme: theme
+        )
+        // No registry entry for `.unknown` and no override → currentLanguage nil → plain.
+        #expect(textView.indentationMode == .plain)
+
+        buffer.languageOverride = "swift"
+
+        // The override observer dispatches its updates through a `Task { @MainActor in }`
+        // so we yield until the indentation flips (or the deadline trips).
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline, textView.indentationMode != .bracketAware {
+            await Task.yield()
+        }
+        #expect(textView.indentationMode == .bracketAware)
+    }
 }

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -911,3 +911,31 @@ private final class TestUndoOwner: NSObject, NSTextViewDelegate {
     let undoManager = UndoManager()
     func undoManager(for view: NSTextView) -> UndoManager? { undoManager }
 }
+
+@Suite("EditorBuffer.languageOverride")
+@MainActor
+struct EditorBufferLanguageOverrideTests {
+    private func buffer(language: String?) -> EditorBuffer {
+        let buf = EditorBuffer(worktreeRoot: URL(fileURLWithPath: "/tmp/repo"), relativePath: "main.swift")
+        buf.setLanguageForTest(language)
+        return buf
+    }
+
+    @Test func effectiveLanguageFallsBackToInferred() {
+        let buf = buffer(language: "swift")
+        #expect(buf.effectiveLanguage == "swift")
+    }
+
+    @Test func effectiveLanguageUsesOverrideWhenSet() {
+        let buf = buffer(language: "swift")
+        buf.languageOverride = "typescript"
+        #expect(buf.effectiveLanguage == "typescript")
+    }
+
+    @Test func effectiveLanguageClearsBackToInferredOnNilOverride() {
+        let buf = buffer(language: "swift")
+        buf.languageOverride = "typescript"
+        buf.languageOverride = nil
+        #expect(buf.effectiveLanguage == "swift")
+    }
+}

--- a/AlasTests/EditorLSPStatusResolverTests.swift
+++ b/AlasTests/EditorLSPStatusResolverTests.swift
@@ -135,4 +135,19 @@ struct EditorLSPStatusResolverTests {
         let result = r.resolve(absolutePath: swiftFile.path, override: nil, worktreeRoot: root)
         #expect(result == .problem(language: "swift", kind: .dead, command: "sourcekit-lsp"))
     }
+
+    /// Regression guard for the `case nil` arm of the resolver. The override
+    /// picker today only surfaces languages with a registry entry, so this
+    /// branch isn't reachable from the badge UI — but the invariant lives in
+    /// the picker, not the resolver, so this seeds the assertion in case a
+    /// future caller (CLI, serialized tab state, tests) sets an override to
+    /// an unregistered language.
+    @Test func problemDisabledWhenAvailabilityReturnsNil() {
+        let r = resolver(
+            availability: FakeAvailability(statusByLanguage: [:], commandByLanguage: [:]),
+            registry: FakeRegistry(languageByExt: [:])
+        )
+        let result = r.resolve(absolutePath: swiftFile.path, override: "unknown", worktreeRoot: root)
+        #expect(result == .problem(language: "unknown", kind: .disabled, command: nil))
+    }
 }

--- a/AlasTests/EditorLSPStatusResolverTests.swift
+++ b/AlasTests/EditorLSPStatusResolverTests.swift
@@ -1,0 +1,138 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite("EditorLSPStatusResolver")
+struct EditorLSPStatusResolverTests {
+    struct FakeManager: EditorLSPStatusResolver.ManagerProbe {
+        var status: WorkspaceLSPManager.DocumentStatus = .none
+        func documentStatus(forFile fileURL: URL, worktreeRoot: URL) -> WorkspaceLSPManager.DocumentStatus {
+            status
+        }
+    }
+
+    struct FakeAvailability: EditorLSPStatusResolver.AvailabilityProbe {
+        var statusByLanguage: [String: LanguageServerAvailability.Status]
+        var commandByLanguage: [String: String]
+        func status(forLanguage language: String) -> LanguageServerAvailability.Status? {
+            statusByLanguage[language]
+        }
+        func command(forLanguage language: String) -> String? {
+            commandByLanguage[language]
+        }
+    }
+
+    struct FakeRegistry: EditorLSPStatusResolver.RegistryProbe {
+        var languageByExt: [String: String]
+        func language(forFileExtension ext: String) -> String? {
+            languageByExt[ext]
+        }
+    }
+
+    private func resolver(
+        manager: FakeManager = .init(),
+        availability: FakeAvailability = .init(statusByLanguage: [:], commandByLanguage: [:]),
+        registry: FakeRegistry = .init(languageByExt: [:])
+    ) -> EditorLSPStatusResolver {
+        EditorLSPStatusResolver(manager: manager, availability: availability, registry: registry)
+    }
+
+    private let root = URL(fileURLWithPath: "/tmp/repo")
+    private let swiftFile = URL(fileURLWithPath: "/tmp/repo/main.swift")
+
+    @Test func noLanguageWhenExtensionUnknown() {
+        let r = resolver()
+        let result = r.resolve(absolutePath: "/tmp/repo/notes.xyz", override: nil, worktreeRoot: root)
+        #expect(result == .noLanguage(fileExtension: "xyz"))
+    }
+
+    @Test func overrideWinsOverExtensionMatch() {
+        let r = resolver(
+            manager: FakeManager(status: .ready),
+            availability: FakeAvailability(
+                statusByLanguage: ["swift": .available, "typescript": .available],
+                commandByLanguage: ["swift": "sourcekit-lsp", "typescript": "tsserver"]
+            ),
+            registry: FakeRegistry(languageByExt: ["swift": "swift"])
+        )
+        let result = r.resolve(absolutePath: swiftFile.path, override: "typescript", worktreeRoot: root)
+        #expect(result == .ready(language: "typescript", command: "tsserver"))
+    }
+
+    @Test func problemDisabledWhenAvailabilityDisabled() {
+        let r = resolver(
+            availability: FakeAvailability(
+                statusByLanguage: ["swift": .disabled],
+                commandByLanguage: ["swift": "sourcekit-lsp"]
+            ),
+            registry: FakeRegistry(languageByExt: ["swift": "swift"])
+        )
+        let result = r.resolve(absolutePath: swiftFile.path, override: nil, worktreeRoot: root)
+        #expect(result == .problem(language: "swift", kind: .disabled, command: "sourcekit-lsp"))
+    }
+
+    @Test func problemNotInstalledWhenAvailabilityNotInstalled() {
+        let r = resolver(
+            availability: FakeAvailability(
+                statusByLanguage: ["swift": .notInstalled],
+                commandByLanguage: ["swift": "sourcekit-lsp"]
+            ),
+            registry: FakeRegistry(languageByExt: ["swift": "swift"])
+        )
+        let result = r.resolve(absolutePath: swiftFile.path, override: nil, worktreeRoot: root)
+        #expect(result == .problem(language: "swift", kind: .notInstalled, command: "sourcekit-lsp"))
+    }
+
+    @Test func loadingWhenNoHolderYet() {
+        let r = resolver(
+            manager: FakeManager(status: .none),
+            availability: FakeAvailability(
+                statusByLanguage: ["swift": .available],
+                commandByLanguage: ["swift": "sourcekit-lsp"]
+            ),
+            registry: FakeRegistry(languageByExt: ["swift": "swift"])
+        )
+        let result = r.resolve(absolutePath: swiftFile.path, override: nil, worktreeRoot: root)
+        #expect(result == .loading(language: "swift"))
+    }
+
+    @Test func loadingWhenHolderStillStarting() {
+        let r = resolver(
+            manager: FakeManager(status: .loading),
+            availability: FakeAvailability(
+                statusByLanguage: ["swift": .available],
+                commandByLanguage: ["swift": "sourcekit-lsp"]
+            ),
+            registry: FakeRegistry(languageByExt: ["swift": "swift"])
+        )
+        let result = r.resolve(absolutePath: swiftFile.path, override: nil, worktreeRoot: root)
+        #expect(result == .loading(language: "swift"))
+    }
+
+    @Test func readyWhenHolderReady() {
+        let r = resolver(
+            manager: FakeManager(status: .ready),
+            availability: FakeAvailability(
+                statusByLanguage: ["swift": .available],
+                commandByLanguage: ["swift": "sourcekit-lsp"]
+            ),
+            registry: FakeRegistry(languageByExt: ["swift": "swift"])
+        )
+        let result = r.resolve(absolutePath: swiftFile.path, override: nil, worktreeRoot: root)
+        #expect(result == .ready(language: "swift", command: "sourcekit-lsp"))
+    }
+
+    @Test func problemDeadWhenHolderDead() {
+        let r = resolver(
+            manager: FakeManager(status: .dead),
+            availability: FakeAvailability(
+                statusByLanguage: ["swift": .available],
+                commandByLanguage: ["swift": "sourcekit-lsp"]
+            ),
+            registry: FakeRegistry(languageByExt: ["swift": "swift"])
+        )
+        let result = r.resolve(absolutePath: swiftFile.path, override: nil, worktreeRoot: root)
+        #expect(result == .problem(language: "swift", kind: .dead, command: "sourcekit-lsp"))
+    }
+}

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -46,4 +46,24 @@ struct WorkspaceLSPManagerStatusTests {
         _ = await mgr.openDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift", text: "")
         #expect(mgr.stateTick > before)
     }
+
+    @Test func restartHolderReopensPreviouslyOpenURIs() async {
+        let mgr = manager()
+        _ = await mgr.openDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift", text: "")
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) != .none)
+        let beforeTick = mgr.stateTick
+        await mgr.restartHolder(forLanguage: "swift", rootURL: root)
+        #expect(mgr.stateTick > beforeTick)
+        // After restart, the document should be tracked again (status is at
+        // least .loading; depending on whether the fake binary "succeeds"
+        // initialize, may be .ready or .dead — but never .none).
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) != .none)
+    }
+
+    @Test func restartHolderOnNoMatchingHolderIsNoOp() async {
+        let mgr = manager()
+        let beforeTick = mgr.stateTick
+        await mgr.restartHolder(forLanguage: "swift", rootURL: root)
+        #expect(mgr.stateTick == beforeTick)
+    }
 }

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -1,0 +1,49 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@MainActor
+@Suite("WorkspaceLSPManager.documentStatus")
+struct WorkspaceLSPManagerStatusTests {
+    private let root: URL
+    private let fileURL: URL
+
+    init() throws {
+        let r = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("alas-lsp-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: r, withIntermediateDirectories: true)
+        self.root = r
+        self.fileURL = r.appendingPathComponent("main.swift")
+    }
+
+    private func manager(withFakeEntry language: String = "swift") -> WorkspaceLSPManager {
+        let registry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: language,
+                extensions: ["swift"],
+                command: "/usr/bin/true",
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        return WorkspaceLSPManager(registry: registry)
+    }
+
+    @Test func documentStatusIsNoneBeforeOpen() {
+        let mgr = manager()
+        #expect(mgr.documentStatus(forFile: fileURL, worktreeRoot: root) == .none)
+    }
+
+    @Test func stateTickStartsAtZero() {
+        let mgr = manager()
+        #expect(mgr.stateTick == 0)
+    }
+
+    @Test func stateTickBumpsWhenHolderInserted() async {
+        let mgr = manager()
+        let before = mgr.stateTick
+        _ = await mgr.openDocument(worktreeRoot: root, fileURL: fileURL, languageId: "swift", text: "")
+        #expect(mgr.stateTick > before)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a small pill badge on the right side of the editor breadcrumb that shows the LSP status for the current file. Four buckets: Ready, Loading, Problem (not installed / crashed / disabled), and No language.
- Clicking the badge opens a popover with state-specific actions (Restart server, Open settings, Cancel) plus a searchable "Treat this file as…" language picker that overrides the file's language for the current tab/session.
- Override is per-buffer and per-session — `EditorBuffer.languageOverride` drives a close+reopen on the underlying LSP holder via the buffer's own ownership of the document lifecycle.

## Implementation notes

- New value type `EditorLSPStatus` + pure `EditorLSPStatusResolver` with truth-table tests.
- `WorkspaceLSPManager` now exposes `documentStatus(forFile:worktreeRoot:)`, an observable `stateTick` that bumps on every holder lifecycle transition, and `restartHolder(forLanguage:rootURL:)`. `client(forFile:)` now filters out `.dead` holders so callers (e.g. `sendLSPDidChange`) don't hit a dead transport.
- LSP open/close routing for overrides lives on `EditorBuffer` (single source of truth via `openedLanguage`). `CodeEditorCoordinator` only mirrors `effectiveLanguage` into `currentLanguage` so hover / definition / completion / diagnostics / didChange route to the right holder when an override is active.
- The override picker's language list is computed lazily on popover open — building it eagerly would run `xcrun --find sourcekit-lsp` and PATH walks on every breadcrumb re-render.

## Test plan

- [x] `EditorLSPStatusResolverTests` — 8 truth-table cases (no language, override, disabled, not installed, no holder, starting, ready, dead)
- [x] `WorkspaceLSPManagerStatusTests` — 5 cases covering documentStatus / stateTick / restartHolder
- [x] `EditorBufferLanguageOverrideTests` — 3 cases on the `effectiveLanguage` getter
- [x] Full `xcodebuild test` run green
- [ ] Manual: open `.swift` file → Ready (green dot + "swift"), popover shows server + Restart action
- [ ] Manual: open file with unknown extension → No-language, picker offers installed languages + link to Settings
- [ ] Manual: override to another language → badge updates, LSP routes to new holder
- [ ] Manual: point a language at a bad command in Settings → Problem state with `!` + override picker
- [ ] Manual: Restart from Ready popover → flips Loading → Ready