### PR TITLE
fix(highlight): address Codex review feedback across language stack

### DIFF
--- a/Alas/Sources/Code/Editor/EditorTheme.swift
+++ b/Alas/Sources/Code/Editor/EditorTheme.swift
@@ -44,9 +44,8 @@ struct EditorTheme {
         case .string:                        return nsColor("add")
         case .number:                        return nsColor("mod")
         case .comment:                       return nsColor("fg-faint")
-        case .attribute:                     return nsColor("syntax-keyword")
-        case .constant, .variable,
-             .parameter, .property,
+        case .attribute, .constant:          return nsColor("syntax-keyword")
+        case .variable, .parameter, .property,
              .operator, .punctuation, .plain:
             return defaultFG
         }

--- a/Alas/Sources/Code/Highlight/LanguageRegistry.swift
+++ b/Alas/Sources/Code/Highlight/LanguageRegistry.swift
@@ -103,21 +103,37 @@ enum LanguageRegistry {
                               bundleNameContains: "TreeSitterBash",
                               language: lang)
         case "js", "mjs", "cjs", "jsx":
-            query = loadQuery(named: "highlights",
-                              bundleNameContains: "TreeSitterJavaScript",
-                              language: lang)
+            // All JS variants share one grammar (it parses JSX natively).
+            // Merge the JSX overlay so JSX tags/attributes get captured —
+            // for pure-JS files the overlay just doesn't match.
+            query = loadMergedQuery(
+                sources: [
+                    ("TreeSitterJavaScript", "highlights"),
+                    ("TreeSitterJavaScript", "highlights-jsx")
+                ],
+                language: lang
+            )
         case "ts":
             // TS query inherits from JS — merge them so strings, functions,
             // comments etc. are colored alongside the TS-specific captures.
+            // No JSX overlay: the TS grammar lacks `jsx_*` nodes, so loading
+            // the overlay would fail Query compilation.
             query = loadMergedQuery(
-                named: "highlights",
-                bundleNeedles: ["TreeSitterJavaScript", "TreeSitterTypeScript_TreeSitterTypeScript"],
+                sources: [
+                    ("TreeSitterJavaScript", "highlights"),
+                    ("TreeSitterTypeScript_TreeSitterTypeScript", "highlights")
+                ],
                 language: lang
             )
         case "tsx":
+            // TSX has both TS-specific nodes and JSX nodes, so include the
+            // JSX overlay alongside the TS overlay.
             query = loadMergedQuery(
-                named: "highlights",
-                bundleNeedles: ["TreeSitterJavaScript", "TreeSitterTypeScript_TreeSitterTSX"],
+                sources: [
+                    ("TreeSitterJavaScript", "highlights"),
+                    ("TreeSitterJavaScript", "highlights-jsx"),
+                    ("TreeSitterTypeScript_TreeSitterTSX", "highlights")
+                ],
                 language: lang
             )
         case "java":
@@ -137,8 +153,10 @@ enum LanguageRegistry {
             // flow, and preprocessor directives are colored alongside
             // the C++-specific overlay (templates, namespaces, etc.).
             query = loadMergedQuery(
-                named: "highlights",
-                bundleNeedles: ["TreeSitterC_TreeSitterC", "TreeSitterCPP_TreeSitterCPP"],
+                sources: [
+                    ("TreeSitterC_TreeSitterC", "highlights"),
+                    ("TreeSitterCPP_TreeSitterCPP", "highlights")
+                ],
                 language: lang
             )
         default:
@@ -165,28 +183,28 @@ enum LanguageRegistry {
         language: Language
     ) -> Query? {
         loadMergedQuery(
-            named: name,
-            bundleNeedles: [needle],
+            sources: [(needle, name)],
             language: language
         )
     }
 
-    /// Loads `.scm` files from multiple bundles and compiles their
-    /// concatenated text as one Query against `language`. Tree-sitter
-    /// grammars often inherit query patterns from a base grammar (e.g.
-    /// TypeScript inherits from JavaScript via a `;;; inherits:` comment
-    /// the SwiftTreeSitter loader doesn't honor); concatenating the
-    /// inherited base file with the derived overlay reproduces the
-    /// expected behavior. Bundles are looked up in order; any missing one
-    /// is silently skipped, which keeps the call sites tidy when an
-    /// optional overlay isn't present.
+    /// Loads `.scm` files from multiple bundles (each pair selects a
+    /// specific `queryName` inside a `bundleNeedle`-matched bundle) and
+    /// compiles their concatenated text as one Query against `language`.
+    ///
+    /// This serves two needs: (a) grammars that inherit query patterns
+    /// from a base grammar via a `;;; inherits:` directive the
+    /// SwiftTreeSitter loader doesn't honor (TS ⇐ JS, C++ ⇐ C), and (b)
+    /// grammars that ship an extension overlay alongside the base query
+    /// (JS+JSX shipping `highlights.scm` + `highlights-jsx.scm`).
+    /// Sources are loaded in order; any missing bundle or file is
+    /// silently skipped.
     private static func loadMergedQuery(
-        named name: String,
-        bundleNeedles needles: [String],
+        sources: [(bundleNeedle: String, queryName: String)],
         language: Language
     ) -> Query? {
         var combined = Data()
-        for needle in needles {
+        for (needle, name) in sources {
             guard let bundle = grammarBundle(named: needle) else { continue }
             let url = bundle.url(forResource: "queries/\(name)", withExtension: "scm")
                 ?? bundle.url(forResource: name, withExtension: "scm",

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -26,36 +26,42 @@ struct TreeSitterHighlighterTests {
         #expect(captures.contains(.string))
     }
 
-    @Test("TypeScript and TSX get keyword + type + string captures")
+    @Test("TypeScript captures types; TSX captures JSX attributes")
     func typescriptBasics() throws {
         let ts = TreeSitterHighlighter.highlight(
             source: "interface User { name: string } const u: User = { name: \"a\" };",
             fileExtension: "ts"
         )
         let tsx = TreeSitterHighlighter.highlight(
-            source: "type Props = { name: string }; const G = (p: Props) => <h1>{p.name}</h1>;",
+            source: #"const G = (p: {n: string}) => <Button primary onClick={() => p.n}>Hi</Button>;"#,
             fileExtension: "tsx"
         )
         #expect(ts.contains(where: { $0.capture == .keyword }))
-        #expect(ts.contains(where: { $0.capture == .string }))
-        #expect(!tsx.isEmpty)
-        #expect(tsx.contains(where: { $0.capture == .keyword }))
+        // `User` parses as `type_identifier @type` — a TS-only capture the
+        // regex fallback would never emit, so this proves the tree-sitter
+        // query path is wired.
+        #expect(ts.contains(where: { $0.capture == .type }))
+        // `primary` / `onClick` are `jsx_attribute (property_identifier) @attribute`
+        // from the JSX overlay — emitted only when the JSX query is loaded.
+        #expect(tsx.contains(where: { $0.capture == .attribute }))
     }
 
-    @Test("JavaScript and JSX get keyword + string + function captures")
+    @Test("JavaScript captures functions; JSX captures attributes via overlay")
     func javascriptBasics() throws {
         let js = TreeSitterHighlighter.highlight(
             source: #"const greet = (name) => `hello, ${name}`;"#,
             fileExtension: "js"
         )
         let jsx = TreeSitterHighlighter.highlight(
-            source: #"const Greeting = ({name}) => <h1>Hi, {name}</h1>;"#,
+            source: #"const G = ({name}) => <Button primary onClick={() => name}>Hi</Button>;"#,
             fileExtension: "jsx"
         )
         #expect(js.contains(where: { $0.capture == .keyword }))
         #expect(js.contains(where: { $0.capture == .string }))
-        #expect(!jsx.isEmpty)
-        #expect(jsx.contains(where: { $0.capture == .keyword }))
+        // `primary` / `onClick` are JSX attribute names — `@attribute` capture
+        // from the JSX overlay. The regex fallback never emits `.attribute`,
+        // so this proves the JSX overlay was merged into the .jsx query.
+        #expect(jsx.contains(where: { $0.capture == .attribute }))
     }
 
     @Test("Bash variable expansion and keywords are captured")
@@ -83,6 +89,7 @@ struct TreeSitterHighlighterTests {
         let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "go")
         let captures = Set(spans.map { $0.capture })
         #expect(captures.contains(.keyword))
+        #expect(captures.contains(.function))
         #expect(captures.contains(.string))
     }
 
@@ -95,12 +102,15 @@ struct TreeSitterHighlighterTests {
         #expect(captures.contains(.string))
     }
 
-    @Test("JSON strings and numbers are captured")
+    @Test("JSON strings, numbers, and literal constants are captured")
     func jsonBasics() throws {
-        let spans = TreeSitterHighlighter.highlight(source: #"{"ok": true, "n": 1, "name": "alas"}"#, fileExtension: "json")
+        let spans = TreeSitterHighlighter.highlight(source: #"{"ok": true, "n": 1, "name": "alas", "x": null}"#, fileExtension: "json")
         #expect(!spans.isEmpty)
         #expect(spans.contains(where: { $0.capture == .string }))
         #expect(spans.contains(where: { $0.capture == .number }))
+        // `true`/`false`/`null` come through as `@constant.builtin` → .constant.
+        // EditorTheme routes .constant to the keyword color so they render.
+        #expect(spans.contains(where: { $0.capture == .constant }))
     }
 
     @Test("Python `def foo()` is captured as keyword + function")


### PR DESCRIPTION
<!-- gg:managed:start -->
Bundles the substantive issues Codex flagged on PRs #289–#301 into one
commit at the top of the stack:

* JSON literals (`true`/`false`/`null`) used to color as `.keyword` via
  the regex fallback; routing through tree-sitter promoted them to
  `@constant.builtin` → `.constant`, which `EditorTheme` rendered as
  default foreground. Route `.constant` to `syntax-keyword` (alongside
  `.attribute`) so builtin constants stay visibly highlighted across
  JSON, Python, etc. (#290).

* `.jsx` files only loaded the base JS query, so JSX tags/attributes
  went uncolored even though we vendor `highlights-jsx.scm`. Now JS
  variants (`.js`/`.mjs`/`.cjs`/`.jsx`) merge the JSX overlay — pure JS
  files just get no matches against it, so the overlay is cost-free
  (#296, #298, #299, #300, #301).

* `.tsx` had the same gap: merged JS+TSX `highlights.scm` but never the
  JSX overlay. Add the overlay to the TSX merge list; leave `.ts` alone
  (the TS grammar lacks `jsx_*` nodes, so loading the overlay there
  would fail Query compilation) (#297, #298, #299, #300, #301).

* `loadMergedQuery` now takes `[(bundleNeedle, queryName)]` tuples
  instead of `(name, [needles])` — this is what made loading two
  different files from the same bundle ergonomic.

Test rigor improvements driven by the same reviews:

* Go test asserts `.function` to match its name (#294).
* JSX/TSX tests assert `.attribute` (a JSX-overlay-only capture the
  regex fallback never emits) to actually prove the tree-sitter query
  pipeline is wired (#297).
* JSON test asserts `.constant` to lock in the literal-coloring fix.
<!-- gg:managed:end -->