### PR TITLE
feat: clickable breadcrumb to reveal file in Files tab

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1512,6 +1512,14 @@ final class AppState {
         )
     }
 
+    func revealInFiles(worktreeId: String, path: String) {
+        guard let worktree = worktree(withId: worktreeId) else { return }
+        config.rightPaneVisible = true
+        _ = saveConfig()
+        let rps = rightPaneStore.state(for: worktree, baseBranch: config.worktrees.baseBranch)
+        rps.reveal(path: path)
+    }
+
     /// Open a markdown relative-link target as a new editor tab in the same worktree.
     /// Delegates to `openFile` which handles find-or-create, activate, and
     /// worktree-switch if necessary.

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -99,7 +99,8 @@ struct CenterPaneView: View {
                                             originatingRelativePath: s.originatingRelativePath,
                                             revealLine: s.revealLine,
                                             revealCharacter: s.revealCharacter,
-                                            appState: state)
+                                            appState: state,
+                                            onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) })
                         } else {
                             EditorTabView(worktreePath: worktree.path,
                                           relativePath: s.relativePath,
@@ -109,7 +110,8 @@ struct CenterPaneView: View {
                                           revealCharacter: s.revealCharacter,
                                           appState: state,
                                           externalAbsolutePath: s.externalAbsolutePath,
-                                          originatingRelativePath: s.originatingRelativePath)
+                                          originatingRelativePath: s.originatingRelativePath,
+                                          onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) })
                         }
                     case .diff(let s):
                         let openAvailable = DiffOpenFileAvailability.isAvailable(
@@ -150,7 +152,8 @@ struct CenterPaneView: View {
                         .id(s.id)
                     case .imagePreview(let s):
                         ImagePreviewTabView(worktreePath: worktree.path,
-                                             relativePath: s.relativePath)
+                                             relativePath: s.relativePath,
+                                             onRevealInFiles: { path in state.revealInFiles(worktreeId: worktree.id, path: path) })
                     case .mergeConflict(let s):
                         MergeConflictTabView(
                             state: state,

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -11,6 +11,7 @@ struct EditorTabView: View {
     let appState: AppState
     let externalAbsolutePath: String?
     let originatingRelativePath: String?
+    let onRevealInFiles: (String) -> Void
     @Environment(\.theme) var theme
 
     @State private var findBarVisible: Bool = false
@@ -143,12 +144,27 @@ struct EditorTabView: View {
         let components = relativePath.split(separator: "/")
         let lastIndex = components.count - 1
         return HStack(spacing: 6) {
-            ForEach(Array(components.enumerated()), id: \.offset) { (i, comp) in
-                Text(comp)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(i == lastIndex ? theme.color("fg") : theme.color("fg-muted"))
-                if i < lastIndex {
-                    Text("/").foregroundColor(theme.color("fg-faint"))
+            if components.isEmpty {
+                Text("").font(.system(size: 11, design: .monospaced))
+            } else {
+                ForEach(Array(components.enumerated()), id: \.offset) { (i, comp) in
+                    let pathPrefix = components[0...i].joined(separator: "/")
+                    Text(String(comp))
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(i == lastIndex ? theme.color("fg") : theme.color("fg-muted"))
+                        .onTapGesture {
+                            onRevealInFiles(String(pathPrefix))
+                        }
+                        .onHover { inside in
+                            if inside {
+                                NSCursor.pointingHand.push()
+                            } else {
+                                NSCursor.pointingHand.pop()
+                            }
+                        }
+                    if i < lastIndex {
+                        Text("/").foregroundColor(theme.color("fg-faint"))
+                    }
                 }
             }
             Spacer()

--- a/Alas/Sources/Center/ImagePreviewTabView.swift
+++ b/Alas/Sources/Center/ImagePreviewTabView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ImagePreviewTabView: View {
     let worktreePath: URL
     let relativePath: String
+    let onRevealInFiles: (String) -> Void
     @Environment(\.theme) private var theme
     @State private var loadState: LoadState = .idle
 
@@ -94,20 +95,27 @@ struct ImagePreviewTabView: View {
         let components = relativePath.split(separator: "/")
         let lastIndex = components.count - 1
         return HStack(spacing: 6) {
-            ForEach(Array(components.enumerated()), id: \.offset) { (i, comp) in
-                Text(comp)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(i == lastIndex ? theme.color("fg") : theme.color("fg-muted"))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                if i < lastIndex {
-                    Text("/").foregroundColor(theme.color("fg-faint"))
+            if components.isEmpty {
+                Text("").font(.system(size: 11, design: .monospaced))
+            } else {
+                ForEach(Array(components.enumerated()), id: \.offset) { (i, comp) in
+                    let pathPrefix = components[0...i].joined(separator: "/")
+                    Text(String(comp))
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(i == lastIndex ? theme.color("fg") : theme.color("fg-muted"))
+                        .onTapGesture { onRevealInFiles(String(pathPrefix)) }
+                        .onHover { inside in
+                            if inside { NSCursor.pointingHand.push() }
+                            else { NSCursor.pointingHand.pop() }
+                        }
+                    if i < lastIndex {
+                        Text("/").foregroundColor(theme.color("fg-faint"))
+                    }
                 }
             }
             Spacer()
         }
-        .padding(.horizontal, 12)
-        .frame(height: 28)
+        .padding(.horizontal, 12).frame(height: 28)
         .background(theme.color("bg-1"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
     }

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -11,6 +11,7 @@ struct MarkdownTabView: View {
     let revealLine: Int?
     let revealCharacter: Int?
     @Bindable var appState: AppState
+    let onRevealInFiles: (String) -> Void
     @Environment(\.theme) var theme
 
     @State private var renderResult: MarkdownRenderResult?
@@ -174,12 +175,22 @@ struct MarkdownTabView: View {
         let components = relativePath.split(separator: "/")
         let lastIndex = components.count - 1
         return HStack(spacing: 6) {
-            ForEach(Array(components.enumerated()), id: \.offset) { (i, comp) in
-                Text(comp)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(i == lastIndex ? theme.color("fg") : theme.color("fg-muted"))
-                if i < lastIndex {
-                    Text("/").foregroundColor(theme.color("fg-faint"))
+            if components.isEmpty {
+                Text("").font(.system(size: 11, design: .monospaced))
+            } else {
+                ForEach(Array(components.enumerated()), id: \.offset) { (i, comp) in
+                    let pathPrefix = components[0...i].joined(separator: "/")
+                    Text(String(comp))
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(i == lastIndex ? theme.color("fg") : theme.color("fg-muted"))
+                        .onTapGesture { onRevealInFiles(String(pathPrefix)) }
+                        .onHover { inside in
+                            if inside { NSCursor.pointingHand.push() }
+                            else { NSCursor.pointingHand.pop() }
+                        }
+                    if i < lastIndex {
+                        Text("/").foregroundColor(theme.color("fg-faint"))
+                    }
                 }
             }
         }

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -23,7 +23,7 @@ struct FilesTabView: View {
                 }
                 .padding(.vertical, 4)
             }
-            .onChange(of: revealTick) { _ in
+            .onChange(of: revealTick) { _, _ in
                 guard let path = revealPath else { return }
                 proxy.scrollTo("file:\(path)", anchor: .top)
                 proxy.scrollTo("dir:\(path)", anchor: .top)

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -8,17 +8,26 @@ struct FilesTabView: View {
     let shouldAutoLoadChildren: (String, DirectoryChildrenState) -> Bool
     let onLoadChildren: (String) -> Void
     let showIgnored: Bool
+    let revealPath: String?
+    let revealTick: Int
 
     @Environment(\.theme) private var theme
 
     var body: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(Self.filteredNodes(nodes, showIgnored: showIgnored)) { node in
-                    renderNode(node, depth: 0)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Self.filteredNodes(nodes, showIgnored: showIgnored)) { node in
+                        renderNode(node, depth: 0)
+                    }
                 }
+                .padding(.vertical, 4)
             }
-            .padding(.vertical, 4)
+            .onChange(of: revealTick) { _ in
+                guard let path = revealPath else { return }
+                proxy.scrollTo("file:\(path)", anchor: .top)
+                proxy.scrollTo("dir:\(path)", anchor: .top)
+            }
         }
     }
 
@@ -84,6 +93,8 @@ struct FilesTabView: View {
                             }
                         }
                         .contentShape(Rectangle())
+                        .background(node.path == revealPath ? theme.color("bg-hover") : Color.clear)
+                        .id(node.id)
                     }
                     .buttonStyle(.plain)
                     if open && canExpand {
@@ -133,6 +144,8 @@ struct FilesTabView: View {
                         }
                     }
                     .contentShape(Rectangle())
+                    .background(node.path == revealPath ? theme.color("bg-hover") : Color.clear)
+                    .id(node.id)
                 }
                 .buttonStyle(.plain)
             )

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -18,7 +18,7 @@ final class RightPaneState {
     var loading: Bool = false
     var openPaths: Set<String> = []   // expanded directories in the tree
     var revealPath: String? = nil
-    var revealTick: Int = 0
+    private(set) var revealTick: Int = 0
     private(set) var loadedFileTreeChildPaths: Set<String> = [""]
     private(set) var loadingFileTreeChildPaths: Set<String> = []
     private(set) var failedFileTreeChildPaths: Set<String> = []

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -17,6 +17,8 @@ final class RightPaneState {
     var fileTree: [FileTreeNode] = []
     var loading: Bool = false
     var openPaths: Set<String> = []   // expanded directories in the tree
+    var revealPath: String? = nil
+    var revealTick: Int = 0
     private(set) var loadedFileTreeChildPaths: Set<String> = [""]
     private(set) var loadingFileTreeChildPaths: Set<String> = []
     private(set) var failedFileTreeChildPaths: Set<String> = []
@@ -442,6 +444,20 @@ final class RightPaneState {
                 logger.error("file tree child load failed for \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
+
+    func reveal(path: String) {
+        activeTab = .files
+        let pathComponents = path.split(separator: "/").map(String.init)
+        for i in 0..<(pathComponents.count - 1) {
+            let ancestor = pathComponents[0...i].joined(separator: "/")
+            openPaths.insert(ancestor)
+            if !loadedFileTreeChildPaths.contains(ancestor) {
+                loadFileTreeChildren(path: ancestor)
+            }
+        }
+        revealPath = path
+        revealTick += 1
     }
 
     /// Paths to discard for the given file path. Expands staged renames into

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -59,7 +59,9 @@ struct RightPaneView: View {
                             rps.shouldAutoLoadFileTreeChildren(path: path, childrenState: childrenState)
                         },
                         onLoadChildren: { rps.loadFileTreeChildren(path: $0) },
-                        showIgnored: state.config.files.showIgnored
+                        showIgnored: state.config.files.showIgnored,
+                        revealPath: rps.revealPath,
+                        revealTick: rps.revealTick
                     )
                 }
             }

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -366,3 +366,57 @@ struct RightPaneStateFileTreeTests {
         ))
     }
 }
+
+@MainActor
+struct RightPaneStateRevealTests {
+    @Test func revealSetsActiveTabToFiles() {
+        let state = makeTestState()
+        state.reveal(path: "Sources/App.swift")
+        #expect(state.activeTab == .files)
+    }
+
+    @Test func revealExpandsAncestorDirsAndSetsRevealPath() {
+        let state = makeTestState()
+        state.reveal(path: "Sources/Center/App.swift")
+        #expect(state.openPaths.contains("Sources"))
+        #expect(state.openPaths.contains("Sources/Center"))
+        #expect(state.revealPath == "Sources/Center/App.swift")
+    }
+
+    @Test func revealBumpsRevealTick() {
+        let state = makeTestState()
+        let before = state.revealTick
+        state.reveal(path: "Sources/App.swift")
+        #expect(state.revealTick == before + 1)
+    }
+
+    @Test func revealForDirectoryDoesNotIncludeSelfInAncestors() {
+        let state = makeTestState()
+        state.reveal(path: "Sources/Center")
+        #expect(state.openPaths.contains("Sources"))
+        #expect(state.openPaths.contains("Sources/Center") == false)
+        #expect(state.revealPath == "Sources/Center")
+    }
+
+    @Test func revealForTopLevelDirHasNoAncestors() {
+        let state = makeTestState()
+        state.reveal(path: "Sources")
+        #expect(state.openPaths.isEmpty)
+        #expect(state.revealPath == "Sources")
+    }
+
+    private func makeTestState() -> RightPaneState {
+        RightPaneState(
+            worktree: Worktree(
+                id: "test",
+                projectId: "proj",
+                name: "main",
+                branch: "main",
+                path: URL(fileURLWithPath: "/tmp/test"),
+                status: .clean,
+                lastActivity: Date()
+            ),
+            baseBranch: "main"
+        )
+    }
+}


### PR DESCRIPTION
Make the file path breadcrumb header in editor/image/markdown tabs clickable. Clicking a directory segment or the filename expands the right sidebar's Files tab to reveal that path, switching to the Files tab and revealing the pane if hidden.

- `RightPaneState.reveal(path:)` — expands ancestor directories, switches to Files tab, sets scroll-to state
- `AppState.revealInFiles(worktreeId:path:)` — reveals right pane and delegates
- `FilesTabView` — `ScrollViewReader` + node `.id()` + highlight via `bg-hover`
- Breadcrumb views (`EditorTabView`, `ImagePreviewTabView`, `MarkdownTabView`) — `.onTapGesture` + `.onHover` pointing hand cursor
- Tests for `reveal(path:)` behavior