### PR TITLE
Save commit edits with Cmd+Enter

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		7C9B1B7376FE5F651D9127D1 /* TreeSitterGo in Frameworks */ = {isa = PBXBuildFile; productRef = DB0D87DDDAD70492540E6906 /* TreeSitterGo */; };
 		7CA34C93E31EA98047AF6D81 /* MergeScrollCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 883981BBADF9816718091CE1 /* MergeScrollCoordinatorTests.swift */; };
 		7CDFA95F095090FF242B8248 /* EmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B24ABE96ED3C62146A3CED62 /* EmptyState.swift */; };
+		7D087329E7B873B1E7A1CE89 /* CommitMessageEditorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95DA6BFFE45ED25669869C76 /* CommitMessageEditorViewTests.swift */; };
 		7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4575017544CD7603B3AB9069 /* GitEventFilter.swift */; };
 		7DEFB0A61614D65F509A11AE /* ImageDiffDifferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
@@ -918,6 +919,7 @@
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
 		94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibility.swift; sourceTree = "<group>"; };
 		9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAction.swift; sourceTree = "<group>"; };
+		95DA6BFFE45ED25669869C76 /* CommitMessageEditorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitMessageEditorViewTests.swift; sourceTree = "<group>"; };
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
 		97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroupViewTests.swift; sourceTree = "<group>"; };
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
@@ -1260,6 +1262,7 @@
 				DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */,
 				E43F9F04AF6A6FF0A4D328F4 /* CommitHeaderViewTests.swift */,
 				9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */,
+				95DA6BFFE45ED25669869C76 /* CommitMessageEditorViewTests.swift */,
 				1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */,
 				6D46BDE72E52818061452ECB /* CommitRowTests.swift */,
 				576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */,
@@ -2705,6 +2708,7 @@
 				E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */,
 				06AD46194E45984A1297D928 /* CommitHeaderViewTests.swift in Sources */,
 				F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */,
+				7D087329E7B873B1E7A1CE89 /* CommitMessageEditorViewTests.swift in Sources */,
 				AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */,
 				B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */,
 				363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */,

--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -41,6 +41,7 @@ struct CommitMessageEditorView: View {
                         .background(canSave ? theme.color("accent") : theme.color("accent").opacity(0.4))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
                 }
+                .keyboardShortcut(.return, modifiers: .command)
                 .buttonStyle(.plain)
                 .disabled(!canSave)
             }
@@ -70,11 +71,5 @@ struct CommitMessageEditorView: View {
         .padding(12)
         .background(theme.color("bg-1"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
-        .onKeyPress(.return, phases: .down) { press in
-            guard press.modifiers == .command else { return .ignored }
-            guard canSave else { return .handled }
-            onSave()
-            return .handled
-        }
     }
 }

--- a/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
+++ b/Alas/Sources/Center/Commit/CommitMessageEditorView.swift
@@ -70,5 +70,11 @@ struct CommitMessageEditorView: View {
         .padding(12)
         .background(theme.color("bg-1"))
         .overlay(Divider().opacity(0.5), alignment: .bottom)
+        .onKeyPress(.return, phases: .down) { press in
+            guard press.modifiers == .command else { return .ignored }
+            guard canSave else { return .handled }
+            onSave()
+            return .handled
+        }
     }
 }

--- a/AlasTests/CommitMessageEditorViewTests.swift
+++ b/AlasTests/CommitMessageEditorViewTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import SwiftUI
+import AppKit
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct CommitMessageEditorViewTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    private func makeView(
+        subject: String = "feat: hello",
+        bodyText: String = "",
+        busy: Bool = false,
+        dirty: Bool = true,
+        error: String? = nil,
+        onSave: @escaping () -> Void = {}
+    ) -> some View {
+        CommitMessageEditorView(
+            subject: .constant(subject),
+            bodyText: .constant(bodyText),
+            aiToolId: .constant(""),
+            title: "Edit abc1234",
+            busy: busy,
+            dirty: dirty,
+            error: error,
+            availableAgents: [],
+            onGenerate: {},
+            onSave: onSave
+        )
+        .environment(\.theme, currentTheme())
+    }
+
+    @Test func rendersWithoutCrashing() {
+        let view = makeView()
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func rendersWhenBusy() {
+        let view = makeView(busy: true)
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func rendersWhenNotDirty() {
+        let view = makeView(dirty: false)
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func rendersWithError() {
+        let view = makeView(error: "Something went wrong")
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func rendersWithEmptySubject() {
+        let view = makeView(subject: "")
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+
+    @Test func rendersWithWhitespaceOnlySubject() {
+        let view = makeView(subject: "   ")
+        let controller = NSHostingController(rootView: view)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view != nil)
+    }
+}


### PR DESCRIPTION
## Summary
- add Cmd+Enter handling to the central commit message editor
- reuse the existing Save changes validation path
- consume disabled-save Cmd+Enter presses inside the editor so they do not fall through to other shortcuts

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test