### PR TITLE
fix(settings): disable format-on-save by default

### DIFF
--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -213,7 +213,7 @@ struct AppConfig: Codable, Equatable {
         code: Code(
             fontFamily: "SF Mono",
             fontSize: 13,
-            formatOnSave: true,
+            formatOnSave: false,
             languageServers: [],
             dismissedInstallNudges: [],
             userDefinedRecipes: [:]
@@ -378,7 +378,7 @@ extension AppConfig {
             let fontFamily = (try? codeContainer.decode(String.self, forKey: .fontFamily)) ?? "SF Mono"
             let rawSize = (try? codeContainer.decode(Int.self, forKey: .fontSize)) ?? 13
             let fontSize = max(8, min(64, rawSize))
-            let formatOnSave = (try? codeContainer.decode(Bool.self, forKey: .formatOnSave)) ?? true
+            let formatOnSave = (try? codeContainer.decode(Bool.self, forKey: .formatOnSave)) ?? false
             let servers = (try? codeContainer.decode([LanguageServerConfig].self, forKey: .languageServers)) ?? []
             let dismissed = (try? codeContainer.decode([String].self, forKey: .dismissedInstallNudges)) ?? []
             let userRecipes = (try? codeContainer.decode([String: [InstallRecipe]].self, forKey: .userDefinedRecipes)) ?? [:]
@@ -394,7 +394,7 @@ extension AppConfig {
             code = Code(
                 fontFamily: "SF Mono",
                 fontSize: 13,
-                formatOnSave: true,
+                formatOnSave: false,
                 languageServers: [],
                 dismissedInstallNudges: [],
                 userDefinedRecipes: [:]

--- a/AlasTests/SettingsSaveNormalizationTests.swift
+++ b/AlasTests/SettingsSaveNormalizationTests.swift
@@ -43,6 +43,24 @@ struct SettingsSaveNormalizationTests {
         #expect(normalized.rootMarkers == ["Package.swift", ".git"])
     }
 
+    @Test func decodeMissingFormatOnSaveDefaultsToFalse() throws {
+        let json = #"{"themeId":"cool-slate","accent":"teal","density":"comfortable","matchSystemTheme":false,"sidebarMaterial":"appKitSidebar","sidebarWidth":244,"rightPaneWidth":320,"rightPaneVisible":true,"sidebarVisible":true,"commitDetailSplitRatio":0.32,"general":{"launchAtLogin":false,"closeToTray":true,"confirmQuit":true,"autoUpdate":true,"updateChannel":"Stable","crashReports":false,"usageAnalytics":false},"worktrees":{"rootPath":"~/.alas/worktrees","pathTemplate":"{worktreeRoot}/{repo}/{branch}","branchPrefix":"feature/","baseBranch":"main","trackUpstream":true,"deleteBranchOnRemove":true,"autoFetch":true,"fetchIntervalMinutes":5,"pruneStale":false},"terminal":{"shell":"/bin/zsh","workingDirectory":"worktreeRoot","startupScript":"","worktreeCreateScript":"","inheritParentEnv":true,"fontFamily":"JetBrains Mono","fontSize":13,"cursorStyle":"beam","cursorBlink":true,"scrollbackLines":10000,"bell":"visual","syncTabTitleWithTerminalTitle":false},"harness":{"notifyOnFinish":true,"notifyOnAwaiting":true},"code":{"fontFamily":"SF Mono","fontSize":13,"languageServers":[],"dismissedInstallNudges":[],"userDefinedRecipes":{}},"markdown":{"defaultViewMode":"editor"},"changes":{"aiToolId":"none","prompt":"Hello"},"agents":{"builtinState":{},"custom":[],"worktreeAutoLaunch":{"agentId":null,"useBypassPermissions":false}},"files":{"showIgnored":true}}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.code.formatOnSave == false)
+    }
+
+    @Test func decodeExplicitFormatOnSaveTrueIsPreserved() throws {
+        let json = #"{"themeId":"cool-slate","accent":"teal","density":"comfortable","matchSystemTheme":false,"sidebarMaterial":"appKitSidebar","sidebarWidth":244,"rightPaneWidth":320,"rightPaneVisible":true,"sidebarVisible":true,"commitDetailSplitRatio":0.32,"general":{"launchAtLogin":false,"closeToTray":true,"confirmQuit":true,"autoUpdate":true,"updateChannel":"Stable","crashReports":false,"usageAnalytics":false},"worktrees":{"rootPath":"~/.alas/worktrees","pathTemplate":"{worktreeRoot}/{repo}/{branch}","branchPrefix":"feature/","baseBranch":"main","trackUpstream":true,"deleteBranchOnRemove":true,"autoFetch":true,"fetchIntervalMinutes":5,"pruneStale":false},"terminal":{"shell":"/bin/zsh","workingDirectory":"worktreeRoot","startupScript":"","worktreeCreateScript":"","inheritParentEnv":true,"fontFamily":"JetBrains Mono","fontSize":13,"cursorStyle":"beam","cursorBlink":true,"scrollbackLines":10000,"bell":"visual","syncTabTitleWithTerminalTitle":false},"harness":{"notifyOnFinish":true,"notifyOnAwaiting":true},"code":{"fontFamily":"SF Mono","fontSize":13,"formatOnSave":true,"languageServers":[],"dismissedInstallNudges":[],"userDefinedRecipes":{}},"markdown":{"defaultViewMode":"editor"},"changes":{"aiToolId":"none","prompt":"Hello"},"agents":{"builtinState":{},"custom":[],"worktreeAutoLaunch":{"agentId":null,"useBypassPermissions":false}},"files":{"showIgnored":true}}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.code.formatOnSave == true)
+    }
+
+    @Test func staticDefaultConfigHasFormatOnSaveDisabled() {
+        #expect(AppConfig.defaults.code.formatOnSave == false)
+    }
+
     @Test func decodeMissingSyncTabTitleField() throws {
         let json = #"{"themeId":"cool-slate","accent":"teal","density":"comfortable","matchSystemTheme":false,"sidebarMaterial":"appKitSidebar","sidebarWidth":244,"rightPaneWidth":320,"rightPaneVisible":true,"sidebarVisible":true,"commitDetailSplitRatio":0.32,"general":{"launchAtLogin":false,"closeToTray":true,"confirmQuit":true,"autoUpdate":true,"updateChannel":"Stable","crashReports":false,"usageAnalytics":false},"worktrees":{"rootPath":"~/.alas/worktrees","pathTemplate":"{worktreeRoot}/{repo}/{branch}","branchPrefix":"feature/","baseBranch":"main","trackUpstream":true,"deleteBranchOnRemove":true,"autoFetch":true,"fetchIntervalMinutes":5,"pruneStale":false},"terminal":{"shell":"/bin/zsh","workingDirectory":"worktreeRoot","startupScript":"","worktreeCreateScript":"","inheritParentEnv":true,"fontFamily":"JetBrains Mono","fontSize":13,"cursorStyle":"beam","cursorBlink":true,"scrollbackLines":10000,"bell":"visual"},"harness":{"notifyOnFinish":true,"notifyOnAwaiting":true},"code":{"fontFamily":"SF Mono","fontSize":13,"formatOnSave":true,"languageServers":[],"dismissedInstallNudges":[],"userDefinedRecipes":{}},"markdown":{"defaultViewMode":"editor"},"changes":{"aiToolId":"none","prompt":"Hello"},"agents":{"builtinState":{},"custom":[],"worktreeAutoLaunch":{"agentId":null,"useBypassPermissions":false}},"files":{"showIgnored":true}}"#
         let data = Data(json.utf8)


### PR DESCRIPTION
Change the formatOnSave default from true to false across the static defaults, decoder fallback (missing key), and decoder fallback (missing code section). Existing user configs with an explicit formatOnSave value are preserved via normal JSON decoding.

Add tests verifying the new default, explicit-true preservation, and the static defaults instance.