### PR TITLE
feat(editor): Add line number gutter

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -270,6 +270,7 @@
 		71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
+		7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */; };
 		7377F6BACEEA621425E54FBC /* TreeSitterTOML in Frameworks */ = {isa = PBXBuildFile; productRef = 69EF3147FDD8F28F8D65D4FC /* TreeSitterTOML */; };
 		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
 		7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */; };
@@ -856,6 +857,7 @@
 		7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkConflictResolveReport.swift; sourceTree = "<group>"; };
 		768D12909DD5233659AC4E03 /* RepoGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupView.swift; sourceTree = "<group>"; };
 		76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolverTests.swift; sourceTree = "<group>"; };
+		76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorLineNumberRulerView.swift; sourceTree = "<group>"; };
 		76F2498E56CBAF84CB67166C /* HarnessKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessKind.swift; sourceTree = "<group>"; };
 		781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionPicker.swift; sourceTree = "<group>"; };
 		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = "$(SRCROOT)/.build/ghostty/GhosttyKit.xcframework"; sourceTree = "<group>"; };
@@ -1901,6 +1903,7 @@
 			isa = PBXGroup;
 			children = (
 				30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */,
+				76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */,
 				FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */,
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
 				64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */,
@@ -2385,6 +2388,7 @@
 				D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */,
 				EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */,
 				41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */,
+				7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */,
 				A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */,
 				0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */,
 				28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */,

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -103,7 +103,8 @@ struct EditorTabView: View {
                 externalAbsolutePath: externalAbsolutePath,
                 originatingRelativePath: originatingRelativePath,
                 fontFamily: appState.config.code.fontFamily,
-                fontSize: appState.config.code.fontSize
+                fontSize: appState.config.code.fontSize,
+                showLineNumbers: appState.config.code.showLineNumbers
             )
         }
         .background(theme.color("bg-1"))

--- a/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
@@ -4,7 +4,6 @@ import SwiftUI
 final class CodeEditorLineNumberRulerView: NSRulerView {
     private weak var codeTextView: CodeTextView?
     private var theme: Theme
-    private var textChangeObserver: NSObjectProtocol?
     private var storageEditObserver: NSObjectProtocol?
     private var boundsObserver: NSObjectProtocol?
     private var lineStarts: [Int] = [0]
@@ -127,17 +126,6 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
     private func observe(textView: CodeTextView, scrollView: NSScrollView) {
         removeObservers()
 
-        textChangeObserver = NotificationCenter.default.addObserver(
-            forName: NSText.didChangeNotification,
-            object: textView,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.rebuildLineStartsAndUpdateThickness()
-                self?.needsDisplay = true
-            }
-        }
-
         observeTextStorage(textView.textStorage)
 
         scrollView.contentView.postsBoundsChangedNotifications = true
@@ -153,10 +141,6 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
     }
 
     private func removeObservers() {
-        if let textChangeObserver {
-            NotificationCenter.default.removeObserver(textChangeObserver)
-            self.textChangeObserver = nil
-        }
         if let storageEditObserver {
             NotificationCenter.default.removeObserver(storageEditObserver)
             self.storageEditObserver = nil
@@ -178,7 +162,11 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
             forName: NSTextStorage.didProcessEditingNotification,
             object: storage,
             queue: .main
-        ) { [weak self] _ in
+        ) { [weak self] notification in
+            guard
+                let storage = notification.object as? NSTextStorage,
+                storage.editedMask.contains(.editedCharacters)
+            else { return }
             Task { @MainActor [weak self] in
                 self?.rebuildLineStartsAndUpdateThickness()
                 self?.needsDisplay = true

--- a/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
@@ -1,0 +1,239 @@
+import AppKit
+import SwiftUI
+
+final class CodeEditorLineNumberRulerView: NSRulerView {
+    private weak var codeTextView: CodeTextView?
+    private var theme: Theme
+    private var textChangeObserver: NSObjectProtocol?
+    private var boundsObserver: NSObjectProtocol?
+    private var lineStarts: [Int] = [0]
+
+    private let minimumThickness: CGFloat = 44
+    private let horizontalPadding: CGFloat = 10
+
+    init(scrollView: NSScrollView, textView: CodeTextView, theme: Theme) {
+        self.codeTextView = textView
+        self.theme = theme
+        super.init(scrollView: scrollView, orientation: .verticalRuler)
+
+        clientView = textView
+        ruleThickness = minimumThickness
+        reservedThicknessForMarkers = 0
+        reservedThicknessForAccessoryView = 0
+        observe(textView: textView, scrollView: scrollView)
+        rebuildLineStartsAndUpdateThickness()
+        needsDisplay = true
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("not used")
+    }
+
+    deinit {
+        removeObservers()
+    }
+
+    func update(textView: CodeTextView, theme: Theme) {
+        if codeTextView !== textView {
+            codeTextView = textView
+            clientView = textView
+            if let scrollView {
+                observe(textView: textView, scrollView: scrollView)
+            }
+            rebuildLineStartsAndUpdateThickness()
+        } else {
+            updateThickness()
+        }
+
+        self.theme = theme
+        needsDisplay = true
+    }
+
+    override func drawHashMarksAndLabels(in rect: NSRect) {
+        NSColor(theme.color("bg-1")).setFill()
+        bounds.fill()
+
+        guard
+            let textView = codeTextView,
+            let layoutManager = textView.layoutManager,
+            let textContainer = textView.textContainer,
+            let scrollView = scrollView
+        else { return }
+
+        updateThickness()
+        layoutManager.ensureLayout(for: textContainer)
+
+        let visibleRect = scrollView.contentView.bounds
+        let inset = textView.textContainerInset
+        let usedRect = layoutManager.usedRect(for: textContainer)
+        let fullWidth = max(textView.bounds.width, usedRect.maxX, visibleRect.maxX, 1)
+        let visibleTextContainerRect = NSRect(
+            x: 0,
+            y: visibleRect.minY - inset.height,
+            width: fullWidth,
+            height: visibleRect.height
+        )
+        let visibleGlyphRange = layoutManager.glyphRange(
+            forBoundingRect: visibleTextContainerRect,
+            in: textContainer
+        )
+
+        let attributes = labelAttributes(font: textView.font)
+        let string = textView.string as NSString
+        var lastDrawnLineIndex: Int?
+
+        if visibleGlyphRange.location != NSNotFound {
+            layoutManager.enumerateLineFragments(forGlyphRange: visibleGlyphRange) { lineRect, _, _, glyphRange, _ in
+                let characterRange = layoutManager.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
+                guard characterRange.location != NSNotFound else { return }
+
+                let lineRange = string.lineRange(for: NSRange(location: characterRange.location, length: 0))
+                let lineIndex = self.lineIndex(containing: lineRange.location)
+                guard lineIndex != lastDrawnLineIndex else { return }
+                lastDrawnLineIndex = lineIndex
+
+                self.drawLineNumber(
+                    lineIndex + 1,
+                    lineRect: lineRect,
+                    textView: textView,
+                    inset: inset,
+                    attributes: attributes
+                )
+            }
+        }
+
+        if shouldDrawExtraLineFragment(for: string) {
+            let extraLineRect = layoutManager.extraLineFragmentRect
+            if extraLineRect.height > 0, extraLineRect.intersects(visibleTextContainerRect) {
+                drawLineNumber(
+                    lineStarts.count,
+                    lineRect: extraLineRect,
+                    textView: textView,
+                    inset: inset,
+                    attributes: attributes
+                )
+            }
+        }
+    }
+
+    private func observe(textView: CodeTextView, scrollView: NSScrollView) {
+        removeObservers()
+
+        textChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSText.didChangeNotification,
+            object: textView,
+            queue: .main
+        ) { [weak self] _ in
+            self?.rebuildLineStartsAndUpdateThickness()
+            self?.needsDisplay = true
+        }
+
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        boundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self] _ in
+            self?.needsDisplay = true
+        }
+    }
+
+    private func removeObservers() {
+        if let textChangeObserver {
+            NotificationCenter.default.removeObserver(textChangeObserver)
+            self.textChangeObserver = nil
+        }
+        if let boundsObserver {
+            NotificationCenter.default.removeObserver(boundsObserver)
+            self.boundsObserver = nil
+        }
+    }
+
+    private func updateThickness() {
+        guard let textView = codeTextView else {
+            ruleThickness = minimumThickness
+            return
+        }
+
+        let lineCount = max(1, lineStarts.count)
+        let digits = String(lineCount).count
+        let sample = String(repeating: "8", count: digits) as NSString
+        let width = ceil(sample.size(withAttributes: labelAttributes(font: textView.font)).width)
+        ruleThickness = max(minimumThickness, width + horizontalPadding * 2)
+    }
+
+    private func labelAttributes(font: NSFont?) -> [NSAttributedString.Key: Any] {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .right
+        return [
+            .font: font ?? .monospacedSystemFont(ofSize: 13, weight: .regular),
+            .foregroundColor: NSColor(theme.color("fg-faint")),
+            .paragraphStyle: paragraph
+        ]
+    }
+
+    private func rebuildLineStartsAndUpdateThickness() {
+        guard let textView = codeTextView else {
+            lineStarts = [0]
+            ruleThickness = minimumThickness
+            return
+        }
+
+        let string = textView.string as NSString
+        var starts = [0]
+        var searchLocation = 0
+        while searchLocation < string.length {
+            let range = NSRange(location: searchLocation, length: string.length - searchLocation)
+            let newlineRange = string.range(of: "\n", options: [], range: range)
+            guard newlineRange.location != NSNotFound else { break }
+            searchLocation = NSMaxRange(newlineRange)
+            starts.append(searchLocation)
+        }
+
+        lineStarts = starts
+        updateThickness()
+    }
+
+    private func lineIndex(containing location: Int) -> Int {
+        var lower = 0
+        var upper = lineStarts.count
+
+        while lower < upper {
+            let middle = (lower + upper) / 2
+            if lineStarts[middle] <= location {
+                lower = middle + 1
+            } else {
+                upper = middle
+            }
+        }
+
+        return max(0, lower - 1)
+    }
+
+    private func shouldDrawExtraLineFragment(for string: NSString) -> Bool {
+        if string.length == 0 {
+            return true
+        }
+        return string.substring(with: NSRange(location: string.length - 1, length: 1)) == "\n"
+    }
+
+    private func drawLineNumber(
+        _ lineNumber: Int,
+        lineRect: NSRect,
+        textView: CodeTextView,
+        inset: NSSize,
+        attributes: [NSAttributedString.Key: Any]
+    ) {
+        let label = "\(lineNumber)" as NSString
+        let labelSize = label.size(withAttributes: attributes)
+        let textViewPoint = NSPoint(x: 0, y: inset.height + lineRect.minY)
+        let rulerPoint = convert(textViewPoint, from: textView)
+        let drawRect = NSRect(
+            x: 0,
+            y: rulerPoint.y + (lineRect.height - labelSize.height) / 2,
+            width: ruleThickness - horizontalPadding,
+            height: labelSize.height
+        )
+        label.draw(in: drawRect, withAttributes: attributes)
+    }
+}

--- a/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
@@ -88,6 +88,8 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
                 guard characterRange.location != NSNotFound else { return }
 
                 let lineRange = string.lineRange(for: NSRange(location: characterRange.location, length: 0))
+                guard characterRange.location == lineRange.location else { return }
+
                 let lineIndex = self.lineIndex(containing: lineRange.location)
                 guard lineIndex != lastDrawnLineIndex else { return }
                 lastDrawnLineIndex = lineIndex

--- a/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
@@ -5,6 +5,7 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
     private weak var codeTextView: CodeTextView?
     private var theme: Theme
     private var textChangeObserver: NSObjectProtocol?
+    private var storageEditObserver: NSObjectProtocol?
     private var boundsObserver: NSObjectProtocol?
     private var lineStarts: [Int] = [0]
     private weak var cachedTextStorage: NSTextStorage?
@@ -31,7 +32,9 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
     }
 
     deinit {
-        removeObservers()
+        MainActor.assumeIsolated {
+            removeObservers()
+        }
     }
 
     func update(textView: CodeTextView, theme: Theme) {
@@ -43,6 +46,7 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
             }
             rebuildLineStartsAndUpdateThickness()
         } else if cachedTextStorage !== textView.textStorage {
+            observeTextStorage(textView.textStorage)
             rebuildLineStartsAndUpdateThickness()
         } else {
             updateThickness()
@@ -128,9 +132,13 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
             object: textView,
             queue: .main
         ) { [weak self] _ in
-            self?.rebuildLineStartsAndUpdateThickness()
-            self?.needsDisplay = true
+            Task { @MainActor [weak self] in
+                self?.rebuildLineStartsAndUpdateThickness()
+                self?.needsDisplay = true
+            }
         }
+
+        observeTextStorage(textView.textStorage)
 
         scrollView.contentView.postsBoundsChangedNotifications = true
         boundsObserver = NotificationCenter.default.addObserver(
@@ -138,7 +146,9 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
             object: scrollView.contentView,
             queue: .main
         ) { [weak self] _ in
-            self?.needsDisplay = true
+            Task { @MainActor [weak self] in
+                self?.needsDisplay = true
+            }
         }
     }
 
@@ -147,9 +157,32 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
             NotificationCenter.default.removeObserver(textChangeObserver)
             self.textChangeObserver = nil
         }
+        if let storageEditObserver {
+            NotificationCenter.default.removeObserver(storageEditObserver)
+            self.storageEditObserver = nil
+        }
         if let boundsObserver {
             NotificationCenter.default.removeObserver(boundsObserver)
             self.boundsObserver = nil
+        }
+    }
+
+    private func observeTextStorage(_ storage: NSTextStorage?) {
+        if let storageEditObserver {
+            NotificationCenter.default.removeObserver(storageEditObserver)
+            self.storageEditObserver = nil
+        }
+        guard let storage else { return }
+
+        storageEditObserver = NotificationCenter.default.addObserver(
+            forName: NSTextStorage.didProcessEditingNotification,
+            object: storage,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.rebuildLineStartsAndUpdateThickness()
+                self?.needsDisplay = true
+            }
         }
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorLineNumberRulerView.swift
@@ -7,6 +7,7 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
     private var textChangeObserver: NSObjectProtocol?
     private var boundsObserver: NSObjectProtocol?
     private var lineStarts: [Int] = [0]
+    private weak var cachedTextStorage: NSTextStorage?
 
     private let minimumThickness: CGFloat = 44
     private let horizontalPadding: CGFloat = 10
@@ -41,6 +42,8 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
                 observe(textView: textView, scrollView: scrollView)
             }
             rebuildLineStartsAndUpdateThickness()
+        } else if cachedTextStorage !== textView.textStorage {
+            rebuildLineStartsAndUpdateThickness()
         } else {
             updateThickness()
         }
@@ -61,18 +64,17 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
         else { return }
 
         updateThickness()
-        layoutManager.ensureLayout(for: textContainer)
 
         let visibleRect = scrollView.contentView.bounds
         let inset = textView.textContainerInset
-        let usedRect = layoutManager.usedRect(for: textContainer)
-        let fullWidth = max(textView.bounds.width, usedRect.maxX, visibleRect.maxX, 1)
+        let fullWidth = max(textContainer.size.width, textView.bounds.width, visibleRect.maxX, 1)
         let visibleTextContainerRect = NSRect(
             x: 0,
             y: visibleRect.minY - inset.height,
             width: fullWidth,
             height: visibleRect.height
         )
+        layoutManager.ensureLayout(forBoundingRect: visibleTextContainerRect, in: textContainer)
         let visibleGlyphRange = layoutManager.glyphRange(
             forBoundingRect: visibleTextContainerRect,
             in: textContainer
@@ -177,10 +179,12 @@ final class CodeEditorLineNumberRulerView: NSRulerView {
     private func rebuildLineStartsAndUpdateThickness() {
         guard let textView = codeTextView else {
             lineStarts = [0]
+            cachedTextStorage = nil
             ruleThickness = minimumThickness
             return
         }
 
+        cachedTextStorage = textView.textStorage
         let string = textView.string as NSString
         var starts = [0]
         var searchLocation = 0

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -27,6 +27,7 @@ struct CodeEditorView: NSViewRepresentable {
     /// causes `updateNSView` to fire when the user changes the font.
     let fontFamily: String
     let fontSize: Int
+    let showLineNumbers: Bool
     @Environment(\.theme) var theme
 
     func makeCoordinator() -> CodeEditorCoordinator {
@@ -94,6 +95,7 @@ struct CodeEditorView: NSViewRepresentable {
         textView.autoresizingMask = []
 
         scroll.documentView = textView
+        configureLineNumberRuler(for: scroll, textView: textView)
 
         context.coordinator.attach(
             textView: textView,
@@ -112,6 +114,10 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
+        if let textView = nsView.documentView as? CodeTextView {
+            configureLineNumberRuler(for: nsView, textView: textView)
+        }
+
         context.coordinator.updateIfNeeded(
             worktreeId: worktreeId,
             worktreeRoot: worktreeRoot,
@@ -129,5 +135,31 @@ struct CodeEditorView: NSViewRepresentable {
         // Detach the coordinator from the text view, but DO NOT close the
         // buffer's LSP document or watcher — the buffer outlives this view.
         coordinator.detach()
+    }
+
+    private func configureLineNumberRuler(for scrollView: NSScrollView, textView: CodeTextView) {
+        guard showLineNumbers else {
+            scrollView.verticalRulerView = nil
+            scrollView.hasVerticalRuler = false
+            scrollView.rulersVisible = false
+            return
+        }
+
+        let ruler: CodeEditorLineNumberRulerView
+        if let existingRuler = scrollView.verticalRulerView as? CodeEditorLineNumberRulerView {
+            existingRuler.update(textView: textView, theme: theme)
+            ruler = existingRuler
+        } else {
+            ruler = CodeEditorLineNumberRulerView(
+                scrollView: scrollView,
+                textView: textView,
+                theme: theme
+            )
+            scrollView.verticalRulerView = ruler
+        }
+
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = true
+        ruler.needsDisplay = true
     }
 }

--- a/Alas/Sources/Code/Editor/CodeEditorView.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorView.swift
@@ -114,10 +114,6 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
-        if let textView = nsView.documentView as? CodeTextView {
-            configureLineNumberRuler(for: nsView, textView: textView)
-        }
-
         context.coordinator.updateIfNeeded(
             worktreeId: worktreeId,
             worktreeRoot: worktreeRoot,
@@ -129,6 +125,10 @@ struct CodeEditorView: NSViewRepresentable {
             externalAbsolutePath: externalAbsolutePath,
             originatingRelativePath: originatingRelativePath
         )
+
+        if let textView = nsView.documentView as? CodeTextView {
+            configureLineNumberRuler(for: nsView, textView: textView)
+        }
     }
 
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: CodeEditorCoordinator) {

--- a/Alas/Sources/Code/Markdown/MarkdownTabView.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownTabView.swift
@@ -137,7 +137,8 @@ struct MarkdownTabView: View {
             externalAbsolutePath: externalAbsolutePath,
             originatingRelativePath: originatingRelativePath,
             fontFamily: appState.config.code.fontFamily,
-            fontSize: appState.config.code.fontSize
+            fontSize: appState.config.code.fontSize,
+            showLineNumbers: appState.config.code.showLineNumbers
         )
     }
 

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -107,12 +107,14 @@ struct AppConfig: Codable, Equatable {
         var fontFamily: String      // "" = system monospaced fallback
         var fontSize: Int           // clamped [8, 64] on decode/write
         var formatOnSave: Bool
+        var showLineNumbers: Bool
         var languageServers: [LanguageServerConfig]
         var dismissedInstallNudges: [String]
         var userDefinedRecipes: [String: [InstallRecipe]]
 
         enum CodingKeys: String, CodingKey {
-            case fontFamily, fontSize, formatOnSave, languageServers, dismissedInstallNudges, userDefinedRecipes
+            case fontFamily, fontSize, formatOnSave, showLineNumbers,
+                 languageServers, dismissedInstallNudges, userDefinedRecipes
         }
     }
 
@@ -214,6 +216,7 @@ struct AppConfig: Codable, Equatable {
             fontFamily: "SF Mono",
             fontSize: 13,
             formatOnSave: true,
+            showLineNumbers: true,
             languageServers: [],
             dismissedInstallNudges: [],
             userDefinedRecipes: [:]
@@ -379,6 +382,7 @@ extension AppConfig {
             let rawSize = (try? codeContainer.decode(Int.self, forKey: .fontSize)) ?? 13
             let fontSize = max(8, min(64, rawSize))
             let formatOnSave = (try? codeContainer.decode(Bool.self, forKey: .formatOnSave)) ?? true
+            let showLineNumbers = (try? codeContainer.decode(Bool.self, forKey: .showLineNumbers)) ?? true
             let servers = (try? codeContainer.decode([LanguageServerConfig].self, forKey: .languageServers)) ?? []
             let dismissed = (try? codeContainer.decode([String].self, forKey: .dismissedInstallNudges)) ?? []
             let userRecipes = (try? codeContainer.decode([String: [InstallRecipe]].self, forKey: .userDefinedRecipes)) ?? [:]
@@ -386,6 +390,7 @@ extension AppConfig {
                 fontFamily: fontFamily,
                 fontSize: fontSize,
                 formatOnSave: formatOnSave,
+                showLineNumbers: showLineNumbers,
                 languageServers: servers,
                 dismissedInstallNudges: dismissed,
                 userDefinedRecipes: userRecipes
@@ -395,6 +400,7 @@ extension AppConfig {
                 fontFamily: "SF Mono",
                 fontSize: 13,
                 formatOnSave: true,
+                showLineNumbers: true,
                 languageServers: [],
                 dismissedInstallNudges: [],
                 userDefinedRecipes: [:]

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -33,6 +33,10 @@ struct CodePane: View {
                             }
                         ), monospaced: true).frame(width: 80)
                     }
+                    SettingsRow(name: "Show line numbers",
+                                desc: "Display a non-selectable gutter in editor panes.") {
+                        AlasToggle(on: state.bind(\.code.showLineNumbers))
+                    }
                     SettingsRow(name: "Format on save",
                                 desc: "Request document formatting from the language server before writing to disk.") {
                         AlasToggle(on: state.bind(\.code.formatOnSave))

--- a/AlasTests/AppConfigCodeInstallTests.swift
+++ b/AlasTests/AppConfigCodeInstallTests.swift
@@ -10,6 +10,11 @@ struct AppConfigCodeInstallTests {
         #expect(AppConfig.defaults.code.userDefinedRecipes == [:])
     }
 
+    @Test("code defaults show line numbers")
+    func defaultsShowLineNumbers() {
+        #expect(AppConfig.defaults.code.showLineNumbers)
+    }
+
     @Test("legacy config without these keys decodes with empty defaults")
     func legacyDecode() throws {
         // Minimal config omitting dismissedInstallNudges and userDefinedRecipes
@@ -49,6 +54,43 @@ struct AppConfigCodeInstallTests {
         #expect(cfg.code.userDefinedRecipes == [:])
     }
 
+    @Test("legacy code config without showLineNumbers decodes as enabled")
+    func legacyDecodeShowLineNumbersDefault() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/code/.worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true},
+          "code": {"fontFamily": "SF Mono", "fontSize": 13, "languageServers": []}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.code.showLineNumbers)
+    }
+
     @Test("populated values round-trip")
     func roundTrip() throws {
         var cfg = AppConfig.defaults
@@ -61,6 +103,17 @@ struct AppConfigCodeInstallTests {
         #expect(decoded.code.dismissedInstallNudges == ["rust", "go"])
         #expect(decoded.code.userDefinedRecipes["zig"]?.first?.package == "zls")
         #expect(decoded.code.userDefinedRecipes["zig"]?.first?.installer == .brew)
+    }
+
+    @Test("explicit disabled line numbers round-trip")
+    func lineNumbersDisabledRoundTrip() throws {
+        var cfg = AppConfig.defaults
+        cfg.code.showLineNumbers = false
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(!decoded.code.showLineNumbers)
     }
 
     @Test("Mason package prefill produces enabled language server config")

--- a/AlasTests/FormatOnSaveTests.swift
+++ b/AlasTests/FormatOnSaveTests.swift
@@ -24,6 +24,7 @@ struct FormatOnSaveTests {
             fontFamily: "SF Mono",
             fontSize: 13,
             formatOnSave: formatOnSave,
+            showLineNumbers: true,
             languageServers: [],
             dismissedInstallNudges: [],
             userDefinedRecipes: [:]

--- a/docs/superpowers/specs/2026-05-26-editor-line-number-gutter-design.md
+++ b/docs/superpowers/specs/2026-05-26-editor-line-number-gutter-design.md
@@ -1,0 +1,74 @@
+# Editor Line Number Gutter Design
+
+## Goal
+
+Add an optional line-number gutter to editable code editor panes. The setting is enabled by default and applies consistently anywhere `CodeEditorView` is used: normal file tabs, markdown editor and split modes, and external-file editor tabs.
+
+The gutter must not interfere with text selection, editing, or drag behavior.
+
+## Placement
+
+Add the setting to `Settings -> Code -> Appearance` as `Show line numbers`. This is a better fit than the app-wide Appearance pane because the option is editor-specific and belongs next to font family, font size, and format-on-save.
+
+Persist the preference as `AppConfig.Code.showLineNumbers`, defaulting to `true`. Existing configs that do not contain the field decode as `true`.
+
+## Architecture
+
+Use an AppKit `NSRulerView` subclass attached to the `NSScrollView` that contains `CodeTextView`.
+
+The ruler is outside the editor document view, so line numbers are not part of the `NSTextView` content and cannot be selected. This also avoids changing the text storage, syntax highlighting, LSP offsets, or editor selection behavior.
+
+`CodeEditorView` passes the persisted `showLineNumbers` value into the representable so SwiftUI triggers `updateNSView` when the setting changes. The view configures the scroll view's vertical ruler:
+
+- when enabled, attach or update a `CodeEditorLineNumberRulerView`;
+- when disabled, clear the vertical ruler and turn off `hasVerticalRuler` so no blank gutter remains.
+
+## Rendering Behavior
+
+The ruler draws only visible line numbers using the text view's layout manager, text container, visible rect, and document visible rect. It uses the current editor font for vertical alignment and a faint theme foreground color for the number text.
+
+The gutter width adapts to the total line count digit width with a sensible minimum, so small files do not waste much space and large files do not clip numbers.
+
+The ruler redraws when:
+
+- the editor scrolls;
+- text changes;
+- the font changes;
+- the theme changes;
+- the setting is toggled.
+
+Line numbers are right-aligned in the gutter and track wrapped or unwrapped TextKit line geometry according to the editor's existing layout. The first visual row for a logical line displays the line number; continuation fragments do not need their own repeated number.
+
+## Scope
+
+In scope:
+
+- editable code editor tabs;
+- markdown source editor mode and split-mode source editor;
+- external-file editor tabs;
+- persisted setting and migration default;
+- focused tests for config decoding/defaults, plus line-number helper tests if the implementation extracts helper logic from the ruler view.
+
+Out of scope:
+
+- diff pane gutter changes;
+- per-language or per-file overrides;
+- relative line numbers;
+- selecting or copying gutter numbers.
+
+## Testing
+
+Add or update Swift Testing coverage for:
+
+- `AppConfig.defaults.code.showLineNumbers == true`;
+- legacy code config JSON without `showLineNumbers` decodes as `true`;
+- round-trip persistence preserves explicit `false`;
+- extracted line-number width or visible-line helper logic, if such helpers are introduced.
+
+Manual verification should cover:
+
+- the gutter appears by default in editable files;
+- toggling `Settings -> Code -> Appearance -> Show line numbers` updates open editors;
+- drag selection starting in the text area behaves as before;
+- the gutter does not select or copy line numbers;
+- markdown split mode and external editor tabs follow the same setting.


### PR DESCRIPTION
## Summary
- add a default-on `showLineNumbers` code setting with legacy config migration
- render editor line numbers through a non-selectable AppKit ruler outside the text view
- wire the setting through normal, markdown, split, and external editor tabs
- add the Settings -> Code -> Appearance toggle

## Validation
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`