### PR TITLE
feat(lsp): handle macOS Gatekeeper-blocked language servers

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */; };
 		095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
+		0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */; };
 		0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
@@ -495,6 +496,7 @@
 		D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */; };
 		D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */; };
 		D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */; };
+		D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */; };
 		D675E5B1E5E95E7239F3A89F /* InstallRecipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */; };
 		D6A8D3925ACCB69DAC380B95 /* AgentPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58DD85A6E01972B39F2D8AD /* AgentPath.swift */; };
 		D6B39CE8878BB196FF2277B6 /* AgentDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */; };
@@ -632,6 +634,7 @@
 		134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeResolverTests.swift; sourceTree = "<group>"; };
 		136BDA12046FB352E183D6A4 /* AgentHookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookEvent.swift; sourceTree = "<group>"; };
 		1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandleTests.swift; sourceTree = "<group>"; };
+		137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessorTests.swift; sourceTree = "<group>"; };
 		137F79BD0DEB96B6F756ABD4 /* JSONHookSettingsFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHookSettingsFile.swift; sourceTree = "<group>"; };
 		14087D57E96448EEF0B80BD9 /* TerminalTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabView.swift; sourceTree = "<group>"; };
 		14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabMergeConflictCodingTests.swift; sourceTree = "<group>"; };
@@ -762,6 +765,7 @@
 		4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardPathsTests.swift; sourceTree = "<group>"; };
 		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltinsTests.swift; sourceTree = "<group>"; };
+		4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessor.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
 		4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTabBar.swift; sourceTree = "<group>"; };
 		4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweep.swift; sourceTree = "<group>"; };
@@ -1789,6 +1793,7 @@
 		98B31DB084754D0D15591339 /* LSP */ = {
 			isa = PBXGroup;
 			children = (
+				4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */,
 				949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */,
 				09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */,
 				A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */,
@@ -1977,6 +1982,7 @@
 		C9BE5D9821AF38B59009DD0B /* LSP */ = {
 			isa = PBXGroup;
 			children = (
+				137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */,
 				134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */,
 				A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */,
 				345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */,
@@ -2451,6 +2457,7 @@
 				AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */,
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
+				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,
 				41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */,
@@ -2741,6 +2748,7 @@
 				F6442CEA8D80C6845ABF0A63 /* FocusDirectionTests.swift in Sources */,
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
+				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
 				8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */,
 				01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */,
 				D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
+		73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */; };
 		7377F6BACEEA621425E54FBC /* TreeSitterTOML in Frameworks */ = {isa = PBXBuildFile; productRef = 69EF3147FDD8F28F8D65D4FC /* TreeSitterTOML */; };
 		737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */; };
 		7445A58BBCAC1DA8EDB0946B /* TextEditCoordinatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50737099AA490FAC6BD9F612 /* TextEditCoordinatesTests.swift */; };
@@ -736,6 +737,7 @@
 		3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilderTests.swift; sourceTree = "<group>"; };
 		3BF2F213480B30034B25B2B8 /* AgentRunError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunError.swift; sourceTree = "<group>"; };
 		3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfo.swift; sourceTree = "<group>"; };
+		3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedNudgeBanner.swift; sourceTree = "<group>"; };
 		3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverWindowControllerTests.swift; sourceTree = "<group>"; };
 		3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPicker.swift; sourceTree = "<group>"; };
 		3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardTests.swift; sourceTree = "<group>"; };
@@ -1919,6 +1921,7 @@
 			isa = PBXGroup;
 			children = (
 				5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */,
+				3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */,
 				30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */,
 				FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */,
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
@@ -2390,6 +2393,7 @@
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
 				4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */,
 				A9AD5B31C3A9FCBE76A15179 /* BlockedLanguageServerNudgeResolver.swift in Sources */,
+				73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */,
 				ACDDE4B18A94164BDFEED06B /* BranchOpsMenu.swift in Sources */,
 				9E302329243407946D47DC91 /* BranchPicker.swift in Sources */,
 				71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -388,6 +388,7 @@
 		A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */; };
 		A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */; };
 		A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */; };
+		A9AD5B31C3A9FCBE76A15179 /* BlockedLanguageServerNudgeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
@@ -479,6 +480,7 @@
 		CF105C488C01331534C65D88 /* MergeConflictBinaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B7FA3997B6A60397B56CD4 /* MergeConflictBinaryView.swift */; };
 		CF12433D8F30CEA05088FFB0 /* CodeTextViewIndentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */; };
 		CF2AD9C6F30BC02C040902A8 /* ShortcutResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8FA892877AE2FDBCD4C747 /* ShortcutResolverTests.swift */; };
+		CF3567FA9501C1358D754D42 /* BlockedLanguageServerNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */; };
 		CF81F0AE28C56D1DF5AD871B /* SurfaceViewShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */; };
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
@@ -805,6 +807,7 @@
 		5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyFeedbackState.swift; sourceTree = "<group>"; };
 		5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighter.swift; sourceTree = "<group>"; };
 		5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFileType.swift; sourceTree = "<group>"; };
+		5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolver.swift; sourceTree = "<group>"; };
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstallerTests.swift; sourceTree = "<group>"; };
 		6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindControllerTests.swift; sourceTree = "<group>"; };
@@ -1040,6 +1043,7 @@
 		CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRendererTests.swift; sourceTree = "<group>"; };
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
+		D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolverTests.swift; sourceTree = "<group>"; };
 		D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayout.swift; sourceTree = "<group>"; };
 		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
 		D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibilityTests.swift; sourceTree = "<group>"; };
@@ -1475,6 +1479,7 @@
 		2ED9D6E2F4F80DC4EC282918 /* Code */ = {
 			isa = PBXGroup;
 			children = (
+				8AB0F2CC9E0D55089456FFA5 /* Editor */,
 				99296E46F8BEA6DE0DFBBBD2 /* Highlight */,
 				C9BE5D9821AF38B59009DD0B /* LSP */,
 			);
@@ -1766,6 +1771,14 @@
 			path = Persistence;
 			sourceTree = "<group>";
 		};
+		8AB0F2CC9E0D55089456FFA5 /* Editor */ = {
+			isa = PBXGroup;
+			children = (
+				D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */,
+			);
+			path = Editor;
+			sourceTree = "<group>";
+		};
 		92D8882514B9187F2418B51B /* src */ = {
 			isa = PBXGroup;
 			children = (
@@ -1905,6 +1918,7 @@
 		B99EAA756E84360237C3E3D2 /* Editor */ = {
 			isa = PBXGroup;
 			children = (
+				5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */,
 				30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */,
 				FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */,
 				FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */,
@@ -2375,6 +2389,7 @@
 				8FE765355607C57A9D3D6CEE /* AppState.swift in Sources */,
 				3B0629E55CC38A713F763AA8 /* AppearancePane.swift in Sources */,
 				4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */,
+				A9AD5B31C3A9FCBE76A15179 /* BlockedLanguageServerNudgeResolver.swift in Sources */,
 				ACDDE4B18A94164BDFEED06B /* BranchOpsMenu.swift in Sources */,
 				9E302329243407946D47DC91 /* BranchPicker.swift in Sources */,
 				71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */,
@@ -2696,6 +2711,7 @@
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
 				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,
+				CF3567FA9501C1358D754D42 /* BlockedLanguageServerNudgeResolverTests.swift in Sources */,
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 @main
@@ -19,6 +20,17 @@ struct AlasApp: App {
 
     init() {
         BundledFontRegistrar.registerFonts()
+        // Refresh Gatekeeper cache when the user returns from System Settings
+        // after granting permission to a blocked LSP binary.
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                GatekeeperAssessor.shared.invalidateAll()
+            }
+        }
         if Self.isRunningUnitTests {
             NSApplication.shared.setActivationPolicy(.accessory)
             NSWindow.allowsAutomaticWindowTabbing = false

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -34,6 +34,7 @@ struct EditorTabView: View {
                 EditorConflictBanner(buffer: buffer)
             }
             InstallNudgeBanner(appState: appState, absolutePath: nudgeAbsolutePath)
+            BlockedNudgeBanner(appState: appState, absolutePath: nudgeAbsolutePath)
             if findBarVisible {
                 EditorFindBarView(
                     findText: $findText,

--- a/Alas/Sources/Code/Editor/BlockedLanguageServerNudgeResolver.swift
+++ b/Alas/Sources/Code/Editor/BlockedLanguageServerNudgeResolver.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Payload for a "this LSP is blocked by macOS Gatekeeper" banner.
+struct BlockedNudgeData: Equatable {
+    let language: String
+    let displayName: String
+    let command: String
+    let realPath: String
+
+    var dismissalKey: String { "blocked:\(realPath)" }
+}
+
+/// Resolves a file path to a `BlockedNudgeData` payload when the matching
+/// LSP entry's binary is blocked by Gatekeeper and the user hasn't dismissed
+/// the banner for that exact `realPath` yet.
+///
+/// Parallels `InstallNudgeResolver` — both feed the same banner host in
+/// `EditorTabView` and read the same `dismissedInstallNudges` store; we
+/// just namespace our keys with `blocked:` so they don't collide with the
+/// install resolver's language-keyed entries.
+@MainActor
+struct BlockedLanguageServerNudgeResolver {
+    let registry: LanguageServerRegistry
+    let dismissedKeys: [String]
+    let availabilityStatus: (LanguageServerConfig) -> LanguageServerAvailability.Status
+
+    init(
+        registry: LanguageServerRegistry,
+        dismissedKeys: [String],
+        availabilityStatus: @escaping (LanguageServerConfig) -> LanguageServerAvailability.Status = {
+            LanguageServerAvailability().status(for: $0)
+        }
+    ) {
+        self.registry = registry
+        self.dismissedKeys = dismissedKeys
+        self.availabilityStatus = availabilityStatus
+    }
+
+    func nudgeData(forAbsolutePath absolutePath: String) -> BlockedNudgeData? {
+        let ext = (absolutePath as NSString).pathExtension.lowercased()
+        guard !ext.isEmpty else { return nil }
+        guard let language = registry.language(forFileExtension: ext) else { return nil }
+        guard let entry = registry.allEntries().first(where: { $0.language == language }) else { return nil }
+
+        guard case .blockedByGatekeeper(let realPath) = availabilityStatus(entry) else { return nil }
+
+        let key = "blocked:\(realPath)"
+        guard !dismissedKeys.contains(key) else { return nil }
+
+        let displayName = RecommendedLanguageCatalog.entry(forLanguage: language)?.displayName ?? language
+        return BlockedNudgeData(
+            language: language,
+            displayName: displayName,
+            command: entry.command,
+            realPath: realPath
+        )
+    }
+}

--- a/Alas/Sources/Code/Editor/BlockedNudgeBanner.swift
+++ b/Alas/Sources/Code/Editor/BlockedNudgeBanner.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import AppKit
+
+/// Non-blocking banner shown above the editor when the file's language
+/// server is blocked by macOS Gatekeeper. Dismissal is per-`realPath` and
+/// persisted in `AppConfig.code.dismissedInstallNudges` under the
+/// `blocked:<realPath>` namespace, so a `brew upgrade` (different inode,
+/// different cache result) re-shows it.
+struct BlockedNudgeBanner: View {
+    let appState: AppState
+    let absolutePath: String
+
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        Group {
+            if let nudge = nudgeData {
+                bannerRow(nudge: nudge)
+            }
+        }
+    }
+
+    private func bannerRow(nudge: BlockedNudgeData) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.shield")
+                .foregroundColor(theme.color("fg-dim"))
+            Text("\(nudge.displayName) language server blocked by macOS — approve it to enable diagnostics")
+                .font(.system(size: 12.5))
+            Spacer()
+            Button("Open Privacy & Security") {
+                openPrivacyAndSecurity()
+            }
+            .buttonStyle(.plain)
+            .foregroundColor(theme.color("fg"))
+            Button(action: { dismiss(key: nudge.dismissalKey) }) {
+                Image(systemName: "xmark")
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-1"))
+        .overlay(Rectangle()
+            .frame(height: 0.5)
+            .foregroundColor(theme.color("line")),
+            alignment: .bottom)
+    }
+
+    private var nudgeData: BlockedNudgeData? {
+        let registry = LanguageServerRegistry(userDefined: appState.config.code.languageServers)
+        let resolver = BlockedLanguageServerNudgeResolver(
+            registry: registry,
+            dismissedKeys: appState.config.code.dismissedInstallNudges
+        )
+        return resolver.nudgeData(forAbsolutePath: absolutePath)
+    }
+
+    private func openPrivacyAndSecurity() {
+        // Anchored URL works on Sequoia+. If a future macOS removes the
+        // anchor, the bare URL still opens the right pane.
+        let anchored = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Allowed_eXecution")!
+        let plain = URL(string: "x-apple.systempreferences:com.apple.preference.security")!
+        if !NSWorkspace.shared.open(anchored) {
+            NSWorkspace.shared.open(plain)
+        }
+    }
+
+    private func dismiss(key: String) {
+        var dismissed = appState.config.code.dismissedInstallNudges
+        if !dismissed.contains(key) {
+            dismissed.append(key)
+            appState.config.code.dismissedInstallNudges = dismissed
+            appState.saveConfig()
+        }
+    }
+}

--- a/Alas/Sources/Code/Editor/InstallNudgeResolver.swift
+++ b/Alas/Sources/Code/Editor/InstallNudgeResolver.swift
@@ -36,6 +36,7 @@ struct InstallNudgeData {
     }
 }
 
+@MainActor
 struct InstallNudgeResolver {
     let registry: LanguageServerRegistry
     let userDefinedRecipes: [String: [InstallRecipe]]

--- a/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
+++ b/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
@@ -11,6 +11,7 @@ import Darwin
 /// per session shells out to spctl (~150-300ms); later lookups are µs-fast
 /// cache reads. Callers run on the main actor — see the spec for the
 /// stutter trade-off.
+@MainActor
 final class GatekeeperAssessor {
     enum Result: Equatable { case allowed, rejected, unknown }
 
@@ -28,7 +29,6 @@ final class GatekeeperAssessor {
     }
 
     private let runner: Runner
-    private let lock = NSLock()
     private var cache: [String: CacheEntry] = [:]
 
     init(runner: @escaping Runner = GatekeeperAssessor.defaultRunner) {
@@ -39,17 +39,18 @@ final class GatekeeperAssessor {
     /// (blocking) on cache miss/stale. Never throws — assessment errors
     /// collapse to `.unknown`, which callers treat as `.allowed` so a
     /// broken check doesn't hide an LSP.
+    ///
+    /// Pass the symlink-resolved path. Use `URL.resolvingSymlinksInPath()` or
+    /// equivalent before calling; otherwise cache keys may not match across
+    /// different paths to the same binary.
     func assess(realPath: String) -> Result {
         let stat = currentStat(path: realPath)
-        lock.lock()
         if let entry = cache[realPath],
            let stat,
            entry.mtime == stat.mtime,
            entry.inode == stat.inode {
-            lock.unlock()
             return entry.result
         }
-        lock.unlock()
 
         let result: Result
         do {
@@ -59,31 +60,30 @@ final class GatekeeperAssessor {
         }
 
         if let stat {
-            lock.lock()
             cache[realPath] = CacheEntry(mtime: stat.mtime, inode: stat.inode, result: result)
-            lock.unlock()
         }
         return result
     }
 
     func invalidate(realPath: String) {
-        lock.lock(); defer { lock.unlock() }
         cache.removeValue(forKey: realPath)
     }
 
     func invalidateAll() {
-        lock.lock(); defer { lock.unlock() }
         cache.removeAll(keepingCapacity: true)
     }
 
     private func currentStat(path: String) -> (mtime: TimeInterval, inode: UInt64)? {
         var buf = Darwin.stat()
+        // Callers pass realPath (already symlink-resolved), so lstat and stat
+        // are equivalent here; lstat also keeps the cache key stable if a caller
+        // accidentally hands us an unresolved symlink.
         guard Darwin.lstat(path, &buf) == 0 else { return nil }
         let mtime = TimeInterval(buf.st_mtimespec.tv_sec) + TimeInterval(buf.st_mtimespec.tv_nsec) / 1_000_000_000
         return (mtime: mtime, inode: UInt64(buf.st_ino))
     }
 
-    static func defaultRunner(realPath: String) throws -> Result {
+    nonisolated static func defaultRunner(realPath: String) throws -> Result {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/sbin/spctl")
         process.arguments = ["--assess", "--type", "execute", realPath]
@@ -94,13 +94,15 @@ final class GatekeeperAssessor {
         try process.run()
         // spctl normally completes in well under a second. We bound the wait
         // with a hard 2s ceiling so a wedged syspolicyd can't hang the UI.
-        let deadline = Date().addingTimeInterval(2.0)
-        while process.isRunning {
-            if Date() > deadline {
-                process.terminate()
-                return .unknown
-            }
-            Thread.sleep(forTimeInterval: 0.01)
+        let sema = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            process.waitUntilExit()
+            sema.signal()
+        }
+        let timedOut = sema.wait(timeout: .now() + 2.0) == .timedOut
+        if timedOut {
+            process.terminate()
+            return .unknown
         }
         return process.terminationStatus == 0 ? .allowed : .rejected
     }

--- a/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
+++ b/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Darwin
+
+/// Wraps `spctl --assess` for an LSP binary so we can pre-flight Gatekeeper
+/// before spawning a subprocess from a GUI app. On macOS Tahoe a GUI app
+/// spawning an ad-hoc-signed binary triggers a Gatekeeper popup the user
+/// must dismiss from System Settings; checking spctl first lets us skip the
+/// spawn and surface an in-app banner instead.
+///
+/// Caches results by (realPath, mtime, inode). The first lookup per binary
+/// per session shells out to spctl (~150-300ms); later lookups are µs-fast
+/// cache reads. Callers run on the main actor — see the spec for the
+/// stutter trade-off.
+final class GatekeeperAssessor {
+    enum Result: Equatable { case allowed, rejected, unknown }
+
+    static let shared = GatekeeperAssessor()
+
+    /// Throwing closure that returns the assessment for `realPath`. The
+    /// default runs `/usr/sbin/spctl --assess --type execute <path>` via
+    /// `Process`. Injected for tests.
+    typealias Runner = (_ realPath: String) throws -> Result
+
+    private struct CacheEntry {
+        let mtime: TimeInterval
+        let inode: UInt64
+        let result: Result
+    }
+
+    private let runner: Runner
+    private let lock = NSLock()
+    private var cache: [String: CacheEntry] = [:]
+
+    init(runner: @escaping Runner = GatekeeperAssessor.defaultRunner) {
+        self.runner = runner
+    }
+
+    /// Returns the cached assessment for `realPath`, or runs the assessor
+    /// (blocking) on cache miss/stale. Never throws — assessment errors
+    /// collapse to `.unknown`, which callers treat as `.allowed` so a
+    /// broken check doesn't hide an LSP.
+    func assess(realPath: String) -> Result {
+        let stat = currentStat(path: realPath)
+        lock.lock()
+        if let entry = cache[realPath],
+           let stat,
+           entry.mtime == stat.mtime,
+           entry.inode == stat.inode {
+            lock.unlock()
+            return entry.result
+        }
+        lock.unlock()
+
+        let result: Result
+        do {
+            result = try runner(realPath)
+        } catch {
+            return .unknown
+        }
+
+        if let stat {
+            lock.lock()
+            cache[realPath] = CacheEntry(mtime: stat.mtime, inode: stat.inode, result: result)
+            lock.unlock()
+        }
+        return result
+    }
+
+    func invalidate(realPath: String) {
+        lock.lock(); defer { lock.unlock() }
+        cache.removeValue(forKey: realPath)
+    }
+
+    func invalidateAll() {
+        lock.lock(); defer { lock.unlock() }
+        cache.removeAll(keepingCapacity: true)
+    }
+
+    private func currentStat(path: String) -> (mtime: TimeInterval, inode: UInt64)? {
+        var buf = Darwin.stat()
+        guard Darwin.lstat(path, &buf) == 0 else { return nil }
+        let mtime = TimeInterval(buf.st_mtimespec.tv_sec) + TimeInterval(buf.st_mtimespec.tv_nsec) / 1_000_000_000
+        return (mtime: mtime, inode: UInt64(buf.st_ino))
+    }
+
+    static func defaultRunner(realPath: String) throws -> Result {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/spctl")
+        process.arguments = ["--assess", "--type", "execute", realPath]
+        let null = Pipe()
+        process.standardOutput = null
+        process.standardError = null
+
+        try process.run()
+        // spctl normally completes in well under a second. We bound the wait
+        // with a hard 2s ceiling so a wedged syspolicyd can't hang the UI.
+        let deadline = Date().addingTimeInterval(2.0)
+        while process.isRunning {
+            if Date() > deadline {
+                process.terminate()
+                return .unknown
+            }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        return process.terminationStatus == 0 ? .allowed : .rejected
+    }
+}

--- a/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
+++ b/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
@@ -104,6 +104,14 @@ final class GatekeeperAssessor {
             process.terminate()
             return .unknown
         }
-        return process.terminationStatus == 0 ? .allowed : .rejected
+        // spctl(8): exit 0 = allowed, exit 3 = denied (Gatekeeper rejection).
+        // Other non-zero codes are operational errors (file unreadable, policy
+        // DB rebuild, etc.); fail open with .unknown so a flaky spctl doesn't
+        // hide a runnable LSP behind a banner.
+        switch process.terminationStatus {
+        case 0: return .allowed
+        case 3: return .rejected
+        default: return .unknown
+        }
     }
 }

--- a/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
+++ b/Alas/Sources/Code/LSP/LanguageServerAvailability.swift
@@ -1,32 +1,44 @@
 import Foundation
 
+@MainActor
 struct LanguageServerAvailability {
     enum Status: Equatable {
         case disabled
         case available
         case notInstalled
+        case blockedByGatekeeper(realPath: String)
     }
 
     private let environment: [String: String]
     private let fileManager: FileManager
     private let xcrunFind: (String) -> String?
     private let additionalPathDirectories: [String]
+    private let gatekeeperAssessor: (String) -> GatekeeperAssessor.Result
 
     init(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default,
         xcrunFind: @escaping (String) -> String? = LanguageServerAvailability.xcrunFind,
-        additionalPathDirectories: [String] = LanguageServerAvailability.defaultAdditionalPathDirectories()
+        additionalPathDirectories: [String] = LanguageServerAvailability.defaultAdditionalPathDirectories(),
+        gatekeeperAssessor: @escaping (String) -> GatekeeperAssessor.Result = { GatekeeperAssessor.shared.assess(realPath: $0) }
     ) {
         self.environment = environment
         self.fileManager = fileManager
         self.xcrunFind = xcrunFind
         self.additionalPathDirectories = additionalPathDirectories
+        self.gatekeeperAssessor = gatekeeperAssessor
     }
 
     func status(for entry: LanguageServerConfig) -> Status {
         guard entry.enabled else { return .disabled }
-        return resolvedCommand(for: entry) != nil ? .available : .notInstalled
+        guard let resolved = resolvedCommand(for: entry) else { return .notInstalled }
+        let realPath = (resolved as NSString).resolvingSymlinksInPath
+        switch gatekeeperAssessor(realPath) {
+        case .rejected:
+            return .blockedByGatekeeper(realPath: realPath)
+        case .allowed, .unknown:
+            return .available
+        }
     }
 
     func resolvedCommand(for entry: LanguageServerConfig) -> String? {
@@ -94,7 +106,7 @@ struct LanguageServerAvailability {
         return path.split(separator: ":", omittingEmptySubsequences: true).map(String.init)
     }
 
-    private static func defaultAdditionalPathDirectories() -> [String] {
+    nonisolated private static func defaultAdditionalPathDirectories() -> [String] {
         var dirs: [String] = [
             "/usr/local/bin",
             "/opt/homebrew/bin",
@@ -120,7 +132,7 @@ struct LanguageServerAvailability {
         return dirs.filter { !$0.isEmpty && seen.insert($0).inserted }
     }
 
-    private static func pathFileEntries(at path: String) -> [String] {
+    nonisolated private static func pathFileEntries(at path: String) -> [String] {
         guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
         return contents
             .split(whereSeparator: \.isNewline)
@@ -128,7 +140,7 @@ struct LanguageServerAvailability {
             .filter { !$0.isEmpty && !$0.hasPrefix("#") }
     }
 
-    private static func xcrunFind(_ tool: String) -> String? {
+    nonisolated private static func xcrunFind(_ tool: String) -> String? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
         process.arguments = ["--find", tool]

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -1,6 +1,13 @@
 import Foundation
 import Observation
 
+extension Notification.Name {
+    /// Posted from `WorkspaceLSPManager` when a language server spawn was
+    /// skipped because the resolved binary is blocked by Gatekeeper.
+    /// userInfo: ["language": String, "realPath": String].
+    static let lspBlockedByGatekeeper = Notification.Name("lspBlockedByGatekeeper")
+}
+
 @MainActor
 protocol DocumentFormatter: AnyObject {
     func language(forFileExtension ext: String) -> String?
@@ -114,6 +121,20 @@ final class WorkspaceLSPManager: DocumentFormatter {
             ready = existing.ready
             isFirstOpener = false
         } else {
+            let availability = LanguageServerAvailability()
+            switch availability.status(for: entry) {
+            case .disabled, .notInstalled:
+                return nil
+            case .blockedByGatekeeper(let realPath):
+                NotificationCenter.default.post(
+                    name: .lspBlockedByGatekeeper,
+                    object: nil,
+                    userInfo: ["language": entry.language, "realPath": realPath]
+                )
+                return nil
+            case .available:
+                break
+            }
             let spawn = Self.resolveSpawn(command: entry.command, args: entry.args, env: entry.env, language: entry.language)
             let transport = LSPTransport(executable: spawn.executable, arguments: spawn.arguments, environment: spawn.environment)
             let newClient = LSPClient(transport: transport, language: languageId, rootURI: lspRoot.lspURI)

--- a/Alas/Sources/Settings/CodePane.swift
+++ b/Alas/Sources/Settings/CodePane.swift
@@ -123,6 +123,9 @@ struct CodePane: View {
         case .notInstalled:
             label = "Not installed"
             color = theme.color("warn")
+        case .blockedByGatekeeper:
+            label = "Blocked by Gatekeeper"
+            color = theme.color("warn")
         }
         return Text(label).font(.system(size: 10.5)).foregroundColor(color)
     }

--- a/AlasTests/Code/Editor/BlockedLanguageServerNudgeResolverTests.swift
+++ b/AlasTests/Code/Editor/BlockedLanguageServerNudgeResolverTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("BlockedLanguageServerNudgeResolver")
+@MainActor
+struct BlockedLanguageServerNudgeResolverTests {
+    @Test("blocked LSP for the file's extension yields a nudge")
+    func blockedYieldsNudge() {
+        let resolver = BlockedLanguageServerNudgeResolver(
+            registry: LanguageServerRegistry(userDefined: []),
+            dismissedKeys: [],
+            availabilityStatus: { entry in
+                entry.language == "kotlin"
+                    ? .blockedByGatekeeper(realPath: "/opt/homebrew/libexec/intellij-server")
+                    : .available
+            }
+        )
+        let nudge = resolver.nudgeData(forAbsolutePath: "/tmp/Main.kt")
+        #expect(nudge?.language == "kotlin")
+        #expect(nudge?.command == "kotlin-lsp")
+        #expect(nudge?.realPath == "/opt/homebrew/libexec/intellij-server")
+        #expect(nudge?.dismissalKey == "blocked:/opt/homebrew/libexec/intellij-server")
+    }
+
+    @Test("dismissed key suppresses the nudge")
+    func dismissedSuppresses() {
+        let resolver = BlockedLanguageServerNudgeResolver(
+            registry: LanguageServerRegistry(userDefined: []),
+            dismissedKeys: ["blocked:/opt/homebrew/libexec/intellij-server"],
+            availabilityStatus: { _ in
+                .blockedByGatekeeper(realPath: "/opt/homebrew/libexec/intellij-server")
+            }
+        )
+        #expect(resolver.nudgeData(forAbsolutePath: "/tmp/Main.kt") == nil)
+    }
+
+    @Test("available LSP yields no nudge")
+    func availableYieldsNone() {
+        let resolver = BlockedLanguageServerNudgeResolver(
+            registry: LanguageServerRegistry(userDefined: []),
+            dismissedKeys: [],
+            availabilityStatus: { _ in .available }
+        )
+        #expect(resolver.nudgeData(forAbsolutePath: "/tmp/Main.kt") == nil)
+    }
+
+    @Test("unknown extension yields no nudge")
+    func unknownExtensionYieldsNone() {
+        let resolver = BlockedLanguageServerNudgeResolver(
+            registry: LanguageServerRegistry(userDefined: []),
+            dismissedKeys: [],
+            availabilityStatus: { _ in
+                .blockedByGatekeeper(realPath: "/any")
+            }
+        )
+        #expect(resolver.nudgeData(forAbsolutePath: "/tmp/Main.unknownext") == nil)
+    }
+}

--- a/AlasTests/Code/LSP/GatekeeperAssessorTests.swift
+++ b/AlasTests/Code/LSP/GatekeeperAssessorTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import Alas
 
+@MainActor
 @Suite("GatekeeperAssessor")
 struct GatekeeperAssessorTests {
     @Test("first lookup invokes the underlying assessor")
@@ -73,6 +74,19 @@ struct GatekeeperAssessorTests {
             throw NSError(domain: "test", code: 1)
         })
         #expect(assessor.assess(realPath: path) == .unknown)
+    }
+
+    @Test("non-existent file runs runner on every call (no cache write)")
+    func missingFileSkipsCache() throws {
+        let path = "/tmp/definitely-does-not-exist-\(UUID().uuidString)"
+        var calls = 0
+        let assessor = GatekeeperAssessor(runner: { _ in
+            calls += 1
+            return .unknown
+        })
+        _ = assessor.assess(realPath: path)
+        _ = assessor.assess(realPath: path)
+        #expect(calls == 2)
     }
 
     private func makeTempExecutable() throws -> String {

--- a/AlasTests/Code/LSP/GatekeeperAssessorTests.swift
+++ b/AlasTests/Code/LSP/GatekeeperAssessorTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("GatekeeperAssessor")
+struct GatekeeperAssessorTests {
+    @Test("first lookup invokes the underlying assessor")
+    func firstLookupRuns() throws {
+        let path = try makeTempExecutable()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        var calls = 0
+        let assessor = GatekeeperAssessor(runner: { _ in
+            calls += 1
+            return .allowed
+        })
+        #expect(assessor.assess(realPath: path) == .allowed)
+        #expect(calls == 1)
+    }
+
+    @Test("second lookup with unchanged file hits the cache")
+    func cachedSecondLookup() throws {
+        let path = try makeTempExecutable()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        var calls = 0
+        let assessor = GatekeeperAssessor(runner: { _ in
+            calls += 1
+            return .rejected
+        })
+        _ = assessor.assess(realPath: path)
+        let second = assessor.assess(realPath: path)
+        #expect(second == .rejected)
+        #expect(calls == 1)
+    }
+
+    @Test("cache entry invalidated when file mtime changes")
+    func mtimeChangeInvalidatesCache() throws {
+        let path = try makeTempExecutable()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        var calls = 0
+        let assessor = GatekeeperAssessor(runner: { _ in
+            calls += 1
+            return calls == 1 ? .rejected : .allowed
+        })
+        _ = assessor.assess(realPath: path)
+        // Bump mtime by writing again
+        try "changed".write(toFile: path, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        let second = assessor.assess(realPath: path)
+        #expect(second == .allowed)
+        #expect(calls == 2)
+    }
+
+    @Test("invalidateAll forces re-assessment")
+    func invalidateAllForcesReassessment() throws {
+        let path = try makeTempExecutable()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        var calls = 0
+        let assessor = GatekeeperAssessor(runner: { _ in
+            calls += 1
+            return .allowed
+        })
+        _ = assessor.assess(realPath: path)
+        assessor.invalidateAll()
+        _ = assessor.assess(realPath: path)
+        #expect(calls == 2)
+    }
+
+    @Test("runner throws → unknown")
+    func runnerErrorBecomesUnknown() throws {
+        let path = try makeTempExecutable()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let assessor = GatekeeperAssessor(runner: { _ in
+            throw NSError(domain: "test", code: 1)
+        })
+        #expect(assessor.assess(realPath: path) == .unknown)
+    }
+
+    private func makeTempExecutable() throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gk-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("bin").path
+        FileManager.default.createFile(atPath: path, contents: Data("x".utf8))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)
+        return path
+    }
+}

--- a/AlasTests/Code/LSP/InstallNudgeResolverTests.swift
+++ b/AlasTests/Code/LSP/InstallNudgeResolverTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import Alas
 
 @Suite("InstallNudgeResolver")
+@MainActor
 struct InstallNudgeResolverTests {
     @Test("unknown extension resolves to installable Mason package")
     func masonFallbackForUnknownExtension() {

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -8,7 +8,7 @@ struct LanguageServerAvailabilityTests {
     @Test("disabled entries report disabled")
     func disabled() {
         let entry = config(language: "swift", command: "sourcekit-lsp", enabled: false)
-        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil }, additionalPathDirectories: [])
+        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
         #expect(availability.status(for: entry) == .disabled)
     }
 
@@ -67,7 +67,8 @@ struct LanguageServerAvailabilityTests {
         let availability = LanguageServerAvailability(
             environment: ["PATH": "/usr/bin:/bin"],
             xcrunFind: { _ in nil },
-            additionalPathDirectories: ["\(NSHomeDirectory())/.npm-global/bin", "/opt/homebrew/bin"]
+            additionalPathDirectories: ["\(NSHomeDirectory())/.npm-global/bin", "/opt/homebrew/bin"],
+            gatekeeperAssessor: { _ in .allowed }
         )
 
         let env = availability.launchEnvironment(for: entry)
@@ -96,7 +97,7 @@ struct LanguageServerAvailabilityTests {
         let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in
             didCallXcrun = true
             return "/usr/local/bin/rust-analyzer"
-        }, additionalPathDirectories: [])
+        }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
 
         #expect(availability.status(for: entry) == .notInstalled)
         #expect(didCallXcrun == false)
@@ -106,7 +107,7 @@ struct LanguageServerAvailabilityTests {
     func resolvedCommandXcrun() {
         let entry = config(language: "swift", command: "sourcekit-lsp")
         let xcrunPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
-        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath }, additionalPathDirectories: [])
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
 
         #expect(availability.resolvedCommand(for: entry) == xcrunPath)
     }
@@ -115,7 +116,7 @@ struct LanguageServerAvailabilityTests {
     func spawnArgumentsXcrun() {
         let entry = config(language: "swift", command: "sourcekit-lsp", args: ["--flag"])
         let xcrunPath = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
-        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath }, additionalPathDirectories: [])
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in xcrunPath }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
         let spawn = availability.spawnArguments(for: entry)
 
         #expect(spawn != nil)
@@ -133,7 +134,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: "test-lsp", args: ["--verbose"])
-        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil }, additionalPathDirectories: [])
+        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
         let spawn = availability.spawnArguments(for: entry)
 
         #expect(spawn != nil)
@@ -144,7 +145,7 @@ struct LanguageServerAvailabilityTests {
     @Test("spawnArguments wraps unresolvable bare command with env")
     func spawnArgumentsEnvFallback() {
         let entry = config(command: "missing-lsp", args: ["--flag"])
-        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil }, additionalPathDirectories: [])
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
         let spawn = availability.spawnArguments(for: entry)
 
         #expect(spawn == nil)
@@ -170,7 +171,8 @@ struct LanguageServerAvailabilityTests {
         let availability = LanguageServerAvailability(
             environment: ["PATH": "/usr/bin:/bin", "HOME": "/Users/test"],
             xcrunFind: { _ in nil },
-            additionalPathDirectories: ["/opt/homebrew/bin", "/custom/bin"]
+            additionalPathDirectories: ["/opt/homebrew/bin", "/custom/bin"],
+            gatekeeperAssessor: { _ in .allowed }
         )
 
         let env = availability.launchEnvironment(for: entry)
@@ -198,7 +200,7 @@ struct LanguageServerAvailabilityTests {
 
         let status = availability.status(for: entry)
         guard case .blockedByGatekeeper(let realPath) = status else {
-            Issue.record("Expected .blockedByGatekeeper, got \(status)")
+            #expect(Bool(false), "Expected .blockedByGatekeeper, got \(status)")
             return
         }
         // realPath should be the executable path with symlinks resolved.

--- a/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
+++ b/AlasTests/Code/LSP/LanguageServerAvailabilityTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import Alas
 
 @Suite("LanguageServerAvailability")
+@MainActor
 struct LanguageServerAvailabilityTests {
     @Test("disabled entries report disabled")
     func disabled() {
@@ -21,7 +22,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: executable.path)
-        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil }, additionalPathDirectories: [])
+        let availability = LanguageServerAvailability(environment: [:], xcrunFind: { _ in nil }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
         #expect(availability.status(for: entry) == .available)
     }
 
@@ -35,7 +36,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: "test-lsp")
-        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil }, additionalPathDirectories: [])
+        let availability = LanguageServerAvailability(environment: ["PATH": dir.path], xcrunFind: { _ in nil }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
         #expect(availability.status(for: entry) == .available)
     }
 
@@ -52,7 +53,8 @@ struct LanguageServerAvailabilityTests {
         let availability = LanguageServerAvailability(
             environment: ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"],
             xcrunFind: { _ in nil },
-            additionalPathDirectories: ["\(NSHomeDirectory())/.npm-global/bin", dir.path]
+            additionalPathDirectories: ["\(NSHomeDirectory())/.npm-global/bin", dir.path],
+            gatekeeperAssessor: { _ in .allowed }
         )
 
         #expect(availability.status(for: entry) == .available)
@@ -81,7 +83,7 @@ struct LanguageServerAvailabilityTests {
         let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { tool in
             requestedTool = tool
             return "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp"
-        }, additionalPathDirectories: [])
+        }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
 
         #expect(availability.status(for: entry) == .available)
         #expect(requestedTool == "sourcekit-lsp")
@@ -158,7 +160,7 @@ struct LanguageServerAvailabilityTests {
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let entry = config(command: "custom-lsp", env: ["PATH": dir.path])
-        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil }, additionalPathDirectories: [])
+        let availability = LanguageServerAvailability(environment: ["PATH": ""], xcrunFind: { _ in nil }, additionalPathDirectories: [], gatekeeperAssessor: { _ in .allowed })
         #expect(availability.status(for: entry) == .available)
     }
 
@@ -176,6 +178,86 @@ struct LanguageServerAvailabilityTests {
         #expect(env["CUSTOM"] == "1")
         #expect(env["HOME"] == "/Users/test")
         #expect(env["PATH"] == "/custom/bin:/usr/bin:/bin:/opt/homebrew/bin")
+    }
+
+    @Test("resolved command + gatekeeper rejected → blockedByGatekeeper(realPath:)")
+    func gatekeeperRejected() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("kotlin-lsp")
+        #expect(FileManager.default.createFile(atPath: executable.path, contents: Data()))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp")
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { _ in .rejected }
+        )
+
+        let status = availability.status(for: entry)
+        guard case .blockedByGatekeeper(let realPath) = status else {
+            Issue.record("Expected .blockedByGatekeeper, got \(status)")
+            return
+        }
+        // realPath should be the executable path with symlinks resolved.
+        #expect(realPath == executable.resolvingSymlinksInPath().path)
+    }
+
+    @Test("resolved command + gatekeeper allowed → available")
+    func gatekeeperAllowed() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("kotlin-lsp")
+        #expect(FileManager.default.createFile(atPath: executable.path, contents: Data()))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp")
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { _ in .allowed }
+        )
+
+        #expect(availability.status(for: entry) == .available)
+    }
+
+    @Test("resolved command + gatekeeper unknown → available (don't hide LSPs on assessor failure)")
+    func gatekeeperUnknownIsAvailable() throws {
+        let dir = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let executable = dir.appendingPathComponent("kotlin-lsp")
+        #expect(FileManager.default.createFile(atPath: executable.path, contents: Data()))
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let entry = config(language: "kotlin", command: "kotlin-lsp")
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": dir.path],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { _ in .unknown }
+        )
+
+        #expect(availability.status(for: entry) == .available)
+    }
+
+    @Test("notInstalled commands never reach the gatekeeper assessor")
+    func notInstalledSkipsAssessor() {
+        var assessorCalled = false
+        let entry = config(language: "kotlin", command: "totally-not-installed-lsp")
+        let availability = LanguageServerAvailability(
+            environment: ["PATH": "/tmp/empty"],
+            xcrunFind: { _ in nil },
+            additionalPathDirectories: [],
+            gatekeeperAssessor: { _ in
+                assessorCalled = true
+                return .rejected
+            }
+        )
+        #expect(availability.status(for: entry) == .notInstalled)
+        #expect(assessorCalled == false)
     }
 
     private func config(language: String = "test", command: String, args: [String] = [], env: [String: String] = [:], enabled: Bool = true) -> LanguageServerConfig {


### PR DESCRIPTION
## Summary

- Adds a pre-flight `spctl --assess` check before Alas spawns any LSP. When macOS Gatekeeper would block the binary (e.g. JetBrains `intellij-server` / `kotlin-lsp`, which is ad-hoc signed), Alas skips the spawn and shows an in-editor banner with a deep-link to System Settings → Privacy & Security instead of triggering the system popup.
- Banner dismissal is keyed by resolved binary path, so a `brew upgrade` (new inode → new spctl result) re-shows it.
- Cache is invalidated on `NSApplication.didBecomeActiveNotification` so allowing the binary in System Settings and switching back to Alas unblocks the LSP on the next file open.

## Architecture

- `GatekeeperAssessor` — `@MainActor` singleton wrapping `spctl --assess --type execute <path>` with an in-memory cache keyed by `(realPath, mtime, inode)`. First lookup blocks ~150-300ms; subsequent lookups are cache hits.
- `LanguageServerAvailability.Status` gains a fourth case `.blockedByGatekeeper(realPath:)`. `status(for:)` consults `GatekeeperAssessor` after resolving the binary's real path.
- `WorkspaceLSPManager.openDocument` pre-flights the status and returns `nil` (no spawn) when blocked, posting `Notification.Name.lspBlockedByGatekeeper`.
- `BlockedLanguageServerNudgeResolver` + `BlockedNudgeBanner` mirror the existing `InstallNudgeResolver` / `InstallNudgeBanner` pair.

## Test plan

- [x] Unit tests: `GatekeeperAssessorTests` (6), `LanguageServerAvailabilityTests` (+4 new), `BlockedLanguageServerNudgeResolverTests` (4) — all green
- [x] Full suite: 1889 tests / 227 suites pass
- [x] Manual: opened a `.kt` file in the dev build with `kotlin-lsp` installed (ad-hoc signed); banner appears, no Gatekeeper popup
- [ ] Manual: click "Open Privacy & Security", approve `intellij-server`, return to Alas, reopen `.kt` tab — banner clears and Kotlin LSP starts

## Notes

- The banner does not auto-clear when the user returns from System Settings (cache invalidates, but the visible banner is rendered from a SwiftUI body that doesn't observe the cache). Re-opening the file refreshes it. Acceptable per design.