### PR TITLE
fix(code): re-apply base style after watcher-driven revert

### DIFF
--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -554,7 +554,16 @@ final class CodeEditorCoordinator {
         if let edit {
             pendingTextEdits.append(edit)
         } else {
+            // Full reload (watcher-driven revert / discard-from-right-pane):
+            // `loadFromDisk` replaced storage with a plain NSAttributedString,
+            // wiping the font/color attributes. `runHighlight` only paints
+            // syntax-colored spans, so without re-applying the base style the
+            // text view falls back to the system proportional font for any
+            // character outside a highlight capture.
             pendingTextEdits.removeAll()
+            if let theme = currentTheme {
+                applyBaseStyle(theme: theme)
+            }
         }
         didChangeTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 150_000_000)


### PR DESCRIPTION
## Summary
- After a right-pane "Discard changes" on an open editor tab (or any file-watcher-driven revert), the editor lost its monospace font and fell back to the system proportional font.
- Root cause: `EditorBuffer.revert()` calls `loadFromDisk()`, which resets storage with a plain `NSAttributedString` (no `.font` / `.foregroundColor`). The coordinator's edit observer hit `scheduleEditPropagation(edit: nil)`, but that path only ran `runHighlight` — which paints syntax-color spans, never the base font. So characters outside highlight captures (whitespace, plain text, unmatched language regions) ended up with no font attribute and TextKit defaulted to the system proportional font.
- Fix: in `scheduleEditPropagation`, the nil-edit branch (full reload) now calls `applyBaseStyle(theme:)` before scheduling the highlight pass — same function `bindBuffer` already uses on initial attach for exactly this reason.

## Test plan
- [x] All existing `TabsManagerBufferTests` + `EditorBufferTests` pass after rebase onto `main`.
- [ ] Manual: open a file, edit it, click "Discard" in the right pane → text refreshes and stays monospaced (previously: switched to system proportional).
- [ ] Manual: edit a file with syntax highlighting (e.g. `.swift`), discard → colors + font both intact.
- [ ] Manual: edit a plain-text file with no language match (e.g. `.txt`), discard → still monospace.