### PR TITLE
ci: cache Xcode SwiftPM packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,35 @@ jobs:
       - name: Generate Xcode project
         run: xcodegen
 
+      - name: Compute Xcode package cache key inputs
+        run: |
+          xcodebuild -version > .xcode-cache-toolchain
+          swift --version >> .xcode-cache-toolchain
+          cat .xcode-cache-toolchain
+
+      - name: Restore SwiftPM package cache
+        id: swiftpm-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .build/xcode/SourcePackages
+          key: swiftpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.xcode-cache-toolchain', 'project.yml', 'Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ThirdParty/TreeSitter*/Package.swift') }}
+          restore-keys: |
+            swiftpm-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Resolve SwiftPM packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Alas.xcodeproj \
+            -scheme Alas \
+            -clonedSourcePackagesDirPath .build/xcode/SourcePackages
+
+      - name: Save SwiftPM package cache
+        if: success() && steps.swiftpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: .build/xcode/SourcePackages
+          key: ${{ steps.swiftpm-cache.outputs.cache-primary-key }}
+
       - name: Build for testing
         # Splitting build/test into `build-for-testing` + `test-without-building`
         # avoids the lsregister/CoreServices hang we observed locally and on CI
@@ -140,6 +169,8 @@ jobs:
         run: |
           xcodebuild -project Alas.xcodeproj -scheme Alas \
             -destination 'platform=macOS,arch=arm64' \
+            -derivedDataPath .build/xcode/DerivedData \
+            -clonedSourcePackagesDirPath .build/xcode/SourcePackages \
             -skipMacroValidation \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
@@ -156,6 +187,8 @@ jobs:
         run: |
           xcodebuild -project Alas.xcodeproj -scheme Alas \
             -destination 'platform=macOS,arch=arm64' \
+            -derivedDataPath .build/xcode/DerivedData \
+            -clonedSourcePackagesDirPath .build/xcode/SourcePackages \
             -only-testing AlasTests/AppConfigTests \
             -only-testing AlasTests/OKLCHTests \
             -only-testing AlasTests/ThemeTests \
@@ -186,6 +219,8 @@ jobs:
         run: |
           xcodebuild -project Alas.xcodeproj -scheme Alas \
             -destination 'platform=macOS,arch=arm64' \
+            -derivedDataPath .build/xcode/DerivedData \
+            -clonedSourcePackagesDirPath .build/xcode/SourcePackages \
             -only-testing AlasTests/ProcessGitTests \
             -skipMacroValidation \
             -parallel-testing-enabled NO \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,12 +121,48 @@ jobs:
         if: steps.skip-check.outputs.skip != 'true'
         run: xcodegen
 
+      - name: Compute Xcode package cache key inputs
+        if: steps.skip-check.outputs.skip != 'true'
+        run: |
+          xcodebuild -version > .xcode-cache-toolchain
+          swift --version >> .xcode-cache-toolchain
+          cat .xcode-cache-toolchain
+
+      - name: Restore SwiftPM package cache
+        if: steps.skip-check.outputs.skip != 'true'
+        id: swiftpm-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .build/xcode/SourcePackages
+          key: swiftpm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.xcode-cache-toolchain', 'project.yml', 'Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ThirdParty/TreeSitter*/Package.swift') }}
+          restore-keys: |
+            swiftpm-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Resolve SwiftPM packages
+        if: steps.skip-check.outputs.skip != 'true'
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Alas.xcodeproj \
+            -scheme Alas \
+            -clonedSourcePackagesDirPath .build/xcode/SourcePackages
+
+      - name: Save SwiftPM package cache
+        if: success()
+          && steps.skip-check.outputs.skip != 'true'
+          && steps.swiftpm-cache.outputs.cache-hit != 'true'
+          && (inputs.ref == '' || inputs.ref == 'main')
+        uses: actions/cache/save@v5
+        with:
+          path: .build/xcode/SourcePackages
+          key: ${{ steps.swiftpm-cache.outputs.cache-primary-key }}
+
       - name: Build release app
         if: steps.skip-check.outputs.skip != 'true'
         run: |
           xcodebuild -project Alas.xcodeproj -scheme Alas \
             -configuration Release \
             -derivedDataPath build \
+            -clonedSourcePackagesDirPath .build/xcode/SourcePackages \
             -destination 'platform=macOS,arch=arm64' \
             -quiet build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,21 @@ jobs:
       - name: Generate project
         run: xcodegen
 
+      - name: Compute Xcode package cache key inputs
+        run: |
+          xcodebuild -version > .xcode-cache-toolchain
+          swift --version >> .xcode-cache-toolchain
+          cat .xcode-cache-toolchain
+
+      - name: Restore SwiftPM package cache
+        id: swiftpm-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .build/xcode/SourcePackages
+          key: swiftpm-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('.xcode-cache-toolchain', 'project.yml', 'Alas.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved', 'ThirdParty/TreeSitter*/Package.swift') }}
+          restore-keys: |
+            swiftpm-${{ runner.os }}-${{ matrix.arch }}-
+
       - name: Compute version from tag
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
@@ -87,11 +102,26 @@ jobs:
           path: ~/Library/Caches/Alas/GhosttyKit/${{ matrix.arch }}
           key: ${{ steps.ghostty-cache.outputs.cache-primary-key }}
 
+      - name: Resolve SwiftPM packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Alas.xcodeproj \
+            -scheme Alas \
+            -clonedSourcePackagesDirPath .build/xcode/SourcePackages
+
+      - name: Save SwiftPM package cache
+        if: success() && steps.swiftpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: .build/xcode/SourcePackages
+          key: ${{ steps.swiftpm-cache.outputs.cache-primary-key }}
+
       - name: Build release app (${{ matrix.arch }})
         run: |
           xcodebuild -project Alas.xcodeproj -scheme Alas \
             -configuration Release \
             -derivedDataPath build \
+            -clonedSourcePackagesDirPath .build/xcode/SourcePackages \
             -destination 'platform=macOS,arch=${{ matrix.arch }}' \
             -quiet build
 


### PR DESCRIPTION
## Summary

- Add a SwiftPM package cache to the build, nightly, and release workflows.
- Resolve Xcode package dependencies explicitly into `.build/xcode/SourcePackages` before the main build step.
- Point CI xcodebuild invocations at the cached package checkout path so tree-sitter and plugin dependencies do not refetch on every run.

## Why

The `Build for testing` step had started spending a long time resolving and downloading the growing set of SwiftPM tree-sitter dependencies on fresh macOS runners. Ghostty already had a dedicated cache, but Xcode package checkouts did not.

## Validation

- `actionlint .github/workflows/build.yml .github/workflows/nightly.yml .github/workflows/release.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/build.yml .github/workflows/nightly.yml .github/workflows/release.yml`
- `git diff --check`
- `xcodegen`
- `xcodebuild -resolvePackageDependencies -project Alas.xcodeproj -scheme Alas -clonedSourcePackagesDirPath .build/xcode/SourcePackages`

I also started the full local `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`, but interrupted it after it entered the long local Ghostty build path; the workflow-level checks and package-resolution path above completed.
