### PR TITLE
feat(agents): add extra terminal args to agent settings

### DIFF
--- a/Alas/Sources/Agents/AgentAutoLaunch.swift
+++ b/Alas/Sources/Agents/AgentAutoLaunch.swift
@@ -63,6 +63,9 @@ enum AgentAutoLaunch {
 
     static func buildCommand(agent: AgentDefinition, useBypass: Bool) -> [String] {
         var argv: [String] = [agent.resolvedBinary]
+        if let extra = agent.extraTerminalArgs, !extra.isEmpty {
+            argv.append(contentsOf: extra)
+        }
         if useBypass, let flag = agent.bypassPermissionsFlag {
             argv.append(flag)
         }

--- a/Alas/Sources/Agents/AgentBuiltins.swift
+++ b/Alas/Sources/Agents/AgentBuiltins.swift
@@ -14,6 +14,7 @@ enum AgentBuiltins {
             binaryOverride: nil,
             promptModeArgs: ["-p"],
             bypassPermissionsFlag: "--dangerously-skip-permissions",
+            extraTerminalArgs: nil,
             isBuiltin: true,
             isEnabled: true,
             builtinLogoAssetName: "agent-claude"
@@ -22,7 +23,7 @@ enum AgentBuiltins {
         // (2026-05-16). The `exec` subcommand is the non-interactive entry
         // point; --dangerously-bypass-approvals-and-sandbox disables all
         // sandboxing and approval prompts. (The previously-assumed
-        // `--full-auto` flag does not exist.)
+        // `--full_auto` flag does not exist.)
         AgentDefinition(
             id: "codex",
             displayName: "Codex",
@@ -30,6 +31,7 @@ enum AgentBuiltins {
             binaryOverride: nil,
             promptModeArgs: ["exec"],
             bypassPermissionsFlag: "--dangerously-bypass-approvals-and-sandbox",
+            extraTerminalArgs: nil,
             isBuiltin: true,
             isEnabled: true,
             builtinLogoAssetName: "agent-codex"
@@ -44,6 +46,7 @@ enum AgentBuiltins {
             binaryOverride: nil,
             promptModeArgs: ["-p"],
             bypassPermissionsFlag: "--force",
+            extraTerminalArgs: nil,
             isBuiltin: true,
             isEnabled: true,
             builtinLogoAssetName: "agent-cursor"
@@ -58,6 +61,7 @@ enum AgentBuiltins {
             binaryOverride: nil,
             promptModeArgs: ["-p"],
             bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: true,
             isEnabled: true,
             builtinLogoAssetName: "agent-pi"
@@ -76,6 +80,7 @@ enum AgentBuiltins {
             binaryOverride: nil,
             promptModeArgs: ["run"],
             bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: true,
             isEnabled: true,
             builtinLogoAssetName: "agent-opencode"
@@ -91,6 +96,7 @@ enum AgentBuiltins {
             binaryOverride: nil,
             promptModeArgs: ["-p"],
             bypassPermissionsFlag: "--yolo",
+            extraTerminalArgs: nil,
             isBuiltin: true,
             isEnabled: true,
             builtinLogoAssetName: "agent-gemini"
@@ -104,6 +110,7 @@ enum AgentBuiltins {
             binaryOverride: nil,
             promptModeArgs: ["-i"],
             bypassPermissionsFlag: "--allow-tool=write",
+            extraTerminalArgs: nil,
             isBuiltin: true,
             isEnabled: true,
             builtinLogoAssetName: "agent-copilot"

--- a/Alas/Sources/Agents/AgentDefinition.swift
+++ b/Alas/Sources/Agents/AgentDefinition.swift
@@ -15,6 +15,7 @@ struct AgentDefinition: Codable, Equatable, Identifiable {
     var binaryOverride: String?
     var promptModeArgs: [String]
     var bypassPermissionsFlag: String?
+    var extraTerminalArgs: [String]?
     var isBuiltin: Bool
     var isEnabled: Bool
     var builtinLogoAssetName: String?

--- a/Alas/Sources/Agents/AgentRegistry.swift
+++ b/Alas/Sources/Agents/AgentRegistry.swift
@@ -4,6 +4,7 @@
 struct BuiltinAgentState: Codable, Equatable {
     var isEnabled: Bool
     var binaryOverride: String?
+    var extraTerminalArgs: [String]?
 }
 
 /// Runtime view over the agent catalog. Built-ins come first (in catalog
@@ -28,6 +29,7 @@ struct AgentRegistry: Equatable {
             if let state = builtinState[builtin.id] {
                 prefersEnabled = state.isEnabled
                 builtin.binaryOverride = state.binaryOverride
+                builtin.extraTerminalArgs = state.extraTerminalArgs
             } else {
                 prefersEnabled = builtin.isEnabled
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -546,6 +546,9 @@ final class AppState {
 
     func agentStartupCommand(for agent: AgentDefinition, project: ProjectConfig) -> String {
         var argv = [agent.resolvedBinary]
+        if let extra = agent.extraTerminalArgs, !extra.isEmpty {
+            argv.append(contentsOf: extra)
+        }
         if agentBypassPermissionsEnabled(for: project),
            let flag = agent.bypassPermissionsFlag {
             argv.append(flag)

--- a/Alas/Sources/Settings/AgentEditView.swift
+++ b/Alas/Sources/Settings/AgentEditView.swift
@@ -41,6 +41,7 @@ struct AgentEditView: View {
                 let persisted = state.config.agents.builtinState[id]
                 builtin.isEnabled = persisted?.isEnabled ?? builtin.isEnabled
                 builtin.binaryOverride = persisted?.binaryOverride
+                builtin.extraTerminalArgs = persisted?.extraTerminalArgs
                 agent = builtin
             } else {
                 agent = AgentDefinition(

--- a/Alas/Sources/Settings/AgentEditView.swift
+++ b/Alas/Sources/Settings/AgentEditView.swift
@@ -110,6 +110,18 @@ struct AgentEditView: View {
                 )
                 .disabled(draft.isBuiltin)
             }
+            SettingsRow(name: "Extra terminal args") {
+                AlasField(
+                    text: Binding(
+                        get: { draft.extraTerminalArgs?.joined(separator: " ") ?? "" },
+                        set: { newValue in
+                            let parts = newValue.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+                            draft.extraTerminalArgs = parts.isEmpty ? nil : parts
+                        }
+                    ),
+                    monospaced: true
+                )
+            }
             SettingsRow(name: "Enabled") {
                 AlasToggle(on: $draft.isEnabled)
             }
@@ -168,6 +180,8 @@ struct AgentEditView: View {
             entry.isEnabled = draft.isEnabled
             let trimmed = draft.binaryOverride?.trimmingCharacters(in: .whitespaces)
             entry.binaryOverride = (trimmed?.isEmpty == false) ? trimmed : nil
+            let trimmedExtra = draft.extraTerminalArgs?.filter { !$0.isEmpty }
+            entry.extraTerminalArgs = (trimmedExtra?.isEmpty == false) ? trimmedExtra : nil
             state.config.agents.builtinState[draft.id] = entry
         } else if isNew {
             state.config.agents.custom.append(draft.normalizedForSettingsSave())
@@ -203,6 +217,8 @@ extension AgentDefinition {
         normalized.binaryOverride = nil
         let trimmedBypass = bypassPermissionsFlag?.trimmingCharacters(in: .whitespaces)
         normalized.bypassPermissionsFlag = (trimmedBypass?.isEmpty == false) ? trimmedBypass : nil
+        let trimmedExtra = extraTerminalArgs?.filter { !$0.isEmpty }
+        normalized.extraTerminalArgs = (trimmedExtra?.isEmpty == false) ? trimmedExtra : nil
         return normalized
     }
 }

--- a/Alas/Sources/Settings/AgentEditView.swift
+++ b/Alas/Sources/Settings/AgentEditView.swift
@@ -24,6 +24,7 @@ struct AgentEditView: View {
                 binaryOverride: nil,
                 promptModeArgs: [],
                 bypassPermissionsFlag: nil,
+                extraTerminalArgs: nil,
                 isBuiltin: false,
                 isEnabled: true,
                 builtinLogoAssetName: nil
@@ -45,6 +46,7 @@ struct AgentEditView: View {
                 agent = AgentDefinition(
                     id: id, displayName: id, binary: "",
                     binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+                    extraTerminalArgs: nil,
                     isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
                 )
             }

--- a/AlasTests/AgentAutoLaunchTests.swift
+++ b/AlasTests/AgentAutoLaunchTests.swift
@@ -6,12 +6,12 @@ import Foundation
 struct AgentAutoLaunchTests {
     // Use non-builtin IDs so the test registry doesn't collide with the
     // AgentBuiltins.catalog entries that AgentRegistry always prepends.
-    private func mkAgent(id: String, binary: String, bypass: String?) -> AgentDefinition {
+    private func mkAgent(id: String, binary: String, bypass: String?, extraArgs: [String]? = nil) -> AgentDefinition {
         AgentDefinition(
             id: id, displayName: id, binary: binary,
             binaryOverride: nil, promptModeArgs: [],
             bypassPermissionsFlag: bypass,
-            extraTerminalArgs: nil,
+            extraTerminalArgs: extraArgs,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
     }
@@ -186,5 +186,29 @@ struct AgentAutoLaunchTests {
 
         #expect(defaultResolved == nil)
         #expect(explicitResolved?.argv == ["claude", "--dangerously-skip-permissions"])
+    }
+
+    @Test func buildCommandInsertsExtraArgsBeforeBypass() {
+        let agent = mkAgent(id: "test-claude", binary: "claude", bypass: "--dangerously-skip-permissions", extraArgs: ["--model", "sonnet"])
+        let argv = AgentAutoLaunch.buildCommand(agent: agent, useBypass: true)
+        #expect(argv == ["claude", "--model", "sonnet", "--dangerously-skip-permissions"])
+    }
+
+    @Test func buildCommandOmitsExtraArgsWhenNil() {
+        let agent = mkAgent(id: "test-claude", binary: "claude", bypass: "--dangerously-skip-permissions")
+        let argv = AgentAutoLaunch.buildCommand(agent: agent, useBypass: true)
+        #expect(argv == ["claude", "--dangerously-skip-permissions"])
+    }
+
+    @Test func buildCommandOmitsExtraArgsWhenEmpty() {
+        let agent = mkAgent(id: "test-claude", binary: "claude", bypass: nil, extraArgs: [])
+        let argv = AgentAutoLaunch.buildCommand(agent: agent, useBypass: false)
+        #expect(argv == ["claude"])
+    }
+
+    @Test func buildCommandWithExtraArgsAndNoBypass() {
+        let agent = mkAgent(id: "test-claude", binary: "claude", bypass: nil, extraArgs: ["--verbose"])
+        let argv = AgentAutoLaunch.buildCommand(agent: agent, useBypass: true)
+        #expect(argv == ["claude", "--verbose"])
     }
 }

--- a/AlasTests/AgentAutoLaunchTests.swift
+++ b/AlasTests/AgentAutoLaunchTests.swift
@@ -11,6 +11,7 @@ struct AgentAutoLaunchTests {
             id: id, displayName: id, binary: binary,
             binaryOverride: nil, promptModeArgs: [],
             bypassPermissionsFlag: bypass,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
     }

--- a/AlasTests/AgentDefinitionTests.swift
+++ b/AlasTests/AgentDefinitionTests.swift
@@ -11,6 +11,7 @@ struct AgentDefinitionTests {
             binaryOverride: "/opt/local/bin/x-bin",
             promptModeArgs: ["-p"],
             bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false,
             isEnabled: true,
             builtinLogoAssetName: nil
@@ -26,6 +27,7 @@ struct AgentDefinitionTests {
             binaryOverride: nil,
             promptModeArgs: [],
             bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false,
             isEnabled: true,
             builtinLogoAssetName: nil
@@ -40,6 +42,7 @@ struct AgentDefinitionTests {
             id: "x", displayName: "X", binary: "x-bin",
             binaryOverride: "   ",
             promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
         #expect(a.resolvedBinary == "x-bin")
@@ -53,6 +56,7 @@ struct AgentDefinitionTests {
             id: "x", displayName: "X", binary: "x-bin",
             binaryOverride: "~/bin/x-bin",
             promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: true, isEnabled: true, builtinLogoAssetName: nil
         )
         let home = NSString(string: "~").expandingTildeInPath
@@ -64,10 +68,22 @@ struct AgentDefinitionTests {
             id: "x", displayName: "X", binary: "~/bin/x-bin",
             binaryOverride: nil,
             promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
         let home = NSString(string: "~").expandingTildeInPath
         #expect(a.resolvedBinary == "\(home)/bin/x-bin")
+    }
+
+    @Test func extraTerminalArgsDefaultsToNil() {
+        let agent = AgentDefinition(
+            id: "test", displayName: "Test", binary: "test",
+            binaryOverride: nil, promptModeArgs: [],
+            bypassPermissionsFlag: nil, extraTerminalArgs: nil,
+            isBuiltin: false,
+            isEnabled: true, builtinLogoAssetName: nil
+        )
+        #expect(agent.extraTerminalArgs == nil)
     }
 
     @Test func resolvedBinaryLeavesBareNameAlone() {
@@ -77,6 +93,7 @@ struct AgentDefinitionTests {
             id: "x", displayName: "X", binary: "claude",
             binaryOverride: nil,
             promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: true, isEnabled: true, builtinLogoAssetName: nil
         )
         #expect(a.resolvedBinary == "claude")

--- a/AlasTests/AgentDetectorTests.swift
+++ b/AlasTests/AgentDetectorTests.swift
@@ -85,6 +85,7 @@ struct AgentDetectorTests {
         let custom = AgentDefinition(
             id: "uuid-1", displayName: "Mine", binary: "myagent",
             binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
         let installed = await AgentDetector.scan(
@@ -106,6 +107,7 @@ struct AgentDetectorTests {
             id: "uuid-abs", displayName: "Abs",
             binary: absolutePath,
             binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
         let installed = await AgentDetector.scan(
@@ -128,6 +130,7 @@ struct AgentDetectorTests {
             id: "uuid-tilde", displayName: "Tilde",
             binary: "~/\(relative)/myagent",
             binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
         let installed = await AgentDetector.scan(

--- a/AlasTests/AgentLauncherModelTests.swift
+++ b/AlasTests/AgentLauncherModelTests.swift
@@ -11,6 +11,7 @@ struct AgentLauncherModelTests {
             binaryOverride: nil,
             promptModeArgs: [],
             bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false,
             isEnabled: true,
             builtinLogoAssetName: nil

--- a/AlasTests/AgentRegistryTests.swift
+++ b/AlasTests/AgentRegistryTests.swift
@@ -49,6 +49,7 @@ struct AgentRegistryTests {
             binaryOverride: nil,
             promptModeArgs: ["-p"],
             bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false,
             isEnabled: true,
             builtinLogoAssetName: nil
@@ -63,6 +64,7 @@ struct AgentRegistryTests {
         let custom = AgentDefinition(
             id: "c1", displayName: "C", binary: "c-bin",
             binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
         let r = AgentRegistry(
@@ -96,6 +98,7 @@ struct AgentRegistryTests {
         let custom = AgentDefinition(
             id: "c1", displayName: "C", binary: "c-bin",
             binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: false, builtinLogoAssetName: nil
         )
         let r = AgentRegistry(
@@ -147,11 +150,13 @@ struct AgentRegistryTests {
         let installed = AgentDefinition(
             id: "c-installed", displayName: "C-In", binary: "c-in",
             binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
         let missing = AgentDefinition(
             id: "c-missing", displayName: "C-Miss", binary: "c-miss",
             binaryOverride: nil, promptModeArgs: [], bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
         let r = AgentRegistry(

--- a/AlasTests/AgentRegistryTests.swift
+++ b/AlasTests/AgentRegistryTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Alas
 
@@ -166,6 +167,21 @@ struct AgentRegistryTests {
         )
         #expect(r.agents.first(where: { $0.id == "c-installed" })!.isEnabled == true)
         #expect(r.agents.first(where: { $0.id == "c-missing"   })!.isEnabled == false)
+    }
+
+    @Test func builtinAgentStateExtraTerminalArgsRoundsTrips() throws {
+        let state = BuiltinAgentState(isEnabled: true, binaryOverride: nil, extraTerminalArgs: ["--model", "sonnet"])
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(BuiltinAgentState.self, from: data)
+        #expect(decoded.extraTerminalArgs == ["--model", "sonnet"])
+    }
+
+    @Test func builtinAgentStateExtraTerminalArgsDefaultsToNil() throws {
+        let json = """
+        {"isEnabled": true, "binaryOverride": null}
+        """
+        let decoded = try JSONDecoder().decode(BuiltinAgentState.self, from: Data(json.utf8))
+        #expect(decoded.extraTerminalArgs == nil)
     }
 
     @Test func defaultInstallerRegistryExposesOnlyAgentsWithInstallers() {

--- a/AlasTests/AgentRunnerInvocationTests.swift
+++ b/AlasTests/AgentRunnerInvocationTests.swift
@@ -35,6 +35,7 @@ struct AgentRunnerInvocationTests {
             id: id, displayName: id, binary: binary,
             binaryOverride: nil, promptModeArgs: args,
             bypassPermissionsFlag: nil,
+            extraTerminalArgs: nil,
             isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
         )
     }

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -12,6 +12,7 @@ struct AgentTerminalLaunchTests {
             binaryOverride: nil,
             promptModeArgs: ["-p"],
             bypassPermissionsFlag: flag,
+            extraTerminalArgs: nil,
             isBuiltin: false,
             isEnabled: true,
             builtinLogoAssetName: nil

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @MainActor
 struct AgentTerminalLaunchTests {
-    private func agent(flag: String? = "--skip") -> AgentDefinition {
+    private func agent(flag: String? = "--skip", extraArgs: [String]? = nil) -> AgentDefinition {
         AgentDefinition(
             id: "test-agent",
             displayName: "Test Agent",
@@ -12,7 +12,7 @@ struct AgentTerminalLaunchTests {
             binaryOverride: nil,
             promptModeArgs: ["-p"],
             bypassPermissionsFlag: flag,
-            extraTerminalArgs: nil,
+            extraTerminalArgs: extraArgs,
             isBuiltin: false,
             isEnabled: true,
             builtinLogoAssetName: nil
@@ -293,5 +293,34 @@ struct AgentTerminalLaunchTests {
 
         #expect(!openerCalled)
         #expect(launchErrorTitle == "Launch Agent Failed")
+    }
+
+    @Test func extraTerminalArgsInsertedBeforeBypassFlag() {
+        let state = AppState(store: MemoryStore())
+        state.config.agents.worktreeAutoLaunch.useBypassPermissions = true
+        let command = state.agentStartupCommand(
+            for: agent(extraArgs: ["--model", "sonnet"]),
+            project: project(mode: .useGlobal, useBypass: false)
+        )
+        #expect(command == "test-agent --model sonnet --skip")
+    }
+
+    @Test func extraTerminalArgsNilDoesNotChangeCommand() {
+        let state = AppState(store: MemoryStore())
+        state.config.agents.worktreeAutoLaunch.useBypassPermissions = true
+        let command = state.agentStartupCommand(
+            for: agent(),
+            project: project(mode: .useGlobal, useBypass: false)
+        )
+        #expect(command == "test-agent --skip")
+    }
+
+    @Test func extraTerminalArgsAloneWithoutBypass() {
+        let state = AppState(store: MemoryStore())
+        let command = state.agentStartupCommand(
+            for: agent(flag: nil, extraArgs: ["--verbose"]),
+            project: project(mode: .disabled, useBypass: false)
+        )
+        #expect(command == "test-agent --verbose")
     }
 }

--- a/AlasTests/AgentsPaneTests.swift
+++ b/AlasTests/AgentsPaneTests.swift
@@ -32,4 +32,16 @@ struct AgentsPaneTests {
         pane.onNavigate(.terminal)
         #expect(navigated == .terminal)
     }
+
+    @Test func agentExtraTerminalArgsStoredCorrectly() {
+        var agent = AgentDefinition(
+            id: "test", displayName: "Test", binary: "test",
+            binaryOverride: nil, promptModeArgs: [],
+            bypassPermissionsFlag: nil, extraTerminalArgs: ["--model", "sonnet"],
+            isBuiltin: false, isEnabled: true, builtinLogoAssetName: nil
+        )
+        #expect(agent.extraTerminalArgs == ["--model", "sonnet"])
+        agent.extraTerminalArgs = nil
+        #expect(agent.extraTerminalArgs == nil)
+    }
 }

--- a/AlasTests/AppConfigAgentsCodingTests.swift
+++ b/AlasTests/AppConfigAgentsCodingTests.swift
@@ -58,6 +58,7 @@ struct AppConfigAgentsCodingTests {
                 id: "uuid-1", displayName: "Mine",
                 binary: "~/bin/mine", binaryOverride: nil,
                 promptModeArgs: ["-p"], bypassPermissionsFlag: "--yolo",
+                extraTerminalArgs: nil,
                 isBuiltin: false, isEnabled: true,
                 builtinLogoAssetName: nil
             )

--- a/AlasTests/AppConfigAgentsCodingTests.swift
+++ b/AlasTests/AppConfigAgentsCodingTests.swift
@@ -51,14 +51,14 @@ struct AppConfigAgentsCodingTests {
         var cfg = AppConfig.defaults
         cfg.agents.builtinState = [
             "codex": BuiltinAgentState(isEnabled: false, binaryOverride: nil),
-            "claude": BuiltinAgentState(isEnabled: true, binaryOverride: "/opt/local/bin/claude"),
+            "claude": BuiltinAgentState(isEnabled: true, binaryOverride: "/opt/local/bin/claude", extraTerminalArgs: ["--model", "sonnet"]),
         ]
         cfg.agents.custom = [
             AgentDefinition(
                 id: "uuid-1", displayName: "Mine",
                 binary: "~/bin/mine", binaryOverride: nil,
                 promptModeArgs: ["-p"], bypassPermissionsFlag: "--yolo",
-                extraTerminalArgs: nil,
+                extraTerminalArgs: ["--verbose"],
                 isBuiltin: false, isEnabled: true,
                 builtinLogoAssetName: nil
             )
@@ -76,12 +76,21 @@ struct AppConfigAgentsCodingTests {
         #expect(decoded.agents.custom.first?.id == "uuid-1")
         #expect(decoded.agents.worktreeAutoLaunch.agentId == "claude")
         #expect(decoded.agents.worktreeAutoLaunch.useBypassPermissions == true)
+        #expect(decoded.agents.builtinState["claude"]?.extraTerminalArgs == ["--model", "sonnet"])
+        #expect(decoded.agents.custom.first?.extraTerminalArgs == ["--verbose"])
+    }
+
+    @Test func decodesBuiltinStateWithoutExtraTerminalArgs() throws {
+        let json = """
+        {"isEnabled": true, "binaryOverride": "/usr/local/bin/claude"}
+        """
+        let state = try JSONDecoder().decode(BuiltinAgentState.self, from: Data(json.utf8))
+        #expect(state.isEnabled == true)
+        #expect(state.binaryOverride == "/usr/local/bin/claude")
+        #expect(state.extraTerminalArgs == nil)
     }
 
     @Test func decodesPartialAgentsBlockWithMissingInnerFields() throws {
-        // `agents` key is present but empty — exercises the `if let
-        // agentsContainer = ...` branch where each inner field's `try?`
-        // decode falls back to its default independently.
         let json = """
         {
           "themeId": "cool-slate",

--- a/AlasTests/SettingsSaveNormalizationTests.swift
+++ b/AlasTests/SettingsSaveNormalizationTests.swift
@@ -11,6 +11,7 @@ struct SettingsSaveNormalizationTests {
             binaryOverride: "  ignored  ",
             promptModeArgs: ["--print"],
             bypassPermissionsFlag: " --dangerously-skip-permissions ",
+            extraTerminalArgs: nil,
             isBuiltin: false,
             isEnabled: true,
             builtinLogoAssetName: nil


### PR DESCRIPTION
## Summary
- Add `extraTerminalArgs: [String]?` field to `AgentDefinition` and `BuiltinAgentState`
- New "Extra terminal args" text field in the agent edit view (settings -> agents -> edit agent details)
- Args inserted between binary and bypass-permissions flag in interactive terminal launches
- Per-agent global default; editable for both built-in and custom agents
- Backward-compatible: old configs without the field decode to `nil`

## Test Plan
- All existing tests pass
- New tests: extraTerminalArgs round-trip, backward compat decode, command assembly, registry overlay

## Example
User types `--model sonnet` in the "Extra terminal args" field for Claude.
When launched in terminal: `claude --model sonnet --dangerously-skip-permissions`