### PR TITLE
Hide draft commit prompt when nothing is staged

### DIFF
--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -74,14 +74,16 @@ struct ChangesTabView: View {
                 onDismissBulkReport: { rps.dismissBulkResolveReport() }
             )
 
-            DraftCommitTriggerRow(
-                stagedCount: stagedCount,
-                stagedAdd: stagedAdd,
-                stagedDel: stagedDel,
-                hasDraft: hasDraftTab,
-                draftNonEmpty: draftNonEmpty,
-                onOpen: openDraftTab
-            )
+            if stagedCount > 0 {
+                DraftCommitTriggerRow(
+                    stagedCount: stagedCount,
+                    stagedAdd: stagedAdd,
+                    stagedDel: stagedDel,
+                    hasDraft: hasDraftTab,
+                    draftNonEmpty: draftNonEmpty,
+                    onOpen: openDraftTab
+                )
+            }
             WorkingTreeSectionView(
                 changes: nonConflictChanges,
                 expanded: $rps.workingTreeExpanded,


### PR DESCRIPTION
## Summary
- Hide the draft commit prompt unless staged files exist in the Changes sidebar
- Avoid reserving space for the draft commit UI in unstaged-only or clean worktree states

## Testing
- Not run; prior build was blocked by missing GhosttyKit dependency in this worktree