### PR TITLE
Add shortcut to focus main worktree

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -383,6 +383,7 @@
 		899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */; };
 		89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */; };
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
+		8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */; };
 		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
 		8B2A37F58F2C7D842204A596 /* ImageDiffOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87F114EBEEACCC95B9EF8D5 /* ImageDiffOverlayView.swift */; };
 		8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F31D837F83B4F8B9FB348BD /* ACPPermissionPolicyTests.swift */; };
@@ -514,6 +515,7 @@
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
 		BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */; };
+		BDBAA6601CA3FD8A5562E637 /* AppStateFocusMainWorktreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */; };
 		BE4E46595AF10611CE0B1C6B /* TabActivityPulse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */; };
 		BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */; };
 		BEDFCA98CA9C992302618128 /* ProjectsManagerHeadUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */; };
@@ -743,6 +745,7 @@
 		1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
 		11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClientTests.swift; sourceTree = "<group>"; };
 		11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTerminalLaunchTests.swift; sourceTree = "<group>"; };
+		11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateFocusMainWorktreeTests.swift; sourceTree = "<group>"; };
 		120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffViewTests.swift; sourceTree = "<group>"; };
 		1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouter.swift; sourceTree = "<group>"; };
 		1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTests.swift; sourceTree = "<group>"; };
@@ -865,6 +868,7 @@
 		39DFD138FE855D8CFC464847 /* SearchFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFooter.swift; sourceTree = "<group>"; };
 		3A0FF718D68E15F539577F56 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
 		3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeBuilderTests.swift; sourceTree = "<group>"; };
+		3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCreateFetchTests.swift; sourceTree = "<group>"; };
 		3BE23A4881B60D7F16A4ACA5 /* GhosttyConfigBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilderTests.swift; sourceTree = "<group>"; };
 		3BF2F213480B30034B25B2B8 /* AgentRunError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunError.swift; sourceTree = "<group>"; };
 		3C01FBF2EE3668E6772CEB1D /* CommitInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfo.swift; sourceTree = "<group>"; };
@@ -1493,6 +1497,7 @@
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
 				08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */,
 				E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */,
+				11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */,
 				6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */,
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
@@ -1666,6 +1671,7 @@
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
 				5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */,
 				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
+				3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */,
 				C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
@@ -3282,6 +3288,7 @@
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,
 				A75289A4560BCA2DACA0760B /* AppStateCreateWorktreeSymlinkTests.swift in Sources */,
+				BDBAA6601CA3FD8A5562E637 /* AppStateFocusMainWorktreeTests.swift in Sources */,
 				ABB5595A9A39C8AF203B5873 /* AppStateOverlayFocusTests.swift in Sources */,
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,
@@ -3482,6 +3489,7 @@
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
 				9BA16B0D5FC26501D54B5192 /* WorkingTreeStageAllActionTests.swift in Sources */,
 				BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */,
+				8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */,
 				E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
 				E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -226,6 +226,11 @@ struct AlasApp: App {
             }
             .keyboardShortcut(state.shortcut(for: .newWorktree))
             .disabled(state.projects.isEmpty)
+            Button("Focus Main Worktree") {
+                NotificationCenter.default.post(name: .alasFocusMainWorktree, object: nil)
+            }
+            .keyboardShortcut(state.shortcut(for: .focusMainWorktree))
+            .disabled(!state.canFocusMainWorktreeForCurrentProject)
             Button("Switch Repository…") {
                 NotificationCenter.default.post(name: .alasOpenRepoSelector, object: nil)
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1492,6 +1492,25 @@ final class AppState {
         return nil
     }
 
+    var canFocusMainWorktreeForCurrentProject: Bool {
+        mainWorktreeForCurrentProject() != nil
+    }
+
+    func focusMainWorktreeForCurrentProject() {
+        guard let main = mainWorktreeForCurrentProject() else { return }
+        selectedWorktreeId = main.id
+    }
+
+    private func mainWorktreeForCurrentProject() -> Worktree? {
+        guard let current = selectedWorktreeId else { return nil }
+        for project in projects {
+            let visible = projectsManager.visibleWorktrees(projectId: project.id)
+            guard visible.contains(where: { $0.id == current }) else { continue }
+            return projectsManager.visibleMainWorktree(projectId: project.id)
+        }
+        return nil
+    }
+
     private func makeSearchEnvironment() -> SearchEnvironment {
         // Invariant: the two synchronous closures below are only invoked
         // from `SearchModel`, which is `@MainActor` — so `assumeIsolated`

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -125,6 +125,11 @@ final class ProjectsManager {
         return worktrees(projectId: projectId).filter { hidden.contains(canonical($0.path)) }
     }
 
+    func visibleMainWorktree(projectId: String) -> Worktree? {
+        guard let project = projects.first(where: { $0.id == projectId }) else { return nil }
+        return visibleWorktrees(projectId: projectId).first { isMainWorktree($0, project: project) }
+    }
+
     func reorderWorktree(projectId: String, fromIndex: Int, toIndex: Int) {
         guard let projectIndex = projects.firstIndex(where: { $0.id == projectId }),
               var rows = worktreesByProject[projectId],

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -353,67 +353,71 @@ private struct RootBaseHandlers: ViewModifier {
                 showNewWorktree = true
             }
         let d = c
+            .onReceive(NotificationCenter.default.publisher(for: .alasFocusMainWorktree)) { _ in
+                state.focusMainWorktreeForCurrentProject()
+            }
+        let e = d
             .onReceive(NotificationCenter.default.publisher(for: .alasNewTerminalTab)) { _ in
                 if let wt = selectedWorktree() { _ = try? state.openTerminalTab(for: wt) }
             }
-        let e = d
+        let f = e
             .onReceive(NotificationCenter.default.publisher(for: .alasCloseTab)) { _ in
                 if let wt = selectedWorktree() {
                     state.handleCloseShortcut(worktreeId: wt.id)
                 }
             }
-        let f = e
+        let g = f
             .onReceive(NotificationCenter.default.publisher(for: .alasActivateTabByNumber)) { notification in
                 guard let number = notification.object as? Int,
                       let wt = selectedWorktree() else { return }
                 state.tabs.activateTabNumber(number, worktreeId: wt.id)
             }
-        let g = f
+        let h = g
             .onReceive(NotificationCenter.default.publisher(for: .alasSaveActiveTab)) { _ in
                 if let wt = selectedWorktree() {
                     state.saveActiveTab(worktreeId: wt.id)
                 }
             }
-        let h = g
+        let i = h
             .onReceive(NotificationCenter.default.publisher(for: .alasSaveActiveTabAs)) { _ in
                 if let wt = selectedWorktree() {
                     state.saveActiveTabAs(worktreeId: wt.id)
                 }
             }
-        let i = h
+        let j = i
             .onReceive(NotificationCenter.default.publisher(for: .alasSaveAllTabs)) { _ in
                 state.saveAllTabs()
             }
-        let j = i
+        let k = j
             .onReceive(NotificationCenter.default.publisher(for: .alasRevertActiveTab)) { _ in
                 if let wt = selectedWorktree() {
                     state.revertActiveTab(worktreeId: wt.id)
                 }
             }
-        let k = j
+        let l = k
             .onReceive(NotificationCenter.default.publisher(for: .alasNewFile)) { _ in
                 if let wt = selectedWorktree() {
                     state.newFile(in: wt.id)
                 }
             }
-        let l = k
+        let m = l
             .onReceive(NotificationCenter.default.publisher(for: .alasRenameActiveFile)) { _ in
                 if let wt = selectedWorktree() {
                     state.renameActiveFile(worktreeId: wt.id)
                 }
             }
-        let m = l
+        let n = m
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenSettings)) { _ in
                 openSettings()
             }
-        let n = m
+        let o = n
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenSearch)) { _ in
                 // Close the repo selector so the two overlays never overlap;
                 // RepoSelectorDialog is mounted after FileSearchDialog and
                 // would otherwise keep capturing keys.
                 state.openSearchOverlay()
             }
-        let o = n
+        let p = o
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenRepoSelector)) { _ in
                 // Toggle: closing if already open, opening (and closing the
                 // file searcher) if not. We also call `search.close()` so an
@@ -421,11 +425,11 @@ private struct RootBaseHandlers: ViewModifier {
                 // continuing in the background under the new overlay.
                 state.toggleRepoSelectorOverlay()
             }
-        let p = o
+        let q = p
             .onReceive(NotificationCenter.default.publisher(for: .alasOpenAgentLauncher)) { _ in
                 state.toggleAgentLauncherOverlay(canOpen: selectedWorktree() != nil)
             }
-        let q = p
+        let r = q
             .onReceive(NotificationCenter.default.publisher(for: .alasRefreshWorktrees)) { _ in
                 let beforeIds = state.allWorktreeIds()
                 Task {
@@ -436,7 +440,7 @@ private struct RootBaseHandlers: ViewModifier {
                     state.cleanupMissingWorktrees(beforeIds: beforeIds)
                 }
             }
-        return q
+        return r
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                 state.stopAllProjectGitWatchers()
                 state.tabs.snapshotDirtyBuffersForQuit()
@@ -495,6 +499,7 @@ extension Notification.Name {
     static let alasToggleRightPane   = Notification.Name("AlasToggleRightPane")
     static let alasCreateProject     = Notification.Name("AlasCreateProject")
     static let alasNewWorktree       = Notification.Name("AlasNewWorktree")
+    static let alasFocusMainWorktree = Notification.Name("AlasFocusMainWorktree")
     static let alasRefreshWorktrees  = Notification.Name("AlasRefreshWorktrees")
     static let alasNewTerminalTab  = Notification.Name("AlasNewTerminalTab")
     static let alasOpenAgentLauncher = Notification.Name("AlasOpenAgentLauncher")

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -15,7 +15,7 @@ enum ShortcutGroup: String, CaseIterable, Sendable {
 enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     // Global
     case searchFiles, switchRepository, findAndReplace, toggleSidebar, toggleRightPane,
-         createProject, newWorktree, newTerminalTab, launchAgentTerminal,
+         createProject, newWorktree, focusMainWorktree, newTerminalTab, launchAgentTerminal,
          increaseFontSize, decreaseFontSize, resetFontSize
     // Code editor
     case splitSelectionIntoLines, toggleMarkdownPreview, commitInComposer
@@ -27,7 +27,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     var group: ShortcutGroup {
         switch self {
         case .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
-             .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal,
+             .createProject, .newWorktree, .focusMainWorktree, .newTerminalTab, .launchAgentTerminal,
              .increaseFontSize, .decreaseFontSize, .resetFontSize:
             return .global
         case .splitSelectionIntoLines, .toggleMarkdownPreview:
@@ -50,6 +50,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .toggleRightPane:          return "Toggle Right Sidebar"
         case .createProject:            return "Create Project"
         case .newWorktree:              return "New Worktree"
+        case .focusMainWorktree:        return "Focus Main Worktree"
         case .newTerminalTab:           return "New Terminal Tab"
         case .launchAgentTerminal:      return "Launch Agent Terminal"
         case .increaseFontSize:         return "Increase Font Size"
@@ -104,6 +105,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .toggleRightPane:          return .init(key: "b",          modifiers: [.command, .option])
         case .createProject:            return .init(key: "n",          modifiers: [.command, .shift])
         case .newWorktree:              return .init(key: "n",          modifiers: [.command, .option])
+        // Cmd+Shift+M is Toggle Markdown Preview; Cmd+Option+M is macOS Minimize All.
+        case .focusMainWorktree:        return .init(key: "m",          modifiers: [.command, .control])
         case .newTerminalTab:           return .init(key: "t",          modifiers: [.command])
         case .launchAgentTerminal:      return .init(key: "t",          modifiers: [.command, .option])
         case .increaseFontSize:         return .init(key: "=",          modifiers: [.command])

--- a/AlasTests/AppStateFocusMainWorktreeTests.swift
+++ b/AlasTests/AppStateFocusMainWorktreeTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite(.serialized)
+struct AppStateFocusMainWorktreeTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        let projectsFile: ProjectsFile
+
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+
+        func readIfExists<T: Decodable>(_ type: T.Type, from url: URL) throws -> T? {
+            if type == ProjectsFile.self {
+                return projectsFile as? T
+            }
+            if type == AppConfig.self {
+                return AppConfig.defaults as? T
+            }
+            return nil
+        }
+    }
+
+    private func makeState(project: ProjectConfig) -> AppState {
+        AppState(store: MemoryStore(projectsFile: ProjectsFile(projects: [project])))
+    }
+
+    private func worktree(path: String, branch: String, projectId: String = "p1") -> Worktree {
+        let url = URL(fileURLWithPath: path)
+        return Worktree(
+            id: Worktree.makeId(path: url),
+            projectId: projectId,
+            name: branch,
+            branch: branch,
+            path: url,
+            status: .clean,
+            lastActivity: Date()
+        )
+    }
+
+    @Test func focusesVisibleMainWorktreeForCurrentProject() {
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date()
+        )
+        let state = makeState(project: project)
+        let main = worktree(path: "/repo", branch: "main")
+        let feature = worktree(path: "/repo/wts/feature", branch: "feature")
+        state.projectsManager.insertOptimisticWorktree(feature)
+        state.projectsManager.insertOptimisticWorktree(main)
+        state.selectedWorktreeId = feature.id
+
+        state.focusMainWorktreeForCurrentProject()
+
+        #expect(state.selectedWorktreeId == main.id)
+        #expect(state.canFocusMainWorktreeForCurrentProject)
+    }
+
+    @Test func focusMainWorktreeNoOpsWhenMainIsNotVisible() {
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date(),
+            hiddenWorktreePaths: ["/repo"]
+        )
+        let state = makeState(project: project)
+        let main = worktree(path: "/repo", branch: "main")
+        let feature = worktree(path: "/repo/wts/feature", branch: "feature")
+        state.projectsManager.insertOptimisticWorktree(feature)
+        state.projectsManager.insertOptimisticWorktree(main)
+        state.selectedWorktreeId = feature.id
+
+        state.focusMainWorktreeForCurrentProject()
+
+        #expect(state.selectedWorktreeId == feature.id)
+        #expect(!state.canFocusMainWorktreeForCurrentProject)
+    }
+}

--- a/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
+++ b/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
@@ -237,6 +237,26 @@ struct ProjectsManagerWorktreeOrderingTests {
         #expect(mgr.visibleWorktrees(projectId: project.id).map(\.branch) == ["main", "feat", "fix"])
     }
 
+    @Test func visibleMainWorktreeReturnsUnarchivedMainOnly() {
+        let main = wt(path: "/repo", branch: "main")
+        let feat = wt(path: "/repo/wts/feat", branch: "feat")
+        let project = ProjectConfig(
+            id: "p1",
+            name: "p1",
+            path: "/repo",
+            color: "blue",
+            addedAt: Date()
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+        seed(mgr, projectId: project.id, [feat, main])
+
+        #expect(mgr.visibleMainWorktree(projectId: project.id)?.id == main.id)
+
+        mgr.setWorktreeHidden(projectId: project.id, path: main.path, hidden: true)
+
+        #expect(mgr.visibleMainWorktree(projectId: project.id) == nil)
+    }
+
     @Test func archivedWorktreesAlsoHaveMainFirst() {
         let main = wt(path: "/repo", branch: "main")
         let feat = wt(path: "/repo/wts/feat", branch: "feat")

--- a/AlasTests/ShortcutActionTests.swift
+++ b/AlasTests/ShortcutActionTests.swift
@@ -27,6 +27,7 @@ struct ShortcutActionTests {
             (.toggleRightPane,      "b",          [.command, .option]),
             (.createProject,        "n",          [.command, .shift]),
             (.newWorktree,          "n",          [.command, .option]),
+            (.focusMainWorktree,    "m",          [.command, .control]),
             (.newTerminalTab,       "t",          [.command]),
             (.launchAgentTerminal,  "t",          [.command, .option]),
             (.increaseFontSize,     "=",          [.command]),
@@ -57,7 +58,7 @@ struct ShortcutActionTests {
         let global: Set<ShortcutAction> = [
             .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
             .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal,
-            .increaseFontSize, .decreaseFontSize, .resetFontSize,
+            .focusMainWorktree, .increaseFontSize, .decreaseFontSize, .resetFontSize,
         ]
         let codeEditor: Set<ShortcutAction> = [
             .splitSelectionIntoLines, .toggleMarkdownPreview,


### PR DESCRIPTION
## Summary
- add a Focus Main Worktree command in the Projects menu
- bind it to Cmd+Control+M because Cmd+Shift+M is already used for Markdown preview and Cmd+Option+M is a macOS minimize-all shortcut
- scope availability to the current selected worktree's project and no-op when the main worktree is not visible

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ShortcutActionTests -only-testing:AlasTests/ProjectsManagerWorktreeOrderingTests -only-testing:AlasTests/AppStateFocusMainWorktreeTests test
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build

Note: full xcodebuild test was attempted but sat in xcodebuild for about 10 minutes without launching the test runner or producing new output, so it was interrupted.