### PR TITLE
Add worktree empty state agent entrypoints

### DIFF
--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -36,9 +36,6 @@ struct AgentLauncherDialog: View {
             }
             .transition(.opacity.combined(with: .offset(y: -6)))
             .onAppear {
-                appState.agentLauncher.prepareForOpen(
-                    defaultMode: appState.config.agents.defaultLauncherMode
-                )
                 requestInputFocus()
             }
             .onChange(of: appState.isAgentLauncherOpen) { _, isOpen in

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -170,9 +170,14 @@ struct AlasApp: App {
             }
             .keyboardShortcut(state.shortcut(for: .newTerminalTab))
             Button("Launch Agent Terminal…") {
-                NotificationCenter.default.post(name: .alasOpenAgentLauncher, object: nil)
+                NotificationCenter.default.post(name: .alasOpenAgentLauncher, object: AppConfig.LauncherMode.terminal)
             }
             .keyboardShortcut(state.shortcut(for: .launchAgentTerminal))
+            .disabled(state.projects.isEmpty)
+            Button("Launch Agent Chat…") {
+                NotificationCenter.default.post(name: .alasOpenAgentLauncher, object: AppConfig.LauncherMode.acp)
+            }
+            .keyboardShortcut(state.shortcut(for: .launchAgentChat))
             .disabled(state.projects.isEmpty)
             Button("Close Tab") {
                 NotificationCenter.default.post(name: .alasCloseTab, object: nil)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -74,18 +74,24 @@ final class AppState {
         }
     }
 
+    func openAgentLauncherOverlay(mode: AppConfig.LauncherMode? = nil) {
+        search.close()
+        isSearchOpen = false
+        repoSelector.close()
+        isRepoSelectorOpen = false
+        agentLauncher.prepareForOpen(
+            defaultMode: mode ?? config.agents.defaultLauncherMode
+        )
+        isAgentLauncherOpen = true
+    }
+
     func toggleAgentLauncherOverlay(canOpen: Bool) {
         guard canOpen else { return }
         if isAgentLauncherOpen {
             agentLauncher.reset()
             isAgentLauncherOpen = false
         } else {
-            search.close()
-            isSearchOpen = false
-            repoSelector.close()
-            isRepoSelectorOpen = false
-            agentLauncher.reset()
-            isAgentLauncherOpen = true
+            openAgentLauncherOverlay(mode: nil)
         }
     }
 

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -214,7 +214,14 @@ struct RootView: View {
                 }
             )
         case .empty:
-            EmptyTabView(onNewTerminal: {})
+            EmptyTabView(
+                onNewTerminal: {},
+                onNewAgentTerminal: {},
+                onNewAgentChat: {},
+                newTerminalShortcut: nil,
+                newAgentTerminalShortcut: nil,
+                newAgentChatShortcut: nil
+            )
         }
     }
 
@@ -426,8 +433,10 @@ private struct RootBaseHandlers: ViewModifier {
                 state.toggleRepoSelectorOverlay()
             }
         let q = p
-            .onReceive(NotificationCenter.default.publisher(for: .alasOpenAgentLauncher)) { _ in
-                state.toggleAgentLauncherOverlay(canOpen: selectedWorktree() != nil)
+            .onReceive(NotificationCenter.default.publisher(for: .alasOpenAgentLauncher)) { notification in
+                guard selectedWorktree() != nil else { return }
+                let mode = notification.object as? AppConfig.LauncherMode
+                state.openAgentLauncherOverlay(mode: mode)
             }
         let r = q
             .onReceive(NotificationCenter.default.publisher(for: .alasRefreshWorktrees)) { _ in

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -89,7 +89,14 @@ struct CenterPaneView: View {
             )
             Group {
                 if tabs.isEmpty {
-                    EmptyTabView(onNewTerminal: openTerminal)
+                    EmptyTabView(
+                        onNewTerminal: openTerminal,
+                        onNewAgentTerminal: { state.openAgentLauncherOverlay(mode: .terminal) },
+                        onNewAgentChat: { state.openAgentLauncherOverlay(mode: .acp) },
+                        newTerminalShortcut: state.binding(for: .newTerminalTab)?.displayString,
+                        newAgentTerminalShortcut: state.binding(for: .launchAgentTerminal)?.displayString,
+                        newAgentChatShortcut: state.binding(for: .launchAgentChat)?.displayString
+                    )
                 } else if let activeId = active,
                           let tab = tabs.first(where: { $0.id == activeId }) {
                     switch tab {

--- a/Alas/Sources/Center/EmptyTabView.swift
+++ b/Alas/Sources/Center/EmptyTabView.swift
@@ -2,10 +2,15 @@ import SwiftUI
 
 struct EmptyTabView: View {
     let onNewTerminal: () -> Void
+    let onNewAgentTerminal: () -> Void
+    let onNewAgentChat: () -> Void
+    let newTerminalShortcut: String?
+    let newAgentTerminalShortcut: String?
+    let newAgentChatShortcut: String?
     @Environment(\.theme) var theme
 
     var body: some View {
-        VStack(spacing: 14) {
+        VStack(spacing: 16) {
             ZStack {
                 LinearGradient(colors: [theme.color("bg-3"), theme.color("bg-2")],
                                startPoint: .topLeading, endPoint: .bottomTrailing)
@@ -15,15 +20,100 @@ struct EmptyTabView: View {
                     .font(.system(size: 30))
                     .foregroundColor(theme.color("accent"))
             }
-            Text("No tabs open")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(theme.color("fg"))
-            Text("Open a terminal to start working in this worktree.")
-                .font(.system(size: 12))
-                .foregroundColor(theme.color("fg-dim"))
-            AlasButton(title: "New terminal", icon: "terminal", style: .primary, action: onNewTerminal)
+            VStack(spacing: 5) {
+                Text("No tabs open")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                Text("Choose how to start working in this worktree.")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            VStack(spacing: 8) {
+                EmptyTabActionRow(
+                    icon: "terminal",
+                    title: "New Terminal",
+                    subtitle: "Open a shell in this worktree",
+                    shortcut: newTerminalShortcut,
+                    action: onNewTerminal
+                )
+                EmptyTabActionRow(
+                    icon: "sparkle",
+                    title: "New Agent Terminal",
+                    subtitle: "Pick an enabled agent to run in a terminal",
+                    shortcut: newAgentTerminalShortcut,
+                    action: onNewAgentTerminal
+                )
+                EmptyTabActionRow(
+                    icon: "sparkle",
+                    title: "New Agent Chat",
+                    subtitle: "Pick an ACP-capable agent for chat",
+                    shortcut: newAgentChatShortcut,
+                    action: onNewAgentChat
+                )
+            }
+            .frame(maxWidth: 420)
+            .padding(.horizontal, 24)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(theme.color("bg-1"))
+    }
+}
+
+private struct EmptyTabActionRow: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+    let shortcut: String?
+    let action: () -> Void
+    @Environment(\.theme) var theme
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Icon(name: icon, size: 14,
+                     color: hovering ? theme.color("fg") : theme.color("fg-muted"))
+                    .frame(width: 20)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(theme.color("fg"))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-faint"))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+                .layoutPriority(1)
+                Spacer(minLength: 12)
+                if let shortcut {
+                    Text(shortcut)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.color("fg-muted"))
+                        .padding(.horizontal, 6)
+                        .frame(height: 21)
+                        .background(theme.color("bg-2"))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 5)
+                                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .fixedSize(horizontal: true, vertical: false)
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 48)
+            .background(hovering ? theme.color("bg-3") : theme.color("bg-2").opacity(0.55))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
     }
 }

--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -102,16 +102,22 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// `xcrun --find sourcekit-lsp` synchronously on the main actor — on
     /// every SwiftUI breadcrumb re-render. Cleared whenever the registry
     /// changes (the only thing that can change the answer).
-    private var cachedAvailability = LanguageServerAvailability()
+    private let makeAvailability: () -> LanguageServerAvailability
+    private var cachedAvailability: LanguageServerAvailability
     private var availabilityCache: [String: LanguageServerAvailability.Status] = [:]
 
-    init(registry: LanguageServerRegistry) {
+    init(
+        registry: LanguageServerRegistry,
+        makeAvailability: @escaping () -> LanguageServerAvailability = { LanguageServerAvailability() }
+    ) {
         self.registry = registry
+        self.makeAvailability = makeAvailability
+        self.cachedAvailability = makeAvailability()
     }
 
     func updateRegistry(_ registry: LanguageServerRegistry) {
         self.registry = registry
-        cachedAvailability = LanguageServerAvailability()
+        cachedAvailability = makeAvailability()
         availabilityCache.removeAll()
     }
 
@@ -182,7 +188,7 @@ final class WorkspaceLSPManager: DocumentFormatter {
             ready = existing.ready
             isFirstOpener = false
         } else {
-            let availability = LanguageServerAvailability()
+            let availability = makeAvailability()
             switch availability.status(for: entry) {
             case .disabled, .notInstalled:
                 return nil
@@ -196,7 +202,13 @@ final class WorkspaceLSPManager: DocumentFormatter {
             case .available:
                 break
             }
-            let spawn = Self.resolveSpawn(command: entry.command, args: entry.args, env: entry.env, language: entry.language)
+            let spawn = Self.resolveSpawn(
+                command: entry.command,
+                args: entry.args,
+                env: entry.env,
+                language: entry.language,
+                availability: availability
+            )
             let transport = LSPTransport(executable: spawn.executable, arguments: spawn.arguments, environment: spawn.environment)
             let newClient = LSPClient(transport: transport, language: languageId, rootURI: lspRoot.lspURI)
             let task = Task<Bool, Never> {
@@ -808,12 +820,17 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// returns an absolute path, we use it directly instead of wrapping
     /// with `/usr/bin/env` — that ensures `sourcekit-lsp` launches even
     /// when it lives inside Xcode.app and isn't on PATH.
-    private static func resolveSpawn(command: String, args: [String], env: [String: String], language: String) -> Spawn {
+    private static func resolveSpawn(
+        command: String,
+        args: [String],
+        env: [String: String],
+        language: String,
+        availability: LanguageServerAvailability
+    ) -> Spawn {
         let probe = LanguageServerConfig(
             language: language, extensions: [], command: command, args: args,
             env: env, rootMarkers: [], enabled: true
         )
-        let availability = LanguageServerAvailability()
         if command.contains("/") {
             return Spawn(
                 executable: URL(fileURLWithPath: command),

--- a/Alas/Sources/Shortcuts/ShortcutAction.swift
+++ b/Alas/Sources/Shortcuts/ShortcutAction.swift
@@ -15,7 +15,7 @@ enum ShortcutGroup: String, CaseIterable, Sendable {
 enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     // Global
     case searchFiles, switchRepository, findAndReplace, toggleSidebar, toggleRightPane,
-         createProject, newWorktree, focusMainWorktree, newTerminalTab, launchAgentTerminal,
+         createProject, newWorktree, focusMainWorktree, newTerminalTab, launchAgentTerminal, launchAgentChat,
          increaseFontSize, decreaseFontSize, resetFontSize
     // Code editor
     case splitSelectionIntoLines, toggleMarkdownPreview, commitInComposer
@@ -27,7 +27,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
     var group: ShortcutGroup {
         switch self {
         case .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
-             .createProject, .newWorktree, .focusMainWorktree, .newTerminalTab, .launchAgentTerminal,
+             .createProject, .newWorktree, .focusMainWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
              .increaseFontSize, .decreaseFontSize, .resetFontSize:
             return .global
         case .splitSelectionIntoLines, .toggleMarkdownPreview:
@@ -53,6 +53,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .focusMainWorktree:        return "Focus Main Worktree"
         case .newTerminalTab:           return "New Terminal Tab"
         case .launchAgentTerminal:      return "Launch Agent Terminal"
+        case .launchAgentChat:          return "Launch Agent Chat"
         case .increaseFontSize:         return "Increase Font Size"
         case .decreaseFontSize:         return "Decrease Font Size"
         case .resetFontSize:            return "Reset Font Size"
@@ -76,7 +77,8 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         switch self {
         case .searchFiles:        return "Open the file search"
         case .switchRepository:   return "Open the repository picker"
-        case .launchAgentTerminal: return "Open the agent launcher"
+        case .launchAgentTerminal: return "Open the agent launcher in Terminal mode"
+        case .launchAgentChat:     return "Open the agent launcher in Chat mode"
         case .commitInComposer:   return "In the draft commit tab"
         default:                  return nil
         }
@@ -109,6 +111,7 @@ enum ShortcutAction: String, CaseIterable, Codable, Sendable {
         case .focusMainWorktree:        return .init(key: "m",          modifiers: [.command, .control])
         case .newTerminalTab:           return .init(key: "t",          modifiers: [.command])
         case .launchAgentTerminal:      return .init(key: "t",          modifiers: [.command, .option])
+        case .launchAgentChat:          return .init(key: "t",          modifiers: [.command, .option, .shift])
         case .increaseFontSize:         return .init(key: "=",          modifiers: [.command])
         case .decreaseFontSize:         return .init(key: "-",          modifiers: [.command])
         case .resetFontSize:            return .init(key: "0",          modifiers: [.command])

--- a/AlasTests/ACP/Adapter/ClaudeCodeACPInstallerTests.swift
+++ b/AlasTests/ACP/Adapter/ClaudeCodeACPInstallerTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite("ClaudeCodeACPInstaller")
 struct ClaudeCodeACPInstallerTests {
-    @Test("install runs `npm install -g @zed-industries/claude-code-acp`")
+    @Test("install runs `npm install -g @agentclientprotocol/claude-agent-acp`")
     func install() async {
         var capturedCommand: [String] = []
         let installer = ClaudeCodeACPInstaller(runner: { cmd, args in
@@ -15,6 +15,6 @@ struct ClaudeCodeACPInstallerTests {
         #expect(capturedCommand.contains("npm"))
         #expect(capturedCommand.contains("install"))
         #expect(capturedCommand.contains("-g"))
-        #expect(capturedCommand.contains("@zed-industries/claude-code-acp"))
+        #expect(capturedCommand.contains("@agentclientprotocol/claude-agent-acp"))
     }
 }

--- a/AlasTests/AppStateOverlayTests.swift
+++ b/AlasTests/AppStateOverlayTests.swift
@@ -51,4 +51,68 @@ struct AppStateOverlayTests {
         #expect(!state.isAgentLauncherOpen)
         #expect(state.agentLauncher.query == "")
     }
+
+    @Test func openingAgentLauncherWithExplicitTerminalModeOverridesDefault() {
+        let state = AppState(store: MemoryStore())
+        state.config.agents.defaultLauncherMode = .acp
+        state.isSearchOpen = true
+        state.isRepoSelectorOpen = true
+        state.agentLauncher.query = "codex"
+        state.agentLauncher.selectedIndex = 4
+
+        state.openAgentLauncherOverlay(mode: .terminal)
+
+        #expect(state.isAgentLauncherOpen)
+        #expect(!state.isSearchOpen)
+        #expect(!state.isRepoSelectorOpen)
+        #expect(state.agentLauncher.mode == .terminal)
+        #expect(state.agentLauncher.query == "")
+        #expect(state.agentLauncher.selectedIndex == 0)
+        #expect(state.config.agents.defaultLauncherMode == .acp)
+    }
+
+    @Test func openingAgentLauncherWithExplicitChatModeOverridesDefault() {
+        let state = AppState(store: MemoryStore())
+        state.config.agents.defaultLauncherMode = .terminal
+
+        state.openAgentLauncherOverlay(mode: .acp)
+
+        #expect(state.isAgentLauncherOpen)
+        #expect(state.agentLauncher.mode == .acp)
+        #expect(state.config.agents.defaultLauncherMode == .terminal)
+    }
+
+    @Test func openingAgentLauncherWithoutModeUsesConfiguredDefault() {
+        let state = AppState(store: MemoryStore())
+        state.config.agents.defaultLauncherMode = .acp
+
+        state.openAgentLauncherOverlay(mode: nil)
+
+        #expect(state.isAgentLauncherOpen)
+        #expect(state.agentLauncher.mode == .acp)
+    }
+
+    @Test func toggleAgentLauncherClosedOpensUsingConfiguredDefault() {
+        let state = AppState(store: MemoryStore())
+        state.config.agents.defaultLauncherMode = .acp
+
+        state.toggleAgentLauncherOverlay(canOpen: true)
+
+        #expect(state.isAgentLauncherOpen)
+        #expect(state.agentLauncher.mode == .acp)
+    }
+
+    @Test func toggleAgentLauncherOpenClosesAndResets() {
+        let state = AppState(store: MemoryStore())
+        state.isAgentLauncherOpen = true
+        state.agentLauncher.mode = .acp
+        state.agentLauncher.query = "claude"
+        state.agentLauncher.selectedIndex = 3
+
+        state.toggleAgentLauncherOverlay(canOpen: true)
+
+        #expect(!state.isAgentLauncherOpen)
+        #expect(state.agentLauncher.query == "")
+        #expect(state.agentLauncher.selectedIndex == 0)
+    }
 }

--- a/AlasTests/ShortcutActionTests.swift
+++ b/AlasTests/ShortcutActionTests.swift
@@ -30,6 +30,7 @@ struct ShortcutActionTests {
             (.focusMainWorktree,    "m",          [.command, .control]),
             (.newTerminalTab,       "t",          [.command]),
             (.launchAgentTerminal,  "t",          [.command, .option]),
+            (.launchAgentChat,      "t",          [.command, .option, .shift]),
             (.increaseFontSize,     "=",          [.command]),
             (.decreaseFontSize,     "-",          [.command]),
             (.resetFontSize,        "0",          [.command]),
@@ -57,7 +58,7 @@ struct ShortcutActionTests {
     @Test func groupAssignmentsMatchSpec() {
         let global: Set<ShortcutAction> = [
             .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
-            .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal,
+            .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
             .focusMainWorktree, .increaseFontSize, .decreaseFontSize, .resetFontSize,
         ]
         let codeEditor: Set<ShortcutAction> = [

--- a/AlasTests/ShortcutResolverTests.swift
+++ b/AlasTests/ShortcutResolverTests.swift
@@ -65,6 +65,13 @@ struct ShortcutResolverTests {
         #expect(conflict == nil)
     }
 
+    @Test func conflictDetectsAgentChatDefaultBinding() async {
+        let state = makeState()
+        let binding = ShortcutBinding(key: "t", modifiers: [.command, .option, .shift])
+        let conflict = state.conflict(for: binding, excluding: .searchFiles)
+        #expect(conflict == .launchAgentChat)
+    }
+
     @Test func conflictNilWhenNoneFound() async {
         let state = makeState()
         let weird = ShortcutBinding(key: "j", modifiers: [.command, .control, .shift])

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -27,7 +27,17 @@ struct WorkspaceLSPManagerStatusTests {
                 enabled: true
             )
         ])
-        return WorkspaceLSPManager(registry: registry)
+        return WorkspaceLSPManager(
+            registry: registry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: [:],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in .allowed }
+                )
+            }
+        )
     }
 
     @Test func documentStatusIsNoneBeforeOpen() {

--- a/docs/superpowers/plans/2026-05-27-worktree-empty-state-agent-entrypoints.md
+++ b/docs/superpowers/plans/2026-05-27-worktree-empty-state-agent-entrypoints.md
@@ -1,0 +1,583 @@
+# Worktree Empty State Agent Entrypoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the worktree empty-state single terminal button with command rows for normal terminal, agent terminal, and agent chat, and add a dedicated shortcut for launching agent chat.
+
+**Architecture:** Reuse the existing `AgentLauncherDialog` and `AgentLauncherModel`; add AppState APIs that open the launcher with an optional requested mode. Keep tab creation paths unchanged: normal terminal still calls `openTerminalTab`, agent terminal still calls `openAgentTerminalTab`, and agent chat still calls `openNewACPSession`.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Observation, Swift Testing, existing Alas shortcut and theme systems.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/Shortcuts/ShortcutAction.swift`: add the new global shortcut action `launchAgentChat`.
+- Modify `AlasTests/ShortcutActionTests.swift`: update default binding and group expectations.
+- Modify `AlasTests/ShortcutResolverTests.swift`: prove the new shortcut participates in conflict detection.
+- Modify `Alas/Sources/App/AppState.swift`: add `openAgentLauncherOverlay(mode:)` and update `toggleAgentLauncherOverlay(canOpen:)` to use it.
+- Modify `Alas/Sources/Agents/AgentLauncherDialog.swift`: stop reapplying the configured default mode on appear.
+- Modify `AlasTests/AppStateOverlayTests.swift`: cover explicit Terminal mode, explicit Chat mode, and default-mode behavior.
+- Modify `Alas/Sources/App/AlasApp.swift`: add the new menu command and shortcut.
+- Modify `Alas/Sources/App/RootView.swift`: route agent launcher notifications with optional mode payloads.
+- Modify `Alas/Sources/Center/EmptyTabView.swift`: replace the single button with themed command rows.
+- Modify `Alas/Sources/Center/CenterPaneView.swift`: wire empty-state callbacks and effective shortcut labels.
+
+## Task 1: Add Agent Chat Shortcut Model
+
+**Files:**
+- Modify: `Alas/Sources/Shortcuts/ShortcutAction.swift`
+- Test: `AlasTests/ShortcutActionTests.swift`
+- Test: `AlasTests/ShortcutResolverTests.swift`
+
+- [ ] **Step 1: Write failing shortcut tests**
+
+In `AlasTests/ShortcutActionTests.swift`, update the `expected` array in `defaultsMatchAlasAppValues()` to include `.launchAgentChat` immediately after `.launchAgentTerminal`:
+
+```swift
+(.newTerminalTab,       "t",          [.command]),
+(.launchAgentTerminal,  "t",          [.command, .option]),
+(.launchAgentChat,      "t",          [.command, .option, .shift]),
+(.increaseFontSize,     "=",          [.command]),
+```
+
+In the same file, update the `global` set in `groupAssignmentsMatchSpec()`:
+
+```swift
+let global: Set<ShortcutAction> = [
+    .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
+    .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
+    .increaseFontSize, .decreaseFontSize, .resetFontSize,
+]
+```
+
+In `AlasTests/ShortcutResolverTests.swift`, add this test before `conflictNilWhenNoneFound()`:
+
+```swift
+@Test func conflictDetectsAgentChatDefaultBinding() async {
+    let state = makeState()
+    let binding = ShortcutBinding(key: "t", modifiers: [.command, .option, .shift])
+    let conflict = state.conflict(for: binding, excluding: .searchFiles)
+    #expect(conflict == .launchAgentChat)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ShortcutActionTests -only-testing:AlasTests/ShortcutResolverTests test
+```
+
+Expected: compile failure because `ShortcutAction.launchAgentChat` does not exist.
+
+- [ ] **Step 3: Implement the shortcut action**
+
+In `Alas/Sources/Shortcuts/ShortcutAction.swift`, add `launchAgentChat` to the global action cases:
+
+```swift
+case searchFiles, switchRepository, findAndReplace, toggleSidebar, toggleRightPane,
+     createProject, newWorktree, newTerminalTab, launchAgentTerminal, launchAgentChat,
+     increaseFontSize, decreaseFontSize, resetFontSize
+```
+
+Update the `group` switch global cases:
+
+```swift
+case .searchFiles, .switchRepository, .findAndReplace, .toggleSidebar, .toggleRightPane,
+     .createProject, .newWorktree, .newTerminalTab, .launchAgentTerminal, .launchAgentChat,
+     .increaseFontSize, .decreaseFontSize, .resetFontSize:
+    return .global
+```
+
+Update `label`:
+
+```swift
+case .launchAgentChat:          return "Launch Agent Chat"
+```
+
+Update `description`:
+
+```swift
+case .launchAgentTerminal: return "Open the agent launcher in Terminal mode"
+case .launchAgentChat:     return "Open the agent launcher in Chat mode"
+```
+
+Update `defaultBinding`:
+
+```swift
+case .launchAgentTerminal:      return .init(key: "t",          modifiers: [.command, .option])
+case .launchAgentChat:          return .init(key: "t",          modifiers: [.command, .option, .shift])
+case .increaseFontSize:         return .init(key: "=",          modifiers: [.command])
+```
+
+- [ ] **Step 4: Run shortcut tests to verify they pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ShortcutActionTests -only-testing:AlasTests/ShortcutResolverTests test
+```
+
+Expected: both test suites pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add Alas/Sources/Shortcuts/ShortcutAction.swift AlasTests/ShortcutActionTests.swift AlasTests/ShortcutResolverTests.swift
+rtk git commit -m "Add agent chat launcher shortcut"
+```
+
+## Task 2: Add Scoped Agent Launcher Opening
+
+**Files:**
+- Modify: `Alas/Sources/App/AppState.swift`
+- Test: `AlasTests/AppStateOverlayTests.swift`
+
+- [ ] **Step 1: Write failing AppState overlay tests**
+
+Append these tests to `AlasTests/AppStateOverlayTests.swift`:
+
+```swift
+@Test func openingAgentLauncherWithExplicitTerminalModeOverridesDefault() {
+    let state = AppState(store: MemoryStore())
+    state.config.agents.defaultLauncherMode = .acp
+    state.isSearchOpen = true
+    state.isRepoSelectorOpen = true
+    state.agentLauncher.query = "codex"
+    state.agentLauncher.selectedIndex = 4
+
+    state.openAgentLauncherOverlay(mode: .terminal)
+
+    #expect(state.isAgentLauncherOpen)
+    #expect(!state.isSearchOpen)
+    #expect(!state.isRepoSelectorOpen)
+    #expect(state.agentLauncher.mode == .terminal)
+    #expect(state.agentLauncher.query == "")
+    #expect(state.agentLauncher.selectedIndex == 0)
+    #expect(state.config.agents.defaultLauncherMode == .acp)
+}
+
+@Test func openingAgentLauncherWithExplicitChatModeOverridesDefault() {
+    let state = AppState(store: MemoryStore())
+    state.config.agents.defaultLauncherMode = .terminal
+
+    state.openAgentLauncherOverlay(mode: .acp)
+
+    #expect(state.isAgentLauncherOpen)
+    #expect(state.agentLauncher.mode == .acp)
+    #expect(state.config.agents.defaultLauncherMode == .terminal)
+}
+
+@Test func openingAgentLauncherWithoutModeUsesConfiguredDefault() {
+    let state = AppState(store: MemoryStore())
+    state.config.agents.defaultLauncherMode = .acp
+
+    state.openAgentLauncherOverlay(mode: nil)
+
+    #expect(state.isAgentLauncherOpen)
+    #expect(state.agentLauncher.mode == .acp)
+}
+
+@Test func toggleAgentLauncherClosedOpensUsingConfiguredDefault() {
+    let state = AppState(store: MemoryStore())
+    state.config.agents.defaultLauncherMode = .acp
+
+    state.toggleAgentLauncherOverlay(canOpen: true)
+
+    #expect(state.isAgentLauncherOpen)
+    #expect(state.agentLauncher.mode == .acp)
+}
+
+@Test func toggleAgentLauncherOpenClosesAndResets() {
+    let state = AppState(store: MemoryStore())
+    state.isAgentLauncherOpen = true
+    state.agentLauncher.mode = .acp
+    state.agentLauncher.query = "claude"
+    state.agentLauncher.selectedIndex = 3
+
+    state.toggleAgentLauncherOverlay(canOpen: true)
+
+    #expect(!state.isAgentLauncherOpen)
+    #expect(state.agentLauncher.query == "")
+    #expect(state.agentLauncher.selectedIndex == 0)
+}
+```
+
+- [ ] **Step 2: Run overlay tests to verify they fail**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AppStateOverlayTests test
+```
+
+Expected: compile failure because `openAgentLauncherOverlay(mode:)` does not exist.
+
+- [ ] **Step 3: Implement scoped launcher opening**
+
+In `Alas/Sources/App/AppState.swift`, replace `toggleAgentLauncherOverlay(canOpen:)` with this pair of methods:
+
+```swift
+func openAgentLauncherOverlay(mode: AppConfig.LauncherMode? = nil) {
+    search.close()
+    isSearchOpen = false
+    repoSelector.close()
+    isRepoSelectorOpen = false
+    agentLauncher.prepareForOpen(
+        defaultMode: mode ?? config.agents.defaultLauncherMode
+    )
+    isAgentLauncherOpen = true
+}
+
+func toggleAgentLauncherOverlay(canOpen: Bool) {
+    guard canOpen else { return }
+    if isAgentLauncherOpen {
+        agentLauncher.reset()
+        isAgentLauncherOpen = false
+    } else {
+        openAgentLauncherOverlay(mode: nil)
+    }
+}
+```
+
+- [ ] **Step 4: Stop AgentLauncherDialog from re-preparing on appear**
+
+In `Alas/Sources/Agents/AgentLauncherDialog.swift`, remove this block from `.onAppear`:
+
+```swift
+appState.agentLauncher.prepareForOpen(
+    defaultMode: appState.config.agents.defaultLauncherMode
+)
+```
+
+Keep the `requestInputFocus()` call, so the resulting `.onAppear` body is:
+
+```swift
+.onAppear {
+    requestInputFocus()
+}
+```
+
+This prevents an explicit `.terminal` or `.acp` request from being overwritten by the configured default when the dialog appears.
+
+- [ ] **Step 5: Run overlay tests to verify they pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AppStateOverlayTests test
+```
+
+Expected: AppState overlay tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add Alas/Sources/App/AppState.swift Alas/Sources/Agents/AgentLauncherDialog.swift AlasTests/AppStateOverlayTests.swift
+rtk git commit -m "Scope agent launcher opening by mode"
+```
+
+## Task 3: Route Agent Terminal and Agent Chat Commands
+
+**Files:**
+- Modify: `Alas/Sources/App/AlasApp.swift`
+- Modify: `Alas/Sources/App/RootView.swift`
+
+- [ ] **Step 1: Add command-menu route for Agent Chat**
+
+In `Alas/Sources/App/AlasApp.swift`, update the existing agent terminal command to pass Terminal mode:
+
+```swift
+Button("Launch Agent Terminal…") {
+    NotificationCenter.default.post(name: .alasOpenAgentLauncher, object: AppConfig.LauncherMode.terminal)
+}
+.keyboardShortcut(state.shortcut(for: .launchAgentTerminal))
+.disabled(state.projects.isEmpty)
+```
+
+Immediately after it, add:
+
+```swift
+Button("Launch Agent Chat…") {
+    NotificationCenter.default.post(name: .alasOpenAgentLauncher, object: AppConfig.LauncherMode.acp)
+}
+.keyboardShortcut(state.shortcut(for: .launchAgentChat))
+.disabled(state.projects.isEmpty)
+```
+
+- [ ] **Step 2: Route optional mode payloads in RootView**
+
+In `Alas/Sources/App/RootView.swift`, replace the `.alasOpenAgentLauncher` handler with:
+
+```swift
+let p = o
+    .onReceive(NotificationCenter.default.publisher(for: .alasOpenAgentLauncher)) { notification in
+        guard selectedWorktree() != nil else { return }
+        let mode = notification.object as? AppConfig.LauncherMode
+        state.openAgentLauncherOverlay(mode: mode)
+    }
+```
+
+Keep `static let alasOpenAgentLauncher = Notification.Name("AlasOpenAgentLauncher")` unchanged.
+
+- [ ] **Step 3: Run shortcut and overlay tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ShortcutActionTests -only-testing:AlasTests/ShortcutResolverTests -only-testing:AlasTests/AppStateOverlayTests test
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add Alas/Sources/App/AlasApp.swift Alas/Sources/App/RootView.swift
+rtk git commit -m "Route agent chat launcher command"
+```
+
+## Task 4: Replace Empty Worktree State With Command Rows
+
+**Files:**
+- Modify: `Alas/Sources/Center/EmptyTabView.swift`
+- Modify: `Alas/Sources/Center/CenterPaneView.swift`
+- Modify: `Alas/Sources/App/RootView.swift`
+
+- [ ] **Step 1: Update EmptyTabView API and UI**
+
+Replace the contents of `Alas/Sources/Center/EmptyTabView.swift` with:
+
+```swift
+import SwiftUI
+
+struct EmptyTabView: View {
+    let onNewTerminal: () -> Void
+    let onNewAgentTerminal: () -> Void
+    let onNewAgentChat: () -> Void
+    let newTerminalShortcut: String?
+    let newAgentTerminalShortcut: String?
+    let newAgentChatShortcut: String?
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ZStack {
+                LinearGradient(colors: [theme.color("bg-3"), theme.color("bg-2")],
+                               startPoint: .topLeading, endPoint: .bottomTrailing)
+                    .frame(width: 80, height: 80)
+                    .clipShape(RoundedRectangle(cornerRadius: 22))
+                Image(systemName: "airplane")
+                    .font(.system(size: 30))
+                    .foregroundColor(theme.color("accent"))
+            }
+            VStack(spacing: 5) {
+                Text("No tabs open")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                Text("Choose how to start working in this worktree.")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            VStack(spacing: 8) {
+                EmptyTabActionRow(
+                    icon: "terminal",
+                    title: "New Terminal",
+                    subtitle: "Open a shell in this worktree",
+                    shortcut: newTerminalShortcut,
+                    action: onNewTerminal
+                )
+                EmptyTabActionRow(
+                    icon: "sparkle",
+                    title: "New Agent Terminal",
+                    subtitle: "Pick an enabled agent to run in a terminal",
+                    shortcut: newAgentTerminalShortcut,
+                    action: onNewAgentTerminal
+                )
+                EmptyTabActionRow(
+                    icon: "sparkle",
+                    title: "New Agent Chat",
+                    subtitle: "Pick an ACP-capable agent for chat",
+                    shortcut: newAgentChatShortcut,
+                    action: onNewAgentChat
+                )
+            }
+            .frame(width: 420)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.color("bg-1"))
+    }
+}
+
+private struct EmptyTabActionRow: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+    let shortcut: String?
+    let action: () -> Void
+    @Environment(\.theme) var theme
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Icon(name: icon, size: 14,
+                     color: hovering ? theme.color("fg") : theme.color("fg-muted"))
+                    .frame(width: 20)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(theme.color("fg"))
+                    Text(subtitle)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-faint"))
+                }
+                Spacer(minLength: 12)
+                if let shortcut {
+                    Text(shortcut)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(theme.color("fg-muted"))
+                        .padding(.horizontal, 6)
+                        .frame(height: 21)
+                        .background(theme.color("bg-2"))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 5)
+                                .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 48)
+            .background(hovering ? theme.color("bg-3") : theme.color("bg-2").opacity(0.55))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+    }
+}
+```
+
+- [ ] **Step 2: Wire CenterPaneView callbacks and shortcuts**
+
+In `Alas/Sources/Center/CenterPaneView.swift`, replace:
+
+```swift
+EmptyTabView(onNewTerminal: openTerminal)
+```
+
+with:
+
+```swift
+EmptyTabView(
+    onNewTerminal: openTerminal,
+    onNewAgentTerminal: { state.openAgentLauncherOverlay(mode: .terminal) },
+    onNewAgentChat: { state.openAgentLauncherOverlay(mode: .acp) },
+    newTerminalShortcut: state.binding(for: .newTerminalTab)?.displayString,
+    newAgentTerminalShortcut: state.binding(for: .launchAgentTerminal)?.displayString,
+    newAgentChatShortcut: state.binding(for: .launchAgentChat)?.displayString
+)
+```
+
+In the `.empty` branch of `RootView.centerContent()`, replace:
+
+```swift
+EmptyTabView(onNewTerminal: {})
+```
+
+with:
+
+```swift
+EmptyTabView(
+    onNewTerminal: {},
+    onNewAgentTerminal: {},
+    onNewAgentChat: {},
+    newTerminalShortcut: nil,
+    newAgentTerminalShortcut: nil,
+    newAgentChatShortcut: nil
+)
+```
+
+- [ ] **Step 3: Compile to catch SwiftUI and icon issues**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add Alas/Sources/Center/EmptyTabView.swift Alas/Sources/Center/CenterPaneView.swift Alas/Sources/App/RootView.swift
+rtk git commit -m "Update worktree empty state entrypoints"
+```
+
+## Task 5: Full Verification
+
+**Files:**
+- No source edits unless verification finds a defect.
+
+- [ ] **Step 1: Regenerate project**
+
+Run:
+
+```bash
+rtk xcodegen
+```
+
+Expected: command succeeds. If `Alas.xcodeproj/project.pbxproj` changes, inspect the diff and include it in the final commit only if source membership changed.
+
+- [ ] **Step 2: Build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: test suite passes.
+
+- [ ] **Step 4: Manual UI check**
+
+Launch the app from Xcode or the built product and select a worktree with no open center tabs. Verify:
+
+- the empty state shows `New Terminal`, `New Agent Terminal`, and `New Agent Chat`;
+- shortcut chips are right-aligned;
+- `New Terminal` opens a shell immediately;
+- `New Agent Terminal` opens the launcher in Terminal mode;
+- `New Agent Chat` opens the launcher in Chat mode;
+- switching modes inside the launcher still works.
+
+- [ ] **Step 5: Inspect and commit verification fixes**
+
+Run:
+
+```bash
+rtk git status --short
+```
+
+Expected: no uncommitted changes. If verification produced changes, inspect them with `rtk git diff`, stage the exact source files shown by `git status`, and commit with:
+
+```bash
+rtk git commit -m "Fix worktree empty state verification issues"
+```

--- a/docs/superpowers/specs/2026-05-27-worktree-empty-state-agent-entrypoints-design.md
+++ b/docs/superpowers/specs/2026-05-27-worktree-empty-state-agent-entrypoints-design.md
@@ -1,0 +1,115 @@
+# Worktree Empty State Agent Entrypoints Design
+
+Date: 2026-05-27
+Status: Approved for implementation planning
+
+## Goal
+
+Update the center-pane empty state for a selected worktree so users can start work through three clear entrypoints:
+
+- a normal terminal,
+- an agent terminal,
+- an agent chat session.
+
+The agent-specific entrypoints should reuse the existing searchable agent launcher instead of introducing separate menus.
+
+## User Experience
+
+When a worktree has no open center tabs, the empty state remains centered but replaces the single `New terminal` button with a compact command list.
+
+The header reads `No tabs open`. The subtitle reads `Choose how to start working in this worktree.`
+
+The command rows are:
+
+- `New Terminal`: opens a normal shell in the selected worktree.
+- `New Agent Terminal`: opens the agent launcher in Terminal mode.
+- `New Agent Chat`: opens the agent launcher in Chat mode.
+
+Each row includes a leading icon, a primary label, a short secondary description, and a trailing shortcut chip when the corresponding shortcut has an effective binding. Shortcut chips are right-aligned so the labels form a stable left column and the keyboard hints scan as a separate right column.
+
+## Launcher Behavior
+
+The existing `AgentLauncherDialog` remains the only agent picker. Empty-state rows and global shortcuts open that dialog with a requested launch mode:
+
+- Terminal mode filters to enabled terminal agents and launches `openAgentTerminalTab(for:agentId:)`.
+- Chat mode filters to enabled ACP-capable agents and launches `openNewACPSession(agentID:)`.
+
+The requested mode should be the initial mode for that invocation, but the dialog should keep its Terminal/Chat segmented control available. Users can still switch modes inside the dialog if they entered through the wrong row or shortcut.
+
+The configured default launcher mode still applies to generic launcher openings that do not specify a mode.
+
+## Shortcuts
+
+The empty-state rows use the effective bindings from `AppState.binding(for:)`, so user overrides and unbound shortcuts are reflected in the UI.
+
+Existing shortcuts stay unchanged:
+
+- `New Terminal Tab`: `Command-T`
+- `Launch Agent Terminal`: `Command-Option-T`
+
+Add a new rebindable global shortcut action:
+
+- `Launch Agent Chat`: `Command-Option-Shift-T`
+
+The new action opens the agent launcher in Chat mode. It should appear in Settings > Shortcuts with the other Global actions and participate in existing shortcut conflict detection and terminal-reservation behavior.
+
+## Components
+
+### EmptyTabView
+
+`EmptyTabView` should accept separate callbacks for normal terminal, agent terminal launcher, and agent chat launcher. It should also accept optional shortcut display strings or bindings for the three rows.
+
+The row component should be local unless another nearby view already has a reusable command-row pattern. It should use the current theme colors and avoid card-heavy styling; these rows are commands, not content cards.
+
+### CenterPaneView
+
+`CenterPaneView` wires the empty-state rows to `AppState`:
+
+- normal terminal calls the existing `openTerminal()` helper,
+- agent terminal opens the launcher with `.terminal`,
+- agent chat opens the launcher with `.acp`,
+- shortcut strings come from the current effective shortcut bindings.
+
+### AppState and Launcher Model
+
+Add an API that opens the agent launcher with an optional requested mode. This should replace ad hoc mutation from views and preserve the current behavior of closing other overlays before showing the launcher.
+
+The launcher model should distinguish the one-shot requested mode from its normal reset state. Opening with a requested mode should not permanently overwrite `config.agents.defaultLauncherMode`.
+
+## Data Flow
+
+1. User clicks `New Agent Terminal` or presses the terminal launcher shortcut.
+2. `AppState` opens `AgentLauncherDialog` with requested mode `.terminal`.
+3. The launcher filters enabled agents for terminal launch.
+4. User selects an agent.
+5. The launcher calls `openAgentTerminalTab(for:agentId:)` for the selected worktree.
+
+Chat follows the same flow, except the requested mode is `.acp`, the list filters to ACP-capable enabled agents, and launch calls `openNewACPSession(agentID:)`.
+
+Normal terminal launch bypasses the agent launcher and creates a standard terminal tab immediately.
+
+## Error and Empty States
+
+The existing launcher empty states remain responsible for missing agents:
+
+- Terminal mode shows `No enabled agents`.
+- Chat mode shows `No ACP-capable agents enabled` and the existing Settings guidance.
+
+If there is no selected worktree when a launcher action fires, no launcher should open and no tab should be created. If the selected worktree changes while the launcher is open, launch uses the current selected worktree, matching existing behavior.
+
+## Tests
+
+Add focused Swift Testing coverage for:
+
+- the new `ShortcutAction.launchAgentChat` label, group, default binding, and shortcut classification,
+- shortcut conflict detection with the new action,
+- opening the launcher with an explicit Terminal mode,
+- opening the launcher with an explicit Chat mode,
+- generic launcher opening still using `config.agents.defaultLauncherMode`,
+- empty-state row configuration using effective shortcut bindings where practical.
+
+Existing agent terminal and ACP launch tests should continue to cover the actual tab creation paths.
+
+## Out of Scope
+
+This change does not add separate per-row menus, direct default-agent launching, new ACP provider support, or persistence changes for ACP sessions.


### PR DESCRIPTION
## Summary

- Add separate worktree empty-state entrypoints for new agent terminals and new agent chats, alongside the existing normal terminal option.
- Route launcher commands by mode so terminal and chat menus open the appropriate agent picker.
- Add shortcut coverage for launching a new agent chat pane.
- Make post-rebase test fixes for ACP installer expectations and LSP status tests after the latest `main` changes.

## Validation

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`