### PR TITLE
fix(lsp): narrow Gatekeeper check to quarantined binaries

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */; };
 		175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */; };
 		175D0A77579A022F3AB81E48 /* SQLiteDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5F20AB3B3F7BCEAA56B143 /* SQLiteDatabase.swift */; };
+		1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */; };
 		17BC1BC2D81DED8B5D31DF3C /* CommitsAheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576619C2726DFDE8F627AE19 /* CommitsAheadTests.swift */; };
 		17DE066D4BDD1F30439DA629 /* TerminalPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */; };
 		188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */; };
@@ -669,6 +670,7 @@
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
+		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */; };
 		F4B9A51A40365909B7644561 /* ShortcutsPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6821B71680094791995C4975 /* ShortcutsPane.swift */; };
@@ -1083,6 +1085,7 @@
 		89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionName.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
+		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
 		8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictColumnView.swift; sourceTree = "<group>"; };
 		8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulse.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
@@ -1238,6 +1241,7 @@
 		C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageTests.swift; sourceTree = "<group>"; };
 		C995611A6313FABE30508248 /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
 		C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentEditView.swift; sourceTree = "<group>"; };
+		C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediatorTests.swift; sourceTree = "<group>"; };
 		CA43AA9C8462D579E733B46C /* AppIntents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppIntents.framework; path = System/Library/Frameworks/AppIntents.framework; sourceTree = SDKROOT; };
 		CA554728676F9D3B5E2C05FA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroup.swift; sourceTree = "<group>"; };
@@ -2267,6 +2271,7 @@
 			isa = PBXGroup;
 			children = (
 				4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */,
+				8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */,
 				949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */,
 				09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */,
 				A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */,
@@ -2489,6 +2494,7 @@
 			isa = PBXGroup;
 			children = (
 				137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */,
+				C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */,
 				134EE8D2BC31085A504D27D8 /* InstallNudgeResolverTests.swift */,
 				A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */,
 				345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */,
@@ -3088,6 +3094,7 @@
 				93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */,
 				B064B59D40A47026CDDEB189 /* FuzzyMatch.swift in Sources */,
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
+				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
 				55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,
 				41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */,
@@ -3420,6 +3427,7 @@
 				3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */,
 				E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */,
 				0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */,
+				F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */,
 				8915EF49F1031BD55C419625 /* GeminiInstallerTests.swift in Sources */,
 				01D2A32A3366C5CF6A225004 /* GhosttyConfigBuilderTests.swift in Sources */,
 				D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */,

--- a/Alas/Sources/Code/Editor/BlockedNudgeBanner.swift
+++ b/Alas/Sources/Code/Editor/BlockedNudgeBanner.swift
@@ -2,15 +2,27 @@ import SwiftUI
 import AppKit
 
 /// Non-blocking banner shown above the editor when the file's language
-/// server is blocked by macOS Gatekeeper. Dismissal is per-`realPath` and
+/// server binary carries `com.apple.quarantine` — the xattr Tahoe's
+/// Gatekeeper checks before allowing a GUI-app spawn. Remediation is
+/// in-app: the Allow button calls `removexattr` and re-assesses. We
+/// never send users to System Settings → Privacy & Security because
+/// that pane is only populated once the OS has already logged a
+/// rejected spawn; our pre-flight skips the spawn, so the pane is
+/// empty when users land there. Dismissal is per-`realPath` and
 /// persisted in `AppConfig.code.dismissedInstallNudges` under the
-/// `blocked:<realPath>` namespace, so a `brew upgrade` (different inode,
-/// different cache result) re-shows it.
+/// `blocked:<realPath>` namespace.
 struct BlockedNudgeBanner: View {
     let appState: AppState
     let absolutePath: String
 
     @Environment(\.theme) var theme
+    @State private var remediationState: RemediationState = .idle
+
+    enum RemediationState: Equatable {
+        case idle
+        case running
+        case error(String)
+    }
 
     var body: some View {
         Group {
@@ -24,14 +36,26 @@ struct BlockedNudgeBanner: View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.shield")
                 .foregroundColor(theme.color("fg-dim"))
-            Text("\(nudge.displayName) language server blocked by macOS — approve it to enable diagnostics")
-                .font(.system(size: 12.5))
-            Spacer()
-            Button("Open Privacy & Security") {
-                openPrivacyAndSecurity()
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(nudge.displayName) language server blocked by macOS Gatekeeper")
+                    .font(.system(size: 12.5))
+                if case .error(let message) = remediationState {
+                    Text(message)
+                        .font(.system(size: 11))
+                        .foregroundColor(theme.color("fg-dim"))
+                }
             }
-            .buttonStyle(.plain)
-            .foregroundColor(theme.color("fg"))
+            Spacer()
+            if remediationState == .running {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Button("Allow") {
+                    Task { await remediate(nudge: nudge) }
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(theme.color("fg"))
+            }
             Button(action: { dismiss(key: nudge.dismissalKey) }) {
                 Image(systemName: "xmark")
                     .foregroundColor(theme.color("fg-dim"))
@@ -56,13 +80,19 @@ struct BlockedNudgeBanner: View {
         return resolver.nudgeData(forAbsolutePath: absolutePath)
     }
 
-    private func openPrivacyAndSecurity() {
-        // Anchored URL works on Sequoia+. If a future macOS removes the
-        // anchor, the bare URL still opens the right pane.
-        let anchored = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Allowed_eXecution")!
-        let plain = URL(string: "x-apple.systempreferences:com.apple.preference.security")!
-        if !NSWorkspace.shared.open(anchored) {
-            NSWorkspace.shared.open(plain)
+    private func remediate(nudge: BlockedNudgeData) async {
+        remediationState = .running
+        let outcome = await GatekeeperRemediator().remediate(realPath: nudge.realPath)
+        switch outcome {
+        case .allowed:
+            remediationState = .idle
+            // Wake up LSP for any open buffers in this language so
+            // diagnostics/hover start without a manual reopen.
+            appState.tabs.reopenLSPDocuments(forLanguage: nudge.language)
+        case .stillBlocked:
+            remediationState = .error("Quarantine removed but \(nudge.displayName) is still blocked. Try reinstalling it.")
+        case .failed(let message):
+            remediationState = .error(message)
         }
     }
 

--- a/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
+++ b/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
@@ -1,16 +1,20 @@
 import Foundation
 import Darwin
 
-/// Wraps `spctl --assess` for an LSP binary so we can pre-flight Gatekeeper
-/// before spawning a subprocess from a GUI app. On macOS Tahoe a GUI app
-/// spawning an ad-hoc-signed binary triggers a Gatekeeper popup the user
-/// must dismiss from System Settings; checking spctl first lets us skip the
-/// spawn and surface an in-app banner instead.
+/// Pre-flight Gatekeeper for an LSP binary by inspecting its
+/// `com.apple.quarantine` xattr. Tahoe's GUI-spawn Gatekeeper block fires
+/// for binaries the user "downloaded" (anything with quarantine on it),
+/// not for arbitrary ad-hoc-signed executables: the previous
+/// `spctl --assess --type execute` heuristic produced false positives
+/// across the board (every Homebrew script, every cargo-installed Rust
+/// binary, every node-script LSP comes back `rejected` even though the
+/// system would happily spawn them). Quarantine presence is the narrow,
+/// accurate signal — the same one the OS uses to decide whether to fire
+/// the System Settings prompt.
 ///
-/// Caches results by (realPath, mtime, inode). The first lookup per binary
-/// per session shells out to spctl (~150-300ms); later lookups are µs-fast
-/// cache reads. Callers run on the main actor — see the spec for the
-/// stutter trade-off.
+/// Caches results by (realPath, mtime, inode); the xattr check itself is
+/// already cheap, but caching keeps the cost off the main actor on the
+/// hot path of editor open / tab switch.
 @MainActor
 final class GatekeeperAssessor {
     enum Result: Equatable { case allowed, rejected, unknown }
@@ -18,8 +22,8 @@ final class GatekeeperAssessor {
     static let shared = GatekeeperAssessor()
 
     /// Throwing closure that returns the assessment for `realPath`. The
-    /// default runs `/usr/sbin/spctl --assess --type execute <path>` via
-    /// `Process`. Injected for tests.
+    /// default reads `com.apple.quarantine` via `getxattr(2)`: present →
+    /// `.rejected`, absent → `.allowed`. Injected for tests.
     typealias Runner = (_ realPath: String) throws -> Result
 
     private struct CacheEntry {
@@ -84,34 +88,15 @@ final class GatekeeperAssessor {
     }
 
     nonisolated static func defaultRunner(realPath: String) throws -> Result {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/sbin/spctl")
-        process.arguments = ["--assess", "--type", "execute", realPath]
-        let null = Pipe()
-        process.standardOutput = null
-        process.standardError = null
-
-        try process.run()
-        // spctl normally completes in well under a second. We bound the wait
-        // with a hard 2s ceiling so a wedged syspolicyd can't hang the UI.
-        let sema = DispatchSemaphore(value: 0)
-        DispatchQueue.global().async {
-            process.waitUntilExit()
-            sema.signal()
+        // getxattr returns the attribute size, or -1 on failure. On
+        // ENOATTR ("no such attribute") the file simply isn't quarantined.
+        // Any other errno is treated as the file being inaccessible —
+        // return .unknown so the availability layer falls open to
+        // .allowed rather than hiding a runnable LSP behind a banner.
+        let size = realPath.withCString { cpath in
+            getxattr(cpath, "com.apple.quarantine", nil, 0, 0, 0)
         }
-        let timedOut = sema.wait(timeout: .now() + 2.0) == .timedOut
-        if timedOut {
-            process.terminate()
-            return .unknown
-        }
-        // spctl(8): exit 0 = allowed, exit 3 = denied (Gatekeeper rejection).
-        // Other non-zero codes are operational errors (file unreadable, policy
-        // DB rebuild, etc.); fail open with .unknown so a flaky spctl doesn't
-        // hide a runnable LSP behind a banner.
-        switch process.terminationStatus {
-        case 0: return .allowed
-        case 3: return .rejected
-        default: return .unknown
-        }
+        if size >= 0 { return .rejected }
+        return errno == ENOATTR ? .allowed : .unknown
     }
 }

--- a/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
+++ b/Alas/Sources/Code/LSP/GatekeeperAssessor.swift
@@ -88,15 +88,37 @@ final class GatekeeperAssessor {
     }
 
     nonisolated static func defaultRunner(realPath: String) throws -> Result {
-        // getxattr returns the attribute size, or -1 on failure. On
-        // ENOATTR ("no such attribute") the file simply isn't quarantined.
-        // Any other errno is treated as the file being inaccessible —
-        // return .unknown so the availability layer falls open to
-        // .allowed rather than hiding a runnable LSP behind a banner.
+        // Probe size first. On ENOATTR the file simply isn't quarantined;
+        // any other errno means inaccessible — return .unknown so the
+        // availability layer falls open to .allowed rather than hiding a
+        // runnable LSP behind a banner.
         let size = realPath.withCString { cpath in
             getxattr(cpath, "com.apple.quarantine", nil, 0, 0, 0)
         }
-        if size >= 0 { return .rejected }
-        return errno == ENOATTR ? .allowed : .unknown
+        if size < 0 { return errno == ENOATTR ? .allowed : .unknown }
+        if size == 0 { return .unknown }
+
+        var buffer = [UInt8](repeating: 0, count: size)
+        let read = buffer.withUnsafeMutableBufferPointer { bufPtr -> Int in
+            realPath.withCString { cpath in
+                getxattr(cpath, "com.apple.quarantine", bufPtr.baseAddress, size, 0, 0)
+            }
+        }
+        if read < 0 { return .unknown }
+        guard let value = String(bytes: buffer[0..<read], encoding: .utf8) else { return .unknown }
+        return interpretQuarantineValue(value)
+    }
+
+    /// Parse the `com.apple.quarantine` xattr value. Format is
+    /// `flags;timestamp;agent;uuid` where `flags` is a hex bitfield.
+    /// Bit `0x40` (`LSQuarantineUserApproved`) is set after the user
+    /// approves the item via macOS Gatekeeper — the OS keeps the xattr
+    /// in place and only flips the flag, so treating "attribute present"
+    /// as a block would re-nudge after the user already approved.
+    nonisolated static func interpretQuarantineValue(_ value: String) -> Result {
+        let firstField = value.split(separator: ";", maxSplits: 1).first.map(String.init) ?? value
+        let trimmed = firstField.trimmingCharacters(in: .whitespaces)
+        guard let flags = UInt32(trimmed, radix: 16) else { return .unknown }
+        return (flags & 0x0040) != 0 ? .allowed : .rejected
     }
 }

--- a/Alas/Sources/Code/LSP/GatekeeperRemediator.swift
+++ b/Alas/Sources/Code/LSP/GatekeeperRemediator.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Orchestrates inline Gatekeeper remediation for a blocked LSP binary.
+///
+/// `GatekeeperAssessor` only flags binaries that carry the
+/// `com.apple.quarantine` xattr (the narrow signal Tahoe's GUI-spawn
+/// Gatekeeper actually acts on), so remediation is just removing that
+/// attribute and re-checking. No admin prompt, no `spctl --add` — those
+/// don't fix the actual block on Tahoe (and `spctl --add` is deprecated
+/// in modern macOS anyway).
+@MainActor
+final class GatekeeperRemediator {
+    enum Outcome: Equatable {
+        case allowed
+        case stillBlocked
+        case failed(String)
+    }
+
+    typealias QuarantineRemover = (_ realPath: String) async -> Bool
+    typealias Reassess = (_ realPath: String) -> GatekeeperAssessor.Result
+    typealias InvalidateCache = (_ realPath: String) -> Void
+
+    private let removeQuarantine: QuarantineRemover
+    private let reassess: Reassess
+    private let invalidate: InvalidateCache
+
+    init(
+        removeQuarantine: @escaping QuarantineRemover = GatekeeperRemediator.defaultRemoveQuarantine,
+        reassess: @escaping Reassess = { GatekeeperAssessor.shared.assess(realPath: $0) },
+        invalidate: @escaping InvalidateCache = { GatekeeperAssessor.shared.invalidate(realPath: $0) }
+    ) {
+        self.removeQuarantine = removeQuarantine
+        self.reassess = reassess
+        self.invalidate = invalidate
+    }
+
+    func remediate(realPath: String) async -> Outcome {
+        let removed = await removeQuarantine(realPath)
+        invalidate(realPath)
+        switch reassess(realPath) {
+        case .allowed:
+            return .allowed
+        case .rejected, .unknown:
+            return removed
+                ? .stillBlocked
+                : .failed("Could not remove the quarantine attribute from \(realPath).")
+        }
+    }
+
+    nonisolated static func defaultRemoveQuarantine(realPath: String) async -> Bool {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                let size = realPath.withCString { cpath in
+                    removexattr(cpath, "com.apple.quarantine", 0)
+                }
+                // 0 → removed. -1 with ENOATTR → wasn't there; treat as
+                // success since the post-state matches the goal.
+                let ok = size == 0 || (size == -1 && errno == ENOATTR)
+                continuation.resume(returning: ok)
+            }
+        }
+    }
+}

--- a/AlasTests/Code/LSP/GatekeeperAssessorTests.swift
+++ b/AlasTests/Code/LSP/GatekeeperAssessorTests.swift
@@ -89,6 +89,29 @@ struct GatekeeperAssessorTests {
         #expect(calls == 2)
     }
 
+    @Test("quarantine flag without approved bit → rejected")
+    func quarantineFlagBlocks() {
+        // 0083: quarantined (bit 0x01), download finished (0x80), no approval.
+        #expect(GatekeeperAssessor.interpretQuarantineValue("0083;abcd;Safari;UUID") == .rejected)
+    }
+
+    @Test("quarantine flag with approved bit (0x40) → allowed")
+    func approvedQuarantineFlagAllows() {
+        // 01c3: previous + LSQuarantineUserApproved (0x40). Sample from the
+        // stackoverflow post Codex linked: 0183 → 01c3 after user approval.
+        #expect(GatekeeperAssessor.interpretQuarantineValue("01c3;abcd;Safari;UUID") == .allowed)
+    }
+
+    @Test("unparseable flag field → unknown")
+    func unparseableFlagsBecomeUnknown() {
+        #expect(GatekeeperAssessor.interpretQuarantineValue("not-hex;abcd;X;Y") == .unknown)
+    }
+
+    @Test("approved-only flag (0x40) → allowed")
+    func approvedFlagAloneAllows() {
+        #expect(GatekeeperAssessor.interpretQuarantineValue("0040") == .allowed)
+    }
+
     private func makeTempExecutable() throws -> String {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("gk-\(UUID().uuidString)", isDirectory: true)

--- a/AlasTests/Code/LSP/GatekeeperRemediatorTests.swift
+++ b/AlasTests/Code/LSP/GatekeeperRemediatorTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("GatekeeperRemediator")
+@MainActor
+struct GatekeeperRemediatorTests {
+    /// Test double recording the orchestration: which steps ran and how
+    /// many times. xattr success and reassess result are scripted per
+    /// test.
+    @MainActor
+    final class Recorder {
+        var steps: [String] = []
+        var xattrCalls = 0
+        var invalidations = 0
+        var xattrOutcome = true
+        var reassessResult: GatekeeperAssessor.Result = .rejected
+    }
+
+    private func makeRemediator(recorder: Recorder) -> GatekeeperRemediator {
+        GatekeeperRemediator(
+            removeQuarantine: { _ in
+                recorder.xattrCalls += 1
+                recorder.steps.append("xattr")
+                return recorder.xattrOutcome
+            },
+            reassess: { _ in
+                recorder.steps.append("assess")
+                return recorder.reassessResult
+            },
+            invalidate: { _ in
+                recorder.invalidations += 1
+                recorder.steps.append("invalidate")
+            }
+        )
+    }
+
+    @Test("xattr removal unblocks the binary")
+    func xattrUnblocks() async {
+        let recorder = Recorder()
+        recorder.reassessResult = .allowed
+        let remediator = makeRemediator(recorder: recorder)
+
+        let outcome = await remediator.remediate(realPath: "/opt/homebrew/bin/gopls")
+
+        #expect(outcome == .allowed)
+        #expect(recorder.xattrCalls == 1)
+        #expect(recorder.invalidations == 1)
+        #expect(recorder.steps == ["xattr", "invalidate", "assess"])
+    }
+
+    @Test("xattr removed but binary still rejected → stillBlocked")
+    func stillBlockedAfterXattr() async {
+        let recorder = Recorder()
+        recorder.xattrOutcome = true
+        recorder.reassessResult = .rejected
+        let remediator = makeRemediator(recorder: recorder)
+
+        let outcome = await remediator.remediate(realPath: "/opt/homebrew/bin/gopls")
+
+        #expect(outcome == .stillBlocked)
+    }
+
+    @Test("xattr removal failed → failed outcome")
+    func xattrFailedSurfacesFailure() async {
+        let recorder = Recorder()
+        recorder.xattrOutcome = false
+        recorder.reassessResult = .rejected
+        let remediator = makeRemediator(recorder: recorder)
+
+        let outcome = await remediator.remediate(realPath: "/opt/homebrew/bin/gopls")
+
+        if case .failed = outcome {
+            // expected
+        } else {
+            Issue.record("expected .failed, got \(outcome)")
+        }
+    }
+
+    @Test(".unknown reassessment after a removal is treated as still blocked")
+    func unknownReassessIsStillBlocked() async {
+        // The remediator can't claim success on an indeterminate signal —
+        // safer to keep the banner and tell the user something's still
+        // off than to hide it on a partial answer.
+        let recorder = Recorder()
+        recorder.reassessResult = .unknown
+        let remediator = makeRemediator(recorder: recorder)
+
+        let outcome = await remediator.remediate(realPath: "/opt/homebrew/bin/gopls")
+
+        #expect(outcome == .stillBlocked)
+    }
+}


### PR DESCRIPTION
## Summary
- `GatekeeperAssessor` now flags a binary as blocked only when `com.apple.quarantine` is present, instead of trusting `spctl --assess --type execute`. The old predicate produced false positives across every LSP installed via Homebrew/cargo/npm (every Mach-O and every Node shebang script came back `rejected` even though Tahoe spawns them fine).
- `BlockedNudgeBanner` now does the remediation inline: the Allow button calls `removexattr(com.apple.quarantine)` and re-assesses. No "Open Privacy & Security" trip — that pane is empty by construction because the pre-flight never lets the OS log a rejected spawn — and no admin prompt, because `spctl --add` is both deprecated on modern macOS and didn't actually unblock anything in testing.
- Adds `GatekeeperRemediator` with the orchestration extracted for unit testing.

## Test plan
- [x] `xcodebuild ... test` — 2074 tests pass, including 4 new `GatekeeperRemediator` cases (xattr unblocks / still rejected / xattr fails / `.unknown` reassessment).
- [x] Manually verified on a machine where every Homebrew-installed LSP was previously showing a blocked banner: with this change none of them trigger the banner.
- [ ] Open a file whose LSP binary does carry `com.apple.quarantine` (e.g. one downloaded fresh) and confirm the Allow button removes the attribute and the banner clears.