### PR TITLE
fix(lsp): drop blockedByGatekeeper from availability cache

### DIFF
--- a/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
+++ b/Alas/Sources/Code/LSP/WorkspaceLSPManager.swift
@@ -127,18 +127,22 @@ final class WorkspaceLSPManager: DocumentFormatter {
     /// badge resolver.
     ///
     /// Only stable results (`.available`, `.disabled`) are cached — those
-    /// don't change without a registry update. `.notInstalled` is re-probed
-    /// on every call so a runtime install (e.g. the install nudge flow) is
-    /// picked up without an explicit cache invalidation hook. The fast-path
-    /// PATH walk is cheap; the `xcrun --find` fallback for `sourcekit-lsp`
-    /// only fires when the binary isn't on PATH, which is uncommon on dev
-    /// machines.
+    /// don't change without a registry update. `.notInstalled` and
+    /// `.blockedByGatekeeper` are re-probed on every call so runtime user
+    /// actions (install via the install nudge, quarantine removal via the
+    /// blocked nudge) are picked up without an explicit cache invalidation
+    /// hook. The fast-path PATH walk is cheap; the `xcrun --find` fallback
+    /// for `sourcekit-lsp` only fires when the binary isn't on PATH, which
+    /// is uncommon on dev machines.
     func availabilityStatus(forLanguage language: String) -> LanguageServerAvailability.Status? {
         if let cached = availabilityCache[language] { return cached }
         guard let entry = registry.allEntries().first(where: { $0.language == language }) else { return nil }
         let status = cachedAvailability.status(for: entry)
-        if status != .notInstalled {
+        switch status {
+        case .available, .disabled:
             availabilityCache[language] = status
+        case .notInstalled, .blockedByGatekeeper:
+            break
         }
         return status
     }

--- a/AlasTests/WorkspaceLSPManagerStatusTests.swift
+++ b/AlasTests/WorkspaceLSPManagerStatusTests.swift
@@ -76,4 +76,72 @@ struct WorkspaceLSPManagerStatusTests {
         await mgr.restartHolder(forLanguage: "swift", rootURL: root)
         #expect(mgr.stateTick == beforeTick)
     }
+
+    @Test func blockedByGatekeeperIsReprobedNotCached() {
+        // After the user clicks Allow on the blocked nudge, the Gatekeeper
+        // assessor flips from .rejected to .allowed. The manager must not
+        // serve a stale .blockedByGatekeeper from its per-language cache,
+        // or the status badge keeps the binary "blocked" until something
+        // else clears it.
+        final class Box { var result: GatekeeperAssessor.Result = .rejected }
+        let box = Box()
+        let registry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: "/usr/bin/true",
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        let mgr = WorkspaceLSPManager(
+            registry: registry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: [:],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in box.result }
+                )
+            }
+        )
+        #expect(mgr.availabilityStatus(forLanguage: "swift") == .blockedByGatekeeper(realPath: "/usr/bin/true"))
+        box.result = .allowed
+        #expect(mgr.availabilityStatus(forLanguage: "swift") == .available)
+    }
+
+    @Test func availableStatusIsCached() {
+        final class Box { var calls = 0 }
+        let box = Box()
+        let registry = LanguageServerRegistry(userDefined: [
+            LanguageServerConfig(
+                language: "swift",
+                extensions: ["swift"],
+                command: "/usr/bin/true",
+                args: [],
+                env: [:],
+                rootMarkers: [],
+                enabled: true
+            )
+        ])
+        let mgr = WorkspaceLSPManager(
+            registry: registry,
+            makeAvailability: {
+                LanguageServerAvailability(
+                    environment: [:],
+                    xcrunFind: { _ in nil },
+                    additionalPathDirectories: [],
+                    gatekeeperAssessor: { _ in
+                        box.calls += 1
+                        return .allowed
+                    }
+                )
+            }
+        )
+        _ = mgr.availabilityStatus(forLanguage: "swift")
+        _ = mgr.availabilityStatus(forLanguage: "swift")
+        #expect(box.calls == 1)
+    }
 }


### PR DESCRIPTION
## Summary
Follow-up to #321 (Codex review caught this after merge). The per-language availability cache in `WorkspaceLSPManager` documented that only `.available` and `.disabled` were cached, but the code cached everything except `.notInstalled`. That pinned a stale `.blockedByGatekeeper` entry after the user clicked Allow in `BlockedNudgeBanner`, so the editor status badge kept showing "blocked" until an unrelated registry/app refresh cleared it.

Aligns the code with its documented invariant: re-probe both `.notInstalled` and `.blockedByGatekeeper` so any runtime user action (install via the install nudge, quarantine removal via the blocked nudge) is reflected immediately.

## Test plan
- [x] `xcodebuild ... test` — 2080 tests pass, including two new ones in `WorkspaceLSPManagerStatusTests`:
  - `blockedByGatekeeperIsReprobedNotCached` — flips an injected assessor from `.rejected` to `.allowed` and confirms the second probe returns `.available`.
  - `availableStatusIsCached` — verifies `.available` is still cached on the hot path (assessor closure called once across two probes).