### PR TITLE
feat(settings): add toggle to disable cross-quit session persistence

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -573,6 +573,7 @@
 		CC64E79B9CF4AF1B3CE31261 /* ACPMentionChipAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */; };
 		CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */; };
 		CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */; };
+		AAAAAAAAAAAAAAAAAAAAAA01 /* AppConfigTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAAAAAAAAAAAAAAAAAAAA02 /* AppConfigTerminalTests.swift */; };
 		CD227C48AA85A5E74A92DF3F /* GitRefNameInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */; };
 		CD7FB3120E4B194063C76817 /* ClaudeCodeACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AFF324FEE695AE18065D5A /* ClaudeCodeACPInstaller.swift */; };
 		CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */; };
@@ -1335,6 +1336,7 @@
 		EBBBF87CC508451B2C0F3A66 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTextStorage.swift; sourceTree = "<group>"; };
 		EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigFilesTests.swift; sourceTree = "<group>"; };
+		AAAAAAAAAAAAAAAAAAAAAA02 /* AppConfigTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTerminalTests.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
 		ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewIndentationTests.swift; sourceTree = "<group>"; };
@@ -1510,6 +1512,7 @@
 				333EA07C2BCA5E18F55E2613 /* AppConfigChangesTests.swift */,
 				D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */,
 				EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */,
+				AAAAAAAAAAAAAAAAAAAAAA02 /* AppConfigTerminalTests.swift */,
 				0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */,
 				987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */,
 				45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */,
@@ -3345,6 +3348,7 @@
 				1DF096E0925EFA91B9033642 /* AppConfigChangesTests.swift in Sources */,
 				D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */,
 				CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */,
+				AAAAAAAAAAAAAAAAAAAAAA01 /* AppConfigTerminalTests.swift in Sources */,
 				8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */,
 				ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */,
 				1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -574,6 +574,7 @@
 		CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */; };
 		CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */; };
 		AAAAAAAAAAAAAAAAAAAAAA01 /* AppConfigTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAAAAAAAAAAAAAAAAAAAA02 /* AppConfigTerminalTests.swift */; };
+		AAAAAAAAAAAAAAAAAAAAAA03 /* AppStateKeepSessionsAliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAAAAAAAAAAAAAAAAAAAA04 /* AppStateKeepSessionsAliveTests.swift */; };
 		CD227C48AA85A5E74A92DF3F /* GitRefNameInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */; };
 		CD7FB3120E4B194063C76817 /* ClaudeCodeACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AFF324FEE695AE18065D5A /* ClaudeCodeACPInstaller.swift */; };
 		CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */; };
@@ -1337,6 +1338,7 @@
 		EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTextStorage.swift; sourceTree = "<group>"; };
 		EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigFilesTests.swift; sourceTree = "<group>"; };
 		AAAAAAAAAAAAAAAAAAAAAA02 /* AppConfigTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTerminalTests.swift; sourceTree = "<group>"; };
+		AAAAAAAAAAAAAAAAAAAAAA04 /* AppStateKeepSessionsAliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateKeepSessionsAliveTests.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
 		ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewIndentationTests.swift; sourceTree = "<group>"; };
@@ -1523,6 +1525,7 @@
 				08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */,
 				E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */,
 				11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */,
+				AAAAAAAAAAAAAAAAAAAAAA04 /* AppStateKeepSessionsAliveTests.swift */,
 				6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */,
 				69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */,
 				8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */,
@@ -3359,6 +3362,7 @@
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,
 				A75289A4560BCA2DACA0760B /* AppStateCreateWorktreeSymlinkTests.swift in Sources */,
 				BDBAA6601CA3FD8A5562E637 /* AppStateFocusMainWorktreeTests.swift in Sources */,
+				AAAAAAAAAAAAAAAAAAAAAA03 /* AppStateKeepSessionsAliveTests.swift in Sources */,
 				ABB5595A9A39C8AF203B5873 /* AppStateOverlayFocusTests.swift in Sources */,
 				51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */,
 				25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -344,6 +344,21 @@ final class AppState {
             projectsManager.worktrees(projectId: $0.id).map(\.id)
         }
         tabs.loadAll(worktreeIds: allWorktreeIds)
+        // When cross-quit persistence is disabled, drop every persisted
+        // terminal tab right after load — across all worktrees, before
+        // any lazy-display path could observe them — so orphan zmx
+        // daemon sessions get killed via `closeTab` and inactive /
+        // other-worktree tabs don't linger waiting for someone to open
+        // them (which is the only thing that drives the per-tab guard
+        // in `restoreTerminalTabIfNeeded`).
+        if !config.terminal.keepSessionsAlive {
+            for worktreeId in allWorktreeIds {
+                for tab in tabs.tabs(forWorktree: worktreeId) {
+                    guard case .terminal = tab else { continue }
+                    closeTab(worktreeId: worktreeId, tabId: tab.id)
+                }
+            }
+        }
         // Persisted terminal-tab leaves are now in memory — refresh their
         // hook symlinks so zmx-persisted shells in undisplayed tabs deliver
         // hooks/CLI requests to the live harness immediately, rather than

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1324,11 +1324,17 @@ final class AppState {
         // Otherwise the toggle would only strip the `zmx attach` wrapper and
         // still resurrect a plain shell in the same tab slot on every
         // relaunch.
+        //
+        // Use `closeTab` (not `tabs.close`) so harness detector state is
+        // unregistered and `terminal.closeSession` issues the best-effort
+        // `zmx kill` for each leaf — otherwise daemon-side sessions left
+        // over from a previous keep-alive=true run stay orphaned with no
+        // tab left to control them.
         if !config.terminal.keepSessionsAlive {
             let hasLiveLeaf = state.root.leaves()
                 .contains { terminal.registry.session(for: $0.id) != nil }
             if !hasLiveLeaf {
-                tabs.close(worktreeId: worktreeId, tabId: tabId)
+                closeTab(worktreeId: worktreeId, tabId: tabId)
                 return nil
             }
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1317,6 +1317,22 @@ final class AppState {
               let worktree = worktree(withId: worktreeId),
               let project = projects.first(where: { $0.id == worktree.projectId }) else { return nil }
 
+        // When the user has opted out of cross-quit persistence and none of
+        // the tab's leaves have a live session (the only way to reach this
+        // branch is a relaunch where the registry is empty for these
+        // leaves), drop the persisted tab instead of opening fresh shells.
+        // Otherwise the toggle would only strip the `zmx attach` wrapper and
+        // still resurrect a plain shell in the same tab slot on every
+        // relaunch.
+        if !config.terminal.keepSessionsAlive {
+            let hasLiveLeaf = state.root.leaves()
+                .contains { terminal.registry.session(for: $0.id) != nil }
+            if !hasLiveLeaf {
+                tabs.close(worktreeId: worktreeId, tabId: tabId)
+                return nil
+            }
+        }
+
         for leaf in state.root.leaves() {
             // Idempotent: skip leaves whose session is already alive in the
             // registry. The leaf's id is the stable identity used as both

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -117,11 +117,63 @@ struct AppConfig: Codable, Equatable {
         var scrollbackLines: Int
         var bell: String                 // off | visual | sound
         var syncTabTitleWithTerminalTitle: Bool
+        /// When true, every interactive pane is wrapped in `zmx attach <name>`
+        /// so the shell (and any running agents) survives app quit/relaunch.
+        /// When false, panes launch as plain shells and die with the app.
+        var keepSessionsAlive: Bool
 
         enum CodingKeys: String, CodingKey {
             case shell, workingDirectory, startupScript, worktreeCreateScript,
                  inheritParentEnv, fontFamily, fontSize, cursorStyle, cursorBlink,
-                 scrollbackLines, bell, syncTabTitleWithTerminalTitle
+                 scrollbackLines, bell, syncTabTitleWithTerminalTitle,
+                 keepSessionsAlive
+        }
+
+        init(
+            shell: String,
+            workingDirectory: String,
+            startupScript: String,
+            worktreeCreateScript: String,
+            inheritParentEnv: Bool,
+            fontFamily: String,
+            fontSize: Int,
+            cursorStyle: String,
+            cursorBlink: Bool,
+            scrollbackLines: Int,
+            bell: String,
+            syncTabTitleWithTerminalTitle: Bool,
+            keepSessionsAlive: Bool = true
+        ) {
+            self.shell = shell
+            self.workingDirectory = workingDirectory
+            self.startupScript = startupScript
+            self.worktreeCreateScript = worktreeCreateScript
+            self.inheritParentEnv = inheritParentEnv
+            self.fontFamily = fontFamily
+            self.fontSize = fontSize
+            self.cursorStyle = cursorStyle
+            self.cursorBlink = cursorBlink
+            self.scrollbackLines = scrollbackLines
+            self.bell = bell
+            self.syncTabTitleWithTerminalTitle = syncTabTitleWithTerminalTitle
+            self.keepSessionsAlive = keepSessionsAlive
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            shell = try c.decode(String.self, forKey: .shell)
+            workingDirectory = try c.decode(String.self, forKey: .workingDirectory)
+            startupScript = try c.decode(String.self, forKey: .startupScript)
+            worktreeCreateScript = try c.decode(String.self, forKey: .worktreeCreateScript)
+            inheritParentEnv = try c.decode(Bool.self, forKey: .inheritParentEnv)
+            fontFamily = try c.decode(String.self, forKey: .fontFamily)
+            fontSize = try c.decode(Int.self, forKey: .fontSize)
+            cursorStyle = try c.decode(String.self, forKey: .cursorStyle)
+            cursorBlink = try c.decode(Bool.self, forKey: .cursorBlink)
+            scrollbackLines = try c.decode(Int.self, forKey: .scrollbackLines)
+            bell = try c.decode(String.self, forKey: .bell)
+            syncTabTitleWithTerminalTitle = (try? c.decode(Bool.self, forKey: .syncTabTitleWithTerminalTitle)) ?? false
+            keepSessionsAlive = (try? c.decode(Bool.self, forKey: .keepSessionsAlive)) ?? true
         }
     }
 
@@ -267,7 +319,8 @@ struct AppConfig: Codable, Equatable {
             cursorBlink: true,
             scrollbackLines: 10000,
             bell: "visual",
-            syncTabTitleWithTerminalTitle: false
+            syncTabTitleWithTerminalTitle: false,
+            keepSessionsAlive: true
         ),
         harness: Harness(notifyOnFinish: true, notifyOnAwaiting: true),
         code: Code(
@@ -405,6 +458,7 @@ extension AppConfig {
             let scrollbackLines = (try? termContainer.decode(Int.self, forKey: .scrollbackLines)) ?? 10000
             let bell = (try? termContainer.decode(String.self, forKey: .bell)) ?? "visual"
             let syncTabTitleWithTerminalTitle = (try? termContainer.decode(Bool.self, forKey: .syncTabTitleWithTerminalTitle)) ?? false
+            let keepSessionsAlive = (try? termContainer.decode(Bool.self, forKey: .keepSessionsAlive)) ?? true
             terminal = Terminal(
                 shell: shell,
                 workingDirectory: workingDirectory,
@@ -417,7 +471,8 @@ extension AppConfig {
                 cursorBlink: cursorBlink,
                 scrollbackLines: scrollbackLines,
                 bell: bell,
-                syncTabTitleWithTerminalTitle: syncTabTitleWithTerminalTitle
+                syncTabTitleWithTerminalTitle: syncTabTitleWithTerminalTitle,
+                keepSessionsAlive: keepSessionsAlive
             )
         } else {
             terminal = Terminal(
@@ -432,7 +487,8 @@ extension AppConfig {
                 cursorBlink: true,
                 scrollbackLines: 10000,
                 bell: "visual",
-                syncTabTitleWithTerminalTitle: false
+                syncTabTitleWithTerminalTitle: false,
+                keepSessionsAlive: true
             )
         }
         harness = try c.decode(Harness.self, forKey: .harness)

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -33,6 +33,13 @@ struct TerminalPane: View {
                     }
                 }
 
+                SettingsGroup(title: "Sessions") {
+                    SettingsRow(name: "Keep sessions alive across app quit",
+                                desc: "Terminal panes (and any running agents inside them) survive quit and relaunch with their shell, scrollback, and state.") {
+                        AlasToggle(on: state.bind(\.terminal.keepSessionsAlive))
+                    }
+                }
+
                 SettingsGroup(title: "Startup scripts") {
                     SettingsRow(name: "Run on session open",
                                 desc: "Executed in every new terminal pane after the shell starts.") {

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -99,9 +99,11 @@ final class TerminalService {
             startupScript: effectiveScript,
             sessionId: sessionId
         )
-        let plan = zmxClient.wrap(
-            sessionName: ZmxSessionName.derive(leafId: sessionId),
-            plan: innerPlan
+        let plan = TerminalService.resolveLaunchPlan(
+            keepAlive: cfg.keepSessionsAlive,
+            zmxClient: zmxClient,
+            sessionId: sessionId,
+            innerPlan: innerPlan
         )
         // Plan-supplied env overrides (e.g. ZDOTDIR for zsh startup scripts)
         // win over inherited env.
@@ -209,6 +211,27 @@ final class TerminalService {
         default:
             return worktree.path
         }
+    }
+
+    /// Decide which launch plan to use for a new pane. When
+    /// `keepAlive` is true and zmx is available, the inner plan is wrapped
+    /// in `zmx attach <name>` so the shell survives app quit. When
+    /// `keepAlive` is false, the inner plan is returned unchanged — pre-#317
+    /// behavior. When zmx is unavailable, `ZmxClient.wrap` returns the inner
+    /// plan unchanged regardless of `keepAlive`.
+    ///
+    /// Static so tests can drive it without spinning up `Ghostty.App`.
+    static func resolveLaunchPlan(
+        keepAlive: Bool,
+        zmxClient: ZmxClient,
+        sessionId: String,
+        innerPlan: StartupScriptInstaller.Plan
+    ) -> StartupScriptInstaller.Plan {
+        guard keepAlive else { return innerPlan }
+        return zmxClient.wrap(
+            sessionName: ZmxSessionName.derive(leafId: sessionId),
+            plan: innerPlan
+        )
     }
 
     private static func composeStartupScript(

--- a/AlasTests/AppConfigTerminalTests.swift
+++ b/AlasTests/AppConfigTerminalTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Foundation
+@testable import Alas
+
+struct AppConfigTerminalTests {
+    @Test func defaultsHaveKeepSessionsAliveOn() {
+        #expect(AppConfig.defaults.terminal.keepSessionsAlive == true)
+    }
+
+    @Test func decodesLegacyTerminalConfigWithoutKeepSessionsAliveKey() throws {
+        // Legacy terminal block with no `keepSessionsAlive` key — matches
+        // configs written before this setting existed. Decode must default
+        // to true so users upgrading from PR #317 see no behavior change.
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/code/.worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true}
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.terminal.keepSessionsAlive == true)
+    }
+
+    @Test func roundTripsKeepSessionsAlive() throws {
+        for value in [true, false] {
+            var cfg = AppConfig.defaults
+            cfg.terminal.keepSessionsAlive = value
+            let data = try JSONEncoder().encode(cfg)
+            let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+            #expect(decoded.terminal.keepSessionsAlive == value)
+        }
+    }
+}

--- a/AlasTests/AppStateKeepSessionsAliveTests.swift
+++ b/AlasTests/AppStateKeepSessionsAliveTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct AppStateKeepSessionsAliveTests {
+    private func makeRepo(name: String) async throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-keepalive-\(name)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        _ = try await Process.git(["init", "-q", "-b", "main"], cwd: dir)
+        _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "init"], cwd: dir)
+        return dir
+    }
+
+    /// On relaunch with `keepSessionsAlive = false`, a persisted terminal
+    /// tab whose leaves have no live session must be pruned instead of
+    /// resurrected with a fresh plain shell. Otherwise the toggle only
+    /// strips the `zmx attach` wrapper while still reopening shells in the
+    /// same tab slot on every relaunch.
+    @Test func restoreDropsPersistedTerminalTabWhenKeepAliveFalse() async throws {
+        let repo = try await makeRepo(name: "drop")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        state.selectedWorktreeId = trees[0].id
+        state.config.terminal.keepSessionsAlive = false
+
+        // Simulate a persisted terminal tab whose underlying session is
+        // gone (post-relaunch — registry is empty for this leaf id).
+        let tab = state.tabs.appendTerminal(
+            worktreeId: trees[0].id, title: "main", sessionId: "leaf-orphan"
+        )
+
+        let restored = try state.restoreTerminalTabIfNeeded(
+            worktreeId: trees[0].id, tabId: tab.id
+        )
+
+        #expect(restored == nil)
+        #expect(state.tabs.tabs(forWorktree: trees[0].id).isEmpty)
+    }
+
+    /// Same scenario but with the setting on: the persisted tab must be
+    /// kept and the standard restore path must run (the open-session call
+    /// itself may fail in this test environment without Ghostty.App, but
+    /// the tab must NOT be pruned).
+    @Test func restoreKeepsPersistedTerminalTabWhenKeepAliveTrue() async throws {
+        let repo = try await makeRepo(name: "keep")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        state.selectedWorktreeId = trees[0].id
+        state.config.terminal.keepSessionsAlive = true
+
+        let tab = state.tabs.appendTerminal(
+            worktreeId: trees[0].id, title: "main", sessionId: "leaf-keep"
+        )
+
+        // openSession can throw in this test env (no bundled Ghostty.App).
+        // The contract under test is "tab is not pruned", which happens
+        // before any openSession call — assert that regardless of throw.
+        _ = try? state.restoreTerminalTabIfNeeded(
+            worktreeId: trees[0].id, tabId: tab.id
+        )
+
+        #expect(state.tabs.tabs(forWorktree: trees[0].id).map(\.id) == [tab.id])
+    }
+}

--- a/AlasTests/AppStateKeepSessionsAliveTests.swift
+++ b/AlasTests/AppStateKeepSessionsAliveTests.swift
@@ -76,4 +76,61 @@ struct AppStateKeepSessionsAliveTests {
 
         #expect(state.tabs.tabs(forWorktree: trees[0].id).map(\.id) == [tab.id])
     }
+
+    /// `reloadTabs` runs once on launch and is the only path that touches
+    /// every persisted terminal tab across every worktree. When
+    /// `keepSessionsAlive` is off, it must prune them all — including
+    /// inactive tabs and tabs in worktrees the user isn't viewing — so
+    /// orphan daemon sessions get killed and stale tabs don't linger.
+    @Test func reloadTabsPrunesAllTerminalTabsWhenKeepAliveFalse() async throws {
+        let repo = try await makeRepo(name: "reload-prune")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        state.selectedWorktreeId = trees[0].id
+
+        // Persist two terminal tabs and one non-terminal tab. The
+        // non-terminal one must survive the prune.
+        _ = state.tabs.appendTerminal(worktreeId: trees[0].id, title: "a", sessionId: "leaf-a")
+        _ = state.tabs.appendTerminal(worktreeId: trees[0].id, title: "b", sessionId: "leaf-b")
+        let editor = state.tabs.appendEditor(
+            worktreeId: trees[0].id, title: "c.txt", relativePath: "c.txt"
+        )
+
+        state.config.terminal.keepSessionsAlive = false
+        state.reloadTabs()
+
+        let remaining = state.tabs.tabs(forWorktree: trees[0].id)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.id == editor.id)
+    }
+
+    /// Counter-test: with the setting on, `reloadTabs` must not prune
+    /// terminal tabs.
+    @Test func reloadTabsKeepsTerminalTabsWhenKeepAliveTrue() async throws {
+        let repo = try await makeRepo(name: "reload-keep")
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(
+            path: repo, displayName: "test", color: "#000000"
+        )
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let trees = state.projectsManager.worktrees(projectId: project.id)
+        state.selectedWorktreeId = trees[0].id
+
+        let term = state.tabs.appendTerminal(
+            worktreeId: trees[0].id, title: "a", sessionId: "leaf-a"
+        )
+
+        state.config.terminal.keepSessionsAlive = true
+        state.reloadTabs()
+
+        #expect(state.tabs.tabs(forWorktree: trees[0].id).map(\.id) == [term.id])
+    }
 }

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -270,6 +270,9 @@ struct TerminalServiceZmxTests {
         #expect(plan.executable == "/bin/zsh")
         #expect(plan.args == ["-l"])
         #expect(plan.envOverrides == ["FOO": "1"])
+        // No subprocess must be spawned — the guard short-circuits before
+        // any zmx command runs.
+        #expect(recorder.calls.isEmpty)
     }
 
     @Test func resolveLaunchPlanReturnsInnerWhenZmxUnavailable() {
@@ -290,5 +293,6 @@ struct TerminalServiceZmxTests {
 
         #expect(plan.executable == "/bin/zsh")
         #expect(plan.args == [])
+        #expect(recorder.calls.isEmpty)
     }
 }

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -229,4 +229,66 @@ struct TerminalServiceZmxTests {
         #expect(recorder.calls.count == 1)
         #expect(recorder.calls[0].args == ["kill", "alas-leaf-A"])
     }
+
+    // MARK: resolveLaunchPlan — keepSessionsAlive gating
+
+    @Test func resolveLaunchPlanWrapsWhenKeepAliveTrueAndZmxAvailable() {
+        let recorder = RecordingRunner()
+        let client = ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
+        let inner = StartupScriptInstaller.Plan(
+            executable: "/bin/zsh", args: ["-l"], envOverrides: ["FOO": "1"]
+        )
+
+        let plan = TerminalService.resolveLaunchPlan(
+            keepAlive: true,
+            zmxClient: client,
+            sessionId: "leaf-1",
+            innerPlan: inner
+        )
+
+        #expect(plan.executable == "/fake/Contents/Resources/zmx/zmx")
+        #expect(plan.args == ["attach", "alas-leaf-1", "/bin/zsh", "-l"])
+        #expect(plan.envOverrides == ["FOO": "1"])
+    }
+
+    @Test func resolveLaunchPlanReturnsInnerWhenKeepAliveFalse() {
+        let recorder = RecordingRunner()
+        let client = ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
+        let inner = StartupScriptInstaller.Plan(
+            executable: "/bin/zsh", args: ["-l"], envOverrides: ["FOO": "1"]
+        )
+
+        let plan = TerminalService.resolveLaunchPlan(
+            keepAlive: false,
+            zmxClient: client,
+            sessionId: "leaf-2",
+            innerPlan: inner
+        )
+
+        // With the setting off, the inner plan is returned untouched —
+        // no zmx in the executable, no extra args, env preserved.
+        #expect(plan.executable == "/bin/zsh")
+        #expect(plan.args == ["-l"])
+        #expect(plan.envOverrides == ["FOO": "1"])
+    }
+
+    @Test func resolveLaunchPlanReturnsInnerWhenZmxUnavailable() {
+        // keepAlive=true, but zmx binary missing: ZmxClient.wrap returns the
+        // input plan unchanged. The helper must propagate that behavior.
+        let recorder = RecordingRunner()
+        let client = ZmxClient(env: makeZmxEnv(available: false), runner: recorder.runner())
+        let inner = StartupScriptInstaller.Plan(
+            executable: "/bin/zsh", args: [], envOverrides: [:]
+        )
+
+        let plan = TerminalService.resolveLaunchPlan(
+            keepAlive: true,
+            zmxClient: client,
+            sessionId: "leaf-3",
+            innerPlan: inner
+        )
+
+        #expect(plan.executable == "/bin/zsh")
+        #expect(plan.args == [])
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a `Settings → Terminal → Sessions → "Keep sessions alive across app quit"` toggle that gates the `zmx attach` wrap introduced in #317.
- Default `true` preserves PR #317 behavior for existing users; toggling off makes new panes launch as plain shells that die with the app. Already-running zmx-wrapped panes are unaffected by toggling off (new-panes-only semantics, matches how every other setting in this app behaves).
- Gating point is a new static helper `TerminalService.resolveLaunchPlan(keepAlive:zmxClient:sessionId:innerPlan:)` — testable without `Ghostty.App`.

## Test plan
- [x] `xcodebuild test` — full suite 2076/2076 passing
- [x] New tests: `AppConfigTerminalTests` (default, legacy-decode, roundtrip) and `TerminalServiceZmxTests.resolveLaunchPlan*` (3 branches, with `recorder.calls.isEmpty` assertions in the non-wrapping paths)
- [x] Manual: toggle visible in Settings → Terminal, on by default
- [ ] Manual (post-merge sanity): toggle off → new pane runs `/bin/zsh` directly, no `zmx attach` in process tree; quit and relaunch confirms the pane is gone

@codex review