### PR TITLE
fix(settings): route language selector settings link to Code section

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -10,6 +10,7 @@ final class AppState {
     var themeStore: ThemeStore
     var projectsManager: ProjectsManager
     var selectedWorktreeId: String?
+    var pendingSettingsSection: SettingsSection?
     @ObservationIgnored
     private var _tabs: TabsManager?
     var tabs: TabsManager {

--- a/Alas/Sources/Center/EditorTabView.swift
+++ b/Alas/Sources/Center/EditorTabView.swift
@@ -275,12 +275,14 @@ struct EditorTabView: View {
                 buffer?.languageOverride = newLanguage
             },
             onOpenSettings: {
+                appState.pendingSettingsSection = .code
                 openWindow(id: "settings")
             },
             onInstall: {
                 // The existing InstallNudgeBanner below the breadcrumb already
                 // handles inline install flows; from the badge popover we
                 // surface the install entry via Settings → Code.
+                appState.pendingSettingsSection = .code
                 openWindow(id: "settings")
             }
         )

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -64,14 +64,24 @@ struct SettingsWindow: View {
         .ignoresSafeArea()
         .onAppear {
             showsDebug = AdvancedSettingsVisibility.isEnabled()
+            consumePendingSettingsSection()
             if !showsDebug, section == .debug {
                 section = .agents
             }
             state.rescanAgents()
         }
+        .onChange(of: state.pendingSettingsSection) {
+            consumePendingSettingsSection()
+        }
     }
 
     private func closeWindow() {
         NSApp.keyWindow?.close()
+    }
+
+    private func consumePendingSettingsSection() {
+        guard let pending = state.pendingSettingsSection else { return }
+        section = pending
+        state.pendingSettingsSection = nil
     }
 }


### PR DESCRIPTION
## Summary
- Route the file editor breadcrumbs language selector settings link to the Code settings section.
- Preserve existing Settings defaults for other entry points.

## Tests
- Not run (shepherd phase).