### PR TITLE
fix(terminal): session restore isolation

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1170,7 +1170,11 @@ final class AppState {
             closeTab(worktreeId: worktreeId, tabId: activeId)
         } else {
             let closedLeafId = outcome.closedLeafId
-            terminal.closeSession(id: closedLeafId, worktreeId: worktreeId)
+            terminal.closeSession(
+                id: closedLeafId,
+                worktreeId: worktreeId,
+                projectPath: projectPath(forWorktreeId: worktreeId)
+            )
             harness.detector.unregister(sessionId: closedLeafId)
             harness.forgetSession(closedLeafId)
         }
@@ -1227,7 +1231,11 @@ final class AppState {
                 tabs.tabs(forWorktree: worktree.id).flatMap { tab -> [TerminalSessionIdentity] in
                     guard case .terminal(let state) = tab else { return [] }
                     return state.root.leaves().map {
-                        TerminalSessionIdentity(worktreeId: worktree.id, leafId: $0.id)
+                        TerminalSessionIdentity(
+                            worktreeId: worktree.id,
+                            projectPath: project.path,
+                            leafId: $0.id
+                        )
                     }
                 }
             }
@@ -1365,7 +1373,8 @@ final class AppState {
                 worktree: worktree, project: project,
                 cfg: config.terminal, theme: themeStore.current,
                 forcedCwd: forcedCwd,
-                leafId: leaf.id
+                leafId: leaf.id,
+                allowLegacyAttach: true
             )
             harness.detector.register(sessionId: session.id) { [weak session] in
                 session?.surface.foregroundPid
@@ -1492,12 +1501,13 @@ final class AppState {
 
     func closeTab(worktreeId: String, tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
+        let projectPath = projectPath(forWorktreeId: worktreeId)
         if let tab = allTabs.first(where: { $0.id == tabId }) {
             if case .terminal(let s) = tab {
                 for leaf in s.root.leaves() {
                     harness.detector.unregister(sessionId: leaf.id)
                     harness.forgetSession(leaf.id)
-                    terminal.closeSession(id: leaf.id, worktreeId: worktreeId)
+                    terminal.closeSession(id: leaf.id, worktreeId: worktreeId, projectPath: projectPath)
                 }
             }
             if case .editor = tab {
@@ -1511,13 +1521,14 @@ final class AppState {
     }
 
     private func cleanupTerminals(worktreeId: String, allTabs: [Tab], tabIds: [TabID]) {
+        let projectPath = projectPath(forWorktreeId: worktreeId)
         for id in tabIds {
             if let tab = allTabs.first(where: { $0.id == id }),
                case .terminal(let s) = tab {
                 for leaf in s.root.leaves() {
                     harness.detector.unregister(sessionId: leaf.id)
                     harness.forgetSession(leaf.id)
-                    terminal.closeSession(id: leaf.id, worktreeId: worktreeId)
+                    terminal.closeSession(id: leaf.id, worktreeId: worktreeId, projectPath: projectPath)
                 }
             }
         }
@@ -1608,6 +1619,11 @@ final class AppState {
             }
         }
         return nil
+    }
+
+    private func projectPath(forWorktreeId id: String) -> String? {
+        guard let worktree = worktree(withId: id) else { return nil }
+        return projects.first(where: { $0.id == worktree.projectId })?.path
     }
 
     var activeTab: Tab? {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1070,8 +1070,8 @@ final class AppState {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             throw NSError(domain: "AppState", code: 2)
         }
-        // Single identity for this pane: used as the zmx session name
-        // suffix, the SessionRegistry key, the leaf id, the persisted
+        // Single identity for this pane: used with the worktree id to derive
+        // the zmx session name, plus the SessionRegistry key, leaf id, persisted
         // sessionId (mirrored to id on encode), and ALAS_SESSION_ID. Generated
         // here so every downstream call site receives the same value.
         let leafId = UUID().uuidString
@@ -1134,8 +1134,9 @@ final class AppState {
             ?? worktree.path
 
         do {
-            // Single identity for the new pane: zmx session name suffix,
-            // SessionRegistry key, leaf id, persisted sessionId, ALAS_SESSION_ID.
+            // Single identity for the new pane: used with the worktree id to
+            // derive the zmx session name, plus the SessionRegistry key, leaf
+            // id, persisted sessionId, and ALAS_SESSION_ID.
             // Generated here so the registry key `terminal.openSession`
             // registers under matches the `newLeafId` the split tree stores.
             let newLeafId = UUID().uuidString
@@ -1169,7 +1170,7 @@ final class AppState {
             closeTab(worktreeId: worktreeId, tabId: activeId)
         } else {
             let closedLeafId = outcome.closedLeafId
-            terminal.closeSession(id: closedLeafId)
+            terminal.closeSession(id: closedLeafId, worktreeId: worktreeId)
             harness.detector.unregister(sessionId: closedLeafId)
             harness.forgetSession(closedLeafId)
         }
@@ -1190,11 +1191,15 @@ final class AppState {
                     return (worktree.id, tab.id)
                 }
             }
-        let persistedLeafIds = allPersistedTerminalLeafIds()
+        let persistedSessions = allPersistedTerminalSessions()
         // Count individual leaves, not tabs — a single tab with split panes
         // contains multiple leaves and `terminateAll` kills every one. Union
         // with the live registry catches any session not yet flushed to disk.
-        let sessionCount = Set(persistedLeafIds).union(terminal.registry.all.map(\.id)).count
+        let sessionCount = Set(persistedSessions)
+            .union(terminal.registry.all.map {
+                TerminalSessionIdentity(worktreeId: $0.worktreeId, leafId: $0.id)
+            })
+            .count
 
         let alert = NSAlert()
         alert.messageText = "Terminate All Terminal Sessions"
@@ -1212,16 +1217,18 @@ final class AppState {
         // own those persisted leaves too. Scoped to OUR instance's known
         // leaves so we don't trample sessions owned by a concurrently-
         // running Alas process under the same ZMX_DIR.
-        terminal.terminateAll(additionalLeafIds: persistedLeafIds)
+        terminal.terminateAll(additionalSessions: persistedSessions)
     }
 
-    /// All terminal-leaf ids persisted under this Alas instance's projects.
-    private func allPersistedTerminalLeafIds() -> [String] {
+    /// All terminal sessions persisted under this Alas instance's projects.
+    private func allPersistedTerminalSessions() -> [TerminalSessionIdentity] {
         projects.flatMap { project in
             projectsManager.worktrees(projectId: project.id).flatMap { worktree in
-                tabs.tabs(forWorktree: worktree.id).flatMap { tab -> [String] in
+                tabs.tabs(forWorktree: worktree.id).flatMap { tab -> [TerminalSessionIdentity] in
                     guard case .terminal(let state) = tab else { return [] }
-                    return state.root.leaves().map(\.id)
+                    return state.root.leaves().map {
+                        TerminalSessionIdentity(worktreeId: worktree.id, leafId: $0.id)
+                    }
                 }
             }
         }
@@ -1490,7 +1497,7 @@ final class AppState {
                 for leaf in s.root.leaves() {
                     harness.detector.unregister(sessionId: leaf.id)
                     harness.forgetSession(leaf.id)
-                    terminal.closeSession(id: leaf.id)
+                    terminal.closeSession(id: leaf.id, worktreeId: worktreeId)
                 }
             }
             if case .editor = tab {
@@ -1503,14 +1510,14 @@ final class AppState {
         tabs.close(worktreeId: worktreeId, tabId: tabId)
     }
 
-    private func cleanupTerminals(allTabs: [Tab], tabIds: [TabID]) {
+    private func cleanupTerminals(worktreeId: String, allTabs: [Tab], tabIds: [TabID]) {
         for id in tabIds {
             if let tab = allTabs.first(where: { $0.id == id }),
                case .terminal(let s) = tab {
                 for leaf in s.root.leaves() {
                     harness.detector.unregister(sessionId: leaf.id)
                     harness.forgetSession(leaf.id)
-                    terminal.closeSession(id: leaf.id)
+                    terminal.closeSession(id: leaf.id, worktreeId: worktreeId)
                 }
             }
         }
@@ -1549,7 +1556,7 @@ final class AppState {
     func closeOtherTabs(worktreeId: String, keeping tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeOthers(worktreeId: worktreeId, keeping: tabId)
-        cleanupTerminals(allTabs: allTabs, tabIds: closed)
+        cleanupTerminals(worktreeId: worktreeId, allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
         cleanupACPSessions(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
     }
@@ -1560,7 +1567,7 @@ final class AppState {
     private func cleanupWorktreeState(worktreeId: String) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeAll(worktreeId: worktreeId)
-        cleanupTerminals(allTabs: allTabs, tabIds: closed)
+        cleanupTerminals(worktreeId: worktreeId, allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
         disposeACPManager(for: worktreeId)
     }
@@ -1572,7 +1579,7 @@ final class AppState {
     func closeTabsToLeft(worktreeId: String, of tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeToLeft(worktreeId: worktreeId, of: tabId)
-        cleanupTerminals(allTabs: allTabs, tabIds: closed)
+        cleanupTerminals(worktreeId: worktreeId, allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
         cleanupACPSessions(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
     }
@@ -1580,7 +1587,7 @@ final class AppState {
     func closeTabsToRight(worktreeId: String, of tabId: TabID) {
         let allTabs = tabs.tabs(forWorktree: worktreeId)
         let closed = tabs.closeToRight(worktreeId: worktreeId, of: tabId)
-        cleanupTerminals(allTabs: allTabs, tabIds: closed)
+        cleanupTerminals(worktreeId: worktreeId, allTabs: allTabs, tabIds: closed)
         cleanupClosedEditorBuffers(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
         cleanupACPSessions(worktreeId: worktreeId, allTabs: allTabs, closedIds: closed)
     }

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -62,7 +62,8 @@ final class TerminalService {
         theme: Theme,
         forcedCwd: URL? = nil,
         startupScriptSuffix: String? = nil,
-        leafId: String = UUID().uuidString
+        leafId: String = UUID().uuidString,
+        allowLegacyAttach: Bool = false
     ) throws -> TerminalSession {
         try ensureApp(cfg: cfg, theme: theme)
         guard let app else { throw NSError(domain: "TerminalService", code: 1) }
@@ -99,7 +100,12 @@ final class TerminalService {
             startupScript: effectiveScript,
             sessionId: sessionId
         )
-        let zmxSessionName = ZmxSessionName.derive(worktreeId: worktree.id, leafId: sessionId)
+        let zmxSessionName = sessionNameForAttach(
+            worktree: worktree,
+            project: project,
+            leafId: sessionId,
+            allowLegacy: allowLegacyAttach
+        )
         let plan = TerminalService.resolveLaunchPlan(
             keepAlive: cfg.keepSessionsAlive,
             zmxClient: zmxClient,
@@ -130,13 +136,18 @@ final class TerminalService {
             projectId: project.id,
             surface: surface,
             executable: plan.executable,
-            args: plan.args
+            args: plan.args,
+            zmxSessionName: (cfg.keepSessionsAlive && zmxClient.isAvailable) ? zmxSessionName : nil
         )
         registry.register(session)
         return session
     }
 
-    func closeSession(id: String, worktreeId explicitWorktreeId: String? = nil) {
+    func closeSession(
+        id: String,
+        worktreeId explicitWorktreeId: String? = nil,
+        projectPath: String? = nil
+    ) {
         let existing = registry.session(for: id)
         if let s = existing {
             s.surface.removeFromSuperview()
@@ -145,10 +156,22 @@ final class TerminalService {
         // `zmxClient.killSession` blocks up to ~5s on a hung daemon. We're
         // on @MainActor here, so dispatch it off-main as fire-and-forget
         // (the call is documented best-effort; we don't read the result).
-        if let worktreeId = explicitWorktreeId ?? existing?.worktreeId {
+        if let existingName = existing?.zmxSessionName {
             let client = zmxClient
-            let sessionName = ZmxSessionName.derive(worktreeId: worktreeId, leafId: id)
-            Task.detached { client.killSession(name: sessionName) }
+            Task.detached { client.killSession(name: existingName) }
+        } else if let worktreeId = explicitWorktreeId ?? existing?.worktreeId {
+            let client = zmxClient
+            Task.detached {
+                let sessionNames = Self.sessionNamesForCleanup(
+                    worktreeId: worktreeId,
+                    projectPath: projectPath,
+                    leafId: id,
+                    zmxClient: client
+                )
+                for sessionName in sessionNames {
+                    client.killSession(name: sessionName)
+                }
+            }
         }
         socketReleaseHandler?(id)
         cleanupRcfile(sessionId: id)
@@ -177,17 +200,22 @@ final class TerminalService {
     /// `ZmxClient.killSession` blocks up to ~5s, so we run the sweep on
     /// `Task.detached` to keep the MainActor (UI) responsive.
     func terminateAll(additionalSessions: [TerminalSessionIdentity] = []) {
-        let live = registry.all.map {
-            TerminalSessionIdentity(worktreeId: $0.worktreeId, leafId: $0.id)
+        let liveNames = registry.all.map {
+            $0.zmxSessionName ?? ZmxSessionName.derive(worktreeId: $0.worktreeId, leafId: $0.id)
         }
-        let allSessions = Set(live).union(additionalSessions)
         let client = zmxClient
         Task.detached {
-            for session in allSessions {
-                client.killSession(name: ZmxSessionName.derive(
+            var allNames = Set(liveNames)
+            for session in additionalSessions {
+                allNames.formUnion(Self.sessionNamesForCleanup(
                     worktreeId: session.worktreeId,
-                    leafId: session.leafId
+                    projectPath: session.projectPath,
+                    leafId: session.leafId,
+                    zmxClient: client
                 ))
+            }
+            for name in allNames {
+                client.killSession(name: name)
             }
         }
     }
@@ -254,5 +282,58 @@ final class TerminalService {
                 return trimmed.isEmpty ? nil : trimmed
             }
             .joined(separator: "\n")
+    }
+
+    private func sessionNameForAttach(
+        worktree: Worktree,
+        project: ProjectConfig,
+        leafId: String,
+        allowLegacy: Bool
+    ) -> String {
+        let scoped = ZmxSessionName.derive(worktreeId: worktree.id, leafId: leafId)
+        guard allowLegacy else { return scoped }
+        let legacy = ZmxSessionName.legacy(leafId: leafId)
+        guard Self.legacySessionBelongsToKnownRoot(
+            legacy,
+            roots: [worktree.id, project.path],
+            zmxClient: zmxClient
+        ) else {
+            return scoped
+        }
+        return legacy
+    }
+
+    nonisolated private static func sessionNamesForCleanup(
+        worktreeId: String,
+        projectPath: String?,
+        leafId: String,
+        zmxClient: ZmxClient
+    ) -> [String] {
+        let scoped = ZmxSessionName.derive(worktreeId: worktreeId, leafId: leafId)
+        let legacy = ZmxSessionName.legacy(leafId: leafId)
+        let roots = [worktreeId] + (projectPath.map { [$0] } ?? [])
+        guard legacySessionBelongsToKnownRoot(legacy, roots: roots, zmxClient: zmxClient) else {
+            return [scoped]
+        }
+        return [scoped, legacy]
+    }
+
+    nonisolated static func legacySessionBelongsToKnownRoot(
+        _ name: String,
+        roots: [String],
+        zmxClient: ZmxClient
+    ) -> Bool {
+        let roots = Set(roots.map { URL(fileURLWithPath: $0).standardizedFileURL.path })
+        return zmxClient.listSessionInfos().contains { info in
+            info.name == name && startDir(info.startDir, belongsToAnyOf: roots)
+        }
+    }
+
+    nonisolated private static func startDir(_ startDir: String?, belongsToAnyOf roots: Set<String>) -> Bool {
+        guard let startDir else { return false }
+        let start = URL(fileURLWithPath: startDir).standardizedFileURL.path
+        return roots.contains { root in
+            start == root || start.hasPrefix(root + "/")
+        }
     }
 }

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -99,10 +99,11 @@ final class TerminalService {
             startupScript: effectiveScript,
             sessionId: sessionId
         )
+        let zmxSessionName = ZmxSessionName.derive(worktreeId: worktree.id, leafId: sessionId)
         let plan = TerminalService.resolveLaunchPlan(
             keepAlive: cfg.keepSessionsAlive,
             zmxClient: zmxClient,
-            sessionId: sessionId,
+            sessionName: zmxSessionName,
             innerPlan: innerPlan
         )
         // Plan-supplied env overrides (e.g. ZDOTDIR for zsh startup scripts)
@@ -135,17 +136,20 @@ final class TerminalService {
         return session
     }
 
-    func closeSession(id: String) {
-        if let s = registry.session(for: id) {
+    func closeSession(id: String, worktreeId explicitWorktreeId: String? = nil) {
+        let existing = registry.session(for: id)
+        if let s = existing {
             s.surface.removeFromSuperview()
         }
         registry.unregister(id: id)
         // `zmxClient.killSession` blocks up to ~5s on a hung daemon. We're
         // on @MainActor here, so dispatch it off-main as fire-and-forget
         // (the call is documented best-effort; we don't read the result).
-        let client = zmxClient
-        let sessionName = ZmxSessionName.derive(leafId: id)
-        Task.detached { client.killSession(name: sessionName) }
+        if let worktreeId = explicitWorktreeId ?? existing?.worktreeId {
+            let client = zmxClient
+            let sessionName = ZmxSessionName.derive(worktreeId: worktreeId, leafId: id)
+            Task.detached { client.killSession(name: sessionName) }
+        }
         socketReleaseHandler?(id)
         cleanupRcfile(sessionId: id)
     }
@@ -160,7 +164,7 @@ final class TerminalService {
 
     /// User-requested "Terminate All Terminal Sessions". Kills every
     /// session we currently know about, including persisted-but-unrestored
-    /// leaves the caller hands in via `additionalLeafIds`. Best-effort:
+    /// sessions the caller hands in via `additionalSessions`. Best-effort:
     /// each kill swallows its own errors.
     ///
     /// We deliberately do NOT enumerate `zmx ls` and kill arbitrary
@@ -172,12 +176,18 @@ final class TerminalService {
     ///
     /// `ZmxClient.killSession` blocks up to ~5s, so we run the sweep on
     /// `Task.detached` to keep the MainActor (UI) responsive.
-    func terminateAll(additionalLeafIds: [String] = []) {
-        let allIds = Set(registry.all.map(\.id)).union(additionalLeafIds)
+    func terminateAll(additionalSessions: [TerminalSessionIdentity] = []) {
+        let live = registry.all.map {
+            TerminalSessionIdentity(worktreeId: $0.worktreeId, leafId: $0.id)
+        }
+        let allSessions = Set(live).union(additionalSessions)
         let client = zmxClient
         Task.detached {
-            for id in allIds {
-                client.killSession(name: ZmxSessionName.derive(leafId: id))
+            for session in allSessions {
+                client.killSession(name: ZmxSessionName.derive(
+                    worktreeId: session.worktreeId,
+                    leafId: session.leafId
+                ))
             }
         }
     }
@@ -224,12 +234,12 @@ final class TerminalService {
     static func resolveLaunchPlan(
         keepAlive: Bool,
         zmxClient: ZmxClient,
-        sessionId: String,
+        sessionName: String,
         innerPlan: StartupScriptInstaller.Plan
     ) -> StartupScriptInstaller.Plan {
         guard keepAlive else { return innerPlan }
         return zmxClient.wrap(
-            sessionName: ZmxSessionName.derive(leafId: sessionId),
+            sessionName: sessionName,
             plan: innerPlan
         )
     }

--- a/Alas/Sources/Terminal/TerminalSession.swift
+++ b/Alas/Sources/Terminal/TerminalSession.swift
@@ -6,9 +6,27 @@
 import Foundation
 import AppKit
 
-struct TerminalSessionIdentity: Hashable, Sendable {
+struct TerminalSessionIdentity: Sendable {
     let worktreeId: String
+    let projectPath: String?
     let leafId: String
+
+    init(worktreeId: String, projectPath: String? = nil, leafId: String) {
+        self.worktreeId = worktreeId
+        self.projectPath = projectPath
+        self.leafId = leafId
+    }
+}
+
+extension TerminalSessionIdentity: Hashable {
+    static func == (lhs: TerminalSessionIdentity, rhs: TerminalSessionIdentity) -> Bool {
+        lhs.worktreeId == rhs.worktreeId && lhs.leafId == rhs.leafId
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(worktreeId)
+        hasher.combine(leafId)
+    }
 }
 
 @MainActor
@@ -21,6 +39,7 @@ final class TerminalSession {
     let surface: AlasGhostty.SurfaceView
     let executable: String
     let args: [String]
+    let zmxSessionName: String?
 
     /// Set by HarnessService in Plan 5 — nil here.
     var harnessKind: String? = nil
@@ -32,7 +51,8 @@ final class TerminalSession {
         projectId: String,
         surface: AlasGhostty.SurfaceView,
         executable: String,
-        args: [String]
+        args: [String],
+        zmxSessionName: String? = nil
     ) {
         self.id = id
         self.worktreeId = worktreeId
@@ -40,6 +60,7 @@ final class TerminalSession {
         self.surface = surface
         self.executable = executable
         self.args = args
+        self.zmxSessionName = zmxSessionName
         self.createdAt = Date()
     }
 }

--- a/Alas/Sources/Terminal/TerminalSession.swift
+++ b/Alas/Sources/Terminal/TerminalSession.swift
@@ -6,6 +6,11 @@
 import Foundation
 import AppKit
 
+struct TerminalSessionIdentity: Hashable, Sendable {
+    let worktreeId: String
+    let leafId: String
+}
+
 @MainActor
 final class TerminalSession {
     let id: String                // matches Tab.id (UUID string)

--- a/Alas/Sources/Terminal/Zmx/ZmxClient.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxClient.swift
@@ -1,6 +1,11 @@
 import Foundation
 import os
 
+struct ZmxSessionInfo: Equatable, Sendable {
+    let name: String
+    let startDir: String?
+}
+
 /// Thin Swift wrapper around the bundled `zmx` CLI. Exposes the three
 /// operations Alas needs (`wrap` for launch, `killSession` for explicit
 /// close, `listSessions` for cleanup walks) and falls back to a no-op
@@ -98,11 +103,49 @@ final class ZmxClient: Sendable {
             .filter { !$0.isEmpty }
     }
 
+    /// Parse full `zmx ls` key-value rows. Used for legacy session migration,
+    /// where `start_dir` lets us avoid attaching an old unscoped session from
+    /// a different worktree.
+    func listSessionInfos() -> [ZmxSessionInfo] {
+        guard env.isAvailable, let binary = env.binaryURL else { return [] }
+        let result = runner.run(binary, ["ls"], zmxEnv(), 5.0)
+        guard result.exitCode == 0 else {
+            if let code = result.exitCode {
+                logger.warning("zmx ls exited \(code, privacy: .public): \(result.stderr, privacy: .public)")
+            } else {
+                logger.warning("zmx ls timed out")
+            }
+            return []
+        }
+        return result.stdout
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { parseSessionInfoLine(String($0)) }
+    }
+
     /// Environment passed to every zmx invocation. Pins `ZMX_DIR` so the
     /// CLI talks to the same daemon/socket dir Alas-spawned shells will use.
     private func zmxEnv() -> [String: String] {
         var inherited = ProcessInfo.processInfo.environment
         if let dir = env.zmxDir { inherited["ZMX_DIR"] = dir.path }
         return inherited
+    }
+
+    private func parseSessionInfoLine(_ line: String) -> ZmxSessionInfo? {
+        let fields = line
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "\t", omittingEmptySubsequences: true)
+        var name: String?
+        var startDir: String?
+        for field in fields {
+            let parts = field.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { continue }
+            switch parts[0] {
+            case "name": name = String(parts[1])
+            case "start_dir": startDir = String(parts[1])
+            default: break
+            }
+        }
+        guard let name else { return nil }
+        return ZmxSessionInfo(name: name, startDir: startDir)
     }
 }

--- a/Alas/Sources/Terminal/Zmx/ZmxSessionName.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxSessionName.swift
@@ -1,10 +1,18 @@
 import Foundation
+import CryptoKit
 
 /// Single derivation point for the zmx session name attached to a pane.
 /// Used by both `ZmxClient.wrap` (at launch) and `TerminalService.closeSession`
 /// (at kill) so the two call sites can never drift.
 enum ZmxSessionName {
-    static func derive(leafId: String) -> String {
-        "alas-\(leafId)"
+    static func derive(worktreeId: String, leafId: String) -> String {
+        "alas-\(hash16(worktreeId))-\(hash16(leafId))"
+    }
+
+    private static func hash16(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8))
+            .prefix(8)
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 }

--- a/Alas/Sources/Terminal/Zmx/ZmxSessionName.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxSessionName.swift
@@ -9,6 +9,10 @@ enum ZmxSessionName {
         "alas-\(hash16(worktreeId))-\(hash16(leafId))"
     }
 
+    static func legacy(leafId: String) -> String {
+        "alas-\(leafId)"
+    }
+
     private static func hash16(_ value: String) -> String {
         SHA256.hash(data: Data(value.utf8))
             .prefix(8)

--- a/Alas/Sources/Terminal/Zmx/ZmxSunPathBudget.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxSunPathBudget.swift
@@ -5,13 +5,13 @@ import Foundation
 /// most 103 bytes. zmx creates sockets named "<sessionName>.sock" under
 /// `ZMX_DIR`; a full bind path is `<dir>/<sessionName>.sock`. The longest
 /// session name we ever produce is
-/// `ZmxSessionName.derive(leafId: UUID().uuidString)` → 41 chars; basename
-/// adds ".sock" for 46 chars, plus the path separator = 47 chars of overhead.
+/// `ZmxSessionName.derive(worktreeId: ..., leafId: ...)` → 38 chars; basename
+/// adds ".sock" for 43 chars, plus the path separator = 44 chars of overhead.
 enum ZmxSunPathBudget {
     /// Total bytes in `sockaddr_un.sun_path` on macOS, including the NUL
     /// terminator. The usable path length is `sunPathTotal - 1`.
     static let sunPathTotal = 104
-    static let longestSocketBasenameOverhead = 47   // "/<41-char-name>.sock"
+    static let longestSocketBasenameOverhead = 44   // "/<38-char-name>.sock"
 
     /// True when `<dir>/<longest-basename>` still fits within sun_path —
     /// reserving one byte for the NUL terminator that `bind(2)` requires.

--- a/Alas/Sources/Terminal/Zmx/ZmxSunPathBudget.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxSunPathBudget.swift
@@ -4,14 +4,14 @@ import Foundation
 /// holds 104 bytes **including the trailing NUL** — so the usable path is at
 /// most 103 bytes. zmx creates sockets named "<sessionName>.sock" under
 /// `ZMX_DIR`; a full bind path is `<dir>/<sessionName>.sock`. The longest
-/// session name we ever produce is
-/// `ZmxSessionName.derive(worktreeId: ..., leafId: ...)` → 38 chars; basename
-/// adds ".sock" for 43 chars, plus the path separator = 44 chars of overhead.
+/// session name we currently support is the legacy `alas-<UUID>` name during
+/// upgrade restore fallback: 41 chars; basename adds ".sock" for 46 chars,
+/// plus the path separator = 47 chars of overhead.
 enum ZmxSunPathBudget {
     /// Total bytes in `sockaddr_un.sun_path` on macOS, including the NUL
     /// terminator. The usable path length is `sunPathTotal - 1`.
     static let sunPathTotal = 104
-    static let longestSocketBasenameOverhead = 44   // "/<38-char-name>.sock"
+    static let longestSocketBasenameOverhead = 47   // "/<41-char-legacy-name>.sock"
 
     /// True when `<dir>/<longest-basename>` still fits within sun_path —
     /// reserving one byte for the NUL terminator that `bind(2)` requires.

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -78,7 +78,7 @@ struct TerminalServiceZmxTests {
         svc.registry.register(session)
         #expect(svc.registry.session(for: "leaf-abc") != nil)
 
-        svc.closeSession(id: "leaf-abc")
+        svc.closeSession(id: "leaf-abc", worktreeId: "wt-1")
 
         #expect(svc.registry.session(for: "leaf-abc") == nil)
     }
@@ -102,11 +102,14 @@ struct TerminalServiceZmxTests {
         )
         svc.registry.register(session)
 
-        svc.closeSession(id: "leaf-xyz")
+        svc.closeSession(id: "leaf-xyz", worktreeId: "wt-1")
         await waitForCalls(recorder, count: 1) { $0.calls.count }
 
         #expect(recorder.calls.count == 1)
-        #expect(recorder.calls[0].args == ["kill", "alas-leaf-xyz"])
+        #expect(recorder.calls[0].args == [
+            "kill",
+            ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-xyz"),
+        ])
     }
 
     @Test func closeSessionIsNoOpForZmxKillWhenUnavailable() {
@@ -126,7 +129,7 @@ struct TerminalServiceZmxTests {
         )
         svc.registry.register(session)
 
-        svc.closeSession(id: "leaf-absent")
+        svc.closeSession(id: "leaf-absent", worktreeId: "wt-1")
 
         // Registry must be cleaned up even when zmx is unavailable.
         #expect(svc.registry.session(for: "leaf-absent") == nil)
@@ -140,10 +143,13 @@ struct TerminalServiceZmxTests {
             zmxClient: ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
         )
         // Should not throw or crash — zmx kill is still attempted for cleanup.
-        svc.closeSession(id: "nonexistent-id")
+        svc.closeSession(id: "nonexistent-id", worktreeId: "wt-1")
         await waitForCalls(recorder, count: 1) { $0.calls.count }
         #expect(recorder.calls.count == 1)
-        #expect(recorder.calls[0].args == ["kill", "alas-nonexistent-id"])
+        #expect(recorder.calls[0].args == [
+            "kill",
+            ZmxSessionName.derive(worktreeId: "wt-1", leafId: "nonexistent-id"),
+        ])
     }
 
     // MARK: detachAll
@@ -196,11 +202,16 @@ struct TerminalServiceZmxTests {
 
         // Pass one persisted-but-not-registered leaf id; expect both to
         // be killed and nothing else.
-        service.terminateAll(additionalLeafIds: ["leaf-persisted-B"])
+        service.terminateAll(additionalSessions: [
+            TerminalSessionIdentity(worktreeId: "wt-2", leafId: "leaf-persisted-B"),
+        ])
         await waitForCalls(recorder, count: 2) { $0.calls.count }
 
         let allArgs = Set(recorder.calls.map(\.args))
-        #expect(allArgs == Set([["kill", "alas-leaf-A"], ["kill", "alas-leaf-persisted-B"]]))
+        #expect(allArgs == Set([
+            ["kill", ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-A")],
+            ["kill", ZmxSessionName.derive(worktreeId: "wt-2", leafId: "leaf-persisted-B")],
+        ]))
         // No `ls` invocation — we no longer enumerate zmx's session list
         // to avoid touching another live Alas instance's sessions.
         #expect(recorder.calls.contains(where: { $0.args.first == "ls" }) == false)
@@ -224,10 +235,15 @@ struct TerminalServiceZmxTests {
         service.registry.register(session)
 
         // leaf-A is in both registry and additionals — should still kill once.
-        service.terminateAll(additionalLeafIds: ["leaf-A"])
+        service.terminateAll(additionalSessions: [
+            TerminalSessionIdentity(worktreeId: "wt-1", leafId: "leaf-A"),
+        ])
         await waitForCalls(recorder, count: 1) { $0.calls.count }
         #expect(recorder.calls.count == 1)
-        #expect(recorder.calls[0].args == ["kill", "alas-leaf-A"])
+        #expect(recorder.calls[0].args == [
+            "kill",
+            ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-A"),
+        ])
     }
 
     // MARK: resolveLaunchPlan — keepSessionsAlive gating
@@ -242,12 +258,17 @@ struct TerminalServiceZmxTests {
         let plan = TerminalService.resolveLaunchPlan(
             keepAlive: true,
             zmxClient: client,
-            sessionId: "leaf-1",
+            sessionName: ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-1"),
             innerPlan: inner
         )
 
         #expect(plan.executable == "/fake/Contents/Resources/zmx/zmx")
-        #expect(plan.args == ["attach", "alas-leaf-1", "/bin/zsh", "-l"])
+        #expect(plan.args == [
+            "attach",
+            ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-1"),
+            "/bin/zsh",
+            "-l",
+        ])
         #expect(plan.envOverrides == ["FOO": "1"])
     }
 
@@ -261,7 +282,7 @@ struct TerminalServiceZmxTests {
         let plan = TerminalService.resolveLaunchPlan(
             keepAlive: false,
             zmxClient: client,
-            sessionId: "leaf-2",
+            sessionName: ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-2"),
             innerPlan: inner
         )
 
@@ -287,7 +308,7 @@ struct TerminalServiceZmxTests {
         let plan = TerminalService.resolveLaunchPlan(
             keepAlive: true,
             zmxClient: client,
-            sessionId: "leaf-3",
+            sessionName: ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-3"),
             innerPlan: inner
         )
 

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -11,10 +11,14 @@ private final class RecordingRunner: @unchecked Sendable {
         let args: [String]
     }
     var calls: [Call] = []
+    var resultsByFirstArg: [String: SubprocessRunner.Result] = [:]
 
     func runner() -> SubprocessRunner {
         SubprocessRunner { exe, args, _, _ in
             self.calls.append(Call(executable: exe, args: args))
+            if let first = args.first, let result = self.resultsByFirstArg[first] {
+                return result
+            }
             return SubprocessRunner.Result(exitCode: 0, stdout: "", stderr: "")
         }
     }
@@ -73,7 +77,8 @@ struct TerminalServiceZmxTests {
             projectId: "proj-1",
             surface: surface,
             executable: "/bin/zsh",
-            args: []
+            args: [],
+            zmxSessionName: ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-abc")
         )
         svc.registry.register(session)
         #expect(svc.registry.session(for: "leaf-abc") != nil)
@@ -98,7 +103,8 @@ struct TerminalServiceZmxTests {
             projectId: "proj-1",
             surface: surface,
             executable: "/bin/zsh",
-            args: []
+            args: [],
+            zmxSessionName: ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-xyz")
         )
         svc.registry.register(session)
 
@@ -143,13 +149,97 @@ struct TerminalServiceZmxTests {
             zmxClient: ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
         )
         // Should not throw or crash — zmx kill is still attempted for cleanup.
+        recorder.resultsByFirstArg["ls"] = .init(exitCode: 0, stdout: "", stderr: "")
+
         svc.closeSession(id: "nonexistent-id", worktreeId: "wt-1")
-        await waitForCalls(recorder, count: 1) { $0.calls.count }
-        #expect(recorder.calls.count == 1)
-        #expect(recorder.calls[0].args == [
+        await waitForCalls(recorder, count: 2) { $0.calls.count }
+        #expect(recorder.calls.map(\.args) == [
+            ["ls"],
+            [
             "kill",
             ZmxSessionName.derive(worktreeId: "wt-1", leafId: "nonexistent-id"),
+            ],
         ])
+    }
+
+    @Test func closeSessionOnUnrestoredLegacySessionKillsScopedAndMatchingLegacyNames() async {
+        let recorder = RecordingRunner()
+        recorder.resultsByFirstArg["ls"] = .init(
+            exitCode: 0,
+            stdout: "  name=alas-legacy-leaf\tpid=1\tclients=0\tcreated=1\tstart_dir=/tmp/wt\tcmd=/bin/zsh -l\n",
+            stderr: ""
+        )
+        let svc = TerminalService(
+            zmxClient: ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
+        )
+
+        svc.closeSession(id: "legacy-leaf", worktreeId: "/tmp/wt")
+        await waitForCalls(recorder, count: 3) { $0.calls.count }
+
+        #expect(recorder.calls.map(\.args) == [
+            ["ls"],
+            ["kill", ZmxSessionName.derive(worktreeId: "/tmp/wt", leafId: "legacy-leaf")],
+            ["kill", "alas-legacy-leaf"],
+        ])
+    }
+
+    @Test func closeSessionOnUnrestoredRepoRootLegacySessionKillsLegacyName() async {
+        let recorder = RecordingRunner()
+        recorder.resultsByFirstArg["ls"] = .init(
+            exitCode: 0,
+            stdout: "  name=alas-legacy-leaf\tpid=1\tclients=0\tcreated=1\tstart_dir=/tmp/repo/subdir\tcmd=/bin/zsh -l\n",
+            stderr: ""
+        )
+        let svc = TerminalService(
+            zmxClient: ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
+        )
+
+        svc.closeSession(id: "legacy-leaf", worktreeId: "/tmp/wt", projectPath: "/tmp/repo")
+        await waitForCalls(recorder, count: 3) { $0.calls.count }
+
+        #expect(recorder.calls.map(\.args) == [
+            ["ls"],
+            ["kill", ZmxSessionName.derive(worktreeId: "/tmp/wt", leafId: "legacy-leaf")],
+            ["kill", "alas-legacy-leaf"],
+        ])
+    }
+
+    @Test func legacySessionOwnershipAcceptsRepoRootStartDir() {
+        let recorder = RecordingRunner()
+        recorder.resultsByFirstArg["ls"] = .init(
+            exitCode: 0,
+            stdout: "  name=alas-legacy-leaf\tpid=1\tclients=0\tcreated=1\tstart_dir=/tmp/repo/subdir\tcmd=/bin/zsh -l\n",
+            stderr: ""
+        )
+        let client = ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
+
+        let belongs = TerminalService.legacySessionBelongsToKnownRoot(
+            ZmxSessionName.legacy(leafId: "legacy-leaf"),
+            roots: ["/tmp/repo-linked-worktree", "/tmp/repo"],
+            zmxClient: client
+        )
+
+        #expect(belongs)
+        #expect(recorder.calls.map(\.args) == [["ls"]])
+    }
+
+    @Test func legacySessionOwnershipRejectsSiblingRepoRootStartDir() {
+        let recorder = RecordingRunner()
+        recorder.resultsByFirstArg["ls"] = .init(
+            exitCode: 0,
+            stdout: "  name=alas-legacy-leaf\tpid=1\tclients=0\tcreated=1\tstart_dir=/tmp/repo-other\tcmd=/bin/zsh -l\n",
+            stderr: ""
+        )
+        let client = ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
+
+        let belongs = TerminalService.legacySessionBelongsToKnownRoot(
+            ZmxSessionName.legacy(leafId: "legacy-leaf"),
+            roots: ["/tmp/repo-linked-worktree", "/tmp/repo"],
+            zmxClient: client
+        )
+
+        #expect(!belongs)
+        #expect(recorder.calls.map(\.args) == [["ls"]])
     }
 
     // MARK: detachAll
@@ -182,10 +272,8 @@ struct TerminalServiceZmxTests {
 
     @Test
     func terminateAllKillsRegistryAndAdditionalLeaves() async {
-        // Use the standard recorder (no scripted ls output): the new
-        // terminateAll does not enumerate `zmx ls` at all, so we should
-        // see ONLY kill calls — none for `ls`.
         let recorder = RecordingRunner()
+        recorder.resultsByFirstArg["ls"] = .init(exitCode: 0, stdout: "", stderr: "")
         let client = ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
         let service = TerminalService(zmxClient: client)
 
@@ -205,21 +293,47 @@ struct TerminalServiceZmxTests {
         service.terminateAll(additionalSessions: [
             TerminalSessionIdentity(worktreeId: "wt-2", leafId: "leaf-persisted-B"),
         ])
-        await waitForCalls(recorder, count: 2) { $0.calls.count }
+        await waitForCalls(recorder, count: 3) { $0.calls.count }
 
         let allArgs = Set(recorder.calls.map(\.args))
         #expect(allArgs == Set([
+            ["ls"],
             ["kill", ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-A")],
             ["kill", ZmxSessionName.derive(worktreeId: "wt-2", leafId: "leaf-persisted-B")],
         ]))
-        // No `ls` invocation — we no longer enumerate zmx's session list
-        // to avoid touching another live Alas instance's sessions.
-        #expect(recorder.calls.contains(where: { $0.args.first == "ls" }) == false)
+    }
+
+    @Test
+    func terminateAllKillsRepoRootLegacyAdditionalLeaves() async {
+        let recorder = RecordingRunner()
+        recorder.resultsByFirstArg["ls"] = .init(
+            exitCode: 0,
+            stdout: "  name=alas-leaf-persisted-B\tpid=1\tclients=0\tcreated=1\tstart_dir=/tmp/repo\tcmd=/bin/zsh -l\n",
+            stderr: ""
+        )
+        let client = ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
+        let service = TerminalService(zmxClient: client)
+
+        service.terminateAll(additionalSessions: [
+            TerminalSessionIdentity(
+                worktreeId: "/tmp/wt",
+                projectPath: "/tmp/repo",
+                leafId: "leaf-persisted-B"
+            ),
+        ])
+        await waitForCalls(recorder, count: 3) { $0.calls.count }
+
+        #expect(Set(recorder.calls.map(\.args)) == Set([
+            ["ls"],
+            ["kill", ZmxSessionName.derive(worktreeId: "/tmp/wt", leafId: "leaf-persisted-B")],
+            ["kill", "alas-leaf-persisted-B"],
+        ]))
     }
 
     @Test
     func terminateAllDeduplicatesRegistryAndAdditional() async {
         let recorder = RecordingRunner()
+        recorder.resultsByFirstArg["ls"] = .init(exitCode: 0, stdout: "", stderr: "")
         let client = ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
         let service = TerminalService(zmxClient: client)
 
@@ -238,11 +352,13 @@ struct TerminalServiceZmxTests {
         service.terminateAll(additionalSessions: [
             TerminalSessionIdentity(worktreeId: "wt-1", leafId: "leaf-A"),
         ])
-        await waitForCalls(recorder, count: 1) { $0.calls.count }
-        #expect(recorder.calls.count == 1)
-        #expect(recorder.calls[0].args == [
-            "kill",
-            ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-A"),
+        await waitForCalls(recorder, count: 2) { $0.calls.count }
+        #expect(recorder.calls.map(\.args) == [
+            ["ls"],
+            [
+                "kill",
+                ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-A"),
+            ],
         ])
     }
 

--- a/AlasTests/ZmxClientTests.swift
+++ b/AlasTests/ZmxClientTests.swift
@@ -184,4 +184,32 @@ struct ZmxClientTests {
         let client = ZmxClient(env: env(available: true), runner: recorder.runner())
         #expect(client.listSessions() == ["alas-AAA", "alas-BBB"])
     }
+
+    @Test
+    func listSessionInfosParsesFullLsOutput() {
+        let recorder = RecordingRunner()
+        recorder.result = SubprocessRunner.Result(
+            exitCode: 0,
+            stdout: """
+              name=alas-old-leaf\tpid=25367\tclients=1\tcreated=1779957881\tstart_dir=/Users/nacho/.alas/.worktrees/alas/nacho-new-worktree-acp\tcmd=/bin/zsh -l
+              name=alas-other\tpid=25368\tclients=0\tcreated=1779957882\tstart_dir=/Volumes/Workspace/alas\tcmd=/bin/zsh -l -i
+
+            """,
+            stderr: ""
+        )
+        let client = ZmxClient(env: env(available: true), runner: recorder.runner())
+        let infos = client.listSessionInfos()
+
+        #expect(infos == [
+            ZmxSessionInfo(
+                name: "alas-old-leaf",
+                startDir: "/Users/nacho/.alas/.worktrees/alas/nacho-new-worktree-acp"
+            ),
+            ZmxSessionInfo(
+                name: "alas-other",
+                startDir: "/Volumes/Workspace/alas"
+            ),
+        ])
+        #expect(recorder.calls[0].args == ["ls"])
+    }
 }

--- a/AlasTests/ZmxSessionNameTests.swift
+++ b/AlasTests/ZmxSessionNameTests.swift
@@ -24,6 +24,11 @@ struct ZmxSessionNameTests {
     }
 
     @Test
+    func legacyNameKeepsPreScopedFormatForUpgradeFallback() {
+        #expect(ZmxSessionName.legacy(leafId: "leaf-123") == "alas-leaf-123")
+    }
+
+    @Test
     func deriveDoesNotMutateInput() {
         let worktreeId = "/tmp/worktree"
         let leafId = "abc-123"

--- a/AlasTests/ZmxSessionNameTests.swift
+++ b/AlasTests/ZmxSessionNameTests.swift
@@ -4,15 +4,31 @@ import Testing
 @Suite
 struct ZmxSessionNameTests {
     @Test
-    func derivePrefixesLeafIdWithAlas() {
+    func deriveIncludesStableWorktreeAndLeafScope() {
+        let worktreeId = "/Users/nacho/.alas/.worktrees/alas/nacho-new-worktree-acp"
         let leafId = "61F2A8E0-2D9F-4B1F-9E5A-9C0B6C3F0F0F"
-        #expect(ZmxSessionName.derive(leafId: leafId) == "alas-61F2A8E0-2D9F-4B1F-9E5A-9C0B6C3F0F0F")
+        #expect(ZmxSessionName.derive(worktreeId: worktreeId, leafId: leafId) == "alas-f07e6273132977f2-c9820693548f0fac")
+    }
+
+    @Test
+    func sameLeafInDifferentWorktreesGetsDifferentName() {
+        let leafId = "shared-leaf-id"
+        let main = ZmxSessionName.derive(worktreeId: "/Volumes/Workspace/alas", leafId: leafId)
+        let worktree = ZmxSessionName.derive(
+            worktreeId: "/Users/nacho/.alas/.worktrees/alas/nacho-new-worktree-acp",
+            leafId: leafId
+        )
+        #expect(main != worktree)
+        #expect(main.hasPrefix("alas-"))
+        #expect(worktree.hasPrefix("alas-"))
     }
 
     @Test
     func deriveDoesNotMutateInput() {
+        let worktreeId = "/tmp/worktree"
         let leafId = "abc-123"
-        _ = ZmxSessionName.derive(leafId: leafId)
+        _ = ZmxSessionName.derive(worktreeId: worktreeId, leafId: leafId)
+        #expect(worktreeId == "/tmp/worktree")
         #expect(leafId == "abc-123")
     }
 }

--- a/AlasTests/ZmxSunPathBudgetTests.swift
+++ b/AlasTests/ZmxSunPathBudgetTests.swift
@@ -3,11 +3,11 @@ import Testing
 
 @Suite
 struct ZmxSunPathBudgetTests {
-    /// Longest socket basename we ever produce:
-    ///   "alas-" + 16-char worktree hash + "-" + 16-char leaf hash + ".sock" = 43 chars
-    /// Plus the path separator after the directory = 44 chars overhead.
+    /// Longest socket basename we currently support:
+    ///   legacy "alas-" + UUID + ".sock" = 46 chars
+    /// Plus the path separator after the directory = 47 chars overhead.
     /// sun_path holds 104 bytes including the NUL terminator, so usable
-    /// path is 103 bytes — budget allows directories up to 103 - 44 = 59 chars.
+    /// path is 103 bytes — budget allows directories up to 103 - 47 = 56 chars.
 
     @Test
     func fitsShortTmpPath() {
@@ -16,17 +16,17 @@ struct ZmxSunPathBudgetTests {
 
     @Test
     func fitsExactBoundary() {
-        // 59 chars exactly should fit (leaving 1 byte for the NUL terminator).
-        let dir = String(repeating: "a", count: 59)
-        #expect(dir.count == 59)
+        // 56 chars exactly should fit (leaving 1 byte for the NUL terminator).
+        let dir = String(repeating: "a", count: 56)
+        #expect(dir.count == 56)
         #expect(ZmxSunPathBudget.fits(dir: dir) == true)
     }
 
     @Test
     func rejectsOneOverBoundary() {
-        // 60 chars would consume all 104 sun_path bytes, leaving no room
+        // 57 chars would consume all 104 sun_path bytes, leaving no room
         // for the NUL terminator that `bind(2)` requires.
-        let dir = String(repeating: "a", count: 60)
+        let dir = String(repeating: "a", count: 57)
         #expect(ZmxSunPathBudget.fits(dir: dir) == false)
     }
 

--- a/AlasTests/ZmxSunPathBudgetTests.swift
+++ b/AlasTests/ZmxSunPathBudgetTests.swift
@@ -4,10 +4,10 @@ import Testing
 @Suite
 struct ZmxSunPathBudgetTests {
     /// Longest socket basename we ever produce:
-    ///   "alas-" + UUID() + ".sock" = 5 + 36 + 5 = 46 chars
-    /// Plus the path separator after the directory = 47 chars overhead.
+    ///   "alas-" + 16-char worktree hash + "-" + 16-char leaf hash + ".sock" = 43 chars
+    /// Plus the path separator after the directory = 44 chars overhead.
     /// sun_path holds 104 bytes including the NUL terminator, so usable
-    /// path is 103 bytes — budget allows directories up to 103 - 47 = 56 chars.
+    /// path is 103 bytes — budget allows directories up to 103 - 44 = 59 chars.
 
     @Test
     func fitsShortTmpPath() {
@@ -16,17 +16,17 @@ struct ZmxSunPathBudgetTests {
 
     @Test
     func fitsExactBoundary() {
-        // 56 chars exactly should fit (leaving 1 byte for the NUL terminator).
-        let dir = String(repeating: "a", count: 56)
-        #expect(dir.count == 56)
+        // 59 chars exactly should fit (leaving 1 byte for the NUL terminator).
+        let dir = String(repeating: "a", count: 59)
+        #expect(dir.count == 59)
         #expect(ZmxSunPathBudget.fits(dir: dir) == true)
     }
 
     @Test
     func rejectsOneOverBoundary() {
-        // 57 chars would consume all 104 sun_path bytes, leaving no room
+        // 60 chars would consume all 104 sun_path bytes, leaving no room
         // for the NUL terminator that `bind(2)` requires.
-        let dir = String(repeating: "a", count: 57)
+        let dir = String(repeating: "a", count: 60)
         #expect(ZmxSunPathBudget.fits(dir: dir) == false)
     }
 


### PR DESCRIPTION
## Summary

- Scope zmx terminal session names by both worktree id and terminal leaf id.
- Thread scoped terminal identities through close and terminate-all paths.
- Add regression coverage for cross-worktree leaf-id collisions and updated socket path budgeting.

## Root Cause

Alas persisted terminal tabs per worktree, but zmx session names were derived only from the terminal leaf id. Because zmx attach is an upsert by session name inside a shared `ZMX_DIR`, any duplicated or stale leaf id could attach a terminal in one worktree to a session created for another worktree.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`