### PR TITLE
fix(ui): consistent loading spinner UI

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		2584552219DE6987E1E6AF36 /* AgentRunError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF2F213480B30034B25B2B8 /* AgentRunError.swift */; };
 		25B497084FDEA8605FF8C5CA /* EditorFindController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */; };
 		25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */; };
+		25CD620AE7FFA7DE82937F7E /* Spinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
 		281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
@@ -1239,6 +1240,7 @@
 		C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStrip.swift; sourceTree = "<group>"; };
 		C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTheme.swift; sourceTree = "<group>"; };
 		C7DD2CA21EC45168D6E43564 /* TabActivityPulseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulseTests.swift; sourceTree = "<group>"; };
+		C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spinner.swift; sourceTree = "<group>"; };
 		C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Surface.swift; sourceTree = "<group>"; };
 		C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageTests.swift; sourceTree = "<group>"; };
 		C995611A6313FABE30508248 /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
@@ -1860,6 +1862,7 @@
 				7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */,
 				EECB91379591DA21D216A894 /* RelativeTime.swift */,
 				489C9B383554D7DAB170C2F8 /* Seg.swift */,
+				C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */,
 				2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */,
 			);
 			path = UI;
@@ -3267,6 +3270,7 @@
 				E51AC728D0735EEC53825C68 /* SidebarChromeTheme.swift in Sources */,
 				190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */,
 				115C50272D2037FB24B8536F /* SidebarView.swift in Sources */,
+				25CD620AE7FFA7DE82937F7E /* Spinner.swift in Sources */,
 				6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */,
 				514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */,
 				899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPConnectingPlaceholder.swift
+++ b/Alas/Sources/ACP/UI/ACPConnectingPlaceholder.swift
@@ -82,16 +82,3 @@ struct ACPConnectingPlaceholder: View {
         )
     }
 }
-
-private struct Spinner: View {
-    @State private var angle: Double = 0
-    @Environment(\.theme) private var theme
-    var body: some View {
-        Circle()
-            .trim(from: 0, to: 0.75)
-            .stroke(theme.color("accent"), style: StrokeStyle(lineWidth: 2, lineCap: .round))
-            .rotationEffect(.degrees(angle))
-            .animation(.linear(duration: 0.8).repeatForever(autoreverses: false), value: angle)
-            .onAppear { angle = 360 }
-    }
-}

--- a/Alas/Sources/ACP/UI/ACPPlanCard.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanCard.swift
@@ -88,7 +88,7 @@ private struct PlanRow: View {
                     .font(.system(size: 8, weight: .bold))
                     .foregroundStyle(theme.color("add"))
             case "in_progress":
-                Spinner()
+                Spinner(lineWidth: 1.5, duration: 0.7)
                     .frame(width: 9, height: 9)
             default:
                 Circle()
@@ -105,18 +105,5 @@ private struct PlanRow: View {
         case "in_progress": return theme.color("accent")
         default:            return theme.color("line")
         }
-    }
-}
-
-private struct Spinner: View {
-    @State private var angle: Double = 0
-    @Environment(\.theme) private var theme
-    var body: some View {
-        Circle()
-            .trim(from: 0, to: 0.75)
-            .stroke(theme.color("accent"), style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
-            .rotationEffect(.degrees(angle))
-            .animation(.linear(duration: 0.7).repeatForever(autoreverses: false), value: angle)
-            .onAppear { angle = 360 }
     }
 }

--- a/Alas/Sources/ACP/UI/ACPSetupNudgeBanner.swift
+++ b/Alas/Sources/ACP/UI/ACPSetupNudgeBanner.swift
@@ -24,7 +24,8 @@ struct ACPSetupNudgeBanner: View {
                 .textSelection(.enabled)
             Spacer()
             if status == .installing {
-                ProgressView().controlSize(.small).scaleEffect(0.7)
+                Spinner(lineWidth: 1.5, duration: 0.7)
+                    .frame(width: 12, height: 12)
             }
             if showsInstallButton {
                 Button(installButtonTitle) { runInstall() }

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -59,7 +59,7 @@ struct ACPToolCallCard: View {
         if toolCall.content.isEmpty {
             HStack(spacing: 6) {
                 if toolCall.status == "in_progress" || toolCall.status == "pending" {
-                    Spinner().frame(width: 10, height: 10)
+                    Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10)
                     Text("Working…")
                 } else if toolCall.status == "canceled" || toolCall.status == "cancelled" {
                     Text("Canceled.")
@@ -90,7 +90,7 @@ struct ACPToolCallCard: View {
     private var statusIndicator: some View {
         switch toolCall.status {
         case "in_progress":
-            Spinner().frame(width: 11, height: 11)
+            Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 11, height: 11)
         case "pending":
             // Static dot while waiting for permission / queue.
             Circle().fill(theme.color("fg-faint")).frame(width: 5, height: 5)
@@ -147,19 +147,5 @@ struct ACPToolCallCard: View {
                 .foregroundStyle(theme.color("accent"))
         }
         .frame(width: 18, height: 18)
-    }
-}
-
-/// Compact circular spinner used by tool cards while a call is in flight.
-private struct Spinner: View {
-    @State private var angle: Double = 0
-    @Environment(\.theme) private var theme
-    var body: some View {
-        Circle()
-            .trim(from: 0, to: 0.75)
-            .stroke(theme.color("accent"), style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
-            .rotationEffect(.degrees(angle))
-            .animation(.linear(duration: 0.7).repeatForever(autoreverses: false), value: angle)
-            .onAppear { angle = 360 }
     }
 }

--- a/Alas/Sources/Center/Commit/CommitDiffView.swift
+++ b/Alas/Sources/Center/Commit/CommitDiffView.swift
@@ -66,7 +66,8 @@ struct CommitDiffView: View {
     private var imageBody: some View {
         Group {
             if !imagePairLoaded {
-                ProgressView()
+                Spinner()
+                    .frame(width: 20, height: 20)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let pair = imagePair {
                 ImageDiffView(
@@ -137,7 +138,9 @@ struct CommitDiffView: View {
     @ViewBuilder
     private var content: some View {
         if loading {
-            ProgressView().padding()
+            Spinner()
+                .frame(width: 16, height: 16)
+                .padding()
         } else if let error {
             Text("Could not load diff for \(path): \(error)")
                 .font(CenterTypography.codeFont(family: codeFontFamily, size: codeFontSize - 2))

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -59,7 +59,9 @@ struct CommitEditorTabView: View {
                 )
                 splitBody(details: details)
             } else if loadingDetails {
-                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+                Spinner()
+                    .frame(width: 20, height: 20)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let error {
                 VStack(spacing: 8) {
                     Text("Could not load commit \(String(tabState.currentSha.prefix(7)))")

--- a/Alas/Sources/Center/Commit/CommitTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitTabView.swift
@@ -34,7 +34,9 @@ struct CommitTabView: View {
                 CommitHeaderView(details: details, expanded: $headerExpanded)
                 splitBody(details: details)
             } else if loadingDetails {
-                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+                Spinner()
+                    .frame(width: 20, height: 20)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let detailsError {
                 VStack(spacing: 8) {
                     Text("Could not load commit \(String(sha.prefix(7)))")

--- a/Alas/Sources/Center/DiffTabView.swift
+++ b/Alas/Sources/Center/DiffTabView.swift
@@ -36,7 +36,8 @@ struct DiffTabView: View {
     private var imageBody: some View {
         Group {
             if !imagePairLoaded {
-                ProgressView()
+                Spinner()
+                    .frame(width: 20, height: 20)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let pair = imagePair {
                 ImageDiffView(
@@ -91,7 +92,9 @@ struct DiffTabView: View {
             }
             ScrollView(.vertical) {
                 if !loaded {
-                    ProgressView().padding()
+                    Spinner()
+                        .frame(width: 16, height: 16)
+                        .padding()
                 } else if diff.hunks.isEmpty {
                     Text("No changes for \(relativePath)").foregroundColor(theme.color("fg-dim")).padding()
                 } else {

--- a/Alas/Sources/Center/ImageDiff/ImageDiffDifferenceView.swift
+++ b/Alas/Sources/Center/ImageDiff/ImageDiffDifferenceView.swift
@@ -21,7 +21,8 @@ struct ImageDiffDifferenceView: View {
                     .interpolation(.none)
                     .aspectRatio(contentMode: .fit)
             } else if computing {
-                ProgressView()
+                Spinner()
+                    .frame(width: 20, height: 20)
             }
         }
         .clipped()

--- a/Alas/Sources/Center/MergeConflictTabView.swift
+++ b/Alas/Sources/Center/MergeConflictTabView.swift
@@ -138,7 +138,9 @@ struct MergeConflictTabView: View {
         if let loadError = model.loadError {
             errorBanner(loadError)
         } else if model.conflictedFile == nil {
-            ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            Spinner()
+                .frame(width: 20, height: 20)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if model.conflictedFile?.isBinary == true {
             MergeConflictBinaryView(
                 conflictedFile: model.conflictedFile!,

--- a/Alas/Sources/Center/MergeConflictToolbar.swift
+++ b/Alas/Sources/Center/MergeConflictToolbar.swift
@@ -51,7 +51,8 @@ struct MergeConflictToolbar: View {
             Button(action: onAskAgentResolve) {
                 HStack(spacing: 4) {
                     if agentBusy {
-                        ProgressView().controlSize(.small)
+                        Spinner(lineWidth: 1.5, duration: 0.7)
+                            .frame(width: 12, height: 12)
                     } else {
                         Image(systemName: "sparkles")
                     }

--- a/Alas/Sources/Code/Editor/BlockedNudgeBanner.swift
+++ b/Alas/Sources/Code/Editor/BlockedNudgeBanner.swift
@@ -47,8 +47,8 @@ struct BlockedNudgeBanner: View {
             }
             Spacer()
             if remediationState == .running {
-                ProgressView()
-                    .controlSize(.small)
+                Spinner(lineWidth: 1.5, duration: 0.7)
+                    .frame(width: 12, height: 12)
             } else {
                 Button("Allow") {
                     Task { await remediate(nudge: nudge) }

--- a/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
+++ b/Alas/Sources/Code/Editor/EditorLSPStatusBadge.swift
@@ -76,7 +76,7 @@ struct EditorLSPStatusBadge: View {
         case .ready:
             Circle().fill(theme.color("add")).frame(width: 7, height: 7).accessibilityHidden(true)
         case .loading:
-            ProgressView().controlSize(.mini).frame(width: 9, height: 9).accessibilityHidden(true)
+            Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 9, height: 9).accessibilityHidden(true)
         case .problem:
             Circle().fill(theme.color("warn")).frame(width: 7, height: 7).accessibilityHidden(true)
         case .noLanguage:

--- a/Alas/Sources/Dialogs/BranchPicker.swift
+++ b/Alas/Sources/Dialogs/BranchPicker.swift
@@ -20,9 +20,7 @@ struct BranchPicker: View {
                     .truncationMode(.middle)
                 Spacer(minLength: 8)
                 if isLoading {
-                    ProgressView()
-                        .controlSize(.small)
-                        .scaleEffect(0.55)
+                    Spinner(lineWidth: 1.5, duration: 0.7)
                         .frame(width: 12, height: 12)
                 }
                 Image(systemName: "chevron.down")

--- a/Alas/Sources/Right/Commit/AiSplitButton.swift
+++ b/Alas/Sources/Right/Commit/AiSplitButton.swift
@@ -27,7 +27,8 @@ struct AiSplitButton: View {
             Button(action: onGenerate) {
                 HStack(spacing: 6) {
                     if busy {
-                        ProgressView().scaleEffect(0.5).frame(width: 12, height: 12)
+                        Spinner(lineWidth: 1.5, duration: 0.7)
+                            .frame(width: 12, height: 12)
                     } else {
                         Text("✨").font(.system(size: 11))
                     }

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -151,7 +151,8 @@ struct CommitsSectionView: View {
     private var footer: some View {
         if isLoadingOlder {
             HStack(spacing: 6) {
-                ProgressView().controlSize(.mini)
+                Spinner(lineWidth: 1.5, duration: 0.7)
+                    .frame(width: 10, height: 10)
                 Text("Loading…")
                     .font(.system(size: 11))
                     .foregroundColor(theme.color("fg-faint"))

--- a/Alas/Sources/Right/ConflictsSection.swift
+++ b/Alas/Sources/Right/ConflictsSection.swift
@@ -98,8 +98,8 @@ struct ConflictsSection: View {
 
     private var progressRow: some View {
         HStack(spacing: 6) {
-            ProgressView()
-                .controlSize(.mini)
+            Spinner(lineWidth: 1.5, duration: 0.7)
+                .frame(width: 10, height: 10)
             Text("Agent resolving conflicts…")
                 .font(.system(size: 10))
                 .foregroundColor(.secondary)

--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -75,9 +75,7 @@ struct FilesTabView: View {
                                 visibilityPill(node)
                             }
                             if Self.showsInlineLoadingIndicator(for: node, open: open, canExpand: canExpand) {
-                                ProgressView()
-                                    .controlSize(.mini)
-                                    .scaleEffect(0.55)
+                                Spinner(lineWidth: 1.5, duration: 0.7)
                                     .frame(width: 12, height: 12)
                                     .accessibilityLabel("Loading \(node.name)")
                             }

--- a/Alas/Sources/UI/Spinner.swift
+++ b/Alas/Sources/UI/Spinner.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct Spinner: View {
+    var lineWidth: CGFloat = 2
+    var duration: Double = 0.8
+
+    @State private var angle: Double = 0
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Circle()
+            .trim(from: 0, to: 0.75)
+            .stroke(theme.color("accent"), style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+            .rotationEffect(.degrees(angle))
+            .animation(.linear(duration: duration).repeatForever(autoreverses: false), value: angle)
+            .onAppear { angle = 360 }
+    }
+}

--- a/docs/research/987-update-loading-spinner-ui.md
+++ b/docs/research/987-update-loading-spinner-ui.md
@@ -1,0 +1,165 @@
+---
+task_id: 987
+title: Update loading spinner UI
+date: 2026-05-28
+project: alas
+phase: backlog
+prior_art:
+  - Alas/Sources/ACP/UI/ACPConnectingPlaceholder.swift (lines 86-97, canonical Spinner)
+  - Alas/Sources/ACP/UI/ACPToolCallCard.swift (lines 154-165)
+  - Alas/Sources/ACP/UI/ACPPlanCard.swift (lines 111-122)
+---
+
+## TL;DR
+
+Straightforward UI consistency task. Three ACP files already define a private
+`Spinner` struct (75%-arc Circle with linear rotation). That same spinner needs
+to replace every `ProgressView()` used as a loading indicator across the app.
+The main work is extracting a single shared `Spinner` view and swapping ~17
+call sites. No architectural changes, no new dependencies.
+
+## Scope confirmation
+
+### In scope (v1)
+
+- Extract a **shared `Spinner` view** from the three identical private structs
+  in the ACP layer, parameterized by size (frame), line width, and animation
+  duration so each call site can match its current visual weight.
+- Replace every `ProgressView()` **spinner** usage in first-party Alas code
+  (see call-site inventory below) with the shared `Spinner`.
+- Preserve existing frame sizes, accessibility modifiers, and layout at each
+  call site — the only visible change should be the spinner style itself.
+
+### Out of scope (v1)
+
+- **ThirdParty/ghostty/** — `UpdatePopoverView.swift` has two `ProgressView()`
+  spinners (lines 103, 239) but this is vendored code; changing it creates
+  merge-conflict risk on upstream syncs.
+- **Determinate progress bars** — `UpdatePopoverView.swift` lines 233, 267 use
+  `ProgressView(value:)` which are progress bars, not spinners.
+- **Color / animation design changes** — we replicate the existing Figma
+  spinner as-is (accent color, 75% arc, linear rotation). Any design tweaks
+  are a separate task.
+
+## Architectural alignment
+
+### The target spinner
+
+All three ACP files define an identical pattern:
+
+```swift
+// ACPConnectingPlaceholder.swift:86-97 (canonical)
+private struct Spinner: View {
+    @State private var angle: Double = 0
+    @Environment(\.theme) private var theme
+    var body: some View {
+        Circle()
+            .trim(from: 0, to: 0.75)
+            .stroke(theme.color("accent"), style: StrokeStyle(lineWidth: 2, lineCap: .round))
+            .rotationEffect(.degrees(angle))
+            .animation(.linear(duration: 0.8).repeatForever(autoreverses: false), value: angle)
+            .onAppear { angle = 360 }
+    }
+}
+```
+
+Variations across the three files: `lineWidth` (2 vs 1.5) and `duration`
+(0.8 vs 0.7). The shared view should accept these as parameters with sensible
+defaults.
+
+### Suggested shared view location
+
+`Alas/Sources/UI/Spinner.swift`. The repo's shared SwiftUI atoms currently
+live under `Alas/Sources/UI` (`AlasButton`, `AlasToggle`, `AlasField`, etc.),
+so the spinner should follow that convention.
+
+### ProgressView() call-site inventory (17 spinner usages)
+
+| # | File | Line | Context | Frame / Size |
+|---|------|------|---------|--------------|
+| 1 | `Center/Commit/CommitTabView.swift` | 37 | Loading commit details | maxWidth/maxHeight: .infinity |
+| 2 | `Center/Commit/CommitEditorTabView.swift` | 62 | Loading commit editor | maxWidth/maxHeight: .infinity |
+| 3 | `Center/Commit/CommitDiffView.swift` | 69 | Loading image diff | default |
+| 4 | `Center/Commit/CommitDiffView.swift` | 140 | Loading text diff | .padding() |
+| 5 | `Center/DiffTabView.swift` | 39 | Loading image diff | default |
+| 6 | `Center/DiffTabView.swift` | 94 | Loading text diff | .padding() |
+| 7 | `Center/MergeConflictToolbar.swift` | 54 | Agent resolving conflicts | .controlSize(.small) |
+| 8 | `Center/MergeConflictTabView.swift` | 141 | Loading conflicted file | maxWidth/maxHeight: .infinity |
+| 9 | `Center/ImageDiff/ImageDiffDifferenceView.swift` | 24 | Computing image diff | default |
+| 10 | `Dialogs/BranchPicker.swift` | 23 | Loading branches | scaled + sized |
+| 11 | `Right/Commit/AiSplitButton.swift` | 30 | AI commit generation | scaleEffect(0.5), 12×12 |
+| 12 | `Right/FilesTabView.swift` | 78 | Loading directory children | default |
+| 13 | `Right/ConflictsSection.swift` | 101 | Bulk conflict resolution | default |
+| 14 | `Right/CommitsSectionView.swift` | 154 | Loading older commits | .controlSize(.mini) |
+| 15 | `ACP/UI/ACPSetupNudgeBanner.swift` | 27 | Installing ACP adapter | .controlSize(.small), scaleEffect(0.7) |
+| 16 | `Code/Editor/BlockedNudgeBanner.swift` | 50 | Gatekeeper remediation running | .controlSize(.small) |
+| 17 | `Code/Editor/EditorLSPStatusBadge.swift` | 79 | LSP server loading | .controlSize(.mini), 9×9 |
+
+Plus 3 existing private `Spinner` structs to consolidate into the shared one.
+
+## Acceptance criteria
+
+1. A single shared `Spinner` view exists with configurable `lineWidth`,
+   `duration`, and frame size (with defaults matching the ACP originals).
+2. All 17 `ProgressView()` spinner call sites in first-party code use the
+   shared `Spinner` instead.
+3. The three private `Spinner` structs in ACP are deleted, replaced by the
+   shared view.
+4. No `ProgressView()` spinner remains in first-party code (determinate
+   progress bars in ThirdParty are excluded).
+5. Visual appearance at each call site matches the Figma spinner (75% arc,
+   accent color, linear rotation, rounded line caps).
+6. Build succeeds with zero warnings on the existing Xcode scheme.
+7. No regressions in existing functionality — spinners appear in the same
+   contexts and same sizes as before.
+
+## Open questions
+
+1. **Where should the shared Spinner live?**
+   Resolved recommendation: `Alas/Sources/UI/Spinner.swift`, matching the
+   existing shared UI atom convention.
+
+2. **Should the spinner color be parameterizable?**
+   Recommendation: No for v1 — all current usages use `theme.color("accent")`.
+   A color parameter can be added later if needed.
+
+3. **Should full-screen spinners (items 1, 2, 8) get a different treatment?**
+   Recommendation: No — just swap the inner `ProgressView()` for `Spinner()`
+   inside the existing `.frame(maxWidth: .infinity, maxHeight: .infinity)`
+   wrapper, picking a reasonable size (e.g. 20×20).
+
+## Implementation order
+
+1. **Create shared `Spinner` view** — `Alas/Sources/UI/Spinner.swift`.
+   Accept `lineWidth: CGFloat = 2`, `duration: Double = 0.8`
+   as init parameters. Frame is applied at the call site, not inside the view.
+2. **Update ACP files** — Replace the three private `Spinner` structs with
+   imports of the shared one. Verify existing frame/lineWidth/duration values
+   are preserved.
+3. **Update call sites in batch** — Replace `ProgressView()` with `Spinner()`
+   at each of the 17 locations, adjusting `lineWidth`/`duration` and frame
+   to match the visual weight of the original `ProgressView` at that size.
+4. **Grep for remaining `ProgressView()`** — Confirm no spinner usages remain
+   (only ThirdParty determinate bars should be left).
+5. **Build and smoke-test** — Verify Xcode build, spot-check a few spinner
+   locations visually.
+
+## Risks / things to watch
+
+- **Frame sizing**: `ProgressView()` with `.controlSize(.mini)` or
+  `.scaleEffect()` has implicit sizing. The custom `Spinner` needs explicit
+  `.frame()` at each site — get the pixel sizes right or things will look off.
+- **Full-screen spinner sizing**: Items 1, 2, 8 wrap `ProgressView()` in
+  `maxWidth/maxHeight: .infinity` — the Spinner needs an explicit size inside
+  that frame or it will stretch to fill the entire area.
+- **Animation lifecycle**: The custom Spinner triggers its animation via
+  `.onAppear { angle = 360 }`. If any call site conditionally shows/hides the
+  spinner without fully removing it from the view hierarchy, the animation
+  might not restart. Test toggle scenarios.
+
+## Definition of done (handoff sign-off)
+
+- Grooming doc reviewed and accepted
+- No open questions blocking implementation
+- Call-site inventory verified against current `main` (line numbers may shift)
+- Ready for design phase (implementer can work from this doc alone)


### PR DESCRIPTION
## Summary
- Recover task #987 changes into a clean branch based on current `main`.
- Add a shared `Spinner` SwiftUI view using the existing 75% accent arc style.
- Replace first-party `ProgressView()` loading spinners with the shared component and remove duplicated private ACP spinners.
- Add the recovered task research note for implementation context.

## Validation
- `git diff --cached --check`
- `xcodebuild -project /Volumes/Ambrosio/repos/alas/Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`

## Notes
- This recovers changes that had landed uncommitted in `/Volumes/Ambrosio/repos/alas` while Mission Control task #987 was waiting on `dirty_repo`.