### PR TITLE
feat(acp): uniform chip row across agents

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		2ED82820F76F5032E4339926 /* ZmxClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */; };
 		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
+		B2E4D8F5A3C6E1D2F3F4A5B6 /* ACPAgentProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E4D8F5A3C6E1D2F3F4A5B7 /* ACPAgentProfiles.swift */; };
 		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
 		30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */; };
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
@@ -354,6 +355,7 @@
 		7DEFB0A61614D65F509A11AE /* ImageDiffDifferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */; };
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
 		7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */; };
+		F1727AFCB9A54DE2941F5A19 /* ACPAgentProfilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7104FDEE0B9C49848BB0EC30 /* ACPAgentProfilesTests.swift */; };
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
 		7FFC3D96011714F0A131FAB8 /* ACPFileChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */; };
@@ -927,6 +929,7 @@
 		4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardPathsTests.swift; sourceTree = "<group>"; };
 		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltinsTests.swift; sourceTree = "<group>"; };
+		7104FDEE0B9C49848BB0EC30 /* ACPAgentProfilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAgentProfilesTests.swift; sourceTree = "<group>"; };
 		4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessor.swift; sourceTree = "<group>"; };
 		4B2FAABB50C8BE2321A1B1DD /* ClaudeCodeACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeCodeACPInstallerTests.swift; sourceTree = "<group>"; };
 		4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClientTests.swift; sourceTree = "<group>"; };
@@ -1113,6 +1116,7 @@
 		93C3F02ECEA5D545FA268DB8 /* ACPSlashPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSlashPicker.swift; sourceTree = "<group>"; };
 		93CDC9895F48619E97461875 /* CodePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePane.swift; sourceTree = "<group>"; };
 		93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltins.swift; sourceTree = "<group>"; };
+		C3E4D8F5A3C6E1D2F3F4A5B7 /* ACPAgentProfiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAgentProfiles.swift; sourceTree = "<group>"; };
 		9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfoTests.swift; sourceTree = "<group>"; };
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
 		94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibility.swift; sourceTree = "<group>"; };
@@ -1497,6 +1501,7 @@
 				D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */,
 				36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */,
 				4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */,
+				7104FDEE0B9C49848BB0EC30 /* ACPAgentProfilesTests.swift */,
 				FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */,
 				3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */,
 				FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */,
@@ -1950,6 +1955,7 @@
 			children = (
 				25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */,
 				93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */,
+				C3E4D8F5A3C6E1D2F3F4A5B7 /* ACPAgentProfiles.swift */,
 				AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */,
 				2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */,
 				FBFB85AF60C0E4520ED0DA8E /* AgentLauncherDialog.swift */,
@@ -2973,6 +2979,7 @@
 				7A2C912B677A34391361B720 /* AdvancedSettingsVisibility.swift in Sources */,
 				F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */,
 				2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */,
+				B2E4D8F5A3C6E1D2F3F4A5B6 /* ACPAgentProfiles.swift in Sources */,
 				D6B39CE8878BB196FF2277B6 /* AgentDefinition.swift in Sources */,
 				10557FBC430EEAB1196D9575 /* AgentDetector.swift in Sources */,
 				E2A49F787B3DC3F45E92854D /* AgentEditView.swift in Sources */,
@@ -3339,6 +3346,7 @@
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,
 				FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */,
 				7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */,
+				F1727AFCB9A54DE2941F5A19 /* ACPAgentProfilesTests.swift in Sources */,
 				2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */,
 				5426DC977050AACBCBDA37E9 /* AgentDetectorTests.swift in Sources */,
 				F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -462,6 +462,8 @@
 		A2E0A755C2854FE489530FE3 /* ImageDiffDifferenceComputer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */; };
 		A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */; };
 		A3EE2DE5C01EB87DE7BCC801 /* ACPStdioClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */; };
+		E186D6B677FCC3311E94A44975A4C93E /* ACPConfigOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0610D059BE91D8B4E751D536EA162F /* ACPConfigOption.swift */; };
+		E80E1B639F57DB01E0792FE449AAA845 /* ACPConfigOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5412B9E2F2AFAD4B33AE960EAF9D1D40 /* ACPConfigOptionTests.swift */; };
 		A4AB930CA0EEA2CEF0302646 /* ImageCheckerboardBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */; };
 		A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
@@ -1149,6 +1151,8 @@
 		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
 		A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAnnotationStrip.swift; sourceTree = "<group>"; };
 		A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdateTests.swift; sourceTree = "<group>"; };
+		DF0610D059BE91D8B4E751D536EA162F /* ACPConfigOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOption.swift; sourceTree = "<group>"; };
+		5412B9E2F2AFAD4B33AE960EAF9D1D40 /* ACPConfigOptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOptionTests.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimer.swift; sourceTree = "<group>"; };
 		A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailView.swift; sourceTree = "<group>"; };
@@ -1757,6 +1761,7 @@
 				2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */,
 				2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */,
 				A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */,
+				5412B9E2F2AFAD4B33AE960EAF9D1D40 /* ACPConfigOptionTests.swift */,
 				5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */,
 			);
 			path = Protocol;
@@ -1991,6 +1996,7 @@
 				67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */,
 				BEBCF3820A017BBF33B0AB07 /* ACPProtocolVersion.swift */,
 				DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */,
+				DF0610D059BE91D8B4E751D536EA162F /* ACPConfigOption.swift */,
 				4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */,
 			);
 			path = Protocol;
@@ -2957,6 +2963,7 @@
 				3F54F0437585F96F5774A3BD /* ACPSetupNudgeBanner.swift in Sources */,
 				C5644E1144140B99E8676064 /* ACPSlashPicker.swift in Sources */,
 				A3EE2DE5C01EB87DE7BCC801 /* ACPStdioClient.swift in Sources */,
+				E186D6B677FCC3311E94A44975A4C93E /* ACPConfigOption.swift in Sources */,
 				8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */,
 				F66BDC777D0BFDE306E8880A /* ACPTabView.swift in Sources */,
 				48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */,
@@ -3326,6 +3333,7 @@
 				08DF3AC4BA50775940371445 /* ACPSessionStoreTests.swift in Sources */,
 				B472D692A8D8D1C664EAC467 /* ACPSessionTests.swift in Sources */,
 				33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */,
+				E80E1B639F57DB01E0792FE449AAA845 /* ACPConfigOptionTests.swift in Sources */,
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
 				E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */,
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -397,6 +397,8 @@
 		8B2A37F58F2C7D842204A596 /* ImageDiffOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87F114EBEEACCC95B9EF8D5 /* ImageDiffOverlayView.swift */; };
 		8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F31D837F83B4F8B9FB348BD /* ACPPermissionPolicyTests.swift */; };
 		8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBEFD27FD7013D458435779 /* ACPSession.swift */; };
+		19BCAEA4D49849CEAE06C8CF /* ACPChipState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418EE57DE5B64765B6665BF9 /* ACPChipState.swift */; };
+		00FC6882E7C2432A859AE437 /* ACPChipStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E09BD4975C4FB286679938 /* ACPChipStateTests.swift */; };
 		8D22459A108B6BF47AEA71F7 /* session-update-available-models.json in Resources */ = {isa = PBXBuildFile; fileRef = 1B0785F1FFC8008C74009584 /* session-update-available-models.json */; };
 		8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */; };
 		8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */; };
@@ -1204,6 +1206,8 @@
 		BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileChip.swift; sourceTree = "<group>"; };
 		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
 		BBBEFD27FD7013D458435779 /* ACPSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSession.swift; sourceTree = "<group>"; };
+		418EE57DE5B64765B6665BF9 /* ACPChipState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipState.swift; sourceTree = "<group>"; };
+		25E09BD4975C4FB286679938 /* ACPChipStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipStateTests.swift; sourceTree = "<group>"; };
 		BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabView.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
@@ -2012,6 +2016,7 @@
 			isa = PBXGroup;
 			children = (
 				321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */,
+				418EE57DE5B64765B6665BF9 /* ACPChipState.swift */,
 				BBBEFD27FD7013D458435779 /* ACPSession.swift */,
 				7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */,
 				F332906E17C5865856DBB90B /* ACPSessionRunner.swift */,
@@ -2334,6 +2339,7 @@
 			isa = PBXGroup;
 			children = (
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
+				25E09BD4975C4FB286679938 /* ACPChipStateTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */,
 				45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */,
@@ -2960,6 +2966,7 @@
 				D5C1783F56883B8AF68BF010 /* ACPRecentSessionsButton.swift in Sources */,
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
+				19BCAEA4D49849CEAE06C8CF /* ACPChipState.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
 				1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */,
 				027A326E7DAB6C6E133E5FD3 /* ACPSessionStore.swift in Sources */,
@@ -3339,6 +3346,7 @@
 				20096441D4850614A3CB8187 /* ACPSessionStoreCRUDTests.swift in Sources */,
 				08DF3AC4BA50775940371445 /* ACPSessionStoreTests.swift in Sources */,
 				B472D692A8D8D1C664EAC467 /* ACPSessionTests.swift in Sources */,
+				00FC6882E7C2432A859AE437 /* ACPChipStateTests.swift in Sources */,
 				33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */,
 				E80E1B639F57DB01E0792FE449AAA845 /* ACPConfigOptionTests.swift in Sources */,
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Per-session configurable option advertised by the agent in
+/// `session/new`. Wire format follows
+/// https://agentclientprotocol.com/protocol/session-config-options —
+/// we only render select-style options today.
+struct ACPConfigOption: Codable, Equatable, Identifiable, Hashable {
+    let id: String
+    let name: String
+    let type: String           // "select" today; other shapes accepted but rendered as empty
+    let category: String?      // e.g. "ThoughtLevel" — used as a routing hint
+    let currentValue: String?
+    let options: [ACPConfigOptionItem]
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, type, category, currentValue, options
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        type = (try? c.decode(String.self, forKey: .type)) ?? "select"
+        category = try? c.decode(String.self, forKey: .category)
+        currentValue = try? c.decode(String.self, forKey: .currentValue)
+        options = (try? c.decode([ACPConfigOptionItem].self, forKey: .options)) ?? []
+    }
+
+    init(id: String, name: String, type: String = "select",
+         category: String? = nil, currentValue: String? = nil,
+         options: [ACPConfigOptionItem] = []) {
+        self.id = id
+        self.name = name
+        self.type = type
+        self.category = category
+        self.currentValue = currentValue
+        self.options = options
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(name, forKey: .name)
+        try c.encode(type, forKey: .type)
+        try c.encodeIfPresent(category, forKey: .category)
+        try c.encodeIfPresent(currentValue, forKey: .currentValue)
+        try c.encode(options, forKey: .options)
+    }
+}
+
+struct ACPConfigOptionItem: Codable, Equatable, Identifiable, Hashable {
+    let id: String
+    let name: String
+    let description: String?
+
+    init(id: String, name: String, description: String? = nil) {
+        self.id = id
+        self.name = name
+        self.description = description
+    }
+}
+
+/// Params for the `session/set_config_option` request — the method that
+/// pushes a new selected value back to the agent.
+struct ACPSessionSetConfigOptionParams: Codable, Equatable {
+    let sessionId: String
+    let configId: String
+    let value: String
+}

--- a/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConfigOption.swift
@@ -58,6 +58,26 @@ struct ACPConfigOptionItem: Codable, Equatable, Identifiable, Hashable {
         self.name = name
         self.description = description
     }
+
+    // Wire format uses `value` for the option identifier; accept both
+    // shapes so older draft payloads (which used `id`) keep decoding.
+    enum CodingKeys: String, CodingKey { case id, value, name, description }
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        if let v = try? c.decode(String.self, forKey: .value) {
+            id = v
+        } else {
+            id = try c.decode(String.self, forKey: .id)
+        }
+        name = try c.decode(String.self, forKey: .name)
+        description = try? c.decode(String.self, forKey: .description)
+    }
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .value)
+        try c.encode(name, forKey: .name)
+        try c.encodeIfPresent(description, forKey: .description)
+    }
 }
 
 /// Params for the `session/set_config_option` request — the method that
@@ -66,4 +86,29 @@ struct ACPSessionSetConfigOptionParams: Codable, Equatable {
     let sessionId: String
     let configId: String
     let value: String
+}
+
+/// Result of `session/set_config_option`. The agent returns the complete
+/// refreshed `configOptions` list because a single change can ripple to
+/// dependent options (e.g. codex's reasoning effort altering available
+/// model variants). Empty when the agent doesn't echo state back; the
+/// caller keeps its optimistic local update in that case.
+struct ACPSessionSetConfigOptionResult: Codable, Equatable {
+    let configOptions: [ACPConfigOption]
+
+    enum CodingKeys: String, CodingKey { case configOptions }
+
+    init(configOptions: [ACPConfigOption] = []) {
+        self.configOptions = configOptions
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        configOptions = (try? c.decode([ACPConfigOption].self, forKey: .configOptions)) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(configOptions, forKey: .configOptions)
+    }
 }

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -52,9 +52,16 @@ final class ACPConnection: @unchecked Sendable {
                                              params: ACPSessionSetModelParams(sessionId: sessionId, modelId: modelId)))
     }
 
-    func setConfigOption(sessionId: String, configId: String, value: String) async throws {
-        _ = try await client.send(ACPRequest(method: "session/set_config_option",
-                                             params: ACPSessionSetConfigOptionParams(sessionId: sessionId, configId: configId, value: value)))
+    /// Sends a config-option change and returns the agent's refreshed
+    /// `configOptions` list. The agent may return empty (older/non-compliant
+    /// implementations) in which case the caller's optimistic local update
+    /// stands; on a full echo the caller should overwrite local state so
+    /// dependent options stay in sync.
+    func setConfigOption(sessionId: String, configId: String, value: String) async throws -> [ACPConfigOption] {
+        let resp = try await client.send(ACPRequest(method: "session/set_config_option",
+                                                    params: ACPSessionSetConfigOptionParams(sessionId: sessionId, configId: configId, value: value)))
+        let result = try? JSONDecoder().decode(ACPSessionSetConfigOptionResult.self, from: resp.body)
+        return result?.configOptions ?? []
     }
 
     func prompt(sessionId: String, blocks: [ACPContentBlock]) async throws {

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -52,6 +52,11 @@ final class ACPConnection: @unchecked Sendable {
                                              params: ACPSessionSetModelParams(sessionId: sessionId, modelId: modelId)))
     }
 
+    func setConfigOption(sessionId: String, configId: String, value: String) async throws {
+        _ = try await client.send(ACPRequest(method: "session/set_config_option",
+                                             params: ACPSessionSetConfigOptionParams(sessionId: sessionId, configId: configId, value: value)))
+    }
+
     func prompt(sessionId: String, blocks: [ACPContentBlock]) async throws {
         _ = try await client.send(ACPRequest(method: "session/prompt",
                                              params: ACPSessionPromptParams(sessionId: sessionId, prompt: blocks)))

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -205,9 +205,10 @@ struct ACPSessionNewResult: Codable, Equatable {
     let currentModel: String?
     let currentMode: String?
     let promptSuggestions: [ACPPromptSuggestion]
+    let configOptions: [ACPConfigOption]
 
     enum CodingKeys: String, CodingKey {
-        case sessionId, availableModels, availableModes, currentModel, currentMode, promptSuggestions
+        case sessionId, availableModels, availableModes, currentModel, currentMode, promptSuggestions, configOptions
         case models, modes
     }
 
@@ -222,6 +223,7 @@ struct ACPSessionNewResult: Codable, Equatable {
         try c.encodeIfPresent(currentModel, forKey: .currentModel)
         try c.encodeIfPresent(currentMode, forKey: .currentMode)
         try c.encode(promptSuggestions, forKey: .promptSuggestions)
+        try c.encode(configOptions, forKey: .configOptions)
     }
 
     init(
@@ -230,7 +232,8 @@ struct ACPSessionNewResult: Codable, Equatable {
         availableModes: [ACPModeInfo],
         currentModel: String?,
         currentMode: String?,
-        promptSuggestions: [ACPPromptSuggestion]
+        promptSuggestions: [ACPPromptSuggestion],
+        configOptions: [ACPConfigOption] = []
     ) {
         self.sessionId = sessionId
         self.availableModels = availableModels
@@ -238,6 +241,7 @@ struct ACPSessionNewResult: Codable, Equatable {
         self.currentModel = currentModel
         self.currentMode = currentMode
         self.promptSuggestions = promptSuggestions
+        self.configOptions = configOptions
     }
 
     init(from decoder: Decoder) throws {
@@ -264,6 +268,7 @@ struct ACPSessionNewResult: Codable, Equatable {
         }
 
         promptSuggestions = (try? c.decode([ACPPromptSuggestion].self, forKey: .promptSuggestions)) ?? []
+        configOptions = (try? c.decode([ACPConfigOption].self, forKey: .configOptions)) ?? []
     }
 }
 

--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -43,7 +43,9 @@ enum ACPSessionUpdate: Codable, Equatable {
             self = .currentModeUpdate(modeId: try c.decode(String.self, forKey: .modeId))
         case "current_model_update":
             self = .currentModelUpdate(modelId: try c.decode(String.self, forKey: .modelId))
-        case "session_config_options_update":
+        // Spec uses `config_option_update`; some drafts/implementations
+        // emit `session_config_options_update`. Accept both.
+        case "config_option_update", "session_config_options_update":
             self = .sessionConfigOptionsUpdate(
                 try c.decode([ACPConfigOption].self, forKey: .configOptions))
         case "available_commands_update":

--- a/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
+++ b/Alas/Sources/ACP/Protocol/ACPSessionUpdate.swift
@@ -14,11 +14,14 @@ enum ACPSessionUpdate: Codable, Equatable {
     case plan([ACPPlanEntry])
     case availableModelsUpdate([ACPModelInfo])
     case currentModeUpdate(modeId: String)
+    case currentModelUpdate(modelId: String)
+    case sessionConfigOptionsUpdate([ACPConfigOption])
     case availableCommandsUpdate([ACPPromptSuggestion])
     case unknown(String)
 
     private enum Keys: String, CodingKey {
-        case sessionUpdate, content, availableModels, modeId, entries, availableCommands
+        case sessionUpdate, content, availableModels, modeId, modelId,
+             entries, availableCommands, configOptions
     }
 
     init(from decoder: Decoder) throws {
@@ -38,6 +41,11 @@ enum ACPSessionUpdate: Codable, Equatable {
             self = .availableModelsUpdate(try c.decode([ACPModelInfo].self, forKey: .availableModels))
         case "current_mode_update":
             self = .currentModeUpdate(modeId: try c.decode(String.self, forKey: .modeId))
+        case "current_model_update":
+            self = .currentModelUpdate(modelId: try c.decode(String.self, forKey: .modelId))
+        case "session_config_options_update":
+            self = .sessionConfigOptionsUpdate(
+                try c.decode([ACPConfigOption].self, forKey: .configOptions))
         case "available_commands_update":
             // Wire format: `{ availableCommands: [{ name, description, input }] }`.
             // We don't surface `input` (argument hints) in v1.
@@ -75,6 +83,12 @@ enum ACPSessionUpdate: Codable, Equatable {
         try c.encode(m, forKey: .availableModels)
         case .currentModeUpdate(let m):     try c.encode("current_mode_update", forKey: .sessionUpdate)
         try c.encode(m, forKey: .modeId)
+        case .currentModelUpdate(let m):
+            try c.encode("current_model_update", forKey: .sessionUpdate)
+            try c.encode(m, forKey: .modelId)
+        case .sessionConfigOptionsUpdate(let opts):
+            try c.encode("session_config_options_update", forKey: .sessionUpdate)
+            try c.encode(opts, forKey: .configOptions)
         case .availableCommandsUpdate: break // not produced by us
         case .toolCall, .toolCallUpdate, .unknown: break
         }

--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -13,9 +13,9 @@ struct ACPChipState: Equatable {
 /// composer knows which RPC to send when the user changes the selection.
 struct ChipSpec: Equatable {
     enum Source: Equatable {
-        case modes                           // dispatch via session/set_mode
+        case mode                            // dispatch via session/set_mode
         case configOption(id: String)        // dispatch via session/set_config_option
-        case models                          // dispatch via session/set_model
+        case model                           // dispatch via session/set_model
     }
     let source: Source
     let options: [Item]
@@ -42,7 +42,7 @@ extension ACPChipState {
         let routing = ACPAgentProfiles.routing(for: agentId)
 
         let models: ChipSpec? = availableModels.isEmpty ? nil : ChipSpec(
-            source: .models,
+            source: .model,
             options: availableModels.map {
                 ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
             },
@@ -51,13 +51,11 @@ extension ACPChipState {
         let mode = chipSpec(from: routing.modeSource,
                             modes: availableModes,
                             currentMode: currentMode,
-                            configOptions: configOptions,
-                            agentId: agentId)
+                            configOptions: configOptions)
         let thinking = chipSpec(from: routing.thinkingSource,
                                 modes: availableModes,
                                 currentMode: currentMode,
-                                configOptions: configOptions,
-                                agentId: agentId)
+                                configOptions: configOptions)
         return ACPChipState(models: models, mode: mode,
                             thinking: thinking, autoRun: routing.autoRun)
     }
@@ -66,8 +64,7 @@ extension ACPChipState {
         from source: ACPAgentProfiles.ChipSource,
         modes: [ACPModeInfo],
         currentMode: String?,
-        configOptions: [ACPConfigOption],
-        agentId: String
+        configOptions: [ACPConfigOption]
     ) -> ChipSpec? {
         switch source {
         case .none:
@@ -75,7 +72,7 @@ extension ACPChipState {
         case .modes:
             guard !modes.isEmpty else { return nil }
             return ChipSpec(
-                source: .modes,
+                source: .mode,
                 options: modes.map {
                     ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
                 },

--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -46,7 +46,7 @@ extension ACPChipState {
         // `availableModels` list. Either way the chip dispatches via the
         // source tag on `ChipSpec`.
         let models: ChipSpec? =
-            modelChipFromConfigOptions(configOptions)
+            chipFromCategoryConfigOption(category: "model", in: configOptions)
             ?? (availableModels.isEmpty ? nil : ChipSpec(
                 source: .model,
                 options: availableModels.map {
@@ -54,10 +54,13 @@ extension ACPChipState {
                 },
                 currentId: currentModel))
 
-        let mode = chipSpec(from: routing.modeSource,
-                            modes: availableModes,
-                            currentMode: currentMode,
-                            configOptions: configOptions)
+        // Same precedence rule for Mode: a `category: "mode"` configOption
+        // wins over the legacy `availableModes` list.
+        let mode = chipFromCategoryConfigOption(category: "mode", in: configOptions)
+            ?? chipSpec(from: routing.modeSource,
+                        modes: availableModes,
+                        currentMode: currentMode,
+                        configOptions: configOptions)
         let thinking = chipSpec(from: routing.thinkingSource,
                                 modes: availableModes,
                                 currentMode: currentMode,
@@ -107,15 +110,19 @@ extension ACPChipState {
             currentId: opt.currentValue)
     }
 
-    /// Finds a configOption that advertises itself as a model selector
-    /// (`category == "model"`, with `"Model"` as an alias for older
-    /// drafts). Returns nil when no such option exists, in which case the
-    /// caller falls back to the legacy `availableModels` list.
-    private static func modelChipFromConfigOptions(_ options: [ACPConfigOption]) -> ChipSpec? {
-        let modelCategories: Set<String> = ["model", "Model"]
+    /// Finds a configOption that advertises itself for the given category
+    /// (e.g. `"model"`, `"mode"`). Older drafts capitalized the marker, so
+    /// the caller accepts both forms by listing each spelling. Returns nil
+    /// when no matching option exists, in which case the caller falls back
+    /// to the legacy list.
+    private static func chipFromCategoryConfigOption(
+        category: String,
+        in options: [ACPConfigOption]
+    ) -> ChipSpec? {
+        let accepted: Set<String> = [category, category.prefix(1).uppercased() + category.dropFirst()]
         guard let opt = options.first(where: {
             guard let c = $0.category else { return false }
-            return modelCategories.contains(c)
+            return accepted.contains(c)
         }) else { return nil }
         return selectOption(id: opt.id, in: options)
     }

--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -41,12 +41,18 @@ extension ACPChipState {
     ) -> ACPChipState {
         let routing = ACPAgentProfiles.routing(for: agentId)
 
-        let models: ChipSpec? = availableModels.isEmpty ? nil : ChipSpec(
-            source: .model,
-            options: availableModels.map {
-                ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
-            },
-            currentId: currentModel)
+        // Prefer a `category: "model"` configOption when the agent advertises
+        // one (the stabilized ACP path); fall back to the legacy
+        // `availableModels` list. Either way the chip dispatches via the
+        // source tag on `ChipSpec`.
+        let models: ChipSpec? =
+            modelChipFromConfigOptions(configOptions)
+            ?? (availableModels.isEmpty ? nil : ChipSpec(
+                source: .model,
+                options: availableModels.map {
+                    ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
+                },
+                currentId: currentModel))
 
         let mode = chipSpec(from: routing.modeSource,
                             modes: availableModes,
@@ -99,5 +105,18 @@ extension ACPChipState {
                 ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
             },
             currentId: opt.currentValue)
+    }
+
+    /// Finds a configOption that advertises itself as a model selector
+    /// (`category == "model"`, with `"Model"` as an alias for older
+    /// drafts). Returns nil when no such option exists, in which case the
+    /// caller falls back to the legacy `availableModels` list.
+    private static func modelChipFromConfigOptions(_ options: [ACPConfigOption]) -> ChipSpec? {
+        let modelCategories: Set<String> = ["model", "Model"]
+        guard let opt = options.first(where: {
+            guard let c = $0.category else { return false }
+            return modelCategories.contains(c)
+        }) else { return nil }
+        return selectOption(id: opt.id, in: options)
     }
 }

--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// The composer-facing capability state. One value per canonical chip:
+/// nil means the chip is hidden for this agent / not yet populated.
+struct ACPChipState: Equatable {
+    var models: ChipSpec?
+    var mode: ChipSpec?
+    var thinking: ChipSpec?
+    var autoRun: ACPAgentProfiles.AutoRunSupport
+}
+
+/// A single chip's data, plus a tag remembering where it came from so the
+/// composer knows which RPC to send when the user changes the selection.
+struct ChipSpec: Equatable {
+    enum Source: Equatable {
+        case modes                           // dispatch via session/set_mode
+        case configOption(id: String)        // dispatch via session/set_config_option
+        case models                          // dispatch via session/set_model
+    }
+    let source: Source
+    let options: [Item]
+    let currentId: String?
+
+    struct Item: Equatable, Hashable {
+        let id: String
+        let name: String
+        let description: String?
+    }
+}
+
+extension ACPChipState {
+    /// Pure normalization. Inputs are raw `ACPSession` fields + the agent id.
+    /// Output is the four-slot chip state. No side effects, no protocol calls.
+    static func normalize(
+        agentId: String,
+        availableModels: [ACPModelInfo],
+        currentModel: String?,
+        availableModes: [ACPModeInfo],
+        currentMode: String?,
+        configOptions: [ACPConfigOption]
+    ) -> ACPChipState {
+        let routing = ACPAgentProfiles.routing(for: agentId)
+
+        let models: ChipSpec? = availableModels.isEmpty ? nil : ChipSpec(
+            source: .models,
+            options: availableModels.map {
+                ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
+            },
+            currentId: currentModel)
+
+        let mode = chipSpec(from: routing.modeSource,
+                            modes: availableModes,
+                            currentMode: currentMode,
+                            configOptions: configOptions,
+                            agentId: agentId)
+        let thinking = chipSpec(from: routing.thinkingSource,
+                                modes: availableModes,
+                                currentMode: currentMode,
+                                configOptions: configOptions,
+                                agentId: agentId)
+        return ACPChipState(models: models, mode: mode,
+                            thinking: thinking, autoRun: routing.autoRun)
+    }
+
+    private static func chipSpec(
+        from source: ACPAgentProfiles.ChipSource,
+        modes: [ACPModeInfo],
+        currentMode: String?,
+        configOptions: [ACPConfigOption],
+        agentId: String
+    ) -> ChipSpec? {
+        switch source {
+        case .none:
+            return nil
+        case .modes:
+            guard !modes.isEmpty else { return nil }
+            return ChipSpec(
+                source: .modes,
+                options: modes.map {
+                    ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
+                },
+                currentId: currentMode)
+        case .configOption(let id):
+            return selectOption(id: id, in: configOptions)
+        case .heuristic:
+            guard let id = ACPAgentProfiles.heuristicThinkingId(from: configOptions) else {
+                return nil
+            }
+            return selectOption(id: id, in: configOptions)
+        }
+    }
+
+    private static func selectOption(id: String,
+                                     in configOptions: [ACPConfigOption]) -> ChipSpec? {
+        guard let opt = configOptions.first(where: { $0.id == id }),
+              opt.type == "select", !opt.options.isEmpty else {
+            return nil
+        }
+        return ChipSpec(
+            source: .configOption(id: opt.id),
+            options: opt.options.map {
+                ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
+            },
+            currentId: opt.currentValue)
+    }
+}

--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -69,7 +69,7 @@ extension ACPChipState {
         switch source {
         case .none:
             return nil
-        case .modes:
+        case .mode:
             guard !modes.isEmpty else { return nil }
             return ChipSpec(
                 source: .mode,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -102,6 +102,12 @@ final class ACPSession: ObservableObject, Identifiable {
             availableModels = ms
         case .currentModeUpdate(let modeId):
             currentMode = modeId
+        case .currentModelUpdate:
+            // Handled in Task 7 (wire chipState into ACPSession)
+            break
+        case .sessionConfigOptionsUpdate:
+            // Handled in Task 7 (wire chipState into ACPSession)
+            break
         case .availableCommandsUpdate(let cmds):
             promptSuggestions = cmds
         case .unknown:

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -14,6 +14,7 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var messages: [ACPMessage] = []
     @Published var availableModels: [ACPModelInfo] = []
     @Published var availableModes: [ACPModeInfo] = []
+    @Published var availableConfigOptions: [ACPConfigOption] = []
     @Published var currentModel: String?
     @Published var currentMode: String?
     @Published var promptSuggestions: [ACPPromptSuggestion] = []
@@ -102,12 +103,10 @@ final class ACPSession: ObservableObject, Identifiable {
             availableModels = ms
         case .currentModeUpdate(let modeId):
             currentMode = modeId
-        case .currentModelUpdate:
-            // Handled in Task 7 (wire chipState into ACPSession)
-            break
-        case .sessionConfigOptionsUpdate:
-            // Handled in Task 7 (wire chipState into ACPSession)
-            break
+        case .currentModelUpdate(let modelId):
+            currentModel = modelId
+        case .sessionConfigOptionsUpdate(let opts):
+            availableConfigOptions = opts
         case .availableCommandsUpdate(let cmds):
             promptSuggestions = cmds
         case .unknown:
@@ -139,6 +138,20 @@ final class ACPSession: ObservableObject, Identifiable {
             }
         }
         return changed
+    }
+
+    /// Composer-facing normalized chip state. Recomputed on each access
+    /// from the current `availableModels` / `availableModes` /
+    /// `availableConfigOptions` / `currentModel` / `currentMode`. Cheap —
+    /// the inputs are small lists.
+    var chipState: ACPChipState {
+        ACPChipState.normalize(
+            agentId: agentId,
+            availableModels: availableModels,
+            currentModel: currentModel,
+            availableModes: availableModes,
+            currentMode: currentMode,
+            configOptions: availableConfigOptions)
     }
 
     // MARK: helpers

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -187,6 +187,7 @@ extension ACPSessionManager {
             session.currentModel = result.currentModel
             session.currentMode = result.currentMode
             session.promptSuggestions = result.promptSuggestions
+            session.availableConfigOptions = result.configOptions
             let runner = ACPSessionRunner(session: session, connection: connection,
                                           store: store, sessionId: sessionId,
                                           worktreePath: worktreePath,

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -270,8 +270,17 @@ struct ACPComposer: View {
             case .model:
                 try? await runner.connection.setModel(sessionId: remoteId, modelId: selectedId)
             case .configOption(let id):
-                try? await runner.connection.setConfigOption(
-                    sessionId: remoteId, configId: id, value: selectedId)
+                // The agent's response carries the refreshed configOptions
+                // (including dependent updates — e.g. switching reasoning
+                // effort can reshape available model variants). Overwrite
+                // the optimistic local update so dependent chips stay in
+                // sync. Empty response → keep the optimistic state.
+                if let updated = try? await runner.connection.setConfigOption(
+                    sessionId: remoteId, configId: id, value: selectedId),
+                   !updated.isEmpty {
+                    session.availableConfigOptions = updated
+                    manager.persist(session)
+                }
             }
         }
     }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -57,10 +57,15 @@ struct ACPComposer: View {
                 hint
                 Spacer()
                 autoRunToggle
-                if !session.availableModes.isEmpty {
-                    modeChip
+                if let thinking = session.chipState.thinking {
+                    thinkingChip(thinking)
                 }
-                modelChip
+                if let mode = session.chipState.mode {
+                    modeChip(mode)
+                }
+                if let models = session.chipState.models {
+                    modelChip(models)
+                }
                 sendButton
             }
             .padding(.horizontal, 2)
@@ -154,7 +159,16 @@ struct ACPComposer: View {
             )
         }
         .buttonStyle(.plain)
-        .help(session.autoRunEnabled ? "Auto-run is ON — agent runs tools without asking" : "Click to skip permission prompts")
+        .help(autoRunHelpText)
+    }
+
+    private var autoRunHelpText: String {
+        if session.chipState.autoRun == .ignored {
+            return "Auto-run has no effect — this agent doesn't request permissions"
+        }
+        return session.autoRunEnabled
+            ? "Auto-run is ON — agent runs tools without asking"
+            : "Click to skip permission prompts"
     }
 
     /// Mirrors the design's outlined-pill treatment: dark accent-tinted
@@ -176,70 +190,90 @@ struct ACPComposer: View {
             : theme.color("fg-muted")
     }
 
-    // MARK: - Mode (plan / agent / etc.)
+    // MARK: - Chip builders driven by ACPChipState
 
-    private var modeItems: [ACPSelectChip.Item] {
-        session.availableModes.map { ACPSelectChip.Item(id: $0.id, name: $0.name, description: $0.description) }
-    }
-    private var modeLabel: String {
-        session.availableModes.first(where: { $0.id == session.currentMode })?.name ?? "Mode"
-    }
-    private func selectMode(_ item: ACPSelectChip.Item) {
-        session.currentMode = item.id
-        manager.persist(session)
-        let sid = session.id
-        let remoteId = session.remoteSessionId ?? sid
-        let mid = item.id
-        Task { @MainActor in
-            if let runner = manager.runners[sid] {
-                try? await runner.connection.setMode(sessionId: remoteId, modeId: mid)
-            }
-        }
+    private func modeChip(_ spec: ChipSpec) -> some View {
+        chip(spec: spec,
+             label: chipLabel(prefix: "Mode", spec: spec),
+             placeholder: "Mode",
+             accent: theme.color("accent"))
     }
 
-    private var modeChip: some View {
+    private func thinkingChip(_ spec: ChipSpec) -> some View {
+        chip(spec: spec,
+             label: chipLabel(prefix: "Thinking", spec: spec),
+             placeholder: "Thinking",
+             accent: theme.color("warn"))
+    }
+
+    private func modelChip(_ spec: ChipSpec) -> some View {
+        chip(spec: spec,
+             label: spec.options.first(where: { $0.id == spec.currentId })?.name
+                    ?? spec.currentId
+                    ?? "Model",
+             placeholder: "Model",
+             accent: theme.color("syntax-keyword"))
+    }
+
+    private func chip(spec: ChipSpec,
+                      label: String,
+                      placeholder: String,
+                      accent: Color) -> some View {
         ACPSelectChip(
-            label: modeLabel,
-            placeholder: "Mode",
-            accent: theme.color("accent"),
-            items: modeItems,
-            selectedId: session.currentMode,
-            onSelect: selectMode
+            label: label,
+            placeholder: placeholder,
+            accent: accent,
+            items: spec.options.map {
+                ACPSelectChip.Item(id: $0.id, name: $0.name, description: $0.description)
+            },
+            selectedId: spec.currentId,
+            onSelect: { item in apply(spec: spec, selectedId: item.id) }
         )
     }
 
-    // MARK: - Model
+    /// "Mode: Plan" when a value is selected, "Mode" while pending.
+    private func chipLabel(prefix: String, spec: ChipSpec) -> String {
+        if let id = spec.currentId,
+           let item = spec.options.first(where: { $0.id == id }) {
+            return "\(prefix): \(item.name)"
+        }
+        return prefix
+    }
 
-    private var modelItems: [ACPSelectChip.Item] {
-        session.availableModels.map { ACPSelectChip.Item(id: $0.id, name: $0.name, description: $0.description) }
-    }
-    private var modelLabel: String {
-        session.availableModels.first(where: { $0.id == session.currentModel })?.name
-            ?? session.currentModel
-            ?? "Model"
-    }
-    private func selectModel(_ item: ACPSelectChip.Item) {
-        session.currentModel = item.id
-        manager.persist(session)
+    /// Dispatch a chip selection to the right RPC based on where the spec
+    /// was sourced from. The composer doesn't need to know about agent
+    /// differences — `ChipSpec.source` carries the dispatch info.
+    private func apply(spec: ChipSpec, selectedId: String) {
         let sid = session.id
         let remoteId = session.remoteSessionId ?? sid
-        let mid = item.id
-        Task { @MainActor in
-            if let runner = manager.runners[sid] {
-                try? await runner.connection.setModel(sessionId: remoteId, modelId: mid)
+        switch spec.source {
+        case .mode:
+            session.currentMode = selectedId
+        case .model:
+            session.currentModel = selectedId
+        case .configOption(let id):
+            if let idx = session.availableConfigOptions.firstIndex(where: { $0.id == id }) {
+                let old = session.availableConfigOptions[idx]
+                session.availableConfigOptions[idx] = ACPConfigOption(
+                    id: old.id, name: old.name, type: old.type,
+                    category: old.category, currentValue: selectedId,
+                    options: old.options)
             }
         }
-    }
+        manager.persist(session)
 
-    private var modelChip: some View {
-        ACPSelectChip(
-            label: modelLabel,
-            placeholder: "Model",
-            accent: theme.color("syntax-keyword"),
-            items: modelItems,
-            selectedId: session.currentModel,
-            onSelect: selectModel
-        )
+        Task { @MainActor in
+            guard let runner = manager.runners[sid] else { return }
+            switch spec.source {
+            case .mode:
+                try? await runner.connection.setMode(sessionId: remoteId, modeId: selectedId)
+            case .model:
+                try? await runner.connection.setModel(sessionId: remoteId, modelId: selectedId)
+            case .configOption(let id):
+                try? await runner.connection.setConfigOption(
+                    sessionId: remoteId, configId: id, value: selectedId)
+            }
+        }
     }
 
     // MARK: - Send button

--- a/Alas/Sources/Agents/ACPAgentProfiles.swift
+++ b/Alas/Sources/Agents/ACPAgentProfiles.swift
@@ -19,6 +19,13 @@ enum ACPAgentProfiles {
         case none                            // chip is hidden for this agent
     }
 
+    /// Whether the local Auto-run toggle has any effect on this agent. Used to
+    /// decide whether the tooltip should warn the user.
+    enum AutoRunSupport: Equatable {
+        case supported    // agent uses ACP requestPermission; toggle skips prompts
+        case ignored      // agent doesn't request permissions; toggle is a no-op
+    }
+
     static func routing(for agentId: String) -> Routing {
         switch agentId {
         case "claude":
@@ -55,11 +62,4 @@ enum ACPAgentProfiles {
         }
         return nil
     }
-}
-
-/// Whether the local Auto-run toggle has any effect on this agent. Used to
-/// decide whether the tooltip should warn the user.
-enum AutoRunSupport: Equatable {
-    case supported    // agent uses ACP requestPermission; toggle skips prompts
-    case ignored      // agent doesn't request permissions; toggle is a no-op
 }

--- a/Alas/Sources/Agents/ACPAgentProfiles.swift
+++ b/Alas/Sources/Agents/ACPAgentProfiles.swift
@@ -1,0 +1,65 @@
+/// Per-agent routing: where each canonical chip pulls its options from.
+///
+/// ACP doesn't dictate what `availableModes` *means* — claude uses it for
+/// permission presets, opencode uses it for agent persona, pi uses it for
+/// thinking level. This table translates between what each agent advertises
+/// and the four canonical UI slots (Model / Mode / Thinking / Auto-run).
+enum ACPAgentProfiles {
+    struct Routing: Equatable {
+        var modeSource: ChipSource
+        var thinkingSource: ChipSource
+        var autoRun: AutoRunSupport
+    }
+
+    /// Where a chip's options come from.
+    enum ChipSource: Equatable {
+        case modes                           // ACPSession.availableModes
+        case configOption(id: String)        // a specific configOption by id
+        case heuristic                       // unknown-agent fallback (see below)
+        case none                            // chip is hidden for this agent
+    }
+
+    static func routing(for agentId: String) -> Routing {
+        switch agentId {
+        case "claude":
+            return .init(modeSource: .modes,
+                         thinkingSource: .configOption(id: "effort"),
+                         autoRun: .supported)
+        case "codex":
+            return .init(modeSource: .modes,
+                         thinkingSource: .configOption(id: "reasoning_effort"),
+                         autoRun: .supported)
+        case "opencode":
+            return .init(modeSource: .modes,
+                         thinkingSource: .configOption(id: "effort"),
+                         autoRun: .supported)
+        case "pi":
+            return .init(modeSource: .none,
+                         thinkingSource: .modes,
+                         autoRun: .ignored)
+        default:
+            return .init(modeSource: .modes,
+                         thinkingSource: .heuristic,
+                         autoRun: .supported)
+        }
+    }
+
+    /// The unknown-agent Thinking heuristic: pick a configOption whose id
+    /// matches a known thinking name OR whose category is "ThoughtLevel".
+    /// Returns nil if no candidate exists.
+    static func heuristicThinkingId(from options: [ACPConfigOption]) -> String? {
+        let knownIds: Set<String> = ["effort", "reasoning_effort", "thinking", "thinking_level"]
+        if let byId = options.first(where: { knownIds.contains($0.id) }) { return byId.id }
+        if let byCategory = options.first(where: { $0.category == "ThoughtLevel" }) {
+            return byCategory.id
+        }
+        return nil
+    }
+}
+
+/// Whether the local Auto-run toggle has any effect on this agent. Used to
+/// decide whether the tooltip should warn the user.
+enum AutoRunSupport: Equatable {
+    case supported    // agent uses ACP requestPermission; toggle skips prompts
+    case ignored      // agent doesn't request permissions; toggle is a no-op
+}

--- a/Alas/Sources/Agents/ACPAgentProfiles.swift
+++ b/Alas/Sources/Agents/ACPAgentProfiles.swift
@@ -52,12 +52,17 @@ enum ACPAgentProfiles {
     }
 
     /// The unknown-agent Thinking heuristic: pick a configOption whose id
-    /// matches a known thinking name OR whose category is "ThoughtLevel".
+    /// matches a known thinking name OR whose category is a thought-level
+    /// marker. Spec uses `thought_level`; older drafts used `ThoughtLevel`.
     /// Returns nil if no candidate exists.
     static func heuristicThinkingId(from options: [ACPConfigOption]) -> String? {
         let knownIds: Set<String> = ["effort", "reasoning_effort", "thinking", "thinking_level"]
+        let thoughtCategories: Set<String> = ["thought_level", "ThoughtLevel"]
         if let byId = options.first(where: { knownIds.contains($0.id) }) { return byId.id }
-        if let byCategory = options.first(where: { $0.category == "ThoughtLevel" }) {
+        if let byCategory = options.first(where: {
+            guard let c = $0.category else { return false }
+            return thoughtCategories.contains(c)
+        }) {
             return byCategory.id
         }
         return nil

--- a/Alas/Sources/Agents/ACPAgentProfiles.swift
+++ b/Alas/Sources/Agents/ACPAgentProfiles.swift
@@ -13,7 +13,7 @@ enum ACPAgentProfiles {
 
     /// Where a chip's options come from.
     enum ChipSource: Equatable {
-        case modes                           // ACPSession.availableModes
+        case mode                            // ACPSession.availableModes
         case configOption(id: String)        // a specific configOption by id
         case heuristic                       // unknown-agent fallback (see below)
         case none                            // chip is hidden for this agent
@@ -29,23 +29,23 @@ enum ACPAgentProfiles {
     static func routing(for agentId: String) -> Routing {
         switch agentId {
         case "claude":
-            return .init(modeSource: .modes,
+            return .init(modeSource: .mode,
                          thinkingSource: .configOption(id: "effort"),
                          autoRun: .supported)
         case "codex":
-            return .init(modeSource: .modes,
+            return .init(modeSource: .mode,
                          thinkingSource: .configOption(id: "reasoning_effort"),
                          autoRun: .supported)
         case "opencode":
-            return .init(modeSource: .modes,
+            return .init(modeSource: .mode,
                          thinkingSource: .configOption(id: "effort"),
                          autoRun: .supported)
         case "pi":
             return .init(modeSource: .none,
-                         thinkingSource: .modes,
+                         thinkingSource: .mode,
                          autoRun: .ignored)
         default:
-            return .init(modeSource: .modes,
+            return .init(modeSource: .mode,
                          thinkingSource: .heuristic,
                          autoRun: .supported)
         }

--- a/AlasTests/ACP/Fixtures/session-new-response-with-config-options.json
+++ b/AlasTests/ACP/Fixtures/session-new-response-with-config-options.json
@@ -1,0 +1,22 @@
+{
+  "jsonrpc":"2.0","id":2,
+  "result":{
+    "sessionId":"sess-abc",
+    "availableModels":[{"id":"opus","name":"Claude Opus"}],
+    "availableModes":[{"id":"plan","name":"Plan"},{"id":"default","name":"Default"}],
+    "currentModel":"opus",
+    "currentMode":"default",
+    "promptSuggestions":[],
+    "configOptions":[
+      {
+        "id":"effort","name":"Effort","type":"select",
+        "category":"ThoughtLevel","currentValue":"medium",
+        "options":[
+          {"id":"low","name":"Low"},
+          {"id":"medium","name":"Medium"},
+          {"id":"high","name":"High"}
+        ]
+      }
+    ]
+  }
+}

--- a/AlasTests/ACP/Fixtures/session-update-config-option.json
+++ b/AlasTests/ACP/Fixtures/session-update-config-option.json
@@ -1,0 +1,7 @@
+{"jsonrpc":"2.0","method":"session/update","params":{
+  "sessionId":"sess-abc",
+  "update":{"sessionUpdate":"config_option_update","configOptions":[
+    {"id":"effort","name":"Effort","type":"select","currentValue":"high",
+     "options":[{"value":"low","name":"Low"},{"value":"high","name":"High"}]}
+  ]}
+}}

--- a/AlasTests/ACP/Fixtures/session-update-config-options.json
+++ b/AlasTests/ACP/Fixtures/session-update-config-options.json
@@ -1,0 +1,1 @@
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-abc","update":{"sessionUpdate":"session_config_options_update","configOptions":[{"id":"effort","name":"Effort","type":"select","currentValue":"high","options":[{"id":"low","name":"Low"},{"id":"high","name":"High"}]}]}}}

--- a/AlasTests/ACP/Fixtures/session-update-current-model.json
+++ b/AlasTests/ACP/Fixtures/session-update-current-model.json
@@ -1,0 +1,1 @@
+{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-abc","update":{"sessionUpdate":"current_model_update","modelId":"opus"}}}

--- a/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPConfigOption")
+struct ACPConfigOptionTests {
+    @Test("decodes a select config option")
+    func decodeSelect() throws {
+        let json = """
+        {
+          "id": "effort",
+          "name": "Effort",
+          "type": "select",
+          "category": "ThoughtLevel",
+          "currentValue": "medium",
+          "options": [
+            { "id": "low", "name": "Low" },
+            { "id": "medium", "name": "Medium" },
+            { "id": "high", "name": "High", "description": "Use more reasoning" }
+          ]
+        }
+        """.data(using: .utf8)!
+        let opt = try JSONDecoder().decode(ACPConfigOption.self, from: json)
+        #expect(opt.id == "effort")
+        #expect(opt.name == "Effort")
+        #expect(opt.type == "select")
+        #expect(opt.category == "ThoughtLevel")
+        #expect(opt.currentValue == "medium")
+        #expect(opt.options.count == 3)
+        #expect(opt.options[2].description == "Use more reasoning")
+    }
+
+    @Test("non-select type decodes with empty options")
+    func decodeUnknownType() throws {
+        let json = """
+        { "id": "x", "name": "X", "type": "text", "currentValue": "" }
+        """.data(using: .utf8)!
+        let opt = try JSONDecoder().decode(ACPConfigOption.self, from: json)
+        #expect(opt.type == "text")
+        #expect(opt.options.isEmpty)
+    }
+
+    @Test("encodes setConfigOption params")
+    func encodeSetParams() throws {
+        let params = ACPSessionSetConfigOptionParams(sessionId: "s", configId: "effort", value: "high")
+        let data = try JSONEncoder().encode(params)
+        let s = String(data: data, encoding: .utf8)!
+        #expect(s.contains("\"sessionId\":\"s\""))
+        #expect(s.contains("\"configId\":\"effort\""))
+        #expect(s.contains("\"value\":\"high\""))
+    }
+}

--- a/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConfigOptionTests.swift
@@ -30,6 +30,26 @@ struct ACPConfigOptionTests {
         #expect(opt.options[2].description == "Use more reasoning")
     }
 
+    @Test("option items decode the `value` wire key")
+    func decodeOptionValueKey() throws {
+        let json = """
+        {
+          "id": "effort",
+          "name": "Effort",
+          "type": "select",
+          "currentValue": "high",
+          "options": [
+            { "value": "low", "name": "Low" },
+            { "value": "high", "name": "High" }
+          ]
+        }
+        """.data(using: .utf8)!
+        let opt = try JSONDecoder().decode(ACPConfigOption.self, from: json)
+        #expect(opt.options.count == 2)
+        #expect(opt.options[0].id == "low")
+        #expect(opt.options[1].id == "high")
+    }
+
     @Test("non-select type decodes with empty options")
     func decodeUnknownType() throws {
         let json = """

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -36,7 +36,7 @@ struct ACPConnectionTests {
         }
 
         let conn = ACPConnection(client: mock)
-        try await conn.setConfigOption(sessionId: "sess-1", configId: "effort", value: "high")
+        _ = try await conn.setConfigOption(sessionId: "sess-1", configId: "effort", value: "high")
 
         let req = try #require(mock.sent.last)
         #expect(req.method == "session/set_config_option")
@@ -45,5 +45,33 @@ struct ACPConnectionTests {
         #expect(params.sessionId == "sess-1")
         #expect(params.configId == "effort")
         #expect(params.value == "high")
+    }
+
+    @Test("setConfigOption returns refreshed configOptions from response")
+    func setConfigOptionAppliesResponse() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "session/set_config_option") { _ in
+            """
+            {"configOptions":[
+                {"id":"effort","name":"Effort","type":"select","currentValue":"high",
+                 "options":[{"value":"low","name":"Low"},{"value":"high","name":"High"}]}
+            ]}
+            """.data(using: .utf8)!
+        }
+
+        let conn = ACPConnection(client: mock)
+        let result = try await conn.setConfigOption(sessionId: "s", configId: "effort", value: "high")
+        #expect(result.count == 1)
+        #expect(result[0].currentValue == "high")
+        #expect(result[0].options.count == 2)
+    }
+
+    @Test("setConfigOption returns empty when agent omits the echo")
+    func setConfigOptionEmptyResponse() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "session/set_config_option") { _ in Data() }
+        let conn = ACPConnection(client: mock)
+        let result = try await conn.setConfigOption(sessionId: "s", configId: "effort", value: "high")
+        #expect(result.isEmpty)
     }
 }

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -27,4 +27,23 @@ struct ACPConnectionTests {
         #expect(new.availableModels.count == 1)
         #expect(new.availableModes.first?.id == "agent")
     }
+
+    @Test("setConfigOption sends session/set_config_option with sessionId, configId, value")
+    func setConfigOptionRPC() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "session/set_config_option") { _ in
+            Data()
+        }
+
+        let conn = ACPConnection(client: mock)
+        try await conn.setConfigOption(sessionId: "sess-1", configId: "effort", value: "high")
+
+        let req = try #require(mock.sent.last)
+        #expect(req.method == "session/set_config_option")
+
+        let params = try #require(req.params as? ACPSessionSetConfigOptionParams)
+        #expect(params.sessionId == "sess-1")
+        #expect(params.configId == "effort")
+        #expect(params.value == "high")
+    }
 }

--- a/AlasTests/ACP/Protocol/ACPSessionLifecycleTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionLifecycleTests.swift
@@ -25,6 +25,25 @@ struct ACPSessionLifecycleTests {
         #expect(r.promptSuggestions.first?.command == "/clear")
     }
 
+    @Test("decodes session/new response with config options")
+    func decodeConfigOptions() throws {
+        let data = try fixture("session-new-response-with-config-options")
+        let env = try JSONDecoder().decode(JSONRPCEnvelope<ACPSessionNewResult>.self, from: data)
+        let r = try #require(env.result)
+        #expect(r.configOptions.count == 1)
+        #expect(r.configOptions[0].id == "effort")
+        #expect(r.configOptions[0].currentValue == "medium")
+        #expect(r.configOptions[0].options.count == 3)
+    }
+
+    @Test("session/new response without configOptions decodes with empty array")
+    func decodeNoConfigOptions() throws {
+        let data = try fixture("session-new-response")
+        let env = try JSONDecoder().decode(JSONRPCEnvelope<ACPSessionNewResult>.self, from: data)
+        let r = try #require(env.result)
+        #expect(r.configOptions.isEmpty)
+    }
+
     @Test("encodes session/cancel request")
     func encodeCancel() throws {
         let env = JSONRPCEnvelope(

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -58,6 +58,16 @@ struct ACPSessionUpdateTests {
         } else { Issue.record("expected sessionConfigOptionsUpdate") }
     }
 
+    @Test("decodes config_option_update (canonical spec discriminator)")
+    func configOptionCanonical() throws {
+        let env = try decode("session-update-config-option")
+        if case .sessionConfigOptionsUpdate(let opts) = env.params!.update {
+            #expect(opts.count == 1)
+            #expect(opts[0].id == "effort")
+            #expect(opts[0].options.first?.id == "low")
+        } else { Issue.record("expected sessionConfigOptionsUpdate") }
+    }
+
     private func decode(_ name: String) throws -> JSONRPCEnvelope<ACPSessionUpdateParams> {
         let url = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent()

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -40,6 +40,24 @@ struct ACPSessionUpdateTests {
         } else { Issue.record("expected availableModelsUpdate") }
     }
 
+    @Test("decodes current_model_update")
+    func currentModel() throws {
+        let env = try decode("session-update-current-model")
+        if case .currentModelUpdate(let modelId) = env.params!.update {
+            #expect(modelId == "opus")
+        } else { Issue.record("expected currentModelUpdate") }
+    }
+
+    @Test("decodes session_config_options_update")
+    func configOptions() throws {
+        let env = try decode("session-update-config-options")
+        if case .sessionConfigOptionsUpdate(let opts) = env.params!.update {
+            #expect(opts.count == 1)
+            #expect(opts[0].id == "effort")
+            #expect(opts[0].currentValue == "high")
+        } else { Issue.record("expected sessionConfigOptionsUpdate") }
+    }
+
     private func decode(_ name: String) throws -> JSONRPCEnvelope<ACPSessionUpdateParams> {
         let url = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent()

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPChipState")
+struct ACPChipStateTests {
+    private func mode(_ id: String, _ name: String) -> ACPModeInfo {
+        ACPModeInfo(id: id, name: name)
+    }
+    private func model(_ id: String, _ name: String) -> ACPModelInfo {
+        ACPModelInfo(id: id, name: name)
+    }
+    private func configOption(_ id: String,
+                              current: String,
+                              options: [(String, String)],
+                              category: String? = nil) -> ACPConfigOption {
+        ACPConfigOption(
+            id: id, name: id.capitalized, type: "select",
+            category: category, currentValue: current,
+            options: options.map { ACPConfigOptionItem(id: $0.0, name: $0.1) })
+    }
+
+    @Test("claude: modes -> Mode chip, effort configOption -> Thinking chip")
+    func claudeFullHouse() {
+        let state = ACPChipState.normalize(
+            agentId: "claude",
+            availableModels: [model("opus", "Opus")],
+            currentModel: "opus",
+            availableModes: [mode("plan", "Plan"), mode("default", "Default")],
+            currentMode: "default",
+            configOptions: [configOption("effort",
+                                         current: "high",
+                                         options: [("low","Low"),("high","High")])])
+        #expect(state.models?.options.count == 1)
+        #expect(state.mode?.options.count == 2)
+        #expect(state.mode?.currentId == "default")
+        #expect(state.mode?.source == .modes)
+        #expect(state.thinking?.currentId == "high")
+        if case .configOption(let id)? = state.thinking?.source { #expect(id == "effort") }
+        else { Issue.record("expected configOption source") }
+        #expect(state.autoRun == .supported)
+    }
+
+    @Test("pi: modes route to Thinking, Mode chip is nil")
+    func piRoutesModesToThinking() {
+        let state = ACPChipState.normalize(
+            agentId: "pi",
+            availableModels: [model("pi-1", "Pi")],
+            currentModel: "pi-1",
+            availableModes: [mode("low","Low"), mode("medium","Medium"), mode("high","High")],
+            currentMode: "medium",
+            configOptions: [])
+        #expect(state.mode == nil)
+        #expect(state.thinking?.options.count == 3)
+        #expect(state.thinking?.currentId == "medium")
+        #expect(state.thinking?.source == .modes)
+        #expect(state.autoRun == .ignored)
+    }
+
+    @Test("claude without effort configOption: Thinking chip is nil")
+    func claudeNoEffort() {
+        let state = ACPChipState.normalize(
+            agentId: "claude",
+            availableModels: [model("opus", "Opus")],
+            currentModel: "opus",
+            availableModes: [mode("plan", "Plan")],
+            currentMode: "plan",
+            configOptions: [])
+        #expect(state.thinking == nil)
+        #expect(state.mode?.options.count == 1)
+    }
+
+    @Test("unknown agent: heuristic picks ThoughtLevel-category option")
+    func unknownAgentByCategory() {
+        let state = ACPChipState.normalize(
+            agentId: "future-agent",
+            availableModels: [model("m", "M")],
+            currentModel: "m",
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [configOption("speed",
+                                         current: "fast",
+                                         options: [("fast","Fast")]),
+                            configOption("brainpower",
+                                         current: "high",
+                                         options: [("low","Low"),("high","High")],
+                                         category: "ThoughtLevel")])
+        if case .configOption(let id)? = state.thinking?.source {
+            #expect(id == "brainpower")
+        } else { Issue.record("expected ThoughtLevel option to be picked") }
+    }
+
+    @Test("non-select configOption is dropped (empty options)")
+    func nonSelectDropped() {
+        let textOpt = ACPConfigOption(id: "effort", name: "Effort",
+                                      type: "text", category: nil,
+                                      currentValue: "", options: [])
+        let state = ACPChipState.normalize(
+            agentId: "claude",
+            availableModels: [model("opus","Opus")],
+            currentModel: "opus",
+            availableModes: [mode("plan","Plan")],
+            currentMode: "plan",
+            configOptions: [textOpt])
+        #expect(state.thinking == nil)
+    }
+
+    @Test("Models chip is nil when availableModels is empty (still loading)")
+    func modelsNilDuringLoad() {
+        let state = ACPChipState.normalize(
+            agentId: "claude",
+            availableModels: [],
+            currentModel: nil,
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [])
+        #expect(state.models == nil)
+    }
+}

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -137,6 +137,44 @@ struct ACPChipStateTests {
         } else { Issue.record("expected configOption source for model chip") }
     }
 
+    @Test("Mode chip sources from category=mode configOption when present")
+    func modeFromConfigOption() {
+        let modeOpt = configOption("posture",
+                                   current: "plan",
+                                   options: [("build","Build"),("plan","Plan")],
+                                   category: "mode")
+        let state = ACPChipState.normalize(
+            agentId: "future-agent",
+            availableModels: [model("m","M")],
+            currentModel: "m",
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [modeOpt])
+        #expect(state.mode?.currentId == "plan")
+        if case .configOption(let id)? = state.mode?.source {
+            #expect(id == "posture")
+        } else { Issue.record("expected configOption source for mode chip") }
+    }
+
+    @Test("configOption mode selector wins over legacy availableModes")
+    func modeConfigOptionWinsOverLegacy() {
+        let modeOpt = configOption("posture",
+                                   current: "plan",
+                                   options: [("build","Build"),("plan","Plan")],
+                                   category: "mode")
+        let state = ACPChipState.normalize(
+            agentId: "claude",
+            availableModels: [model("opus","Opus")],
+            currentModel: "opus",
+            availableModes: [mode("legacy","Legacy")],
+            currentMode: "legacy",
+            configOptions: [modeOpt])
+        if case .configOption(let id)? = state.mode?.source {
+            #expect(id == "posture")
+        } else { Issue.record("configOption mode chip should win") }
+        #expect(state.mode?.currentId == "plan")
+    }
+
     @Test("configOption model selector wins over legacy availableModels")
     func modelConfigOptionWinsOverLegacy() {
         let modelOpt = configOption("preset",

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -34,7 +34,7 @@ struct ACPChipStateTests {
         #expect(state.models?.options.count == 1)
         #expect(state.mode?.options.count == 2)
         #expect(state.mode?.currentId == "default")
-        #expect(state.mode?.source == .modes)
+        #expect(state.mode?.source == .mode)
         #expect(state.thinking?.currentId == "high")
         if case .configOption(let id)? = state.thinking?.source { #expect(id == "effort") }
         else { Issue.record("expected configOption source") }
@@ -53,7 +53,7 @@ struct ACPChipStateTests {
         #expect(state.mode == nil)
         #expect(state.thinking?.options.count == 3)
         #expect(state.thinking?.currentId == "medium")
-        #expect(state.thinking?.source == .modes)
+        #expect(state.thinking?.source == .mode)
         #expect(state.autoRun == .ignored)
     }
 

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -116,4 +116,43 @@ struct ACPChipStateTests {
             configOptions: [])
         #expect(state.models == nil)
     }
+
+    @Test("Models chip sources from category=model configOption when present")
+    func modelFromConfigOption() {
+        let modelOpt = configOption("preset",
+                                    current: "sonnet",
+                                    options: [("opus","Opus"),("sonnet","Sonnet")],
+                                    category: "model")
+        let state = ACPChipState.normalize(
+            agentId: "future-agent",
+            availableModels: [],
+            currentModel: nil,
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [modelOpt])
+        #expect(state.models?.currentId == "sonnet")
+        #expect(state.models?.options.count == 2)
+        if case .configOption(let id)? = state.models?.source {
+            #expect(id == "preset")
+        } else { Issue.record("expected configOption source for model chip") }
+    }
+
+    @Test("configOption model selector wins over legacy availableModels")
+    func modelConfigOptionWinsOverLegacy() {
+        let modelOpt = configOption("preset",
+                                    current: "sonnet",
+                                    options: [("opus","Opus"),("sonnet","Sonnet")],
+                                    category: "model")
+        let state = ACPChipState.normalize(
+            agentId: "claude",
+            availableModels: [model("legacy","Legacy")],
+            currentModel: "legacy",
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [modelOpt])
+        #expect(state.models?.currentId == "sonnet")
+        if case .configOption(let id)? = state.models?.source {
+            #expect(id == "preset")
+        } else { Issue.record("configOption model chip should win") }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -92,6 +92,6 @@ struct ACPSessionTests {
         let state = session.chipState
         #expect(state.mode == nil)
         #expect(state.thinking?.currentId == "high")
-        #expect(state.autoRun == ACPAgentProfiles.AutoRunSupport.ignored)
+        #expect(state.autoRun == .ignored)
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -43,4 +43,55 @@ struct ACPSessionTests {
         session.apply(.availableModelsUpdate([.init(id: "x", name: "X")]))
         #expect(session.availableModels.count == 1)
     }
+
+    @Test("currentModelUpdate updates currentModel")
+    func currentModelUpdates() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.availableModelsUpdate([
+            ACPModelInfo(id: "opus", name: "Opus"),
+            ACPModelInfo(id: "sonnet", name: "Sonnet")]))
+        session.apply(.currentModelUpdate(modelId: "sonnet"))
+        #expect(session.currentModel == "sonnet")
+    }
+
+    @Test("sessionConfigOptionsUpdate replaces availableConfigOptions")
+    func configOptionsUpdate() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let opt = ACPConfigOption(id: "effort", name: "Effort", type: "select",
+                                  category: nil, currentValue: "high",
+                                  options: [ACPConfigOptionItem(id: "high", name: "High")])
+        session.apply(.sessionConfigOptionsUpdate([opt]))
+        #expect(session.availableConfigOptions.count == 1)
+        #expect(session.availableConfigOptions[0].currentValue == "high")
+    }
+
+    @Test("chipState reflects current ACPSession fields")
+    func chipStateRecomputed() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.availableModels = [ACPModelInfo(id: "opus", name: "Opus")]
+        session.currentModel = "opus"
+        session.availableModes = [ACPModeInfo(id: "plan", name: "Plan")]
+        session.currentMode = "plan"
+        session.availableConfigOptions = [
+            ACPConfigOption(id: "effort", name: "Effort", type: "select",
+                            category: nil, currentValue: "low",
+                            options: [ACPConfigOptionItem(id: "low", name: "Low")])
+        ]
+        let state = session.chipState
+        #expect(state.mode?.currentId == "plan")
+        #expect(state.thinking?.currentId == "low")
+    }
+
+    @Test("chipState for pi hides Mode and routes modes to Thinking")
+    func chipStatePi() async {
+        let session = ACPSession(id: "s", agentId: "pi", worktreeId: "w", title: "t")
+        session.availableModels = [ACPModelInfo(id: "pi", name: "Pi")]
+        session.currentModel = "pi"
+        session.availableModes = [ACPModeInfo(id: "high", name: "High")]
+        session.currentMode = "high"
+        let state = session.chipState
+        #expect(state.mode == nil)
+        #expect(state.thinking?.currentId == "high")
+        #expect(state.autoRun == ACPAgentProfiles.AutoRunSupport.ignored)
+    }
 }

--- a/AlasTests/ACPAgentProfilesTests.swift
+++ b/AlasTests/ACPAgentProfilesTests.swift
@@ -43,4 +43,46 @@ struct ACPAgentProfilesTests {
         #expect(p.thinkingSource == .heuristic)
         #expect(p.autoRun == .supported)
     }
+
+    @Test("heuristic picks known id (effort) when present")
+    func heuristicKnownId() {
+        let opts = [
+            ACPConfigOption(id: "effort", name: "Effort", currentValue: "medium",
+                            options: [ACPConfigOptionItem(id: "medium", name: "Medium")])
+        ]
+        #expect(ACPAgentProfiles.heuristicThinkingId(from: opts) == "effort")
+    }
+
+    @Test("heuristic picks ThoughtLevel-category option when no known id")
+    func heuristicByCategory() {
+        let opts = [
+            ACPConfigOption(id: "speed", name: "Speed", currentValue: "fast",
+                            options: [ACPConfigOptionItem(id: "fast", name: "Fast")]),
+            ACPConfigOption(id: "brainpower", name: "Brainpower", category: "ThoughtLevel",
+                            currentValue: "high",
+                            options: [ACPConfigOptionItem(id: "high", name: "High")])
+        ]
+        #expect(ACPAgentProfiles.heuristicThinkingId(from: opts) == "brainpower")
+    }
+
+    @Test("heuristic prefers known id over ThoughtLevel category")
+    func heuristicKnownIdWins() {
+        let opts = [
+            ACPConfigOption(id: "brainpower", name: "Brainpower", category: "ThoughtLevel",
+                            currentValue: "high",
+                            options: [ACPConfigOptionItem(id: "high", name: "High")]),
+            ACPConfigOption(id: "thinking", name: "Thinking", currentValue: "deep",
+                            options: [ACPConfigOptionItem(id: "deep", name: "Deep")])
+        ]
+        #expect(ACPAgentProfiles.heuristicThinkingId(from: opts) == "thinking")
+    }
+
+    @Test("heuristic returns nil when nothing matches")
+    func heuristicNoMatch() {
+        let opts = [
+            ACPConfigOption(id: "speed", name: "Speed", currentValue: "fast",
+                            options: [ACPConfigOptionItem(id: "fast", name: "Fast")])
+        ]
+        #expect(ACPAgentProfiles.heuristicThinkingId(from: opts) == nil)
+    }
 }

--- a/AlasTests/ACPAgentProfilesTests.swift
+++ b/AlasTests/ACPAgentProfilesTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPAgentProfiles")
+struct ACPAgentProfilesTests {
+    @Test("claude uses modes for Mode, effort configOption for Thinking")
+    func claude() {
+        let p = ACPAgentProfiles.routing(for: "claude")
+        #expect(p.modeSource == .modes)
+        #expect(p.thinkingSource == .configOption(id: "effort"))
+        #expect(p.autoRun == .supported)
+    }
+
+    @Test("codex uses reasoning_effort for Thinking")
+    func codex() {
+        let p = ACPAgentProfiles.routing(for: "codex")
+        #expect(p.modeSource == .modes)
+        #expect(p.thinkingSource == .configOption(id: "reasoning_effort"))
+        #expect(p.autoRun == .supported)
+    }
+
+    @Test("opencode uses modes (agents) for Mode, effort for Thinking")
+    func opencode() {
+        let p = ACPAgentProfiles.routing(for: "opencode")
+        #expect(p.modeSource == .modes)
+        #expect(p.thinkingSource == .configOption(id: "effort"))
+        #expect(p.autoRun == .supported)
+    }
+
+    @Test("pi puts thinking in modes, has no Mode and ignores autoRun")
+    func pi() {
+        let p = ACPAgentProfiles.routing(for: "pi")
+        #expect(p.modeSource == .none)
+        #expect(p.thinkingSource == .modes)
+        #expect(p.autoRun == .ignored)
+    }
+
+    @Test("unknown agent falls back to modes for Mode + heuristic Thinking")
+    func unknown() {
+        let p = ACPAgentProfiles.routing(for: "some-new-agent")
+        #expect(p.modeSource == .modes)
+        #expect(p.thinkingSource == .heuristic)
+        #expect(p.autoRun == .supported)
+    }
+}

--- a/AlasTests/ACPAgentProfilesTests.swift
+++ b/AlasTests/ACPAgentProfilesTests.swift
@@ -7,7 +7,7 @@ struct ACPAgentProfilesTests {
     @Test("claude uses modes for Mode, effort configOption for Thinking")
     func claude() {
         let p = ACPAgentProfiles.routing(for: "claude")
-        #expect(p.modeSource == .modes)
+        #expect(p.modeSource == .mode)
         #expect(p.thinkingSource == .configOption(id: "effort"))
         #expect(p.autoRun == .supported)
     }
@@ -15,7 +15,7 @@ struct ACPAgentProfilesTests {
     @Test("codex uses reasoning_effort for Thinking")
     func codex() {
         let p = ACPAgentProfiles.routing(for: "codex")
-        #expect(p.modeSource == .modes)
+        #expect(p.modeSource == .mode)
         #expect(p.thinkingSource == .configOption(id: "reasoning_effort"))
         #expect(p.autoRun == .supported)
     }
@@ -23,7 +23,7 @@ struct ACPAgentProfilesTests {
     @Test("opencode uses modes (agents) for Mode, effort for Thinking")
     func opencode() {
         let p = ACPAgentProfiles.routing(for: "opencode")
-        #expect(p.modeSource == .modes)
+        #expect(p.modeSource == .mode)
         #expect(p.thinkingSource == .configOption(id: "effort"))
         #expect(p.autoRun == .supported)
     }
@@ -32,14 +32,14 @@ struct ACPAgentProfilesTests {
     func pi() {
         let p = ACPAgentProfiles.routing(for: "pi")
         #expect(p.modeSource == .none)
-        #expect(p.thinkingSource == .modes)
+        #expect(p.thinkingSource == .mode)
         #expect(p.autoRun == .ignored)
     }
 
     @Test("unknown agent falls back to modes for Mode + heuristic Thinking")
     func unknown() {
         let p = ACPAgentProfiles.routing(for: "some-new-agent")
-        #expect(p.modeSource == .modes)
+        #expect(p.modeSource == .mode)
         #expect(p.thinkingSource == .heuristic)
         #expect(p.autoRun == .supported)
     }

--- a/AlasTests/ACPAgentProfilesTests.swift
+++ b/AlasTests/ACPAgentProfilesTests.swift
@@ -65,6 +65,18 @@ struct ACPAgentProfilesTests {
         #expect(ACPAgentProfiles.heuristicThinkingId(from: opts) == "brainpower")
     }
 
+    @Test("heuristic picks thought_level-category option (canonical spec)")
+    func heuristicBySnakeCaseCategory() {
+        let opts = [
+            ACPConfigOption(id: "speed", name: "Speed", currentValue: "fast",
+                            options: [ACPConfigOptionItem(id: "fast", name: "Fast")]),
+            ACPConfigOption(id: "reasoning", name: "Reasoning", category: "thought_level",
+                            currentValue: "high",
+                            options: [ACPConfigOptionItem(id: "high", name: "High")])
+        ]
+        #expect(ACPAgentProfiles.heuristicThinkingId(from: opts) == "reasoning")
+    }
+
     @Test("heuristic prefers known id over ThoughtLevel category")
     func heuristicKnownIdWins() {
         let opts = [


### PR DESCRIPTION
## Summary

Adds a uniform chip row to the ACP chat composer (Model / Mode / Thinking / Auto-run) that works consistently across every ACP agent. Each agent advertises capabilities differently — claude/codex/opencode pack permission/persona presets into `availableModes`, pi puts thinking levels there, others carry effort/reasoning_effort via `configOptions` (which we didn't read at all before). This routes each agent's advertised options into the right semantic chip slot, hiding chips for slots the agent doesn't support.

Architecture:
- New normalization layer (`ACPChipState.normalize`) — pure function from raw `ACPSession` fields to a four-slot chip state
- Per-agent routing profile (`ACPAgentProfiles`) — small table mapping agent id → where each chip pulls its data from, with a `ThoughtLevel`-aware heuristic fallback for unknown agents
- `ChipSpec.Source` dispatch tag — composer routes selections to the right RPC (`session/set_mode`, `session/set_model`, new `session/set_config_option`) based on where the chip's data originated
- Wire-type additions for `configOptions` (in `session/new` and `session/update`)

Composer becomes data-driven: reads `session.chipState`, never special-cases agents.

Per-agent result:
- **claude** / **codex** / **opencode**: Model + Mode + Thinking (Thinking finally surfaces — was invisible before because `configOptions` were unread)
- **pi**: Model + Thinking only; Mode hidden; Auto-run tooltip notes it has no effect

## Test plan

- [x] Unit tests at every layer (wire types, decoders, RPC, routing, normalization, session integration) — 2107 tests pass
- [x] Build clean, no new warnings
- [ ] Smoke test in running app — open a session with each agent and visually verify:
  - claude: three chips, Thinking now visible
  - codex: changing Thinking does NOT reset the selected Model
  - opencode: Mode shows agent personas; Thinking options reshape on Model change
  - pi: only Model + Thinking; Mode hidden; Auto-run tooltip says "no effect"

## Spec / plan

- Spec: \`docs/superpowers/specs/2026-05-28-acp-uniform-chip-row-design.md\` (gitignored)
- Plan: \`docs/superpowers/plans/2026-05-28-acp-uniform-chip-row.md\` (gitignored)

## Open follow-ups

- Decide whether Mode and Auto-run should merge once we've lived with both for a few releases (per spec; deliberate side-by-side period)
- Visual chip order: spec mockup shows `Model | Mode | Thinking | Auto-run`; implementation renders the right cluster as `Auto-run | Thinking | Mode | Model` (preserves pre-refactor convention). Pick a winner during smoke test.