### PR TITLE
fix(acp): adapter PATH detection

### DIFF
--- a/Alas/Sources/ACP/Adapter/ACPAdapterInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/ACPAdapterInstaller.swift
@@ -15,6 +15,19 @@ enum ACPInstallError: LocalizedError {
     }
 }
 
+enum ACPProcessEnvironment {
+    static func augmented(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment,
+        additionalPathDirectories: [String] = AgentPath.wellKnownDirectories
+    ) -> [String: String] {
+        var env = environment
+        env["PATH"] = AgentPath.augment(
+            base: env["PATH"] ?? "",
+            wellKnown: additionalPathDirectories)
+        return env
+    }
+}
+
 enum ACPInstallerRegistry {
     static func installer(for agentID: String) -> ACPAdapterInstaller? {
         switch agentID {

--- a/Alas/Sources/ACP/Adapter/ACPSetupChecker.swift
+++ b/Alas/Sources/ACP/Adapter/ACPSetupChecker.swift
@@ -2,6 +2,15 @@ import Foundation
 
 struct ACPSetupChecker {
     let env: [String: String]
+    let additionalPathDirectories: [String]
+
+    init(
+        env: [String: String],
+        additionalPathDirectories: [String] = AgentPath.wellKnownDirectories
+    ) {
+        self.env = env
+        self.additionalPathDirectories = additionalPathDirectories
+    }
 
     func evaluate(_ check: ACPSetupCheck) async -> ACPSetupResult {
         switch check {
@@ -21,7 +30,9 @@ struct ACPSetupChecker {
     }
 
     private func resolve(_ name: String) -> String? {
-        let pathValue = env["PATH"] ?? ""
+        let pathValue = AgentPath.augment(
+            base: env["PATH"] ?? "",
+            wellKnown: additionalPathDirectories)
         for dir in pathValue.split(separator: ":") {
             let candidate = "\(dir)/\(name)"
             if FileManager.default.isExecutableFile(atPath: candidate) { return candidate }
@@ -35,6 +46,9 @@ struct ACPSetupChecker {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: npm)
         proc.arguments = ["root", "-g"]
+        proc.environment = ACPProcessEnvironment.augmented(
+            env,
+            additionalPathDirectories: additionalPathDirectories)
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = Pipe()

--- a/Alas/Sources/ACP/Adapter/ClaudeCodeACPInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/ClaudeCodeACPInstaller.swift
@@ -24,6 +24,7 @@ struct ClaudeCodeACPInstaller: ACPAdapterInstaller {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         proc.arguments = [cmd] + args
+        proc.environment = ACPProcessEnvironment.augmented()
         let err = Pipe()
         proc.standardError = err
         proc.standardOutput = Pipe()

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -216,7 +216,7 @@ extension ACPSessionManager {
     }
 
     private static func mergeEnv(extra: [String: String]) -> [String: String] {
-        var env = ProcessInfo.processInfo.environment
+        var env = ACPProcessEnvironment.augmented()
         // Strip env vars that mark this process as running INSIDE a coding
         // agent's session. Without this, `claude-code-acp` (and likely any
         // other Anthropic-aware tool we spawn) refuses to start, reporting

--- a/AlasTests/ACP/Adapter/ACPSetupCheckerTests.swift
+++ b/AlasTests/ACP/Adapter/ACPSetupCheckerTests.swift
@@ -4,6 +4,16 @@ import Testing
 
 @Suite("ACPSetupChecker")
 struct ACPSetupCheckerTests {
+    private func makeExecutable(named name: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-acp-setup-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let executable = dir.appendingPathComponent(name)
+        try "#!/bin/sh\nexit 0\n".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return executable
+    }
+
     @Test("binaryOnPath returns ready when /bin/ls is on PATH")
     func binaryPresent() async {
         let checker = ACPSetupChecker(env: ProcessInfo.processInfo.environment)
@@ -16,5 +26,17 @@ struct ACPSetupCheckerTests {
         let checker = ACPSetupChecker(env: ["PATH": "/var/empty"])
         let r = await checker.evaluate(.binaryOnPath(name: "ls"))
         if case .missing = r {} else { Issue.record("expected .missing") }
+    }
+
+    @Test("binaryOnPath checks additional GUI-missing tool directories")
+    func binaryInAdditionalDirectory() async throws {
+        let executable = try makeExecutable(named: "codex-acp")
+        defer { try? FileManager.default.removeItem(at: executable.deletingLastPathComponent()) }
+
+        let checker = ACPSetupChecker(
+            env: ["PATH": "/usr/bin:/bin:/usr/sbin:/sbin"],
+            additionalPathDirectories: [executable.deletingLastPathComponent().path])
+        let r = await checker.evaluate(.binaryOnPath(name: "codex-acp"))
+        #expect(r == .ready)
     }
 }


### PR DESCRIPTION
## Summary

Fix ACP adapter setup, launch, and install paths so GUI-launched Alas can find tools installed in common user directories such as Homebrew, npm-global, Volta, and related agent CLI locations.

## Root Cause

ACP setup checks and installer processes were using the raw macOS app environment. When Alas was launched as a GUI app, that environment could omit directories containing `npm` or ACP adapter binaries, causing installed providers to be reported as missing and install attempts to fail with `/usr/bin/env npm` exit 127.

## Changes

- Add a shared ACP process environment helper that augments `PATH` using the existing `AgentPath` well-known directories.
- Use the augmented PATH for ACP setup checks, global npm package detection, ACP adapter installs, and ACP process launch.
- Add a regression test covering adapter binaries found only through additional GUI-missing PATH directories.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`