### PR TITLE
fix(tabs): show loading spinner while restoring worktree tabs

### DIFF
--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -88,7 +88,9 @@ struct CenterPaneView: View {
                 }
             )
             Group {
-                if tabs.isEmpty {
+                if tabs.isEmpty, !state.tabs.hasLoaded {
+                    Spinner()
+                } else if tabs.isEmpty {
                     EmptyTabView(
                         onNewTerminal: openTerminal,
                         onNewAgentTerminal: { state.openAgentLauncherOverlay(mode: .terminal) },

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -21,6 +21,10 @@ final class TabsManager {
     }
 
     private var byWorktree: [String: TabsFile] = [:]
+    /// `true` once `loadAll` has been called at least once, meaning any
+    /// persisted tabs have been read from disk. Views use this to
+    /// distinguish "no tabs yet (still loading)" from "genuinely empty".
+    private(set) var hasLoaded = false
     private let store = PersistenceStore()
     private let bufferStore: EditorBufferStore
     private var buffers: [BufferKey: EditorBuffer] = [:]
@@ -108,6 +112,7 @@ final class TabsManager {
                 byWorktree[id] = file
             }
         }
+        hasLoaded = true
     }
 
     @discardableResult

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -765,4 +765,15 @@ struct TabsManagerRuntimeTitleTests {
         let tab = mgr.appendEditor(worktreeId: "wt", title: "README.md", relativePath: "README.md")
         #expect(mgr.displayTerminalTitle(for: tab) == nil)
     }
+
+    @Test func hasLoadedIsFalseBeforeLoadAll() {
+        let mgr = TabsManager()
+        #expect(mgr.hasLoaded == false)
+    }
+
+    @Test func hasLoadedIsTrueAfterLoadAll() {
+        let mgr = TabsManager()
+        mgr.loadAll(worktreeIds: [])
+        #expect(mgr.hasLoaded == true)
+    }
 }


### PR DESCRIPTION
## Summary
- add a TabsManager loading-complete flag for persisted tab restoration
- show a spinner instead of the empty tab state before initial tabs load completes
- cover the loading flag behavior in TabsManager tests

## Tests
- Not run in this shepherd phase