### PR TITLE
Persist worktree launch defaults per project

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -854,6 +854,15 @@ final class AppState {
         saveProjects()
     }
 
+    func setWorktreeLaunchDefaults(projectId: String, openAfterCreate: Bool, launcherMode: AppConfig.LauncherMode) {
+        projectsManager.setWorktreeLaunchDefaults(
+            projectId: projectId,
+            openAfterCreate: openAfterCreate,
+            launcherMode: launcherMode
+        )
+        saveProjects()
+    }
+
     /// Archive (hide) a worktree. Closes all tabs/terminals/harness state for
     /// it, marks the path hidden in `ProjectConfig`, and re-points selection if
     /// the archived worktree was selected. Does NOT touch git or disk.

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -169,6 +169,12 @@ final class ProjectsManager {
         hiddenSet(projectId: projectId).contains(canonical(path))
     }
 
+    func setWorktreeLaunchDefaults(projectId: String, openAfterCreate: Bool, launcherMode: AppConfig.LauncherMode) {
+        guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return }
+        projects[idx].worktreeOpenAfterCreate = openAfterCreate
+        projects[idx].worktreeDefaultLauncherMode = launcherMode
+    }
+
     func setWorktreeHidden(projectId: String, path: URL, hidden: Bool) {
         guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return }
         let key = canonical(path)

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -14,6 +14,9 @@ struct NewWorktreeDialog: View {
     @State private var runStartup: Bool = true
     @State private var openAfterCreate: Bool = true
     @State private var launchMode: AppConfig.LauncherMode = .terminal
+    /// The launcher mode to persist — preserves the user's intent even when
+    /// ACP is temporarily unavailable and `launchMode` has been coerced.
+    @State private var persistableLaunchMode: AppConfig.LauncherMode = .terminal
     @State private var launchAgentId: String = "none"
     @State private var branches: [String] = []
     @State private var isLoadingBranches = false
@@ -212,6 +215,7 @@ struct NewWorktreeDialog: View {
             acpSegmentEnabled: acpSegmentEnabled
         )
         launchMode = defaults.launchMode
+        persistableLaunchMode = defaults.persistableLaunchMode
         openAfterCreate = defaults.openAfterCreate
         let initialAgent = effectiveAutoLaunchAgent?.id ?? "none"
         launchAgentId = Self.resolvedLaunchAgent(
@@ -255,7 +259,7 @@ struct NewWorktreeDialog: View {
         state.setWorktreeLaunchDefaults(
             projectId: project.id,
             openAfterCreate: openAfterCreate,
-            launcherMode: launchMode
+            launcherMode: persistableLaunchMode
         )
         createErrorMessage = nil
         presented = false
@@ -364,6 +368,7 @@ struct NewWorktreeDialog: View {
                 ) {
                     openAfterCreate = true
                     launchMode = .terminal
+                    persistableLaunchMode = .terminal
                     launchAgentId = Self.resolvedLaunchAgent(
                         initialAgentId: launchAgentId,
                         mode: .terminal,
@@ -379,6 +384,7 @@ struct NewWorktreeDialog: View {
                 ) {
                     openAfterCreate = true
                     launchMode = .acp
+                    persistableLaunchMode = .acp
                     launchAgentId = Self.resolvedLaunchAgent(
                         initialAgentId: launchAgentId,
                         mode: .acp,
@@ -475,18 +481,20 @@ struct NewWorktreeDialog: View {
     }
 
     /// Resolve launch mode and openAfterCreate from per-project config,
-    /// falling back to global defaults. Returns the effective values.
+    /// falling back to global defaults. Returns the effective UI values plus the
+    /// persistable mode (which preserves the user's intent when ACP is temporarily unavailable).
     nonisolated static func resolvedLaunchDefaults(
         projectOpenAfterCreate: Bool?,
         projectLauncherMode: AppConfig.LauncherMode?,
         globalLauncherMode: AppConfig.LauncherMode,
         acpSegmentEnabled: Bool
-    ) -> (openAfterCreate: Bool, launchMode: AppConfig.LauncherMode) {
-        var mode = projectLauncherMode ?? globalLauncherMode
+    ) -> (openAfterCreate: Bool, launchMode: AppConfig.LauncherMode, persistableLaunchMode: AppConfig.LauncherMode) {
+        let intended = projectLauncherMode ?? globalLauncherMode
+        var mode = intended
         if mode == .acp, !acpSegmentEnabled {
             mode = .terminal
         }
         let open = projectOpenAfterCreate ?? true
-        return (open, mode)
+        return (open, mode, intended)
     }
 }

--- a/Alas/Sources/Dialogs/NewWorktreeDialog.swift
+++ b/Alas/Sources/Dialogs/NewWorktreeDialog.swift
@@ -104,28 +104,11 @@ struct NewWorktreeDialog: View {
             if branch.isEmpty {
                 branch = state.config.worktrees.branchPrefix
             }
-            launchMode = state.config.agents.defaultLauncherMode
-            if launchMode == .acp, !acpSegmentEnabled {
-                // Fall back to terminal if the default surface is ACP
-                // but no ACP-capable agent is enabled.
-                launchMode = .terminal
-            }
-            openAfterCreate = true
-            let initialAgent = effectiveAutoLaunchAgent?.id ?? "none"
-            launchAgentId = Self.resolvedLaunchAgent(
-                initialAgentId: initialAgent,
-                mode: launchMode,
-                enabledAgents: state.agentRegistry.enabled()
-            )
+            applyLaunchDefaults(for: projectId)
             loadBranchesForSelectedProject()
         }
         .onChange(of: projectId) { _, _ in
-            let initialAgent = effectiveAutoLaunchAgent?.id ?? "none"
-            launchAgentId = Self.resolvedLaunchAgent(
-                initialAgentId: initialAgent,
-                mode: launchMode,
-                enabledAgents: state.agentRegistry.enabled()
-            )
+            applyLaunchDefaults(for: projectId)
             loadBranchesForSelectedProject()
         }
         .onChange(of: branch) { _, _ in
@@ -220,6 +203,24 @@ struct NewWorktreeDialog: View {
         }
     }
 
+    private func applyLaunchDefaults(for selectedProjectId: String) {
+        let project = state.projects.first { $0.id == selectedProjectId }
+        let defaults = Self.resolvedLaunchDefaults(
+            projectOpenAfterCreate: project?.worktreeOpenAfterCreate,
+            projectLauncherMode: project?.worktreeDefaultLauncherMode,
+            globalLauncherMode: state.config.agents.defaultLauncherMode,
+            acpSegmentEnabled: acpSegmentEnabled
+        )
+        launchMode = defaults.launchMode
+        openAfterCreate = defaults.openAfterCreate
+        let initialAgent = effectiveAutoLaunchAgent?.id ?? "none"
+        launchAgentId = Self.resolvedLaunchAgent(
+            initialAgentId: initialAgent,
+            mode: launchMode,
+            enabledAgents: state.agentRegistry.enabled()
+        )
+    }
+
     private func create() {
         guard let project = state.projects.first(where: { $0.id == projectId }) else { return }
         let dest = URL(fileURLWithPath: renderedPath)
@@ -251,6 +252,11 @@ struct NewWorktreeDialog: View {
             createErrorMessage = "A worktree already exists at this path."
             return
         }
+        state.setWorktreeLaunchDefaults(
+            projectId: project.id,
+            openAfterCreate: openAfterCreate,
+            launcherMode: launchMode
+        )
         createErrorMessage = nil
         presented = false
     }
@@ -466,5 +472,21 @@ struct NewWorktreeDialog: View {
             }
             return capable.first?.id ?? "none"
         }
+    }
+
+    /// Resolve launch mode and openAfterCreate from per-project config,
+    /// falling back to global defaults. Returns the effective values.
+    nonisolated static func resolvedLaunchDefaults(
+        projectOpenAfterCreate: Bool?,
+        projectLauncherMode: AppConfig.LauncherMode?,
+        globalLauncherMode: AppConfig.LauncherMode,
+        acpSegmentEnabled: Bool
+    ) -> (openAfterCreate: Bool, launchMode: AppConfig.LauncherMode) {
+        var mode = projectLauncherMode ?? globalLauncherMode
+        if mode == .acp, !acpSegmentEnabled {
+            mode = .terminal
+        }
+        let open = projectOpenAfterCreate ?? true
+        return (open, mode)
     }
 }

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -82,9 +82,14 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var hiddenWorktreePaths: [String] = []
     var worktreeOrder: [String] = []
     var startupScripts: ProjectStartupScripts = .defaults
+    /// Per-project "open after create" preference. `nil` = use global default (true).
+    var worktreeOpenAfterCreate: Bool?
+    /// Per-project launcher mode preference. `nil` = use global default.
+    var worktreeDefaultLauncherMode: AppConfig.LauncherMode?
 
     enum CodingKeys: String, CodingKey {
-        case id, name, path, color, addedAt, hiddenWorktreePaths, worktreeOrder, startupScripts
+        case id, name, path, color, addedAt, hiddenWorktreePaths, worktreeOrder, startupScripts,
+             worktreeOpenAfterCreate, worktreeDefaultLauncherMode
     }
 
     init(
@@ -95,7 +100,9 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         addedAt: Date,
         hiddenWorktreePaths: [String] = [],
         worktreeOrder: [String] = [],
-        startupScripts: ProjectStartupScripts = .defaults
+        startupScripts: ProjectStartupScripts = .defaults,
+        worktreeOpenAfterCreate: Bool? = nil,
+        worktreeDefaultLauncherMode: AppConfig.LauncherMode? = nil
     ) {
         self.id = id
         self.name = name
@@ -105,6 +112,8 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.hiddenWorktreePaths = hiddenWorktreePaths
         self.worktreeOrder = worktreeOrder
         self.startupScripts = startupScripts
+        self.worktreeOpenAfterCreate = worktreeOpenAfterCreate
+        self.worktreeDefaultLauncherMode = worktreeDefaultLauncherMode
     }
 
     // Tolerant decode: older projects.json files predate hiddenWorktreePaths
@@ -120,5 +129,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         worktreeOrder = (try? c.decode([String].self, forKey: .worktreeOrder)) ?? []
         startupScripts = (try? c.decode(ProjectStartupScripts.self, forKey: .startupScripts))
             ?? .defaults
+        worktreeOpenAfterCreate = try? c.decode(Bool.self, forKey: .worktreeOpenAfterCreate)
+        worktreeDefaultLauncherMode = try? c.decode(AppConfig.LauncherMode.self, forKey: .worktreeDefaultLauncherMode)
     }
 }

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -263,6 +263,7 @@ struct NewWorktreeDialogTests {
         )
         #expect(result.openAfterCreate == false)
         #expect(result.launchMode == .acp)
+        #expect(result.persistableLaunchMode == .acp)
     }
 
     @Test func resolvedLaunchDefaultsFallsBackToGlobalWhenProjectIsNil() {
@@ -274,6 +275,7 @@ struct NewWorktreeDialogTests {
         )
         #expect(result.openAfterCreate == true)
         #expect(result.launchMode == .acp)
+        #expect(result.persistableLaunchMode == .acp)
     }
 
     @Test func resolvedLaunchDefaultsFallsBackToTerminalWhenACPDisabled() {
@@ -285,6 +287,8 @@ struct NewWorktreeDialogTests {
         )
         #expect(result.openAfterCreate == true)
         #expect(result.launchMode == .terminal)
+        // persistableLaunchMode preserves the intended .acp preference
+        #expect(result.persistableLaunchMode == .acp)
     }
 
     @Test func resolvedLaunchDefaultsProjectOpenAfterCreateOverridesGlobal() {
@@ -296,5 +300,6 @@ struct NewWorktreeDialogTests {
         )
         #expect(result.openAfterCreate == false)
         #expect(result.launchMode == .terminal)
+        #expect(result.persistableLaunchMode == .terminal)
     }
 }

--- a/AlasTests/NewWorktreeDialogTests.swift
+++ b/AlasTests/NewWorktreeDialogTests.swift
@@ -251,4 +251,50 @@ struct NewWorktreeDialogTests {
         )
         #expect(resolved == "none")
     }
+
+    // MARK: - Per-project launch defaults
+
+    @Test func resolvedLaunchDefaultsUsesProjectPreference() {
+        let result = NewWorktreeDialog.resolvedLaunchDefaults(
+            projectOpenAfterCreate: false,
+            projectLauncherMode: .acp,
+            globalLauncherMode: .terminal,
+            acpSegmentEnabled: true
+        )
+        #expect(result.openAfterCreate == false)
+        #expect(result.launchMode == .acp)
+    }
+
+    @Test func resolvedLaunchDefaultsFallsBackToGlobalWhenProjectIsNil() {
+        let result = NewWorktreeDialog.resolvedLaunchDefaults(
+            projectOpenAfterCreate: nil,
+            projectLauncherMode: nil,
+            globalLauncherMode: .acp,
+            acpSegmentEnabled: true
+        )
+        #expect(result.openAfterCreate == true)
+        #expect(result.launchMode == .acp)
+    }
+
+    @Test func resolvedLaunchDefaultsFallsBackToTerminalWhenACPDisabled() {
+        let result = NewWorktreeDialog.resolvedLaunchDefaults(
+            projectOpenAfterCreate: nil,
+            projectLauncherMode: .acp,
+            globalLauncherMode: .terminal,
+            acpSegmentEnabled: false
+        )
+        #expect(result.openAfterCreate == true)
+        #expect(result.launchMode == .terminal)
+    }
+
+    @Test func resolvedLaunchDefaultsProjectOpenAfterCreateOverridesGlobal() {
+        let result = NewWorktreeDialog.resolvedLaunchDefaults(
+            projectOpenAfterCreate: false,
+            projectLauncherMode: nil,
+            globalLauncherMode: .terminal,
+            acpSegmentEnabled: true
+        )
+        #expect(result.openAfterCreate == false)
+        #expect(result.launchMode == .terminal)
+    }
 }

--- a/AlasTests/ProjectConfigTests.swift
+++ b/AlasTests/ProjectConfigTests.swift
@@ -87,4 +87,42 @@ struct ProjectConfigTests {
         #expect(file.projects[0].hiddenWorktreePaths == ["/tmp/alpha/wt"])
         #expect(file.projects[0].startupScripts == .defaults)
     }
+
+    @Test func decodingOlderProjectWithoutLaunchDefaultsYieldsNil() throws {
+        let json = """
+        {
+          "version": 1,
+          "projects": [{
+            "id": "abc",
+            "name": "alpha",
+            "path": "/tmp/alpha",
+            "color": "#5fb7c4",
+            "addedAt": 0
+          }]
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let file = try decoder.decode(ProjectsFile.self, from: json)
+        #expect(file.projects[0].worktreeOpenAfterCreate == nil)
+        #expect(file.projects[0].worktreeDefaultLauncherMode == nil)
+    }
+
+    @Test func roundTripPreservesLaunchDefaults() throws {
+        let project = ProjectConfig(
+            id: "abc", name: "alpha", path: "/tmp/alpha",
+            color: "#5fb7c4", addedAt: Date(timeIntervalSince1970: 0),
+            worktreeOpenAfterCreate: false,
+            worktreeDefaultLauncherMode: .acp
+        )
+        let file = ProjectsFile(projects: [project])
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(file)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(ProjectsFile.self, from: data)
+        #expect(decoded.projects[0].worktreeOpenAfterCreate == false)
+        #expect(decoded.projects[0].worktreeDefaultLauncherMode == .acp)
+    }
 }

--- a/AlasTests/ProjectsManagerTests.swift
+++ b/AlasTests/ProjectsManagerTests.swift
@@ -90,6 +90,39 @@ struct ProjectsManagerTests {
         #expect(mgr.projects[0].color == "#d77b88")
         #expect(mgr.projects[1] == other)
     }
+
+    @Test func setWorktreeLaunchDefaultsPersistsPerProject() {
+        let project = ProjectConfig(
+            id: "project-1",
+            name: "Alpha",
+            path: "/tmp/alpha",
+            color: "#5fb7c4",
+            addedAt: Date(timeIntervalSince1970: 0)
+        )
+        let mgr = ProjectsManager(persistedProjects: [project])
+
+        #expect(mgr.projects[0].worktreeOpenAfterCreate == nil)
+        #expect(mgr.projects[0].worktreeDefaultLauncherMode == nil)
+
+        mgr.setWorktreeLaunchDefaults(
+            projectId: "project-1",
+            openAfterCreate: false,
+            launcherMode: .acp
+        )
+
+        #expect(mgr.projects[0].worktreeOpenAfterCreate == false)
+        #expect(mgr.projects[0].worktreeDefaultLauncherMode == .acp)
+    }
+
+    @Test func setWorktreeLaunchDefaultsIgnoresMissingProject() {
+        let mgr = ProjectsManager(persistedProjects: [])
+        mgr.setWorktreeLaunchDefaults(
+            projectId: "missing",
+            openAfterCreate: true,
+            launcherMode: .terminal
+        )
+        #expect(mgr.projects.isEmpty)
+    }
 }
 
 extension ProjectsManagerTests {


### PR DESCRIPTION
## Summary
- persist New Worktree open-after-create defaults per project
- restore project-specific launch surface when opening or switching projects in the dialog
- add coverage for config decoding, projects manager mutation, and launch default resolution

## Tests
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test