### PR TITLE
Fix ACP transcript tail restore

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -24,6 +24,10 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var setupState: SetupState = .checking
     @Published var lastError: String?
     @Published var disconnected: Bool = false
+    /// Runtime-only transcript scroll intent. When true, the ACP message
+    /// list follows new content and restores to the latest bottom after
+    /// returning to this session. Set false when the user scrolls upward.
+    @Published var followsTranscriptTail: Bool = true
     /// True once a runner has been started for this session — meaning
     /// `initialize` + `session/new` succeeded and we have a live agent on
     /// stdio. Reset to false on detach or when the process exits. The

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -253,6 +253,9 @@ extension ACPSessionRunner {
             await MainActor.run {
                 let before = self.session.messages.count
                 let titleBefore = self.session.title
+                if !self.session.followsTranscriptTail {
+                    self.session.followsTranscriptTail = true
+                }
                 self.session.recordUserPrompt(text: text, attachments: attachments)
                 self.persistFromIndex(before)
                 // First-prompt path auto-renames the session to the

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct ACPMessageList: View {
@@ -6,6 +7,10 @@ struct ACPMessageList: View {
     let policy: ACPPermissionPolicy?
     let scopeKey: String
     @Environment(\.theme) private var theme
+    @State private var viewportHeight: CGFloat = 0
+    @State private var tailFrame: CGRect = .zero
+    @State private var isRestoringTail = false
+    @State private var userInterruptedTailRestore = false
 
     /// Height of an invisible spacer at the tail of the VStack. The
     /// composer pill plus its outer padding occupies roughly this much
@@ -13,6 +18,8 @@ struct ACPMessageList: View {
     /// bottom we guarantee the streaming caret / last message sits
     /// above the composer instead of behind it.
     private let composerSpacerHeight: CGFloat = 220
+    private let tailTolerance: CGFloat = 36
+    private var scrollSpaceName: String { "acp-message-list-\(session.id)" }
 
     /// Cheap signature of the entire transcript. SwiftUI re-evaluates when
     /// any cell mutates (e.g. an agent_message_chunk merging into the
@@ -44,40 +51,65 @@ struct ACPMessageList: View {
 
     var body: some View {
         ScrollViewReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    ForEach(Array(session.messages.enumerated()), id: \.offset) { idx, message in
-                        row(for: message).id(idx)
+            GeometryReader { viewport in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        ForEach(Array(session.messages.enumerated()), id: \.offset) { idx, message in
+                            row(for: message).id(idx)
+                        }
+                        if session.pendingPermission != nil, let policy = policy {
+                            ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
+                                .id("__pending_perm__")
+                        }
+                        if session.streamingState == .streaming {
+                            StreamingCaret().frame(width: 8, height: 14)
+                                .id("__streaming_caret__")
+                        }
+                        // Invisible tail spacer that the auto-scroll pins to
+                        // the viewport bottom; this guarantees the streaming
+                        // caret / last message sits above the composer pill.
+                        Color.clear
+                            .frame(height: composerSpacerHeight)
+                            .id("__composer_spacer__")
+                            .background(
+                                GeometryReader { tail in
+                                    Color.clear.preference(
+                                        key: ACPTailFramePreferenceKey.self,
+                                        value: tail.frame(in: .named(scrollSpaceName))
+                                    )
+                                }
+                            )
                     }
-                    if session.pendingPermission != nil, let policy = policy {
-                        ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
-                            .id("__pending_perm__")
-                    }
-                    if session.streamingState == .streaming {
-                        StreamingCaret().frame(width: 8, height: 14)
-                            .id("__streaming_caret__")
-                    }
-                    // Invisible tail spacer that the auto-scroll pins to
-                    // the viewport bottom; this guarantees the streaming
-                    // caret / last message sits above the composer pill.
-                    Color.clear
-                        .frame(height: composerSpacerHeight)
-                        .id("__composer_spacer__")
+                    .frame(maxWidth: 720, alignment: .leading)
+                    .padding(.horizontal, 28)
+                    .padding(.top, 24)
+                    .frame(maxWidth: .infinity, alignment: .center)
                 }
-                .frame(maxWidth: 720, alignment: .leading)
-                .padding(.horizontal, 28)
-                .padding(.top, 24)
-                .frame(maxWidth: .infinity, alignment: .center)
-            }
-            .onChange(of: scrollSignature) { _, _ in
-                withAnimation(.easeOut(duration: 0.12)) {
-                    proxy.scrollTo("__composer_spacer__", anchor: .bottom)
+                .coordinateSpace(name: scrollSpaceName)
+                .background(
+                    ACPScrollEventObserver { userDriven in
+                        updateTailFollowingFromCurrentFrame(userDriven: userDriven)
+                    }
+                )
+                .onAppear {
+                    viewportHeight = viewport.size.height
+                    restoreTailIfNeeded(proxy: proxy, animated: false)
                 }
-            }
-            .onChange(of: session.streamingState) { _, new in
-                if new == .streaming || new == .sending {
-                    withAnimation(.easeOut(duration: 0.12)) {
-                        proxy.scrollTo("__composer_spacer__", anchor: .bottom)
+                .onChange(of: viewport.size.height) { _, height in
+                    viewportHeight = height
+                    restoreTailIfNeeded(proxy: proxy, animated: false)
+                }
+                .onPreferenceChange(ACPTailFramePreferenceKey.self) { frame in
+                    tailFrame = frame
+                }
+                .onChange(of: scrollSignature) { _, _ in
+                    if session.followsTranscriptTail {
+                        scrollToTail(proxy: proxy, animated: true)
+                    }
+                }
+                .onChange(of: session.streamingState) { _, new in
+                    if session.followsTranscriptTail && (new == .streaming || new == .sending) {
+                        scrollToTail(proxy: proxy, animated: true)
                     }
                 }
             }
@@ -88,6 +120,57 @@ struct ACPMessageList: View {
                 startPoint: .top, endPoint: .bottom
             )
         )
+    }
+
+    private func restoreTailIfNeeded(proxy: ScrollViewProxy, animated: Bool) {
+        guard session.followsTranscriptTail else { return }
+        scrollToTail(proxy: proxy, animated: animated)
+    }
+
+    private func scrollToTail(proxy: ScrollViewProxy, animated: Bool) {
+        isRestoringTail = true
+        userInterruptedTailRestore = false
+        let scroll = {
+            proxy.scrollTo("__composer_spacer__", anchor: .bottom)
+        }
+        if animated {
+            withAnimation(.easeOut(duration: 0.12)) {
+                scroll()
+            }
+        } else {
+            scroll()
+        }
+        let releaseRestoring = {
+            if !userInterruptedTailRestore {
+                setFollowsTranscriptTail(true)
+            }
+            isRestoringTail = false
+        }
+        if animated {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+                releaseRestoring()
+            }
+        } else {
+            DispatchQueue.main.async {
+                releaseRestoring()
+            }
+        }
+    }
+
+    private func updateTailFollowingFromCurrentFrame(userDriven: Bool) {
+        guard viewportHeight > 0 else { return }
+        if isRestoringTail {
+            guard userDriven else { return }
+            userInterruptedTailRestore = true
+            setFollowsTranscriptTail(false)
+            return
+        }
+        setFollowsTranscriptTail(tailFrame.maxY <= viewportHeight + tailTolerance)
+    }
+
+    private func setFollowsTranscriptTail(_ follows: Bool) {
+        guard session.followsTranscriptTail != follows else { return }
+        session.followsTranscriptTail = follows
     }
 
     @ViewBuilder
@@ -107,6 +190,104 @@ struct ACPMessageList: View {
             ACPPlanCard(items: items)
         case .systemNotice(let text):
             ACPSystemNoticeView(text: text)
+        }
+    }
+}
+
+private struct ACPTailFramePreferenceKey: PreferenceKey {
+    static let defaultValue: CGRect = .zero
+
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        value = nextValue()
+    }
+}
+
+private struct ACPScrollEventObserver: NSViewRepresentable {
+    let onScroll: (Bool) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScroll: onScroll)
+    }
+
+    func makeNSView(context: Context) -> ResolverView {
+        let view = ResolverView()
+        view.onResolve = { scrollView in
+            context.coordinator.observe(scrollView: scrollView)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: ResolverView, context: Context) {
+        context.coordinator.onScroll = onScroll
+        nsView.resolve()
+    }
+
+    @MainActor
+    final class Coordinator {
+        var onScroll: (Bool) -> Void
+        private weak var observedScrollView: NSScrollView?
+        private var observer: NSObjectProtocol?
+
+        init(onScroll: @escaping (Bool) -> Void) {
+            self.onScroll = onScroll
+        }
+
+        deinit {
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
+
+        func observe(scrollView: NSScrollView) {
+            guard observedScrollView !== scrollView else { return }
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            observedScrollView = scrollView
+            scrollView.contentView.postsBoundsChangedNotifications = true
+            observer = NotificationCenter.default.addObserver(
+                forName: NSView.boundsDidChangeNotification,
+                object: scrollView.contentView,
+                queue: .main
+            ) { [weak self] _ in
+                let userDriven = Self.isUserDrivenScrollEvent
+                Task { @MainActor in
+                    self?.onScroll(userDriven)
+                }
+            }
+        }
+
+        private static var isUserDrivenScrollEvent: Bool {
+            guard let event = NSApp.currentEvent else { return false }
+            switch event.type {
+            case .scrollWheel, .leftMouseDragged, .gesture, .magnify, .swipe:
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    final class ResolverView: NSView {
+        var onResolve: ((NSScrollView) -> Void)?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            resolve()
+        }
+
+        func resolve() {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                var ancestor = self.superview
+                while let view = ancestor {
+                    if let scrollView = view as? NSScrollView {
+                        self.onResolve?(scrollView)
+                        return
+                    }
+                    ancestor = view.superview
+                }
+            }
         }
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -34,6 +34,34 @@ struct ACPSessionRunnerTests {
         #expect(rows[0].kind == "agent")
     }
 
+    @Test("sending a prompt resumes transcript tail following")
+    func sendResumesTranscriptTailFollowing() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        let mock = ACPMockClient()
+        mock.script(method: "session/prompt") { _ in Data("{}".utf8) }
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        session.followsTranscriptTail = false
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+
+        runner.send(text: "new turn", attachments: [])
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(session.followsTranscriptTail)
+        #expect(session.messages.count == 1)
+        #expect(mock.sent.contains { $0.method == "session/prompt" })
+    }
+
     @Test("sliceLines honours line + limit parameters")
     func sliceLinesRange() {
         let full = "one\ntwo\nthree\nfour\nfive"

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -24,6 +24,17 @@ struct ACPSessionTests {
         else { Issue.record("expected user message") }
     }
 
+    @Test("transcript tail following is runtime state")
+    func transcriptTailFollowingDefaultsToEnabled() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        #expect(session.followsTranscriptTail)
+
+        session.followsTranscriptTail = false
+        session.apply(.agentMessageChunk(.text("background update")))
+
+        #expect(!session.followsTranscriptTail)
+    }
+
     @Test("plan update creates / replaces the plan message")
     func plan() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")


### PR DESCRIPTION
## Summary
- Track whether each ACP session is following the transcript tail at runtime.
- Restore to the latest bottom when returning to an ACP pane only if it was already following the tail.
- Preserve manual scroll-up behavior and keep streaming/new-message auto-scroll gated on that tail-follow state.

## Verification
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`