### PR TITLE
fix(tabs): always show close icon even with single tab

### DIFF
--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -47,7 +47,7 @@ struct TabBarView: View {
                     titleLookup: titleLookup,
                     tab: tab,
                     active: tab.id == activeId,
-                    showClose: tabs.count > 1,
+                    showClose: true,
                     harnessInfo: harnessLookup(tab.id),
                     dirty: dirtyLookup(tab.id),
                     onActivate: { onActivate(tab.id) },


### PR DESCRIPTION
## Summary
- Always render the tab close icon, including when only one tab is open.

## Testing
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS -quiet build