### PR TITLE
fix(acp): surface work badge for ACP sessions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F332906E17C5865856DBB90B /* ACPSessionRunner.swift */; };
 		20096441D4850614A3CB8187 /* ACPSessionStoreCRUDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */; };
 		209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */; };
+		AAAA111122223333AAAA0002 /* ACPHarnessBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA111122223333AAAA0001 /* ACPHarnessBridge.swift */; };
+		AAAA111122223333AAAA0004 /* ACPHarnessBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA111122223333AAAA0003 /* ACPHarnessBridgeTests.swift */; };
 		20BEEDF1A7F5A549B299C9D5 /* CodexACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A203964F9055BEF3F6142684 /* CodexACPInstallerTests.swift */; };
 		21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */; };
 		214A48509F96D0B6613A1D1D /* AlasSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98D0A96093087BF4C284053 /* AlasSlider.swift */; };
@@ -1064,6 +1066,8 @@
 		7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulkConflictResolveReport.swift; sourceTree = "<group>"; };
 		75DFDC1BD30B1D1CC469D54C /* ZmxEnvTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxEnvTests.swift; sourceTree = "<group>"; };
 		7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManager.swift; sourceTree = "<group>"; };
+		AAAA111122223333AAAA0001 /* ACPHarnessBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridge.swift; sourceTree = "<group>"; };
+		AAAA111122223333AAAA0003 /* ACPHarnessBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridgeTests.swift; sourceTree = "<group>"; };
 		768D12909DD5233659AC4E03 /* RepoGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupView.swift; sourceTree = "<group>"; };
 		76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolverTests.swift; sourceTree = "<group>"; };
 		76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorLineNumberRulerView.swift; sourceTree = "<group>"; };
@@ -1933,6 +1937,7 @@
 				4DB62FEBC3C8536A56117C23 /* Protocol */,
 				51D8A9EE658EB05F836A321A /* Session */,
 				8050E4DD79EA4EEE490BC1F1 /* UI */,
+				AAAA111122223333AAAA0001 /* ACPHarnessBridge.swift */,
 			);
 			path = ACP;
 			sourceTree = "<group>";
@@ -2162,6 +2167,7 @@
 				FDD6B99A5214227965308D70 /* Permissions */,
 				28DACFA5F60339EEE14A135F /* Protocol */,
 				A72D9EE2C6FD478C41435DBA /* Session */,
+				AAAA111122223333AAAA0003 /* ACPHarnessBridgeTests.swift */,
 			);
 			path = ACP;
 			sourceTree = "<group>";
@@ -3001,6 +3007,7 @@
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
+				AAAA111122223333AAAA0002 /* ACPHarnessBridge.swift in Sources */,
 				1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */,
 				027A326E7DAB6C6E133E5FD3 /* ACPSessionStore.swift in Sources */,
 				9AB33F6B645EBA3F92A4E40F /* ACPSessionUpdate.swift in Sources */,
@@ -3364,6 +3371,7 @@
 			files = (
 				CC531074F02A34E48A1E6133 /* ACPAgentProfilesTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
+				AAAA111122223333AAAA0004 /* ACPHarnessBridgeTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,
 				B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */,

--- a/Alas/Sources/ACP/ACPHarnessBridge.swift
+++ b/Alas/Sources/ACP/ACPHarnessBridge.swift
@@ -38,6 +38,45 @@ final class ACPHarnessBridge {
         harness.forgetSession(sessionId)
     }
 
+    /// Attach a manager. Subscribes to its `$sessions` so every session
+    /// that ever enters the dict gets observed, and every session that
+    /// leaves gets forgotten. Idempotent per worktree.
+    func attach(manager: ACPSessionManager) {
+        let worktreeId = manager.worktreeId
+        // Drop any prior attachment for the same worktree to avoid double-subs.
+        detach(worktreeId: worktreeId)
+
+        managerCancellables[worktreeId] = manager.$sessions
+            .sink { [weak self] sessions in
+                guard let self else { return }
+                self.reconcile(worktreeId: worktreeId, sessions: sessions)
+            }
+    }
+
+    /// Detach a manager. Cancels the sessions-dict subscription and forgets
+    /// every session previously observed for that worktree.
+    func detach(worktreeId: String) {
+        managerCancellables[worktreeId] = nil
+        if let ids = observedSessionsByManager.removeValue(forKey: worktreeId) {
+            for id in ids { forget(sessionId: id) }
+        }
+    }
+
+    private func reconcile(worktreeId: String, sessions: [ACPSession.ID: ACPSession]) {
+        let current = Set(sessions.keys)
+        let previous = observedSessionsByManager[worktreeId] ?? []
+
+        // Newly added: observe.
+        for id in current.subtracting(previous) {
+            if let session = sessions[id] { observe(session: session) }
+        }
+        // Removed: forget.
+        for id in previous.subtracting(current) {
+            forget(sessionId: id)
+        }
+        observedSessionsByManager[worktreeId] = current
+    }
+
     private func apply(state: ACPSession.StreamingState, session: ACPSession) {
         let agent = Self.agentKind(for: session.agentId)
         switch state {

--- a/Alas/Sources/ACP/ACPHarnessBridge.swift
+++ b/Alas/Sources/ACP/ACPHarnessBridge.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Combine
+
+/// Bridge from ACP session activity (`ACPSession.streamingState`) into the
+/// `HarnessService` activity dictionary, so worktree work badges in the
+/// sidebar surface ACP work alongside terminal-harness work.
+///
+/// Manager-attach (Task 3) wires this into `AppState.acpManager(for:)` so
+/// every session that enters a manager's `sessions` dict gets observed
+/// automatically. Detach removes the entry from `HarnessService` so the
+/// badge disappears when the session is closed.
+@MainActor
+final class ACPHarnessBridge {
+    private let harness: HarnessService
+    private var sessionCancellables: [ACPSession.ID: AnyCancellable] = [:]
+    private var managerCancellables: [String: AnyCancellable] = [:]
+    private var observedSessionsByManager: [String: Set<ACPSession.ID>] = [:]
+
+    init(harness: HarnessService) {
+        self.harness = harness
+    }
+
+    /// Subscribe to a session's `streamingState` and mirror it into the
+    /// harness service. Idempotent — re-observing a session replaces the
+    /// existing subscription.
+    func observe(session: ACPSession) {
+        sessionCancellables[session.id] = session.$streamingState
+            .sink { [weak self, weak session] state in
+                guard let self, let session else { return }
+                self.apply(state: state, session: session)
+            }
+    }
+
+    /// Stop observing a session and drop its harness entry. Called when
+    /// the session leaves its manager's `sessions` dict.
+    func forget(sessionId: ACPSession.ID) {
+        sessionCancellables[sessionId] = nil
+        harness.forgetSession(sessionId)
+    }
+
+    private func apply(state: ACPSession.StreamingState, session: ACPSession) {
+        let agent = Self.agentKind(for: session.agentId)
+        switch state {
+        case .idle:
+            harness.forgetSession(session.id)
+        case .sending, .streaming:
+            harness.setExternalActivity(sessionId: session.id, agent: agent, state: .busy)
+        case .awaitingPermission:
+            harness.setExternalActivity(sessionId: session.id, agent: agent, state: .permissionRequest)
+        }
+    }
+
+    /// Map the ACP `agentId` string (free-form, sourced from
+    /// `AgentBuiltins.catalog`) to `AgentKind`. Unknown ids fall back to
+    /// `.claude` — badge rendering is state-driven, not agent-driven, so
+    /// the only consumer of `agent` is the click-activation path which
+    /// works purely off `sessionId`.
+    static func agentKind(for agentId: String) -> AgentKind {
+        switch agentId {
+        case "claude":       return .claude
+        case "codex":        return .codex
+        case "cursor-agent": return .cursor
+        case "gemini":       return .gemini
+        case "opencode":     return .opencode
+        case "pi":           return .pi
+        case "copilot":      return .copilot
+        default:             return .claude
+        }
+    }
+}

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -213,7 +213,14 @@ extension ACPSessionManager {
             runner.stop()
             await runner.connection.shutdown()
         }
-        sessions[sessionId]?.attached = false
+        // Reset transient state so a later reopen of the same session
+        // doesn't surface stale `streamingState` (e.g. an `.awaitingPermission`
+        // left over from a closed tab would otherwise leave the sidebar work
+        // badge stuck on `[wait]` via the harness bridge).
+        if let session = sessions[sessionId] {
+            session.attached = false
+            session.streamingState = .idle
+        }
     }
 
     private static func mergeEnv(extra: [String: String]) -> [String: String] {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1037,11 +1037,12 @@ final class AppState {
     }
 
     /// Activate a specific harness session: bring the app to front, select
-    /// the worktree, activate the terminal tab hosting `sessionId`, and
-    /// focus the pane within that tab that owns the session (so keyboard
-    /// input and the tab-bar harness badge follow the user's intent).
-    /// If the tab is no longer present (session was closed mid-flight) the
-    /// worktree is still selected so the user lands somewhere sensible.
+    /// the worktree, activate the terminal or ACP tab hosting `sessionId`.
+    /// For terminal tabs the owning leaf is also focused (so keyboard input
+    /// follows the user's intent); ACP tabs are single-pane so no leaf
+    /// focusing is needed. If the tab is no longer present (session was
+    /// closed mid-flight) the worktree is still selected so the user lands
+    /// somewhere sensible.
     func activateHarnessSession(projectId _: String, worktreeId: String, sessionId: String) {
         selectedWorktreeId = worktreeId
         var matchedTabId: TabID?

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1053,6 +1053,15 @@ final class AppState {
             matchedLeafId = leaf.id
             break
         }
+        // Fall through to ACP tabs: no leaf focusing needed — an ACP tab
+        // is a single pane.
+        if matchedTabId == nil {
+            for tab in tabs.tabs(forWorktree: worktreeId) {
+                guard case .acpSession(let s) = tab, s.sessionId == sessionId else { continue }
+                matchedTabId = tab.id
+                break
+            }
+        }
         if let tabId = matchedTabId {
             if let leafId = matchedLeafId {
                 _ = tabs.setFocusedLeaf(worktreeId: worktreeId, tabId: tabId, leafId: leafId)

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2263,6 +2263,12 @@ final class AppState {
     @ObservationIgnored
     private var acpManagers: [String: ACPSessionManager] = [:]
 
+    /// Mirrors `ACPSession.streamingState` into `HarnessService.activityBySession`
+    /// so the sidebar work badge surfaces ACP activity. Attached for every
+    /// manager created via `acpManager(for:)`; detached from `disposeACPManager(for:)`.
+    @ObservationIgnored
+    private lazy var acpHarnessBridge = ACPHarnessBridge(harness: harness)
+
     /// Returns `true` when the editor has a live, dirty (unsaved) buffer for
     /// the given absolute path within the given worktree.
     func editorHasDirtyBuffer(for absolutePath: String, worktreeId: String) -> Bool {
@@ -2306,6 +2312,7 @@ final class AppState {
                 }
             )
             acpManagers[worktree.id] = mgr
+            acpHarnessBridge.attach(manager: mgr)
             return mgr
         } catch {
             return nil
@@ -2321,6 +2328,7 @@ final class AppState {
     /// after the UI was torn down.
     func disposeACPManager(for worktreeId: String) {
         guard let manager = acpManagers.removeValue(forKey: worktreeId) else { return }
+        acpHarnessBridge.detach(worktreeId: worktreeId)
         let sessionIds = Array(manager.runners.keys)
         // Synchronously cancel the runner's async loops so they stop
         // pumping the agent's stdout into our handlers immediately —

--- a/Alas/Sources/Harness/HarnessService.swift
+++ b/Alas/Sources/Harness/HarnessService.swift
@@ -210,6 +210,17 @@ final class HarnessService {
         pendingCursorIdleEvents.removeValue(forKey: sessionId)
     }
 
+    /// Peer-write entry point alongside socket events. Lets non-hook sources
+    /// (currently the ACP bridge) report activity for sessions they own.
+    /// No notification side effects — those remain socket-driven so we don't
+    /// double-fire when both hooks and ACP cover the same session.
+    func setExternalActivity(sessionId: String, agent: AgentKind, state: ActivityState) {
+        activityBySession[sessionId] = HarnessActivityState(
+            agent: agent, state: state, pid: nil,
+            lastBody: nil, updatedAt: Date()
+        )
+    }
+
     enum AggregatedState: String, Equatable {
         case running, awaiting
     }

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -47,8 +47,11 @@ struct SidebarView: View {
                                 },
                                 harnessSummary: { worktreeId in
                                     let ids = state.tabs.tabs(forWorktree: worktreeId).flatMap { tab -> [String] in
-                                        if case .terminal(let s) = tab { return s.root.leaves().map(\.sessionId) }
-                                        return []
+                                        switch tab {
+                                        case .terminal(let s):   return s.root.leaves().map(\.sessionId)
+                                        case .acpSession(let s): return [s.sessionId]
+                                        default:                 return []
+                                        }
                                     }
                                     return state.harness.summary(forSessionIds: ids)
                                 },
@@ -79,8 +82,11 @@ struct SidebarView: View {
                                 showKeepBranchOption: state.config.worktrees.deleteBranchOnRemove,
                                 onActivateHarness: { wt in
                                     let ids = state.tabs.tabs(forWorktree: wt.id).flatMap { tab -> [String] in
-                                        if case .terminal(let s) = tab { return s.root.leaves().map(\.sessionId) }
-                                        return []
+                                        switch tab {
+                                        case .terminal(let s):   return s.root.leaves().map(\.sessionId)
+                                        case .acpSession(let s): return [s.sessionId]
+                                        default:                 return []
+                                        }
                                     }
                                     guard let summary = state.harness.summary(forSessionIds: ids) else { return }
                                     state.activateHarnessSession(

--- a/AlasTests/ACP/ACPHarnessBridgeTests.swift
+++ b/AlasTests/ACP/ACPHarnessBridgeTests.swift
@@ -137,6 +137,27 @@ struct ACPHarnessBridgeTests {
         #expect(harness.activityBySession[session.id] == nil)
     }
 
+    @Test("manager.detach resets streamingState so the bridge clears its harness entry")
+    func managerDetachClearsBridgeEntry() async throws {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bridge-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = manager.createSession(agentId: "claude")
+        bridge.attach(manager: manager)
+        session.streamingState = .awaitingPermission
+        await Task.yield()
+        #expect(harness.activityBySession[session.id]?.state == .permissionRequest)
+
+        await manager.detach(sessionId: session.id)
+        await Task.yield()
+
+        #expect(session.streamingState == .idle)
+        #expect(harness.activityBySession[session.id] == nil)
+    }
+
     @Test("detach stops observing and clears all the manager's sessions")
     func detachStopsObservation() async throws {
         let harness = makeHarness()

--- a/AlasTests/ACP/ACPHarnessBridgeTests.swift
+++ b/AlasTests/ACP/ACPHarnessBridgeTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPHarnessBridge")
+struct ACPHarnessBridgeTests {
+
+    private func makeHarness() -> HarnessService {
+        HarnessService(
+            socketServer: AgentHookSocketServer(socketPath: "/dev/null"),
+            cursorIdleDebounceInterval: 2.0
+        )
+    }
+
+    @Test("streamingState .sending writes .busy")
+    func sendingMapsToBusy() async {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
+        bridge.observe(session: session)
+        session.streamingState = .sending
+        await Task.yield()
+        #expect(harness.activityBySession["s1"]?.state == .busy)
+        #expect(harness.activityBySession["s1"]?.agent == .claude)
+    }
+
+    @Test("streamingState .streaming writes .busy")
+    func streamingMapsToBusy() async {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let session = ACPSession(id: "s1", agentId: "codex", worktreeId: "wt", title: "t")
+        bridge.observe(session: session)
+        session.streamingState = .streaming
+        await Task.yield()
+        #expect(harness.activityBySession["s1"]?.state == .busy)
+        #expect(harness.activityBySession["s1"]?.agent == .codex)
+    }
+
+    @Test("streamingState .awaitingPermission writes .permissionRequest")
+    func awaitingPermissionMapsToPermissionRequest() async {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
+        bridge.observe(session: session)
+        session.streamingState = .awaitingPermission
+        await Task.yield()
+        #expect(harness.activityBySession["s1"]?.state == .permissionRequest)
+    }
+
+    @Test("streamingState .idle removes the entry")
+    func idleClearsEntry() async {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
+        bridge.observe(session: session)
+        session.streamingState = .streaming
+        await Task.yield()
+        session.streamingState = .idle
+        await Task.yield()
+        #expect(harness.activityBySession["s1"] == nil)
+    }
+
+    @Test("cursor-agent agentId maps to .cursor AgentKind")
+    func cursorAgentMaps() async {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let session = ACPSession(id: "s1", agentId: "cursor-agent", worktreeId: "wt", title: "t")
+        bridge.observe(session: session)
+        session.streamingState = .streaming
+        await Task.yield()
+        #expect(harness.activityBySession["s1"]?.agent == .cursor)
+    }
+
+    @Test("unknown agentId falls back to .claude")
+    func unknownAgentFallsBack() async {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let session = ACPSession(id: "s1", agentId: "made-up-agent", worktreeId: "wt", title: "t")
+        bridge.observe(session: session)
+        session.streamingState = .streaming
+        await Task.yield()
+        #expect(harness.activityBySession["s1"]?.agent == .claude)
+    }
+}

--- a/AlasTests/ACP/ACPHarnessBridgeTests.swift
+++ b/AlasTests/ACP/ACPHarnessBridgeTests.swift
@@ -5,7 +5,6 @@ import Testing
 @MainActor
 @Suite("ACPHarnessBridge")
 struct ACPHarnessBridgeTests {
-
     private func makeHarness() -> HarnessService {
         HarnessService(
             socketServer: AgentHookSocketServer(socketPath: "/dev/null"),

--- a/AlasTests/ACP/ACPHarnessBridgeTests.swift
+++ b/AlasTests/ACP/ACPHarnessBridgeTests.swift
@@ -82,4 +82,83 @@ struct ACPHarnessBridgeTests {
         await Task.yield()
         #expect(harness.activityBySession["s1"]?.agent == .claude)
     }
+
+    @Test("attach observes existing sessions and writes their state")
+    func attachObservesExistingSessions() async throws {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bridge-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = manager.createSession(agentId: "claude")
+
+        bridge.attach(manager: manager)
+        session.streamingState = .streaming
+        await Task.yield()
+
+        #expect(harness.activityBySession[session.id]?.state == .busy)
+    }
+
+    @Test("attach observes sessions added after attach")
+    func attachObservesSessionsAddedLater() async throws {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bridge-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        bridge.attach(manager: manager)
+
+        let session = manager.createSession(agentId: "claude")
+        await Task.yield()
+        session.streamingState = .streaming
+        await Task.yield()
+
+        #expect(harness.activityBySession[session.id]?.state == .busy)
+    }
+
+    @Test("removing a session from the manager forgets its harness entry")
+    func removingSessionForgetsHarnessEntry() async throws {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bridge-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = manager.createSession(agentId: "claude")
+        bridge.attach(manager: manager)
+        session.streamingState = .streaming
+        await Task.yield()
+        #expect(harness.activityBySession[session.id]?.state == .busy)
+
+        manager.closeSession(id: session.id)
+        await Task.yield()
+
+        #expect(harness.activityBySession[session.id] == nil)
+    }
+
+    @Test("detach stops observing and clears all the manager's sessions")
+    func detachStopsObservation() async throws {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bridge-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = manager.createSession(agentId: "claude")
+        bridge.attach(manager: manager)
+        session.streamingState = .streaming
+        await Task.yield()
+
+        bridge.detach(worktreeId: "wt")
+        await Task.yield()
+
+        #expect(harness.activityBySession[session.id] == nil)
+
+        // Further streamingState changes are not mirrored.
+        session.streamingState = .awaitingPermission
+        await Task.yield()
+        #expect(harness.activityBySession[session.id] == nil)
+    }
 }

--- a/AlasTests/HarnessServiceTests.swift
+++ b/AlasTests/HarnessServiceTests.swift
@@ -382,6 +382,34 @@ struct HarnessServiceTests {
         #expect(service.activityBySession["session-1"]?.state == .idle)
     }
 
+    @Test func setExternalActivityUpsertsBusyState() {
+        let (service, _) = makeService()
+        service.setExternalActivity(sessionId: "acp-1", agent: .claude, state: .busy)
+        #expect(service.activityBySession["acp-1"]?.state == .busy)
+        #expect(service.activityBySession["acp-1"]?.agent == .claude)
+    }
+
+    @Test func setExternalActivityReplacesExistingState() {
+        let (service, _) = makeService()
+        service.setExternalActivity(sessionId: "acp-1", agent: .claude, state: .busy)
+        service.setExternalActivity(sessionId: "acp-1", agent: .claude, state: .permissionRequest)
+        #expect(service.activityBySession["acp-1"]?.state == .permissionRequest)
+    }
+
+    @Test func setExternalActivityDoesNotPostNotifications() {
+        let (service, collector) = makeService()
+        service.setExternalActivity(sessionId: "acp-1", agent: .claude, state: .awaitingInput)
+        #expect(collector.requests.isEmpty)
+    }
+
+    @Test func setExternalActivityContributesToSummary() {
+        let (service, _) = makeService()
+        service.setExternalActivity(sessionId: "acp-1", agent: .claude, state: .busy)
+        let s = service.summary(forSessionIds: ["acp-1"])
+        #expect(s?.state == .running)
+        #expect(s?.primarySessionId == "acp-1")
+    }
+
     @Test func forgetSession_cancelsCursorIdleDebounce() async throws {
         let (service, _) = makeService(cursorIdleDebounceInterval: 0.05)
         service.handleSocketEvent(


### PR DESCRIPTION
## Summary

- Worktree work badges in the left sidebar now surface ACP chat activity alongside terminal-harness activity. Previously, a worktree whose only active work was an ACP conversation appeared idle.
- New `ACPHarnessBridge` translates `ACPSession.streamingState` (`.sending`/`.streaming` → `.busy`, `.awaitingPermission` → `.permissionRequest`, `.idle` → forget) into writes against `HarnessService.activityBySession` via a new `setExternalActivity` peer-write entry point. Single source of truth preserved.
- Sidebar widens its session-ID collection to include `.acpSession` tabs; click-to-activate falls through to focus the ACP tab when the primary session is an ACP one.

## Test plan

- [x] Bridge unit tests (10) cover every `streamingState` branch, agentId mapping (including `cursor-agent` and unknown fallback), attach over existing sessions, attach-then-add, manager-driven removal, and detach.
- [x] `HarnessService.setExternalActivity` tests (4) cover upsert, replacement, no-notification side effect, and summary integration.
- [x] Full test suite: 2162 tests across 278 suites, all green.
- [ ] Manual: send an ACP prompt → row badge flips to `[• run]`, clears when response settles.
- [ ] Manual: trigger a tool-call permission prompt → badge flips to `[• wait]`.
- [ ] Manual: click the badge → ACP tab is brought to focus.
- [ ] Manual: collapsed repo group → rolled-up dot reflects ACP activity.