### PR TITLE
Persist ACP composer drafts

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
+		1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */; };
 		1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */; };
 		175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */; };
 		175D0A77579A022F3AB81E48 /* SQLiteDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5F20AB3B3F7BCEAA56B143 /* SQLiteDatabase.swift */; };
@@ -1234,6 +1235,7 @@
 		B86E7E91F81AA92ED7108D82 /* GitStatusCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCacheTests.swift; sourceTree = "<group>"; };
 		B87F114EBEEACCC95B9EF8D5 /* ImageDiffOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffOverlayView.swift; sourceTree = "<group>"; };
 		B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunnerTests.swift; sourceTree = "<group>"; };
+		B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftBridgeTests.swift; sourceTree = "<group>"; };
 		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
 		BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileChip.swift; sourceTree = "<group>"; };
 		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
@@ -2043,6 +2045,7 @@
 			isa = PBXGroup;
 			children = (
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
+				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -3409,6 +3412,7 @@
 				CC531074F02A34E48A1E6133 /* ACPAgentProfilesTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
+				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */; };
 		34F18AB368DC5D93196056CA /* ACPComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C496549308D5C3DD20E988AD /* ACPComposer.swift */; };
 		35024237A37355969D6FA76A /* MergeResultPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC787CE0F5625F8114C9F6F /* MergeResultPane.swift */; };
+		3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */; };
 		35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */; };
 		35A0942B075D267EBB9A4484 /* RightPaneStateFileTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */; };
 		363F31C705CF7D17162E2CF6 /* CommitTabStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2FC38CF24F011448A3705F9 /* CommitTabStateTests.swift */; };
@@ -666,6 +667,7 @@
 		E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */; };
 		E51AC728D0735EEC53825C68 /* SidebarChromeTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02161104BA524379A359CB2D /* SidebarChromeTheme.swift */; };
 		E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */; };
+		E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
 		E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */; };
 		E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */; };
@@ -1185,6 +1187,7 @@
 		A35E05B1FB7CC5229ACCB065 /* LSPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPClient.swift; sourceTree = "<group>"; };
 		A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChevronStabilityTests.swift; sourceTree = "<group>"; };
 		A42BB90D7C9A270876F470EB /* FocusDirectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusDirectionTests.swift; sourceTree = "<group>"; };
+		A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraft.swift; sourceTree = "<group>"; };
 		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
 		A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAnnotationStrip.swift; sourceTree = "<group>"; };
 		A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdateTests.swift; sourceTree = "<group>"; };
@@ -1304,6 +1307,7 @@
 		D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolverTests.swift; sourceTree = "<group>"; };
 		D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayout.swift; sourceTree = "<group>"; };
 		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
+		D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftTests.swift; sourceTree = "<group>"; };
 		D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibilityTests.swift; sourceTree = "<group>"; };
 		D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewShortcutTests.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
@@ -2064,6 +2068,7 @@
 			isa = PBXGroup;
 			children = (
 				DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */,
+				A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */,
 				321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */,
 				BBBEFD27FD7013D458435779 /* ACPSession.swift */,
 				7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */,
@@ -2397,6 +2402,7 @@
 			isa = PBXGroup;
 			children = (
 				239125BB939233233D405EB8 /* ACPChipStateTests.swift */,
+				D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */,
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */,
@@ -3007,6 +3013,7 @@
 				EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */,
 				34F18AB368DC5D93196056CA /* ACPComposer.swift in Sources */,
 				1C5D64F032EAD5EA28B2482B /* ACPComposerActions.swift in Sources */,
+				E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */,
 				C04150547C17399FA9D7947C /* ACPComposerShell.swift in Sources */,
 				1298147855092677E3184AC2 /* ACPConfigOption.swift in Sources */,
 				809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */,
@@ -3402,6 +3409,7 @@
 				CC531074F02A34E48A1E6133 /* ACPAgentProfilesTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
+				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,
 				B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPMockClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMockClient.swift
@@ -3,6 +3,7 @@ import Foundation
 final class ACPMockClient: ACPClient, @unchecked Sendable {
     private(set) var sent: [ACPRequest] = []
     private var scripts: [String: (ACPRequest) throws -> Data] = [:]
+    private var asyncScripts: [String: (ACPRequest) async throws -> Data] = [:]
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
     private let filesCont: AsyncStream<ACPFileRequest>.Continuation
@@ -25,6 +26,9 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
 
     func send(_ request: ACPRequest) async throws -> ACPResponse {
         sent.append(request)
+        if let script = asyncScripts[request.method] {
+            return ACPResponse(body: try await script(request))
+        }
         guard let script = scripts[request.method] else {
             throw ACPClientError.noScript(method: request.method)
         }
@@ -53,6 +57,10 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
 
     func script(method: String, _ handler: @escaping (ACPRequest) throws -> Data) {
         scripts[method] = handler
+    }
+
+    func scriptAsync(method: String, _ handler: @escaping (ACPRequest) async throws -> Data) {
+        asyncScripts[method] = handler
     }
 
     func shutdown() async {

--- a/Alas/Sources/ACP/Session/ACPComposerDraft.swift
+++ b/Alas/Sources/ACP/Session/ACPComposerDraft.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+struct ACPComposerDraft: Codable, Equatable {
+    var segments: [Segment]
+
+    static let empty = ACPComposerDraft(segments: [])
+
+    var isEmpty: Bool {
+        segments.allSatisfy { segment in
+            switch segment {
+            case .text(let value):
+                value.isEmpty
+            case .mention:
+                false
+            }
+        }
+    }
+
+    enum Segment: Codable, Equatable {
+        case text(String)
+        case mention(displayName: String, uri: String)
+
+        private enum CodingKeys: String, CodingKey {
+            case type
+            case text
+            case displayName
+            case uri
+        }
+
+        private enum SegmentType: String, Codable {
+            case text
+            case mention
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let type = try container.decode(SegmentType.self, forKey: .type)
+            switch type {
+            case .text:
+                self = .text(try container.decode(String.self, forKey: .text))
+            case .mention:
+                self = .mention(
+                    displayName: try container.decode(String.self, forKey: .displayName),
+                    uri: try container.decode(String.self, forKey: .uri)
+                )
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .text(let value):
+                try container.encode(SegmentType.text, forKey: .type)
+                try container.encode(value, forKey: .text)
+            case .mention(let displayName, let uri):
+                try container.encode(SegmentType.mention, forKey: .type)
+                try container.encode(displayName, forKey: .displayName)
+                try container.encode(uri, forKey: .uri)
+            }
+        }
+    }
+}

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -20,6 +20,7 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var promptSuggestions: [ACPPromptSuggestion] = []
     @Published var autoRunEnabled: Bool = false
     @Published var composerDraft: ACPComposerDraft = .empty
+    @Published private(set) var composerDraftRevision: Int = 0
     @Published var pendingPermission: PendingPermission?
     @Published var streamingState: StreamingState = .idle
     @Published var setupState: SetupState = .checking
@@ -42,6 +43,11 @@ final class ACPSession: ObservableObject, Identifiable {
     /// as the persistence key in `ACPSessionStore`.
     /// Not persisted — recreated on each `attach()` if missing.
     var remoteSessionId: String?
+
+    func replaceComposerDraft(_ draft: ACPComposerDraft) {
+        composerDraft = draft
+        composerDraftRevision += 1
+    }
 
     enum StreamingState: Equatable { case idle, sending, streaming, awaitingPermission }
     enum SetupState: Equatable {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -19,6 +19,7 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var currentMode: String?
     @Published var promptSuggestions: [ACPPromptSuggestion] = []
     @Published var autoRunEnabled: Bool = false
+    @Published var composerDraft: ACPComposerDraft = .empty
     @Published var pendingPermission: PendingPermission?
     @Published var streamingState: StreamingState = .idle
     @Published var setupState: SetupState = .checking

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -59,7 +59,7 @@ final class ACPSessionManager: ObservableObject {
         session.currentMode = row.currentMode
         session.autoRunEnabled = row.autoRun
         if let loadedDraft = try? store.loadComposerDraft(sessionId: id) {
-            session.composerDraft = loadedDraft
+            session.replaceComposerDraft(loadedDraft)
         }
         sessions[id] = session
         try? store.upsertSession(touch(row))
@@ -114,7 +114,7 @@ final class ACPSessionManager: ObservableObject {
     }
 
     func persistComposerDraft(_ draft: ACPComposerDraft, for session: ACPSession) {
-        session.composerDraft = draft
+        session.replaceComposerDraft(draft)
         if draft.isEmpty {
             try? store.deleteComposerDraft(sessionId: session.id)
         } else {
@@ -124,8 +124,31 @@ final class ACPSessionManager: ObservableObject {
     }
 
     func clearComposerDraft(for session: ACPSession) {
-        session.composerDraft = .empty
+        session.replaceComposerDraft(.empty)
         try? store.deleteComposerDraft(sessionId: session.id)
+    }
+
+    func clearComposerDraft(
+        for session: ACPSession,
+        ifCurrentDraftEquals expected: ACPComposerDraft,
+        revision expectedRevision: Int
+    ) {
+        guard session.composerDraft == expected,
+              session.composerDraftRevision == expectedRevision
+        else { return }
+        clearComposerDraft(for: session)
+    }
+
+    func persistComposerDraft(
+        _ draft: ACPComposerDraft,
+        for session: ACPSession,
+        ifCurrentDraftEquals expected: ACPComposerDraft,
+        revision expectedRevision: Int
+    ) {
+        guard session.composerDraft == expected,
+              session.composerDraftRevision == expectedRevision
+        else { return }
+        persistComposerDraft(draft, for: session)
     }
 
     func refreshRecent() {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -58,6 +58,9 @@ final class ACPSessionManager: ObservableObject {
         session.currentModel = row.currentModel
         session.currentMode = row.currentMode
         session.autoRunEnabled = row.autoRun
+        if let loadedDraft = try? store.loadComposerDraft(sessionId: id) {
+            session.composerDraft = loadedDraft
+        }
         sessions[id] = session
         try? store.upsertSession(touch(row))
         refreshRecent()
@@ -108,6 +111,21 @@ final class ACPSessionManager: ObservableObject {
             createdAt: row.createdAt, updatedAt: now,
             lastOpenedAt: row.lastOpenedAt, archived: row.archived))
         refreshRecent()
+    }
+
+    func persistComposerDraft(_ draft: ACPComposerDraft, for session: ACPSession) {
+        session.composerDraft = draft
+        if draft.isEmpty {
+            try? store.deleteComposerDraft(sessionId: session.id)
+        } else {
+            let now = Int64(Date().timeIntervalSince1970)
+            try? store.upsertComposerDraft(sessionId: session.id, draft: draft, updatedAt: now)
+        }
+    }
+
+    func clearComposerDraft(for session: ACPSession) {
+        session.composerDraft = .empty
+        try? store.deleteComposerDraft(sessionId: session.id)
     }
 
     func refreshRecent() {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -34,6 +34,9 @@ final class ACPSessionRunner {
     private var permissionsTask: Task<Void, Never>?
     private var filesTask: Task<Void, Never>?
     private var seq: Int64 = 0
+    private var nextPromptID = 0
+    private var activePromptID: Int?
+    private var cancelledPromptIDs: Set<Int> = []
 
     init(session: ACPSession, connection: ACPConnection, store: ACPSessionStore,
          sessionId: String, worktreePath: String,
@@ -227,6 +230,10 @@ final class ACPSessionRunner {
         let remoteId = session.remoteSessionId ?? sessionId
         try? await connection.cancel(sessionId: remoteId)
         await MainActor.run {
+            if let promptID = activePromptID {
+                cancelledPromptIDs.insert(promptID)
+                activePromptID = nil
+            }
             policy.userCancelled()
             let changedIndices = session.cancelInFlightToolCalls()
             for i in changedIndices {
@@ -252,12 +259,15 @@ extension ACPSessionRunner {
         for a in attachments {
             blocks.append(.resourceLink(uri: a.uri, name: a.name))
         }
+        let promptID = nextPromptID
+        nextPromptID += 1
         Task { [weak self, onPromptFinished] in
             guard let self else {
                 await MainActor.run { onPromptFinished?(false) }
                 return
             }
             await MainActor.run {
+                self.activePromptID = promptID
                 let before = self.session.messages.count
                 let titleBefore = self.session.title
                 if !self.session.followsTranscriptTail {
@@ -286,14 +296,32 @@ extension ACPSessionRunner {
                 // `.streaming` froze the UI on Stop after every
                 // successful reply.
                 await MainActor.run {
-                    self.session.streamingState = .idle
-                    onPromptFinished?(true)
+                    let isActivePrompt = self.activePromptID == promptID
+                    let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
+                    if isActivePrompt {
+                        self.activePromptID = nil
+                        self.session.streamingState = .idle
+                    }
+                    self.cancelledPromptIDs.remove(promptID)
+                    if !hasNewerActivePrompt {
+                        onPromptFinished?(true)
+                    }
                 }
             } catch {
                 await MainActor.run {
-                    self.session.lastError = "prompt failed: \(error.localizedDescription)"
-                    self.session.streamingState = .idle
-                    onPromptFinished?(false)
+                    let wasCancelled = self.cancelledPromptIDs.remove(promptID) != nil
+                    let isActivePrompt = self.activePromptID == promptID
+                    let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
+                    if isActivePrompt {
+                        self.activePromptID = nil
+                        self.session.streamingState = .idle
+                    }
+                    if !wasCancelled, isActivePrompt {
+                        self.session.lastError = "prompt failed: \(error.localizedDescription)"
+                    }
+                    if !hasNewerActivePrompt {
+                        onPromptFinished?(wasCancelled)
+                    }
                 }
             }
         }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -243,13 +243,20 @@ final class ACPSessionRunner {
 }
 
 extension ACPSessionRunner {
-    func send(text: String, attachments: [ACPMessage.Attachment]) {
+    func send(
+        text: String,
+        attachments: [ACPMessage.Attachment],
+        onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
+    ) {
         var blocks: [ACPContentBlock] = [.text(text)]
         for a in attachments {
             blocks.append(.resourceLink(uri: a.uri, name: a.name))
         }
-        Task { [weak self] in
-            guard let self else { return }
+        Task { [weak self, onPromptFinished] in
+            guard let self else {
+                await MainActor.run { onPromptFinished?(false) }
+                return
+            }
             await MainActor.run {
                 let before = self.session.messages.count
                 let titleBefore = self.session.title
@@ -278,11 +285,15 @@ extension ACPSessionRunner {
                 // composer accepts the next prompt; leaving it on
                 // `.streaming` froze the UI on Stop after every
                 // successful reply.
-                await MainActor.run { self.session.streamingState = .idle }
+                await MainActor.run {
+                    self.session.streamingState = .idle
+                    onPromptFinished?(true)
+                }
             } catch {
                 await MainActor.run {
                     self.session.lastError = "prompt failed: \(error.localizedDescription)"
                     self.session.streamingState = .idle
+                    onPromptFinished?(false)
                 }
             }
         }

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 1
+    static let targetSchemaVersion = 2
     let db: SQLiteDatabase
 
     init(path: String) throws {
@@ -26,6 +26,7 @@ final class ACPSessionStore {
         let rows = try db.query("SELECT version FROM schema_version LIMIT 1")
         let current = Int((rows.first?["version"] as? Int64) ?? 0)
         if current < 1 { try migrate_to_v1() }
+        if current < 2 { try migrate_to_v2() }
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
         } else if current < Self.targetSchemaVersion {
@@ -70,6 +71,16 @@ final class ACPSessionStore {
           scope       TEXT NOT NULL,
           decided_at  INTEGER NOT NULL,
           PRIMARY KEY (session_id, scope_key)
+        )
+        """)
+    }
+
+    private func migrate_to_v2() throws {
+        try db.exec("""
+        CREATE TABLE IF NOT EXISTS composer_drafts (
+          session_id  TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+          payload     BLOB NOT NULL,
+          updated_at  INTEGER NOT NULL
         )
         """)
     }
@@ -132,6 +143,29 @@ extension ACPSessionStore {
 
     func deleteSession(id: String) throws {
         try db.exec("DELETE FROM sessions WHERE id = ?", bindings: [id])
+    }
+
+    func loadComposerDraft(sessionId: String) throws -> ACPComposerDraft? {
+        let rows = try db.query("""
+        SELECT payload FROM composer_drafts WHERE session_id = ?
+        """, bindings: [sessionId])
+        guard let payload = rows.first?["payload"] as? Data else { return nil }
+        return try JSONDecoder().decode(ACPComposerDraft.self, from: payload)
+    }
+
+    func upsertComposerDraft(sessionId: String, draft: ACPComposerDraft, updatedAt: Int64) throws {
+        let payload = try JSONEncoder().encode(draft)
+        try db.exec("""
+        INSERT INTO composer_drafts (session_id, payload, updated_at)
+        VALUES (?,?,?)
+        ON CONFLICT(session_id) DO UPDATE SET
+            payload = excluded.payload,
+            updated_at = excluded.updated_at
+        """, bindings: [sessionId, payload, updatedAt])
+    }
+
+    func deleteComposerDraft(sessionId: String) throws {
+        try db.exec("DELETE FROM composer_drafts WHERE session_id = ?", bindings: [sessionId])
     }
 
     func setArchived(id: String, archived: Bool) throws {

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -87,6 +87,8 @@ struct ACPInputField: NSViewRepresentable {
         var theme: Theme?
         weak var textView: NSTextView?
         private var restoringDraft = false
+        private var nextSubmitID = 0
+        private var pendingSubmitID: Int?
 
         init(
             worktreeRoot: URL,
@@ -136,6 +138,7 @@ struct ACPInputField: NSViewRepresentable {
             else { return }
             ACPMarkdownLiveStyler.restyle(storage)
             guard !restoringDraft else { return }
+            pendingSubmitID = nil
             onDraftChange(Self.draft(from: storage))
         }
 
@@ -147,17 +150,13 @@ struct ACPInputField: NSViewRepresentable {
             // Rejected submits keep the editable draft in place. Accepted
             // submits clear only the visible text view here; persisted
             // draft deletion waits for the async prompt completion.
+            let submitID = nextSubmitID
+            nextSubmitID += 1
             if onSubmit(text, attachments, draft, { [weak self, weak textView] succeeded in
                 guard let self else { return }
-                if succeeded {
-                    self.onDraftClear()
-                } else {
-                    self.onDraftChange(draft)
-                    if let textView {
-                        self.restore(draft, into: textView)
-                    }
-                }
+                self.finishSubmit(id: submitID, draft: draft, succeeded: succeeded, textView: textView)
             }) {
+                pendingSubmitID = submitID
                 clearVisibleDraft(in: textView)
             }
         }
@@ -181,6 +180,24 @@ struct ACPInputField: NSViewRepresentable {
             textView.string = ""
             textView.needsDisplay = true
             restoringDraft = false
+        }
+
+        private func finishSubmit(
+            id: Int,
+            draft: ACPComposerDraft,
+            succeeded: Bool,
+            textView: NSTextView?
+        ) {
+            guard pendingSubmitID == id else { return }
+            pendingSubmitID = nil
+            if succeeded {
+                onDraftClear()
+            } else {
+                onDraftChange(draft)
+                if let textView {
+                    restore(draft, into: textView)
+                }
+            }
         }
 
         static func draft(from attributed: NSAttributedString) -> ACPComposerDraft {

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -8,6 +8,8 @@ struct ACPInputField: NSViewRepresentable {
     /// Returns `true` when the host accepted the submission (and the
     /// textview should be cleared) or `false` to keep the draft in
     /// place (e.g. session not ready, prompt already in flight).
+    let onDraftChange: (ACPComposerDraft) -> Void
+    let onDraftClear: () -> Void
     let onSubmit: (_ text: String, _ attachments: [ACPMessage.Attachment]) -> Bool
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -24,6 +26,7 @@ struct ACPInputField: NSViewRepresentable {
         textView.textColor = NSColor(named: "fg") ?? NSColor.labelColor
         textView.insertionPointColor = NSColor.controlAccentColor
         context.coordinator.textView = textView
+        context.coordinator.restoreInitialDraft(into: textView)
         // Publish the submit closure so the SwiftUI send button can fire
         // the same code path as ⏎.
         let coord = context.coordinator
@@ -53,20 +56,39 @@ struct ACPInputField: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(worktreeRoot: worktreeRoot, onSubmit: onSubmit)
+        Coordinator(
+            worktreeRoot: worktreeRoot,
+            initialDraft: session.composerDraft,
+            onDraftChange: onDraftChange,
+            onDraftClear: onDraftClear,
+            onSubmit: onSubmit
+        )
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         let worktreeRoot: URL
+        let initialDraft: ACPComposerDraft
+        let onDraftChange: (ACPComposerDraft) -> Void
+        let onDraftClear: () -> Void
         let onSubmit: (_ text: String, _ attachments: [ACPMessage.Attachment]) -> Bool
         var promptSuggestions: [ACPPromptSuggestion] = []
         /// Snapshotted at makeNSView time so the AppKit-only slash panel
         /// can render its SwiftUI content with our theme tokens.
         var theme: Theme?
         weak var textView: NSTextView?
+        private var restoringDraft = false
 
-        init(worktreeRoot: URL, onSubmit: @escaping (_ text: String, _ attachments: [ACPMessage.Attachment]) -> Bool) {
+        init(
+            worktreeRoot: URL,
+            initialDraft: ACPComposerDraft,
+            onDraftChange: @escaping (ACPComposerDraft) -> Void,
+            onDraftClear: @escaping () -> Void,
+            onSubmit: @escaping (_ text: String, _ attachments: [ACPMessage.Attachment]) -> Bool
+        ) {
             self.worktreeRoot = worktreeRoot
+            self.initialDraft = initialDraft
+            self.onDraftChange = onDraftChange
+            self.onDraftClear = onDraftClear
             self.onSubmit = onSubmit
         }
 
@@ -103,6 +125,8 @@ struct ACPInputField: NSViewRepresentable {
                   let storage = tv.textStorage
             else { return }
             ACPMarkdownLiveStyler.restyle(storage)
+            guard !restoringDraft else { return }
+            onDraftChange(Self.draft(from: storage))
         }
 
         func submit(_ textView: NSTextView) {
@@ -115,7 +139,64 @@ struct ACPInputField: NSViewRepresentable {
             // though the callback rejected the prompt.
             if onSubmit(text, attachments) {
                 textView.string = ""
+                onDraftClear()
             }
+        }
+
+        func restoreInitialDraft(into textView: NSTextView) {
+            guard !initialDraft.isEmpty, let storage = textView.textStorage else { return }
+            restoringDraft = true
+            storage.setAttributedString(Self.attributedString(from: initialDraft))
+            ACPMarkdownLiveStyler.restyle(storage)
+            textView.needsDisplay = true
+            restoringDraft = false
+        }
+
+        static func draft(from attributed: NSAttributedString) -> ACPComposerDraft {
+            var segments: [ACPComposerDraft.Segment] = []
+            attributed.enumerateAttribute(
+                .attachmentURI,
+                in: NSRange(location: 0, length: attributed.length)
+            ) { value, range, _ in
+                if let uri = value as? String,
+                   let chip = attributed.attribute(.attachment, at: range.location, effectiveRange: nil)
+                            as? ACPMentionChipAttachment {
+                    segments.append(.mention(displayName: chip.displayName, uri: uri))
+                } else if let uri = value as? String {
+                    let segment = attributed.attributedSubstring(from: range).string
+                    let displayName = segment.trimmingCharacters(in: .init(charactersIn: "@ "))
+                    segments.append(.mention(displayName: displayName, uri: uri))
+                } else {
+                    let text = attributed.attributedSubstring(from: range).string
+                    if !text.isEmpty {
+                        segments.append(.text(text))
+                    }
+                }
+            }
+            return ACPComposerDraft(segments: segments)
+        }
+
+        static func attributedString(from draft: ACPComposerDraft) -> NSAttributedString {
+            let result = NSMutableAttributedString(string: "")
+            let baseAttributes: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 13),
+                .foregroundColor: NSColor.labelColor,
+            ]
+            for segment in draft.segments {
+                switch segment {
+                case .text(let text):
+                    result.append(NSAttributedString(string: text, attributes: baseAttributes))
+                case .mention(let displayName, let uri):
+                    let attachment = ACPMentionChipAttachment(displayName: displayName, uri: uri)
+                    let chip = NSMutableAttributedString(attachment: attachment)
+                    chip.addAttributes([
+                        .attachmentURI: uri,
+                        .toolTip: URL(string: uri)?.path ?? uri,
+                    ], range: NSRange(location: 0, length: chip.length))
+                    result.append(chip)
+                }
+            }
+            return result
         }
 
         /// Walks the attributed string. Mention chips (attachments tagged
@@ -313,6 +394,7 @@ final class ACPNSTextView: NSTextView {
         chipString.append(NSAttributedString(string: " ", attributes: [.font: NSFont.systemFont(ofSize: 13)]))
         textStorage?.append(chipString)
         setSelectedRange(NSRange(location: (textStorage?.length ?? 0), length: 0))
+        didChangeText()
     }
 
     private func insertSlash(_ suggestion: ACPPromptSuggestion) {

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -63,6 +63,9 @@ struct ACPInputField: NSViewRepresentable {
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         context.coordinator.promptSuggestions = session.promptSuggestions
         context.coordinator.theme = context.environment.theme
+        if let textView = nsView.documentView as? NSTextView {
+            context.coordinator.syncPersistedDraft(session.composerDraft, into: textView)
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -87,6 +90,7 @@ struct ACPInputField: NSViewRepresentable {
         var theme: Theme?
         weak var textView: NSTextView?
         private var restoringDraft = false
+        private var lastSyncedDraft: ACPComposerDraft
         private var nextSubmitID = 0
         private var pendingSubmitID: Int?
 
@@ -99,6 +103,7 @@ struct ACPInputField: NSViewRepresentable {
         ) {
             self.worktreeRoot = worktreeRoot
             self.initialDraft = initialDraft
+            self.lastSyncedDraft = initialDraft
             self.onDraftChange = onDraftChange
             self.onDraftClear = onDraftClear
             self.onSubmit = onSubmit
@@ -139,7 +144,9 @@ struct ACPInputField: NSViewRepresentable {
             ACPMarkdownLiveStyler.restyle(storage)
             guard !restoringDraft else { return }
             pendingSubmitID = nil
-            onDraftChange(Self.draft(from: storage))
+            let draft = Self.draft(from: storage)
+            lastSyncedDraft = draft
+            onDraftChange(draft)
         }
 
         func submit(_ textView: NSTextView) {
@@ -153,8 +160,11 @@ struct ACPInputField: NSViewRepresentable {
             let submitID = nextSubmitID
             nextSubmitID += 1
             if onSubmit(text, attachments, draft, { [weak self, weak textView] succeeded in
-                guard let self else { return }
-                self.finishSubmit(id: submitID, draft: draft, succeeded: succeeded, textView: textView)
+                if let self {
+                    self.finishSubmit(id: submitID, draft: draft, succeeded: succeeded, textView: textView)
+                }
+                // Durable draft finalization lives with the submit owner, so
+                // tab switches can outlive this coordinator.
             }) {
                 pendingSubmitID = submitID
                 clearVisibleDraft(in: textView)
@@ -166,6 +176,16 @@ struct ACPInputField: NSViewRepresentable {
             restore(initialDraft, into: textView)
         }
 
+        func syncPersistedDraft(_ draft: ACPComposerDraft, into textView: NSTextView) {
+            let currentDraft = Self.draft(from: textView.attributedString())
+            if currentDraft == draft {
+                lastSyncedDraft = draft
+                return
+            }
+            guard currentDraft == lastSyncedDraft else { return }
+            restore(draft, into: textView)
+        }
+
         private func restore(_ draft: ACPComposerDraft, into textView: NSTextView) {
             guard let storage = textView.textStorage else { return }
             restoringDraft = true
@@ -173,6 +193,7 @@ struct ACPInputField: NSViewRepresentable {
             ACPMarkdownLiveStyler.restyle(storage)
             textView.needsDisplay = true
             restoringDraft = false
+            lastSyncedDraft = draft
         }
 
         private func clearVisibleDraft(in textView: NSTextView) {

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -1,6 +1,14 @@
 import SwiftUI
 import AppKit
 
+typealias ACPComposerSubmitCompletion = @MainActor (_ succeeded: Bool) -> Void
+typealias ACPComposerSubmitHandler = (
+    _ text: String,
+    _ attachments: [ACPMessage.Attachment],
+    _ draft: ACPComposerDraft,
+    _ completion: @escaping ACPComposerSubmitCompletion
+) -> Bool
+
 struct ACPInputField: NSViewRepresentable {
     @ObservedObject var session: ACPSession
     let worktreeRoot: URL
@@ -12,7 +20,7 @@ struct ACPInputField: NSViewRepresentable {
     /// Returns `true` when the host accepted the submission (and the
     /// textview should be cleared) or `false` to keep the draft in
     /// place (e.g. session not ready, prompt already in flight).
-    let onSubmit: (_ text: String, _ attachments: [ACPMessage.Attachment]) -> Bool
+    let onSubmit: ACPComposerSubmitHandler
 
     func makeNSView(context: Context) -> NSScrollView {
         let textView = ACPNSTextView()
@@ -72,7 +80,7 @@ struct ACPInputField: NSViewRepresentable {
         let initialDraft: ACPComposerDraft
         let onDraftChange: (ACPComposerDraft) -> Void
         let onDraftClear: () -> Void
-        let onSubmit: (_ text: String, _ attachments: [ACPMessage.Attachment]) -> Bool
+        let onSubmit: ACPComposerSubmitHandler
         var promptSuggestions: [ACPPromptSuggestion] = []
         /// Snapshotted at makeNSView time so the AppKit-only slash panel
         /// can render its SwiftUI content with our theme tokens.
@@ -85,7 +93,7 @@ struct ACPInputField: NSViewRepresentable {
             initialDraft: ACPComposerDraft,
             onDraftChange: @escaping (ACPComposerDraft) -> Void,
             onDraftClear: @escaping () -> Void,
-            onSubmit: @escaping (_ text: String, _ attachments: [ACPMessage.Attachment]) -> Bool
+            onSubmit: @escaping ACPComposerSubmitHandler
         ) {
             self.worktreeRoot = worktreeRoot
             self.initialDraft = initialDraft
@@ -135,21 +143,42 @@ struct ACPInputField: NSViewRepresentable {
             let attributed = textView.attributedString()
             let (text, attachments) = Self.extract(attributed)
             guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-            // Only clear the draft when the host accepts the
-            // submission. Pressing ⏎ while the agent is connecting /
-            // disconnected / streaming used to wipe the textview even
-            // though the callback rejected the prompt.
-            if onSubmit(text, attachments) {
-                textView.string = ""
-                onDraftClear()
+            let draft = Self.draft(from: attributed)
+            // Rejected submits keep the editable draft in place. Accepted
+            // submits clear only the visible text view here; persisted
+            // draft deletion waits for the async prompt completion.
+            if onSubmit(text, attachments, draft, { [weak self, weak textView] succeeded in
+                guard let self else { return }
+                if succeeded {
+                    self.onDraftClear()
+                } else {
+                    self.onDraftChange(draft)
+                    if let textView {
+                        self.restore(draft, into: textView)
+                    }
+                }
+            }) {
+                clearVisibleDraft(in: textView)
             }
         }
 
         func restoreInitialDraft(into textView: NSTextView) {
-            guard !initialDraft.isEmpty, let storage = textView.textStorage else { return }
+            guard !initialDraft.isEmpty else { return }
+            restore(initialDraft, into: textView)
+        }
+
+        private func restore(_ draft: ACPComposerDraft, into textView: NSTextView) {
+            guard let storage = textView.textStorage else { return }
             restoringDraft = true
-            storage.setAttributedString(Self.attributedString(from: initialDraft))
+            storage.setAttributedString(Self.attributedString(from: draft))
             ACPMarkdownLiveStyler.restyle(storage)
+            textView.needsDisplay = true
+            restoringDraft = false
+        }
+
+        private func clearVisibleDraft(in textView: NSTextView) {
+            restoringDraft = true
+            textView.string = ""
             textView.needsDisplay = true
             restoringDraft = false
         }

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -5,11 +5,13 @@ struct ACPInputField: NSViewRepresentable {
     @ObservedObject var session: ACPSession
     let worktreeRoot: URL
     let actions: ACPComposerActions
+    /// Persists the current composer draft after text storage changes.
+    let onDraftChange: (ACPComposerDraft) -> Void
+    /// Clears the persisted draft after an accepted submission.
+    let onDraftClear: () -> Void
     /// Returns `true` when the host accepted the submission (and the
     /// textview should be cleared) or `false` to keep the draft in
     /// place (e.g. session not ready, prompt already in flight).
-    let onDraftChange: (ACPComposerDraft) -> Void
-    let onDraftClear: () -> Void
     let onSubmit: (_ text: String, _ attachments: [ACPMessage.Attachment]) -> Bool
 
     func makeNSView(context: Context) -> NSScrollView {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -49,6 +49,8 @@ struct ACPComposer: View {
                 session: session,
                 worktreeRoot: worktreeRoot,
                 actions: actions,
+                onDraftChange: { draft in manager.persistComposerDraft(draft, for: session) },
+                onDraftClear: { manager.clearComposerDraft(for: session) },
                 onSubmit: onSubmit
             )
             .frame(minHeight: 44, maxHeight: 140)

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -8,7 +8,7 @@ struct ACPComposer: View {
     let manager: ACPSessionManager
     let worktreeRoot: URL
     let agentLookup: (String) -> AgentDefinition?
-    let onSubmit: (_ text: String, _ attachments: [ACPMessage.Attachment]) -> Bool
+    let onSubmit: ACPComposerSubmitHandler
 
     @Environment(\.theme) private var theme
     @FocusState private var inputFocused: Bool

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -125,7 +125,7 @@ private struct ACPSessionView: View {
                 manager: manager,
                 worktreeRoot: worktree.path,
                 agentLookup: { state.agent(id: $0) }
-            ) { text, attachments -> Bool in
+            ) { text, attachments, _, onPromptFinished -> Bool in
                 // Gate: if the runner isn't ready (initial attach in
                 // flight, agent crashed, etc.) or a prompt turn is
                 // already in flight (streaming/sending — send button
@@ -138,7 +138,7 @@ private struct ACPSessionView: View {
                       session.streamingState != .streaming,
                       session.streamingState != .sending,
                       let runner = manager.runners[sessionId] else { return false }
-                runner.send(text: text, attachments: attachments)
+                runner.send(text: text, attachments: attachments, onPromptFinished: onPromptFinished)
                 return true
             }
         }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -125,7 +125,7 @@ private struct ACPSessionView: View {
                 manager: manager,
                 worktreeRoot: worktree.path,
                 agentLookup: { state.agent(id: $0) }
-            ) { text, attachments, _, onPromptFinished -> Bool in
+            ) { text, attachments, draft, onPromptFinished -> Bool in
                 // Gate: if the runner isn't ready (initial attach in
                 // flight, agent crashed, etc.) or a prompt turn is
                 // already in flight (streaming/sending — send button
@@ -138,7 +138,24 @@ private struct ACPSessionView: View {
                       session.streamingState != .streaming,
                       session.streamingState != .sending,
                       let runner = manager.runners[sessionId] else { return false }
-                runner.send(text: text, attachments: attachments, onPromptFinished: onPromptFinished)
+                let draftRevision = session.composerDraftRevision
+                runner.send(text: text, attachments: attachments) { succeeded in
+                    if succeeded {
+                        manager.clearComposerDraft(
+                            for: session,
+                            ifCurrentDraftEquals: draft,
+                            revision: draftRevision
+                        )
+                    } else {
+                        manager.persistComposerDraft(
+                            draft,
+                            for: session,
+                            ifCurrentDraftEquals: draft,
+                            revision: draftRevision
+                        )
+                    }
+                    onPromptFinished(succeeded)
+                }
                 return true
             }
         }

--- a/AlasTests/ACP/Session/ACPComposerDraftTests.swift
+++ b/AlasTests/ACP/Session/ACPComposerDraftTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPComposerDraft")
+struct ACPComposerDraftTests {
+    @Test("codable round trip preserves ordered text and mention segments")
+    func codableRoundTrip() throws {
+        let draft = ACPComposerDraft(segments: [
+            .text("Please inspect "),
+            .mention(displayName: "File.swift", uri: "file:///tmp/File.swift"),
+            .text("\nThen explain the bug.")
+        ])
+
+        let data = try JSONEncoder().encode(draft)
+        let decoded = try JSONDecoder().decode(ACPComposerDraft.self, from: data)
+
+        #expect(decoded == draft)
+    }
+
+    @Test("empty only when it has no meaningful storage segments")
+    func emptyState() {
+        #expect(ACPComposerDraft.empty.isEmpty)
+        #expect(ACPComposerDraft(segments: [.text("")]).isEmpty)
+        #expect(!ACPComposerDraft(segments: [.text(" ")]).isEmpty)
+        #expect(!ACPComposerDraft(segments: [.mention(displayName: "a.swift", uri: "file:///a.swift")]).isEmpty)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -15,4 +15,51 @@ struct ACPSessionManagerTests {
         let row = try store.loadSession(id: s.id)
         #expect(row?.agentId == "claude")
     }
+
+    @Test("openSession restores persisted composer draft")
+    func openSessionRestoresComposerDraft() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let draft = ACPComposerDraft(segments: [.text("unsent prompt")])
+        try store.upsertComposerDraft(sessionId: "s", draft: draft, updatedAt: 123)
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = try #require(mgr.openSession(id: "s"))
+
+        #expect(session.composerDraft == draft)
+    }
+
+    @Test("persistComposerDraft stores non-empty drafts and clears empty drafts")
+    func persistComposerDraftStoresAndClears() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-clear-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let draft = ACPComposerDraft(segments: [.text("keep me")])
+
+        mgr.persistComposerDraft(draft, for: session)
+        #expect(session.composerDraft == draft)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == draft)
+
+        mgr.persistComposerDraft(.empty, for: session)
+        #expect(session.composerDraft == .empty)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
+    }
+
+    @Test("clearComposerDraft removes draft from memory and store")
+    func clearComposerDraft() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-clear-explicit-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        mgr.persistComposerDraft(ACPComposerDraft(segments: [.text("sent")]), for: session)
+
+        mgr.clearComposerDraft(for: session)
+
+        #expect(session.composerDraft == .empty)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -42,10 +42,12 @@ struct ACPSessionManagerTests {
 
         mgr.persistComposerDraft(draft, for: session)
         #expect(session.composerDraft == draft)
+        #expect(session.composerDraftRevision == 1)
         #expect(try store.loadComposerDraft(sessionId: session.id) == draft)
 
         mgr.persistComposerDraft(.empty, for: session)
         #expect(session.composerDraft == .empty)
+        #expect(session.composerDraftRevision == 2)
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
     }
 
@@ -61,5 +63,46 @@ struct ACPSessionManagerTests {
 
         #expect(session.composerDraft == .empty)
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
+    }
+
+    @Test("conditional composer draft clear only clears the submitted draft")
+    func conditionalComposerDraftClear() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-conditional-clear-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let submitted = ACPComposerDraft(segments: [.text("sent")])
+        let newer = ACPComposerDraft(segments: [.text("newer")])
+
+        mgr.persistComposerDraft(submitted, for: session)
+        let submittedRevision = session.composerDraftRevision
+        mgr.clearComposerDraft(for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
+        #expect(session.composerDraft == .empty)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
+
+        mgr.persistComposerDraft(newer, for: session)
+        mgr.clearComposerDraft(for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
+        #expect(session.composerDraft == newer)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == newer)
+    }
+
+    @Test("conditional composer draft persist does not overwrite a newer draft revision")
+    func conditionalComposerDraftPersistByRevision() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-conditional-persist-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let submitted = ACPComposerDraft(segments: [.text("sent")])
+
+        mgr.persistComposerDraft(submitted, for: session)
+        let submittedRevision = session.composerDraftRevision
+        mgr.persistComposerDraft(submitted, for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
+        #expect(session.composerDraft == submitted)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
+
+        mgr.persistComposerDraft(submitted, for: session)
+        mgr.persistComposerDraft(.empty, for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
+        #expect(session.composerDraft == submitted)
+        #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -5,6 +5,37 @@ import Testing
 @MainActor
 @Suite("ACPSessionRunner")
 struct ACPSessionRunnerTests {
+    @Test("send reports failed completion when session prompt fails")
+    func sendReportsFailedCompletionWhenPromptFails() async throws {
+        let (runner, _) = try makeRunner()
+
+        let succeeded = await withCheckedContinuation { continuation in
+            runner.send(text: "hello", attachments: []) { succeeded in
+                continuation.resume(returning: succeeded)
+            }
+        }
+
+        #expect(succeeded == false)
+        #expect(runner.session.lastError?.contains("prompt failed") == true)
+        #expect(runner.session.streamingState == .idle)
+    }
+
+    @Test("send reports successful completion when session prompt succeeds")
+    func sendReportsSuccessfulCompletionWhenPromptSucceeds() async throws {
+        let (runner, mock) = try makeRunner()
+        mock.script(method: "session/prompt") { _ in Data("{}".utf8) }
+
+        let succeeded = await withCheckedContinuation { continuation in
+            runner.send(text: "hello", attachments: []) { succeeded in
+                continuation.resume(returning: succeeded)
+            }
+        }
+
+        #expect(succeeded == true)
+        #expect(runner.session.lastError == nil)
+        #expect(runner.session.streamingState == .idle)
+    }
+
     @Test("emitted session/update lands on the session and persists a message row")
     func runnerWiresUpdates() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
@@ -77,5 +108,24 @@ struct ACPSessionRunnerTests {
 
         // `limit` exceeding remaining lines returns the tail.
         #expect(ACPSessionRunner.sliceLines(full, line: 4, limit: 99) == "four\nfive")
+    }
+
+    private func makeRunner() throws -> (ACPSessionRunner, ACPMockClient) {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        return (runner, mock)
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -36,6 +36,133 @@ struct ACPSessionRunnerTests {
         #expect(runner.session.streamingState == .idle)
     }
 
+    @Test("send treats user-cancelled prompt errors as accepted completion")
+    func sendTreatsCancelledPromptErrorsAsAcceptedCompletion() async throws {
+        let (runner, mock) = try makeRunner()
+        let promptStarted = AsyncGate()
+        let finishPrompt = AsyncGate()
+        mock.scriptAsync(method: "session/prompt") { _ in
+            await promptStarted.open()
+            await finishPrompt.wait()
+            throw ACPClientError.noScript(method: "session/prompt")
+        }
+
+        var completion: Bool?
+        runner.send(text: "hello", attachments: []) { succeeded in
+            completion = succeeded
+        }
+        await promptStarted.wait()
+
+        await runner.userCancel()
+        await finishPrompt.open()
+
+        for _ in 0..<20 where completion == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(completion == true)
+        #expect(runner.session.lastError == nil)
+        #expect(runner.session.streamingState == .idle)
+        #expect(mock.sent.contains { $0.method == "session/cancel" })
+    }
+
+    @Test("cancelled prompt completion does not idle a newer prompt")
+    func cancelledPromptCompletionDoesNotIdleNewerPrompt() async throws {
+        let (runner, mock) = try makeRunner()
+        let promptCounter = AsyncCounter()
+        let firstStarted = AsyncGate()
+        let finishFirst = AsyncGate()
+        let secondStarted = AsyncGate()
+        let finishSecond = AsyncGate()
+        mock.scriptAsync(method: "session/prompt") { _ in
+            let promptNumber = await promptCounter.next()
+            if promptNumber == 1 {
+                await firstStarted.open()
+                await finishFirst.wait()
+                throw ACPClientError.noScript(method: "session/prompt")
+            }
+            await secondStarted.open()
+            await finishSecond.wait()
+            return Data("{}".utf8)
+        }
+
+        var firstCompletion: Bool?
+        var secondCompletion: Bool?
+        runner.send(text: "first", attachments: []) { succeeded in
+            firstCompletion = succeeded
+        }
+        await firstStarted.wait()
+        await runner.userCancel()
+
+        runner.send(text: "second", attachments: []) { succeeded in
+            secondCompletion = succeeded
+        }
+        await secondStarted.wait()
+        await finishFirst.open()
+
+        for _ in 0..<20 where firstCompletion == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(firstCompletion == nil)
+        #expect(secondCompletion == nil)
+        #expect(runner.session.streamingState == .sending)
+
+        await finishSecond.open()
+        for _ in 0..<20 where secondCompletion == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(secondCompletion == true)
+        #expect(runner.session.streamingState == .idle)
+    }
+
+    @Test("cancelled prompt success does not complete over a newer prompt")
+    func cancelledPromptSuccessDoesNotCompleteOverNewerPrompt() async throws {
+        let (runner, mock) = try makeRunner()
+        let promptCounter = AsyncCounter()
+        let firstStarted = AsyncGate()
+        let finishFirst = AsyncGate()
+        let secondStarted = AsyncGate()
+        let finishSecond = AsyncGate()
+        mock.scriptAsync(method: "session/prompt") { _ in
+            let promptNumber = await promptCounter.next()
+            if promptNumber == 1 {
+                await firstStarted.open()
+                await finishFirst.wait()
+                return Data("{}".utf8)
+            }
+            await secondStarted.open()
+            await finishSecond.wait()
+            return Data("{}".utf8)
+        }
+
+        var firstCompletion: Bool?
+        var secondCompletion: Bool?
+        runner.send(text: "first", attachments: []) { succeeded in
+            firstCompletion = succeeded
+        }
+        await firstStarted.wait()
+        await runner.userCancel()
+
+        runner.send(text: "second", attachments: []) { succeeded in
+            secondCompletion = succeeded
+        }
+        await secondStarted.wait()
+        await finishFirst.open()
+
+        for _ in 0..<20 where runner.session.streamingState != .sending {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(firstCompletion == nil)
+        #expect(secondCompletion == nil)
+        #expect(runner.session.streamingState == .sending)
+
+        await finishSecond.open()
+        for _ in 0..<20 where secondCompletion == nil {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(secondCompletion == true)
+        #expect(runner.session.streamingState == .idle)
+    }
+
     @Test("emitted session/update lands on the session and persists a message row")
     func runnerWiresUpdates() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
@@ -127,5 +254,36 @@ struct ACPSessionRunnerTests {
             worktreePath: FileManager.default.temporaryDirectory.path
         )
         return (runner, mock)
+    }
+}
+
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let continuations = waiters
+        waiters.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+}
+
+private actor AsyncCounter {
+    private var value = 0
+
+    func next() -> Int {
+        value += 1
+        return value
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -52,4 +52,41 @@ struct ACPSessionStoreCRUDTests {
         #expect(loaded.map(\.kind) == ["user", "agent"])
         #expect(loaded[0].payload == m1)
     }
+
+    @Test("composer draft upsert load and delete round-trips")
+    func composerDraftCRUD() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        let draft = ACPComposerDraft(segments: [
+            .text("Read "),
+            .mention(displayName: "A.swift", uri: "file:///tmp/A.swift"),
+            .text(" please")
+        ])
+        try store.upsertComposerDraft(sessionId: "s", draft: draft, updatedAt: 123)
+
+        #expect(try store.loadComposerDraft(sessionId: "s") == draft)
+
+        try store.deleteComposerDraft(sessionId: "s")
+        #expect(try store.loadComposerDraft(sessionId: "s") == nil)
+    }
+
+    @Test("composer draft is deleted with owning session")
+    func composerDraftCascadesWithSession() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: ACPComposerDraft(segments: [.text("unsent")]),
+            updatedAt: 123
+        )
+
+        try store.deleteSession(id: "s")
+
+        #expect(try store.loadComposerDraft(sessionId: "s") == nil)
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -4,9 +4,12 @@ import Testing
 
 @Suite("ACPSessionStore CRUD")
 struct ACPSessionStoreCRUDTests {
+    private func tmpURL() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("acp-crud-\(UUID()).sqlite")
+    }
+
     private func tmp() throws -> ACPSessionStore {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent("acp-crud-\(UUID()).sqlite")
-        return try ACPSessionStore(path: url.path)
+        try ACPSessionStore(path: tmpURL().path)
     }
 
     @Test("insert + load session round-trips fields")
@@ -55,7 +58,8 @@ struct ACPSessionStoreCRUDTests {
 
     @Test("composer draft upsert load and delete round-trips")
     func composerDraftCRUD() throws {
-        let store = try tmp()
+        let url = tmpURL()
+        let store = try ACPSessionStore(path: url.path)
         try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
             currentModel: nil, currentMode: nil, autoRun: false,
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
@@ -68,6 +72,7 @@ struct ACPSessionStoreCRUDTests {
         try store.upsertComposerDraft(sessionId: "s", draft: draft, updatedAt: 123)
 
         #expect(try store.loadComposerDraft(sessionId: "s") == draft)
+        #expect(try ACPSessionStore(path: url.path).loadComposerDraft(sessionId: "s") == draft)
 
         try store.deleteComposerDraft(sessionId: "s")
         #expect(try store.loadComposerDraft(sessionId: "s") == nil)

--- a/AlasTests/ACP/Session/ACPSessionStoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreTests.swift
@@ -22,4 +22,65 @@ struct ACPSessionStoreSchemaTests {
         _ = try ACPSessionStore(path: url.path)
         _ = try ACPSessionStore(path: url.path) // must not throw
     }
+
+    @Test("migrates schema version 1 to version 2")
+    func migratesV1ToV2() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("acp-store-\(UUID()).sqlite")
+        do {
+            let db = try SQLiteDatabase(path: url.path)
+            try db.exec("""
+            CREATE TABLE schema_version (
+              version INTEGER NOT NULL
+            )
+            """)
+            try db.exec("""
+            CREATE TABLE sessions (
+              id              TEXT PRIMARY KEY,
+              agent_id        TEXT NOT NULL,
+              title           TEXT NOT NULL,
+              current_model   TEXT,
+              current_mode    TEXT,
+              auto_run        INTEGER NOT NULL DEFAULT 0,
+              created_at      INTEGER NOT NULL,
+              updated_at      INTEGER NOT NULL,
+              last_opened_at  INTEGER NOT NULL,
+              archived        INTEGER NOT NULL DEFAULT 0
+            )
+            """)
+            try db.exec("CREATE INDEX sessions_recent_idx ON sessions(archived, last_opened_at DESC)")
+            try db.exec("""
+            CREATE TABLE messages (
+              id          TEXT PRIMARY KEY,
+              session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+              kind        TEXT NOT NULL,
+              seq         INTEGER NOT NULL,
+              payload     BLOB NOT NULL,
+              created_at  INTEGER NOT NULL
+            )
+            """)
+            try db.exec("CREATE INDEX messages_session_seq_idx ON messages(session_id, seq)")
+            try db.exec("""
+            CREATE TABLE permission_decisions (
+              session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+              scope_key   TEXT NOT NULL,
+              decision    TEXT NOT NULL,
+              scope       TEXT NOT NULL,
+              decided_at  INTEGER NOT NULL,
+              PRIMARY KEY (session_id, scope_key)
+            )
+            """)
+            try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(1)])
+        }
+
+        let store = try ACPSessionStore(path: url.path)
+        #expect(try store.currentSchemaVersion() == 2)
+
+        let draft = ACPComposerDraft(segments: [.text("migrated")])
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        try store.upsertComposerDraft(sessionId: "s", draft: draft, updatedAt: 123)
+
+        #expect(try store.loadComposerDraft(sessionId: "s") == draft)
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionStoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreTests.swift
@@ -9,10 +9,11 @@ struct ACPSessionStoreSchemaTests {
         return try ACPSessionStore(path: url.path)
     }
 
-    @Test("opens a fresh DB at schema version 1")
+    @Test("opens a fresh DB at schema version 2")
     func freshSchema() throws {
         let store = try tmpStore()
         #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
+        #expect(ACPSessionStore.targetSchemaVersion == 2)
     }
 
     @Test("re-opening doesn't double-apply migrations")

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -6,6 +6,74 @@ import Testing
 @MainActor
 @Suite("ACP composer draft bridge")
 struct ACPComposerDraftBridgeTests {
+    @Test("accepted submit restores structured draft when async completion fails")
+    func acceptedSubmitRestoresDraftWhenCompletionFails() {
+        let draft = ACPComposerDraft(segments: [
+            .text("Read "),
+            .mention(displayName: "File.swift", uri: "file:///tmp/File.swift"),
+            .text(" before replying")
+        ])
+        let textView = NSTextView()
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: draft))
+        var changedDrafts: [ACPComposerDraft] = []
+        var clearCount = 0
+        var completion: (@MainActor (Bool) -> Void)?
+
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            onDraftChange: { changedDrafts.append($0) },
+            onDraftClear: { clearCount += 1 },
+            onSubmit: { _, _, submittedDraft, onFinished in
+                #expect(submittedDraft == draft)
+                completion = onFinished
+                return true
+            }
+        )
+        coordinator.textView = textView
+
+        coordinator.submit(textView)
+        #expect(textView.string.isEmpty)
+        #expect(changedDrafts.isEmpty)
+        #expect(clearCount == 0)
+
+        completion?(false)
+
+        #expect(changedDrafts == [draft])
+        #expect(clearCount == 0)
+        #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == draft)
+    }
+
+    @Test("accepted submit clears persisted draft when async completion succeeds")
+    func acceptedSubmitClearsDraftWhenCompletionSucceeds() {
+        let draft = ACPComposerDraft(segments: [.text("hello")])
+        let textView = NSTextView()
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: draft))
+        var changedDrafts: [ACPComposerDraft] = []
+        var clearCount = 0
+        var completion: (@MainActor (Bool) -> Void)?
+
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            onDraftChange: { changedDrafts.append($0) },
+            onDraftClear: { clearCount += 1 },
+            onSubmit: { _, _, submittedDraft, onFinished in
+                #expect(submittedDraft == draft)
+                completion = onFinished
+                return true
+            }
+        )
+        coordinator.textView = textView
+
+        coordinator.submit(textView)
+        completion?(true)
+
+        #expect(changedDrafts.isEmpty)
+        #expect(clearCount == 1)
+        #expect(textView.string.isEmpty)
+    }
+
     @Test("serializes plain text and mention chips in order")
     func serializesAttributedDraft() {
         let attributed = NSMutableAttributedString(string: "Read ")

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -1,0 +1,43 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP composer draft bridge")
+struct ACPComposerDraftBridgeTests {
+    @Test("serializes plain text and mention chips in order")
+    func serializesAttributedDraft() {
+        let attributed = NSMutableAttributedString(string: "Read ")
+        let attachment = ACPMentionChipAttachment(displayName: "File.swift", uri: "file:///tmp/File.swift")
+        let chip = NSMutableAttributedString(attachment: attachment)
+        chip.addAttributes([
+            .attachmentURI: "file:///tmp/File.swift",
+            .toolTip: "/tmp/File.swift",
+        ], range: NSRange(location: 0, length: chip.length))
+        attributed.append(chip)
+        attributed.append(NSAttributedString(string: " now"))
+
+        let draft = ACPInputField.Coordinator.draft(from: attributed)
+
+        #expect(draft == ACPComposerDraft(segments: [
+            .text("Read "),
+            .mention(displayName: "File.swift", uri: "file:///tmp/File.swift"),
+            .text(" now")
+        ]))
+    }
+
+    @Test("restores mention chips from draft")
+    func restoresAttributedDraft() {
+        let draft = ACPComposerDraft(segments: [
+            .text("Read "),
+            .mention(displayName: "File.swift", uri: "file:///tmp/File.swift"),
+            .text(" now")
+        ])
+
+        let attributed = ACPInputField.Coordinator.attributedString(from: draft)
+        let serialized = ACPInputField.Coordinator.draft(from: attributed)
+
+        #expect(serialized == draft)
+    }
+}

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -146,6 +146,53 @@ struct ACPComposerDraftBridgeTests {
         #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == newerDraft)
     }
 
+    @Test("persisted draft sync clears a remounted submitted draft")
+    func persistedDraftSyncClearsRemountedSubmittedDraft() {
+        let submittedDraft = ACPComposerDraft(segments: [.text("already sent")])
+        let textView = NSTextView()
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: submittedDraft))
+        var changedDrafts: [ACPComposerDraft] = []
+        var clearCount = 0
+
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: submittedDraft,
+            onDraftChange: { changedDrafts.append($0) },
+            onDraftClear: { clearCount += 1 },
+            onSubmit: { _, _, _, _ in true }
+        )
+
+        coordinator.syncPersistedDraft(.empty, into: textView)
+
+        #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == .empty)
+        #expect(changedDrafts.isEmpty)
+        #expect(clearCount == 0)
+    }
+
+    @Test("persisted draft sync does not overwrite unsynced local edits")
+    func persistedDraftSyncDoesNotOverwriteUnsyncedLocalEdits() {
+        let submittedDraft = ACPComposerDraft(segments: [.text("already sent")])
+        let localDraft = ACPComposerDraft(segments: [.text("still typing")])
+        let textView = NSTextView()
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: localDraft))
+        var changedDrafts: [ACPComposerDraft] = []
+        var clearCount = 0
+
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: submittedDraft,
+            onDraftChange: { changedDrafts.append($0) },
+            onDraftClear: { clearCount += 1 },
+            onSubmit: { _, _, _, _ in true }
+        )
+
+        coordinator.syncPersistedDraft(.empty, into: textView)
+
+        #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == localDraft)
+        #expect(changedDrafts.isEmpty)
+        #expect(clearCount == 0)
+    }
+
     @Test("serializes plain text and mention chips in order")
     func serializesAttributedDraft() {
         let attributed = NSMutableAttributedString(string: "Read ")

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -74,6 +74,78 @@ struct ACPComposerDraftBridgeTests {
         #expect(textView.string.isEmpty)
     }
 
+    @Test("successful completion does not clear newer draft after intervening edit")
+    func successfulCompletionDoesNotClearNewerDraftAfterInterveningEdit() {
+        let submittedDraft = ACPComposerDraft(segments: [.text("hello")])
+        let newerDraft = ACPComposerDraft(segments: [
+            .text("new "),
+            .mention(displayName: "File.swift", uri: "file:///tmp/File.swift")
+        ])
+        let textView = NSTextView()
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: submittedDraft))
+        var changedDrafts: [ACPComposerDraft] = []
+        var clearCount = 0
+        var completion: (@MainActor (Bool) -> Void)?
+
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            onDraftChange: { changedDrafts.append($0) },
+            onDraftClear: { clearCount += 1 },
+            onSubmit: { _, _, draft, onFinished in
+                #expect(draft == submittedDraft)
+                completion = onFinished
+                return true
+            }
+        )
+        coordinator.textView = textView
+
+        coordinator.submit(textView)
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: newerDraft))
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        completion?(true)
+
+        #expect(changedDrafts == [newerDraft])
+        #expect(clearCount == 0)
+        #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == newerDraft)
+    }
+
+    @Test("failed completion does not restore submitted draft after intervening edit")
+    func failedCompletionDoesNotRestoreSubmittedDraftAfterInterveningEdit() {
+        let submittedDraft = ACPComposerDraft(segments: [.text("hello")])
+        let newerDraft = ACPComposerDraft(segments: [
+            .text("new "),
+            .mention(displayName: "File.swift", uri: "file:///tmp/File.swift")
+        ])
+        let textView = NSTextView()
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: submittedDraft))
+        var changedDrafts: [ACPComposerDraft] = []
+        var clearCount = 0
+        var completion: (@MainActor (Bool) -> Void)?
+
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            onDraftChange: { changedDrafts.append($0) },
+            onDraftClear: { clearCount += 1 },
+            onSubmit: { _, _, draft, onFinished in
+                #expect(draft == submittedDraft)
+                completion = onFinished
+                return true
+            }
+        )
+        coordinator.textView = textView
+
+        coordinator.submit(textView)
+        textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: newerDraft))
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        completion?(false)
+
+        #expect(changedDrafts == [newerDraft])
+        #expect(clearCount == 0)
+        #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == newerDraft)
+    }
+
     @Test("serializes plain text and mention chips in order")
     func serializesAttributedDraft() {
         let attributed = NSMutableAttributedString(string: "Read ")

--- a/docs/superpowers/specs/2026-05-28-acp-composer-draft-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-28-acp-composer-draft-persistence-design.md
@@ -1,0 +1,124 @@
+# ACP Composer Draft Persistence Design
+
+## Context
+
+ACP composer text currently lives only inside the AppKit `NSTextView` used by
+`ACPInputField`. Switching away from an ACP pane can tear down that view, and
+returning to the pane creates a fresh text view with no saved draft. ACP
+sessions and transcripts already persist through `ACPSessionStore`, so the
+draft should be persisted as part of the ACP session rather than as transient
+SwiftUI/AppKit view state.
+
+## Goals
+
+- Preserve unsent ACP composer contents when switching worktrees or tabs.
+- Restore the draft when reopening the same ACP session after app restart.
+- Preserve ordered text and `@mention` file chips so the restored composer
+  displays the same prompt content and submits the same prompt attachments.
+- Clear the persisted draft only after the prompt is accepted for sending.
+- Keep drafts scoped to one ACP session and delete them when the session is
+  deleted.
+
+## Non-Goals
+
+- Persist caret position, selection, undo history, slash-picker state, or focus.
+- Persist generated markdown styling attributes. Styling can be regenerated from
+  the literal text.
+- Share one draft across different ACP sessions in the same worktree.
+
+## Approach
+
+Use `ACPSessionStore` as the source of truth for unsent ACP composer drafts.
+Add a `composer_drafts` table keyed by `session_id`, with a JSON payload and an
+`updated_at` timestamp. The table must reference `sessions(id)` with
+`ON DELETE CASCADE` so deleting an ACP session also removes its draft.
+
+The JSON payload must represent an ordered list of segments:
+
+- `text`: plain composer text.
+- `mention`: a file chip with `displayName` and `uri`.
+
+This avoids flattening chips into plain text. It also lets the composer rebuild
+an attributed string containing `ACPMentionChipAttachment` instances, so a
+restored draft submits the same visible text and the same resource-link
+attachments as before.
+
+## Data Flow
+
+1. `ACPSessionManager.openSession(id:)` loads the persisted draft from
+   `ACPSessionStore` and assigns it to the `ACPSession`.
+2. `ACPInputField` receives the session draft when it mounts and initializes
+   the underlying `NSTextView` once, before the user starts editing.
+3. On composer edits, the coordinator serializes the current attributed string
+   to the draft payload and asks the manager/store to upsert it.
+4. If the composer becomes empty, the stored draft is deleted.
+5. On submit, the current extraction path still builds prompt text and
+   attachments from the attributed string.
+6. When `onSubmit` returns `true`, the text view is cleared and the stored draft
+   is deleted. When `onSubmit` returns `false`, the text view and persisted
+   draft remain intact.
+
+## Components
+
+### Draft Model
+
+Add a small codable model near the ACP session code, for example
+`ACPComposerDraft`, with segment cases for text and mention. Keep conversion
+helpers close to the composer UI because they depend on AppKit attributed
+string details.
+
+### Session Store
+
+Extend `ACPSessionStore` with:
+
+- schema migration from version 1 to version 2;
+- `loadComposerDraft(sessionId:)`;
+- `upsertComposerDraft(sessionId:draft:updatedAt:)`;
+- `deleteComposerDraft(sessionId:)`.
+
+The migration must be idempotent and preserve existing databases.
+
+### Session Manager
+
+Expose narrow draft operations from `ACPSessionManager` so the UI does not
+write to SQLite directly. Loading a session should populate the in-memory
+draft. Clearing a sent draft should update both memory and persistence.
+
+### Composer UI
+
+`ACPInputField.Coordinator` serializes the attributed text on edits. It
+rebuilds the attributed text from the stored draft on mount. Restoring happens
+only once per text view instance so SwiftUI updates do not
+overwrite active user typing.
+
+## Error Handling
+
+Draft persistence failures must not block typing or sending. The app should
+best-effort save, mirroring existing ACP persistence behavior. If saving fails,
+the live text remains in the composer for the current view lifetime.
+
+If a stored draft payload cannot decode, ignore it and leave the composer empty.
+This avoids breaking access to the ACP session because of a corrupt draft.
+
+## Testing
+
+Add focused Swift Testing coverage for:
+
+- schema migration to version 2 on fresh and existing databases;
+- draft upsert/load/delete round trip;
+- draft deletion when the owning ACP session is deleted;
+- manager `openSession` restoring an existing draft;
+- manager clear operation removing the draft from memory and store;
+- pure composer draft serialization for text plus mention-chip ordering using
+  `NSAttributedString` and `ACPMentionChipAttachment`.
+
+## Acceptance Criteria
+
+- Typing in an ACP composer, switching to another worktree, and returning to
+  the ACP pane restores the draft.
+- Quitting and relaunching the app restores the same draft when the ACP session
+  is reopened.
+- `@mention` file chips survive restore and submit as attachments.
+- Pressing send while the session is not ready keeps the draft.
+- A successful send clears the composer and removes the persisted draft.
+- Deleting an ACP session removes its stored draft.


### PR DESCRIPTION
## Summary
- Persist ACP composer drafts per session in the ACP SQLite store, including text and file mention chips.
- Restore drafts when ACP panes are recreated and after app restart.
- Defer clearing persisted drafts until async prompt send succeeds, preserving newer drafts typed while a prompt is in flight.

## Test Plan
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPComposerDraftTests -only-testing:AlasTests/ACPSessionStoreSchemaTests -only-testing:AlasTests/ACPSessionStoreCRUDTests -only-testing:AlasTests/ACPSessionManagerTests -only-testing:AlasTests/ACPSessionRunnerTests -only-testing:AlasTests/ACPComposerDraftBridgeTests`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`