### PR TITLE
feat(acp): color chat code blocks

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		2281077800674169E69C6C3B /* HoverWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9032BA9542C617A09EF848 /* HoverWindowControllerTests.swift */; };
 		22FDE2FB05952993DA2D0EB7 /* WorkingTreeSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */; };
 		23013D3D2538AC2D1BD3403D /* ChangesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C682FF74C86B77BDCF46CF25 /* ChangesTabView.swift */; };
+		238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */; };
 		2434A66A45EDF2609BA9F1D3 /* session-update-config-options.json in Resources */ = {isa = PBXBuildFile; fileRef = 97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */; };
 		24F8EA15B87C38C319B8A66B /* AlasField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E6D61B213F3378243B4A26 /* AlasField.swift */; };
 		250F0E2CB26CC16D2FFDB9DD /* DiffSelectableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */; };
@@ -680,6 +681,7 @@
 		E99E4DB46496707E7A3F044A /* PiACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F36C31DB1C13D86416B4B /* PiACPInstaller.swift */; };
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */; };
+		EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */; };
 		EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */; };
 		ECEE8511CA84DF4A15F01DC1 /* AppConfigTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
@@ -980,6 +982,7 @@
 		524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibility.swift; sourceTree = "<group>"; };
 		52C55C85672956E1340B03B1 /* MergeSidePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSidePane.swift; sourceTree = "<group>"; };
 		5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioClientTests.swift; sourceTree = "<group>"; };
+		530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighter.swift; sourceTree = "<group>"; };
 		5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolver.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
@@ -1099,6 +1102,7 @@
 		802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeView.swift; sourceTree = "<group>"; };
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
 		8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverWindowController.swift; sourceTree = "<group>"; };
+		81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighterTests.swift; sourceTree = "<group>"; };
 		822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorModel.swift; sourceTree = "<group>"; };
 		82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceBehindStatusTests.swift; sourceTree = "<group>"; };
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
@@ -2031,6 +2035,14 @@
 			path = Themes;
 			sourceTree = "<group>";
 		};
+		4A87288C819AD4B9E41D1858 /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
+			);
+			path = UI;
+			sourceTree = "<group>";
+		};
 		4DB62FEBC3C8536A56117C23 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
@@ -2177,6 +2189,7 @@
 				FDD6B99A5214227965308D70 /* Permissions */,
 				28DACFA5F60339EEE14A135F /* Protocol */,
 				A72D9EE2C6FD478C41435DBA /* Session */,
+				4A87288C819AD4B9E41D1858 /* UI */,
 			);
 			path = ACP;
 			sourceTree = "<group>";
@@ -2197,6 +2210,7 @@
 			isa = PBXGroup;
 			children = (
 				D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */,
+				530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */,
 				C496549308D5C3DD20E988AD /* ACPComposer.swift */,
 				2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */,
 				906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */,
@@ -2990,6 +3004,7 @@
 				56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */,
 				C00E549FA69AB3D3C55B85EB /* ACPChipState.swift in Sources */,
 				A70A62FDF7EA38F99D9E2B06 /* ACPClient.swift in Sources */,
+				EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */,
 				34F18AB368DC5D93196056CA /* ACPComposer.swift in Sources */,
 				1C5D64F032EAD5EA28B2482B /* ACPComposerActions.swift in Sources */,
 				C04150547C17399FA9D7947C /* ACPComposerShell.swift in Sources */,
@@ -3386,6 +3401,7 @@
 			files = (
 				CC531074F02A34E48A1E6133 /* ACPAgentProfilesTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
+				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,
 				B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
+++ b/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
@@ -29,6 +29,7 @@ enum ACPCodeLanguage {
         case "ts", "typescript": return "ts"
         case "tsx": return "tsx"
         case "sh", "bash", "shell", "zsh", "console", "terminal": return "sh"
+        case "md", "markdown": return "md"
         case "json": return "json"
         case "yaml", "yml": return "yaml"
         case "toml": return "toml"

--- a/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
+++ b/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
@@ -1,0 +1,88 @@
+import AppKit
+import Foundation
+
+enum ACPCodeLanguage {
+    static func highlighterExtension(for label: String?) -> String? {
+        guard let label else { return nil }
+        var normalized = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return nil }
+
+        if let first = normalized.split(whereSeparator: { $0.isWhitespace }).first {
+            normalized = String(first)
+        }
+        normalized = normalized
+            .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+            .lowercased()
+
+        if normalized.hasPrefix("{"), normalized.hasSuffix("}") {
+            normalized = String(normalized.dropFirst().dropLast())
+        }
+        if normalized.hasPrefix(".") {
+            normalized = String(normalized.dropFirst())
+        }
+
+        switch normalized {
+        case "swift": return "swift"
+        case "py", "python": return "py"
+        case "js", "javascript", "mjs", "cjs": return "js"
+        case "jsx": return "jsx"
+        case "ts", "typescript": return "ts"
+        case "tsx": return "tsx"
+        case "sh", "bash", "shell", "zsh", "console", "terminal": return "sh"
+        case "json": return "json"
+        case "yaml", "yml": return "yaml"
+        case "toml": return "toml"
+        case "rs", "rust": return "rs"
+        case "go", "golang": return "go"
+        case "java": return "java"
+        case "kt", "kotlin": return "kt"
+        case "kts": return "kts"
+        case "c": return "c"
+        case "h": return "h"
+        case "cpp", "c++": return "cpp"
+        case "cc": return "cc"
+        case "cxx": return "cxx"
+        case "hpp": return "hpp"
+        case "diff", "patch": return "diff"
+        case "html": return "html"
+        case "xml": return "xml"
+        case "css": return "css"
+        case "scss": return "scss"
+        case "sass": return "sass"
+        case "sql": return "sql"
+        default: return nil
+        }
+    }
+}
+
+enum ACPCodeBlockHighlighter {
+    static func attributedString(
+        code: String,
+        language: String?,
+        theme: Theme,
+        fontSize: CGFloat = 12
+    ) -> NSAttributedString {
+        let editorTheme = EditorTheme(theme: theme)
+        let baseAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+            .foregroundColor: editorTheme.defaultFG,
+        ]
+        let attributed = NSMutableAttributedString(string: code, attributes: baseAttributes)
+        guard !code.isEmpty,
+              let ext = ACPCodeLanguage.highlighterExtension(for: language) else {
+            return attributed
+        }
+
+        let length = (code as NSString).length
+        let spans = TreeSitterHighlighter.highlight(source: code, fileExtension: ext)
+        for span in spans {
+            guard span.range.location != NSNotFound,
+                  span.range.location >= 0,
+                  NSMaxRange(span.range) <= length else {
+                continue
+            }
+            attributed.addAttributes(editorTheme.attributes(for: span.capture), range: span.range)
+        }
+        return attributed
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -269,13 +269,17 @@ private struct CodeBlockView: View {
         VStack(alignment: .leading, spacing: 0) {
             header
             ScrollView(.horizontal, showsIndicators: false) {
-                Text(code)
-                    .font(.system(size: 12, design: .monospaced))
-                    .foregroundStyle(theme.color("fg"))
-                    .lineSpacing(2)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 10).padding(.vertical, 8)
+                Text(AttributedString(ACPCodeBlockHighlighter.attributedString(
+                    code: code,
+                    language: language,
+                    theme: theme
+                )))
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(theme.color("fg"))
+                .lineSpacing(2)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 10).padding(.vertical, 8)
             }
         }
         .background(theme.color("bg-0").opacity(0.6))

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -286,7 +286,6 @@ private enum RegexFallbackHighlighter {
     private static func booleanAttributeSpans(source: String, existingSpans: [HighlightSpan]) -> [HighlightSpan] {
         let attributePattern = #"\s+([A-Za-z_:][A-Za-z0-9_:.-]*)(?=\s*(?:=|/?>|\s))"#
         guard let attributeRegex = try? NSRegularExpression(pattern: attributePattern) else { return [] }
-        let nsSource = source as NSString
         let protectedSpans = existingSpans.filter { $0.capture == .comment || $0.capture == .string }
         var spans: [HighlightSpan] = []
         for tagRange in openingTagRanges(source: source, protectedSpans: protectedSpans) {

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -132,6 +132,7 @@ private enum RegexFallbackHighlighter {
         switch language {
         case "diff": return diffSpans(source: source)
         case "markup": return markupSpans(source: source)
+        case "css": return cssSpans(source: source)
         default: break
         }
         let keywords = keywordSet(for: language)
@@ -164,7 +165,42 @@ private enum RegexFallbackHighlighter {
     }
 
     private static func diffSpans(source: String) -> [HighlightSpan] {
-        let pattern = #"(?m)^(@@.*@@|diff --git .*$|index .*$|--- .*$|\+\+\+ .*$|\+.*$|-.*$)"#
+        let nsSource = source as NSString
+        var spans: [HighlightSpan] = []
+        var offset = 0
+        var inHunk = false
+        while offset < nsSource.length {
+            let lineRange = nsSource.lineRange(for: NSRange(location: offset, length: 0))
+            var contentRange = lineRange
+            while contentRange.length > 0 {
+                let char = nsSource.character(at: contentRange.location + contentRange.length - 1)
+                guard char == 10 || char == 13 else { break }
+                contentRange.length -= 1
+            }
+            let text = nsSource.substring(with: contentRange)
+            if let capture = diffCapture(for: text, inHunk: inHunk) {
+                spans.append(HighlightSpan(range: contentRange, capture: capture))
+            }
+            if text.hasPrefix("@@"), text.contains("@@") {
+                inHunk = true
+            }
+            offset = lineRange.location + lineRange.length
+        }
+        return spans
+    }
+
+    private static func diffCapture(for line: String, inHunk: Bool) -> HighlightCapture? {
+        if line.hasPrefix("@@"), line.contains("@@") { return .keyword }
+        if line.hasPrefix("diff --git ") || line.hasPrefix("index ") { return .keyword }
+        if !inHunk, line.hasPrefix("--- ") || line.hasPrefix("+++ ") { return .keyword }
+        if line.hasPrefix("+") { return .string }
+        if line.hasPrefix("-") { return .comment }
+        return nil
+    }
+
+    private static func cssSpans(source: String) -> [HighlightSpan] {
+        let keywords = keywordSet(for: "css")
+        let pattern = #"(/\*[\s\S]*?\*/)|("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(#(?:[0-9A-Fa-f]{3,8}|[A-Za-z_][A-Za-z0-9_-]*))|(\b\d+(?:\.\d+)?\b)|([A-Za-z_-][A-Za-z0-9_-]*)"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
         let nsSource = source as NSString
         var spans: [HighlightSpan] = []
@@ -172,14 +208,20 @@ private enum RegexFallbackHighlighter {
             guard let match else { return }
             let text = nsSource.substring(with: match.range)
             let capture: HighlightCapture
-            if text.hasPrefix("+") {
-                capture = text.hasPrefix("+++ ") ? .keyword : .string
-            } else if text.hasPrefix("-") {
-                capture = text.hasPrefix("--- ") ? .keyword : .comment
-            } else {
+            if match.range(at: 1).location != NSNotFound {
+                capture = .comment
+            } else if match.range(at: 2).location != NSNotFound {
+                capture = .string
+            } else if match.range(at: 3).location != NSNotFound || match.range(at: 4).location != NSNotFound {
+                capture = .number
+            } else if keywords.contains(text) || keywords.contains(text.lowercased()) {
                 capture = .keyword
+            } else {
+                capture = .plain
             }
-            spans.append(HighlightSpan(range: match.range, capture: capture))
+            if capture != .plain {
+                spans.append(HighlightSpan(range: match.range, capture: capture))
+            }
         }
         return spans
     }
@@ -212,24 +254,67 @@ private enum RegexFallbackHighlighter {
     }
 
     private static func booleanAttributeSpans(source: String, existingSpans: [HighlightSpan]) -> [HighlightSpan] {
-        let tagPattern = #"<[A-Za-z][A-Za-z0-9:-]*(?:\s+[^<>]*?)?/?>"#
         let attributePattern = #"\s+([A-Za-z_:][A-Za-z0-9_:.-]*)(?=\s*(?:=|/?>|\s))"#
-        guard let tagRegex = try? NSRegularExpression(pattern: tagPattern),
-              let attributeRegex = try? NSRegularExpression(pattern: attributePattern) else { return [] }
+        guard let attributeRegex = try? NSRegularExpression(pattern: attributePattern) else { return [] }
         let nsSource = source as NSString
+        let protectedSpans = existingSpans.filter { $0.capture == .comment || $0.capture == .string }
         var spans: [HighlightSpan] = []
-        tagRegex.enumerateMatches(in: source, range: NSRange(location: 0, length: nsSource.length)) { tagMatch, _, _ in
-            guard let tagMatch else { return }
-            attributeRegex.enumerateMatches(in: source, range: tagMatch.range) { attributeMatch, _, _ in
+        for tagRange in openingTagRanges(source: source, protectedSpans: protectedSpans) {
+            attributeRegex.enumerateMatches(in: source, range: tagRange) { attributeMatch, _, _ in
                 guard let attributeMatch else { return }
                 let range = attributeMatch.range(at: 1)
                 guard range.location != NSNotFound,
+                      !protectedSpans.contains(where: { contains($0.range, range) }),
                       !existingSpans.contains(where: { $0.capture == .attribute && $0.range == range }),
                       !spans.contains(where: { $0.range == range }) else { return }
                 spans.append(HighlightSpan(range: range, capture: .attribute))
             }
         }
         return spans
+    }
+
+    private static func openingTagRanges(source: String, protectedSpans: [HighlightSpan]) -> [NSRange] {
+        let nsSource = source as NSString
+        var ranges: [NSRange] = []
+        var offset = 0
+        while offset < nsSource.length {
+            guard nsSource.character(at: offset) == 60,
+                  !protectedSpans.contains(where: { contains($0.range, NSRange(location: offset, length: 1)) }),
+                  offset + 1 < nsSource.length else {
+                offset += 1
+                continue
+            }
+            let next = nsSource.character(at: offset + 1)
+            guard isMarkupNameStart(next) else {
+                offset += 1
+                continue
+            }
+            var cursor = offset + 1
+            var quote: unichar?
+            while cursor < nsSource.length {
+                let char = nsSource.character(at: cursor)
+                if let currentQuote = quote {
+                    if char == currentQuote { quote = nil }
+                } else if char == 34 || char == 39 {
+                    quote = char
+                } else if char == 62 {
+                    ranges.append(NSRange(location: offset, length: cursor - offset + 1))
+                    offset = cursor
+                    break
+                }
+                cursor += 1
+            }
+            offset += 1
+        }
+        return ranges
+    }
+
+    private static func contains(_ outer: NSRange, _ inner: NSRange) -> Bool {
+        inner.location >= outer.location && NSMaxRange(inner) <= NSMaxRange(outer)
+    }
+
+    private static func isMarkupNameStart(_ char: unichar) -> Bool {
+        (char >= 65 && char <= 90) || (char >= 97 && char <= 122)
     }
 
     private static func language(forFileExtension ext: String) -> String {

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -178,6 +178,9 @@ private enum RegexFallbackHighlighter {
                 contentRange.length -= 1
             }
             let text = nsSource.substring(with: contentRange)
+            if text.hasPrefix("diff --git ") {
+                inHunk = false
+            }
             if let capture = diffCapture(for: text, inHunk: inHunk) {
                 spans.append(HighlightSpan(range: contentRange, capture: capture))
             }

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -172,10 +172,10 @@ private enum RegexFallbackHighlighter {
             guard let match else { return }
             let text = nsSource.substring(with: match.range)
             let capture: HighlightCapture
-            if text.hasPrefix("+"), !text.hasPrefix("+++") {
-                capture = .string
-            } else if text.hasPrefix("-"), !text.hasPrefix("---") {
-                capture = .comment
+            if text.hasPrefix("+") {
+                capture = text.hasPrefix("+++ ") ? .keyword : .string
+            } else if text.hasPrefix("-") {
+                capture = text.hasPrefix("--- ") ? .keyword : .comment
             } else {
                 capture = .keyword
             }
@@ -185,7 +185,7 @@ private enum RegexFallbackHighlighter {
     }
 
     private static func markupSpans(source: String) -> [HighlightSpan] {
-        let pattern = #"(<!--[\s\S]*?-->)|("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(<\/?[A-Za-z][A-Za-z0-9:-]*)|([A-Za-z_:][A-Za-z0-9_:.-]*)(?=\=)"#
+        let pattern = #"(<!--[\s\S]*?-->)|("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(<\/?[A-Za-z][A-Za-z0-9:-]*)|([A-Za-z_:][A-Za-z0-9_:.-]*)(?=\s*\=)"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
         let nsSource = source as NSString
         var spans: [HighlightSpan] = []
@@ -205,6 +205,28 @@ private enum RegexFallbackHighlighter {
             }
             if capture != .plain {
                 spans.append(HighlightSpan(range: match.range, capture: capture))
+            }
+        }
+        spans.append(contentsOf: booleanAttributeSpans(source: source, existingSpans: spans))
+        return spans
+    }
+
+    private static func booleanAttributeSpans(source: String, existingSpans: [HighlightSpan]) -> [HighlightSpan] {
+        let tagPattern = #"<[A-Za-z][A-Za-z0-9:-]*(?:\s+[^<>]*?)?/?>"#
+        let attributePattern = #"\s+([A-Za-z_:][A-Za-z0-9_:.-]*)(?=\s*(?:=|/?>|\s))"#
+        guard let tagRegex = try? NSRegularExpression(pattern: tagPattern),
+              let attributeRegex = try? NSRegularExpression(pattern: attributePattern) else { return [] }
+        let nsSource = source as NSString
+        var spans: [HighlightSpan] = []
+        tagRegex.enumerateMatches(in: source, range: NSRange(location: 0, length: nsSource.length)) { tagMatch, _, _ in
+            guard let tagMatch else { return }
+            attributeRegex.enumerateMatches(in: source, range: tagMatch.range) { attributeMatch, _, _ in
+                guard let attributeMatch else { return }
+                let range = attributeMatch.range(at: 1)
+                guard range.location != NSNotFound,
+                      !existingSpans.contains(where: { $0.capture == .attribute && $0.range == range }),
+                      !spans.contains(where: { $0.range == range }) else { return }
+                spans.append(HighlightSpan(range: range, capture: .attribute))
             }
         }
         return spans

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -129,6 +129,11 @@ private enum RegexFallbackHighlighter {
     static func highlight(source: String, fileExtension ext: String) -> [HighlightSpan] {
         let language = language(forFileExtension: ext)
         guard language != "plain" else { return [] }
+        switch language {
+        case "diff": return diffSpans(source: source)
+        case "markup": return markupSpans(source: source)
+        default: break
+        }
         let keywords = keywordSet(for: language)
         let pattern = #"(//[^\n]*|/\*[\s\S]*?\*/|#[^\n]*)|("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(\b\d+(?:\.\d+)?\b)|([A-Za-z_][A-Za-z0-9_]*)"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
@@ -144,10 +149,57 @@ private enum RegexFallbackHighlighter {
                 capture = .string
             } else if match.range(at: 3).location != NSNotFound {
                 capture = .number
-            } else if keywords.contains(text) {
+            } else if keywords.contains(text) || keywords.contains(text.lowercased()) {
                 capture = .keyword
             } else if text.first?.isUppercase == true {
                 capture = .type
+            } else {
+                capture = .plain
+            }
+            if capture != .plain {
+                spans.append(HighlightSpan(range: match.range, capture: capture))
+            }
+        }
+        return spans
+    }
+
+    private static func diffSpans(source: String) -> [HighlightSpan] {
+        let pattern = #"(?m)^(@@.*@@|diff --git .*$|index .*$|--- .*$|\+\+\+ .*$|\+.*$|-.*$)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let nsSource = source as NSString
+        var spans: [HighlightSpan] = []
+        regex.enumerateMatches(in: source, range: NSRange(location: 0, length: nsSource.length)) { match, _, _ in
+            guard let match else { return }
+            let text = nsSource.substring(with: match.range)
+            let capture: HighlightCapture
+            if text.hasPrefix("+"), !text.hasPrefix("+++") {
+                capture = .string
+            } else if text.hasPrefix("-"), !text.hasPrefix("---") {
+                capture = .comment
+            } else {
+                capture = .keyword
+            }
+            spans.append(HighlightSpan(range: match.range, capture: capture))
+        }
+        return spans
+    }
+
+    private static func markupSpans(source: String) -> [HighlightSpan] {
+        let pattern = #"(<!--[\s\S]*?-->)|("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(<\/?[A-Za-z][A-Za-z0-9:-]*)|([A-Za-z_:][A-Za-z0-9_:.-]*)(?=\=)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let nsSource = source as NSString
+        var spans: [HighlightSpan] = []
+        regex.enumerateMatches(in: source, range: NSRange(location: 0, length: nsSource.length)) { match, _, _ in
+            guard let match else { return }
+            let capture: HighlightCapture
+            if match.range(at: 1).location != NSNotFound {
+                capture = .comment
+            } else if match.range(at: 2).location != NSNotFound {
+                capture = .string
+            } else if match.range(at: 3).location != NSNotFound {
+                capture = .keyword
+            } else if match.range(at: 4).location != NSNotFound {
+                capture = .attribute
             } else {
                 capture = .plain
             }
@@ -167,6 +219,10 @@ private enum RegexFallbackHighlighter {
         case "py": return "python"
         case "ts", "tsx", "js", "jsx": return "ts"
         case "kt", "kts": return "kotlin"
+        case "diff", "patch": return "diff"
+        case "html", "xml": return "markup"
+        case "css", "scss", "sass": return "css"
+        case "sql": return "sql"
         default: return "plain"
         }
     }
@@ -202,6 +258,19 @@ private enum RegexFallbackHighlighter {
                 "is", "as", "by", "where", "out", "reified", "inline", "noinline", "crossinline",
                 "operator", "infix", "tailrec", "suspend", "internal", "public", "private", "protected",
                 "expect", "actual", "const", "vararg", "dynamic", "external"
+            ]
+        case "css":
+            return [
+                "display", "flex", "grid", "block", "inline", "none", "color", "background", "border",
+                "margin", "padding", "position", "relative", "absolute", "fixed", "var", "calc",
+                "media", "import", "font", "width", "height", "min", "max"
+            ]
+        case "sql":
+            return [
+                "select", "from", "where", "join", "inner", "left", "right", "full", "outer", "on",
+                "insert", "into", "update", "delete", "values", "set", "create", "alter", "drop",
+                "table", "view", "index", "and", "or", "not", "null", "true", "false", "group",
+                "by", "order", "having", "limit", "offset", "as", "distinct"
             ]
         default:
             return []

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -218,6 +218,8 @@ private enum RegexFallbackHighlighter {
             "index ",
             "new file mode ",
             "deleted file mode ",
+            "old mode ",
+            "new mode ",
             "similarity index ",
             "dissimilarity index ",
             "rename from ",
@@ -256,7 +258,7 @@ private enum RegexFallbackHighlighter {
     }
 
     private static func markupSpans(source: String) -> [HighlightSpan] {
-        let pattern = #"(<!--[\s\S]*?-->)|("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(<\/?[A-Za-z][A-Za-z0-9:-]*)|([A-Za-z_:][A-Za-z0-9_:.-]*)(?=\s*\=)"#
+        let pattern = #"(<!--[\s\S]*?-->)|("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(<\/?[A-Za-z][A-Za-z0-9:-]*)"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
         let nsSource = source as NSString
         var spans: [HighlightSpan] = []
@@ -269,8 +271,6 @@ private enum RegexFallbackHighlighter {
                 capture = .string
             } else if match.range(at: 3).location != NSNotFound {
                 capture = .keyword
-            } else if match.range(at: 4).location != NSNotFound {
-                capture = .attribute
             } else {
                 capture = .plain
             }

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -166,9 +166,8 @@ private enum RegexFallbackHighlighter {
 
     private static func diffSpans(source: String) -> [HighlightSpan] {
         let nsSource = source as NSString
-        var spans: [HighlightSpan] = []
+        var lines: [(range: NSRange, text: String)] = []
         var offset = 0
-        var inHunk = false
         while offset < nsSource.length {
             let lineRange = nsSource.lineRange(for: NSRange(location: offset, length: 0))
             var contentRange = lineRange
@@ -177,28 +176,55 @@ private enum RegexFallbackHighlighter {
                 guard char == 10 || char == 13 else { break }
                 contentRange.length -= 1
             }
-            let text = nsSource.substring(with: contentRange)
-            if text.hasPrefix("diff --git ") {
+            lines.append((contentRange, nsSource.substring(with: contentRange)))
+            offset = lineRange.location + lineRange.length
+        }
+
+        var spans: [HighlightSpan] = []
+        var inHunk = false
+        for index in lines.indices {
+            let line = lines[index]
+            if line.text.hasPrefix("diff ") {
                 inHunk = false
             }
-            if let capture = diffCapture(for: text, inHunk: inHunk) {
-                spans.append(HighlightSpan(range: contentRange, capture: capture))
+            let previous = index > lines.startIndex ? lines[lines.index(before: index)].text : nil
+            let next = index < lines.index(before: lines.endIndex) ? lines[lines.index(after: index)].text : nil
+            let nextNextIndex = lines.index(index, offsetBy: 2, limitedBy: lines.index(before: lines.endIndex))
+            let nextNext = nextNextIndex.map { lines[$0].text }
+            if let capture = diffCapture(for: line.text, previous: previous, next: next, nextNext: nextNext, inHunk: inHunk) {
+                spans.append(HighlightSpan(range: line.range, capture: capture))
             }
-            if text.hasPrefix("@@"), text.contains("@@") {
+            if line.text.hasPrefix("@@"), line.text.contains("@@") {
                 inHunk = true
             }
-            offset = lineRange.location + lineRange.length
         }
         return spans
     }
 
-    private static func diffCapture(for line: String, inHunk: Bool) -> HighlightCapture? {
+    private static func diffCapture(for line: String, previous: String?, next: String?, nextNext: String?, inHunk: Bool) -> HighlightCapture? {
         if line.hasPrefix("@@"), line.contains("@@") { return .keyword }
-        if line.hasPrefix("diff --git ") || line.hasPrefix("index ") { return .keyword }
+        if isDiffMetadata(line) { return .keyword }
+        if line.hasPrefix("--- "), next?.hasPrefix("+++ ") == true, !inHunk || nextNext?.hasPrefix("@@") == true { return .keyword }
+        if line.hasPrefix("+++ "), previous?.hasPrefix("--- ") == true, !inHunk || next?.hasPrefix("@@") == true { return .keyword }
         if !inHunk, line.hasPrefix("--- ") || line.hasPrefix("+++ ") { return .keyword }
         if line.hasPrefix("+") { return .string }
         if line.hasPrefix("-") { return .comment }
         return nil
+    }
+
+    private static func isDiffMetadata(_ line: String) -> Bool {
+        [
+            "diff ",
+            "index ",
+            "new file mode ",
+            "deleted file mode ",
+            "similarity index ",
+            "dissimilarity index ",
+            "rename from ",
+            "rename to ",
+            "copy from ",
+            "copy to "
+        ].contains(where: { line.hasPrefix($0) })
     }
 
     private static func cssSpans(source: String) -> [HighlightSpan] {

--- a/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
+++ b/Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift
@@ -225,7 +225,8 @@ private enum RegexFallbackHighlighter {
             "rename from ",
             "rename to ",
             "copy from ",
-            "copy to "
+            "copy to ",
+            "\\ No newline at end of file"
         ].contains(where: { line.hasPrefix($0) })
     }
 

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -1,0 +1,59 @@
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP code block highlighter")
+struct ACPCodeBlockHighlighterTests {
+    @Test("maps common ACP fence labels to highlighter extensions")
+    func mapsFenceLabels() {
+        #expect(ACPCodeLanguage.highlighterExtension(for: "swift") == "swift")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "python") == "py")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "typescript") == "ts")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "javascript") == "js")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "shell") == "sh")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "zsh") == "sh")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "c++") == "cpp")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "{.swift}") == "swift")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "swift title=Example.swift") == "swift")
+    }
+
+    @Test("unknown and empty fence labels remain plain")
+    func unknownFenceLabels() {
+        #expect(ACPCodeLanguage.highlighterExtension(for: nil) == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "not-a-language") == nil)
+    }
+
+    @Test("Swift code applies syntax color while preserving monospaced font")
+    func swiftCodeAppliesSyntaxColor() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let attributed = ACPCodeBlockHighlighter.attributedString(
+            code: "func greet() {}",
+            language: "swift",
+            theme: theme
+        )
+        let ns = attributed.string as NSString
+        let funcRange = ns.range(of: "func")
+        let font = attributed.attribute(.font, at: funcRange.location, effectiveRange: nil) as? NSFont
+        let color = attributed.attribute(.foregroundColor, at: funcRange.location, effectiveRange: nil) as? NSColor
+
+        #expect(font?.isFixedPitch == true)
+        #expect(color != EditorTheme(theme: theme).defaultFG)
+    }
+
+    @Test("unknown code remains default-colored monospaced text")
+    func unknownCodeRemainsPlain() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let attributed = ACPCodeBlockHighlighter.attributedString(
+            code: "plain text",
+            language: "not-a-language",
+            theme: theme
+        )
+        let font = attributed.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        let color = attributed.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+
+        #expect(font?.isFixedPitch == true)
+        #expect(color == EditorTheme(theme: theme).defaultFG)
+    }
+}

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -58,4 +58,17 @@ struct ACPCodeBlockHighlighterTests {
         #expect(font?.isFixedPitch == true)
         #expect(color == EditorTheme(theme: theme).defaultFG)
     }
+
+    @Test("highlighted output bridges to Swift AttributedString")
+    func highlightedOutputBridgesToSwiftAttributedString() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let nsAttributed = ACPCodeBlockHighlighter.attributedString(
+            code: "let value = 1",
+            language: "swift",
+            theme: theme
+        )
+        let swiftAttributed = AttributedString(nsAttributed)
+
+        #expect(String(swiftAttributed.characters) == "let value = 1")
+    }
 }

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -11,6 +11,8 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(for: "python") == "py")
         #expect(ACPCodeLanguage.highlighterExtension(for: "typescript") == "ts")
         #expect(ACPCodeLanguage.highlighterExtension(for: "javascript") == "js")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "md") == "md")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "markdown") == "md")
         #expect(ACPCodeLanguage.highlighterExtension(for: "shell") == "sh")
         #expect(ACPCodeLanguage.highlighterExtension(for: "zsh") == "sh")
         #expect(ACPCodeLanguage.highlighterExtension(for: "c++") == "cpp")

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -235,6 +235,23 @@ struct TreeSitterHighlighterTests {
         #expect(capture(for: "++++ heading", in: src, spans: spans) == .string)
     }
 
+    @Test("diff fallback classifies post-hunk file marker lines as changed content")
+    func diffFallbackPostHunkMarkerLines() throws {
+        let src = """
+        --- a/file.md
+        +++ b/file.md
+        @@ -1,2 +1,2 @@
+        --- heading
+        +++ heading
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "diff")
+
+        #expect(capture(for: "--- a/file.md", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "+++ b/file.md", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "--- heading", in: src, spans: spans) == .comment)
+        #expect(capture(for: "+++ heading", in: src, spans: spans) == .string)
+    }
+
     @Test("markup, CSS, and SQL fallback emit useful spans")
     func chatFallbackBasics() throws {
         let html = TreeSitterHighlighter.highlight(source: #"<button class="primary">Save</button>"#, fileExtension: "html")
@@ -248,6 +265,17 @@ struct TreeSitterHighlighterTests {
         #expect(sql.contains(where: { $0.capture == .keyword }))
     }
 
+    @Test("CSS fallback does not treat hashes as line comments")
+    func cssFallbackDoesNotTreatHashesAsLineComments() throws {
+        let src = #".primary { color: #fff; background: red; } #app { display: grid; }"#
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "css")
+        let swallowedRange = NSRange(src.range(of: "#fff; background")!, in: src)
+
+        #expect(capture(for: "background", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "display", in: src, spans: spans) == .keyword)
+        #expect(!spans.contains(where: { $0.capture == .comment && NSIntersectionRange($0.range, swallowedRange).length == swallowedRange.length }))
+    }
+
     @Test("markup fallback captures spaced and boolean attributes exactly")
     func markupFallbackExactAttributes() throws {
         let src = #"<button class = "primary" disabled>Save</button>"#
@@ -256,6 +284,16 @@ struct TreeSitterHighlighterTests {
         #expect(capture(for: "class", in: src, spans: spans) == .attribute)
         #expect(capture(for: "disabled", in: src, spans: spans) == .attribute)
         #expect(capture(for: #""primary""#, in: src, spans: spans) == .string)
+    }
+
+    @Test("markup fallback does not recover boolean attributes inside comments or strings")
+    func markupFallbackSkipsBooleanAttributesInsideCommentsAndStrings() throws {
+        let src = #"<!-- <button disabled> --> <input disabled value="<tag disabled>">"#
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "html")
+
+        #expect(capture(for: "disabled", occurrence: 0, in: src, spans: spans) != .attribute)
+        #expect(capture(for: "disabled", occurrence: 1, in: src, spans: spans) == .attribute)
+        #expect(capture(for: "disabled", occurrence: 2, in: src, spans: spans) != .attribute)
     }
 
     @Test("string literal captured")
@@ -293,5 +331,26 @@ struct TreeSitterHighlighterTests {
         guard let range = source.range(of: substring) else { return nil }
         let nsRange = NSRange(range, in: source)
         return spans.first(where: { $0.range == nsRange })?.capture
+    }
+
+    private func capture(
+        for substring: String,
+        occurrence: Int,
+        in source: String,
+        spans: [HighlightSpan]
+    ) -> HighlightCapture? {
+        guard let range = range(of: substring, occurrence: occurrence, in: source) else { return nil }
+        let nsRange = NSRange(range, in: source)
+        return spans.first(where: { $0.range == nsRange })?.capture
+    }
+
+    private func range(of substring: String, occurrence: Int, in source: String) -> Range<String.Index>? {
+        var searchRange = source.startIndex..<source.endIndex
+        for index in 0...occurrence {
+            guard let range = source.range(of: substring, range: searchRange) else { return nil }
+            if index == occurrence { return range }
+            searchRange = range.upperBound..<source.endIndex
+        }
+        return nil
     }
 }

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -203,6 +203,32 @@ struct TreeSitterHighlighterTests {
         #expect(yaml.contains(where: { $0.capture == .property }))
     }
 
+    @Test("diff fallback colors added, removed, and hunk lines")
+    func diffFallbackBasics() throws {
+        let src = """
+        @@ -1,2 +1,2 @@
+        -old line
+        +new line
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "diff")
+        #expect(spans.contains(where: { $0.capture == .keyword }))
+        #expect(spans.contains(where: { $0.capture == .string }))
+        #expect(spans.contains(where: { $0.capture == .comment }))
+    }
+
+    @Test("markup, CSS, and SQL fallback emit useful spans")
+    func chatFallbackBasics() throws {
+        let html = TreeSitterHighlighter.highlight(source: #"<button class="primary">Save</button>"#, fileExtension: "html")
+        let css = TreeSitterHighlighter.highlight(source: #".primary { display: flex; color: #fff; }"#, fileExtension: "css")
+        let sql = TreeSitterHighlighter.highlight(source: #"SELECT id FROM users WHERE active = true;"#, fileExtension: "sql")
+
+        #expect(html.contains(where: { $0.capture == .keyword }))
+        #expect(html.contains(where: { $0.capture == .attribute }))
+        #expect(html.contains(where: { $0.capture == .string }))
+        #expect(css.contains(where: { $0.capture == .keyword }))
+        #expect(sql.contains(where: { $0.capture == .keyword }))
+    }
+
     @Test("string literal captured")
     func stringLiteral() throws {
         let src = #"let x = "hi""#

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -304,6 +304,7 @@ struct TreeSitterHighlighterTests {
         new mode 100755
         rename from old.txt
         rename to new.txt
+        \\ No newline at end of file
         """
         let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "patch")
 
@@ -313,6 +314,7 @@ struct TreeSitterHighlighterTests {
         #expect(capture(for: "new mode 100755", in: src, spans: spans) == .keyword)
         #expect(capture(for: "rename from old.txt", in: src, spans: spans) == .keyword)
         #expect(capture(for: "rename to new.txt", in: src, spans: spans) == .keyword)
+        #expect(capture(for: #"\ No newline at end of file"#, in: src, spans: spans) == .keyword)
     }
 
     @Test("markup, CSS, and SQL fallback emit useful spans")

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -252,6 +252,29 @@ struct TreeSitterHighlighterTests {
         #expect(capture(for: "+++ heading", in: src, spans: spans) == .string)
     }
 
+    @Test("diff fallback resets header state for each file block")
+    func diffFallbackResetsHeaderStateForEachFileBlock() throws {
+        let src = """
+        diff --git a/first.md b/first.md
+        index 1111111..2222222 100644
+        --- a/first.md
+        +++ b/first.md
+        @@ -1 +1 @@
+        +first line
+        diff --git a/second.md b/second.md
+        index 3333333..4444444 100644
+        --- a/second.md
+        +++ b/second.md
+        @@ -1 +1 @@
+        +++ heading
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "diff")
+
+        #expect(capture(for: "--- a/second.md", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "+++ b/second.md", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "+++ heading", in: src, spans: spans) == .string)
+    }
+
     @Test("markup, CSS, and SQL fallback emit useful spans")
     func chatFallbackBasics() throws {
         let html = TreeSitterHighlighter.highlight(source: #"<button class="primary">Save</button>"#, fileExtension: "html")

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -300,6 +300,8 @@ struct TreeSitterHighlighterTests {
         let src = """
         diff -u a b
         new file mode 100644
+        old mode 100644
+        new mode 100755
         rename from old.txt
         rename to new.txt
         """
@@ -307,6 +309,8 @@ struct TreeSitterHighlighterTests {
 
         #expect(capture(for: "diff -u a b", in: src, spans: spans) == .keyword)
         #expect(capture(for: "new file mode 100644", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "old mode 100644", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "new mode 100755", in: src, spans: spans) == .keyword)
         #expect(capture(for: "rename from old.txt", in: src, spans: spans) == .keyword)
         #expect(capture(for: "rename to new.txt", in: src, spans: spans) == .keyword)
     }
@@ -342,6 +346,16 @@ struct TreeSitterHighlighterTests {
 
         #expect(capture(for: "class", in: src, spans: spans) == .attribute)
         #expect(capture(for: "disabled", in: src, spans: spans) == .attribute)
+        #expect(capture(for: #""primary""#, in: src, spans: spans) == .string)
+    }
+
+    @Test("markup fallback does not classify assigned text outside tags as attributes")
+    func markupFallbackDoesNotClassifyAssignedTextOutsideTagsAsAttributes() throws {
+        let src = #"x = 1 <button class="primary">Save</button>"#
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "html")
+
+        #expect(capture(for: "x", in: src, spans: spans) != .attribute)
+        #expect(capture(for: "class", in: src, spans: spans) == .attribute)
         #expect(capture(for: #""primary""#, in: src, spans: spans) == .string)
     }
 

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -275,6 +275,42 @@ struct TreeSitterHighlighterTests {
         #expect(capture(for: "+++ heading", in: src, spans: spans) == .string)
     }
 
+    @Test("diff fallback recognizes adjacent non-Git file headers after hunks")
+    func diffFallbackRecognizesAdjacentNonGitFileHeadersAfterHunks() throws {
+        let src = """
+        --- first.txt
+        +++ first.txt
+        @@ -1 +1 @@
+        -old
+        +new
+        --- second.txt
+        +++ second.txt
+        @@ -1 +1 @@
+        +++ heading
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "patch")
+
+        #expect(capture(for: "--- second.txt", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "+++ second.txt", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "+++ heading", in: src, spans: spans) == .string)
+    }
+
+    @Test("diff fallback colors common metadata lines")
+    func diffFallbackCommonMetadataLines() throws {
+        let src = """
+        diff -u a b
+        new file mode 100644
+        rename from old.txt
+        rename to new.txt
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "patch")
+
+        #expect(capture(for: "diff -u a b", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "new file mode 100644", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "rename from old.txt", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "rename to new.txt", in: src, spans: spans) == .keyword)
+    }
+
     @Test("markup, CSS, and SQL fallback emit useful spans")
     func chatFallbackBasics() throws {
         let html = TreeSitterHighlighter.highlight(source: #"<button class="primary">Save</button>"#, fileExtension: "html")

--- a/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+++ b/AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
@@ -216,6 +216,25 @@ struct TreeSitterHighlighterTests {
         #expect(spans.contains(where: { $0.capture == .comment }))
     }
 
+    @Test("diff fallback classifies headers and changed marker runs exactly")
+    func diffFallbackExactMarkerClassification() throws {
+        let src = """
+        diff --git a/file.md b/file.md
+        index 1111111..2222222 100644
+        --- a/file.md
+        +++ b/file.md
+        @@ -1,2 +1,2 @@
+        ---- heading
+        ++++ heading
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "diff")
+
+        #expect(capture(for: "--- a/file.md", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "+++ b/file.md", in: src, spans: spans) == .keyword)
+        #expect(capture(for: "---- heading", in: src, spans: spans) == .comment)
+        #expect(capture(for: "++++ heading", in: src, spans: spans) == .string)
+    }
+
     @Test("markup, CSS, and SQL fallback emit useful spans")
     func chatFallbackBasics() throws {
         let html = TreeSitterHighlighter.highlight(source: #"<button class="primary">Save</button>"#, fileExtension: "html")
@@ -227,6 +246,16 @@ struct TreeSitterHighlighterTests {
         #expect(html.contains(where: { $0.capture == .string }))
         #expect(css.contains(where: { $0.capture == .keyword }))
         #expect(sql.contains(where: { $0.capture == .keyword }))
+    }
+
+    @Test("markup fallback captures spaced and boolean attributes exactly")
+    func markupFallbackExactAttributes() throws {
+        let src = #"<button class = "primary" disabled>Save</button>"#
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "html")
+
+        #expect(capture(for: "class", in: src, spans: spans) == .attribute)
+        #expect(capture(for: "disabled", in: src, spans: spans) == .attribute)
+        #expect(capture(for: #""primary""#, in: src, spans: spans) == .string)
     }
 
     @Test("string literal captured")
@@ -258,5 +287,11 @@ struct TreeSitterHighlighterTests {
         let spans = await session.highlight(source: #"let value = "hello""#, fileExtension: "swift", edits: [])
         let captures = Set(spans.map { $0.capture })
         #expect(captures.contains(.string))
+    }
+
+    private func capture(for substring: String, in source: String, spans: [HighlightSpan]) -> HighlightCapture? {
+        guard let range = source.range(of: substring) else { return nil }
+        let nsRange = NSRange(range, in: source)
+        return spans.first(where: { $0.range == nsRange })?.capture
     }
 }

--- a/docs/superpowers/plans/2026-05-28-acp-code-block-syntax-coloring.md
+++ b/docs/superpowers/plans/2026-05-28-acp-code-block-syntax-coloring.md
@@ -1,0 +1,569 @@
+# ACP Code Block Syntax Coloring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add theme-consistent syntax coloring to fenced code blocks rendered in ACP chat.
+
+**Architecture:** Keep ACP markdown parsing unchanged and add a focused code-block highlighter helper used by `CodeBlockView`. The helper maps Markdown fence labels to the existing `TreeSitterHighlighter` extension API, builds an `NSAttributedString`, and applies `EditorTheme` colors to valid highlight spans while preserving plain text behavior for unknown languages.
+
+**Tech Stack:** Swift 5.9, SwiftUI, AppKit `NSAttributedString`, Swift Testing, existing `TreeSitterHighlighter`, existing `EditorTheme`.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift`
+  - Owns ACP-specific fence-label normalization.
+  - Builds attributed code strings for ACP code blocks.
+  - Has no SwiftUI view responsibility.
+- Modify `Alas/Sources/ACP/UI/ACPMarkdownText.swift`
+  - Replaces `Text(code)` in `CodeBlockView` with attributed highlighted text.
+  - Keeps layout, copy behavior, scrolling, selection, spacing, and code block chrome unchanged.
+- Modify `Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift`
+  - Extends the existing private regex fallback for chat-only pseudo-extensions: `diff`, `patch`, `html`, `xml`, `css`, `scss`, `sass`, `sql`.
+  - Does not add Tree-sitter packages.
+- Create `AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift`
+  - Tests alias mapping and attributed output.
+- Modify `AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift`
+  - Tests the regex fallback additions through the public `TreeSitterHighlighter.highlight` API.
+
+---
+
+### Task 1: ACP Code Block Highlighter Helper
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift`
+- Create: `AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift`
+
+- [ ] **Step 1: Write failing tests for ACP language mapping and attributed output**
+
+Create `AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift`:
+
+```swift
+import AppKit
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP code block highlighter")
+struct ACPCodeBlockHighlighterTests {
+    @Test("maps common ACP fence labels to highlighter extensions")
+    func mapsFenceLabels() {
+        #expect(ACPCodeLanguage.highlighterExtension(for: "swift") == "swift")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "python") == "py")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "typescript") == "ts")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "javascript") == "js")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "shell") == "sh")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "zsh") == "sh")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "c++") == "cpp")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "{.swift}") == "swift")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "swift title=Example.swift") == "swift")
+    }
+
+    @Test("unknown and empty fence labels remain plain")
+    func unknownFenceLabels() {
+        #expect(ACPCodeLanguage.highlighterExtension(for: nil) == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "not-a-language") == nil)
+    }
+
+    @Test("Swift code applies syntax color while preserving monospaced font")
+    func swiftCodeAppliesSyntaxColor() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let attributed = ACPCodeBlockHighlighter.attributedString(
+            code: "func greet() {}",
+            language: "swift",
+            theme: theme
+        )
+        let ns = attributed.string as NSString
+        let funcRange = ns.range(of: "func")
+        let font = attributed.attribute(.font, at: funcRange.location, effectiveRange: nil) as? NSFont
+        let color = attributed.attribute(.foregroundColor, at: funcRange.location, effectiveRange: nil) as? NSColor
+
+        #expect(font?.isFixedPitch == true)
+        #expect(color != EditorTheme(theme: theme).defaultFG)
+    }
+
+    @Test("unknown code remains default-colored monospaced text")
+    func unknownCodeRemainsPlain() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let attributed = ACPCodeBlockHighlighter.attributedString(
+            code: "plain text",
+            language: "not-a-language",
+            theme: theme
+        )
+        let font = attributed.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        let color = attributed.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+
+        #expect(font?.isFixedPitch == true)
+        #expect(color == EditorTheme(theme: theme).defaultFG)
+    }
+}
+```
+
+- [ ] **Step 2: Run the new test file to verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPCodeBlockHighlighterTests
+```
+
+Expected: FAIL because `ACPCodeLanguage` and `ACPCodeBlockHighlighter` do not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift`:
+
+```swift
+import AppKit
+import Foundation
+
+enum ACPCodeLanguage {
+    static func highlighterExtension(for label: String?) -> String? {
+        guard let label else { return nil }
+        var normalized = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return nil }
+
+        if let first = normalized.split(whereSeparator: { $0.isWhitespace }).first {
+            normalized = String(first)
+        }
+        normalized = normalized
+            .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+            .lowercased()
+
+        if normalized.hasPrefix("{."), normalized.hasSuffix("}") {
+            normalized = String(normalized.dropFirst(2).dropLast())
+        } else if normalized.hasPrefix(".") {
+            normalized = String(normalized.dropFirst())
+        }
+
+        switch normalized {
+        case "swift": return "swift"
+        case "py", "python": return "py"
+        case "js", "javascript", "mjs", "cjs": return "js"
+        case "jsx": return "jsx"
+        case "ts", "typescript": return "ts"
+        case "tsx": return "tsx"
+        case "sh", "bash", "shell", "zsh", "console", "terminal": return "sh"
+        case "json": return "json"
+        case "yaml", "yml": return "yaml"
+        case "toml": return "toml"
+        case "rs", "rust": return "rs"
+        case "go", "golang": return "go"
+        case "java": return "java"
+        case "kt", "kotlin": return "kt"
+        case "kts": return "kts"
+        case "c": return "c"
+        case "h": return "h"
+        case "cpp", "c++": return "cpp"
+        case "cc": return "cc"
+        case "cxx": return "cxx"
+        case "hpp": return "hpp"
+        case "diff", "patch": return "diff"
+        case "html": return "html"
+        case "xml": return "xml"
+        case "css": return "css"
+        case "scss": return "scss"
+        case "sass": return "sass"
+        case "sql": return "sql"
+        default: return nil
+        }
+    }
+}
+
+enum ACPCodeBlockHighlighter {
+    static func attributedString(
+        code: String,
+        language: String?,
+        theme: Theme,
+        fontSize: CGFloat = 12
+    ) -> NSAttributedString {
+        let editorTheme = EditorTheme(theme: theme)
+        let baseAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+            .foregroundColor: editorTheme.defaultFG,
+        ]
+        let attributed = NSMutableAttributedString(string: code, attributes: baseAttributes)
+        guard !code.isEmpty,
+              let ext = ACPCodeLanguage.highlighterExtension(for: language) else {
+            return attributed
+        }
+
+        let length = (code as NSString).length
+        let spans = TreeSitterHighlighter.highlight(source: code, fileExtension: ext)
+        for span in spans {
+            guard span.range.location != NSNotFound,
+                  span.range.location >= 0,
+                  NSMaxRange(span.range) <= length else {
+                continue
+            }
+            attributed.addAttributes(editorTheme.attributes(for: span.capture), range: span.range)
+        }
+        return attributed
+    }
+}
+```
+
+- [ ] **Step 4: Run the helper tests to verify they pass**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPCodeBlockHighlighterTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+git commit -m "feat(acp): add code block highlighter helper"
+```
+
+---
+
+### Task 2: Chat-Oriented Regex Fallback Extensions
+
+**Files:**
+- Modify: `Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift`
+- Modify: `AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift`
+
+- [ ] **Step 1: Write failing tests for chat-only fallback extensions**
+
+Append these tests to `AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift` inside `TreeSitterHighlighterTests`:
+
+```swift
+    @Test("diff fallback colors added, removed, and hunk lines")
+    func diffFallbackBasics() throws {
+        let src = """
+        @@ -1,2 +1,2 @@
+        -old line
+        +new line
+        """
+        let spans = TreeSitterHighlighter.highlight(source: src, fileExtension: "diff")
+        #expect(spans.contains(where: { $0.capture == .keyword }))
+        #expect(spans.contains(where: { $0.capture == .string }))
+        #expect(spans.contains(where: { $0.capture == .comment }))
+    }
+
+    @Test("markup, CSS, and SQL fallback emit useful spans")
+    func chatFallbackBasics() throws {
+        let html = TreeSitterHighlighter.highlight(source: #"<button class="primary">Save</button>"#, fileExtension: "html")
+        let css = TreeSitterHighlighter.highlight(source: #".primary { display: flex; color: #fff; }"#, fileExtension: "css")
+        let sql = TreeSitterHighlighter.highlight(source: #"SELECT id FROM users WHERE active = true;"#, fileExtension: "sql")
+
+        #expect(html.contains(where: { $0.capture == .keyword }))
+        #expect(html.contains(where: { $0.capture == .attribute }))
+        #expect(html.contains(where: { $0.capture == .string }))
+        #expect(css.contains(where: { $0.capture == .keyword }))
+        #expect(sql.contains(where: { $0.capture == .keyword }))
+    }
+```
+
+- [ ] **Step 2: Run the fallback tests to verify they fail**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/TreeSitterHighlighterTests/diffFallbackBasics -only-testing:AlasTests/TreeSitterHighlighterTests/chatFallbackBasics
+```
+
+Expected: FAIL because these extensions currently return no spans.
+
+- [ ] **Step 3: Extend the regex fallback**
+
+In `Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift`, update `RegexFallbackHighlighter.highlight(source:fileExtension:)` so it dispatches special fallback lexers before the generic regex:
+
+```swift
+    static func highlight(source: String, fileExtension ext: String) -> [HighlightSpan] {
+        let language = language(forFileExtension: ext)
+        guard language != "plain" else { return [] }
+        switch language {
+        case "diff": return diffSpans(source: source)
+        case "markup": return markupSpans(source: source)
+        default: break
+        }
+
+        let keywords = keywordSet(for: language)
+        let pattern = #"(//[^\n]*|/\*[\s\S]*?\*/|#[^\n]*)|("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(\b\d+(?:\.\d+)?\b)|([A-Za-z_][A-Za-z0-9_]*)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let nsSource = source as NSString
+        var spans: [HighlightSpan] = []
+        regex.enumerateMatches(in: source, range: NSRange(location: 0, length: nsSource.length)) { match, _, _ in
+            guard let match else { return }
+            let text = nsSource.substring(with: match.range)
+            let capture: HighlightCapture
+            if match.range(at: 1).location != NSNotFound {
+                capture = .comment
+            } else if match.range(at: 2).location != NSNotFound {
+                capture = .string
+            } else if match.range(at: 3).location != NSNotFound {
+                capture = .number
+            } else if keywords.contains(text) || keywords.contains(text.lowercased()) {
+                capture = .keyword
+            } else if text.first?.isUppercase == true {
+                capture = .type
+            } else {
+                capture = .plain
+            }
+            if capture != .plain {
+                spans.append(HighlightSpan(range: match.range, capture: capture))
+            }
+        }
+        return spans
+    }
+```
+
+Add these private helpers inside `RegexFallbackHighlighter`:
+
+```swift
+    private static func diffSpans(source: String) -> [HighlightSpan] {
+        let pattern = #"(?m)^(@@.*@@|diff --git .*$|index .*$|--- .*$|\+\+\+ .*$|\+.*$|-.*$)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let nsSource = source as NSString
+        var spans: [HighlightSpan] = []
+        regex.enumerateMatches(in: source, range: NSRange(location: 0, length: nsSource.length)) { match, _, _ in
+            guard let match else { return }
+            let text = nsSource.substring(with: match.range)
+            let capture: HighlightCapture
+            if text.hasPrefix("+"), !text.hasPrefix("+++") {
+                capture = .string
+            } else if text.hasPrefix("-"), !text.hasPrefix("---") {
+                capture = .comment
+            } else {
+                capture = .keyword
+            }
+            spans.append(HighlightSpan(range: match.range, capture: capture))
+        }
+        return spans
+    }
+
+    private static func markupSpans(source: String) -> [HighlightSpan] {
+        let pattern = #"(<!--[\s\S]*?-->)|("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')|(<\/?[A-Za-z][A-Za-z0-9:-]*)|([A-Za-z_:][A-Za-z0-9_:.-]*)(?=\=)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let nsSource = source as NSString
+        var spans: [HighlightSpan] = []
+        regex.enumerateMatches(in: source, range: NSRange(location: 0, length: nsSource.length)) { match, _, _ in
+            guard let match else { return }
+            let capture: HighlightCapture
+            if match.range(at: 1).location != NSNotFound {
+                capture = .comment
+            } else if match.range(at: 2).location != NSNotFound {
+                capture = .string
+            } else if match.range(at: 3).location != NSNotFound {
+                capture = .keyword
+            } else if match.range(at: 4).location != NSNotFound {
+                capture = .attribute
+            } else {
+                capture = .plain
+            }
+            if capture != .plain {
+                spans.append(HighlightSpan(range: match.range, capture: capture))
+            }
+        }
+        return spans
+    }
+```
+
+Update `language(forFileExtension:)`:
+
+```swift
+    private static func language(forFileExtension ext: String) -> String {
+        switch ext.lowercased() {
+        case "swift": return "swift"
+        case "rs": return "rust"
+        case "json": return "json"
+        case "md", "markdown": return "markdown"
+        case "py": return "python"
+        case "ts", "tsx", "js", "jsx": return "ts"
+        case "kt", "kts": return "kotlin"
+        case "diff", "patch": return "diff"
+        case "html", "xml": return "markup"
+        case "css", "scss", "sass": return "css"
+        case "sql": return "sql"
+        default: return "plain"
+        }
+    }
+```
+
+Extend `keywordSet(for:)` with CSS and SQL:
+
+```swift
+        case "css":
+            return [
+                "display", "flex", "grid", "block", "inline", "none", "color", "background", "border",
+                "margin", "padding", "position", "relative", "absolute", "fixed", "var", "calc",
+                "media", "import", "font", "width", "height", "min", "max"
+            ]
+        case "sql":
+            return [
+                "select", "from", "where", "join", "inner", "left", "right", "full", "outer", "on",
+                "insert", "into", "update", "delete", "values", "set", "create", "alter", "drop",
+                "table", "view", "index", "and", "or", "not", "null", "true", "false", "group",
+                "by", "order", "having", "limit", "offset", "as", "distinct"
+            ]
+```
+
+- [ ] **Step 4: Run the fallback tests to verify they pass**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/TreeSitterHighlighterTests/diffFallbackBasics -only-testing:AlasTests/TreeSitterHighlighterTests/chatFallbackBasics
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift AlasTests/Code/Highlight/TreeSitterHighlighterTests.swift
+git commit -m "feat(code): extend regex highlighting fallbacks"
+```
+
+---
+
+### Task 3: Wire Highlighting Into ACP Code Blocks
+
+**Files:**
+- Modify: `Alas/Sources/ACP/UI/ACPMarkdownText.swift`
+- Modify: `AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift`
+
+- [ ] **Step 1: Add a bridge test for SwiftUI-compatible attributed output**
+
+Append this test to `AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift` inside `ACPCodeBlockHighlighterTests`:
+
+```swift
+    @Test("highlighted output bridges to Swift AttributedString")
+    func highlightedOutputBridgesToSwiftAttributedString() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let nsAttributed = ACPCodeBlockHighlighter.attributedString(
+            code: "let value = 1",
+            language: "swift",
+            theme: theme
+        )
+        let swiftAttributed = AttributedString(nsAttributed)
+
+        #expect(String(swiftAttributed.characters) == "let value = 1")
+    }
+```
+
+- [ ] **Step 2: Run the ACP helper tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPCodeBlockHighlighterTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Update `CodeBlockView` to render highlighted attributed text**
+
+In `Alas/Sources/ACP/UI/ACPMarkdownText.swift`, replace this block:
+
+```swift
+                Text(code)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(theme.color("fg"))
+                    .lineSpacing(2)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 10).padding(.vertical, 8)
+```
+
+with:
+
+```swift
+                Text(AttributedString(ACPCodeBlockHighlighter.attributedString(
+                    code: code,
+                    language: language,
+                    theme: theme
+                )))
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(theme.color("fg"))
+                .lineSpacing(2)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 10).padding(.vertical, 8)
+```
+
+Keep all other `CodeBlockView` code unchanged.
+
+- [ ] **Step 4: Run the ACP helper tests again**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPCodeBlockHighlighterTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add Alas/Sources/ACP/UI/ACPMarkdownText.swift AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+git commit -m "feat(acp): color chat code blocks"
+```
+
+---
+
+### Task 4: Final Verification
+
+**Files:**
+- Verify all files changed by Tasks 1-3.
+
+- [ ] **Step 1: Regenerate the Xcode project**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: exits 0. This may be a no-op if the source tree is already picked up by folder references, but run it because project instructions require it before finishing.
+
+- [ ] **Step 2: Build the app**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Inspect the final diff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline -5
+```
+
+Expected: only intentional generated changes remain uncommitted, or the worktree is clean. Recent commits should include the task commits from this plan.
+
+- [ ] **Step 5: Commit generated project changes if xcodegen changed them**
+
+If `git status --short` shows changes to `Alas.xcodeproj/project.pbxproj`, run:
+
+```bash
+git add Alas.xcodeproj/project.pbxproj
+git commit -m "chore: regenerate Xcode project"
+```
+
+Expected: generated project updates are committed. If `git status --short` is clean, skip this step.

--- a/docs/superpowers/specs/2026-05-28-acp-code-block-syntax-coloring-design.md
+++ b/docs/superpowers/specs/2026-05-28-acp-code-block-syntax-coloring-design.md
@@ -1,0 +1,115 @@
+# Design: ACP Code Block Syntax Coloring
+
+**Date:** 2026-05-28
+**Status:** Draft
+
+## Problem
+
+ACP chat messages render fenced code blocks in `Alas/Sources/ACP/UI/ACPMarkdownText.swift` as plain monospaced text. This preserves content and copy behavior, but makes agent answers harder to scan when they include Swift, shell, JSON, TypeScript, or other code examples.
+
+The app already has a Tree-sitter backed highlighter in `TreeSitterHighlighter`, a regex fallback for supported-but-unavailable language paths, and theme-aware capture styling in `EditorTheme`. Markdown file preview already uses this path for fenced code blocks. ACP chat should reuse the same infrastructure instead of adding a second syntax coloring system.
+
+## Solution
+
+Add syntax coloring to ACP fenced code blocks by converting each code fence language label into the file extension expected by `TreeSitterHighlighter.highlight(source:fileExtension:)`, then applying the returned `HighlightSpan`s to an attributed string displayed by `CodeBlockView`.
+
+The change is scoped to ACP chat rendering:
+
+- Existing code block layout, header, copy button, scrolling, selection, spacing, and background chrome stay unchanged.
+- Supported Tree-sitter languages use the existing parser and query path.
+- Known labels with no parser package can use the existing regex fallback where possible or remain plain.
+- Unknown or missing language labels render as plain monospaced text.
+- Syntax colors come from `EditorTheme.attributes(for:)`, keeping ACP chat consistent with the editor and Markdown preview.
+
+## Component Changes
+
+### ACPCodeLanguage
+
+Add a small, testable mapper near the ACP markdown renderer or in a focused ACP UI support file:
+
+```swift
+enum ACPCodeLanguage {
+    static func highlighterExtension(for label: String?) -> String?
+}
+```
+
+The mapper normalizes fence labels by lowercasing and trimming common Markdown fence metadata. Examples:
+
+| Labels | Extension |
+|--------|-----------|
+| `swift` | `swift` |
+| `py`, `python` | `py` |
+| `js`, `javascript`, `mjs`, `cjs` | `js` |
+| `jsx` | `jsx` |
+| `ts`, `typescript` | `ts` |
+| `tsx` | `tsx` |
+| `sh`, `bash`, `shell`, `zsh`, `console`, `terminal` | `sh` |
+| `json` | `json` |
+| `yaml`, `yml` | `yaml` |
+| `toml` | `toml` |
+| `rs`, `rust` | `rs` |
+| `go`, `golang` | `go` |
+| `java` | `java` |
+| `kt`, `kotlin`, `kts` | `kt` / `kts` |
+| `c`, `h` | `c` / `h` |
+| `cpp`, `c++`, `cc`, `cxx`, `hpp` | `cpp` / matching C++ extension |
+
+Common chat labels without current Tree-sitter coverage are allowed but should degrade predictably:
+
+- `diff`, `patch`
+- `html`, `xml`
+- `css`, `scss`, `sass`
+- `sql`
+
+For these labels, the mapper may return a stable pseudo-extension only if the fallback path can color something useful. Otherwise it should return nil and render plain text. The implementation should not add new parser packages for this feature.
+
+### CodeBlockView
+
+Replace `Text(code)` with a small attributed string builder:
+
+```swift
+private func highlightedCode() -> AttributedString
+```
+
+Behavior:
+
+1. Start with the full code string in the existing monospaced 12pt font and default foreground color.
+2. Resolve the fence label through `ACPCodeLanguage`.
+3. If no extension is found, return the plain attributed string.
+4. Call `TreeSitterHighlighter.highlight(source:fileExtension:)`.
+5. Apply `EditorTheme(theme: theme).attributes(for:)` to each valid span.
+6. Return the attributed string to SwiftUI `Text`.
+
+Invalid spans should be ignored defensively. Highlighting should not change the copied text.
+
+### Optional Regex Coverage
+
+If the current fallback does not color desired chat-only labels, extend `RegexFallbackHighlighter` conservatively for simple languages only. This is optional and should be limited to labels where a small keyword/string/comment pattern gives useful output without pretending to be a full parser.
+
+## Error Handling
+
+- Empty code block: render an empty monospaced block as today.
+- Empty or missing language label: render plain monospaced text.
+- Unknown language label: render plain monospaced text.
+- Tree-sitter parser or query unavailable: use the existing highlighter fallback behavior.
+- Malformed source for a language: return whatever spans Tree-sitter produces; never hide or modify code text.
+- Span range outside the string: skip that span.
+
+## Testing
+
+Add focused Swift Testing coverage:
+
+- `ACPCodeLanguage` maps common aliases such as `python`, `typescript`, `shell`, `zsh`, `javascript`, and `c++`.
+- Unknown labels map to nil.
+- The attributed code builder applies a non-default foreground color to `func` in a Swift code block.
+- Unknown-language code remains monospaced and default-colored.
+
+If direct SwiftUI `View` inspection is awkward, keep the highlight application in a pure helper and test that helper.
+
+## Out of Scope
+
+- Adding new Tree-sitter parser packages.
+- Replacing `ACPMarkdownText` with the full Markdown preview renderer.
+- Syntax coloring inline code in ACP prose.
+- Highlighting code while the user types in the ACP composer.
+- Changing ACP message persistence or protocol handling.


### PR DESCRIPTION
## Summary
- Add syntax coloring for fenced code blocks in ACP chat using the existing Tree-sitter highlighter path.
- Map common Markdown fence labels to supported extensions and add bounded regex fallback support for diff/patch, markup, CSS, and SQL.
- Keep code block layout and copy behavior unchanged while adding focused test coverage.

## Test Plan
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`