### PR TITLE
feat(acp): chat queue + steering

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */; };
 		0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */; };
 		0F560F9B2458B94C807E96A1 /* CodeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBC01971BF41E6D0B9B317CF /* CodeTextView.swift */; };
+		0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */; };
 		10190501C79554DA17FBC5F7 /* permission-request.json in Resources */ = {isa = PBXBuildFile; fileRef = C48DB0098D71F26ABF594615 /* permission-request.json */; };
 		102686FD795DE94337B3A030 /* SQLiteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D0843198D3386919147FF /* SQLiteError.swift */; };
 		10557FBC430EEAB1196D9575 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */; };
@@ -86,6 +87,7 @@
 		1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */; };
 		1B1A33B610D29116A1D08A74 /* PointingHandCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */; };
 		1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */; };
+		1B7A283F7F585BA8D67C1959 /* ACPSteerUndoToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */; };
 		1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E1AD3C6506DA5E6BFF4864 /* ImagePreviewTabView.swift */; };
 		1BC03FAEA1E89F3A74A98DE4 /* AppConfigShortcutsCodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */; };
 		1C5D64F032EAD5EA28B2482B /* ACPComposerActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */; };
@@ -197,6 +199,7 @@
 		3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E62B501E0490F48CCA830 /* EditorFindBarView.swift */; };
 		3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8A28C3DBC50749BB1D2BEA /* HeadReaderTests.swift */; };
 		3F54F0437585F96F5774A3BD /* ACPSetupNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6791BB640C39115289BF6D07 /* ACPSetupNudgeBanner.swift */; };
+		3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */; };
 		3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64C0B7363363C77718B446C /* CopilotInstaller.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */; };
@@ -254,6 +257,7 @@
 		51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25493E3B18A1AB94EA6985C3 /* EventHolder.swift */; };
 		513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */; };
 		514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */; };
+		518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */; };
 		51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */; };
 		523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE8B45ECF898B83A616586D /* SubHeader.swift */; };
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
@@ -382,6 +386,7 @@
 		82D3560952F0B800F56377D7 /* AgentHookInstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */; };
 		82E9F713C1BFF433E540314C /* AgentLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F6E707551671670D8CBA38 /* AgentLogoView.swift */; };
 		8312A5067AD6E0143FA83023 /* JSONRPCStdioTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A1EB96EBED0DEDCA5CD094 /* JSONRPCStdioTransport.swift */; };
+		832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */; };
 		8352A6C0D7AE371907E50217 /* TreeSitterPython in Frameworks */ = {isa = PBXBuildFile; productRef = 7D55FFC5D9F65DAD0178FB0E /* TreeSitterPython */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
@@ -437,6 +442,7 @@
 		94354D17B0FEF3F0046B452A /* ACPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */; };
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
 		956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */; };
+		9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */; };
 		9707DC02317F0E92AB06196B /* ImageDiffModeApplicabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE911B77AC087704180BDB5 /* ImageDiffModeApplicabilityTests.swift */; };
 		9782C5866410EFE13E670AFF /* FilesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A3B9B1103346242438940 /* FilesTabView.swift */; };
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
@@ -525,6 +531,7 @@
 		B58BF89C3A788A31CBED2067 /* TreeSitterJava in Frameworks */ = {isa = PBXBuildFile; productRef = 33EB43DCB691861654EC147A /* TreeSitterJava */; };
 		B5E38A6134CDE9F8D5EA76D1 /* CompletionWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */; };
 		B614CD7F894DD6908C903254 /* InstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */; };
+		B6580745C7EDF5AA65DB0A86 /* QueuedPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */; };
 		B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA5E54A30636928F5D3B3E /* GitIgnoreService.swift */; };
 		B6713CE9BFA38B7F1D089E5A /* CopilotInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */; };
 		B6C31E7AC3CE21AFEA371389 /* cool-slate.json in Resources */ = {isa = PBXBuildFile; fileRef = 8DEB85132B767DB3B253620C /* cool-slate.json */; };
@@ -544,6 +551,7 @@
 		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
+		BD1CDAECF2D1928C95796F63 /* ACPSessionStoreQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */; };
 		BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */; };
 		BDBAA6601CA3FD8A5562E637 /* AppStateFocusMainWorktreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */; };
 		BE4E46595AF10611CE0B1C6B /* TabActivityPulse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */; };
@@ -627,6 +635,7 @@
 		D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */; };
 		D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */; };
 		D55386035B99B2B1769ED47F /* NumstatParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */; };
+		D56C78F4D6A2BDFDF5A05B55 /* ACPSessionRunnerQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */; };
 		D57EB5733286B9E762F67698 /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1EC032FDD03ED4A86B96A8 /* SettingsWindow.swift */; };
 		D5C1783F56883B8AF68BF010 /* ACPRecentSessionsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEFEC5C44608F4F70105798 /* ACPRecentSessionsButton.swift */; };
 		D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */; };
@@ -638,6 +647,7 @@
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
 		D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABD3A575FAEC381A5744BFA /* FileTreeBuilderTests.swift */; };
 		D8741FB38F9FB2C180FE37E3 /* AppStateCreateWorktreeLaunchSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8A5932B664C88F20BF00CA /* AppStateCreateWorktreeLaunchSurfaceTests.swift */; };
+		D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */; };
 		D8ACECF849D38029FB56C303 /* CenterTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0307CFD55404D01F14A5B602 /* CenterTypography.swift */; };
 		DA5ED6D708DD8C0B5563AB4F /* WindowDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */; };
 		DAA6F5DABE3214693628C730 /* ACPFilesystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D9E527A76820947F426A8 /* ACPFilesystem.swift */; };
@@ -699,6 +709,7 @@
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
+		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
 		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */; };
@@ -758,6 +769,7 @@
 		0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCache.swift; sourceTree = "<group>"; };
 		0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSplitButton.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
+		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
 		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
 		05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
@@ -775,6 +787,7 @@
 		0A442AC7909A919582DF4372 /* SQLiteStatement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteStatement.swift; sourceTree = "<group>"; };
 		0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateUnstagePathsTests.swift; sourceTree = "<group>"; };
 		0AF8152B18C9D6290724122F /* HoverFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeature.swift; sourceTree = "<group>"; };
+		0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionQueueAPITests.swift; sourceTree = "<group>"; };
 		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
 		0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionPrompt.swift; sourceTree = "<group>"; };
 		0C5373F76231F229D3F96AF3 /* session-update-config-option.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-option.json"; sourceTree = "<group>"; };
@@ -788,6 +801,7 @@
 		0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThoughtView.swift; sourceTree = "<group>"; };
 		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
 		1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
+		10602801D3FA990E60CB072D /* ACPQueueHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueueHeader.swift; sourceTree = "<group>"; };
 		11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClientTests.swift; sourceTree = "<group>"; };
 		11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTerminalLaunchTests.swift; sourceTree = "<group>"; };
 		11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateFocusMainWorktreeTests.swift; sourceTree = "<group>"; };
@@ -850,6 +864,7 @@
 		25CBAF6618B6D11EC3B9CC76 /* InstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeResolver.swift; sourceTree = "<group>"; };
 		25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderViewTests.swift; sourceTree = "<group>"; };
 		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
+		26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntentTests.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
 		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
 		27A92711BC1D9A78D8A80561 /* GitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypes.swift; sourceTree = "<group>"; };
@@ -995,6 +1010,7 @@
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
 		542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationState.swift; sourceTree = "<group>"; };
+		547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunnerQueueTests.swift; sourceTree = "<group>"; };
 		54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallContentTests.swift; sourceTree = "<group>"; };
 		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
 		561094BA96058468F12002A1 /* ConflictsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictsSection.swift; sourceTree = "<group>"; };
@@ -1117,6 +1133,7 @@
 		8526C9DB63760BDD2CE998BD /* fs-write.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fs-write.json"; sourceTree = "<group>"; };
 		8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpec.swift; sourceTree = "<group>"; };
 		856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscardTests.swift; sourceTree = "<group>"; };
+		85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerPlaceholderTests.swift; sourceTree = "<group>"; };
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
 		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
 		881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputer.swift; sourceTree = "<group>"; };
@@ -1165,6 +1182,7 @@
 		97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-options.json"; sourceTree = "<group>"; };
 		97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshotTests.swift; sourceTree = "<group>"; };
 		9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOptionTests.swift; sourceTree = "<group>"; };
+		987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueuedBubble.swift; sourceTree = "<group>"; };
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
 		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
@@ -1196,6 +1214,7 @@
 		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
 		A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAnnotationStrip.swift; sourceTree = "<group>"; };
 		A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdateTests.swift; sourceTree = "<group>"; };
+		A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntent.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimer.swift; sourceTree = "<group>"; };
 		A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailView.swift; sourceTree = "<group>"; };
@@ -1264,6 +1283,7 @@
 		BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstallerTests.swift; sourceTree = "<group>"; };
 		BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequest.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
+		BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPrompt.swift; sourceTree = "<group>"; };
 		C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeAgentTests.swift; sourceTree = "<group>"; };
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
 		C204307EE573512D731B8307 /* ACPGeminiE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPGeminiE2ETests.swift; sourceTree = "<group>"; };
@@ -1286,6 +1306,7 @@
 		C6CA79B71B4AA72697392702 /* NumstatParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParser.swift; sourceTree = "<group>"; };
 		C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
 		C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStrip.swift; sourceTree = "<group>"; };
+		C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSteerUndoToast.swift; sourceTree = "<group>"; };
 		C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTheme.swift; sourceTree = "<group>"; };
 		C7DD2CA21EC45168D6E43564 /* TabActivityPulseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulseTests.swift; sourceTree = "<group>"; };
 		C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spinner.swift; sourceTree = "<group>"; };
@@ -1442,6 +1463,7 @@
 		FC4A215AF2876091E31F6F8A /* LineEnding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineEnding.swift; sourceTree = "<group>"; };
 		FC8E722C16FFBEEEC43337D5 /* ACPSetupCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupCheck.swift; sourceTree = "<group>"; };
 		FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorView.swift; sourceTree = "<group>"; };
+		FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPromptTests.swift; sourceTree = "<group>"; };
 		FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstaller.swift; sourceTree = "<group>"; };
 		FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipeTests.swift; sourceTree = "<group>"; };
 		FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceUpstreamTests.swift; sourceTree = "<group>"; };
@@ -2054,6 +2076,7 @@
 			children = (
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
+				85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -2087,7 +2110,9 @@
 				7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */,
 				F332906E17C5865856DBB90B /* ACPSessionRunner.swift */,
 				E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */,
+				A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */,
 				9F3A345F0B643467352DB5F3 /* ProcessKiller.swift */,
+				BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -2243,10 +2268,13 @@
 				3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */,
 				0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */,
 				5E3365E06CDDF9C235A03BA6 /* ACPPlanCard.swift */,
+				987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */,
+				10602801D3FA990E60CB072D /* ACPQueueHeader.swift */,
 				4DEFEC5C44608F4F70105798 /* ACPRecentSessionsButton.swift */,
 				B5E898E9F7E2680132FF54D4 /* ACPSelectChip.swift */,
 				6791BB640C39115289BF6D07 /* ACPSetupNudgeBanner.swift */,
 				93C3F02ECEA5D545FA268DB8 /* ACPSlashPicker.swift */,
+				C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */,
 				C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */,
 				B832ED19AC178DAD77C78D37 /* ACPTabView.swift */,
 				0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */,
@@ -2420,10 +2448,15 @@
 				AA11223300AA4455667788CC /* ACPMessageStableIdTests.swift */,
 				AA22334400BB5566778899EE /* ACPStreamingTextTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
+				0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */,
+				547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */,
 				B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */,
 				45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */,
+				03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */,
 				F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */,
 				1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */,
+				26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */,
+				FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */,
 			);
 			path = Session;
 			sourceTree = "<group>";
@@ -3056,6 +3089,8 @@
 				823AA3E801A11C535C9438BD /* ACPPermissionScope.swift in Sources */,
 				1DB47076C613039ECE164F28 /* ACPPlanCard.swift in Sources */,
 				7556121D51C54458FCAFED2A /* ACPProtocolVersion.swift in Sources */,
+				F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */,
+				518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */,
 				D5C1783F56883B8AF68BF010 /* ACPRecentSessionsButton.swift in Sources */,
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
@@ -3070,6 +3105,8 @@
 				3F54F0437585F96F5774A3BD /* ACPSetupNudgeBanner.swift in Sources */,
 				C5644E1144140B99E8676064 /* ACPSlashPicker.swift in Sources */,
 				A3EE2DE5C01EB87DE7BCC801 /* ACPStdioClient.swift in Sources */,
+				1B7A283F7F585BA8D67C1959 /* ACPSteerUndoToast.swift in Sources */,
+				9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */,
 				8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */,
 				F66BDC777D0BFDE306E8880A /* ACPTabView.swift in Sources */,
 				48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */,
@@ -3327,6 +3364,7 @@
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
 				6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */,
 				50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */,
+				0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */,
 				3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
@@ -3428,6 +3466,7 @@
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,
+				3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,
 				B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */,
@@ -3445,13 +3484,17 @@
 				8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */,
 				C51451EC8E103EB5FEF82EFE /* ACPSessionLifecycleTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
+				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,
+				D56C78F4D6A2BDFDF5A05B55 /* ACPSessionRunnerQueueTests.swift in Sources */,
 				57A5A3F4F14E75F6C00A2DC0 /* ACPSessionRunnerTests.swift in Sources */,
 				20096441D4850614A3CB8187 /* ACPSessionStoreCRUDTests.swift in Sources */,
+				BD1CDAECF2D1928C95796F63 /* ACPSessionStoreQueueTests.swift in Sources */,
 				08DF3AC4BA50775940371445 /* ACPSessionStoreTests.swift in Sources */,
 				B472D692A8D8D1C664EAC467 /* ACPSessionTests.swift in Sources */,
 				33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */,
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
 				E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */,
+				D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */,
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,
 				FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */,
@@ -3641,6 +3684,7 @@
 				9C20E8B060C753308748CE05 /* ProjectsManagerProjectOrderingTests.swift in Sources */,
 				6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */,
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
+				B6580745C7EDF5AA65DB0A86 /* QueuedPromptTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -41,6 +41,16 @@ final class ACPSession: ObservableObject, Identifiable {
     /// as the persistence key in `ACPSessionStore`.
     /// Not persisted — recreated on each `attach()` if missing.
     var remoteSessionId: String?
+    @Published var queue: [QueuedPrompt] = []
+    @Published var steerUndo: SteerUndoState?
+
+    struct SteerUndoState: Equatable {
+        /// Unique per-snapshot id used by SwiftUI for view diffing — letting
+        /// us reset the 5s timer-task whenever a new steer happens before
+        /// the previous toast has expired.
+        let id: UUID
+        let snapshot: [QueuedPrompt]
+    }
 
     func replaceComposerDraft(_ draft: ACPComposerDraft) {
         composerDraft = draft
@@ -135,6 +145,96 @@ final class ACPSession: ObservableObject, Identifiable {
 
     func appendFileEdit(_ edit: ACPMessage.FileEdit) {
         transcript.messages.append(.fileEdit(id: UUID(), edit))
+    }
+
+    /// Append a new pending item to the tail of the queue. Used by the
+    /// runner when the user submits while the agent is busy (or while
+    /// the queue is already non-empty — see ACPSubmitRoute).
+    func enqueue(blocks: [ACPContentBlock]) {
+        queue.append(QueuedPrompt(blocks: blocks))
+    }
+
+    /// Remove a specific item by id. The drag-handle X on the bubble
+    /// calls this. Safe on .sending items because the UI hides X then —
+    /// but we double-guard here to avoid yanking an in-flight RPC.
+    func removeFromQueue(id: UUID) {
+        guard let idx = queue.firstIndex(where: { $0.id == id }) else { return }
+        if queue[idx].status == .sending { return }
+        queue.remove(at: idx)
+    }
+
+    /// Reorder within the queue. Refuses to move a `.sending` head — the
+    /// UI hides the grip on `.sending` items, this is the belt-and-
+    /// suspenders guard.
+    func moveInQueue(from src: Int, to dst: Int) {
+        guard src >= 0, src < queue.count, dst >= 0, dst <= queue.count else { return }
+        if queue.indices.contains(src), queue[src].status == .sending { return }
+        // If moving across the .sending head (index 0 when sending), refuse.
+        if !queue.isEmpty, queue[0].status == .sending, dst == 0 { return }
+        let item = queue.remove(at: src)
+        queue.insert(item, at: min(dst, queue.count))
+    }
+
+    /// Edit the prompt blocks of a `.pending` item. No-op for `.sending`.
+    func editQueueItem(id: UUID, blocks: [ACPContentBlock]) {
+        guard let idx = queue.firstIndex(where: { $0.id == id }) else { return }
+        if queue[idx].status == .sending { return }
+        queue[idx].blocks = blocks
+    }
+
+    /// Remove all `.pending` items; return the snapshot in original order so
+    /// the steer-undo toast (or the "Clear queue" header button) can restore
+    /// them. A `.sending` item is left in place — it's mid-RPC.
+    @discardableResult
+    func clearPendingQueue() -> [QueuedPrompt] {
+        let snapshot = queue.filter { $0.status == .pending }
+        queue.removeAll { $0.status == .pending }
+        return snapshot
+    }
+
+    /// Re-prepend a previously-cleared snapshot. Used by the steer-undo
+    /// toast. If a `.sending` head exists (e.g. the steer redirect already
+    /// completed and the flusher promoted a follow-up to in-flight before
+    /// the user tapped Undo), the restored items go AFTER it — otherwise
+    /// the in-flight `sendNow`'s `popQueueHead` would key off the wrong
+    /// item and the `.sending` head would stay stranded in the queue.
+    func restorePendingSnapshot(_ snapshot: [QueuedPrompt]) {
+        let insertAt = (queue.first?.status == .sending) ? 1 : 0
+        queue.insert(contentsOf: snapshot, at: insertAt)
+    }
+
+    /// Mark the head item `.sending`. Called by the flusher right before
+    /// it spawns the prompt RPC. Clears any previous `lastError` so a
+    /// retried item displays cleanly while in-flight.
+    func markQueueHeadSending() {
+        guard !queue.isEmpty, queue[0].status == .pending else { return }
+        queue[0].status = .sending
+        queue[0].lastError = nil
+    }
+
+    /// Pop the head only if it's currently `.sending`. Returns it. Used by
+    /// the flusher's success path.
+    @discardableResult
+    func popQueueHead() -> QueuedPrompt? {
+        guard !queue.isEmpty, queue[0].status == .sending else { return nil }
+        return queue.removeFirst()
+    }
+
+    /// Roll the `.sending` head back to `.pending` with an error message.
+    /// Used by the flusher's failure path. Keeps the item at the head so
+    /// the user sees "Retry" on the bubble.
+    func setQueueHeadError(_ message: String) {
+        guard !queue.isEmpty else { return }
+        queue[0].status = .pending
+        queue[0].lastError = message
+    }
+
+    /// Replace the queue wholesale with a normalized restore set. Called
+    /// from `ACPSessionManager.openSession` after pulling rows from the
+    /// store. `.sending` items get flipped to `.pending` here so the
+    /// flusher re-attempts on next idle.
+    func restoreQueue(_ items: [QueuedPrompt]) {
+        queue = items.map { $0.normalizedAfterRestore() }
     }
 
     /// Mark any pending/in_progress tool calls as canceled. Called when

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -55,6 +55,10 @@ final class ACPSessionManager: ObservableObject {
                 }
             }
         }
+        // Restore queue
+        if let queue = try? store.loadQueue(sessionId: id) {
+            session.restoreQueue(queue)
+        }
         session.currentModel = row.currentModel
         session.currentMode = row.currentMode
         session.autoRunEnabled = row.autoRun
@@ -126,6 +130,16 @@ final class ACPSessionManager: ObservableObject {
     func clearComposerDraft(for session: ACPSession) {
         session.replaceComposerDraft(.empty)
         try? store.deleteComposerDraft(sessionId: session.id)
+    }
+
+    /// Persist the in-memory queue to SQLite. The runner has the same
+    /// `persistQueue` method, but UI actions on a session that has no
+    /// runner yet (setup nudge, launch failure) must still reach the
+    /// store directly — otherwise removing or clearing queue items
+    /// only mutates the cached `ACPSession`, and the supposedly-removed
+    /// prompts reappear on relaunch.
+    func persistQueue(for session: ACPSession) {
+        try? store.upsertQueue(sessionId: session.id, items: session.queue)
     }
 
     func clearComposerDraft(
@@ -237,6 +251,7 @@ extension ACPSessionManager {
             runner.start()
             runners[sessionId] = runner
             session.attached = true
+            runner.flushQueueIfIdle()
             stderrTask.cancel()
         } catch {
             // Give stderr a moment to drain so the message is the real cause.
@@ -250,17 +265,35 @@ extension ACPSessionManager {
     }
 
     func detach(sessionId: ACPSession.ID) async {
-        if let runner = runners.removeValue(forKey: sessionId) {
-            runner.stop()
-            await runner.connection.shutdown()
-        }
-        // Reset transient state so a later reopen of the same session
-        // doesn't surface stale `streamingState` (e.g. an `.awaitingPermission`
-        // left over from a closed tab would otherwise leave the sidebar work
-        // badge stuck on `[wait]` via the harness bridge).
+        // Reset transient session state SYNCHRONOUSLY before any await.
+        // The steer task is unstructured and can resume during the
+        // `connection.shutdown()` await below — if `session.attached`
+        // is still true at that point, its post-`userCancel` liveness
+        // check passes and it dispatches `sendNow` against a connection
+        // being torn down. Flipping the flag here closes that window.
         if let session = sessions[sessionId] {
             session.attached = false
             session.transcript.streamingState = .idle
+            // Normalize any in-flight queue head: the sendNow task that
+            // owned it is gone with the runner, so the next attach must
+            // see a `.pending` head to be able to flush it. Without this,
+            // closing a tab mid-flush leaves the cached session's head
+            // as `.sending`; the next openSession returns the cached
+            // object (skipping `restoreQueue`), the post-attach flush
+            // sees `.sending`, and the queue stays stuck until a full
+            // app restart reloads from SQLite.
+            session.restoreQueue(session.queue)
+        }
+        if let runner = runners.removeValue(forKey: sessionId) {
+            // Invalidate the in-flight prompt BEFORE shutting down the
+            // connection. The unstructured `sendNow` task survives stop()
+            // and the connection close will make its RPC throw — we want
+            // its catch path to recognise the failure as "deliberately
+            // cancelled" so it skips `setQueueHeadError` and the queue
+            // head can come back as cleanly `.pending` after restoreQueue.
+            runner.invalidateActivePrompt()
+            runner.stop()
+            await runner.connection.shutdown()
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -34,9 +34,22 @@ final class ACPSessionRunner {
     private var permissionsTask: Task<Void, Never>?
     private var filesTask: Task<Void, Never>?
     private var seq: Int64 = 0
+    private var steerUndoExpiryTask: Task<Void, Never>?
+    /// Monotonic prompt counter + active/cancelled bookkeeping (inherited
+    /// from main / PR #338). Reused by the queue's sendNow path:
+    /// `activePromptID` identifies the task that currently owns
+    /// `streamingState`; `cancelledPromptIDs` carries explicit
+    /// invalidations (steer, userCancel) so a slow `session/cancel`
+    /// can't let a stale completion clobber the successor task.
     private var nextPromptID = 0
     private var activePromptID: Int?
     private var cancelledPromptIDs: Set<Int> = []
+    /// Set while `steer` is between `userCancel` and the redirect's
+    /// `sendNow`. `flushQueueIfIdle` no-ops while this is true so an
+    /// Undo tapped during the cancel round-trip can't drain the just-
+    /// restored snapshot ahead of the steer's replacement prompt. Once
+    /// the redirect is in flight, normal drain semantics resume.
+    private var steerInProgress: Bool = false
 
     init(session: ACPSession, connection: ACPConnection, store: ACPSessionStore,
          sessionId: String, worktreePath: String,
@@ -79,6 +92,9 @@ final class ACPSessionRunner {
                 self.session.disconnected = true
                 self.session.attached = false
                 self.session.transcript.streamingState = .idle
+                // No flushQueueIfIdle() here: the connection is dead, so
+                // the next prompt would just fail. The queue stays put
+                // and drains naturally on the next successful reattach.
                 self.appendAndPersistSystemNotice("Agent disconnected.")
             }
         }
@@ -174,6 +190,22 @@ final class ACPSessionRunner {
         filesTask?.cancel()
     }
 
+    /// Cancel ownership of any in-flight prompt RPC. The unstructured
+    /// `sendNow` task survives `stop()` (it isn't a child task); calling
+    /// this marks its `activePromptID` as cancelled so when the RPC
+    /// eventually fails (because `connection.shutdown()` killed it) the
+    /// catch path treats it as a deliberate cancel — skipping
+    /// `setQueueHeadError`. Without this, detach during a queued flush
+    /// would persist a `lastError` on the queue head, and the next
+    /// attach's `flushQueueIfIdle` would skip it (guard requires
+    /// `lastError == nil`), forcing the user to click Retry.
+    func invalidateActivePrompt() {
+        if let promptID = activePromptID {
+            cancelledPromptIDs.insert(promptID)
+            activePromptID = nil
+        }
+    }
+
     /// Re-upsert the session's persistence row to capture changes to
     /// title / model / mode / autoRun that the runner mutated directly.
     /// `ACPSessionManager.persist` does the same thing plus a recent-
@@ -227,12 +259,44 @@ final class ACPSessionRunner {
     /// canceled, posts a system notice, and flips `streamingState` back
     /// to `.idle`. Persists all mutations so they survive a reload.
     func userCancel() async {
+        // Capture the prompt + queue head the user INTENDED to stop
+        // BEFORE awaiting `connection.cancel`. Without this snapshot, a
+        // natural completion of the in-flight prompt during the cancel
+        // round-trip would let the success path drain a queue item, and
+        // `activePromptID` after the await would point at the freshly-
+        // flushed queued send — so Stop would cancel + pop a prompt the
+        // user only queued, not the one they pressed Stop on.
+        // Snapshot the intended target AND insert it into
+        // `cancelledPromptIDs` BEFORE awaiting `connection.cancel`. The
+        // cancel notification can make the in-flight `session/prompt`
+        // RPC throw before we resume; if `cancelledPromptIDs` isn't
+        // populated by then, the prompt task's catch path reads
+        // `wasCancelled == false`, calls `setQueueHeadError`, and
+        // flips the queue head back to `.pending` with a lastError.
+        // The post-await block below then can't pop it (status no
+        // longer `.sending`), leaving the cancelled prompt stuck at
+        // the front of the queue. Pre-registering the cancellation
+        // makes the catch path skip the error path entirely.
+        let intended: (promptID: Int?, queueHeadID: UUID?) = await MainActor.run {
+            let snapshot: (promptID: Int?, queueHeadID: UUID?) = (
+                activePromptID,
+                session.queue.first.flatMap { $0.status == .sending ? $0.id : nil }
+            )
+            if let promptID = snapshot.promptID {
+                cancelledPromptIDs.insert(promptID)
+            }
+            return snapshot
+        }
         let remoteId = session.remoteSessionId ?? sessionId
         try? await connection.cancel(sessionId: remoteId)
         await MainActor.run {
-            if let promptID = activePromptID {
-                cancelledPromptIDs.insert(promptID)
-                activePromptID = nil
+            if let promptID = intended.promptID {
+                // Only clear activePromptID if it's still ours — a
+                // natural completion + queued promotion during the
+                // cancel await would have moved it on.
+                if activePromptID == promptID {
+                    activePromptID = nil
+                }
             }
             policy.userCancelled()
             let changedIndices = session.cancelInFlightToolCalls()
@@ -243,64 +307,307 @@ final class ACPSessionRunner {
                     try? store.updateMessagePayload(id: id, payload: payload)
                 }
             }
+            // Pop the head ONLY if it's the same `.sending` item we
+            // were aiming at. If a queued item promoted itself during
+            // the await it's a fresh prompt the user hasn't stopped —
+            // leave it alone.
+            if let stoppedID = intended.queueHeadID,
+               let current = session.queue.first,
+               current.id == stoppedID,
+               current.status == .sending {
+                session.queue.removeFirst()
+                persistQueue()
+            }
             appendAndPersistSystemNotice("Interrupted by user.")
-            session.transcript.streamingState = .idle
+            // Only force state to .idle if a successor prompt hasn't
+            // already taken ownership. A natural completion of the
+            // intended prompt during the cancel await can let
+            // flushQueueIfIdle promote a queued head to .sending and
+            // dispatch its sendNow; that successor now owns
+            // streamingState. Forcing .idle here would make the UI
+            // think the agent is free, hide the Stop pill, and let the
+            // composer accept another direct send mid-flight.
+            let successorOwnsState = activePromptID != nil
+                && activePromptID != intended.promptID
+            if !successorOwnsState {
+                session.transcript.streamingState = .idle
+            }
+            flushQueueIfIdle()
         }
     }
 }
 
 extension ACPSessionRunner {
+    /// Legacy callsite shim: defaults to `.auto` intent (immediate send
+    /// when idle, queue when busy).
+    func send(text: String, attachments: [ACPMessage.Attachment]) {
+        send(text: text, attachments: attachments, intent: .auto, onPromptFinished: nil)
+    }
+
+    /// Backwards-compatible shim for callers that supply a completion but
+    /// don't care about intent (e.g. existing tests, pre-queue callers).
     func send(
         text: String,
         attachments: [ACPMessage.Attachment],
+        onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)?
+    ) {
+        send(text: text, attachments: attachments, intent: .auto, onPromptFinished: onPromptFinished)
+    }
+
+    func send(
+        text: String,
+        attachments: [ACPMessage.Attachment],
+        intent: ACPSubmitIntent,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
         var blocks: [ACPContentBlock] = [.text(text)]
         for a in attachments {
             blocks.append(.resourceLink(uri: a.uri, name: a.name))
         }
+        send(blocks: blocks, intent: intent, onPromptFinished: onPromptFinished)
+    }
+
+    /// Primary entry. Resolves the routing then dispatches to one of:
+    ///   - sendNow  → records the user prompt, awaits prompt RPC
+    ///   - enqueue  → appends to queue + persists
+    ///   - steer    → cancels in-flight + clears queue + sends (Task 8)
+    ///   - noOp     → empty composer, ignore
+    func send(
+        blocks: [ACPContentBlock],
+        intent: ACPSubmitIntent,
+        onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
+    ) {
+        let route = ACPSubmitRoute.resolve(
+            intent: intent,
+            state: session.transcript.streamingState,
+            queueEmpty: session.queue.isEmpty,
+            blocksEmpty: blocks.isEmpty,
+            inFlightSteer: steerInProgress)
+        switch route {
+        case .noOp:
+            // Composer guards empty submits before invoking onSubmit, but
+            // tell the caller the submit was rejected so its draft state
+            // stays consistent.
+            Task { @MainActor in onPromptFinished?(false) }
+        case .sendNow:
+            sendNow(blocks: blocks, queuedItemId: nil, onPromptFinished: onPromptFinished)
+        case .enqueue:
+            session.enqueue(blocks: blocks)
+            persistQueue()
+            // The user's prompt was accepted into the queue — from the
+            // composer's perspective this is a successful submission so
+            // the persisted draft can be cleared. The actual RPC fires
+            // later when the flusher drains the head.
+            Task { @MainActor in onPromptFinished?(true) }
+        case .steer:
+            steer(blocks: blocks, onPromptFinished: onPromptFinished)
+        }
+    }
+
+    /// Persist the current queue snapshot. Called after every mutation:
+    /// enqueue, edit, remove, reorder, head-status flip. Failures are
+    /// swallowed — the same pattern as transcript persistence; surfacing
+    /// would block the UI for a transient SQLite error and we'd rather
+    /// lose a queue snapshot than the user's draft.
+    func persistQueue() {
+        try? store.upsertQueue(sessionId: sessionId, items: session.queue)
+    }
+
+    /// Drain the queue head if (a) state is `.idle`, (b) the head is
+    /// `.pending`, and (c) the head has no `lastError`. Marks the head
+    /// `.sending`, persists, and dispatches `sendNow` with the head's
+    /// id so success can pop the right item and failure can flag the
+    /// right item without disturbing the rest of the queue.
+    ///
+    /// Chained drain is implicit: sendNow's completion sets state to
+    /// `.idle` and calls back here.
+    func flushQueueIfIdle() {
+        guard !steerInProgress,
+              session.transcript.streamingState == .idle,
+              let head = session.queue.first,
+              head.status == .pending,
+              head.lastError == nil
+        else { return }
+        session.markQueueHeadSending()
+        persistQueue()
+        sendNow(blocks: head.blocks, queuedItemId: head.id)
+    }
+
+    /// Cancel the in-flight turn (if any), discard the ENTIRE queue
+    /// (including any `.sending` head whose `sendNow` task is mid-RPC),
+    /// then send the new prompt as a fresh turn. Only the `.pending`
+    /// items are snapshotted for undo — restoring a previously-`.sending`
+    /// item would just re-fire the prompt the user just redirected away
+    /// from. The stale in-flight task gets neutralised because `sendNow`
+    /// guards every completion-side mutation on `queue.first?.id ==
+    /// queuedItemId`; once we've emptied the queue, the orphan task
+    /// resolves to a no-op.
+    func steer(
+        blocks: [ACPContentBlock],
+        onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
+    ) {
+        let snapshot = session.queue.filter { $0.status == .pending }
+        session.queue.removeAll()
+        if !snapshot.isEmpty {
+            session.steerUndo = .init(id: UUID(), snapshot: snapshot)
+            armSteerUndoExpiry()
+        }
+        persistQueue()
+        // Invalidate the in-flight prompt NOW (before awaiting userCancel)
+        // so its completion can't race the redirect during the cancel
+        // round-trip. Without this, a slow `session/cancel` leaves the
+        // old `activePromptID` valid; the cancelled RPC's completion
+        // would then flip state to .idle, opening a window where the
+        // composer could accept another submit before the redirect's
+        // `sendNow` installs a new one.
+        if let promptID = activePromptID {
+            cancelledPromptIDs.insert(promptID)
+            activePromptID = nil
+        }
+        // Suppress queue flushing until the redirect is installed: while
+        // userCancel awaits the cancel notification, an Undo tap would
+        // re-prepend the snapshot to the queue and userCancel's own
+        // trailing flushQueueIfIdle would then dispatch the "discarded"
+        // item ahead of the steer's replacement prompt.
+        steerInProgress = true
+
+        Task { [weak self] in
+            guard let self else { return }
+            await self.userCancel()
+            await MainActor.run {
+                self.steerInProgress = false
+                // If the session was detached while we were awaiting
+                // `userCancel` (tab closed, worktree torn down), the
+                // runner has been removed from `ACPSessionManager` and
+                // the connection shut down. Firing `sendNow` now would
+                // append the redirect to a detached session and persist
+                // a `lastError` against the dead connection. Bail out
+                // and tell the composer the submit didn't land so its
+                // draft stays put.
+                guard self.session.attached, !self.session.disconnected else {
+                    onPromptFinished?(false)
+                    return
+                }
+                self.sendNow(blocks: blocks, queuedItemId: nil, onPromptFinished: onPromptFinished)
+            }
+        }
+    }
+
+    /// Re-prepend the most-recent steer-undo snapshot to the queue and
+    /// clear the buffer. Called when the user taps "Undo" on the toast.
+    func steerUndo() {
+        guard let undo = session.steerUndo, !undo.snapshot.isEmpty else { return }
+        session.restorePendingSnapshot(undo.snapshot)
+        session.steerUndo = nil
+        steerUndoExpiryTask?.cancel()
+        steerUndoExpiryTask = nil
+        persistQueue()
+        flushQueueIfIdle()
+    }
+
+    /// Exposed for tests + the toast view so it can show / hide.
+    func steerUndoSnapshot() -> [QueuedPrompt]? { session.steerUndo?.snapshot }
+
+    private func armSteerUndoExpiry() {
+        steerUndoExpiryTask?.cancel()
+        steerUndoExpiryTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            await MainActor.run {
+                self?.session.steerUndo = nil
+                self?.steerUndoExpiryTask = nil
+            }
+        }
+    }
+
+    /// Direct prompt RPC path. `queuedItemId` is set when called by the
+    /// flusher; nil when called from the user-typed-and-submitted path.
+    /// `onPromptFinished` fires when the active turn ends (success or
+    /// cancel/failure) and lets the composer reconcile its persisted
+    /// draft. Stale completions (steer cancelled us; another sendNow
+    /// took ownership) skip the callback so the composer stays in sync
+    /// with the SUCCESSOR turn only.
+    func sendNow(
+        blocks: [ACPContentBlock],
+        queuedItemId: UUID?,
+        onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
+    ) {
         let promptID = nextPromptID
         nextPromptID += 1
+        // Register ownership SYNCHRONOUSLY, before the Task spawn. Without
+        // this, `detach.invalidateActivePrompt()` (or another concurrent
+        // cancel) could land between the increment above and the Task's
+        // first `MainActor.run`, see no active prompt to invalidate, and
+        // the Task would then run normally, fail on `connection.shutdown`,
+        // and persist `lastError` on the queue head — defeating the
+        // detach-clears-cleanly fix from the previous commit.
+        activePromptID = promptID
         Task { [weak self, onPromptFinished] in
             guard let self else {
                 await MainActor.run { onPromptFinished?(false) }
                 return
             }
-            await MainActor.run {
-                self.activePromptID = promptID
-                let before = self.session.transcript.messages.count
-                let titleBefore = self.session.title
-                if !self.session.followsTranscriptTail {
-                    self.session.followsTranscriptTail = true
+            let proceeded = await MainActor.run { () -> Bool in
+                // If we were cancelled while this Task was being scheduled,
+                // exit without touching transcript or state. The connection
+                // may already be torn down by detach, and recording the
+                // user prompt now would leak transcript writes into a
+                // detached session.
+                if self.activePromptID != promptID {
+                    self.cancelledPromptIDs.remove(promptID)
+                    return false
                 }
-                self.session.recordUserPrompt(text: text, attachments: attachments)
-                self.persistFromIndex(before)
-                // First-prompt path auto-renames the session to the
-                // prompt prefix. Persist the row so the new title
-                // survives a reload — without this the toolbar showed
-                // the derived name in-memory but the SQLite row stayed
-                // on "New session" until the user manually renamed.
-                if self.session.title != titleBefore {
-                    self.persistSessionRow()
+                // Record the user prompt BEFORE awaiting `session/prompt`.
+                // The agent streams `session/update` notifications through
+                // `incomingUpdates` while the RPC is in flight, so if we
+                // recorded after the await an agent_message_chunk could
+                // land first and the transcript would render answer-
+                // before-question. Skip for a queued retry whose prompt
+                // is already in the transcript from the previous attempt.
+                let shouldRecord: Bool = {
+                    if let qid = queuedItemId,
+                       let idx = self.session.queue.firstIndex(where: { $0.id == qid }),
+                       self.session.queue[idx].transcriptRecorded {
+                        return false
+                    }
+                    return true
+                }()
+                if shouldRecord {
+                    let before = self.session.transcript.messages.count
+                    let titleBefore = self.session.title
+                    if !self.session.followsTranscriptTail {
+                        self.session.followsTranscriptTail = true
+                    }
+                    self.session.recordUserPrompt(text: Self.textPreview(of: blocks),
+                                                  attachments: Self.attachments(of: blocks))
+                    self.persistFromIndex(before)
+                    if self.session.title != titleBefore { self.persistSessionRow() }
+                    if let qid = queuedItemId,
+                       let idx = self.session.queue.firstIndex(where: { $0.id == qid }) {
+                        self.session.queue[idx].transcriptRecorded = true
+                        self.persistQueue()
+                    }
                 }
                 self.session.transcript.streamingState = .sending
+                return true
+            }
+            guard proceeded else {
+                await MainActor.run { onPromptFinished?(false) }
+                return
             }
             do {
                 let remoteId = self.session.remoteSessionId ?? self.sessionId
                 try await self.connection.prompt(sessionId: remoteId, blocks: blocks)
-                // The `session/prompt` response is the END of the
-                // turn — by the time `prompt` returns the agent has
-                // emitted every update for this turn and the response
-                // carries the stop reason. Flip back to `.idle` so the
-                // composer accepts the next prompt; leaving it on
-                // `.streaming` froze the UI on Stop after every
-                // successful reply.
                 await MainActor.run {
                     let isActivePrompt = self.activePromptID == promptID
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
+                        if queuedItemId != nil {
+                            _ = self.session.popQueueHead()
+                            self.persistQueue()
+                        }
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
+                        self.flushQueueIfIdle()
                     }
                     self.cancelledPromptIDs.remove(promptID)
                     if !hasNewerActivePrompt {
@@ -313,17 +620,47 @@ extension ACPSessionRunner {
                     let isActivePrompt = self.activePromptID == promptID
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
+                        if queuedItemId != nil, !wasCancelled {
+                            // Queued send failed naturally — leave the item
+                            // at the head with lastError so the bubble shows
+                            // Retry. Cancelled queued sends had the item
+                            // discarded elsewhere (steer) and don't surface.
+                            self.session.setQueueHeadError(error.localizedDescription)
+                            self.persistQueue()
+                        } else if queuedItemId == nil, !wasCancelled {
+                            self.session.lastError = "prompt failed: \(error.localizedDescription)"
+                        }
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
-                    }
-                    if !wasCancelled, isActivePrompt {
-                        self.session.lastError = "prompt failed: \(error.localizedDescription)"
+                        self.flushQueueIfIdle()
                     }
                     if !hasNewerActivePrompt {
                         onPromptFinished?(wasCancelled)
                     }
                 }
             }
+        }
+    }
+
+    /// First text block as the user-facing preview. Used when recording
+    /// the queued item's bubble in the transcript on flush. Concatenating
+    /// every text block matches the wire shape we already send.
+    static func textPreview(of blocks: [ACPContentBlock]) -> String {
+        blocks.compactMap { b -> String? in
+            if case .text(let s) = b { return s }
+            return nil
+        }.joined()
+    }
+
+    /// Resource-link attachments derived from the prompt blocks. Mirrors
+    /// the shape `recordUserPrompt` expects (which previously came from
+    /// the composer-level attachments array).
+    static func attachments(of blocks: [ACPContentBlock]) -> [ACPMessage.Attachment] {
+        blocks.compactMap { b -> ACPMessage.Attachment? in
+            if case .resourceLink(let uri, let name) = b {
+                return ACPMessage.Attachment(uri: uri, name: name)
+            }
+            return nil
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 2
+    static let targetSchemaVersion = 3
     let db: SQLiteDatabase
 
     init(path: String) throws {
@@ -27,6 +27,7 @@ final class ACPSessionStore {
         let current = Int((rows.first?["version"] as? Int64) ?? 0)
         if current < 1 { try migrate_to_v1() }
         if current < 2 { try migrate_to_v2() }
+        if current < 3 { try migrate_to_v3() }
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
         } else if current < Self.targetSchemaVersion {
@@ -78,6 +79,20 @@ final class ACPSessionStore {
     private func migrate_to_v2() throws {
         try db.exec("""
         CREATE TABLE IF NOT EXISTS composer_drafts (
+          session_id  TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+          payload     BLOB NOT NULL,
+          updated_at  INTEGER NOT NULL
+        )
+        """)
+    }
+
+    private func migrate_to_v3() throws {
+        // One row per session holds the JSON-encoded queue payload.
+        // We rewrite the whole row on every mutation — items are small
+        // and queue churn is low, so the cost is negligible. ON DELETE
+        // CASCADE keeps the row in lockstep with the session.
+        try db.exec("""
+        CREATE TABLE IF NOT EXISTS session_queue (
           session_id  TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
           payload     BLOB NOT NULL,
           updated_at  INTEGER NOT NULL
@@ -211,5 +226,34 @@ extension ACPSessionStore {
             updatedAt: (r["updated_at"] as? Int64) ?? 0,
             lastOpenedAt: (r["last_opened_at"] as? Int64) ?? 0,
             archived: ((r["archived"] as? Int64) ?? 0) != 0)
+    }
+}
+
+extension ACPSessionStore {
+    /// Replace the persisted queue for `sessionId` with `items`. An empty
+    /// array deletes the row so `loadQueue` returns `[]` cleanly without
+    /// an empty-array JSON blob lingering.
+    func upsertQueue(sessionId: String, items: [QueuedPrompt]) throws {
+        if items.isEmpty {
+            try db.exec("DELETE FROM session_queue WHERE session_id = ?", bindings: [sessionId])
+            return
+        }
+        let payload = try JSONEncoder().encode(items)
+        let now = Int64(Date().timeIntervalSince1970)
+        try db.exec("""
+        INSERT INTO session_queue (session_id, payload, updated_at)
+        VALUES (?,?,?)
+        ON CONFLICT(session_id) DO UPDATE SET
+            payload = excluded.payload,
+            updated_at = excluded.updated_at
+        """, bindings: [sessionId, payload, now])
+    }
+
+    func loadQueue(sessionId: String) throws -> [QueuedPrompt] {
+        let rows = try db.query(
+            "SELECT payload FROM session_queue WHERE session_id = ?",
+            bindings: [sessionId])
+        guard let payload = rows.first?["payload"] as? Data else { return [] }
+        return (try? JSONDecoder().decode([QueuedPrompt].self, from: payload)) ?? []
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSubmitIntent.swift
+++ b/Alas/Sources/ACP/Session/ACPSubmitIntent.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+enum ACPSubmitIntent: Equatable { case auto, steer }
+
+enum ACPSubmitRoute: Equatable {
+    /// State is idle AND queue is empty — send the prompt directly.
+    case sendNow
+    /// State is busy OR queue is already non-empty — append to the queue.
+    /// Routing the second case through the queue (not directly) keeps the
+    /// flusher's FIFO order intact even if the user submits another prompt
+    /// in the microsecond gap between state→.idle and the flusher firing.
+    case enqueue
+    /// User explicitly steered: cancel the in-flight turn (if any), clear
+    /// the queue, and send the new prompt as a fresh turn. Falls back to
+    /// `.sendNow` only when there's literally nothing to interrupt
+    /// (idle + empty queue) — handled by the resolver.
+    case steer
+    /// Empty composer — nothing to send. Never cancels a turn.
+    case noOp
+
+    static func resolve(intent: ACPSubmitIntent,
+                        state: ACPSession.StreamingState,
+                        queueEmpty: Bool,
+                        blocksEmpty: Bool,
+                        inFlightSteer: Bool = false) -> ACPSubmitRoute
+    {
+        if blocksEmpty { return .noOp }
+        // While a steer is mid-flight, `userCancel` has already flipped
+        // streamingState to .idle but the redirect's `sendNow` hasn't
+        // installed itself yet. Forcing every non-empty submit through
+        // the queue closes that window — the redirect fires first, and
+        // whatever the user typed during it drains afterwards instead of
+        // racing the redirect.
+        if inFlightSteer { return .enqueue }
+        switch intent {
+        case .auto:
+            return (state == .idle && queueEmpty) ? .sendNow : .enqueue
+        case .steer:
+            return (state == .idle && queueEmpty) ? .sendNow : .steer
+        }
+    }
+}

--- a/Alas/Sources/ACP/Session/QueuedPrompt.swift
+++ b/Alas/Sources/ACP/Session/QueuedPrompt.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+struct QueuedPrompt: Identifiable, Equatable, Codable {
+    enum Status: String, Codable, Equatable { case pending, sending }
+
+    let id: UUID
+    var blocks: [ACPContentBlock]
+    let enqueuedAt: Date
+    var status: Status
+    var lastError: String?
+    /// Set the first time `sendNow` dispatches this item: the user prompt
+    /// has been appended to the transcript. Retries (after `lastError`)
+    /// don't re-record it, so the message list doesn't grow a duplicate
+    /// user bubble per retry. Persisted so a relaunch-mid-attempt
+    /// doesn't double-record either.
+    var transcriptRecorded: Bool
+
+    init(id: UUID = UUID(),
+         blocks: [ACPContentBlock],
+         enqueuedAt: Date = Date(),
+         status: Status = .pending,
+         lastError: String? = nil,
+         transcriptRecorded: Bool = false)
+    {
+        self.id = id
+        self.blocks = blocks
+        self.enqueuedAt = enqueuedAt
+        self.status = status
+        self.lastError = lastError
+        self.transcriptRecorded = transcriptRecorded
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, blocks, enqueuedAt, status, lastError, transcriptRecorded
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        blocks = try c.decode([ACPContentBlock].self, forKey: .blocks)
+        enqueuedAt = try c.decode(Date.self, forKey: .enqueuedAt)
+        status = try c.decode(Status.self, forKey: .status)
+        lastError = try? c.decode(String.self, forKey: .lastError)
+        transcriptRecorded = (try? c.decode(Bool.self, forKey: .transcriptRecorded)) ?? false
+    }
+
+    /// Used by the persistence decoder: any item that was mid-send when
+    /// the app exited gets reset to `.pending` so the next flusher run
+    /// re-attempts the prompt. `lastError` is preserved so a previously
+    /// failed item that the user hasn't acked stays visibly errored.
+    func normalizedAfterRestore() -> QueuedPrompt {
+        guard status == .sending else { return self }
+        var copy = self
+        copy.status = .pending
+        return copy
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -5,6 +5,7 @@ typealias ACPComposerSubmitCompletion = @MainActor (_ succeeded: Bool) -> Void
 typealias ACPComposerSubmitHandler = (
     _ text: String,
     _ attachments: [ACPMessage.Attachment],
+    _ intent: ACPSubmitIntent,
     _ draft: ACPComposerDraft,
     _ completion: @escaping ACPComposerSubmitCompletion
 ) -> Bool
@@ -13,6 +14,10 @@ struct ACPInputField: NSViewRepresentable {
     @ObservedObject var session: ACPSession
     let worktreeRoot: URL
     let actions: ACPComposerActions
+    /// True when ⏎ should submit with `.auto` intent (the default mapping
+    /// — queue while busy). False when the user inverted the setting so
+    /// ⏎ steers; the placeholder reverses accordingly while busy.
+    let sendOnEnter: Bool
     /// Persists the current composer draft after text storage changes.
     let onDraftChange: (ACPComposerDraft) -> Void
     /// Clears the persisted draft after an accepted submission.
@@ -40,9 +45,9 @@ struct ACPInputField: NSViewRepresentable {
         // Publish the submit closure so the SwiftUI send button can fire
         // the same code path as ⏎.
         let coord = context.coordinator
-        actions.submit = { [weak coord] in
+        actions.submitWithIntent = { [weak coord] intent in
             guard let coord, let tv = coord.textView else { return }
-            coord.submit(tv)
+            coord.submit(tv, intent: intent)
         }
         let scroll = NSScrollView()
         scroll.hasVerticalScroller = true
@@ -63,8 +68,26 @@ struct ACPInputField: NSViewRepresentable {
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         context.coordinator.promptSuggestions = session.promptSuggestions
         context.coordinator.theme = context.environment.theme
-        if let textView = nsView.documentView as? NSTextView {
-            context.coordinator.syncPersistedDraft(session.composerDraft, into: textView)
+        context.coordinator.sendOnEnter = sendOnEnter
+        if let tv = nsView.documentView as? ACPNSTextView {
+            tv.placeholderText = Self.placeholder(for: session.transcript.streamingState, sendOnEnter: sendOnEnter)
+            tv.needsDisplay = true
+            context.coordinator.syncPersistedDraft(session.composerDraft, into: tv)
+        }
+    }
+
+    /// When busy, the placeholder advertises whichever action ⏎ will
+    /// trigger under the current settings — so a user who inverted the
+    /// shortcut (sendOnEnter = false) sees "Steer the agent…" instead of
+    /// being told ⏎ queues.
+    static func placeholder(for state: ACPSession.StreamingState,
+                            sendOnEnter: Bool) -> String {
+        switch state {
+        case .idle: return "Plan, ask, or build — type / for commands"
+        case .sending, .streaming, .awaitingPermission:
+            return sendOnEnter
+                ? "Queue a follow-up… (⌥⏎ to steer)"
+                : "Steer the agent… (⌥⏎ to queue)"
         }
     }
 
@@ -72,6 +95,7 @@ struct ACPInputField: NSViewRepresentable {
         Coordinator(
             worktreeRoot: worktreeRoot,
             initialDraft: session.composerDraft,
+            sendOnEnter: sendOnEnter,
             onDraftChange: onDraftChange,
             onDraftClear: onDraftClear,
             onSubmit: onSubmit
@@ -81,6 +105,14 @@ struct ACPInputField: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         let worktreeRoot: URL
         let initialDraft: ACPComposerDraft
+        /// Keyboard-only inversion flag. The coordinator resolves the
+        /// raw modifier-derived intent (`.auto` for ⏎, `.steer` for ⌥⏎)
+        /// against this and emits a FINAL intent to `onSubmit`. The
+        /// toolbar send button bypasses the coordinator's keyboard
+        /// handler, so mouse clicks are never inverted — clicking the
+        /// visible ↑ button always submits with the intent the button's
+        /// help text advertises.
+        var sendOnEnter: Bool
         let onDraftChange: (ACPComposerDraft) -> Void
         let onDraftClear: () -> Void
         let onSubmit: ACPComposerSubmitHandler
@@ -97,12 +129,14 @@ struct ACPInputField: NSViewRepresentable {
         init(
             worktreeRoot: URL,
             initialDraft: ACPComposerDraft,
+            sendOnEnter: Bool,
             onDraftChange: @escaping (ACPComposerDraft) -> Void,
             onDraftClear: @escaping () -> Void,
             onSubmit: @escaping ACPComposerSubmitHandler
         ) {
             self.worktreeRoot = worktreeRoot
             self.initialDraft = initialDraft
+            self.sendOnEnter = sendOnEnter
             self.lastSyncedDraft = initialDraft
             self.onDraftChange = onDraftChange
             self.onDraftClear = onDraftClear
@@ -124,11 +158,22 @@ struct ACPInputField: NSViewRepresentable {
             if selector == #selector(NSResponder.insertNewline(_:)) {
                 let event = NSApp.currentEvent
                 let shift = event?.modifierFlags.contains(.shift) == true
+                let option = event?.modifierFlags.contains(.option) == true
                 if shift {
                     textView.insertText("\n", replacementRange: textView.selectedRange())
                     return true
                 }
-                submit(textView)
+                // Resolve the keyboard mapping HERE so the upstream
+                // handler receives a final intent. The toolbar send
+                // button goes through `actions.submitWithIntent` (which
+                // calls `submit(_:intent:)` directly) and bypasses this
+                // resolution — clicking ↑ always submits with the
+                // intent the button advertises.
+                let raw: ACPSubmitIntent = option ? .steer : .auto
+                let final: ACPSubmitIntent = sendOnEnter
+                    ? raw
+                    : (raw == .auto ? .steer : .auto)
+                submit(textView, intent: final)
                 return true
             }
             return false
@@ -149,7 +194,7 @@ struct ACPInputField: NSViewRepresentable {
             onDraftChange(draft)
         }
 
-        func submit(_ textView: NSTextView) {
+        func submit(_ textView: NSTextView, intent: ACPSubmitIntent = .auto) {
             let attributed = textView.attributedString()
             let (text, attachments) = Self.extract(attributed)
             guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
@@ -159,7 +204,7 @@ struct ACPInputField: NSViewRepresentable {
             // draft deletion waits for the async prompt completion.
             let submitID = nextSubmitID
             nextSubmitID += 1
-            if onSubmit(text, attachments, draft, { [weak self, weak textView] succeeded in
+            if onSubmit(text, attachments, intent, draft, { [weak self, weak textView] succeeded in
                 if let self {
                     self.finishSubmit(id: submitID, draft: draft, succeeded: succeeded, textView: textView)
                 }

--- a/Alas/Sources/ACP/UI/ACPComposerActions.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActions.swift
@@ -1,13 +1,12 @@
 import Foundation
 
-/// Tiny shared object the composer shell uses to invoke the AppKit-
-/// backed input field's submit / cancel pathways from SwiftUI buttons.
-/// The input field's coordinator wires up the closures during
-/// `makeCoordinator`; the shell reads them when the user clicks the
-/// send button (or any future toolbar action that needs to act on the
-/// NSTextView's storage).
+/// Bridge object the SwiftUI composer chrome uses to fire submission
+/// through the AppKit textview's coordinator. The coordinator publishes
+/// `submitWithIntent` on `makeNSView`; the send button calls it with
+/// the resolved intent (auto vs steer based on ⌥ modifier).
 @MainActor
 final class ACPComposerActions: ObservableObject {
-    var submit: (() -> Void)?
-    var clear: (() -> Void)?
+    var submitWithIntent: ((ACPSubmitIntent) -> Void)?
+    /// Convenience used by call sites that just want default submit.
+    func submit() { submitWithIntent?(.auto) }
 }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -8,6 +8,10 @@ struct ACPComposer: View {
     let manager: ACPSessionManager
     let worktreeRoot: URL
     let agentLookup: (String) -> AgentDefinition?
+    /// Current value of the `acpSendOnEnter` setting. Threaded down to
+    /// `ACPInputField` so its placeholder reflects whichever action ⏎
+    /// triggers under the current mapping.
+    let sendOnEnter: Bool
     let onSubmit: ACPComposerSubmitHandler
 
     @Environment(\.theme) private var theme
@@ -49,6 +53,7 @@ struct ACPComposer: View {
                 session: session,
                 worktreeRoot: worktreeRoot,
                 actions: actions,
+                sendOnEnter: sendOnEnter,
                 onDraftChange: { draft in manager.persistComposerDraft(draft, for: session) },
                 onDraftClear: { manager.clearComposerDraft(for: session) },
                 onSubmit: onSubmit
@@ -58,6 +63,7 @@ struct ACPComposer: View {
             HStack(spacing: 8) {
                 hint
                 Spacer()
+                stopPill
                 autoRunToggle
                 if let thinking = session.chipState.thinking {
                     thinkingChip(thinking)
@@ -302,20 +308,73 @@ struct ACPComposer: View {
         }
     }
 
+    // MARK: - Stop pill (separate from send; visible only while busy)
+
+    @ViewBuilder
+    private var stopPill: some View {
+        if isBusy {
+            Button {
+                stopTapped()
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 10, weight: .bold))
+                    Text("Stop")
+                        .font(.system(size: 11, weight: .medium))
+                }
+                .foregroundStyle(theme.color("del"))
+                .padding(.horizontal, 8)
+                .frame(height: 24)
+                .background(
+                    RoundedRectangle(cornerRadius: 6).fill(theme.color("del").opacity(0.15))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("del").opacity(0.45), lineWidth: 0.75)
+                )
+            }
+            .buttonStyle(.plain)
+            .help("Stop the running turn (Esc)")
+        }
+    }
+
+    private var isBusy: Bool {
+        switch session.transcript.streamingState {
+        case .streaming, .sending, .awaitingPermission: return true
+        case .idle: return false
+        }
+    }
+
+    private func stopTapped() {
+        let sid = session.id
+        Task { @MainActor in
+            if let runner = manager.runners[sid] {
+                await runner.userCancel()
+            } else {
+                session.transcript.streamingState = .idle
+            }
+        }
+    }
+
     // MARK: - Send button
 
     private var sendButton: some View {
         Button {
             sendButtonTapped()
         } label: {
-            ZStack {
-                RoundedRectangle(cornerRadius: 7).fill(buttonBg)
-                Image(systemName: buttonGlyph)
-                    .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(buttonFg)
+            ZStack(alignment: .topTrailing) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 7).fill(buttonBg)
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(buttonFg)
+                }
+                .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(buttonBorder, lineWidth: 0.5))
+                .frame(width: 28, height: 28)
+                if session.queue.count > 0 {
+                    queueBadge
+                        .offset(x: 6, y: -6)
+                }
             }
-            .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(buttonBorder, lineWidth: 0.5))
-            .frame(width: 28, height: 28)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -324,77 +383,54 @@ struct ACPComposer: View {
         .help(sendHelpText)
     }
 
-    /// True while we can't deliver a prompt: the agent process isn't
-    /// attached yet, or it disconnected. Streaming/sending isn't covered
-    /// here — those states swap the button to the cancel mode, which IS
-    /// clickable.
+    /// Disabled only when the agent isn't reachable. State.streaming /
+    /// .sending no longer disable — they queue.
     private var sendDisabled: Bool {
-        switch session.transcript.streamingState {
-        case .streaming, .sending: return false
-        default: return !session.attached || session.disconnected
-        }
+        !session.attached || session.disconnected
     }
 
     private var sendHelpText: String {
-        switch session.transcript.streamingState {
-        case .streaming, .sending: return "Stop streaming"
-        default:
-            if session.disconnected { return "Agent disconnected" }
-            if !session.attached    { return "Agent connecting…" }
-            return "Send (⏎)"
+        if session.disconnected { return "Agent disconnected" }
+        if !session.attached    { return "Agent connecting…" }
+        if session.transcript.streamingState == .idle, session.queue.isEmpty {
+            return "Send (⏎). Hold ⌥ to steer."
         }
+        return "Queue (⏎). Hold ⌥ to steer."
     }
 
-    /// Click handler: send while idle, stop while streaming.
+    /// Always submit; the runner's routing decides queue vs send vs steer.
     private func sendButtonTapped() {
-        switch session.transcript.streamingState {
-        case .streaming, .sending:
-            let sid = session.id
-            Task { @MainActor in
-                if let runner = manager.runners[sid] {
-                    await runner.userCancel()
-                } else {
-                    session.transcript.streamingState = .idle
-                }
-            }
-        default:
-            guard !sendDisabled else { return }
-            actions.submit?()
-        }
+        guard !sendDisabled else { return }
+        let option = NSApp.currentEvent?.modifierFlags.contains(.option) == true
+        actions.submitWithIntent?(option ? .steer : .auto)
     }
 
-    /// Matches the design's `.chat-send` states. Idle = dark fill + line
-    /// border (the "no input" look), ready = solid accent + accent
-    /// border + dark icon, stop = solid del + dark icon.
     private var buttonBg: Color {
-        switch session.transcript.streamingState {
-        case .streaming, .sending: return theme.color("del")
-        default:
-            return sendDisabled
-                ? theme.color("bg-3").opacity(0.7)
-                : theme.color("accent")
-        }
+        sendDisabled
+            ? theme.color("bg-3").opacity(0.7)
+            : theme.color("accent")
     }
     private var buttonFg: Color {
-        switch session.transcript.streamingState {
-        case .streaming, .sending: return theme.color("bg-0")
-        default:
-            return sendDisabled ? theme.color("fg-dim") : theme.color("bg-0")
-        }
+        sendDisabled ? theme.color("fg-dim") : theme.color("bg-0")
     }
     private var buttonBorder: Color {
-        switch session.transcript.streamingState {
-        case .streaming, .sending: return theme.color("del").opacity(0.7)
-        default:
-            return sendDisabled
-                ? theme.color("line")
-                : theme.color("accent").opacity(0.7)
-        }
+        sendDisabled
+            ? theme.color("line")
+            : theme.color("accent").opacity(0.7)
     }
-    private var buttonGlyph: String {
-        switch session.transcript.streamingState {
-        case .streaming, .sending: return "stop.fill"
-        default:                   return "arrow.up"
-        }
+
+    /// Small badge with the queue count, sitting at the top-right of
+    /// the send button.
+    private var queueBadge: some View {
+        Text("\(session.queue.count)")
+            .font(.system(size: 9, weight: .bold, design: .rounded))
+            .monospacedDigit()
+            .foregroundStyle(theme.color("bg-0"))
+            .padding(.horizontal, 4)
+            .frame(minWidth: 16, minHeight: 14)
+            .background(
+                Capsule().fill(theme.color("warn"))
+            )
+            .overlay(Capsule().strokeBorder(theme.color("bg-0"), lineWidth: 1))
     }
 }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -7,6 +7,13 @@ struct ACPMessageList: View {
     let onOpenDiff: (String) -> Void
     let policy: ACPPermissionPolicy?
     let scopeKey: String
+    /// Callbacks invoked by the pending bubbles + header. The host wires
+    /// these to the runner.
+    let onQueueEdit: (QueuedPrompt) -> Void
+    let onQueueRemove: (UUID) -> Void
+    let onQueueRetry: (UUID) -> Void
+    let onQueueReorder: (Int, Int) -> Void
+    let onQueueClearAll: () -> Void
     @Environment(\.theme) private var theme
     @State private var viewportHeight: CGFloat = 0
     @State private var tailFrame: CGRect = .zero
@@ -29,6 +36,7 @@ struct ACPMessageList: View {
     private var scrollSignature: Int {
         var hasher = Hasher()
         hasher.combine(transcript.messages.count)
+        hasher.combine(session.queue.count)
         // Streaming chunks mutate the buffer in place without re-publishing
         // the transcript array; the tick gives the body a reason to re-eval
         // so this signature changes and the tail-scroll fires per chunk.
@@ -71,6 +79,27 @@ struct ACPMessageList: View {
                         if transcript.streamingState == .streaming {
                             StreamingCaret().frame(width: 8, height: 14)
                                 .id("__streaming_caret__")
+                        }
+                        if session.queue.count > 1 {
+                            ACPQueueHeader(count: session.queue.count, onClear: onQueueClearAll)
+                                .id("__queue_header__")
+                        }
+                        ForEach(Array(session.queue.enumerated()), id: \.element.id) { idx, item in
+                            ACPQueuedBubble(
+                                item: item,
+                                onEdit: { onQueueEdit(item) },
+                                onRemove: { onQueueRemove(item.id) },
+                                onRetry: { onQueueRetry(item.id) }
+                            )
+                            .dropDestination(for: String.self) { items, _ in
+                                guard let s = items.first,
+                                      let uuid = UUID(uuidString: s),
+                                      let src = session.queue.firstIndex(where: { $0.id == uuid })
+                                else { return false }
+                                onQueueReorder(src, idx)
+                                return true
+                            }
+                            .id("__queue_\(item.id)")
                         }
                         // Invisible tail spacer that the auto-scroll pins to
                         // the viewport bottom; this guarantees the streaming

--- a/Alas/Sources/ACP/UI/ACPQueueHeader.swift
+++ b/Alas/Sources/ACP/UI/ACPQueueHeader.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Thin header that sits above the pending bubbles when the queue has
+/// more than one item. Shows the count on the left and a "Clear queue"
+/// text button on the right.
+struct ACPQueueHeader: View {
+    let count: Int
+    let onClear: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("\(count) queued")
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.4)
+                .textCase(.uppercase)
+                .foregroundStyle(theme.color("fg-faint"))
+            Spacer()
+            Button(action: onClear) {
+                Text("Clear queue")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(theme.color("fg-muted"))
+            }
+            .buttonStyle(.plain)
+            .help("Remove all pending items (a sending item is left alone)")
+        }
+        .padding(.horizontal, 4)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
+++ b/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+/// A single queued-item bubble, rendered below the transcript. Right-
+/// aligned (same as the user message bubble) but with a dashed border,
+/// reduced opacity, and a "Queued" pill. Hover reveals edit / remove
+/// affordances. Items in `.sending` lose those affordances and gain a
+/// spinner-edged border.
+struct ACPQueuedBubble: View {
+    let item: QueuedPrompt
+    let onEdit: () -> Void
+    let onRemove: () -> Void
+    let onRetry: () -> Void
+
+    @State private var isHovering = false
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Spacer(minLength: 40)
+            VStack(alignment: .trailing, spacing: 4) {
+                HStack(spacing: 6) {
+                    if item.status == .sending {
+                        ProgressView().scaleEffect(0.45).frame(width: 12, height: 12)
+                    }
+                    Text(item.status == .sending ? "Sending" : "Queued")
+                        .font(.system(size: 9, weight: .semibold))
+                        .tracking(0.4)
+                        .textCase(.uppercase)
+                        .foregroundStyle(theme.color("fg-faint"))
+                    if let err = item.lastError {
+                        Text("· \(err)")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(theme.color("del"))
+                            .lineLimit(1)
+                    }
+                    if isHovering, item.status == .pending {
+                        actionsRow
+                    }
+                }
+                ACPMarkdownText(raw: Self.textPreview(of: item.blocks))
+                    .padding(.vertical, 9).padding(.horizontal, 13)
+                    .background(theme.color("accent").opacity(0.10))
+                    .clipShape(
+                        UnevenRoundedRectangle(
+                            cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
+                        )
+                    )
+                    .overlay(
+                        UnevenRoundedRectangle(
+                            cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
+                        )
+                        .strokeBorder(borderColor, style: borderStyle)
+                    )
+            }
+            .opacity(item.status == .sending ? 0.85 : 0.6)
+            .frame(maxWidth: 540, alignment: .trailing)
+        }
+        .frame(maxWidth: .infinity)
+        .onHover { isHovering = $0 }
+        .modifier(PendingDraggableModifier(enabled: item.status == .pending, payload: item.id.uuidString))
+    }
+
+    private var borderColor: Color {
+        if item.lastError != nil { return theme.color("del").opacity(0.7) }
+        return theme.color("accent").opacity(0.5)
+    }
+    private var borderStyle: StrokeStyle {
+        item.status == .sending
+            ? StrokeStyle(lineWidth: 0.75)
+            : StrokeStyle(lineWidth: 0.75, dash: [3, 3])
+    }
+
+    private var actionsRow: some View {
+        HStack(spacing: 4) {
+            if item.lastError != nil {
+                Button(action: onRetry) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(theme.color("warn"))
+                }
+                .buttonStyle(.plain)
+                .help("Retry")
+            }
+            Button(action: onEdit) {
+                Image(systemName: "pencil")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(theme.color("fg-muted"))
+            }
+            .buttonStyle(.plain)
+            .help("Edit")
+            Button(action: onRemove) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(theme.color("fg-muted"))
+            }
+            .buttonStyle(.plain)
+            .help("Remove from queue")
+        }
+    }
+
+    private static func textPreview(of blocks: [ACPContentBlock]) -> String {
+        blocks.compactMap { b -> String? in
+            if case .text(let s) = b { return s }
+            return nil
+        }.joined()
+    }
+}
+
+/// Conditional `.draggable` modifier. SwiftUI doesn't expose a clean
+/// "drag if X" view modifier, so we wrap it in a ViewModifier that
+/// short-circuits when disabled.
+private struct PendingDraggableModifier: ViewModifier {
+    let enabled: Bool
+    let payload: String
+    func body(content: Content) -> some View {
+        if enabled {
+            content.draggable(payload)
+        } else {
+            content
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPSteerUndoToast.swift
+++ b/Alas/Sources/ACP/UI/ACPSteerUndoToast.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Non-blocking 5-second toast that appears at the bottom of the chat
+/// pane after a steer that discarded queued items. Tapping Undo
+/// re-prepends the snapshot.
+struct ACPSteerUndoToast: View {
+    let discardedCount: Int
+    let onUndo: () -> Void
+    let onDismiss: () -> Void
+
+    @Environment(\.theme) private var theme
+    @State private var visible: Bool = true
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "arrow.uturn.backward")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(theme.color("fg-muted"))
+            Text("Discarded \(discardedCount) queued message\(discardedCount == 1 ? "" : "s")")
+                .font(.system(size: 12))
+                .foregroundStyle(theme.color("fg"))
+            Button("Undo", action: {
+                onUndo()
+                visible = false
+            })
+            .buttonStyle(.plain)
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(theme.color("accent"))
+            Button {
+                visible = false
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10))
+                    .foregroundStyle(theme.color("fg-faint"))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(theme.color("line"), lineWidth: 0.5))
+        .shadow(color: .black.opacity(0.4), radius: 10, y: 4)
+        .opacity(visible ? 1 : 0)
+        .animation(.easeInOut(duration: 0.2), value: visible)
+        .task {
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            visible = false
+            onDismiss()
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -124,7 +124,44 @@ private struct ACPSessionView: View {
                     // lives) — otherwise the user's click can't resolve the
                     // pending permission request.
                     policy: manager.runners[sessionId]?.policy,
-                    scopeKey: scopeKey(for: session.transcript.pendingPermission)
+                    scopeKey: scopeKey(for: session.transcript.pendingPermission),
+                    onQueueEdit: { item in
+                        // Inline editor is a future enhancement (see plan §4.4).
+                        // For v1, clicking the pencil removes the item from
+                        // the queue so the user can re-type in the composer.
+                        session.removeFromQueue(id: item.id)
+                        manager.persistQueue(for: session)
+                        // Discarding the head can unblock a successor
+                        // that was waiting behind a `lastError` head.
+                        manager.runners[sessionId]?.flushQueueIfIdle()
+                    },
+                    onQueueRemove: { id in
+                        session.removeFromQueue(id: id)
+                        manager.persistQueue(for: session)
+                        manager.runners[sessionId]?.flushQueueIfIdle()
+                    },
+                    onQueueRetry: { id in
+                        guard let idx = session.queue.firstIndex(where: { $0.id == id }) else { return }
+                        session.queue[idx].lastError = nil
+                        manager.persistQueue(for: session)
+                        manager.runners[sessionId]?.flushQueueIfIdle()
+                    },
+                    onQueueReorder: { src, dst in
+                        session.moveInQueue(from: src, to: dst)
+                        manager.persistQueue(for: session)
+                        // Reordering can move a clean prompt to the head
+                        // where it can finally drain.
+                        manager.runners[sessionId]?.flushQueueIfIdle()
+                    },
+                    onQueueClearAll: {
+                        session.clearPendingQueue()
+                        manager.persistQueue(for: session)
+                        // No-op if the queue is now empty, but if a
+                        // `.sending` head survives the clear and the
+                        // user re-enqueues, the next idle drain still
+                        // needs to fire from this path.
+                        manager.runners[sessionId]?.flushQueueIfIdle()
+                    }
                 )
             }
 
@@ -132,22 +169,17 @@ private struct ACPSessionView: View {
                 session: session,
                 manager: manager,
                 worktreeRoot: worktree.path,
-                agentLookup: { state.agent(id: $0) }
-            ) { text, attachments, draft, onPromptFinished -> Bool in
-                // Gate: if the runner isn't ready (initial attach in
-                // flight, agent crashed, etc.) or a prompt turn is
-                // already in flight (streaming/sending — send button
-                // is showing Stop), reject the submission and KEEP
-                // the draft. Returning `false` tells the textview not
-                // to clear, which is the difference from a no-op:
-                // we don't want ⏎ to silently erase the user's
-                // unsent prompt.
+                agentLookup: { state.agent(id: $0) },
+                sendOnEnter: state.config.harness.acpSendOnEnter
+            ) { text, attachments, intent, draft, onPromptFinished -> Bool in
                 guard session.attached, !session.disconnected,
-                      session.transcript.streamingState != .streaming,
-                      session.transcript.streamingState != .sending,
                       let runner = manager.runners[sessionId] else { return false }
+                // `intent` is already resolved by the composer for keyboard
+                // submits; the toolbar send button bypasses the keyboard
+                // inversion and supplies its own intent directly. No
+                // further resolution here.
                 let draftRevision = session.composerDraftRevision
-                runner.send(text: text, attachments: attachments) { succeeded in
+                runner.send(text: text, attachments: attachments, intent: intent) { succeeded in
                     if succeeded {
                         manager.clearComposerDraft(
                             for: session,
@@ -165,6 +197,21 @@ private struct ACPSessionView: View {
                     onPromptFinished(succeeded)
                 }
                 return true
+            }
+
+            if let undo = session.steerUndo, !undo.snapshot.isEmpty {
+                VStack {
+                    Spacer()
+                    ACPSteerUndoToast(
+                        discardedCount: undo.snapshot.count,
+                        onUndo: { manager.runners[sessionId]?.steerUndo() },
+                        onDismiss: { session.steerUndo = nil }
+                    )
+                    .id(undo.id)
+                    .padding(.bottom, 200)
+                }
+                .frame(maxWidth: .infinity)
+                .transition(.opacity)
             }
         }
     }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -182,16 +182,27 @@ struct AppConfig: Codable, Equatable {
         var notifyOnAwaiting: Bool
         var dismissedHookInstallNudges: [String]
         var dismissedACPSetupNudges: [String]
+        /// When true (default): ⏎ submits with .auto intent, ⌥⏎ steers.
+        /// When false: the two are inverted — ⏎ steers, ⌥⏎ queues. The
+        /// label in Settings is "Send on ⏎, queue on ⌥⏎ while busy".
+        var acpSendOnEnter: Bool
 
         enum CodingKeys: String, CodingKey {
-            case notifyOnFinish, notifyOnAwaiting, dismissedHookInstallNudges, dismissedACPSetupNudges
+            case notifyOnFinish, notifyOnAwaiting,
+                 dismissedHookInstallNudges, dismissedACPSetupNudges,
+                 acpSendOnEnter
         }
 
-        init(notifyOnFinish: Bool, notifyOnAwaiting: Bool, dismissedHookInstallNudges: [String] = [], dismissedACPSetupNudges: [String] = []) {
+        init(notifyOnFinish: Bool, notifyOnAwaiting: Bool,
+             dismissedHookInstallNudges: [String] = [],
+             dismissedACPSetupNudges: [String] = [],
+             acpSendOnEnter: Bool = true)
+        {
             self.notifyOnFinish = notifyOnFinish
             self.notifyOnAwaiting = notifyOnAwaiting
             self.dismissedHookInstallNudges = dismissedHookInstallNudges
             self.dismissedACPSetupNudges = dismissedACPSetupNudges
+            self.acpSendOnEnter = acpSendOnEnter
         }
 
         init(from decoder: Decoder) throws {
@@ -200,6 +211,7 @@ struct AppConfig: Codable, Equatable {
             notifyOnAwaiting = (try? c.decode(Bool.self, forKey: .notifyOnAwaiting)) ?? true
             dismissedHookInstallNudges = (try? c.decode([String].self, forKey: .dismissedHookInstallNudges)) ?? []
             dismissedACPSetupNudges = (try? c.decode([String].self, forKey: .dismissedACPSetupNudges)) ?? []
+            acpSendOnEnter = (try? c.decode(Bool.self, forKey: .acpSendOnEnter)) ?? true
         }
     }
 

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -126,6 +126,14 @@ struct TerminalPane: View {
                                 desc: "Show a clickable notification when a detected harness is waiting for input.") {
                         AlasToggle(on: state.bind(\.harness.notifyOnAwaiting))
                     }
+                    SettingsRow(name: "While busy, ⏎ queues; ⌥⏎ steers",
+                                desc: "Turn off to swap — ⏎ steers and ⌥⏎ queues. Steering cancels the running turn and discards any pending queue items.") {
+                        AlasToggle(on: Binding(
+                            get: { state.config.harness.acpSendOnEnter },
+                            set: { state.config.harness.acpSendOnEnter = $0
+                            state.saveConfig() }
+                        ))
+                    }
                     ForEach(installerRegistry.supportedAgents) { agent in
                         SettingsRow(name: agent.displayName) {
                             HStack {

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -105,4 +105,48 @@ struct ACPSessionManagerTests {
         #expect(session.composerDraft == submitted)
         #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
     }
+
+    @Test("detach normalizes a .sending queue head so re-attach can flush")
+    func detachNormalizesSendingHead() async throws {
+        // Regression: closing a tab while the flusher had promoted the
+        // head to .sending used to leave the cached ACPSession with a
+        // .sending head. The next openSession returns the cached object
+        // (no `restoreQueue`), and the post-attach `flushQueueIfIdle`
+        // sees `.sending` and no-ops — the queue is stuck until a full
+        // app restart reloads from SQLite.
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-detach-q-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        session.enqueue(blocks: [.text("queued")])
+        session.markQueueHeadSending()
+        #expect(session.queue[0].status == .sending)
+
+        await mgr.detach(sessionId: session.id)
+        #expect(session.queue[0].status == .pending)
+    }
+
+    @Test("persistQueue writes to SQLite without requiring a runner")
+    func persistQueueWithoutRunner() throws {
+        // Regression: ACPTabView's queue actions used to call
+        // `manager.runners[sessionId]?.persistQueue()`, which silently
+        // no-oped when no runner was attached (setup nudge / launch
+        // failure). Edits then lived only in memory; relaunch restored
+        // the supposedly-removed prompts from SQLite.
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-persist-q-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        session.enqueue(blocks: [.text("a")])
+        session.enqueue(blocks: [.text("b")])
+
+        mgr.persistQueue(for: session)
+        let persisted = try store.loadQueue(sessionId: session.id)
+        #expect(persisted == session.queue)
+
+        session.clearPendingQueue()
+        mgr.persistQueue(for: session)
+        let afterClear = try store.loadQueue(sessionId: session.id)
+        #expect(afterClear.isEmpty)
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
+++ b/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSession queue API")
+struct ACPSessionQueueAPITests {
+    private func mkSession() -> ACPSession {
+        ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+    }
+
+    @Test("queue starts empty")
+    func empty() {
+        #expect(mkSession().queue.isEmpty)
+    }
+
+    @Test("enqueue(blocks:) appends a pending item")
+    func enqueue() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("hello")])
+        #expect(s.queue.count == 1)
+        #expect(s.queue[0].status == .pending)
+        #expect(s.queue[0].blocks == [.text("hello")])
+    }
+
+    @Test("remove(id:) drops matching item, leaves others")
+    func remove() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("b")])
+        let firstId = s.queue[0].id
+        s.removeFromQueue(id: firstId)
+        #expect(s.queue.count == 1)
+        #expect(s.queue[0].blocks == [.text("b")])
+    }
+
+    @Test("move(from:to:) reorders within pending region")
+    func move() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("b")])
+        s.enqueue(blocks: [.text("c")])
+        s.moveInQueue(from: 0, to: 2)
+        #expect(s.queue.map { $0.blocks } == [[.text("b")], [.text("c")], [.text("a")]])
+    }
+
+    @Test("move(from:to:) refuses to move a .sending head")
+    func moveSendingNoop() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("b")])
+        s.markQueueHeadSending()
+        s.moveInQueue(from: 0, to: 1)
+        #expect(s.queue[0].status == .sending)
+        #expect(s.queue[0].blocks == [.text("a")])
+    }
+
+    @Test("clearPendingQueue() removes all .pending items but leaves .sending head")
+    func clearPendingKeepsSending() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("b")])
+        s.markQueueHeadSending()
+        let snapshot = s.clearPendingQueue()
+        #expect(s.queue.count == 1)
+        #expect(s.queue[0].status == .sending)
+        #expect(snapshot.map { $0.blocks } == [[.text("b")]])
+    }
+
+    @Test("markQueueHeadSending flips .pending to .sending; clears lastError")
+    func markHeadSending() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.setQueueHeadError("boom")
+        s.markQueueHeadSending()
+        #expect(s.queue[0].status == .sending)
+        #expect(s.queue[0].lastError == nil)
+    }
+
+    @Test("popQueueHead removes the head when it's .sending; returns it")
+    func popHead() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("b")])
+        s.markQueueHeadSending()
+        let popped = s.popQueueHead()
+        #expect(popped?.blocks == [.text("a")])
+        #expect(s.queue.count == 1)
+        #expect(s.queue[0].blocks == [.text("b")])
+    }
+
+    @Test("setQueueHeadError flips .sending back to .pending and records the message")
+    func setHeadError() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.markQueueHeadSending()
+        s.setQueueHeadError("network")
+        #expect(s.queue[0].status == .pending)
+        #expect(s.queue[0].lastError == "network")
+    }
+
+    @Test("editQueueItem(id:blocks:) replaces blocks of a .pending item only")
+    func editPending() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        let id = s.queue[0].id
+        s.editQueueItem(id: id, blocks: [.text("a2")])
+        #expect(s.queue[0].blocks == [.text("a2")])
+    }
+
+    @Test("editQueueItem refuses to edit a .sending item")
+    func editSendingRefused() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.markQueueHeadSending()
+        let id = s.queue[0].id
+        s.editQueueItem(id: id, blocks: [.text("a2")])
+        #expect(s.queue[0].blocks == [.text("a")])
+    }
+
+    @Test("restoreQueue normalizes .sending → .pending")
+    func restoreNormalizes() {
+        let s = mkSession()
+        let sending = QueuedPrompt(blocks: [.text("a")], status: .sending)
+        let pending = QueuedPrompt(blocks: [.text("b")], status: .pending)
+        s.restoreQueue([sending, pending])
+        #expect(s.queue.map { $0.status } == [.pending, .pending])
+        #expect(s.queue.map { $0.blocks } == [[.text("a")], [.text("b")]])
+    }
+
+    @Test("restorePendingSnapshot keeps a .sending head at index 0")
+    func restoreSnapshotPreservesSendingHead() {
+        // Regression: undo-clicked-while-already-flushing scenario. The
+        // restored items must NOT displace an in-flight .sending head; if
+        // they did, the in-flight sendNow's popQueueHead would pop the
+        // wrong item and the .sending item would be stuck in the queue.
+        let s = mkSession()
+        s.enqueue(blocks: [.text("in-flight")])
+        s.markQueueHeadSending()
+        s.restorePendingSnapshot([
+            QueuedPrompt(blocks: [.text("restored-a")], status: .pending),
+            QueuedPrompt(blocks: [.text("restored-b")], status: .pending),
+        ])
+        #expect(s.queue.count == 3)
+        #expect(s.queue[0].status == .sending)
+        #expect(s.queue[0].blocks == [.text("in-flight")])
+        #expect(s.queue[1].blocks == [.text("restored-a")])
+        #expect(s.queue[2].blocks == [.text("restored-b")])
+    }
+
+    @Test("restorePendingSnapshot inserts at the head when no .sending item exists")
+    func restoreSnapshotPrependsWhenIdle() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("existing-pending")])
+        s.restorePendingSnapshot([
+            QueuedPrompt(blocks: [.text("restored")], status: .pending),
+        ])
+        #expect(s.queue.count == 2)
+        #expect(s.queue[0].blocks == [.text("restored")])
+        #expect(s.queue[1].blocks == [.text("existing-pending")])
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -1,0 +1,477 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSessionRunner queue routing")
+struct ACPSessionRunnerQueueTests {
+    private func mkRunner() throws -> (ACPSessionRunner, ACPMockClient, ACPSession, ACPSessionStore) {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-q-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path)
+        return (runner, mock, session, store)
+    }
+
+    @Test(".auto while .streaming with empty queue → enqueues; persists; no prompt RPC")
+    func enqueuesWhileStreaming() async throws {
+        let (runner, mock, session, store) = try mkRunner()
+        session.transcript.streamingState = .streaming
+        runner.send(blocks: [.text("queued")], intent: .auto)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].blocks == [.text("queued")])
+        #expect(mock.sent.contains { $0.method == "session/prompt" } == false)
+        let persisted = try store.loadQueue(sessionId: "s")
+        #expect(persisted == session.queue)
+    }
+
+    @Test(".auto while .idle with empty queue → calls session/prompt; queue stays empty")
+    func sendsImmediatelyWhenIdle() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        runner.send(blocks: [.text("hi")], intent: .auto)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(mock.sent.contains { $0.method == "session/prompt" })
+        #expect(session.queue.isEmpty)
+    }
+
+    @Test(".auto while .idle with non-empty queue → enqueues (queue is authoritative)")
+    func enqueuesWhenIdleAndQueueNonEmpty() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        // Pre-seed queue with an item to make queueEmpty == false.
+        session.enqueue(blocks: [.text("first")])
+        runner.send(blocks: [.text("second")], intent: .auto)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(session.queue.count == 2)
+        #expect(session.queue.map { $0.blocks } == [[.text("first")], [.text("second")]])
+        #expect(mock.sent.contains { $0.method == "session/prompt" } == false)
+    }
+
+    @Test("empty blocks → noOp; nothing queued, no RPC, no state change")
+    func emptyNoOp() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        session.transcript.streamingState = .streaming
+        runner.send(blocks: [], intent: .steer)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(session.queue.isEmpty)
+        #expect(mock.sent.isEmpty)
+        #expect(session.transcript.streamingState == .streaming)
+    }
+
+    @Test("flushQueueIfIdle drains head when state is .idle")
+    func drainsHeadWhenIdle() async throws {
+        let (runner, mock, session, store) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.enqueue(blocks: [.text("first")])
+        session.enqueue(blocks: [.text("second")])
+        runner.persistQueue()
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 250_000_000)
+        // Both items should drain in order; queue ends empty.
+        #expect(session.queue.isEmpty)
+        let prompts = mock.sent.filter { $0.method == "session/prompt" }
+        #expect(prompts.count == 2)
+        // Persisted queue is empty after drain.
+        #expect(try store.loadQueue(sessionId: "s").isEmpty)
+    }
+
+    @Test("flushQueueIfIdle is a no-op while state is .streaming")
+    func noopWhileStreaming() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        session.transcript.streamingState = .streaming
+        session.enqueue(blocks: [.text("nope")])
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(session.queue.count == 1)
+        #expect(mock.sent.contains { $0.method == "session/prompt" } == false)
+    }
+
+    @Test("flushQueueIfIdle is a no-op while state is .awaitingPermission")
+    func noopAwaitingPermission() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        session.transcript.streamingState = .awaitingPermission
+        session.enqueue(blocks: [.text("nope")])
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(session.queue.count == 1)
+        #expect(mock.sent.contains { $0.method == "session/prompt" } == false)
+    }
+
+    @Test("flushQueueIfIdle skips a head with lastError; doesn't auto-retry")
+    func skipsErroredHead() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        session.enqueue(blocks: [.text("broken")])
+        session.setQueueHeadError("network")
+        runner.persistQueue()
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 100_000_000)
+        // Head untouched; no RPC made.
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].lastError == "network")
+        #expect(mock.sent.contains { $0.method == "session/prompt" } == false)
+    }
+
+    @Test("flush failure flips head back to .pending with lastError; queue not popped")
+    func flushFailureKeepsItem() async throws {
+        let (runner, mock, session, store) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in
+            throw ACPClientError.noScript(method: "session/prompt")  // any throw
+        }
+        session.enqueue(blocks: [.text("will-fail")])
+        runner.persistQueue()
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].status == .pending)
+        #expect(session.queue[0].lastError != nil)
+        let persisted = try store.loadQueue(sessionId: "s")
+        #expect(persisted == session.queue)
+    }
+
+    @Test(".steer while streaming with queue → cancel sent, queue cleared, new prompt sent, snapshot captured")
+    func steerClearsAndSends() async throws {
+        let (runner, mock, session, store) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        // Pre-seed queue + put session in streaming.
+        session.attached = true
+        session.transcript.streamingState = .streaming
+        session.enqueue(blocks: [.text("stale-a")])
+        session.enqueue(blocks: [.text("stale-b")])
+        runner.persistQueue()
+
+        runner.send(blocks: [.text("redirect")], intent: .steer)
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        // session/cancel was sent
+        #expect(mock.sent.contains { $0.method == "session/cancel" })
+        // queue is empty after drain (cleared by steer, redirect popped after send)
+        #expect(session.queue.isEmpty)
+        // session/prompt was sent with the steer blocks
+        let prompts = mock.sent.filter { $0.method == "session/prompt" }
+        #expect(prompts.count == 1)
+        // Undo snapshot captured
+        #expect(runner.steerUndoSnapshot()?.count == 2)
+        #expect(runner.steerUndoSnapshot()?.map { $0.blocks } == [[.text("stale-a")], [.text("stale-b")]])
+        // Persisted queue empty
+        #expect(try store.loadQueue(sessionId: "s").isEmpty)
+    }
+
+    @Test("steer that races a detach skips the redirect on a torn-down session")
+    func steerSkipsRedirectAfterDetach() async throws {
+        // Regression: the unstructured steer Task survives the runner +
+        // connection it was spawned in. If the user closes the tab while
+        // we're awaiting `userCancel`, `ACPSessionManager.detach` flips
+        // `session.attached = false` and shuts down the connection but
+        // doesn't cancel this task. Without a liveness check, the trailing
+        // `sendNow` would append the redirect prompt and persist a
+        // `lastError` on the detached session.
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.attached = true
+        session.transcript.streamingState = .streaming
+
+        runner.send(blocks: [.text("redirect")], intent: .steer)
+        // Simulate the detach landing while userCancel is still in flight.
+        session.attached = false
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        // session/cancel still went out (we started userCancel before the
+        // detach was observable), but the redirect prompt was suppressed.
+        #expect(mock.sent.contains { $0.method == "session/cancel" })
+        let prompts = mock.sent.filter { $0.method == "session/prompt" }
+        #expect(prompts.isEmpty)
+    }
+
+    @Test("steerUndo() re-prepends snapshot and drains it on next idle")
+    func steerUndoRestores() async throws {
+        let (runner, mock, session, store) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.attached = true
+        session.transcript.streamingState = .streaming
+        session.enqueue(blocks: [.text("a")])
+        runner.send(blocks: [.text("redirect")], intent: .steer)
+        try await Task.sleep(nanoseconds: 250_000_000)
+        // Steer fired: redirect sent, snapshot captured, state .idle.
+        #expect(runner.steerUndoSnapshot() != nil)
+        #expect(session.queue.isEmpty)
+        let promptsAfterSteer = mock.sent.filter { $0.method == "session/prompt" }.count
+        #expect(promptsAfterSteer == 1)
+
+        runner.steerUndo()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        // Undo restored "a" to the queue AND the flusher drained it
+        // (state was .idle, so flushQueueIfIdle ran). Final state:
+        // queue empty, 2 prompts total (redirect + the undone item).
+        #expect(session.queue.isEmpty)
+        let promptsAfterUndo = mock.sent.filter { $0.method == "session/prompt" }.count
+        #expect(promptsAfterUndo == 2)
+        let persisted = try store.loadQueue(sessionId: "s")
+        #expect(persisted.isEmpty)
+        // Snapshot is consumed after undo.
+        #expect(runner.steerUndoSnapshot() == nil)
+    }
+
+    @Test("steerUndo() is a no-op when snapshot is empty / expired")
+    func steerUndoEmptyNoop() {
+        let (runner, _, session, _) = try! mkRunner()
+        session.enqueue(blocks: [.text("x")])
+        runner.steerUndo()
+        // Queue unchanged.
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].blocks == [.text("x")])
+    }
+
+    @Test("queued flush records the user prompt at dispatch (before await)")
+    func queuedFlushRecordsBeforeAwait() async throws {
+        // Regression for "answer before question" ordering. Streamed
+        // session/update notifications can arrive while session/prompt is
+        // still in flight; the user prompt must be appended to the
+        // transcript at dispatch time. Verified via the failure path:
+        // with no script, the RPC throws, and yet the user message is in
+        // the transcript afterward — proof that recording happened BEFORE
+        // the await rather than inside the success handler.
+        let (runner, _, session, _) = try mkRunner()
+        // No mock.script for session/prompt → mock.send throws noScript.
+        session.enqueue(blocks: [.text("queued-q")])
+        runner.persistQueue()
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        // RPC failed; item back at head with lastError; transcriptRecorded
+        // flipped, AND the user message is in the transcript.
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].lastError != nil)
+        #expect(session.queue[0].transcriptRecorded == true)
+        var userTexts: [String] = []
+        for msg in session.transcript.messages {
+            if case .user(_, let text, _) = msg { userTexts.append(text) }
+        }
+        #expect(userTexts == ["queued-q"])
+    }
+
+    @Test("queued retry doesn't double-record the user prompt")
+    func queuedRetryDoesNotDoubleRecord() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        // First attempt fails (no script). User clicks Retry. Second
+        // attempt succeeds (script wired below). Verify the transcript
+        // contains the user prompt exactly once across both attempts.
+        session.enqueue(blocks: [.text("retry-me")])
+        runner.persistQueue()
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].lastError != nil)
+        #expect(session.queue[0].transcriptRecorded == true)
+        var users = session.transcript.messages.filter { if case .user = $0 { return true } else { return false } }
+        #expect(users.count == 1)
+
+        // Simulate Retry: wire success script + clear lastError + flush.
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.queue[0].lastError = nil
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(session.queue.isEmpty)
+        users = session.transcript.messages.filter { if case .user = $0 { return true } else { return false } }
+        #expect(users.count == 1)
+    }
+
+    @Test("steer drops a .sending head and excludes it from the undo snapshot")
+    func steerDiscardsSendingHead() async throws {
+        // Regression for the race where steer happens while the flusher
+        // has already marked the head .sending. The .sending item must
+        // be evicted along with the .pending tail; otherwise the stale
+        // in-flight RPC would settle later and mutate session state
+        // behind the steer.
+        let (runner, mock, session, store) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.attached = true
+        // Simulate: flusher already promoted the head to .sending; a
+        // pending tail is sitting behind it.
+        session.enqueue(blocks: [.text("in-flight")])
+        session.markQueueHeadSending()
+        session.enqueue(blocks: [.text("tail-pending")])
+        runner.persistQueue()
+        session.transcript.streamingState = .sending
+
+        runner.send(blocks: [.text("redirect")], intent: .steer)
+        try await Task.sleep(nanoseconds: 250_000_000)
+
+        // Both queued items are gone; only the redirect prompt fired.
+        #expect(session.queue.isEmpty)
+        #expect(mock.sent.contains { $0.method == "session/cancel" })
+        let prompts = mock.sent.filter { $0.method == "session/prompt" }
+        #expect(prompts.count == 1)
+        // The .sending head MUST NOT appear in the undo snapshot — it was
+        // mid-flight; resurrecting it would just re-fire the prompt the
+        // user steered away from. Only the .pending tail is restorable.
+        let snapshot = runner.steerUndoSnapshot() ?? []
+        #expect(snapshot.map { $0.blocks } == [[.text("tail-pending")]])
+        #expect(try store.loadQueue(sessionId: "s").isEmpty)
+    }
+
+    @Test("userCancel() drains queue after canceling the running turn")
+    func cancelThenFlushDrainsQueue() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.transcript.streamingState = .streaming
+        session.enqueue(blocks: [.text("queued-after-esc")])
+        await runner.userCancel()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(session.queue.isEmpty)
+        #expect(mock.sent.contains { $0.method == "session/cancel" })
+        #expect(mock.sent.contains { $0.method == "session/prompt" })
+    }
+
+    @Test("a sendNow cancelled before its Task starts is a complete no-op")
+    func sendNowCancelledBeforeTaskStartsIsNoOp() async throws {
+        // Regression for the TOCTOU race between flushQueueIfIdle
+        // dispatching sendNow and detach/userCancel running their
+        // invalidateActivePrompt path before the Task body's first
+        // MainActor.run reaches the activePromptID assignment. Without
+        // the synchronous registration + early-exit guard, the Task
+        // would proceed, eventually fail on a dead connection, and
+        // persist a `lastError` on the queue head — defeating the
+        // detach-clears-cleanly invariant.
+        let (runner, mock, session, _) = try mkRunner()
+        // Drive sendNow directly. Immediately after dispatch — before
+        // its Task body runs its first MainActor hop — invalidate the
+        // active prompt. The Task's stillActive guard must fire and
+        // the user prompt must NOT appear in the transcript.
+        runner.sendNow(blocks: [.text("doomed")], queuedItemId: nil)
+        runner.invalidateActivePrompt()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        let users = session.transcript.messages.filter { if case .user = $0 { return true } else { return false } }
+        #expect(users.isEmpty)
+        #expect(mock.sent.contains { $0.method == "session/prompt" } == false)
+        #expect(session.transcript.streamingState == .idle)
+    }
+
+    @Test("userCancel with no .sending queue head leaves queued items alone")
+    func userCancelNoSendingHeadPreservesQueue() async throws {
+        // Regression: userCancel used to capture activePromptID + queue
+        // state AFTER awaiting connection.cancel. If a natural prompt
+        // completion during the await flushed a queued item to .sending,
+        // the post-await logic would happily insert that queued item's
+        // ID into cancelledPromptIDs and pop it — Stop killing a prompt
+        // the user only queued. Capturing the intended target BEFORE
+        // the await means a .pending queue head at Stop-time stays put.
+        let (runner, _, session, store) = try mkRunner()
+        // Pre-state: a direct turn is streaming (no .sending head), with
+        // a pending tail waiting in the queue.
+        session.transcript.streamingState = .streaming
+        session.enqueue(blocks: [.text("untouched")])
+        runner.persistQueue()
+        // Note: no markQueueHeadSending — the head is .pending.
+
+        await runner.userCancel()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Queue remains intact — Stop targeted the running direct turn,
+        // not the queued item.
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].blocks == [.text("untouched")])
+        #expect(session.queue[0].status == .pending)
+        let persisted = try store.loadQueue(sessionId: "s")
+        #expect(persisted == session.queue)
+    }
+
+    @Test("userCancel pops a .sending queue head so it doesn't stay stuck")
+    func userCancelPopsSendingHead() async throws {
+        // Regression: when Stop/Esc fires while the flusher is mid-RPC on
+        // a queued head, the cancelled sendNow's completion can no
+        // longer mutate the queue (it's no longer the active prompt),
+        // and flushQueueIfIdle requires `.pending`. Without this fix
+        // the head would stay stuck `.sending` forever.
+        let (runner, _, session, store) = try mkRunner()
+        session.enqueue(blocks: [.text("in-flight")])
+        session.enqueue(blocks: [.text("queued-tail")])
+        session.markQueueHeadSending()
+        session.transcript.streamingState = .sending
+        runner.persistQueue()
+
+        await runner.userCancel()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // Head popped, tail remains as .pending; persisted state matches.
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].blocks == [.text("queued-tail")])
+        #expect(session.queue[0].status == .pending)
+        let persisted = try store.loadQueue(sessionId: "s")
+        #expect(persisted == session.queue)
+    }
+
+    @Test("flushQueueIfIdle is a no-op while .awaitingPermission, then drains after .idle")
+    func awaitingPermissionDefersDrain() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        mock.script(method: "session/prompt") { _ in Data("null".utf8) }
+        session.transcript.streamingState = .awaitingPermission
+        session.enqueue(blocks: [.text("waits")])
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(session.queue.count == 1)     // still queued; no RPC
+
+        // Permission resolved → state returns to idle through the normal
+        // turn-end path. Simulate by flipping state directly.
+        session.transcript.streamingState = .idle
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(session.queue.isEmpty)
+        #expect(mock.sent.contains { $0.method == "session/prompt" })
+    }
+
+    @Test("queue survives runner restart: persist + restart + drain")
+    func persistenceRoundTrip() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-rt-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "rt", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        // First runner: enqueue, mark sending, persist.
+        let mock1 = ACPMockClient()
+        let session1 = ACPSession(id: "rt", agentId: "claude", worktreeId: "wt", title: "t")
+        let runner1 = ACPSessionRunner(
+            session: session1, connection: ACPConnection(client: mock1), store: store,
+            sessionId: "rt", worktreePath: FileManager.default.temporaryDirectory.path)
+        session1.transcript.streamingState = .streaming
+        runner1.send(blocks: [.text("alpha")], intent: .auto)
+        runner1.send(blocks: [.text("beta")], intent: .auto)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        // Simulate the "in-flight head when app quit" case by flipping
+        // the head to .sending and persisting.
+        session1.markQueueHeadSending()
+        runner1.persistQueue()
+        let persisted = try store.loadQueue(sessionId: "rt")
+        #expect(persisted.count == 2)
+        #expect(persisted[0].status == .sending)
+
+        // Second runner: fresh session, restored queue, then drain.
+        let mock2 = ACPMockClient()
+        mock2.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: FileManager.default.temporaryDirectory.path, store: store)
+        let session2 = mgr.openSession(id: "rt")!
+        #expect(session2.queue.count == 2)
+        // .sending was normalized to .pending on restore.
+        #expect(session2.queue[0].status == .pending)
+        let runner2 = ACPSessionRunner(
+            session: session2, connection: ACPConnection(client: mock2), store: store,
+            sessionId: "rt", worktreePath: FileManager.default.temporaryDirectory.path)
+        runner2.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 400_000_000)
+        #expect(session2.queue.isEmpty)
+        let prompts = mock2.sent.filter { $0.method == "session/prompt" }
+        #expect(prompts.count == 2)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionStoreQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreQueueTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPSessionStore queue")
+struct ACPSessionStoreQueueTests {
+    private func mkStore() throws -> (ACPSessionStore, String) {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("acp-queue-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "sx", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        return (store, "sx")
+    }
+
+    @Test("loadQueue returns empty for a session with no queue")
+    func emptyWhenAbsent() throws {
+        let (store, sid) = try mkStore()
+        let q = try store.loadQueue(sessionId: sid)
+        #expect(q.isEmpty)
+    }
+
+    @Test("upsertQueue + loadQueue round-trips items in order")
+    func roundTrip() throws {
+        let (store, sid) = try mkStore()
+        let items = [
+            QueuedPrompt(blocks: [.text("one")], status: .pending),
+            QueuedPrompt(blocks: [.text("two")], status: .sending),
+        ]
+        try store.upsertQueue(sessionId: sid, items: items)
+        let loaded = try store.loadQueue(sessionId: sid)
+        #expect(loaded == items)
+    }
+
+    @Test("upsertQueue replaces previous queue for the same session")
+    func upsertReplaces() throws {
+        let (store, sid) = try mkStore()
+        try store.upsertQueue(sessionId: sid, items: [QueuedPrompt(blocks: [.text("a")])])
+        try store.upsertQueue(sessionId: sid, items: [QueuedPrompt(blocks: [.text("b")])])
+        let loaded = try store.loadQueue(sessionId: sid)
+        #expect(loaded.count == 1)
+        #expect(loaded[0].blocks == [.text("b")])
+    }
+
+    @Test("upsertQueue with empty array deletes the row")
+    func emptyDeletes() throws {
+        let (store, sid) = try mkStore()
+        try store.upsertQueue(sessionId: sid, items: [QueuedPrompt(blocks: [.text("a")])])
+        try store.upsertQueue(sessionId: sid, items: [])
+        let loaded = try store.loadQueue(sessionId: sid)
+        #expect(loaded.isEmpty)
+    }
+
+    @Test("schema target version includes session_queue (v3+)")
+    func schemaIsV3() throws {
+        let (store, _) = try mkStore()
+        #expect(try store.currentSchemaVersion() == 3)
+        #expect(ACPSessionStore.targetSchemaVersion == 3)
+    }
+}
+
+@MainActor
+@Suite("ACPSessionManager queue restore")
+struct ACPSessionManagerQueueRestoreTests {
+    @Test("openSession restores persisted queue, flipping .sending to .pending")
+    func restoreNormalizes() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-q-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "sm", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        try store.upsertQueue(sessionId: "sm", items: [
+            QueuedPrompt(blocks: [.text("a")], status: .sending, lastError: nil),
+            QueuedPrompt(blocks: [.text("b")], status: .pending, lastError: "previously failed"),
+        ])
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp", store: store)
+        let session = mgr.openSession(id: "sm")
+        #expect(session != nil)
+        #expect(session?.queue.count == 2)
+        #expect(session?.queue[0].status == .pending)   // was .sending
+        #expect(session?.queue[1].status == .pending)
+        #expect(session?.queue[1].lastError == "previously failed")
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionStoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreTests.swift
@@ -9,11 +9,11 @@ struct ACPSessionStoreSchemaTests {
         return try ACPSessionStore(path: url.path)
     }
 
-    @Test("opens a fresh DB at schema version 2")
+    @Test("opens a fresh DB at schema version 3")
     func freshSchema() throws {
         let store = try tmpStore()
         #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
-        #expect(ACPSessionStore.targetSchemaVersion == 2)
+        #expect(ACPSessionStore.targetSchemaVersion == 3)
     }
 
     @Test("re-opening doesn't double-apply migrations")
@@ -23,8 +23,8 @@ struct ACPSessionStoreSchemaTests {
         _ = try ACPSessionStore(path: url.path) // must not throw
     }
 
-    @Test("migrates schema version 1 to version 2")
-    func migratesV1ToV2() throws {
+    @Test("migrates schema version 1 to current target")
+    func migratesV1ToCurrent() throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("acp-store-\(UUID()).sqlite")
         do {
             let db = try SQLiteDatabase(path: url.path)
@@ -73,7 +73,7 @@ struct ACPSessionStoreSchemaTests {
         }
 
         let store = try ACPSessionStore(path: url.path)
-        #expect(try store.currentSchemaVersion() == 2)
+        #expect(try store.currentSchemaVersion() == 3)
 
         let draft = ACPComposerDraft(segments: [.text("migrated")])
         try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",

--- a/AlasTests/ACP/Session/ACPSubmitIntentTests.swift
+++ b/AlasTests/ACP/Session/ACPSubmitIntentTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPSubmitRoute")
+struct ACPSubmitRouteTests {
+    @Test(".auto + idle + empty queue → sendNow")
+    func idleEmptyAuto() {
+        let r = ACPSubmitRoute.resolve(intent: .auto, state: .idle, queueEmpty: true, blocksEmpty: false)
+        #expect(r == .sendNow)
+    }
+
+    @Test(".auto + idle + non-empty queue → enqueue (queue is authoritative once non-empty)")
+    func idleNonEmptyAuto() {
+        let r = ACPSubmitRoute.resolve(intent: .auto, state: .idle, queueEmpty: false, blocksEmpty: false)
+        #expect(r == .enqueue)
+    }
+
+    @Test(".auto + streaming → enqueue")
+    func streamingAuto() {
+        let r = ACPSubmitRoute.resolve(intent: .auto, state: .streaming, queueEmpty: true, blocksEmpty: false)
+        #expect(r == .enqueue)
+    }
+
+    @Test(".auto + sending → enqueue")
+    func sendingAuto() {
+        let r = ACPSubmitRoute.resolve(intent: .auto, state: .sending, queueEmpty: true, blocksEmpty: false)
+        #expect(r == .enqueue)
+    }
+
+    @Test(".auto + awaitingPermission → enqueue")
+    func awaitingPermAuto() {
+        let r = ACPSubmitRoute.resolve(intent: .auto, state: .awaitingPermission, queueEmpty: true, blocksEmpty: false)
+        #expect(r == .enqueue)
+    }
+
+    @Test(".steer + busy → steer")
+    func steerWhileBusy() {
+        let r = ACPSubmitRoute.resolve(intent: .steer, state: .streaming, queueEmpty: false, blocksEmpty: false)
+        #expect(r == .steer)
+    }
+
+    @Test(".steer + idle + empty queue → sendNow (nothing to interrupt)")
+    func steerIdleEmpty() {
+        let r = ACPSubmitRoute.resolve(intent: .steer, state: .idle, queueEmpty: true, blocksEmpty: false)
+        #expect(r == .sendNow)
+    }
+
+    @Test(".steer + idle + non-empty queue → steer (clears queue, sends now)")
+    func steerIdleNonEmpty() {
+        let r = ACPSubmitRoute.resolve(intent: .steer, state: .idle, queueEmpty: false, blocksEmpty: false)
+        #expect(r == .steer)
+    }
+
+    @Test("empty blocks → noOp regardless of intent")
+    func emptyBlocksNoOp() {
+        #expect(ACPSubmitRoute.resolve(intent: .auto,  state: .idle,      queueEmpty: true,  blocksEmpty: true) == .noOp)
+        #expect(ACPSubmitRoute.resolve(intent: .steer, state: .streaming, queueEmpty: false, blocksEmpty: true) == .noOp)
+    }
+
+    @Test("inFlightSteer forces enqueue even when state looks idle and queue is empty")
+    func inFlightSteerForcesEnqueue() {
+        // Regression: between userCancel finishing and the steer redirect's
+        // sendNow installing itself, the session briefly looks idle+empty.
+        // A user submit in that window must queue behind the redirect, not
+        // race it with another sendNow.
+        let auto = ACPSubmitRoute.resolve(
+            intent: .auto, state: .idle, queueEmpty: true, blocksEmpty: false, inFlightSteer: true)
+        #expect(auto == .enqueue)
+        let steer = ACPSubmitRoute.resolve(
+            intent: .steer, state: .idle, queueEmpty: true, blocksEmpty: false, inFlightSteer: true)
+        #expect(steer == .enqueue)
+    }
+
+    @Test("inFlightSteer still respects noOp for empty composer")
+    func inFlightSteerNoOp() {
+        let r = ACPSubmitRoute.resolve(
+            intent: .auto, state: .idle, queueEmpty: true, blocksEmpty: true, inFlightSteer: true)
+        #expect(r == .noOp)
+    }
+}

--- a/AlasTests/ACP/Session/QueuedPromptTests.swift
+++ b/AlasTests/ACP/Session/QueuedPromptTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("QueuedPrompt")
+struct QueuedPromptTests {
+    @Test("round-trips JSON with default status .pending")
+    func roundTripDefault() throws {
+        let id = UUID()
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let original = QueuedPrompt(
+            id: id,
+            blocks: [.text("hello"), .resourceLink(uri: "file:///a.txt", name: "a.txt")],
+            enqueuedAt: date,
+            status: .pending,
+            lastError: nil
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(QueuedPrompt.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test("normalizeAfterRestore flips .sending to .pending and clears lastError untouched")
+    func normalize() {
+        let q = QueuedPrompt(id: UUID(), blocks: [.text("x")],
+                             enqueuedAt: .init(), status: .sending, lastError: "boom")
+        let n = q.normalizedAfterRestore()
+        #expect(n.status == .pending)
+        #expect(n.lastError == "boom")    // lastError survives; only status flips
+    }
+
+    @Test("encodes status as raw string")
+    func statusRaw() throws {
+        let q = QueuedPrompt(id: UUID(), blocks: [.text("x")],
+                             enqueuedAt: .init(), status: .sending, lastError: nil)
+        let json = String(data: try JSONEncoder().encode(q), encoding: .utf8)!
+        #expect(json.contains("\"status\":\"sending\""))
+    }
+}

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -22,9 +22,10 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
-            onSubmit: { _, _, submittedDraft, onFinished in
+            onSubmit: { _, _, _, submittedDraft, onFinished in
                 #expect(submittedDraft == draft)
                 completion = onFinished
                 return true
@@ -32,7 +33,7 @@ struct ACPComposerDraftBridgeTests {
         )
         coordinator.textView = textView
 
-        coordinator.submit(textView)
+        coordinator.submit(textView, intent: .auto)
         #expect(textView.string.isEmpty)
         #expect(changedDrafts.isEmpty)
         #expect(clearCount == 0)
@@ -56,9 +57,10 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
-            onSubmit: { _, _, submittedDraft, onFinished in
+            onSubmit: { _, _, _, submittedDraft, onFinished in
                 #expect(submittedDraft == draft)
                 completion = onFinished
                 return true
@@ -90,9 +92,10 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
-            onSubmit: { _, _, draft, onFinished in
+            onSubmit: { _, _, _, draft, onFinished in
                 #expect(draft == submittedDraft)
                 completion = onFinished
                 return true
@@ -126,9 +129,10 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
-            onSubmit: { _, _, draft, onFinished in
+            onSubmit: { _, _, _, draft, onFinished in
                 #expect(draft == submittedDraft)
                 completion = onFinished
                 return true
@@ -157,9 +161,10 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: submittedDraft,
+            sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
-            onSubmit: { _, _, _, _ in true }
+            onSubmit: { _, _, _, _, _ in true }
         )
 
         coordinator.syncPersistedDraft(.empty, into: textView)
@@ -181,9 +186,10 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: submittedDraft,
+            sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
-            onSubmit: { _, _, _, _ in true }
+            onSubmit: { _, _, _, _, _ in true }
         )
 
         coordinator.syncPersistedDraft(.empty, into: textView)
@@ -191,6 +197,36 @@ struct ACPComposerDraftBridgeTests {
         #expect(ACPInputField.Coordinator.draft(from: textView.attributedString()) == localDraft)
         #expect(changedDrafts.isEmpty)
         #expect(clearCount == 0)
+    }
+
+    @Test("toolbar send button bypasses keyboard inversion (sendOnEnter=false)")
+    func toolbarSubmitBypassesInversion() {
+        // Regression: the inversion was previously applied to ALL submits
+        // upstream of the composer, including the toolbar send button.
+        // With `acpSendOnEnter = false`, a plain ↑ click would have been
+        // converted to `.steer` (cancel + discard) instead of `.auto`
+        // (queue/send). The fix moves the keyboard inversion INTO the
+        // coordinator's `doCommandBy`; `submit(_:intent:)` (which the
+        // button calls via `actions.submitWithIntent`) emits the intent
+        // verbatim.
+        let textView = NSTextView()
+        textView.string = "hello"
+        var received: ACPSubmitIntent?
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            sendOnEnter: false,           // user inverted the setting
+            onDraftChange: { _ in },
+            onDraftClear: {},
+            onSubmit: { _, _, intent, _, _ in
+                received = intent
+                return true
+            }
+        )
+        coordinator.textView = textView
+
+        coordinator.submit(textView, intent: .auto)
+        #expect(received == .auto)        // NOT inverted by the button path
     }
 
     @Test("serializes plain text and mention chips in order")

--- a/AlasTests/ACP/UI/ACPComposerPlaceholderTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerPlaceholderTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPInputField placeholder")
+struct ACPComposerPlaceholderTests {
+    @Test("idle ignores sendOnEnter and shows the default prompt")
+    func idle() {
+        #expect(ACPInputField.placeholder(for: .idle, sendOnEnter: true)
+                == "Plan, ask, or build — type / for commands")
+        #expect(ACPInputField.placeholder(for: .idle, sendOnEnter: false)
+                == "Plan, ask, or build — type / for commands")
+    }
+
+    @Test("busy + sendOnEnter advertises ⏎ as queue and ⌥⏎ as steer")
+    func busyDefault() {
+        let queueText = "Queue a follow-up… (⌥⏎ to steer)"
+        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission] {
+            #expect(ACPInputField.placeholder(for: state, sendOnEnter: true) == queueText)
+        }
+    }
+
+    @Test("busy + inverted mapping advertises ⏎ as steer and ⌥⏎ as queue")
+    func busyInverted() {
+        let steerText = "Steer the agent… (⌥⏎ to queue)"
+        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission] {
+            #expect(ACPInputField.placeholder(for: state, sendOnEnter: false) == steerText)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a per-session prompt queue and steering interaction to the ACP chat pane, comparable to the queue/interrupt UX in Codex, Claude Code, and opencode.

- **Queue while busy.** Submitting (⏎) while the agent is streaming appends the prompt to a per-session queue, rendered as dashed-border pending bubbles below the transcript. Items auto-drain in order when the agent returns to idle.
- **Steer.** ⌥⏎ cancels the running turn and immediately sends the new prompt, discarding any queued items (with a 5s undo toast).
- **Persistence.** Queue lives in a new SQLite `session_queue` table and survives app restart. Any item left mid-send when the app exits is rolled back to pending and re-tried on the next idle transition.
- **Settings.** Toggle "Send on ⏎, queue on ⌥⏎ while busy" — when off, the mapping inverts.
- **UI:** dedicated stop pill (separated from the send button), queue counter badge on the send button, drag-reorder for pending bubbles, state-aware composer placeholder.

Spec: `docs/superpowers/specs/2026-05-28-acp-chat-queue-steering-design.md` (gitignored).
Plan: `docs/superpowers/plans/2026-05-28-acp-chat-queue-steering.md` (gitignored).

## Architecture

- `QueuedPrompt` model with `pending`/`sending` status + restore-time normalization.
- Pure routing function `ACPSubmitRoute.resolve(intent:state:queueEmpty:blocksEmpty:)` — fully unit-tested.
- `ACPSessionRunner.send(blocks:intent:)` routes to `sendNow` / `enqueue` / `steer`.
- `flushQueueIfIdle()` drains the head whenever state transitions to `.idle` (success, failure, ESC, attach). Chained drain is implicit via `sendNow`'s completion calling back.
- Steer captures a 5s undo snapshot on `session.steerUndo: SteerUndoState?` (Published), so SwiftUI re-renders the toast reactively.
- Failed queued sends stay at the head with `lastError` + manual Retry — no auto-retry, no silent loss.

## Test plan

- [x] 33 new unit/integration tests (queue routing, drain, steer + undo, persistence round-trip, ESC drain, awaitingPermission deferral)
- [x] Full suite green (2193 tests, 283 suites) after rebase on `origin/main`
- [ ] Manual: queue while streaming, observe bubble morph; steer + undo; quit/relaunch with queued items; toggle settings inversion
- [ ] Manual: ⌥⏎ with empty composer is a no-op; ESC cancels turn, queue auto-drains afterward; permission-prompt path defers drain

## Notes

- Spec deviation: inline editing of queued items is reduced to "remove + re-type" for v1 (pencil opens removal). Full inline editor is follow-up.
- Schema migration uses sequential `if current < N { migrate_to_vN() }` — final reviewer flagged this as fragile for future v3; left for whoever adds the next migration.