### PR TITLE
feat(acp): stable per-row identity for transcript diffing

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -610,6 +610,7 @@
 		D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C9B383554D7DAB170C2F8 /* Seg.swift */; };
 		D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6600436B01C75D85C01FFA /* Clipboard.swift */; };
 		D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */; };
+		AA11223300AA4455667788BB /* ACPMessageStableIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11223300AA4455667788CC /* ACPMessageStableIdTests.swift */; };
 		D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */; };
 		D1C14B54BE27D97E354F448B /* ProcessGitDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
@@ -1284,6 +1285,7 @@
 		C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spinner.swift; sourceTree = "<group>"; };
 		C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Surface.swift; sourceTree = "<group>"; };
 		C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageTests.swift; sourceTree = "<group>"; };
+		AA11223300AA4455667788CC /* ACPMessageStableIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageStableIdTests.swift; sourceTree = "<group>"; };
 		C995611A6313FABE30508248 /* WorktreeRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowView.swift; sourceTree = "<group>"; };
 		C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentEditView.swift; sourceTree = "<group>"; };
 		C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediatorTests.swift; sourceTree = "<group>"; };
@@ -2407,6 +2409,7 @@
 				239125BB939233233D405EB8 /* ACPChipStateTests.swift */,
 				D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */,
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
+				AA11223300AA4455667788CC /* ACPMessageStableIdTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */,
 				45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */,
@@ -3423,6 +3426,7 @@
 				603D2F40A0368A139822CE80 /* ACPLaunchCatalogTests.swift in Sources */,
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
 				D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */,
+				AA11223300AA4455667788BB /* ACPMessageStableIdTests.swift in Sources */,
 				395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */,
 				4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */,
 				57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -1,13 +1,27 @@
 import Foundation
 
 enum ACPMessage: Equatable {
-    case user(text: String, attachments: [Attachment])
-    case agent(text: String)
-    case thought(text: String)
+    case user(id: UUID, text: String, attachments: [Attachment])
+    case agent(id: UUID, text: String)
+    case thought(id: UUID, text: String)
     case toolCall(ToolCall)
-    case fileEdit(FileEdit)
-    case plan([PlanItem])
-    case systemNotice(text: String)
+    case fileEdit(id: UUID, FileEdit)
+    case plan(id: UUID, [PlanItem])
+    case systemNotice(id: UUID, text: String)
+
+    var stableId: String {
+        switch self {
+        case .user(let id, _, _),
+             .agent(let id, _),
+             .thought(let id, _),
+             .fileEdit(let id, _),
+             .plan(let id, _),
+             .systemNotice(let id, _):
+            return id.uuidString
+        case .toolCall(let tc):
+            return "tc-\(tc.toolCallId)"
+        }
+    }
 
     var kind: String {
         switch self {
@@ -102,13 +116,13 @@ enum ACPMessageCodec {
 
     static func encode(_ m: ACPMessage) throws -> Data {
         switch m {
-        case .user(let text, let atts): return try encoder.encode(UserPayload(text: text, attachments: atts))
-        case .agent(let text):           return try encoder.encode(TextPayload(text: text))
-        case .thought(let text):         return try encoder.encode(TextPayload(text: text))
-        case .toolCall(let tc):          return try encoder.encode(tc)
-        case .fileEdit(let fe):          return try encoder.encode(fe)
-        case .plan(let items):           return try encoder.encode(PlanPayload(items: items))
-        case .systemNotice(let text):    return try encoder.encode(TextPayload(text: text))
+        case .user(_, let text, let atts): return try encoder.encode(UserPayload(text: text, attachments: atts))
+        case .agent(_, let text):           return try encoder.encode(TextPayload(text: text))
+        case .thought(_, let text):         return try encoder.encode(TextPayload(text: text))
+        case .toolCall(let tc):             return try encoder.encode(tc)
+        case .fileEdit(_, let fe):          return try encoder.encode(fe)
+        case .plan(_, let items):           return try encoder.encode(PlanPayload(items: items))
+        case .systemNotice(_, let text):    return try encoder.encode(TextPayload(text: text))
         }
     }
 
@@ -116,21 +130,21 @@ enum ACPMessageCodec {
         switch kind {
         case "user":
             let p = try JSONDecoder().decode(UserPayload.self, from: payload)
-            return .user(text: p.text, attachments: p.attachments)
+            return .user(id: UUID(), text: p.text, attachments: p.attachments)
         case "agent":
-            return .agent(text: try JSONDecoder().decode(TextPayload.self, from: payload).text)
+            return .agent(id: UUID(), text: try JSONDecoder().decode(TextPayload.self, from: payload).text)
         case "thought":
-            return .thought(text: try JSONDecoder().decode(TextPayload.self, from: payload).text)
+            return .thought(id: UUID(), text: try JSONDecoder().decode(TextPayload.self, from: payload).text)
         case "tool_call":
             return .toolCall(try JSONDecoder().decode(ACPMessage.ToolCall.self, from: payload))
         case "file_edit":
-            return .fileEdit(try JSONDecoder().decode(ACPMessage.FileEdit.self, from: payload))
+            return .fileEdit(id: UUID(), try JSONDecoder().decode(ACPMessage.FileEdit.self, from: payload))
         case "plan":
-            return .plan(try JSONDecoder().decode(PlanPayload.self, from: payload).items)
+            return .plan(id: UUID(), try JSONDecoder().decode(PlanPayload.self, from: payload).items)
         case "system":
-            return .systemNotice(text: try JSONDecoder().decode(TextPayload.self, from: payload).text)
+            return .systemNotice(id: UUID(), text: try JSONDecoder().decode(TextPayload.self, from: payload).text)
         default:
-            return .systemNotice(text: "(unknown message kind: \(kind))")
+            return .systemNotice(id: UUID(), text: "(unknown message kind: \(kind))")
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -69,7 +69,7 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {
-        messages.append(.user(text: text, attachments: attachments))
+        messages.append(.user(id: UUID(), text: text, attachments: attachments))
         if title == "" || title == "New session" {
             title = String(text.prefix(40))
         }
@@ -78,12 +78,12 @@ final class ACPSession: ObservableObject, Identifiable {
     func apply(_ update: ACPSessionUpdate) {
         switch update {
         case .agentMessageChunk(let block):
-            append(text: text(of: block), into: { lastAgent() }, fallback: .agent(text: ""))
+            append(text: text(of: block), into: { lastAgent() }, fallback: .agent(id: UUID(), text: ""))
         case .userMessageChunk(let block):
             // Agents rarely emit these; treat as informational.
-            messages.append(.systemNotice(text: text(of: block)))
+            messages.append(.systemNotice(id: UUID(), text: text(of: block)))
         case .agentThoughtChunk(let block):
-            append(text: text(of: block), into: { lastThought() }, fallback: .thought(text: ""))
+            append(text: text(of: block), into: { lastThought() }, fallback: .thought(id: UUID(), text: ""))
         case .toolCall(let payload):
             let full = payload.content.flatMap { Self.flatten($0) } ?? ""
             messages.append(.toolCall(.init(
@@ -106,9 +106,11 @@ final class ACPSession: ObservableObject, Identifiable {
         case .plan(let entries):
             let items = entries.map { ACPMessage.PlanItem(content: $0.content, status: $0.status) }
             if let i = messages.lastIndex(where: { if case .plan = $0 { return true } else { return false } }) {
-                messages[i] = .plan(items)
+                if case .plan(let existingId, _) = messages[i] {
+                    messages[i] = .plan(id: existingId, items)
+                }
             } else {
-                messages.append(.plan(items))
+                messages.append(.plan(id: UUID(), items))
             }
         case .availableModelsUpdate(let ms):
             availableModels = ms
@@ -126,11 +128,11 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     func appendSystemNotice(_ text: String) {
-        messages.append(.systemNotice(text: text))
+        messages.append(.systemNotice(id: UUID(), text: text))
     }
 
     func appendFileEdit(_ edit: ACPMessage.FileEdit) {
-        messages.append(.fileEdit(edit))
+        messages.append(.fileEdit(id: UUID(), edit))
     }
 
     /// Mark any pending/in_progress tool calls as canceled. Called when
@@ -253,14 +255,14 @@ final class ACPSession: ObservableObject, Identifiable {
     private func append(text addition: String, into locate: () -> Int?, fallback: ACPMessage) {
         if let i = locate() {
             switch messages[i] {
-            case .agent(let t):   messages[i] = .agent(text: t + addition)
-            case .thought(let t): messages[i] = .thought(text: t + addition)
+            case .agent(let id, let t):   messages[i] = .agent(id: id, text: t + addition)
+            case .thought(let id, let t): messages[i] = .thought(id: id, text: t + addition)
             default: messages.append(fallback)
             }
         } else {
             switch fallback {
-            case .agent: messages.append(.agent(text: addition))
-            case .thought: messages.append(.thought(text: addition))
+            case .agent:   messages.append(.agent(id: UUID(), text: addition))
+            case .thought: messages.append(.thought(id: UUID(), text: addition))
             default: messages.append(fallback)
             }
         }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -31,18 +31,18 @@ struct ACPMessageList: View {
         if let last = session.messages.last {
             hasher.combine(last.kind)
             switch last {
-            case .agent(let t), .thought(let t), .systemNotice(let t):
+            case .agent(_, let t), .thought(_, let t), .systemNotice(_, let t):
                 hasher.combine(t.count)
             case .toolCall(let tc):
                 hasher.combine(tc.status)
                 hasher.combine(tc.content.count)
-            case .fileEdit(let e):
+            case .fileEdit(_, let e):
                 hasher.combine(e.added)
                 hasher.combine(e.removed)
-            case .plan(let items):
+            case .plan(_, let items):
                 hasher.combine(items.count)
                 for it in items { hasher.combine(it.status) }
-            case .user(let t, _):
+            case .user(_, let t, _):
                 hasher.combine(t.count)
             }
         }
@@ -54,8 +54,8 @@ struct ACPMessageList: View {
             GeometryReader { viewport in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
-                        ForEach(Array(session.messages.enumerated()), id: \.offset) { idx, message in
-                            row(for: message).id(idx)
+                        ForEach(session.messages, id: \.stableId) { message in
+                            row(for: message)
                         }
                         if session.pendingPermission != nil, let policy = policy {
                             ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
@@ -176,19 +176,19 @@ struct ACPMessageList: View {
     @ViewBuilder
     private func row(for m: ACPMessage) -> some View {
         switch m {
-        case .user(let text, let attachments):
+        case .user(_, let text, let attachments):
             UserMessageRow(text: text, attachments: attachments)
-        case .agent(let text):
+        case .agent(_, let text):
             AgentMessageRow(text: text)
-        case .thought(let text):
+        case .thought(_, let text):
             ACPThoughtView(text: text)
         case .toolCall(let tc):
             ACPToolCallCard(toolCall: tc)
-        case .fileEdit(let edit):
+        case .fileEdit(_, let edit):
             ACPFileEditCard(edit: edit, onOpenDiff: { onOpenDiff(edit.path) })
-        case .plan(let items):
+        case .plan(_, let items):
             ACPPlanCard(items: items)
-        case .systemNotice(let text):
+        case .systemNotice(_, let text):
             ACPSystemNoticeView(text: text)
         }
     }

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPMessage stable identity")
+struct ACPMessageStableIdTests {
+    @Test("user/agent rows get distinct stable ids on append")
+    func distinctIds() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.recordUserPrompt(text: "hi", attachments: [])
+        s.apply(.agentMessageChunk(.text("hello")))
+        #expect(s.messages.count == 2)
+        #expect(s.messages[0].stableId != s.messages[1].stableId)
+    }
+
+    @Test("appending a new agent chunk to an existing agent row keeps the same stable id")
+    func chunkPreservesId() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.apply(.agentMessageChunk(.text("hello ")))
+        let id1 = s.messages[0].stableId
+        s.apply(.agentMessageChunk(.text("world")))
+        #expect(s.messages.count == 1)
+        #expect(s.messages[0].stableId == id1)
+    }
+
+    @Test("toolCall row stable id matches its toolCallId")
+    func toolCallId() async {
+        let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        s.apply(.toolCall(.init(toolCallId: "tc-1", title: "t", kind: nil, status: "in_progress", content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        guard case .toolCall(let tc) = s.messages[0] else { Issue.record("expected tool call")
+        return }
+        #expect(s.messages[0].stableId == "tc-\(tc.toolCallId)")
+    }
+}

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -6,17 +6,27 @@ import Testing
 struct ACPMessageTests {
     @Test("user message round-trips through JSON")
     func userRoundtrip() throws {
-        let m = ACPMessage.user(text: "hello", attachments: [.init(uri: "file:///a.swift", name: "a.swift")])
+        let m = ACPMessage.user(id: UUID(), text: "hello", attachments: [.init(uri: "file:///a.swift", name: "a.swift")])
         let payload = try ACPMessageCodec.encode(m)
         let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
-        #expect(back == m)
+        guard case .user(_, let text, let atts) = back else {
+            Issue.record("expected user message")
+            return
+        }
+        #expect(text == "hello")
+        #expect(atts.count == 1)
+        #expect(atts[0].uri == "file:///a.swift")
     }
     @Test("agent message round-trips")
     func agentRoundtrip() throws {
-        let m = ACPMessage.agent(text: "world")
+        let m = ACPMessage.agent(id: UUID(), text: "world")
         let payload = try ACPMessageCodec.encode(m)
         let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
-        #expect(back == m)
+        guard case .agent(_, let text) = back else {
+            Issue.record("expected agent message")
+            return
+        }
+        #expect(text == "world")
     }
     @Test("tool call round-trips")
     func toolRoundtrip() throws {
@@ -30,9 +40,15 @@ struct ACPMessageTests {
     }
     @Test("file edit round-trips")
     func editRoundtrip() throws {
-        let m = ACPMessage.fileEdit(.init(path: "x.swift", added: 4, removed: 1))
+        let m = ACPMessage.fileEdit(id: UUID(), .init(path: "x.swift", added: 4, removed: 1))
         let payload = try ACPMessageCodec.encode(m)
         let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
-        #expect(back == m)
+        guard case .fileEdit(_, let edit) = back else {
+            Issue.record("expected file edit")
+            return
+        }
+        #expect(edit.path == "x.swift")
+        #expect(edit.added == 4)
+        #expect(edit.removed == 1)
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -11,7 +11,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("hello ")))
         session.apply(.agentMessageChunk(.text("world")))
         #expect(session.messages.count == 1)
-        if case .agent(let text) = session.messages[0] { #expect(text == "hello world") }
+        if case .agent(_, let text) = session.messages[0] { #expect(text == "hello world") }
         else { Issue.record("expected single agent message") }
     }
 
@@ -20,7 +20,7 @@ struct ACPSessionTests {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         session.recordUserPrompt(text: "hi", attachments: [])
         #expect(session.messages.count == 1)
-        if case .user(let text, _) = session.messages[0] { #expect(text == "hi") }
+        if case .user(_, let text, _) = session.messages[0] { #expect(text == "hi") }
         else { Issue.record("expected user message") }
     }
 
@@ -42,7 +42,7 @@ struct ACPSessionTests {
         session.apply(.plan([.init(content: "a", priority: nil, status: "completed"),
                              .init(content: "b", priority: nil, status: "in_progress")]))
         #expect(session.messages.count == 1)
-        if case .plan(let items) = session.messages[0] {
+        if case .plan(_, let items) = session.messages[0] {
             #expect(items.count == 2)
             #expect(items[0].status == "completed")
         } else { Issue.record("expected plan") }


### PR DESCRIPTION
<!-- gg:managed:start -->
Switch ACPMessage to carry a UUID per value case (toolCall keeps its
existing toolCallId) and use it as the SwiftUI ForEach key. Streaming
chunks that merge into an existing agent/thought row preserve the
row's id, so the SwiftUI diff no longer invalidates every row after
the change point. The fallback branch of append(text:into:fallback:)
mints its own UUID rather than reusing the caller's, so the invariant
is enforced by the function instead of by each call site.
<!-- gg:managed:end -->