### PR TITLE
refactor(acp): migrate call sites to ACPTranscript, drop forwarders

### DIFF
--- a/Alas/Sources/ACP/Permissions/ACPPermissionPolicy.swift
+++ b/Alas/Sources/ACP/Permissions/ACPPermissionPolicy.swift
@@ -38,8 +38,8 @@ final class ACPPermissionPolicy {
     private var pendingContinuation: CheckedContinuation<ACPPermissionResponse, Never>?
 
     private func awaitUserDecision(scopeKey: String, params: ACPPermissionRequestParams) async -> ACPPermissionResponse {
-        session.streamingState = .awaitingPermission
-        session.pendingPermission = .init(id: .number(0), params: params)
+        session.transcript.streamingState = .awaitingPermission
+        session.transcript.pendingPermission = .init(id: .number(0), params: params)
         return await withCheckedContinuation { (c: CheckedContinuation<ACPPermissionResponse, Never>) in
             pendingContinuation = c
         }
@@ -52,16 +52,16 @@ final class ACPPermissionPolicy {
         if let scope = persistScope {
             try? log.record(sessionId: session.id, scopeKey: scopeKey, decision: decision, scope: scope)
         }
-        session.pendingPermission = nil
-        session.streamingState = .streaming
+        session.transcript.pendingPermission = nil
+        session.transcript.streamingState = .streaming
         let cont = pendingContinuation
         pendingContinuation = nil
         cont?.resume(returning: .init(outcome: .selected(optionId: optionId)))
     }
 
     func userCancelled() {
-        session.pendingPermission = nil
-        session.streamingState = .idle
+        session.transcript.pendingPermission = nil
+        session.transcript.streamingState = .idle
         let cont = pendingContinuation
         pendingContinuation = nil
         cont?.resume(returning: .init(outcome: .cancelled))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -21,18 +21,6 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var autoRunEnabled: Bool = false
     @Published var composerDraft: ACPComposerDraft = .empty
     @Published private(set) var composerDraftRevision: Int = 0
-    var messages: [ACPMessage] {
-        get { transcript.messages }
-        set { transcript.messages = newValue }
-    }
-    var pendingPermission: PendingPermission? {
-        get { transcript.pendingPermission }
-        set { transcript.pendingPermission = newValue }
-    }
-    var streamingState: StreamingState {
-        get { transcript.streamingState }
-        set { transcript.streamingState = newValue }
-    }
     @Published var setupState: SetupState = .checking
     @Published var lastError: String?
     @Published var disconnected: Bool = false
@@ -53,14 +41,6 @@ final class ACPSession: ObservableObject, Identifiable {
     /// as the persistence key in `ACPSessionStore`.
     /// Not persisted — recreated on each `attach()` if missing.
     var remoteSessionId: String?
-
-    /// Forwards transcript publishes to ACPSession.objectWillChange while
-    /// the messages/streamingState/pendingPermission forwarders are in
-    /// place. Without it, views that observe ACPSession but read through
-    /// the forwarders never get notified of transcript-only updates.
-    /// Removed when the forwarders are removed and all consumers observe
-    /// ACPTranscript directly.
-    private var transcriptBridge: AnyCancellable?
 
     func replaceComposerDraft(_ draft: ACPComposerDraft) {
         composerDraft = draft
@@ -84,13 +64,10 @@ final class ACPSession: ObservableObject, Identifiable {
         self.worktreeId = worktreeId
         self.title = title
         self.createdAt = createdAt
-        self.transcriptBridge = transcript.objectWillChange.sink { [weak self] in
-            self?.objectWillChange.send()
-        }
     }
 
     func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {
-        messages.append(.user(id: UUID(), text: text, attachments: attachments))
+        transcript.messages.append(.user(id: UUID(), text: text, attachments: attachments))
         if title == "" || title == "New session" {
             title = String(text.prefix(40))
         }
@@ -102,12 +79,12 @@ final class ACPSession: ObservableObject, Identifiable {
             append(text: text(of: block), into: { lastAgent() }, fallback: .agent(id: UUID(), text: ""))
         case .userMessageChunk(let block):
             // Agents rarely emit these; treat as informational.
-            messages.append(.systemNotice(id: UUID(), text: text(of: block)))
+            transcript.messages.append(.systemNotice(id: UUID(), text: text(of: block)))
         case .agentThoughtChunk(let block):
             append(text: text(of: block), into: { lastThought() }, fallback: .thought(id: UUID(), text: ""))
         case .toolCall(let payload):
             let full = payload.content.flatMap { Self.flatten($0) } ?? ""
-            messages.append(.toolCall(.init(
+            transcript.messages.append(.toolCall(.init(
                 toolCallId: payload.toolCallId,
                 title: payload.title,
                 kind: payload.kind,
@@ -126,12 +103,12 @@ final class ACPSession: ObservableObject, Identifiable {
             }
         case .plan(let entries):
             let items = entries.map { ACPMessage.PlanItem(content: $0.content, status: $0.status) }
-            if let i = messages.lastIndex(where: { if case .plan = $0 { return true } else { return false } }) {
-                if case .plan(let existingId, _) = messages[i] {
-                    messages[i] = .plan(id: existingId, items)
+            if let i = transcript.messages.lastIndex(where: { if case .plan = $0 { return true } else { return false } }) {
+                if case .plan(let existingId, _) = transcript.messages[i] {
+                    transcript.messages[i] = .plan(id: existingId, items)
                 }
             } else {
-                messages.append(.plan(id: UUID(), items))
+                transcript.messages.append(.plan(id: UUID(), items))
             }
         case .availableModelsUpdate(let ms):
             availableModels = ms
@@ -149,11 +126,11 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     func appendSystemNotice(_ text: String) {
-        messages.append(.systemNotice(id: UUID(), text: text))
+        transcript.messages.append(.systemNotice(id: UUID(), text: text))
     }
 
     func appendFileEdit(_ edit: ACPMessage.FileEdit) {
-        messages.append(.fileEdit(id: UUID(), edit))
+        transcript.messages.append(.fileEdit(id: UUID(), edit))
     }
 
     /// Mark any pending/in_progress tool calls as canceled. Called when
@@ -163,11 +140,11 @@ final class ACPSession: ObservableObject, Identifiable {
     /// persist them.
     func cancelInFlightToolCalls() -> [Int] {
         var changed: [Int] = []
-        for i in messages.indices {
-            if case .toolCall(var tc) = messages[i],
+        for i in transcript.messages.indices {
+            if case .toolCall(var tc) = transcript.messages[i],
                tc.status == "in_progress" || tc.status == "pending" {
                 tc.status = "canceled"
-                messages[i] = .toolCall(tc)
+                transcript.messages[i] = .toolCall(tc)
                 changed.append(i)
             }
         }
@@ -252,47 +229,47 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     private func lastAgent() -> Int? {
-        for i in stride(from: messages.count - 1, through: 0, by: -1) {
+        for i in stride(from: transcript.messages.count - 1, through: 0, by: -1) {
             // STOP on .user — every new user turn starts a fresh
             // agent reply. Without this the agent's response to a NEW
             // prompt gets appended to the previous turn's trailing
             // agent message, breaking the conversation order.
-            if case .user = messages[i] { return nil }
-            if case .agent = messages[i] { return i }
-            if case .toolCall = messages[i] { return nil }
-            if case .fileEdit = messages[i] { return nil }
+            if case .user = transcript.messages[i] { return nil }
+            if case .agent = transcript.messages[i] { return i }
+            if case .toolCall = transcript.messages[i] { return nil }
+            if case .fileEdit = transcript.messages[i] { return nil }
         }
         return nil
     }
     private func lastThought() -> Int? {
-        for i in stride(from: messages.count - 1, through: 0, by: -1) {
-            if case .user = messages[i] { return nil }
-            if case .thought = messages[i] { return i }
-            if case .agent = messages[i] { return nil }
-            if case .toolCall = messages[i] { return nil }
+        for i in stride(from: transcript.messages.count - 1, through: 0, by: -1) {
+            if case .user = transcript.messages[i] { return nil }
+            if case .thought = transcript.messages[i] { return i }
+            if case .agent = transcript.messages[i] { return nil }
+            if case .toolCall = transcript.messages[i] { return nil }
         }
         return nil
     }
     private func append(text addition: String, into locate: () -> Int?, fallback: ACPMessage) {
         if let i = locate() {
-            switch messages[i] {
-            case .agent(let id, let t):   messages[i] = .agent(id: id, text: t + addition)
-            case .thought(let id, let t): messages[i] = .thought(id: id, text: t + addition)
-            default: messages.append(fallback)
+            switch transcript.messages[i] {
+            case .agent(let id, let t):   transcript.messages[i] = .agent(id: id, text: t + addition)
+            case .thought(let id, let t): transcript.messages[i] = .thought(id: id, text: t + addition)
+            default: transcript.messages.append(fallback)
             }
         } else {
             switch fallback {
-            case .agent:   messages.append(.agent(id: UUID(), text: addition))
-            case .thought: messages.append(.thought(id: UUID(), text: addition))
-            default: messages.append(fallback)
+            case .agent:   transcript.messages.append(.agent(id: UUID(), text: addition))
+            case .thought: transcript.messages.append(.thought(id: UUID(), text: addition))
+            default: transcript.messages.append(fallback)
             }
         }
     }
     private func updateToolCall(id: String, _ mutate: (inout ACPMessage.ToolCall) -> Void) {
-        for i in messages.indices {
-            if case .toolCall(var tc) = messages[i], tc.toolCallId == id {
+        for i in transcript.messages.indices {
+            if case .toolCall(var tc) = transcript.messages[i], tc.toolCallId == id {
                 mutate(&tc)
-                messages[i] = .toolCall(tc)
+                transcript.messages[i] = .toolCall(tc)
                 return
             }
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -51,7 +51,7 @@ final class ACPSessionManager: ObservableObject {
         if let stored = try? store.loadMessages(sessionId: id) {
             for m in stored {
                 if let decoded = try? ACPMessageCodec.decode(kind: m.kind, payload: m.payload) {
-                    session.messages.append(decoded)
+                    session.transcript.messages.append(decoded)
                 }
             }
         }
@@ -82,13 +82,13 @@ final class ACPSessionManager: ObservableObject {
         refreshRecent()
     }
 
-    /// Persist a fresh trailing chunk of messages (`from..<session.messages.count`)
+    /// Persist a fresh trailing chunk of messages (`from..<session.transcript.messages.count`)
     /// to the store. Used by code paths that mutate the session outside the
     /// runner's update loop (composer fallback when no runner is attached
     /// yet, or any direct manager call) so the messages survive a reload.
     func persistTrailingMessages(_ session: ACPSession, fromIndex from: Int) {
         let now = Int64(Date().timeIntervalSince1970)
-        let messages = session.messages
+        let messages = session.transcript.messages
         guard from < messages.count else { return }
         for i in from..<messages.count {
             let m = messages[i]
@@ -260,7 +260,7 @@ extension ACPSessionManager {
         // badge stuck on `[wait]` via the harness bridge).
         if let session = sessions[sessionId] {
             session.attached = false
-            session.streamingState = .idle
+            session.transcript.streamingState = .idle
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -64,7 +64,7 @@ final class ACPSessionRunner {
             guard let self else { return }
             for await u in self.connection.client.incomingUpdates {
                 await MainActor.run {
-                    let before = self.session.messages.count
+                    let before = self.session.transcript.messages.count
                     self.session.apply(u.update)
                     self.persistFromIndex(before)
                 }
@@ -78,7 +78,7 @@ final class ACPSessionRunner {
             await MainActor.run {
                 self.session.disconnected = true
                 self.session.attached = false
-                self.session.streamingState = .idle
+                self.session.transcript.streamingState = .idle
                 self.appendAndPersistSystemNotice("Agent disconnected.")
             }
         }
@@ -237,14 +237,14 @@ final class ACPSessionRunner {
             policy.userCancelled()
             let changedIndices = session.cancelInFlightToolCalls()
             for i in changedIndices {
-                let m = session.messages[i]
+                let m = session.transcript.messages[i]
                 if let payload = try? ACPMessageCodec.encode(m) {
                     let id = "msg-\(sessionId)-\(i)"
                     try? store.updateMessagePayload(id: id, payload: payload)
                 }
             }
             appendAndPersistSystemNotice("Interrupted by user.")
-            session.streamingState = .idle
+            session.transcript.streamingState = .idle
         }
     }
 }
@@ -268,7 +268,7 @@ extension ACPSessionRunner {
             }
             await MainActor.run {
                 self.activePromptID = promptID
-                let before = self.session.messages.count
+                let before = self.session.transcript.messages.count
                 let titleBefore = self.session.title
                 if !self.session.followsTranscriptTail {
                     self.session.followsTranscriptTail = true
@@ -283,7 +283,7 @@ extension ACPSessionRunner {
                 if self.session.title != titleBefore {
                     self.persistSessionRow()
                 }
-                self.session.streamingState = .sending
+                self.session.transcript.streamingState = .sending
             }
             do {
                 let remoteId = self.session.remoteSessionId ?? self.sessionId
@@ -300,7 +300,7 @@ extension ACPSessionRunner {
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
                         self.activePromptID = nil
-                        self.session.streamingState = .idle
+                        self.session.transcript.streamingState = .idle
                     }
                     self.cancelledPromptIDs.remove(promptID)
                     if !hasNewerActivePrompt {
@@ -314,7 +314,7 @@ extension ACPSessionRunner {
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
                         self.activePromptID = nil
-                        self.session.streamingState = .idle
+                        self.session.transcript.streamingState = .idle
                     }
                     if !wasCancelled, isActivePrompt {
                         self.session.lastError = "prompt failed: \(error.localizedDescription)"
@@ -331,14 +331,14 @@ extension ACPSessionRunner {
     /// instead of `session.appendSystemNotice` directly so the message
     /// survives a session reload.
     func appendAndPersistSystemNotice(_ text: String) {
-        let before = session.messages.count
+        let before = session.transcript.messages.count
         session.appendSystemNotice(text)
         persistFromIndex(before)
     }
 
     /// Append a file-edit card to the session AND persist it.
     func appendAndPersistFileEdit(_ edit: ACPMessage.FileEdit) {
-        let before = session.messages.count
+        let before = session.transcript.messages.count
         session.appendFileEdit(edit)
         persistFromIndex(before)
     }
@@ -357,7 +357,7 @@ extension ACPSessionRunner {
     /// text was visible in memory but never written, so reopening a
     /// session lost most of the conversation.
     func persistFromIndex(_ from: Int) {
-        let messages = session.messages
+        let messages = session.transcript.messages
         guard messages.count > 0 else { return }
 
         let lowerBound: Int

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Floating glass pill composer. Wraps the AppKit-backed `ACPInputField`
 /// in the design's chrome: heavy blur, model + mode pickers on the right,
-/// animated send button that mirrors `session.streamingState`.
+/// animated send button that mirrors `session.transcript.streamingState`.
 struct ACPComposer: View {
     @ObservedObject var session: ACPSession
     let manager: ACPSessionManager
@@ -169,7 +169,7 @@ struct ACPComposer: View {
 
     private var autoRunDisabled: Bool {
         if session.chipState.autoRun == .ignored { return true }
-        switch session.streamingState {
+        switch session.transcript.streamingState {
         case .streaming, .sending: return true
         default: return !session.attached || session.disconnected
         }
@@ -179,8 +179,8 @@ struct ACPComposer: View {
         if session.chipState.autoRun == .ignored {
             return "Auto-run has no effect — this agent doesn't request permissions"
         }
-        if case .streaming = session.streamingState { return "Auto-run cannot be changed while streaming" }
-        if case .sending = session.streamingState { return "Auto-run cannot be changed while sending" }
+        if case .streaming = session.transcript.streamingState { return "Auto-run cannot be changed while streaming" }
+        if case .sending = session.transcript.streamingState { return "Auto-run cannot be changed while sending" }
         if !session.attached { return "Agent connecting…" }
         if session.disconnected { return "Agent disconnected" }
         return session.autoRunEnabled
@@ -329,14 +329,14 @@ struct ACPComposer: View {
     /// here — those states swap the button to the cancel mode, which IS
     /// clickable.
     private var sendDisabled: Bool {
-        switch session.streamingState {
+        switch session.transcript.streamingState {
         case .streaming, .sending: return false
         default: return !session.attached || session.disconnected
         }
     }
 
     private var sendHelpText: String {
-        switch session.streamingState {
+        switch session.transcript.streamingState {
         case .streaming, .sending: return "Stop streaming"
         default:
             if session.disconnected { return "Agent disconnected" }
@@ -347,14 +347,14 @@ struct ACPComposer: View {
 
     /// Click handler: send while idle, stop while streaming.
     private func sendButtonTapped() {
-        switch session.streamingState {
+        switch session.transcript.streamingState {
         case .streaming, .sending:
             let sid = session.id
             Task { @MainActor in
                 if let runner = manager.runners[sid] {
                     await runner.userCancel()
                 } else {
-                    session.streamingState = .idle
+                    session.transcript.streamingState = .idle
                 }
             }
         default:
@@ -367,7 +367,7 @@ struct ACPComposer: View {
     /// border (the "no input" look), ready = solid accent + accent
     /// border + dark icon, stop = solid del + dark icon.
     private var buttonBg: Color {
-        switch session.streamingState {
+        switch session.transcript.streamingState {
         case .streaming, .sending: return theme.color("del")
         default:
             return sendDisabled
@@ -376,14 +376,14 @@ struct ACPComposer: View {
         }
     }
     private var buttonFg: Color {
-        switch session.streamingState {
+        switch session.transcript.streamingState {
         case .streaming, .sending: return theme.color("bg-0")
         default:
             return sendDisabled ? theme.color("fg-dim") : theme.color("bg-0")
         }
     }
     private var buttonBorder: Color {
-        switch session.streamingState {
+        switch session.transcript.streamingState {
         case .streaming, .sending: return theme.color("del").opacity(0.7)
         default:
             return sendDisabled
@@ -392,7 +392,7 @@ struct ACPComposer: View {
         }
     }
     private var buttonGlyph: String {
-        switch session.streamingState {
+        switch session.transcript.streamingState {
         case .streaming, .sending: return "stop.fill"
         default:                   return "arrow.up"
         }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct ACPMessageList: View {
     @ObservedObject var session: ACPSession
+    @ObservedObject var transcript: ACPTranscript
     let onOpenDiff: (String) -> Void
     let policy: ACPPermissionPolicy?
     let scopeKey: String
@@ -27,8 +28,8 @@ struct ACPMessageList: View {
     /// edits in addition to brand-new rows.
     private var scrollSignature: Int {
         var hasher = Hasher()
-        hasher.combine(session.messages.count)
-        if let last = session.messages.last {
+        hasher.combine(transcript.messages.count)
+        if let last = transcript.messages.last {
             hasher.combine(last.kind)
             switch last {
             case .agent(_, let t), .thought(_, let t), .systemNotice(_, let t):
@@ -54,14 +55,14 @@ struct ACPMessageList: View {
             GeometryReader { viewport in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
-                        ForEach(session.messages, id: \.stableId) { message in
+                        ForEach(transcript.messages, id: \.stableId) { message in
                             row(for: message)
                         }
-                        if session.pendingPermission != nil, let policy = policy {
+                        if transcript.pendingPermission != nil, let policy = policy {
                             ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
                                 .id("__pending_perm__")
                         }
-                        if session.streamingState == .streaming {
+                        if transcript.streamingState == .streaming {
                             StreamingCaret().frame(width: 8, height: 14)
                                 .id("__streaming_caret__")
                         }
@@ -107,7 +108,7 @@ struct ACPMessageList: View {
                         scrollToTail(proxy: proxy, animated: true)
                     }
                 }
-                .onChange(of: session.streamingState) { _, new in
+                .onChange(of: transcript.streamingState) { _, new in
                     if session.followsTranscriptTail && (new == .streaming || new == .sending) {
                         scrollToTail(proxy: proxy, animated: true)
                     }

--- a/Alas/Sources/ACP/UI/ACPPermissionPrompt.swift
+++ b/Alas/Sources/ACP/UI/ACPPermissionPrompt.swift
@@ -10,7 +10,7 @@ struct ACPPermissionPrompt: View {
     @Environment(\.theme) private var theme
 
     var body: some View {
-        if let pending = session.pendingPermission {
+        if let pending = session.transcript.pendingPermission {
             content(for: pending.params)
         }
     }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -13,7 +13,8 @@ struct ACPTabView: View {
                 state: state,
                 worktree: worktree,
                 manager: manager,
-                session: session
+                session: session,
+                transcript: session.transcript
             )
         } else {
             VStack {
@@ -35,6 +36,12 @@ private struct ACPSessionView: View {
     let worktree: Worktree
     let manager: ACPSessionManager
     @ObservedObject var session: ACPSession
+    /// Observed so the body re-evaluates when `pendingPermission`
+    /// arrives — `scopeKey(for:)` reads through this and the value
+    /// is passed down to `ACPMessageList`; otherwise the message
+    /// list gets a stale `""` scope and persisted allow/reject_always
+    /// decisions land under the wrong key.
+    @ObservedObject var transcript: ACPTranscript
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -66,7 +73,7 @@ private struct ACPSessionView: View {
             transcriptAndComposer
         }
         .task(id: sessionId) {
-            let freshlyCreated = manager.runners[sessionId] == nil && session.messages.isEmpty
+            let freshlyCreated = manager.runners[sessionId] == nil && session.transcript.messages.isEmpty
             await manager.attach(to: sessionId, freshlyCreated: freshlyCreated)
         }
         .focusable()
@@ -79,8 +86,8 @@ private struct ACPSessionView: View {
     /// Esc cancels the in-flight request. Idempotent — safe to press
     /// when nothing's streaming.
     private func handleEscape() {
-        guard session.streamingState == .streaming || session.streamingState == .sending
-              || session.streamingState == .awaitingPermission
+        guard session.transcript.streamingState == .streaming || session.transcript.streamingState == .sending
+              || session.transcript.streamingState == .awaitingPermission
         else { return }
         Task {
             if let runner = manager.runners[sessionId] {
@@ -97,7 +104,7 @@ private struct ACPSessionView: View {
         if case .needsSetup = session.setupState { return false }
         if session.lastError != nil { return false }
         if session.disconnected { return false }
-        return session.messages.isEmpty
+        return session.transcript.messages.isEmpty
     }
 
     private var transcriptAndComposer: some View {
@@ -109,6 +116,7 @@ private struct ACPSessionView: View {
             } else {
                 ACPMessageList(
                     session: session,
+                    transcript: session.transcript,
                     onOpenDiff: { relativePath in
                         state.openDiffTab(forFileInWorktree: worktree, relativePath: relativePath)
                     },
@@ -116,7 +124,7 @@ private struct ACPSessionView: View {
                     // lives) — otherwise the user's click can't resolve the
                     // pending permission request.
                     policy: manager.runners[sessionId]?.policy,
-                    scopeKey: scopeKey(for: session.pendingPermission)
+                    scopeKey: scopeKey(for: session.transcript.pendingPermission)
                 )
             }
 
@@ -135,8 +143,8 @@ private struct ACPSessionView: View {
                 // we don't want ⏎ to silently erase the user's
                 // unsent prompt.
                 guard session.attached, !session.disconnected,
-                      session.streamingState != .streaming,
-                      session.streamingState != .sending,
+                      session.transcript.streamingState != .streaming,
+                      session.transcript.streamingState != .sending,
                       let runner = manager.runners[sessionId] else { return false }
                 let draftRevision = session.composerDraftRevision
                 runner.send(text: text, attachments: attachments) { succeeded in
@@ -173,7 +181,7 @@ private struct ACPSessionView: View {
         await manager.detach(sessionId: sessionId)
         session.lastError = nil
         session.setupState = .checking
-        let freshlyCreated = session.messages.isEmpty
+        let freshlyCreated = session.transcript.messages.isEmpty
         await manager.attach(to: sessionId, freshlyCreated: freshlyCreated)
     }
 

--- a/AlasTests/ACP/ACPHarnessBridgeTests.swift
+++ b/AlasTests/ACP/ACPHarnessBridgeTests.swift
@@ -18,7 +18,7 @@ struct ACPHarnessBridgeTests {
         let bridge = ACPHarnessBridge(harness: harness)
         let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
         bridge.observe(session: session)
-        session.streamingState = .sending
+        session.transcript.streamingState = .sending
         await Task.yield()
         #expect(harness.activityBySession["s1"]?.state == .busy)
         #expect(harness.activityBySession["s1"]?.agent == .claude)
@@ -30,7 +30,7 @@ struct ACPHarnessBridgeTests {
         let bridge = ACPHarnessBridge(harness: harness)
         let session = ACPSession(id: "s1", agentId: "codex", worktreeId: "wt", title: "t")
         bridge.observe(session: session)
-        session.streamingState = .streaming
+        session.transcript.streamingState = .streaming
         await Task.yield()
         #expect(harness.activityBySession["s1"]?.state == .busy)
         #expect(harness.activityBySession["s1"]?.agent == .codex)
@@ -42,7 +42,7 @@ struct ACPHarnessBridgeTests {
         let bridge = ACPHarnessBridge(harness: harness)
         let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
         bridge.observe(session: session)
-        session.streamingState = .awaitingPermission
+        session.transcript.streamingState = .awaitingPermission
         await Task.yield()
         #expect(harness.activityBySession["s1"]?.state == .permissionRequest)
     }
@@ -53,9 +53,9 @@ struct ACPHarnessBridgeTests {
         let bridge = ACPHarnessBridge(harness: harness)
         let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
         bridge.observe(session: session)
-        session.streamingState = .streaming
+        session.transcript.streamingState = .streaming
         await Task.yield()
-        session.streamingState = .idle
+        session.transcript.streamingState = .idle
         await Task.yield()
         #expect(harness.activityBySession["s1"] == nil)
     }
@@ -66,7 +66,7 @@ struct ACPHarnessBridgeTests {
         let bridge = ACPHarnessBridge(harness: harness)
         let session = ACPSession(id: "s1", agentId: "cursor-agent", worktreeId: "wt", title: "t")
         bridge.observe(session: session)
-        session.streamingState = .streaming
+        session.transcript.streamingState = .streaming
         await Task.yield()
         #expect(harness.activityBySession["s1"]?.agent == .cursor)
     }
@@ -77,7 +77,7 @@ struct ACPHarnessBridgeTests {
         let bridge = ACPHarnessBridge(harness: harness)
         let session = ACPSession(id: "s1", agentId: "made-up-agent", worktreeId: "wt", title: "t")
         bridge.observe(session: session)
-        session.streamingState = .streaming
+        session.transcript.streamingState = .streaming
         await Task.yield()
         #expect(harness.activityBySession["s1"]?.agent == .claude)
     }
@@ -93,7 +93,7 @@ struct ACPHarnessBridgeTests {
         let session = manager.createSession(agentId: "claude")
 
         bridge.attach(manager: manager)
-        session.streamingState = .streaming
+        session.transcript.streamingState = .streaming
         await Task.yield()
 
         #expect(harness.activityBySession[session.id]?.state == .busy)
@@ -111,7 +111,7 @@ struct ACPHarnessBridgeTests {
 
         let session = manager.createSession(agentId: "claude")
         await Task.yield()
-        session.streamingState = .streaming
+        session.transcript.streamingState = .streaming
         await Task.yield()
 
         #expect(harness.activityBySession[session.id]?.state == .busy)
@@ -127,7 +127,7 @@ struct ACPHarnessBridgeTests {
         let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
         let session = manager.createSession(agentId: "claude")
         bridge.attach(manager: manager)
-        session.streamingState = .streaming
+        session.transcript.streamingState = .streaming
         await Task.yield()
         #expect(harness.activityBySession[session.id]?.state == .busy)
 
@@ -147,14 +147,14 @@ struct ACPHarnessBridgeTests {
         let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
         let session = manager.createSession(agentId: "claude")
         bridge.attach(manager: manager)
-        session.streamingState = .awaitingPermission
+        session.transcript.streamingState = .awaitingPermission
         await Task.yield()
         #expect(harness.activityBySession[session.id]?.state == .permissionRequest)
 
         await manager.detach(sessionId: session.id)
         await Task.yield()
 
-        #expect(session.streamingState == .idle)
+        #expect(session.transcript.streamingState == .idle)
         #expect(harness.activityBySession[session.id] == nil)
     }
 
@@ -168,7 +168,7 @@ struct ACPHarnessBridgeTests {
         let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
         let session = manager.createSession(agentId: "claude")
         bridge.attach(manager: manager)
-        session.streamingState = .streaming
+        session.transcript.streamingState = .streaming
         await Task.yield()
 
         bridge.detach(worktreeId: "wt")
@@ -177,7 +177,7 @@ struct ACPHarnessBridgeTests {
         #expect(harness.activityBySession[session.id] == nil)
 
         // Further streamingState changes are not mirrored.
-        session.streamingState = .awaitingPermission
+        session.transcript.streamingState = .awaitingPermission
         await Task.yield()
         #expect(harness.activityBySession[session.id] == nil)
     }

--- a/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageStableIdTests.swift
@@ -10,26 +10,26 @@ struct ACPMessageStableIdTests {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         s.recordUserPrompt(text: "hi", attachments: [])
         s.apply(.agentMessageChunk(.text("hello")))
-        #expect(s.messages.count == 2)
-        #expect(s.messages[0].stableId != s.messages[1].stableId)
+        #expect(s.transcript.messages.count == 2)
+        #expect(s.transcript.messages[0].stableId != s.transcript.messages[1].stableId)
     }
 
     @Test("appending a new agent chunk to an existing agent row keeps the same stable id")
     func chunkPreservesId() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         s.apply(.agentMessageChunk(.text("hello ")))
-        let id1 = s.messages[0].stableId
+        let id1 = s.transcript.messages[0].stableId
         s.apply(.agentMessageChunk(.text("world")))
-        #expect(s.messages.count == 1)
-        #expect(s.messages[0].stableId == id1)
+        #expect(s.transcript.messages.count == 1)
+        #expect(s.transcript.messages[0].stableId == id1)
     }
 
     @Test("toolCall row stable id matches its toolCallId")
     func toolCallId() async {
         let s = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         s.apply(.toolCall(.init(toolCallId: "tc-1", title: "t", kind: nil, status: "in_progress", content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
-        guard case .toolCall(let tc) = s.messages[0] else { Issue.record("expected tool call")
+        guard case .toolCall(let tc) = s.transcript.messages[0] else { Issue.record("expected tool call")
         return }
-        #expect(s.messages[0].stableId == "tc-\(tc.toolCallId)")
+        #expect(s.transcript.messages[0].stableId == "tc-\(tc.toolCallId)")
     }
 }

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -17,7 +17,7 @@ struct ACPSessionRunnerTests {
 
         #expect(succeeded == false)
         #expect(runner.session.lastError?.contains("prompt failed") == true)
-        #expect(runner.session.streamingState == .idle)
+        #expect(runner.session.transcript.streamingState == .idle)
     }
 
     @Test("send reports successful completion when session prompt succeeds")
@@ -33,7 +33,7 @@ struct ACPSessionRunnerTests {
 
         #expect(succeeded == true)
         #expect(runner.session.lastError == nil)
-        #expect(runner.session.streamingState == .idle)
+        #expect(runner.session.transcript.streamingState == .idle)
     }
 
     @Test("send treats user-cancelled prompt errors as accepted completion")
@@ -61,7 +61,7 @@ struct ACPSessionRunnerTests {
         }
         #expect(completion == true)
         #expect(runner.session.lastError == nil)
-        #expect(runner.session.streamingState == .idle)
+        #expect(runner.session.transcript.streamingState == .idle)
         #expect(mock.sent.contains { $0.method == "session/cancel" })
     }
 
@@ -104,14 +104,14 @@ struct ACPSessionRunnerTests {
         }
         #expect(firstCompletion == nil)
         #expect(secondCompletion == nil)
-        #expect(runner.session.streamingState == .sending)
+        #expect(runner.session.transcript.streamingState == .sending)
 
         await finishSecond.open()
         for _ in 0..<20 where secondCompletion == nil {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
         #expect(secondCompletion == true)
-        #expect(runner.session.streamingState == .idle)
+        #expect(runner.session.transcript.streamingState == .idle)
     }
 
     @Test("cancelled prompt success does not complete over a newer prompt")
@@ -148,19 +148,19 @@ struct ACPSessionRunnerTests {
         await secondStarted.wait()
         await finishFirst.open()
 
-        for _ in 0..<20 where runner.session.streamingState != .sending {
+        for _ in 0..<20 where runner.session.transcript.streamingState != .sending {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
         #expect(firstCompletion == nil)
         #expect(secondCompletion == nil)
-        #expect(runner.session.streamingState == .sending)
+        #expect(runner.session.transcript.streamingState == .sending)
 
         await finishSecond.open()
         for _ in 0..<20 where secondCompletion == nil {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
         #expect(secondCompletion == true)
-        #expect(runner.session.streamingState == .idle)
+        #expect(runner.session.transcript.streamingState == .idle)
     }
 
     @Test("emitted session/update lands on the session and persists a message row")
@@ -186,7 +186,7 @@ struct ACPSessionRunnerTests {
         // Allow the actor hop
         try await Task.sleep(nanoseconds: 50_000_000)
 
-        #expect(session.messages.count == 1)
+        #expect(session.transcript.messages.count == 1)
         let rows = try store.loadMessages(sessionId: "s")
         #expect(rows.count == 1)
         #expect(rows[0].kind == "agent")
@@ -216,7 +216,7 @@ struct ACPSessionRunnerTests {
         try await Task.sleep(nanoseconds: 50_000_000)
 
         #expect(session.followsTranscriptTail)
-        #expect(session.messages.count == 1)
+        #expect(session.transcript.messages.count == 1)
         #expect(mock.sent.contains { $0.method == "session/prompt" })
     }
 

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -10,8 +10,8 @@ struct ACPSessionTests {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         session.apply(.agentMessageChunk(.text("hello ")))
         session.apply(.agentMessageChunk(.text("world")))
-        #expect(session.messages.count == 1)
-        if case .agent(_, let text) = session.messages[0] { #expect(text == "hello world") }
+        #expect(session.transcript.messages.count == 1)
+        if case .agent(_, let text) = session.transcript.messages[0] { #expect(text == "hello world") }
         else { Issue.record("expected single agent message") }
     }
 
@@ -19,8 +19,8 @@ struct ACPSessionTests {
     func userPrompt() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
         session.recordUserPrompt(text: "hi", attachments: [])
-        #expect(session.messages.count == 1)
-        if case .user(_, let text, _) = session.messages[0] { #expect(text == "hi") }
+        #expect(session.transcript.messages.count == 1)
+        if case .user(_, let text, _) = session.transcript.messages[0] { #expect(text == "hi") }
         else { Issue.record("expected user message") }
     }
 
@@ -41,8 +41,8 @@ struct ACPSessionTests {
         session.apply(.plan([.init(content: "a", priority: nil, status: "pending")]))
         session.apply(.plan([.init(content: "a", priority: nil, status: "completed"),
                              .init(content: "b", priority: nil, status: "in_progress")]))
-        #expect(session.messages.count == 1)
-        if case .plan(_, let items) = session.messages[0] {
+        #expect(session.transcript.messages.count == 1)
+        if case .plan(_, let items) = session.transcript.messages[0] {
             #expect(items.count == 2)
             #expect(items[0].status == "completed")
         } else { Issue.record("expected plan") }
@@ -118,8 +118,8 @@ struct ACPSessionTests {
             toolCallId: "tc-1", status: "completed",
             content: [.content(.text("file contents\nline two"))],
             rawOutput: nil)))
-        #expect(session.messages.count == 1)
-        if case .toolCall(let tc) = session.messages[0] {
+        #expect(session.transcript.messages.count == 1)
+        if case .toolCall(let tc) = session.transcript.messages[0] {
             #expect(tc.content == "file contents\nline two")
             #expect(tc.preview == "file contents")
             #expect(tc.status == "completed")
@@ -136,8 +136,8 @@ struct ACPSessionTests {
             toolCallId: "tc-2", status: "completed",
             content: [.diff(path: "a.swift", oldText: "let x = 1\n", newText: "let x = 2\n")],
             rawOutput: nil)))
-        #expect(session.messages.count == 1)
-        if case .toolCall(let tc) = session.messages[0] {
+        #expect(session.transcript.messages.count == 1)
+        if case .toolCall(let tc) = session.transcript.messages[0] {
             #expect(tc.content == "--- a.swift\n-let x = 1\n+let x = 2")
         } else { Issue.record("expected toolCall message") }
     }


### PR DESCRIPTION
<!-- gg:managed:start -->
Push every reader and writer of messages / streamingState /
pendingPermission onto session.transcript directly, then remove the
three forwarding computed properties from ACPSession. With observers
pointed at the narrow ACPTranscript object, model and mode updates
on the session no longer invalidate the message list view.
<!-- gg:managed:end -->