### PR TITLE
feat(acp): O(1) streaming append via shared StreamingText buffer

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -410,6 +410,8 @@
 		8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F31D837F83B4F8B9FB348BD /* ACPPermissionPolicyTests.swift */; };
 		8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBEFD27FD7013D458435779 /* ACPSession.swift */; };
 		E6383351E33B4FA1B6E83415 /* ACPTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103D13C1CC4B4940844078F7 /* ACPTranscript.swift */; };
+		AA22334400BB5566778899FF /* ACPStreamingText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA22334400BB5566778899DD /* ACPStreamingText.swift */; };
+		AA22334400BB556677889900 /* ACPStreamingTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA22334400BB5566778899EE /* ACPStreamingTextTests.swift */; };
 		8D22459A108B6BF47AEA71F7 /* session-update-available-models.json in Resources */ = {isa = PBXBuildFile; fileRef = 1B0785F1FFC8008C74009584 /* session-update-available-models.json */; };
 		8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */; };
 		8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */; };
@@ -1243,6 +1245,8 @@
 		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
 		BBBEFD27FD7013D458435779 /* ACPSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSession.swift; sourceTree = "<group>"; };
 		103D13C1CC4B4940844078F7 /* ACPTranscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscript.swift; sourceTree = "<group>"; };
+		AA22334400BB5566778899DD /* ACPStreamingText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStreamingText.swift; sourceTree = "<group>"; };
+		AA22334400BB5566778899EE /* ACPStreamingTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStreamingTextTests.swift; sourceTree = "<group>"; };
 		BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabView.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
@@ -2079,6 +2083,7 @@
 				321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */,
 				BBBEFD27FD7013D458435779 /* ACPSession.swift */,
 				103D13C1CC4B4940844078F7 /* ACPTranscript.swift */,
+				AA22334400BB5566778899DD /* ACPStreamingText.swift */,
 				7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */,
 				F332906E17C5865856DBB90B /* ACPSessionRunner.swift */,
 				E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */,
@@ -2413,6 +2418,7 @@
 				D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */,
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
 				AA11223300AA4455667788CC /* ACPMessageStableIdTests.swift */,
+				AA22334400BB5566778899EE /* ACPStreamingTextTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */,
 				45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */,
@@ -3054,6 +3060,7 @@
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
 				E6383351E33B4FA1B6E83415 /* ACPTranscript.swift in Sources */,
+				AA22334400BB5566778899FF /* ACPStreamingText.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
 				1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */,
 				027A326E7DAB6C6E133E5FD3 /* ACPSessionStore.swift in Sources */,
@@ -3431,6 +3438,7 @@
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
 				D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */,
 				AA11223300AA4455667788BB /* ACPMessageStableIdTests.swift in Sources */,
+				AA22334400BB556677889900 /* ACPStreamingTextTests.swift in Sources */,
 				395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */,
 				4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */,
 				57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -2,8 +2,8 @@ import Foundation
 
 enum ACPMessage: Equatable {
     case user(id: UUID, text: String, attachments: [Attachment])
-    case agent(id: UUID, text: String)
-    case thought(id: UUID, text: String)
+    case agent(id: UUID, StreamingText)
+    case thought(id: UUID, StreamingText)
     case toolCall(ToolCall)
     case fileEdit(id: UUID, FileEdit)
     case plan(id: UUID, [PlanItem])
@@ -114,11 +114,12 @@ enum ACPMessageCodec {
         return e
     }()
 
+    @MainActor
     static func encode(_ m: ACPMessage) throws -> Data {
         switch m {
         case .user(_, let text, let atts): return try encoder.encode(UserPayload(text: text, attachments: atts))
-        case .agent(_, let text):           return try encoder.encode(TextPayload(text: text))
-        case .thought(_, let text):         return try encoder.encode(TextPayload(text: text))
+        case .agent(_, let buf):            return try encoder.encode(TextPayload(text: buf.value))
+        case .thought(_, let buf):          return try encoder.encode(TextPayload(text: buf.value))
         case .toolCall(let tc):             return try encoder.encode(tc)
         case .fileEdit(_, let fe):          return try encoder.encode(fe)
         case .plan(_, let items):           return try encoder.encode(PlanPayload(items: items))
@@ -126,15 +127,16 @@ enum ACPMessageCodec {
         }
     }
 
+    @MainActor
     static func decode(kind: String, payload: Data) throws -> ACPMessage {
         switch kind {
         case "user":
             let p = try JSONDecoder().decode(UserPayload.self, from: payload)
             return .user(id: UUID(), text: p.text, attachments: p.attachments)
         case "agent":
-            return .agent(id: UUID(), text: try JSONDecoder().decode(TextPayload.self, from: payload).text)
+            return .agent(id: UUID(), StreamingText(try JSONDecoder().decode(TextPayload.self, from: payload).text))
         case "thought":
-            return .thought(id: UUID(), text: try JSONDecoder().decode(TextPayload.self, from: payload).text)
+            return .thought(id: UUID(), StreamingText(try JSONDecoder().decode(TextPayload.self, from: payload).text))
         case "tool_call":
             return .toolCall(try JSONDecoder().decode(ACPMessage.ToolCall.self, from: payload))
         case "file_edit":

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -76,12 +76,16 @@ final class ACPSession: ObservableObject, Identifiable {
     func apply(_ update: ACPSessionUpdate) {
         switch update {
         case .agentMessageChunk(let block):
-            append(text: text(of: block), into: { lastAgent() }, fallback: .agent(id: UUID(), text: ""))
+            let txt = text(of: block)
+            appendStreaming(text: txt, locate: { lastAgent() },
+                            makeNew: { .agent(id: UUID(), StreamingText(txt)) })
         case .userMessageChunk(let block):
             // Agents rarely emit these; treat as informational.
             transcript.messages.append(.systemNotice(id: UUID(), text: text(of: block)))
         case .agentThoughtChunk(let block):
-            append(text: text(of: block), into: { lastThought() }, fallback: .thought(id: UUID(), text: ""))
+            let txt = text(of: block)
+            appendStreaming(text: txt, locate: { lastThought() },
+                            makeNew: { .thought(id: UUID(), StreamingText(txt)) })
         case .toolCall(let payload):
             let full = payload.content.flatMap { Self.flatten($0) } ?? ""
             transcript.messages.append(.toolCall(.init(
@@ -250,20 +254,20 @@ final class ACPSession: ObservableObject, Identifiable {
         }
         return nil
     }
-    private func append(text addition: String, into locate: () -> Int?, fallback: ACPMessage) {
+    private func appendStreaming(text addition: String,
+                                locate: () -> Int?,
+                                makeNew: () -> ACPMessage) {
         if let i = locate() {
             switch transcript.messages[i] {
-            case .agent(let id, let t):   transcript.messages[i] = .agent(id: id, text: t + addition)
-            case .thought(let id, let t): transcript.messages[i] = .thought(id: id, text: t + addition)
-            default: transcript.messages.append(fallback)
-            }
-        } else {
-            switch fallback {
-            case .agent:   transcript.messages.append(.agent(id: UUID(), text: addition))
-            case .thought: transcript.messages.append(.thought(id: UUID(), text: addition))
-            default: transcript.messages.append(fallback)
+            case .agent(_, let buf), .thought(_, let buf):
+                buf.append(addition)
+                transcript.streamingTick &+= 1
+                return
+            default:
+                break
             }
         }
+        transcript.messages.append(makeNew())
     }
     private func updateToolCall(id: String, _ mutate: (inout ACPMessage.ToolCall) -> Void) {
         for i in transcript.messages.indices {

--- a/Alas/Sources/ACP/Session/ACPStreamingText.swift
+++ b/Alas/Sources/ACP/Session/ACPStreamingText.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Combine
+
+/// Reference-typed text buffer shared between an `ACPMessage` value and
+/// the SwiftUI row rendering it. Appending streaming chunks mutates one
+/// String in place (amortized O(1)) instead of rebuilding the enclosing
+/// enum case + reassigning the @Published transcript array on every
+/// chunk (which over the lifetime of a message is O(n²) in chars).
+///
+/// Equality is by reference identity: two `.agent(id, buf)` values that
+/// share the same buffer compare equal even as the text grows, so the
+/// transcript-array diff doesn't fire on streaming. The inner row view
+/// observes the buffer directly via @ObservedObject and re-renders
+/// when `value` changes.
+@MainActor
+final class StreamingText: ObservableObject {
+    @Published private(set) var value: String
+
+    init(_ initial: String = "") {
+        self.value = initial
+    }
+
+    func append(_ s: String) {
+        value.append(s)
+    }
+}
+
+extension StreamingText: Equatable {
+    nonisolated static func == (lhs: StreamingText, rhs: StreamingText) -> Bool { lhs === rhs }
+}

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -11,4 +11,13 @@ final class ACPTranscript: ObservableObject {
     @Published var messages: [ACPMessage] = []
     @Published var streamingState: ACPSession.StreamingState = .idle
     @Published var pendingPermission: ACPSession.PendingPermission?
+    /// Tick incremented on every streaming chunk that mutates an existing
+    /// agent/thought buffer. The buffer itself publishes (so the row's
+    /// inner Text re-renders), but the transcript array doesn't change —
+    /// without this tick, `ACPMessageList`'s body wouldn't re-evaluate
+    /// and the tail-scroll signature wouldn't recompute, so long replies
+    /// drift below the viewport mid-stream. Body re-eval is cheap because
+    /// stableId + StreamingText identity equality keep the ForEach row
+    /// tree stable across ticks.
+    @Published var streamingTick: UInt32 = 0
 }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -29,10 +29,16 @@ struct ACPMessageList: View {
     private var scrollSignature: Int {
         var hasher = Hasher()
         hasher.combine(transcript.messages.count)
+        // Streaming chunks mutate the buffer in place without re-publishing
+        // the transcript array; the tick gives the body a reason to re-eval
+        // so this signature changes and the tail-scroll fires per chunk.
+        hasher.combine(transcript.streamingTick)
         if let last = transcript.messages.last {
             hasher.combine(last.kind)
             switch last {
-            case .agent(_, let t), .thought(_, let t), .systemNotice(_, let t):
+            case .agent(_, let buf), .thought(_, let buf):
+                hasher.combine(buf.value.count)
+            case .systemNotice(_, let t):
                 hasher.combine(t.count)
             case .toolCall(let tc):
                 hasher.combine(tc.status)
@@ -179,10 +185,10 @@ struct ACPMessageList: View {
         switch m {
         case .user(_, let text, let attachments):
             UserMessageRow(text: text, attachments: attachments)
-        case .agent(_, let text):
-            AgentMessageRow(text: text)
-        case .thought(_, let text):
-            ACPThoughtView(text: text)
+        case .agent(_, let buf):
+            AgentMessageRow(buffer: buf)
+        case .thought(_, let buf):
+            ACPThoughtView(buffer: buf)
         case .toolCall(let tc):
             ACPToolCallCard(toolCall: tc)
         case .fileEdit(_, let edit):
@@ -345,9 +351,9 @@ private struct UserMessageRow: View {
 // MARK: - Agent prose (markdown-rendered, full-width)
 
 private struct AgentMessageRow: View {
-    let text: String
+    @ObservedObject var buffer: StreamingText
     var body: some View {
-        ACPMarkdownText(raw: text)
+        ACPMarkdownText(raw: buffer.value)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/Alas/Sources/ACP/UI/ACPThoughtView.swift
+++ b/Alas/Sources/ACP/UI/ACPThoughtView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Collapsed-by-default "Thinking…" row. Click to expand and read the raw
 /// reasoning text. Visually anchored by a left vertical accent bar.
 struct ACPThoughtView: View {
-    let text: String
+    @ObservedObject var buffer: StreamingText
     @State private var expanded = false
     @Environment(\.theme) private var theme
 
@@ -28,7 +28,7 @@ struct ACPThoughtView: View {
                 .buttonStyle(.plain)
 
                 if expanded {
-                    Text(text)
+                    Text(buffer.value)
                         .font(.system(size: 12, design: .default).italic())
                         .foregroundStyle(theme.color("fg-dim"))
                         .lineSpacing(2)

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import Alas
 
+@MainActor
 @Suite("ACPMessage")
 struct ACPMessageTests {
     @Test("user message round-trips through JSON")
@@ -19,14 +20,14 @@ struct ACPMessageTests {
     }
     @Test("agent message round-trips")
     func agentRoundtrip() throws {
-        let m = ACPMessage.agent(id: UUID(), text: "world")
+        let m = ACPMessage.agent(id: UUID(), StreamingText("world"))
         let payload = try ACPMessageCodec.encode(m)
         let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
-        guard case .agent(_, let text) = back else {
+        guard case .agent(_, let buf) = back else {
             Issue.record("expected agent message")
             return
         }
-        #expect(text == "world")
+        #expect(buf.value == "world")
     }
     @Test("tool call round-trips")
     func toolRoundtrip() throws {

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -11,7 +11,7 @@ struct ACPSessionTests {
         session.apply(.agentMessageChunk(.text("hello ")))
         session.apply(.agentMessageChunk(.text("world")))
         #expect(session.transcript.messages.count == 1)
-        if case .agent(_, let text) = session.transcript.messages[0] { #expect(text == "hello world") }
+        if case .agent(_, let buf) = session.transcript.messages[0] { #expect(buf.value == "hello world") }
         else { Issue.record("expected single agent message") }
     }
 

--- a/AlasTests/ACP/Session/ACPStreamingTextTests.swift
+++ b/AlasTests/ACP/Session/ACPStreamingTextTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPStreamingText")
+struct ACPStreamingTextTests {
+    @Test("append concatenates and exposes the latest value")
+    func appendsAndExposes() async {
+        let t = StreamingText("a")
+        t.append("b")
+        t.append("c")
+        #expect(t.value == "abc")
+    }
+
+    @Test("two ACPMessage.agent values backed by the same buffer compare equal")
+    func identityEqualityForSharedBuffer() async {
+        let buf = StreamingText("hi")
+        let id = UUID()
+        let lhs = ACPMessage.agent(id: id, buf)
+        let rhs = ACPMessage.agent(id: id, buf)
+        #expect(lhs == rhs)
+    }
+
+    @Test("two ACPMessage.agent values with different buffers do NOT compare equal")
+    func differentBuffersAreUnequal() async {
+        let id = UUID()
+        let lhs = ACPMessage.agent(id: id, StreamingText("hi"))
+        let rhs = ACPMessage.agent(id: id, StreamingText("hi"))
+        #expect(lhs != rhs)
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
ACPMessage.agent and .thought now carry a reference-typed StreamingText
buffer instead of an inline String. Appending a chunk mutates the
buffer in place (amortized O(1)) rather than reallocating the message
text and reassigning the @Published transcript array on every chunk
(which over the lifetime of a long agent reply was O(n²) in chars).

StreamingText is ObservableObject with @Published value. Row views
hold the buffer via @ObservedObject and re-render on append. Two
ACPMessage values that share the same buffer compare equal (identity
equality), so the transcript-array diff stays stable across streaming
growth — only the inner row re-renders.

Persistence is unchanged: codec encodes buf.value and decodes back
into a fresh buffer wrapper.
<!-- gg:managed:end -->