### PR TITLE
feat(acp): incremental markdown rendering with inline memoization

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -689,6 +689,8 @@
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
 		EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */; };
 		EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */; };
+		D0670FAF5CFC4112B110711D /* ACPMarkdownBlockCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D7C6F94464B4EB2E289B9 /* ACPMarkdownBlockCache.swift */; };
+		078F49E0346F4AD481D7E7BD /* ACPMarkdownBlockCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C6A1DD81E94F59A16B7A34 /* ACPMarkdownBlockCacheTests.swift */; };
 		EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */; };
 		ECEE8511CA84DF4A15F01DC1 /* AppConfigTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
@@ -990,6 +992,8 @@
 		52C55C85672956E1340B03B1 /* MergeSidePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSidePane.swift; sourceTree = "<group>"; };
 		5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioClientTests.swift; sourceTree = "<group>"; };
 		530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighter.swift; sourceTree = "<group>"; };
+		B44D7C6F94464B4EB2E289B9 /* ACPMarkdownBlockCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCache.swift; sourceTree = "<group>"; };
+		D1C6A1DD81E94F59A16B7A34 /* ACPMarkdownBlockCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCacheTests.swift; sourceTree = "<group>"; };
 		5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolver.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
@@ -2053,6 +2057,7 @@
 			isa = PBXGroup;
 			children = (
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
+				D1C6A1DD81E94F59A16B7A34 /* ACPMarkdownBlockCacheTests.swift */,
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
 			);
 			path = UI;
@@ -2237,6 +2242,7 @@
 				29D7631D754795D16E946440 /* ACPFileEditCard.swift */,
 				E2C5BD0110EB8EDE7BB4ED93 /* ACPHistorySidebar.swift */,
 				2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */,
+				B44D7C6F94464B4EB2E289B9 /* ACPMarkdownBlockCache.swift */,
 				DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */,
 				329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */,
 				E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */,
@@ -3042,6 +3048,7 @@
 				433EC05E13C676C1C2EB6888 /* ACPLaunchCatalog.swift in Sources */,
 				542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */,
 				6AE129E340CA74CC26B34B66 /* ACPMarkdownLiveStyler.swift in Sources */,
+				D0670FAF5CFC4112B110711D /* ACPMarkdownBlockCache.swift in Sources */,
 				E6F317EB2FF5522C77B30B62 /* ACPMarkdownText.swift in Sources */,
 				CC64E79B9CF4AF1B3CE31261 /* ACPMentionChipAttachment.swift in Sources */,
 				2B823A7361BB54D8D93D7C99 /* ACPMentionPicker.swift in Sources */,
@@ -3426,6 +3433,7 @@
 				CC531074F02A34E48A1E6133 /* ACPAgentProfilesTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
+				078F49E0346F4AD481D7E7BD /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -20,4 +20,25 @@ final class ACPTranscript: ObservableObject {
     /// stableId + StreamingText identity equality keep the ForEach row
     /// tree stable across ticks.
     @Published var streamingTick: UInt32 = 0
+
+    // MARK: - Per-message markdown caches
+
+    private var markdownCaches: [String: ACPMarkdownBlockCache] = [:]
+
+    func markdownCache(forMessage id: String) -> ACPMarkdownBlockCache {
+        if let c = markdownCaches[id] { return c }
+        let c = ACPMarkdownBlockCache()
+        markdownCaches[id] = c
+        return c
+    }
+
+    func dropMarkdownCache(forMessage id: String) {
+        markdownCaches.removeValue(forKey: id)
+    }
+
+    /// Clear all per-message caches; call when the transcript itself is
+    /// discarded (e.g. session close).
+    func resetMarkdownCaches() {
+        markdownCaches.removeAll()
+    }
 }

--- a/Alas/Sources/ACP/UI/ACPMarkdownBlockCache.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownBlockCache.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Incrementally parses streaming markdown. Promotes already-completed
+/// prefix into `stableBlocks` at every blank line that lies outside a
+/// fenced code block (fence depth zero). Only the un-promoted tail is
+/// re-parsed on each streaming chunk.
+///
+/// Behavior-preserving: `stableBlocks + ACPMarkdownText.parse(tailUnparsed)`
+/// must equal `ACPMarkdownText.parse(fullText)` for any prefix-extending
+/// stream. If a chunk arrives that does NOT extend the previous text
+/// (e.g. the message was edited or replaced), the cache resets.
+@MainActor
+final class ACPMarkdownBlockCache {
+    private(set) var stableBlocks: [ACPMarkdownText.Block] = []
+    private(set) var tailUnparsed: String = ""
+    private var stablePrefixLength: Int = 0
+    private var lastFullText: String = ""
+
+    func update(with full: String) {
+        // Detect non-extending updates and reset.
+        if !full.hasPrefix(lastFullText) {
+            stableBlocks = []
+            stablePrefixLength = 0
+        }
+        lastFullText = full
+        tailUnparsed = String(full.dropFirst(stablePrefixLength))
+        promoteIfPossible()
+    }
+
+    /// Walk tailUnparsed; find the latest blank line at fence depth zero
+    /// (counting ```-fenced blocks). Everything up to and including that
+    /// blank line gets parsed once and frozen.
+    private func promoteIfPossible() {
+        guard let safeEnd = ACPMarkdownBlockCache.lastSafePromotionIndex(in: tailUnparsed) else {
+            return
+        }
+        let promoted = String(tailUnparsed.prefix(safeEnd))
+        let newBlocks = ACPMarkdownText.parse(promoted)
+        stableBlocks.append(contentsOf: newBlocks)
+        stablePrefixLength += promoted.count
+        tailUnparsed = String(tailUnparsed.dropFirst(safeEnd))
+    }
+
+    /// Returns the offset (Int count of Characters) just past the last
+    /// blank line at fence depth zero, or nil if no such boundary
+    /// exists yet. Operates over `text` only — does not see prior
+    /// stable prefix; for streaming, "fence at start of tail" implies
+    /// the prior stable parse closed any earlier fences.
+    static func lastSafePromotionIndex(in text: String) -> Int? {
+        var fenceDepth = 0
+        var lastSafeEnd: Int? = nil
+        var line = ""
+        var idx = 0
+        for ch in text {
+            if ch == "\n" {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("```") {
+                    fenceDepth = (fenceDepth == 0) ? 1 : 0
+                }
+                if trimmed.isEmpty && fenceDepth == 0 {
+                    lastSafeEnd = idx + 1 // include the newline
+                }
+                line = ""
+            } else {
+                line.append(ch)
+            }
+            idx += 1
+        }
+        return lastSafeEnd
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPMarkdownText.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownText.swift
@@ -12,27 +12,37 @@ import AppKit
 /// blank out an agent message.
 struct ACPMarkdownText: View {
     let raw: String
+    var cache: ACPMarkdownBlockCache? = nil
     @Environment(\.theme) private var theme
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(Array(parse(raw).enumerated()), id: \.offset) { _, block in
+            ForEach(Array(currentBlocks().enumerated()), id: \.offset) { _, block in
                 view(for: block)
             }
         }
+    }
+
+    private func currentBlocks() -> [Block] {
+        if let cache {
+            cache.update(with: raw)
+            let tailBlocks = ACPMarkdownText.parse(cache.tailUnparsed)
+            return cache.stableBlocks + tailBlocks
+        }
+        return ACPMarkdownText.parse(raw)
     }
 
     @ViewBuilder
     private func view(for block: Block) -> some View {
         switch block {
         case .heading(let level, let text):
-            Text(inlineMarkdown(text))
+            Text(ACPMarkdownText.inlineMarkdown(text))
                 .font(.system(size: headingSize(level), weight: .bold))
                 .foregroundStyle(theme.color("fg"))
                 .textSelection(.enabled)
                 .padding(.top, level == 1 ? 4 : 2)
         case .paragraph(let text):
-            Text(inlineMarkdown(text))
+            Text(ACPMarkdownText.inlineMarkdown(text))
                 .font(.system(size: 13.5))
                 .foregroundStyle(theme.color("fg"))
                 .lineSpacing(3)
@@ -43,7 +53,7 @@ struct ACPMarkdownText: View {
                 Rectangle()
                     .fill(theme.color("accent").opacity(0.55))
                     .frame(width: 2)
-                Text(inlineMarkdown(text))
+                Text(ACPMarkdownText.inlineMarkdown(text))
                     .font(.system(size: 13).italic())
                     .foregroundStyle(theme.color("fg-muted"))
                     .lineSpacing(2)
@@ -80,7 +90,7 @@ struct ACPMarkdownText: View {
         HStack(alignment: .top, spacing: 0) {
             ForEach(0..<columnCount, id: \.self) { i in
                 let value = i < cells.count ? cells[i] : ""
-                Text(inlineMarkdown(value))
+                Text(ACPMarkdownText.inlineMarkdown(value))
                     .font(.system(size: isHeader ? 11.5 : 12, weight: isHeader ? .semibold : .regular))
                     .foregroundStyle(isHeader ? theme.color("fg-muted") : theme.color("fg"))
                     .frame(minWidth: 80, alignment: .leading)
@@ -102,23 +112,40 @@ struct ACPMarkdownText: View {
         }
     }
 
+    // MARK: - Inline memoization
+
+    private static let inlineCache: NSCache<NSString, NSAttributedString> = {
+        let c = NSCache<NSString, NSAttributedString>()
+        c.countLimit = 512
+        return c
+    }()
+
     /// Inline parser: bold / italic / inline code / links via the
-    /// system AttributedString initializer.
-    private func inlineMarkdown(_ s: String) -> AttributedString {
-        if let attr = try? AttributedString(
+    /// system AttributedString initializer. Results are memoized in a
+    /// process-static NSCache; stable blocks stay warm across chunks.
+    static func inlineMarkdown(_ s: String) -> AttributedString {
+        let key = s as NSString
+        if let hit = inlineCache.object(forKey: key) {
+            return AttributedString(hit)
+        }
+        let attr: AttributedString
+        if let parsed = try? AttributedString(
             markdown: s,
             options: AttributedString.MarkdownParsingOptions(
                 interpretedSyntax: .inlineOnlyPreservingWhitespace
             )
         ) {
-            return attr
+            attr = parsed
+        } else {
+            attr = AttributedString(s)
         }
-        return AttributedString(s)
+        inlineCache.setObject(NSAttributedString(attr), forKey: key)
+        return attr
     }
 
     // MARK: - Block parser
 
-    enum Block {
+    enum Block: Equatable {
         case heading(level: Int, text: String)
         case paragraph(String)
         case quote(String)
@@ -131,7 +158,7 @@ struct ACPMarkdownText: View {
     ///   |----|----|
     ///   | a  | b  |
     /// Returns header cells + body rows + number of consumed lines, or nil.
-    private func matchTable(from lines: [String], at start: Int) -> ([String], [[String]], Int)? {
+    private static func matchTable(from lines: [String], at start: Int) -> ([String], [[String]], Int)? {
         guard start + 1 < lines.count else { return nil }
         let head = lines[start].trimmingCharacters(in: .whitespaces)
         let sep = lines[start + 1].trimmingCharacters(in: .whitespaces)
@@ -160,7 +187,7 @@ struct ACPMarkdownText: View {
         return (header, rows, j - start)
     }
 
-    private func splitTableRow(_ raw: String) -> [String] {
+    private static func splitTableRow(_ raw: String) -> [String] {
         var s = raw
         if s.hasPrefix("|") { s.removeFirst() }
         if s.hasSuffix("|") { s.removeLast() }
@@ -170,7 +197,7 @@ struct ACPMarkdownText: View {
 
     /// Detect `# Heading` / `## Subheading` etc. (1–6 `#`s, then whitespace,
     /// then content). Returns `(level, text)` or nil.
-    private func matchHeading(_ line: String) -> (Int, String)? {
+    private static func matchHeading(_ line: String) -> (Int, String)? {
         var level = 0
         var idx = line.startIndex
         while idx < line.endIndex, line[idx] == "#", level < 6 {
@@ -183,7 +210,7 @@ struct ACPMarkdownText: View {
         return (level, String(body))
     }
 
-    private func parse(_ text: String) -> [Block] {
+    static func parse(_ text: String) -> [Block] {
         var blocks: [Block] = []
         var i = 0
         let lines = text.components(separatedBy: "\n")

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -185,8 +185,8 @@ struct ACPMessageList: View {
         switch m {
         case .user(_, let text, let attachments):
             UserMessageRow(text: text, attachments: attachments)
-        case .agent(_, let buf):
-            AgentMessageRow(buffer: buf)
+        case .agent(let id, let buf):
+            AgentMessageRow(messageId: id.uuidString, transcript: transcript, buffer: buf)
         case .thought(_, let buf):
             ACPThoughtView(buffer: buf)
         case .toolCall(let tc):
@@ -351,9 +351,11 @@ private struct UserMessageRow: View {
 // MARK: - Agent prose (markdown-rendered, full-width)
 
 private struct AgentMessageRow: View {
+    let messageId: String
+    let transcript: ACPTranscript
     @ObservedObject var buffer: StreamingText
     var body: some View {
-        ACPMarkdownText(raw: buffer.value)
+        ACPMarkdownText(raw: buffer.value, cache: transcript.markdownCache(forMessage: messageId))
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownBlockCacheTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPMarkdownBlockCache")
+struct ACPMarkdownBlockCacheTests {
+    @Test("two paragraphs separated by blank line both become stable once a third arrives")
+    func paragraphsPromoteOnBoundary() async {
+        let cache = ACPMarkdownBlockCache()
+        cache.update(with: "para 1\n\npara 2")
+        let firstStable = cache.stableBlocks.count
+        cache.update(with: "para 1\n\npara 2\n\npara 3")
+        #expect(cache.stableBlocks.count > firstStable)
+    }
+
+    @Test("blank line inside an unclosed fence does NOT promote stable blocks")
+    func fenceKeepsUnstable() async {
+        let cache = ACPMarkdownBlockCache()
+        cache.update(with: "intro\n\n```\ncode line 1")
+        let stableAfterOpen = cache.stableBlocks.count
+        cache.update(with: "intro\n\n```\ncode line 1\n\ncode line 2 still inside fence")
+        // Blank line inside the fence: no new stable blocks.
+        #expect(cache.stableBlocks.count == stableAfterOpen)
+        cache.update(with: "intro\n\n```\ncode line 1\n\ncode line 2\n```\n\nafter")
+        // Fence closed + blank line: the code block (and intro) are now stable.
+        #expect(cache.stableBlocks.count > stableAfterOpen)
+    }
+
+    @Test("cached output equals direct parse for the same input")
+    func cacheParityWithDirectParse() async {
+        let raw = """
+        # Heading
+
+        First paragraph with **bold**.
+
+        ```
+        let x = 1
+        ```
+
+        Closing paragraph.
+        """
+        let cache = ACPMarkdownBlockCache()
+        cache.update(with: raw)
+        let cached = cache.stableBlocks + ACPMarkdownText.parse(cache.tailUnparsed)
+        let direct = ACPMarkdownText.parse(raw)
+        // Block-by-block comparison: Block must conform to Equatable
+        // (synthesized; its associated values are String / [String] / Int).
+        #expect(cached == direct)
+    }
+}


### PR DESCRIPTION
<!-- gg:managed:start -->
ACPMarkdownText previously re-parsed the entire message string on
every streaming chunk, and every block re-invoked
AttributedString(markdown:) for inline grammar. With multiple
concurrent agent streams, that work dominated the main thread.

Two layers of caching:

  1. Per-message ACPMarkdownBlockCache promotes already-completed
     prefix into a frozen [Block] at blank lines that lie outside any
     fenced code region (fence-depth zero). Only the un-promoted tail
     re-parses on each chunk. Behavior-preserving: cached output
     equals direct parse output (covered by a parity test).

  2. Process-static NSCache memoizes inlineMarkdown(_:) by string
     key. Stable blocks stay warm; only the tail re-parses.

ACPTranscript owns one cache per message id; user-message bubbles
stay on the uncached path.
<!-- gg:managed:end -->