### PR TITLE
perf(acp): fast-path composer draft extraction when no chips

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -267,14 +267,29 @@ struct ACPInputField: NSViewRepresentable {
         }
 
         static func draft(from attributed: NSAttributedString) -> ACPComposerDraft {
+            let full = NSRange(location: 0, length: attributed.length)
+            guard attributed.length > 0 else { return ACPComposerDraft(segments: []) }
+
+            // Fast path: no chip mentions in the storage. The whole
+            // string is plain text, so skip the enumerateAttribute walk
+            // entirely. This is the common case while typing.
+            var hasChip = false
+            attributed.enumerateAttribute(.attachmentURI, in: full) { value, _, stop in
+                if value != nil {
+                    hasChip = true
+                    stop.pointee = true
+                }
+            }
+            if !hasChip {
+                let text = attributed.string
+                return ACPComposerDraft(segments: text.isEmpty ? [] : [.text(text)])
+            }
+
             var segments: [ACPComposerDraft.Segment] = []
-            attributed.enumerateAttribute(
-                .attachmentURI,
-                in: NSRange(location: 0, length: attributed.length)
-            ) { value, range, _ in
+            attributed.enumerateAttribute(.attachmentURI, in: full) { value, range, _ in
                 if let uri = value as? String,
                    let chip = attributed.attribute(.attachment, at: range.location, effectiveRange: nil)
-                            as? ACPMentionChipAttachment {
+                   as? ACPMentionChipAttachment {
                     segments.append(.mention(displayName: chip.displayName, uri: uri))
                 } else if let uri = value as? String {
                     let segment = attributed.attributedSubstring(from: range).string


### PR DESCRIPTION
<!-- gg:managed:start -->
Composer textDidChange called draft(from:) on every keystroke, which
walked the entire attributed string via enumerateAttribute to split
out chip mentions. The common case while typing is no chips at all,
so a single pre-scan checks for any .attachmentURI; when absent, the
draft is emitted as one .text segment without the per-range walk.
<!-- gg:managed:end -->