### PR TITLE
perf(acp): debounce SQLite composer draft writes

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -16,6 +16,13 @@ final class ACPSessionManager: ObservableObject {
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
     private(set) var runners: [ACPSession.ID: ACPSessionRunner] = [:]
+    /// Per-session debounced write tasks for `composer_drafts`. The
+    /// in-memory `session.composerDraft` updates on every keystroke;
+    /// the SQLite write only fires after a brief idle (or a forced
+    /// flush on submit / delete). Cancelled and re-scheduled on each
+    /// further keystroke so a typing burst produces one write.
+    private var pendingDraftWrites: [ACPSession.ID: Task<Void, Never>] = [:]
+    private static let draftDebounceNanos: UInt64 = 300_000_000
 
     init(worktreeId: String, worktreePath: String, store: ACPSessionStore,
          onDirtyCheck: ((String) -> Bool)? = nil,
@@ -72,10 +79,15 @@ final class ACPSessionManager: ObservableObject {
     }
 
     func closeSession(id: ACPSession.ID) {
+        // Flush any pending draft write before dropping the in-memory
+        // session reference — otherwise a tab-switch-while-typing
+        // window can lose the last ~300ms of input.
+        flushPendingDraftWrite(for: id)
         sessions[id] = nil
     }
 
     func deleteSession(id: ACPSession.ID) {
+        cancelPendingDraftWrite(for: id)
         sessions[id] = nil
         try? store.deleteSession(id: id)
         refreshRecent()
@@ -118,18 +130,62 @@ final class ACPSessionManager: ObservableObject {
     }
 
     func persistComposerDraft(_ draft: ACPComposerDraft, for session: ACPSession) {
+        // In-memory state updates instantly so cross-tab restore is live.
+        // The SQLite write is debounced so a typing burst produces at
+        // most one upsert per ~300ms instead of one per keystroke.
         session.replaceComposerDraft(draft)
-        if draft.isEmpty {
-            try? store.deleteComposerDraft(sessionId: session.id)
-        } else {
-            let now = Int64(Date().timeIntervalSince1970)
-            try? store.upsertComposerDraft(sessionId: session.id, draft: draft, updatedAt: now)
-        }
+        scheduleDraftPersistence(for: session.id)
     }
 
     func clearComposerDraft(for session: ACPSession) {
         session.replaceComposerDraft(.empty)
+        cancelPendingDraftWrite(for: session.id)
         try? store.deleteComposerDraft(sessionId: session.id)
+    }
+
+    private func scheduleDraftPersistence(for sessionId: ACPSession.ID) {
+        pendingDraftWrites[sessionId]?.cancel()
+        pendingDraftWrites[sessionId] = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: Self.draftDebounceNanos)
+            guard !Task.isCancelled else { return }
+            await self?.flushPendingDraftWrite(for: sessionId)
+        }
+    }
+
+    private func flushPendingDraftWrite(for sessionId: ACPSession.ID) {
+        pendingDraftWrites[sessionId] = nil
+        // Write the LATEST in-memory state, not whatever was captured at
+        // schedule time — additional keystrokes may have come in during
+        // the debounce window.
+        guard let session = sessions[sessionId] else { return }
+        let draft = session.composerDraft
+        if draft.isEmpty {
+            try? store.deleteComposerDraft(sessionId: sessionId)
+        } else {
+            let now = Int64(Date().timeIntervalSince1970)
+            try? store.upsertComposerDraft(sessionId: sessionId, draft: draft, updatedAt: now)
+        }
+    }
+
+    private func cancelPendingDraftWrite(for sessionId: ACPSession.ID) {
+        pendingDraftWrites[sessionId]?.cancel()
+        pendingDraftWrites[sessionId] = nil
+    }
+
+    /// Flush every pending debounced draft write synchronously. Hook for
+    /// app-termination, scene resign, or tests that need a deterministic
+    /// post-write read.
+    func flushPendingDraftWrites() {
+        for sessionId in Array(pendingDraftWrites.keys) {
+            flushPendingDraftWrite(for: sessionId)
+        }
+    }
+
+    /// Flush the debounced draft write for one session. Hook for the
+    /// tab-close path (single session goes away while the worktree's
+    /// manager stays alive).
+    func flushPendingDraftWrite(forSession sessionId: ACPSession.ID) {
+        flushPendingDraftWrite(for: sessionId)
     }
 
     /// Persist the in-memory queue to SQLite. The runner has the same

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1575,8 +1575,13 @@ final class AppState {
     /// tears down the whole worktree's manager — this leaves the
     /// manager (and any sibling sessions) running.
     private func cleanupACPSession(worktreeId: String, sessionId: String) {
-        guard let manager = acpManagers[worktreeId],
-              let runner = manager.runners[sessionId] else { return }
+        guard let manager = acpManagers[worktreeId] else { return }
+        // Flush any in-flight debounced draft write for this session
+        // before the tab goes away. The manager itself stays alive
+        // (other tabs may share it), so the global flush from
+        // disposeACPManager wouldn't fire here.
+        manager.flushPendingDraftWrite(forSession: sessionId)
+        guard let runner = manager.runners[sessionId] else { return }
         runner.stop()
         Task { @MainActor in
             await manager.detach(sessionId: sessionId)
@@ -2282,6 +2287,16 @@ final class AppState {
     @ObservationIgnored
     private var acpManagers: [String: ACPSessionManager] = [:]
 
+    /// Force-flush every per-session debounced composer-draft write across
+    /// all live managers. Called from app-will-terminate so an in-flight
+    /// typing burst doesn't lose its last ~300ms of input to the
+    /// debounce window.
+    func flushAllACPComposerDrafts() {
+        for manager in acpManagers.values {
+            manager.flushPendingDraftWrites()
+        }
+    }
+
     /// Mirrors `ACPSession.streamingState` into `HarnessService.activityBySession`
     /// so the sidebar work badge surfaces ACP activity. Attached for every
     /// manager created via `acpManager(for:)`; detached from `disposeACPManager(for:)`.
@@ -2347,6 +2362,10 @@ final class AppState {
     /// after the UI was torn down.
     func disposeACPManager(for worktreeId: String) {
         guard let manager = acpManagers.removeValue(forKey: worktreeId) else { return }
+        // Flush any pending debounced draft writes before tearing the
+        // manager down — otherwise the last ~300ms of typing in any
+        // composer for this worktree never reaches SQLite.
+        manager.flushPendingDraftWrites()
         acpHarnessBridge.detach(worktreeId: worktreeId)
         let sessionIds = Array(manager.runners.keys)
         // Synchronously cancel the runner's async loops so they stop

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -456,6 +456,7 @@ private struct RootBaseHandlers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                 state.stopAllProjectGitWatchers()
                 state.tabs.snapshotDirtyBuffersForQuit()
+                state.flushAllACPComposerDrafts()
                 // Cancel the hook socket accept loop and any pending cursor
                 // idle debouncers before the process tears down. Otherwise
                 // in-flight hook subprocesses (cursor-agent fires a 1s `nc -U`

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -43,11 +43,13 @@ struct ACPSessionManagerTests {
         mgr.persistComposerDraft(draft, for: session)
         #expect(session.composerDraft == draft)
         #expect(session.composerDraftRevision == 1)
+        mgr.flushPendingDraftWrites()
         #expect(try store.loadComposerDraft(sessionId: session.id) == draft)
 
         mgr.persistComposerDraft(.empty, for: session)
         #expect(session.composerDraft == .empty)
         #expect(session.composerDraftRevision == 2)
+        mgr.flushPendingDraftWrites()
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
     }
 
@@ -83,6 +85,7 @@ struct ACPSessionManagerTests {
         mgr.persistComposerDraft(newer, for: session)
         mgr.clearComposerDraft(for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
         #expect(session.composerDraft == newer)
+        mgr.flushPendingDraftWrites()
         #expect(try store.loadComposerDraft(sessionId: session.id) == newer)
     }
 
@@ -98,11 +101,13 @@ struct ACPSessionManagerTests {
         let submittedRevision = session.composerDraftRevision
         mgr.persistComposerDraft(submitted, for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
         #expect(session.composerDraft == submitted)
+        mgr.flushPendingDraftWrites()
         #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
 
         mgr.persistComposerDraft(submitted, for: session)
         mgr.persistComposerDraft(.empty, for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
         #expect(session.composerDraft == submitted)
+        mgr.flushPendingDraftWrites()
         #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
     }
 


### PR DESCRIPTION
<!-- gg:managed:start -->
Every composer keystroke fired a synchronous SQLite UPSERT on the
main thread (JSONEncoder + db.exec). A typist at 8 chars/sec drove
8 writes per second per active composer.

In-memory state still updates instantly so cross-tab restore is
live. The SQLite write is now scheduled on a per-session Task that
sleeps 300ms then writes the LATEST in-memory draft. Further
keystrokes within the window cancel and re-schedule, so a typing
burst produces one write.

closeSession flushes the pending write before dropping the in-memory
session — otherwise a tab-switch-while-typing window can lose the
last ~300ms of input. deleteSession cancels pending writes since
the row is going away.

flushPendingDraftWrites() exposed for app-termination hooks and for
tests that need deterministic post-write reads.
<!-- gg:managed:end -->