### PR TITLE
fix(terminal): strip ZMX_SESSION from inherited env to stop cross-pane re-attach

### DIFF
--- a/Alas/Sources/Terminal/EnvBuilder.swift
+++ b/Alas/Sources/Terminal/EnvBuilder.swift
@@ -9,8 +9,12 @@ enum EnvBuilder {
         // terminal, or because we're building env for a sibling pane), passing
         // it through means a subsequent `zmx attach <other>` from anywhere in
         // the new shell falls into zmx's switchSesh path and re-attaches the
-        // pane to a different session. See zmx#151.
-        "ZMX_SESSION", "ZMX_SESSION_PREFIX",
+        // pane to a different session. See zmx#151. Note: ZMX_SESSION_PREFIX
+        // is intentionally NOT stripped — it's a user-facing zmx config knob
+        // (prefixes session names for all commands), and as long as both
+        // spawned shells and Alas's own zmx CLI invocations see the same
+        // prefix, name resolution stays consistent.
+        "ZMX_SESSION",
     ]
 
     static func build(

--- a/Alas/Sources/Terminal/EnvBuilder.swift
+++ b/Alas/Sources/Terminal/EnvBuilder.swift
@@ -4,6 +4,13 @@ enum EnvBuilder {
     private static let strippedKeys: Set<String> = [
         "TERM", "TERMINFO", "TERMINFO_DIRS",
         "TERM_PROGRAM", "TERM_PROGRAM_VERSION", "COLORTERM",
+        // zmx injects ZMX_SESSION into the shell it spawns. If Alas inherits
+        // that env (because Alas itself was launched from a zmx-attached
+        // terminal, or because we're building env for a sibling pane), passing
+        // it through means a subsequent `zmx attach <other>` from anywhere in
+        // the new shell falls into zmx's switchSesh path and re-attaches the
+        // pane to a different session. See zmx#151.
+        "ZMX_SESSION", "ZMX_SESSION_PREFIX",
     ]
 
     static func build(

--- a/Alas/Sources/Terminal/Zmx/ZmxClient.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxClient.swift
@@ -125,19 +125,17 @@ final class ZmxClient: Sendable {
     /// Environment passed to every zmx invocation. Pins `ZMX_DIR` so the
     /// CLI talks to the same daemon/socket dir Alas-spawned shells will use.
     ///
-    /// Strips `ZMX_SESSION` and `ZMX_SESSION_PREFIX` for the same reason
-    /// `EnvBuilder` strips them from spawned pane shells: if Alas itself
-    /// was launched from a zmx-attached terminal, those vars leak into
-    /// `ProcessInfo.environment`. With `ZMX_SESSION_PREFIX` left in env,
-    /// `zmx kill <bare-name>`/`zmx ls` resolve to `<prefix><bare-name>`
-    /// while the bare name is what `EnvBuilder` (which strips the prefix
-    /// from the shell env) and `wrap` actually used to create the
-    /// session — so cleanup targets a different name and the real
-    /// session leaks.
+    /// Strips `ZMX_SESSION` for the same reason `EnvBuilder` strips it from
+    /// spawned pane shells: if Alas itself was launched from a zmx-attached
+    /// terminal, the parent's session name leaks into
+    /// `ProcessInfo.environment` and trips zmx's `switchSesh` path on
+    /// `attach`. `ZMX_SESSION_PREFIX` is intentionally left intact — it's a
+    /// legitimate user-configured knob, and as long as both shell-side
+    /// (`EnvBuilder`) and CLI-side (here) see the same prefix, kill/ls/wrap
+    /// agree on the resolved name.
     private func zmxEnv() -> [String: String] {
         var inherited = ProcessInfo.processInfo.environment
         inherited.removeValue(forKey: "ZMX_SESSION")
-        inherited.removeValue(forKey: "ZMX_SESSION_PREFIX")
         if let dir = env.zmxDir { inherited["ZMX_DIR"] = dir.path }
         return inherited
     }

--- a/Alas/Sources/Terminal/Zmx/ZmxClient.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxClient.swift
@@ -124,8 +124,20 @@ final class ZmxClient: Sendable {
 
     /// Environment passed to every zmx invocation. Pins `ZMX_DIR` so the
     /// CLI talks to the same daemon/socket dir Alas-spawned shells will use.
+    ///
+    /// Strips `ZMX_SESSION` and `ZMX_SESSION_PREFIX` for the same reason
+    /// `EnvBuilder` strips them from spawned pane shells: if Alas itself
+    /// was launched from a zmx-attached terminal, those vars leak into
+    /// `ProcessInfo.environment`. With `ZMX_SESSION_PREFIX` left in env,
+    /// `zmx kill <bare-name>`/`zmx ls` resolve to `<prefix><bare-name>`
+    /// while the bare name is what `EnvBuilder` (which strips the prefix
+    /// from the shell env) and `wrap` actually used to create the
+    /// session — so cleanup targets a different name and the real
+    /// session leaks.
     private func zmxEnv() -> [String: String] {
         var inherited = ProcessInfo.processInfo.environment
+        inherited.removeValue(forKey: "ZMX_SESSION")
+        inherited.removeValue(forKey: "ZMX_SESSION_PREFIX")
         if let dir = env.zmxDir { inherited["ZMX_DIR"] = dir.path }
         return inherited
     }

--- a/AlasTests/EnvBuilderTests.swift
+++ b/AlasTests/EnvBuilderTests.swift
@@ -89,12 +89,14 @@ struct EnvBuilderTests {
         #expect(env["TERMINFO"] == nil)
     }
 
-    /// zmx injects ZMX_SESSION/ZMX_SESSION_PREFIX into the shells it spawns.
-    /// If Alas inherits that env and forwards it into a freshly-spawned pane,
-    /// any later `zmx attach <other>` from that shell silently hits zmx's
-    /// switchSesh path and re-binds the pane to a different daemon's session,
-    /// leaving one Alas tab piped into another tab's shell. See zmx#151.
-    @Test func stripsZmxSessionVarsFromInheritedParent() {
+    /// zmx injects ZMX_SESSION into the shells it spawns. If Alas inherits
+    /// that env and forwards it into a freshly-spawned pane, any later
+    /// `zmx attach <other>` from that shell silently hits zmx's switchSesh
+    /// path and re-binds the pane to a different daemon's session, leaving
+    /// one Alas tab piped into another tab's shell. See zmx#151.
+    /// `ZMX_SESSION_PREFIX` is left intact so user-configured prefixes flow
+    /// through to both the spawned shell and Alas's own zmx CLI calls.
+    @Test func stripsZmxSessionButKeepsPrefixFromInheritedParent() {
         let project = ProjectConfig(id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date())
         let wt = Worktree(id: "w", projectId: "p", name: "m", branch: "m",
                           path: URL(fileURLWithPath: "/wt"),
@@ -106,12 +108,12 @@ struct EnvBuilderTests {
             parent: [
                 "PATH": "/x",
                 "ZMX_SESSION": "alas-foo",
-                "ZMX_SESSION_PREFIX": "alas-",
+                "ZMX_SESSION_PREFIX": "team-",
             ]
         )
         #expect(env["PATH"] == "/x")
         #expect(env["ZMX_SESSION"] == nil)
-        #expect(env["ZMX_SESSION_PREFIX"] == nil)
+        #expect(env["ZMX_SESSION_PREFIX"] == "team-")
     }
 
     @Test func zmxDirIsEmittedWhenProvided() {

--- a/AlasTests/EnvBuilderTests.swift
+++ b/AlasTests/EnvBuilderTests.swift
@@ -89,6 +89,31 @@ struct EnvBuilderTests {
         #expect(env["TERMINFO"] == nil)
     }
 
+    /// zmx injects ZMX_SESSION/ZMX_SESSION_PREFIX into the shells it spawns.
+    /// If Alas inherits that env and forwards it into a freshly-spawned pane,
+    /// any later `zmx attach <other>` from that shell silently hits zmx's
+    /// switchSesh path and re-binds the pane to a different daemon's session,
+    /// leaving one Alas tab piped into another tab's shell. See zmx#151.
+    @Test func stripsZmxSessionVarsFromInheritedParent() {
+        let project = ProjectConfig(id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date())
+        let wt = Worktree(id: "w", projectId: "p", name: "m", branch: "m",
+                          path: URL(fileURLWithPath: "/wt"),
+                          status: .clean, lastActivity: Date())
+        let env = EnvBuilder.build(
+            project: project, worktree: wt, sessionId: "s",
+            socketPath: nil,
+            inheritParent: true,
+            parent: [
+                "PATH": "/x",
+                "ZMX_SESSION": "alas-foo",
+                "ZMX_SESSION_PREFIX": "alas-",
+            ]
+        )
+        #expect(env["PATH"] == "/x")
+        #expect(env["ZMX_SESSION"] == nil)
+        #expect(env["ZMX_SESSION_PREFIX"] == nil)
+    }
+
     @Test func zmxDirIsEmittedWhenProvided() {
         let project = ProjectConfig(id: "p", name: "x/y", path: "/r", color: "#0", addedAt: Date())
         let wt = Worktree(id: "w", projectId: "p", name: "m", branch: "m",

--- a/AlasTests/ZmxClientTests.swift
+++ b/AlasTests/ZmxClientTests.swift
@@ -104,17 +104,17 @@ struct ZmxClientTests {
     }
 
     /// If Alas itself was launched from a zmx-attached terminal,
-    /// `ProcessInfo.environment` carries `ZMX_SESSION_PREFIX` (and/or
-    /// `ZMX_SESSION`). Letting those leak into `zmx kill`/`zmx ls` makes
-    /// the CLI resolve a bare `alas-XYZ` name as `<prefix>alas-XYZ`,
-    /// while the session zmx actually created (via `EnvBuilder` + `wrap`,
-    /// which both strip the prefix) is plain `alas-XYZ` — so cleanup
-    /// targets the wrong name and the real session leaks. Mirror
-    /// `EnvBuilder`'s strip on the CLI-invocation env.
+    /// `ProcessInfo.environment` carries `ZMX_SESSION`. Letting it leak
+    /// into `zmx attach` (which the kill/ls calls don't issue, but the
+    /// daemon's leader client does) trips zmx's switchSesh path. Mirror
+    /// `EnvBuilder`'s strip on the CLI-invocation env so both sides agree.
+    /// `ZMX_SESSION_PREFIX` is intentionally kept — it's a user-configured
+    /// knob that has to flow through identically to both shell-side and
+    /// CLI-side paths for name resolution to stay consistent.
     @Test
-    func killSessionStripsLeakedZmxSessionEnvVars() {
+    func killSessionStripsZmxSessionButKeepsPrefix() {
         setenv("ZMX_SESSION", "alas-leaked-name", 1)
-        setenv("ZMX_SESSION_PREFIX", "alas-leaked-prefix-", 1)
+        setenv("ZMX_SESSION_PREFIX", "team-", 1)
         defer {
             unsetenv("ZMX_SESSION")
             unsetenv("ZMX_SESSION_PREFIX")
@@ -126,7 +126,7 @@ struct ZmxClientTests {
         #expect(recorder.calls.count == 1)
         let call = recorder.calls[0]
         #expect(call.env["ZMX_SESSION"] == nil)
-        #expect(call.env["ZMX_SESSION_PREFIX"] == nil)
+        #expect(call.env["ZMX_SESSION_PREFIX"] == "team-")
         // ZMX_DIR pinning is preserved.
         #expect(call.env["ZMX_DIR"] == "/tmp/alas-zmx-test")
     }

--- a/AlasTests/ZmxClientTests.swift
+++ b/AlasTests/ZmxClientTests.swift
@@ -103,10 +103,10 @@ struct ZmxClientTests {
         #expect(call.env["ZMX_DIR"] == "/tmp/alas-zmx-test")
     }
 
-    /// Codex review (#351): if Alas itself was launched from a zmx-attached
-    /// terminal, `ProcessInfo.environment` carries `ZMX_SESSION_PREFIX`
-    /// (and/or `ZMX_SESSION`). Letting those leak into `zmx kill`/`zmx ls`
-    /// makes the CLI resolve a bare `alas-XYZ` name as `<prefix>alas-XYZ`,
+    /// If Alas itself was launched from a zmx-attached terminal,
+    /// `ProcessInfo.environment` carries `ZMX_SESSION_PREFIX` (and/or
+    /// `ZMX_SESSION`). Letting those leak into `zmx kill`/`zmx ls` makes
+    /// the CLI resolve a bare `alas-XYZ` name as `<prefix>alas-XYZ`,
     /// while the session zmx actually created (via `EnvBuilder` + `wrap`,
     /// which both strip the prefix) is plain `alas-XYZ` — so cleanup
     /// targets the wrong name and the real session leaks. Mirror

--- a/AlasTests/ZmxClientTests.swift
+++ b/AlasTests/ZmxClientTests.swift
@@ -103,6 +103,34 @@ struct ZmxClientTests {
         #expect(call.env["ZMX_DIR"] == "/tmp/alas-zmx-test")
     }
 
+    /// Codex review (#351): if Alas itself was launched from a zmx-attached
+    /// terminal, `ProcessInfo.environment` carries `ZMX_SESSION_PREFIX`
+    /// (and/or `ZMX_SESSION`). Letting those leak into `zmx kill`/`zmx ls`
+    /// makes the CLI resolve a bare `alas-XYZ` name as `<prefix>alas-XYZ`,
+    /// while the session zmx actually created (via `EnvBuilder` + `wrap`,
+    /// which both strip the prefix) is plain `alas-XYZ` — so cleanup
+    /// targets the wrong name and the real session leaks. Mirror
+    /// `EnvBuilder`'s strip on the CLI-invocation env.
+    @Test
+    func killSessionStripsLeakedZmxSessionEnvVars() {
+        setenv("ZMX_SESSION", "alas-leaked-name", 1)
+        setenv("ZMX_SESSION_PREFIX", "alas-leaked-prefix-", 1)
+        defer {
+            unsetenv("ZMX_SESSION")
+            unsetenv("ZMX_SESSION_PREFIX")
+        }
+        let recorder = RecordingRunner()
+        let client = ZmxClient(env: env(available: true), runner: recorder.runner())
+        client.killSession(name: "alas-XYZ")
+
+        #expect(recorder.calls.count == 1)
+        let call = recorder.calls[0]
+        #expect(call.env["ZMX_SESSION"] == nil)
+        #expect(call.env["ZMX_SESSION_PREFIX"] == nil)
+        // ZMX_DIR pinning is preserved.
+        #expect(call.env["ZMX_DIR"] == "/tmp/alas-zmx-test")
+    }
+
     @Test
     func killSessionIsNoOpWhenZmxUnavailable() {
         let recorder = RecordingRunner()


### PR DESCRIPTION
## Summary
- When Alas itself is launched from inside a zmx-attached terminal, the parent env carries `ZMX_SESSION` (and `ZMX_SESSION_PREFIX`) through every pane we spawn. Any subsequent `zmx attach <other>` from that shell — directly, via an agent CLI, a completion hook, anything — falls into zmx's `switchSesh` path (it reads `ZMX_SESSION` before the CLI argument and forwards a `Switch` IPC), silently re-binding the active pane to a different daemon's session. End state: one tab is piped into another tab's shell, and the original daemon shuts down once its last client leaves (its on-disk socket file disappears).
- Add `ZMX_SESSION` and `ZMX_SESSION_PREFIX` to `EnvBuilder.strippedKeys` so every pane gets only its own scoped name.
- See [zmx#151](https://github.com/neurosnap/zmx/issues/151) for the upstream behaviour; this PR closes the leak from the Alas side.

## Test plan
- [x] New `EnvBuilderTests.stripsZmxSessionVarsFromInheritedParent` mirrors the existing TERM-stripping coverage.
- [x] `xcodebuild ... -only-testing AlasTests/EnvBuilderTests test` — all 9 tests pass locally.
- [ ] CI green.
- [ ] Smoke: open Alas from a zmx-attached terminal, spawn a tab, run `zmx attach <other>` — original pane stays bound to its own session.