### PR TITLE
feat(acp): ACP terminal channel with live tail rendering

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		10F83C7DA89B3BF168E47310 /* DiffSelectableTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */; };
 		11315A703B2F9C4CBB3CABD3 /* CommitRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCEFADD952DB870B8BAB890 /* CommitRow.swift */; };
 		115C50272D2037FB24B8536F /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */; };
+		11827C40372D7209868161C0 /* ACPTerminalHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3914A1820E1098DA558CD0 /* ACPTerminalHostTests.swift */; };
 		11B4AA1D032F054C666DD7F4 /* PendingDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856607304A9F2409EF40BD5F /* PendingDiscardTests.swift */; };
 		11BA08BA4E2FE30CD6D4DA87 /* NewWorktreeDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */; };
 		1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */; };
@@ -213,6 +214,7 @@
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
+		41E0F62323F788B8A3D3D731 /* ACPTerminalHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E504D11F9B69ACCE7B8E5CA4 /* ACPTerminalHost.swift */; };
 		41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CBB25BA2F2C558713FB0E4 /* CodeEditorCoordinator.swift */; };
 		41F7A0E0854B545F99062BDC /* EditorTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */; };
 		4200B95D724A2433F50C1B7C /* BaseBranchSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002C8D5C52466955E0A90606 /* BaseBranchSelector.swift */; };
@@ -241,6 +243,7 @@
 		478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */; };
 		48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */; };
 		4896E5C8D1D4A5C0EC7473BF /* fs-write.json in Resources */ = {isa = PBXBuildFile; fileRef = 8526C9DB63760BDD2CE998BD /* fs-write.json */; };
+		48AD9728403D96C9C5958AC6 /* ACPSessionTerminalRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */; };
 		48E0B43B698544C1C4524242 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */; };
 		48EFAD2DE1F112D72B5F9FAC /* AgentPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37987D5884297401F95478D3 /* AgentPathTests.swift */; };
 		4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92F1C71C2574B1077964E5E1 /* ACPPermissionDecisionLogTests.swift */; };
@@ -306,6 +309,7 @@
 		5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */; };
 		603D2F40A0368A139822CE80 /* ACPLaunchCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */; };
 		604E881461FC839C4233B0AF /* LSPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D394D40BC9060833DD640A /* LSPInstaller.swift */; };
+		610486A9FA350E77D1BF594B /* ACPTerminalTailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */; };
 		6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */; };
 		61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D30693F45966ED1456811E /* ACPSessionHydrator.swift */; };
 		6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1874031C788ADB4398151FF1 /* StageChip.swift */; };
@@ -400,6 +404,7 @@
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
 		8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */; };
+		8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */; };
 		859AD39BA8D5A9FCC905648D /* ImageDiffViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */; };
 		85C7E65296AB9500FF52060A /* session-update-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = 7094534860369BA79FC5A877 /* session-update-plan.json */; };
 		85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */; };
@@ -418,6 +423,7 @@
 		899E7B2794DD3F2114B38AFC /* StartupScriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743E347E3DE3EEAD3942CD78 /* StartupScriptResolver.swift */; };
 		89A3BEAA64625C766E73F58E /* ZmxSessionNameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */; };
 		89A5E5AD13431B6C9E16669B /* ImageFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */; };
+		89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F8802F19E02CED256495755 /* ACPTerminalTests.swift */; };
 		8ACF2EE38E46F72F5466DB01 /* SettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */; };
 		8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */; };
 		8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3328C0EF905A8AC6F6F34D /* MarkdownViewModeTests.swift */; };
@@ -443,6 +449,7 @@
 		90BB0EFFD7E0EF8DE64296E6 /* ShortcutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */; };
 		90F619F67402DB675E2614CC /* TabActivityPulseTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F650CFAC8E61B1EC99CD04A /* TabActivityPulseTransitionTests.swift */; };
 		91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C69060B922A729DD807920 /* LSPURI.swift */; };
+		929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */; };
 		92EEAFAEFB3E637FB72174A8 /* TreeSitterYAML in Frameworks */ = {isa = PBXBuildFile; productRef = 2B4C3DD473FF121828FD3CA5 /* TreeSitterYAML */; };
 		93B1DC70731B7F661D3AE26F /* FontSizeCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44D759586280250330A9A04 /* FontSizeCommands.swift */; };
 		9422B6F8F6C1E3E64B259712 /* LanguageServerRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */; };
@@ -557,6 +564,7 @@
 		B87B51AC9B374F318CCF1F08 /* AppStateKeepSessionsAliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46554893BA6205CD856B99B5 /* AppStateKeepSessionsAliveTests.swift */; };
 		B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */; };
 		B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */; };
+		B8BA936481455853CFC3393F /* ANSIStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */; };
 		B8D2EB18303D58777D79CDBA /* SearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0FF718D68E15F539577F56 /* SearchResult.swift */; };
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
 		B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06BA06E4A620EEE773E1672 /* SubprocessRunner.swift */; };
@@ -687,10 +695,12 @@
 		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
 		E2A49F787B3DC3F45E92854D /* AgentEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */; };
 		E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */; };
+		E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */; };
 		E31120BCB281A62D767D85BC /* HunkPatchBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA486F66BE4CEB2A16EB148B /* HunkPatchBuilderTests.swift */; };
 		E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */; };
 		E3B38707284D08326C3183E4 /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E444D51CB35528C8E5AB150A /* FuzzyMatchTests.swift */; };
 		E433BB79E6D79DAF4532172A /* Kbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16CA8FEE64D73BDEBAF74878 /* Kbd.swift */; };
+		E44EBD2F2F9A398207E55C6D /* ACPTerminal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0594E7E039B5FC403783C6E8 /* ACPTerminal.swift */; };
 		E468E95C778E0C9BE6F1EDED /* LegacyHookSweep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */; };
 		E4C6E2BE1C7F20AD29C66DF0 /* ACPPermissionDecisionLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F128D8543DA5FC5C39C22E9 /* ACPPermissionDecisionLog.swift */; };
 		E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66950F2226F1182DCDD39A /* RightPaneView.swift */; };
@@ -715,6 +725,7 @@
 		EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */; };
 		EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */; };
 		EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */; };
+		EC3209AD2538061259084545 /* ACPTerminalMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */; };
 		ECEE8511CA84DF4A15F01DC1 /* AppConfigTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
@@ -774,6 +785,7 @@
 		01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoGroupViewLayoutTests.swift; sourceTree = "<group>"; };
 		019A03B92542169A6595D432 /* HoverHighlightFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeature.swift; sourceTree = "<group>"; };
 		01B42244BDE33A69EDE16562 /* PromptEditorBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptEditorBody.swift; sourceTree = "<group>"; };
+		01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioTerminalDispatchTests.swift; sourceTree = "<group>"; };
 		01F0314E357190EF2A1F861B /* CodexInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInstaller.swift; sourceTree = "<group>"; };
 		02161104BA524379A359CB2D /* SidebarChromeTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarChromeTheme.swift; sourceTree = "<group>"; };
 		02347E4D2EA79A5CB8DF82DC /* session-update-current-model.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-current-model.json"; sourceTree = "<group>"; };
@@ -787,6 +799,7 @@
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
 		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
 		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
+		0594E7E039B5FC403783C6E8 /* ACPTerminal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminal.swift; sourceTree = "<group>"; };
 		05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
 		05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDiffGeneratorTests.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
@@ -820,6 +833,7 @@
 		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
 		1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStoreTests.swift; sourceTree = "<group>"; };
 		10602801D3FA990E60CB072D /* ACPQueueHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueueHeader.swift; sourceTree = "<group>"; };
+		10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalMessages.swift; sourceTree = "<group>"; };
 		11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClientTests.swift; sourceTree = "<group>"; };
 		11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTerminalLaunchTests.swift; sourceTree = "<group>"; };
 		11DB4509E8835E63F9532E43 /* AppStateFocusMainWorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateFocusMainWorktreeTests.swift; sourceTree = "<group>"; };
@@ -967,6 +981,7 @@
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
 		3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupChecker.swift; sourceTree = "<group>"; };
 		3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeatureRenderingTests.swift; sourceTree = "<group>"; };
+		3F3914A1820E1098DA558CD0 /* ACPTerminalHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalHostTests.swift; sourceTree = "<group>"; };
 		3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Code.swift; sourceTree = "<group>"; };
 		3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageList.swift; sourceTree = "<group>"; };
 		4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutResolver.swift; sourceTree = "<group>"; };
@@ -1014,6 +1029,7 @@
 		4D63B166AF2C533BE6E59365 /* session-update-agent-chunk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-agent-chunk.json"; sourceTree = "<group>"; };
 		4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLeafEncodeTests.swift; sourceTree = "<group>"; };
 		4DC787CE0F5625F8114C9F6F /* MergeResultPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeResultPane.swift; sourceTree = "<group>"; };
+		4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeJSONRPCTransport.swift; sourceTree = "<group>"; };
 		4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerTests.swift; sourceTree = "<group>"; };
 		4FB0C89AA6E07A2402934FD2 /* DraftCommitTabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabsManagerTests.swift; sourceTree = "<group>"; };
 		4FE58EF9CF8EC461667D9430 /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
@@ -1146,6 +1162,7 @@
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
 		7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshot.swift; sourceTree = "<group>"; };
 		7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+CommitEditing.swift"; sourceTree = "<group>"; };
+		7F8802F19E02CED256495755 /* ACPTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalTests.swift; sourceTree = "<group>"; };
 		7FFC9539E615699AC90A7412 /* ProjectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManager.swift; sourceTree = "<group>"; };
 		802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeView.swift; sourceTree = "<group>"; };
 		8062405A67C934905EE61D98 /* TextEditCoordinates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditCoordinates.swift; sourceTree = "<group>"; };
@@ -1163,6 +1180,7 @@
 		85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerPlaceholderTests.swift; sourceTree = "<group>"; };
 		866CFEB75B7F754485C6BE77 /* WorkingTreeSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeSectionView.swift; sourceTree = "<group>"; };
 		8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitsOlderTests.swift; sourceTree = "<group>"; };
+		86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStreamTests.swift; sourceTree = "<group>"; };
 		881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputer.swift; sourceTree = "<group>"; };
 		88379ACE40F42BE4A3257659 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		883981BBADF9816718091CE1 /* MergeScrollCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -1216,6 +1234,7 @@
 		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
 		9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-diff.json"; sourceTree = "<group>"; };
+		9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTerminalRoutingTests.swift; sourceTree = "<group>"; };
 		9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSunPathBudget.swift; sourceTree = "<group>"; };
 		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
@@ -1292,6 +1311,7 @@
 		B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftBridgeTests.swift; sourceTree = "<group>"; };
 		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
 		BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileChip.swift; sourceTree = "<group>"; };
+		BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStream.swift; sourceTree = "<group>"; };
 		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
 		BBBEFD27FD7013D458435779 /* ACPSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSession.swift; sourceTree = "<group>"; };
 		BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabView.swift; sourceTree = "<group>"; };
@@ -1351,6 +1371,7 @@
 		CB2EB554CB6AF797545DB95D /* HeadReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadReader.swift; sourceTree = "<group>"; };
 		CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPaneTests.swift; sourceTree = "<group>"; };
 		CB68E9C3C8853AF7E8AB5DB4 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalTailView.swift; sourceTree = "<group>"; };
 		CC13E4C0AF55A2524341EB36 /* ImageDiffSideBySideViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSideBySideViewTests.swift; sourceTree = "<group>"; };
 		CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallCard.swift; sourceTree = "<group>"; };
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
@@ -1426,6 +1447,7 @@
 		E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPicker.swift; sourceTree = "<group>"; };
 		E4C4BEC7F392AF938F468B1F /* ACPConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnection.swift; sourceTree = "<group>"; };
 		E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibilityTests.swift; sourceTree = "<group>"; };
+		E504D11F9B69ACCE7B8E5CA4 /* ACPTerminalHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalHost.swift; sourceTree = "<group>"; };
 		E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictMinimap.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -1875,7 +1897,9 @@
 				2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */,
 				A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */,
 				5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */,
+				01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */,
 				54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */,
+				4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -2017,6 +2041,7 @@
 				3265338C21E4088B279578DE /* Permissions */,
 				4DB62FEBC3C8536A56117C23 /* Protocol */,
 				51D8A9EE658EB05F836A321A /* Session */,
+				CA233550C2BD925CFDD848F8 /* Terminal */,
 				8050E4DD79EA4EEE490BC1F1 /* UI */,
 			);
 			path = ACP;
@@ -2127,6 +2152,7 @@
 				BEBCF3820A017BBF33B0AB07 /* ACPProtocolVersion.swift */,
 				DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */,
 				4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */,
+				10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -2268,6 +2294,7 @@
 				FDD6B99A5214227965308D70 /* Permissions */,
 				28DACFA5F60339EEE14A135F /* Protocol */,
 				A72D9EE2C6FD478C41435DBA /* Session */,
+				A1A3A80C34560A6058614B9E /* Terminal */,
 				4A87288C819AD4B9E41D1858 /* UI */,
 			);
 			path = ACP;
@@ -2315,6 +2342,7 @@
 				C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */,
 				C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */,
 				B832ED19AC178DAD77C78D37 /* ACPTabView.swift */,
+				CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */,
 				0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */,
 				E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */,
 				CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */,
@@ -2462,6 +2490,16 @@
 			path = ghostty;
 			sourceTree = "<group>";
 		};
+		A1A3A80C34560A6058614B9E /* Terminal */ = {
+			isa = PBXGroup;
+			children = (
+				3F3914A1820E1098DA558CD0 /* ACPTerminalHostTests.swift */,
+				7F8802F19E02CED256495755 /* ACPTerminalTests.swift */,
+				86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */,
+			);
+			path = Terminal;
+			sourceTree = "<group>";
+		};
 		A1CA0BEB25542A9B175DBDFE /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -2496,6 +2534,7 @@
 				45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */,
 				03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */,
 				F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */,
+				9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */,
 				1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */,
 				F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */,
 				26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */,
@@ -2681,6 +2720,16 @@
 				B746CC368DA0E9BE09E7C3A7 /* Install */,
 			);
 			path = LSP;
+			sourceTree = "<group>";
+		};
+		CA233550C2BD925CFDD848F8 /* Terminal */ = {
+			isa = PBXGroup;
+			children = (
+				0594E7E039B5FC403783C6E8 /* ACPTerminal.swift */,
+				E504D11F9B69ACCE7B8E5CA4 /* ACPTerminalHost.swift */,
+				BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */,
+			);
+			path = Terminal;
 			sourceTree = "<group>";
 		};
 		D693E9FFCCA3C968C18E4437 /* ThirdParty */ = {
@@ -3158,10 +3207,15 @@
 				9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */,
 				8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */,
 				F66BDC777D0BFDE306E8880A /* ACPTabView.swift in Sources */,
+				E44EBD2F2F9A398207E55C6D /* ACPTerminal.swift in Sources */,
+				41E0F62323F788B8A3D3D731 /* ACPTerminalHost.swift in Sources */,
+				EC3209AD2538061259084545 /* ACPTerminalMessages.swift in Sources */,
+				610486A9FA350E77D1BF594B /* ACPTerminalTailView.swift in Sources */,
 				48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */,
 				3C30C1EAE4786BB1BE42F994 /* ACPToolCallCard.swift in Sources */,
 				312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */,
 				8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */,
+				B8BA936481455853CFC3393F /* ANSIStream.swift in Sources */,
 				095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */,
 				7A2C912B677A34391361B720 /* AdvancedSettingsVisibility.swift in Sources */,
 				F9BE25DD2C3A008328978575 /* AgentAutoLaunch.swift in Sources */,
@@ -3547,15 +3601,20 @@
 				20096441D4850614A3CB8187 /* ACPSessionStoreCRUDTests.swift in Sources */,
 				BD1CDAECF2D1928C95796F63 /* ACPSessionStoreQueueTests.swift in Sources */,
 				08DF3AC4BA50775940371445 /* ACPSessionStoreTests.swift in Sources */,
+				48AD9728403D96C9C5958AC6 /* ACPSessionTerminalRoutingTests.swift in Sources */,
 				B472D692A8D8D1C664EAC467 /* ACPSessionTests.swift in Sources */,
 				33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */,
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
 				E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */,
+				929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */,
 				1B16FCB3621BB868C34334D7 /* ACPStreamingTextTests.swift in Sources */,
 				D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */,
+				11827C40372D7209868161C0 /* ACPTerminalHostTests.swift in Sources */,
+				89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */,
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
 				4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
+				E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */,
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,
 				FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */,
 				7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */,
@@ -3649,6 +3708,7 @@
 				1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */,
 				C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */,
 				51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */,
+				8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */,
 				7602FDB0353222613CD39FFE /* FileIndexTests.swift in Sources */,
 				D85B5032B8F2A71AFF5A13B6 /* FileTreeBuilderTests.swift in Sources */,
 				6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPClient.swift
@@ -46,8 +46,13 @@ protocol ACPClient: AnyObject {
     /// Filesystem requests (`fs/read_text_file`, `fs/write_text_file`).
     var fileRequests: AsyncStream<ACPFileRequest> { get }
 
+    /// Terminal requests (`terminal/create`, `terminal/output`,
+    /// `terminal/wait_for_exit`, `terminal/kill`, `terminal/release`).
+    var terminalRequests: AsyncStream<ACPTerminalRequest> { get }
+
     func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse)
     func respondToFileRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>)
+    func respondToTerminalRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>)
 
     func shutdown() async
 }

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -11,7 +11,9 @@ final class ACPConnection: @unchecked Sendable {
         let req = ACPRequest(method: "initialize",
                              params: ACPInitializeParams(
                                 protocolVersion: ACPProtocolVersion.current,
-                                clientCapabilities: .init(fs: .init(readTextFile: true, writeTextFile: true))))
+                                clientCapabilities: .init(
+                                    fs: .init(readTextFile: true, writeTextFile: true),
+                                    terminal: true)))
         _ = try await client.send(req)
     }
 

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -53,6 +53,9 @@ struct ACPInitializeParams: Codable, Equatable {
 
 struct ACPClientCapabilities: Codable, Equatable {
     let fs: ACPFsCapabilities
+    /// Agents must check `clientCapabilities.terminal` during initialize
+    /// and only invoke `terminal/*` methods when it is true (ACP spec).
+    let terminal: Bool
 
     struct ACPFsCapabilities: Codable, Equatable {
         let readTextFile: Bool

--- a/Alas/Sources/ACP/Protocol/ACPMockClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMockClient.swift
@@ -7,10 +7,14 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
     private let filesCont: AsyncStream<ACPFileRequest>.Continuation
+    private let terminalsCont: AsyncStream<ACPTerminalRequest>.Continuation
 
     let incomingUpdates: AsyncStream<ACPSessionUpdateParams>
     let permissionRequests: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>
     let fileRequests: AsyncStream<ACPFileRequest>
+    let terminalRequests: AsyncStream<ACPTerminalRequest>
+
+    var terminalResponses: [JSONRPCID: Result<Data, JSONRPCError>] = [:]
 
     init() {
         var u: AsyncStream<ACPSessionUpdateParams>.Continuation!
@@ -22,6 +26,9 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
         var f: AsyncStream<ACPFileRequest>.Continuation!
         self.fileRequests = AsyncStream { f = $0 }
         self.filesCont = f
+        var t: AsyncStream<ACPTerminalRequest>.Continuation!
+        self.terminalRequests = AsyncStream { t = $0 }
+        self.terminalsCont = t
     }
 
     func send(_ request: ACPRequest) async throws -> ACPResponse {
@@ -45,6 +52,7 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     func emit(_ update: ACPSessionUpdateParams) { updatesCont.yield(update) }
     func emitPermission(id: JSONRPCID, params: ACPPermissionRequestParams) { permsCont.yield((id, params)) }
     func emitFile(_ req: ACPFileRequest) { filesCont.yield(req) }
+    func emitTerminal(_ req: ACPTerminalRequest) { terminalsCont.yield(req) }
 
     var permissionResponses: [JSONRPCID: ACPPermissionResponse] = [:]
     func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse) {
@@ -53,6 +61,9 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     var fileResponses: [JSONRPCID: Result<Data, JSONRPCError>] = [:]
     func respondToFileRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
         fileResponses[id] = result
+    }
+    func respondToTerminalRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
+        terminalResponses[id] = result
     }
 
     func script(method: String, _ handler: @escaping (ACPRequest) throws -> Data) {
@@ -67,5 +78,6 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
         updatesCont.finish()
         permsCont.finish()
         filesCont.finish()
+        terminalsCont.finish()
     }
 }

--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -5,11 +5,13 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
     private let filesCont: AsyncStream<ACPFileRequest>.Continuation
+    private let terminalsCont: AsyncStream<ACPTerminalRequest>.Continuation
     private let stderrCont: AsyncStream<Data>.Continuation
 
     let incomingUpdates: AsyncStream<ACPSessionUpdateParams>
     let permissionRequests: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>
     let fileRequests: AsyncStream<ACPFileRequest>
+    let terminalRequests: AsyncStream<ACPTerminalRequest>
     let incomingStderr: AsyncStream<Data>
 
     private let stateLock = NSLock()
@@ -42,9 +44,44 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         self.fileRequests = AsyncStream { fC = $0 }
         self.filesCont = fC
 
+        var tC: AsyncStream<ACPTerminalRequest>.Continuation!
+        self.terminalRequests = AsyncStream { tC = $0 }
+        self.terminalsCont = tC
+
         var eC: AsyncStream<Data>.Continuation!
         self.incomingStderr = AsyncStream { eC = $0 }
         self.stderrCont = eC
+    }
+
+    /// Test-only initialiser: accepts a pre-built transport directly,
+    /// skipping the real-subprocess setup.
+    init(transport: JSONRPCStdioTransporting) {
+        self.transport = transport
+
+        var uC: AsyncStream<ACPSessionUpdateParams>.Continuation!
+        self.incomingUpdates = AsyncStream { uC = $0 }
+        self.updatesCont = uC
+
+        var pC: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation!
+        self.permissionRequests = AsyncStream { pC = $0 }
+        self.permsCont = pC
+
+        var fC: AsyncStream<ACPFileRequest>.Continuation!
+        self.fileRequests = AsyncStream { fC = $0 }
+        self.filesCont = fC
+
+        var tC: AsyncStream<ACPTerminalRequest>.Continuation!
+        self.terminalRequests = AsyncStream { tC = $0 }
+        self.terminalsCont = tC
+
+        var eC: AsyncStream<Data>.Continuation!
+        self.incomingStderr = AsyncStream { eC = $0 }
+        self.stderrCont = eC
+    }
+
+    /// Convenience factory for tests — wraps `init(transport:)`.
+    static func makeForTesting(transport: JSONRPCStdioTransporting) -> ACPStdioClient {
+        ACPStdioClient(transport: transport)
     }
 
     func start() throws {
@@ -72,6 +109,7 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
             updatesCont.finish()
             permsCont.finish()
             filesCont.finish()
+            terminalsCont.finish()
             stderrCont.finish()
         }
     }
@@ -114,6 +152,21 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         case "fs/write_text_file":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPFsWriteParams>.self, from: data),
                let id = env.id, let p = env.params { filesCont.yield(.write(id: id, params: p)) }
+        case "terminal/create":
+            if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalCreateParams>.self, from: data),
+               let id = env.id, let p = env.params { terminalsCont.yield(.create(id: id, params: p)) }
+        case "terminal/output":
+            if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalOutputParams>.self, from: data),
+               let id = env.id, let p = env.params { terminalsCont.yield(.output(id: id, params: p)) }
+        case "terminal/wait_for_exit":
+            if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalIdParams>.self, from: data),
+               let id = env.id, let p = env.params { terminalsCont.yield(.waitForExit(id: id, params: p)) }
+        case "terminal/kill":
+            if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalIdParams>.self, from: data),
+               let id = env.id, let p = env.params { terminalsCont.yield(.kill(id: id, params: p)) }
+        case "terminal/release":
+            if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPTerminalIdParams>.self, from: data),
+               let id = env.id, let p = env.params { terminalsCont.yield(.release(id: id, params: p)) }
         default:
             break
         }
@@ -186,6 +239,13 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     }
 
     func respondToFileRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
+        Task { [weak self] in
+            guard let self else { return }
+            self.respondFile(id: id, result: result)
+        }
+    }
+
+    func respondToTerminalRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
         Task { [weak self] in
             guard let self else { return }
             self.respondFile(id: id, result: result)

--- a/Alas/Sources/ACP/Protocol/ACPTerminalMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPTerminalMessages.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+struct ACPEnvVar: Codable, Equatable {
+    let name: String
+    let value: String
+}
+
+struct ACPTerminalCreateParams: Codable, Equatable {
+    let sessionId: String
+    let command: String
+    let args: [String]?
+    let env: [ACPEnvVar]?
+    let cwd: String?
+    let outputByteLimit: Int?
+}
+
+struct ACPTerminalCreateResult: Codable, Equatable {
+    let terminalId: String
+}
+
+struct ACPTerminalOutputParams: Codable, Equatable {
+    let sessionId: String
+    let terminalId: String
+}
+
+struct ACPTerminalOutputResult: Codable, Equatable {
+    let output: String
+    let truncated: Bool
+    let exitStatus: ACPTerminalExitStatus?
+}
+
+struct ACPTerminalExitStatus: Codable, Equatable {
+    let exitCode: Int?
+    let signal: String?
+}
+
+struct ACPTerminalIdParams: Codable, Equatable {
+    let sessionId: String
+    let terminalId: String
+}
+
+// `terminal/wait_for_exit` returns the exit status object itself
+// (`{ exitCode, signal }`) — ACP spec WaitForTerminalExitResponse. The
+// host method therefore returns `ACPTerminalExitStatus` directly; no
+// wrapper type.
+
+enum ACPTerminalRequest {
+    case create(id: JSONRPCID, params: ACPTerminalCreateParams)
+    case output(id: JSONRPCID, params: ACPTerminalOutputParams)
+    case waitForExit(id: JSONRPCID, params: ACPTerminalIdParams)
+    case kill(id: JSONRPCID, params: ACPTerminalIdParams)
+    case release(id: JSONRPCID, params: ACPTerminalIdParams)
+}

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -54,10 +54,16 @@ enum ACPMessage: Equatable {
         /// scan the full content during rendering.
         var preview: String?
         var locations: [String]
+        /// Terminal IDs referenced by this call's structured content, in
+        /// declaration order. The expanded card renders one
+        /// `ACPTerminalTailView` per id, in addition to whatever text
+        /// content the agent emitted.
+        var terminalIds: [String]
 
         init(toolCallId: String, title: String, kind: String? = nil,
              status: String, content: String = "", preview: String? = nil,
-             locations: [String] = []) {
+             locations: [String] = [], terminalIds: [String] = [])
+        {
             self.toolCallId = toolCallId
             self.title = title
             self.kind = kind
@@ -65,6 +71,7 @@ enum ACPMessage: Equatable {
             self.content = content
             self.preview = preview
             self.locations = locations
+            self.terminalIds = terminalIds
         }
 
         // Backwards-compatible decoder: older messages persisted only a
@@ -72,7 +79,7 @@ enum ACPMessage: Equatable {
         // session history doesn't go blank after upgrade.
         enum CodingKeys: String, CodingKey {
             case toolCallId, title, kind, status, content, preview,
-                 contentSummary, locations
+                 contentSummary, locations, terminalIds
         }
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
@@ -84,6 +91,7 @@ enum ACPMessage: Equatable {
             preview = (try? c.decode(String.self, forKey: .preview))
                 ?? (try? c.decode(String.self, forKey: .contentSummary))
             locations = (try? c.decode([String].self, forKey: .locations)) ?? []
+            terminalIds = (try? c.decode([String].self, forKey: .terminalIds)) ?? []
         }
         func encode(to encoder: Encoder) throws {
             var c = encoder.container(keyedBy: CodingKeys.self)
@@ -94,6 +102,7 @@ enum ACPMessage: Equatable {
             try c.encode(content, forKey: .content)
             try c.encodeIfPresent(preview, forKey: .preview)
             try c.encode(locations, forKey: .locations)
+            try c.encode(terminalIds, forKey: .terminalIds)
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -10,6 +10,7 @@ final class ACPSession: ObservableObject, Identifiable {
     let worktreeId: String
     let createdAt: Date
     let transcript = ACPTranscript()
+    let terminalHost: ACPTerminalHost = ACPTerminalHost(sessionCwd: "/", sessionEnv: [:])
 
     @Published var title: String
     @Published var availableModels: [ACPModelInfo] = []
@@ -90,6 +91,12 @@ final class ACPSession: ObservableObject, Identifiable {
         self.hydrationState = hydrationState
     }
 
+    deinit {
+        // Foundation cannot await main-actor methods from deinit; dispatch.
+        let host = terminalHost
+        Task { @MainActor in host.killAll() }
+    }
+
     func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {
         transcript.messages.append(.user(id: UUID(), text: text, attachments: attachments))
         if title == "" || title == "New session" {
@@ -111,7 +118,9 @@ final class ACPSession: ObservableObject, Identifiable {
             appendStreaming(text: txt, locate: { lastThought() },
                             makeNew: { .thought(id: UUID(), StreamingText(txt)) })
         case .toolCall(let payload):
-            let full = payload.content.flatMap { Self.flatten($0) } ?? ""
+            let items = payload.content ?? []
+            let full = Self.stripWrappingFence(Self.flatten(items),
+                                               isFinal: Self.isFinalStatus(payload.status))
             transcript.messages.append(.toolCall(.init(
                 toolCallId: payload.toolCallId,
                 title: payload.title,
@@ -119,14 +128,22 @@ final class ACPSession: ObservableObject, Identifiable {
                 status: payload.status,
                 content: full,
                 preview: Self.previewLine(full),
-                locations: payload.locations?.map(\.path) ?? [])))
+                locations: payload.locations?.map(\.path) ?? [],
+                terminalIds: Self.extractTerminalIds(items))))
         case .toolCallUpdate(let u):
             updateToolCall(id: u.toolCallId) { tc in
                 if let s = u.status { tc.status = s }
                 if let c = u.content {
-                    let full = Self.flatten(c)
+                    // ACP content updates are full replacement snapshots,
+                    // so terminalIds tracks the *current* content — assign
+                    // unconditionally, including the empty case, so a
+                    // text/diff-only final update doesn't leave a stale
+                    // terminal tail rendering in the card.
+                    let full = Self.stripWrappingFence(Self.flatten(c),
+                                                      isFinal: Self.isFinalStatus(tc.status))
                     tc.content = full
                     tc.preview = Self.previewLine(full)
+                    tc.terminalIds = Self.extractTerminalIds(c)
                 }
             }
         case .plan(let entries):
@@ -314,9 +331,10 @@ final class ACPSession: ObservableObject, Identifiable {
                     lines.append("+\(line)")
                 }
                 out.append(lines.joined(separator: "\n"))
-            case .terminal(let id):
-                // Placeholder until the follow-up wires real terminal output.
-                out.append("[terminal: \(id)]")
+            case .terminal:
+                // IDs are tracked on tc.terminalIds; the UI renders the live
+                // tail structurally, so no text placeholder is appended here.
+                continue
             case .unknown:
                 // Skipped rather than rendered empty.
                 continue
@@ -344,6 +362,50 @@ final class ACPSession: ObservableObject, Identifiable {
         let s = String(firstLine).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !s.isEmpty else { return nil }
         return s.count > 80 ? String(s.prefix(80)) + "…" : s
+    }
+
+    private static func extractTerminalIds(_ items: [ACPToolCallContent]) -> [String] {
+        items.compactMap { if case .terminal(let id) = $0 { return id } else { return nil } }
+    }
+
+    /// Best-effort strip of a single pair of markdown code fences that
+    /// wrap the entire tool output. Claude sometimes returns its output
+    /// inside a ```…``` block; Codex returns raw text. The opening fence
+    /// is only recognized at line 1 col 0 so a fence inside the real
+    /// output is left alone. The trailing fence is dropped only when
+    /// `isFinal` is true — mid-stream we can't tell a closing ``` from a
+    /// line of real output that happens to be three backticks.
+    static func stripWrappingFence(_ full: String, isFinal: Bool) -> String {
+        guard !full.isEmpty else { return full }
+        var lines = full.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard let first = lines.first, isOpeningFence(first) else { return full }
+        lines.removeFirst()
+        if isFinal {
+            var trailingEmpty = 0
+            while let last = lines.last, last.isEmpty {
+                lines.removeLast()
+                trailingEmpty += 1
+            }
+            if lines.last == "```" {
+                lines.removeLast()
+            } else {
+                for _ in 0..<trailingEmpty { lines.append("") }
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func isOpeningFence(_ line: String) -> Bool {
+        guard line.hasPrefix("```") else { return false }
+        let rest = line.dropFirst(3)
+        return rest.allSatisfy { $0.isLetter || $0.isNumber || $0 == "_" || $0 == "+" || $0 == "-" }
+    }
+
+    private static func isFinalStatus(_ status: String) -> Bool {
+        switch status {
+        case "completed", "failed", "canceled", "cancelled": return true
+        default: return false
+        }
     }
 
     private func text(of block: ACPContentBlock) -> String {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -404,6 +404,7 @@ extension ACPSessionManager {
             let runner = ACPSessionRunner(session: session, connection: connection,
                                           store: store, sessionId: sessionId,
                                           worktreePath: worktreePath,
+                                          agentEnv: Self.mergeEnv(extra: spec.extraEnv),
                                           onDirtyCheck: onDirtyCheck,
                                           onLiveBufferRead: onLiveBufferRead)
             runner.start()

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -30,9 +30,16 @@ final class ACPSessionRunner {
     /// contents for an open dirty buffer, falling back to disk when the
     /// closure returns `nil`. Lets the agent see what the user sees.
     private let onLiveBufferRead: ((String) -> String?)?
+    /// The sanitized + extras-merged env the agent process itself was
+    /// launched with. Used to seed the terminal host so agent-spawned
+    /// commands inherit exactly the same view — including the stripped
+    /// CLAUDECODE/CLAUDE_SESSION_ID markers that would otherwise leak
+    /// back in via a re-augment from `ProcessInfo`.
+    private let agentEnv: [String: String]
     private var updatesTask: Task<Void, Never>?
     private var permissionsTask: Task<Void, Never>?
     private var filesTask: Task<Void, Never>?
+    private var terminalsTask: Task<Void, Never>?
     private var seq: Int64 = 0
     private var steerUndoExpiryTask: Task<Void, Never>?
     /// Monotonic prompt counter + active/cancelled bookkeeping (inherited
@@ -53,6 +60,7 @@ final class ACPSessionRunner {
 
     init(session: ACPSession, connection: ACPConnection, store: ACPSessionStore,
          sessionId: String, worktreePath: String,
+         agentEnv: [String: String] = ProcessInfo.processInfo.environment,
          onDirtyCheck: ((String) -> Bool)? = nil,
          onLiveBufferRead: ((String) -> String?)? = nil)
     {
@@ -61,6 +69,7 @@ final class ACPSessionRunner {
         self.store = store
         self.sessionId = sessionId
         self.worktreePath = worktreePath
+        self.agentEnv = agentEnv
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
         self.policy = ACPPermissionPolicy(
@@ -107,6 +116,14 @@ final class ACPSessionRunner {
                 self.connection.client.respondToPermission(id: id, response: response)
             }
         }
+
+        // Agent-spawned terminals must see the exact env the agent
+        // itself was launched with — same augmented PATH (npm / cargo
+        // resolve under launchd's minimal PATH) and same scrubbed
+        // CLAUDECODE/CLAUDE_SESSION_ID markers (otherwise a Claude-
+        // aware CLI run from the terminal refuses to start).
+        session.terminalHost.updateContext(sessionCwd: worktreePath,
+                                           sessionEnv: agentEnv)
 
         filesTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -182,12 +199,103 @@ final class ACPSessionRunner {
                 }
             }
         }
+
+        terminalsTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await req in self.connection.client.terminalRequests {
+                self.handleTerminalRequest(req)
+            }
+        }
     }
 
     func stop() {
         updatesTask?.cancel()
         permissionsTask?.cancel()
         filesTask?.cancel()
+        terminalsTask?.cancel()
+        // Kill agent-spawned subprocesses now. ACPSessionManager keeps
+        // the ACPSession cached after detach, so the session's deinit-
+        // time killAll() won't fire on tab close — without this an
+        // active `npm test`/`sleep`/server outlives the agent.
+        session.terminalHost.killAll()
+    }
+
+    private func handleTerminalRequest(_ req: ACPTerminalRequest) {
+        let host = self.session.terminalHost
+        switch req {
+        case .create(let id, let p):
+            do {
+                let res = try host.create(p)
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .success(try JSONEncoder().encode(res)))
+            } catch ACPTerminalHostError.tooManyTerminals {
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .failure(.init(code: -32000, message: "too many terminals", data: nil)))
+            } catch ACPTerminalHostError.spawnFailed(let msg) {
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .failure(.init(code: -32000, message: msg, data: nil)))
+            } catch {
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .failure(.init(code: -32000, message: error.localizedDescription, data: nil)))
+            }
+        case .output(let id, let p):
+            do {
+                let res = try host.output(p)
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .success(try JSONEncoder().encode(res)))
+            } catch ACPTerminalHostError.notFound {
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .failure(.init(code: -32602, message: "terminal not found", data: nil)))
+            } catch {
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .failure(.init(code: -32000, message: error.localizedDescription, data: nil)))
+            }
+        case .waitForExit(let id, let p):
+            // Capture only the host + client so a long-running waitForExit
+            // doesn't pin the runner (and its session) in memory if the
+            // session is torn down before the agent's underlying process
+            // exits. ACPTerminalHost has no back-reference to ACPSession,
+            // so this lets the session deinit (and its killAll()) run
+            // while the wait task is still parked on the host.
+            let client = self.connection.client
+            Task { @MainActor in
+                do {
+                    let res = try await host.waitForExit(p)
+                    client.respondToTerminalRequest(
+                        id: id, result: .success(try JSONEncoder().encode(res)))
+                } catch ACPTerminalHostError.notFound {
+                    client.respondToTerminalRequest(
+                        id: id, result: .failure(.init(code: -32602, message: "terminal not found", data: nil)))
+                } catch {
+                    client.respondToTerminalRequest(
+                        id: id, result: .failure(.init(code: -32000, message: error.localizedDescription, data: nil)))
+                }
+            }
+        case .kill(let id, let p):
+            do {
+                try host.kill(p)
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .success(Data("null".utf8)))
+            } catch ACPTerminalHostError.notFound {
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .failure(.init(code: -32602, message: "terminal not found", data: nil)))
+            } catch {
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .failure(.init(code: -32000, message: error.localizedDescription, data: nil)))
+            }
+        case .release(let id, let p):
+            do {
+                try host.release(p)
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .success(Data("null".utf8)))
+            } catch ACPTerminalHostError.notFound {
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .failure(.init(code: -32602, message: "terminal not found", data: nil)))
+            } catch {
+                self.connection.client.respondToTerminalRequest(
+                    id: id, result: .failure(.init(code: -32000, message: error.localizedDescription, data: nil)))
+            }
+        }
     }
 
     /// Cancel ownership of any in-flight prompt RPC. The unstructured
@@ -300,6 +408,7 @@ final class ACPSessionRunner {
             }
             policy.userCancelled()
             let changedIndices = session.cancelInFlightToolCalls()
+            session.terminalHost.killAll()
             for i in changedIndices {
                 let m = session.transcript.messages[i]
                 if let payload = try? ACPMessageCodec.encode(m) {

--- a/Alas/Sources/ACP/Terminal/ACPTerminal.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminal.swift
@@ -1,0 +1,446 @@
+import Foundation
+import Combine
+
+/// Wraps one agent-spawned subprocess. Owns the merged stdout+stderr
+/// rolling buffer (capped at 1 MiB), captures the exit status, and
+/// publishes a "buffer changed" signal so UI subscribers can re-render
+/// the live tail without polling.
+@MainActor
+final class ACPTerminal: ObservableObject {
+    /// 1 MiB internal cap. Independent from the agent-supplied
+    /// `outputByteLimit`, which only governs what we return via
+    /// `terminal/output` — never how much we keep around for the UI.
+    static let internalBufferCap = 1 << 20
+
+    let id: String
+    let createdAt: Date
+    let outputByteLimit: Int
+
+    @Published private(set) var buffer: Data = Data()
+    @Published private(set) var truncated: Bool = false
+    @Published private(set) var exitStatus: ACPTerminalExitStatus?
+    /// Flipped by `release()`. The host uses this to reject further
+    /// `terminal/*` protocol calls against this id while still letting
+    /// the UI render the retained buffer.
+    private(set) var released: Bool = false
+
+    private let process: Process
+    private let pipe: Pipe
+    private var exitWaiters: [CheckedContinuation<ACPTerminalExitStatus, Never>] = []
+    /// True once the readability handler has observed an empty chunk —
+    /// the canonical EOF signal. `handleExit` polls this before
+    /// publishing `exitStatus` so a fast-exiting command's final bytes
+    /// land in the buffer before `wait_for_exit` waiters resume.
+    private var sawEOF: Bool = false
+    /// Set as soon as `terminationHandler` fires. We can't trust
+    /// `process.isRunning` after that — the OS may reuse the root pid
+    /// for an unrelated process, and `isRunning` polls by pid. Used by
+    /// `kill()` to decide whether it's still safe to signal the root.
+    nonisolated(unsafe) private var rootHasExited: Bool = false
+    /// `(pid, command)` pairs accumulated by the periodic tracker
+    /// while the root is alive. Needed because `terminationHandler`
+    /// runs after the kernel has already reaped the root and
+    /// reparented its children to init — a fresh ppid walk from the
+    /// root pid would then return nothing, so a later `kill()` could
+    /// never reach a backgrounded child that holds the pipe open.
+    /// The command name lets us re-verify the PID still belongs to
+    /// our terminal before signaling it late (PID reuse is rare on
+    /// macOS over a few-second window but not impossible).
+    private var orphanedDescendants: Set<DescendantKey> = []
+    private var descendantTracker: Task<Void, Never>?
+
+    struct DescendantKey: Hashable {
+        let pid: pid_t
+        let command: String
+    }
+
+    init(id: String,
+         command: String,
+         args: [String],
+         env: [String: String],
+         cwd: String,
+         outputByteLimit: Int) throws
+    {
+        self.id = id
+        self.createdAt = Date()
+        // Cap against the internal buffer so an agent can't ask us to
+        // return more than we ever retain. Floor at 1 so callers that
+        // pass 0 or negative don't trip divide-by-zero / nonsense math
+        // downstream — but otherwise honor the requested limit, even
+        // when it's very small (agents may deliberately request a tight
+        // tail). Per ACP `outputByteLimit` contract.
+        self.outputByteLimit = max(1, min(outputByteLimit, Self.internalBufferCap))
+
+        self.process = Process()
+        self.pipe = Pipe()
+        // Spawn via /usr/bin/env so bare commands (npm, cargo, etc.) are
+        // resolved against PATH. Foundation's Process only looks at the
+        // exact URL otherwise, which would fail every non-absolute command
+        // the agent sends. `--` stops env's option parsing so a command
+        // that looks like a flag still works.
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["--", command] + args
+        process.environment = env
+        process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+        process.standardOutput = pipe
+        process.standardError = pipe
+        // Detach from the controlling terminal's stdin so the child can't
+        // try to read from our parent's stdin handle if Foundation defaults
+        // to inheriting it.
+        process.standardInput = FileHandle.nullDevice
+
+        let weakSelf = WeakBox(self)
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                // Empty chunk = EOF on the read end (every writer fd
+                // closed). Signal the exit path; further callbacks
+                // won't fire after this.
+                Task { @MainActor in
+                    weakSelf.value?.signalEOF()
+                }
+                return
+            }
+            Task { @MainActor in
+                weakSelf.value?.appendChunk(chunk)
+            }
+        }
+        process.terminationHandler = { proc in
+            // Mark the root as exited synchronously here so any kill()
+            // call that races ahead of the @MainActor handleExit Task
+            // already sees the flag and skips signaling rootPid.
+            weakSelf.value?.rootHasExited = true
+            let status: ACPTerminalExitStatus
+            if proc.terminationReason == .uncaughtSignal {
+                status = ACPTerminalExitStatus(exitCode: nil, signal: Self.signalName(proc.terminationStatus))
+            } else {
+                status = ACPTerminalExitStatus(exitCode: Int(proc.terminationStatus), signal: nil)
+            }
+            Task { @MainActor in
+                await weakSelf.value?.handleExit(status: status)
+            }
+        }
+        try process.run()
+        startDescendantTracker()
+        // Move the child into its own process group so signals from
+        // `kill()` can be delivered to the whole tree via `kill(-pid, …)`.
+        // Foundation's Process doesn't expose POSIX_SPAWN_SETPGROUP, so
+        // we race the child via the parent — either side may EACCES once
+        // exec completes, but at least one of those two calls succeeds
+        // and the child ends up as group leader.
+        _ = setpgid(process.processIdentifier, process.processIdentifier)
+    }
+
+    func waitForExit() async -> ACPTerminalExitStatus {
+        if let s = exitStatus { return s }
+        return await withCheckedContinuation { cont in
+            exitWaiters.append(cont)
+        }
+    }
+
+    func kill() {
+        let pid = process.processIdentifier
+        // `pid > 0` guards against signalling pid 0 (our own group)
+        // when the process never launched. We intentionally do NOT
+        // gate on exitStatus — a release()/killAll() after the EOF
+        // timeout fired still needs to reach orphan descendants we
+        // captured in the tracker. signalTargets handles the stale-
+        // rootPid risk via `rootHasExited` and stale-descendant risk
+        // via per-PID command-name validation.
+        guard pid > 0 else { return }
+        let rootAlive = !rootHasExited
+        // Union of: live ppid walk (works while root is alive) +
+        // tracker-accumulated snapshot (catches descendants spawned
+        // while the root was still alive but reparented after exit).
+        var initial = Set(Self.collectDescendants(of: pid))
+        for d in orphanedDescendants { initial.insert(d) }
+        signalTargets(rootPid: pid, rootAlive: rootAlive, descendants: initial, signal: SIGTERM)
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            var union = initial
+            for d in Self.collectDescendants(of: pid) { union.insert(d) }
+            for d in self.orphanedDescendants { union.insert(d) }
+            self.signalTargets(rootPid: pid, rootAlive: !self.rootHasExited,
+                               descendants: union, signal: SIGKILL)
+        }
+    }
+
+    /// Sends `signal` to root + descendants when the root is still
+    /// alive, or only to descendants when it has already exited. In
+    /// the root-exited path, per-PID identity is re-checked via the
+    /// captured command name so we don't signal an unrelated process
+    /// that the OS has reused a descendant PID for.
+    private func signalTargets(rootPid: pid_t, rootAlive: Bool,
+                               descendants: Set<DescendantKey>, signal: Int32)
+    {
+        if rootAlive {
+            // Root is alive → process group signal reaches the whole
+            // tree, no identity check needed.
+            _ = Darwin.kill(-rootPid, signal)
+            _ = Darwin.kill(rootPid, signal)
+            for d in descendants { _ = Darwin.kill(d.pid, signal) }
+        } else {
+            for d in descendants where Self.pidStillMatches(d) {
+                _ = Darwin.kill(d.pid, signal)
+            }
+        }
+    }
+
+    private func startDescendantTracker() {
+        descendantTracker = Task { @MainActor [weak self] in
+            // Walk the live process tree every second while the root is
+            // alive, accumulating every descendant we observe. The last
+            // pre-exit snapshot is what `kill()` relies on after
+            // terminationHandler runs (children are reparented to init
+            // by then and unfindable via a ppid walk from the root).
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.refreshOrphanSet()
+                if !self.process.isRunning { return }
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+    }
+
+    private func refreshOrphanSet() {
+        let pid = process.processIdentifier
+        guard pid > 0 else { return }
+        for d in Self.collectDescendants(of: pid) {
+            orphanedDescendants.insert(d)
+        }
+    }
+
+    /// Sends `signal` to the root pid, its process group, and every
+    /// supplied descendant pid. The group signal succeeds when the
+    /// parent-side `setpgid` won the race against the child's `exec`
+    /// (often loses on macOS, since Foundation's Process can't pass
+    /// POSIX_SPAWN_SETPGROUP). The descendant list is the fallback.
+    /// Per-pid kills are no-ops for already-dead/unrelated PIDs.
+
+    nonisolated private static func collectDescendants(of root: pid_t) -> [DescendantKey] {
+        // `comm=` is the executable name (no header). It's stable
+        // across reads of the same process and changes when the PID is
+        // reused, so it's a cheap identity marker for late validation.
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+        proc.arguments = ["-o", "pid=,ppid=,comm=", "-ax"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+        } catch {
+            return []
+        }
+        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
+                             encoding: .utf8) else { return [] }
+        var childrenOf: [pid_t: [(pid: pid_t, command: String)]] = [:]
+        for line in s.split(separator: "\n") {
+            // pid, ppid, then command (which may contain spaces).
+            let trimmed = line.drop(while: { $0 == " " })
+            let parts = trimmed.split(separator: " ", maxSplits: 2,
+                                      omittingEmptySubsequences: true)
+            guard parts.count >= 3,
+                  let pid = pid_t(parts[0]),
+                  let ppid = pid_t(parts[1]) else { continue }
+            childrenOf[ppid, default: []].append((pid, String(parts[2])))
+        }
+        var out: [DescendantKey] = []
+        var queue: [pid_t] = [root]
+        while let p = queue.popLast() {
+            for c in childrenOf[p] ?? [] {
+                out.append(DescendantKey(pid: c.pid, command: c.command))
+                queue.append(c.pid)
+            }
+        }
+        return out
+    }
+
+    /// Returns true when the current command for `pid` matches the
+    /// command captured when we recorded it. Used to skip stale cached
+    /// PIDs whose original process has exited and whose PID may have
+    /// been reused for an unrelated process.
+    nonisolated private static func pidStillMatches(_ key: DescendantKey) -> Bool {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/ps")
+        proc.arguments = ["-p", "\(key.pid)", "-o", "comm="]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+            proc.waitUntilExit()
+        } catch {
+            return false
+        }
+        guard let s = String(data: pipe.fileHandleForReading.readDataToEndOfFile(),
+                             encoding: .utf8) else { return false }
+        let current = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !current.isEmpty && current == key.command
+    }
+
+    /// Marks the terminal as released. Per the ACP spec the id can no
+    /// longer be used with `terminal/*` methods, but tool calls that
+    /// already reference it MUST keep rendering the captured output —
+    /// so the buffer is retained. The readability handler is left
+    /// installed so the killed process's `handleExit` can still observe
+    /// the EOF empty-chunk and publish `exitStatus`; otherwise the
+    /// terminal would never finalize and would count as live against
+    /// `maxLiveTerminals` indefinitely.
+    func release() {
+        released = true
+        kill()
+    }
+
+    /// Returns the last `byteLimit` bytes of the buffer as ANSI-stripped
+    /// text. The slice start is normalized to a parser-safe boundary:
+    /// 1. Extended backwards through any unterminated ANSI escape in a
+    ///    short lookback window so the parser doesn't treat the tail of
+    ///    a cut `ESC[31m…` as plain text.
+    /// 2. Then advanced past any leading UTF-8 continuation bytes so
+    ///    multibyte codepoints aren't split mid-sequence.
+    func snapshot(byteLimit: Int) -> (text: String, truncated: Bool) {
+        let limit = max(1, min(byteLimit, Self.internalBufferCap))
+        let didTruncate = buffer.count > limit
+        let slice: Data
+        if didTruncate {
+            let all = [UInt8](buffer)
+            var start = all.count - limit
+            // Lookback for an unterminated CSI escape. CSI param bytes
+            // are 0x30..0x3F; finals are 0x40..0x7E. If we find an ESC
+            // within 16 bytes of the cut whose final hasn't yet been
+            // seen, extend the slice start back to include it.
+            let lookbackFloor = max(0, start - 16)
+            var i = start - 1
+            while i >= lookbackFloor {
+                if all[i] == 0x1B {
+                    var hasFinal = false
+                    if i + 1 < start, all[i + 1] == 0x5B {
+                        for k in (i + 2) ..< start where all[k] >= 0x40 && all[k] <= 0x7E {
+                            hasFinal = true
+                            break
+                        }
+                    } else {
+                        hasFinal = true  // 2-char ESC (already complete) or OSC (handled by parser)
+                    }
+                    if !hasFinal { start = i }
+                    break
+                }
+                i -= 1
+            }
+            // Skip leading UTF-8 continuation bytes (10xxxxxx).
+            while start < all.count, (all[start] & 0xC0) == 0x80 {
+                start += 1
+            }
+            slice = Data(all[start ..< all.count])
+        } else {
+            slice = buffer
+        }
+        // Strip ANSI for the JSON response (agents shouldn't see escape codes).
+        var stream = ANSIStream()
+        let runs = stream.feed(slice)
+        let text = runs.map(\.text).joined()
+        return (text, truncated || didTruncate)
+    }
+
+    // MARK: - Helpers
+
+    private func appendChunk(_ chunk: Data) {
+        buffer.append(chunk)
+        if buffer.count > Self.internalBufferCap {
+            let drop = buffer.count - Self.internalBufferCap
+            buffer.removeFirst(drop)
+            // The bulk drop may have landed mid-codepoint. Advance the
+            // start past any leading UTF-8 continuation bytes so the
+            // buffer always begins on a valid character boundary —
+            // snapshot/output paths can then trust the invariant even
+            // when no further truncation is needed at read time.
+            while let first = buffer.first, (first & 0xC0) == 0x80 {
+                buffer.removeFirst(1)
+            }
+            // The drop may have ALSO landed mid-ANSI-escape. Unlike
+            // snapshot, we can't look backwards for the ESC byte (it
+            // was just removed), so strip any leading partial CSI tail
+            // heuristically: `[param-bytes]* m` is by far the common
+            // case (SGR color codes). Conservative — only acts on a
+            // leading run of digits/`;`/`:` followed by `m` within a
+            // short window. Cursor-move finals are intentionally NOT
+            // included to avoid eating bytes like `12A` in real text.
+            stripLeadingPartialSGR()
+            truncated = true
+        }
+    }
+
+    private func stripLeadingPartialSGR() {
+        var n = 0
+        while n < min(buffer.count, 16) {
+            let b = buffer[buffer.startIndex + n]
+            if (b >= 0x30 && b <= 0x3F) {  // CSI param byte
+                n += 1
+                continue
+            }
+            if b == 0x6D, n > 0 {  // 'm' final after at least one param
+                n += 1
+                break
+            }
+            n = 0
+            break
+        }
+        if n > 0 { buffer.removeFirst(n) }
+    }
+
+    private func handleExit(status: ACPTerminalExitStatus) async {
+        descendantTracker?.cancel()
+        // Close the parent-side write end so the read end can EOF after
+        // the kernel buffer drains. `Pipe()` retains both ends; if we
+        // leave the write end open, the readability handler's final
+        // empty-chunk EOF never fires. The child's own write fd was
+        // closed by the kernel when it exited.
+        try? pipe.fileHandleForWriting.close()
+        // Wait up to 5 s for the readability handler to deliver every
+        // buffered byte and the empty-chunk EOF marker. The dispatch
+        // source runs on a separate queue, so a `Task.yield()` isn't
+        // enough — we have to actually wait for event delivery. Bound
+        // the wait so a backgrounded descendant that inherited the
+        // pipe and held it open indefinitely can't permanently leak
+        // the terminal slot. The periodic descendant tracker is
+        // best-effort and can't always catch children spawned in the
+        // microseconds before the root exits.
+        let deadline = ContinuousClock.now + .milliseconds(5000)
+        while !sawEOF, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        pipe.fileHandleForReading.readabilityHandler = nil
+        exitStatus = status
+        let waiters = exitWaiters
+        exitWaiters.removeAll()
+        for c in waiters { c.resume(returning: status) }
+    }
+
+    /// Called by the readability handler when an empty chunk arrives
+    /// (every writer fd closed = EOF). The polling loop in `handleExit`
+    /// observes this flag and proceeds to publish `exitStatus`.
+    private func signalEOF() {
+        sawEOF = true
+    }
+
+    nonisolated private static func signalName(_ raw: Int32) -> String {
+        switch raw {
+        case SIGTERM: return "SIGTERM"
+        case SIGKILL: return "SIGKILL"
+        case SIGINT: return "SIGINT"
+        case SIGHUP: return "SIGHUP"
+        case SIGSEGV: return "SIGSEGV"
+        default: return "SIG\(raw)"
+        }
+    }
+}
+
+/// Weak indirection for the readability handler / termination
+/// handler, which both fire on background queues and might outlive
+/// the terminal briefly.
+private final class WeakBox<T: AnyObject>: @unchecked Sendable {
+    weak var value: T?
+    init(_ value: T) { self.value = value }
+}

--- a/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
+++ b/Alas/Sources/ACP/Terminal/ACPTerminalHost.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+enum ACPTerminalHostError: Error, Equatable {
+    case notFound(String)
+    case tooManyTerminals
+    case spawnFailed(String)
+}
+
+@MainActor
+final class ACPTerminalHost: ObservableObject {
+    static let maxLiveTerminals = 32
+
+    private(set) var sessionCwd: String
+    private(set) var sessionEnv: [String: String]
+    @Published private(set) var terminals: [String: ACPTerminal] = [:]
+
+    init(sessionCwd: String, sessionEnv: [String: String]) {
+        self.sessionCwd = sessionCwd
+        self.sessionEnv = sessionEnv
+    }
+
+    /// UI lookup: returns released terminals too, so a tool card can keep
+    /// rendering the captured output after the agent calls `terminal/release`.
+    func terminal(id: String) -> ACPTerminal? { terminals[id] }
+
+    /// Protocol lookup: returns nil for released terminals so callers
+    /// surface a `notFound` to the agent. Matches the ACP rule that a
+    /// released id can no longer be used with `terminal/*` methods.
+    private func liveTerminal(_ id: String) -> ACPTerminal? {
+        guard let term = terminals[id], !term.released else { return nil }
+        return term
+    }
+
+    func create(_ p: ACPTerminalCreateParams) throws -> ACPTerminalCreateResult {
+        let liveCount = terminals.values.filter { $0.exitStatus == nil }.count
+        if liveCount >= Self.maxLiveTerminals {
+            throw ACPTerminalHostError.tooManyTerminals
+        }
+        let id = UUID().uuidString.lowercased()
+        let cwd = resolveCwd(p.cwd)
+        let env = mergedEnv(p.env)
+        let limit = p.outputByteLimit ?? 65_536
+        do {
+            let term = try ACPTerminal(
+                id: id,
+                command: p.command,
+                args: p.args ?? [],
+                env: env,
+                cwd: cwd,
+                outputByteLimit: limit)
+            terminals[id] = term
+            return ACPTerminalCreateResult(terminalId: id)
+        } catch {
+            throw ACPTerminalHostError.spawnFailed(error.localizedDescription)
+        }
+    }
+
+    func output(_ p: ACPTerminalOutputParams) throws -> ACPTerminalOutputResult {
+        guard let term = liveTerminal(p.terminalId) else {
+            throw ACPTerminalHostError.notFound(p.terminalId)
+        }
+        let snap = term.snapshot(byteLimit: term.outputByteLimit)
+        return ACPTerminalOutputResult(
+            output: snap.text,
+            truncated: snap.truncated,
+            exitStatus: term.exitStatus)
+    }
+
+    func waitForExit(_ p: ACPTerminalIdParams) async throws -> ACPTerminalExitStatus {
+        guard let term = liveTerminal(p.terminalId) else {
+            throw ACPTerminalHostError.notFound(p.terminalId)
+        }
+        return await term.waitForExit()
+    }
+
+    func kill(_ p: ACPTerminalIdParams) throws {
+        guard let term = liveTerminal(p.terminalId) else {
+            throw ACPTerminalHostError.notFound(p.terminalId)
+        }
+        term.kill()
+    }
+
+    /// Per ACP spec: kills the command if still running and invalidates
+    /// the id for subsequent `terminal/*` calls — but the entry stays
+    /// in the registry so any tool card referencing it keeps rendering
+    /// the captured output. `liveTerminal(_:)` enforces the invalidation.
+    func release(_ p: ACPTerminalIdParams) throws {
+        guard let term = liveTerminal(p.terminalId) else {
+            throw ACPTerminalHostError.notFound(p.terminalId)
+        }
+        term.release()
+    }
+
+    /// Terminates every live terminal. Dictionary entries are intentionally
+    /// retained so UI subscribers can render the post-mortem footer for
+    /// tool cards that still reference these ids.
+    func killAll() {
+        for term in terminals.values { term.kill() }
+    }
+
+    func updateContext(sessionCwd: String, sessionEnv: [String: String]) {
+        self.sessionCwd = sessionCwd
+        self.sessionEnv = sessionEnv
+    }
+
+    // MARK: - Helpers
+
+    private func resolveCwd(_ requested: String?) -> String {
+        guard let r = requested, !r.isEmpty else { return sessionCwd }
+        return (r as NSString).isAbsolutePath
+            ? r
+            : (sessionCwd as NSString).appendingPathComponent(r)
+    }
+
+    private func mergedEnv(_ overlay: [ACPEnvVar]?) -> [String: String] {
+        var out = sessionEnv
+        for v in overlay ?? [] { out[v.name] = v.value }
+        return out
+    }
+}

--- a/Alas/Sources/ACP/Terminal/ANSIStream.swift
+++ b/Alas/Sources/ACP/Terminal/ANSIStream.swift
@@ -1,0 +1,316 @@
+import Foundation
+
+/// One contiguous run of text sharing identical visual attributes.
+struct AttributedRun: Equatable {
+    var text: String
+    var attributes: ANSIAttributes
+}
+
+struct ANSIAttributes: Equatable {
+    var foreground: ANSIColor = .default
+    var background: ANSIColor = .default
+    var bold: Bool = false
+    var dim: Bool = false
+    var italic: Bool = false
+    var underline: Bool = false
+
+    static let `default` = ANSIAttributes()
+}
+
+enum ANSIColor: Equatable {
+    case `default`
+    case black, red, green, yellow, blue, magenta, cyan, white
+    case brightBlack, brightRed, brightGreen, brightYellow
+    case brightBlue, brightMagenta, brightCyan, brightWhite
+    case rgb(red: Int, green: Int, blue: Int)
+}
+
+/// Stateful byte-stream parser. Caller feeds raw bytes from a process
+/// pipe and receives runs of styled text. Maintains parser state
+/// across calls so that escape sequences split mid-stream still
+/// decode correctly.
+struct ANSIStream {
+    private enum State { case text, esc, csiParams, oscString, oscST }
+
+    private var state: State = .text
+    private var attributes = ANSIAttributes()
+    private var currentLine: String = ""
+    private var emitted: [AttributedRun] = []
+    private var paramBuf: String = ""
+    /// Bytes accepted in `.text` state, decoded as UTF-8 in batches at
+    /// safe boundaries. Multibyte sequences (è, emoji, etc.) would
+    /// otherwise be appended scalar-per-byte and render as mojibake. A
+    /// sequence split across two `feed()` calls stays here until the
+    /// continuation bytes arrive.
+    private var textBytes: [UInt8] = []
+    /// Index in `emitted` where the current logical line started. A CR
+    /// (line restart) discards everything from this point onward —
+    /// covers the case where a colored progress line was already split
+    /// into runs by an SGR change before the CR arrives.
+    private var emittedLineStart: Int = 0
+
+    mutating func feed(_ data: Data) -> [AttributedRun] {
+        emitted.removeAll(keepingCapacity: true)
+        // `emittedLineStart` indexes into `emitted`. Each feed returns a
+        // fresh `emitted` array, so the marker must reset to 0 — runs
+        // emitted in earlier feeds have already been handed off to the
+        // caller, and CR can only truncate what's in the current batch.
+        emittedLineStart = 0
+        let bytes = [UInt8](data)
+        var i = 0
+        while i < bytes.count {
+            let b = bytes[i]
+            switch state {
+            case .text:
+                handleTextByte(b)
+            case .esc:
+                handleEscByte(b)
+            case .csiParams:
+                handleCsiParamByte(b)
+            case .oscString:
+                handleOscByte(b)
+            case .oscST:
+                handleOscSTByte(b)
+            }
+            i += 1
+        }
+        flushCurrentLine()
+        return emitted
+    }
+
+    private mutating func handleTextByte(_ b: UInt8) {
+        switch b {
+        case 0x1B:                      // ESC
+            flushTextBytes()
+            flushCurrentLine()
+            state = .esc
+        case 0x0D:                      // CR — line restart
+            // Drop the partially-buffered tail AND any colored runs the
+            // SGR path already emitted for this line. Without the
+            // emitted-run truncation, `\u{1B}[31m10%\r\u{1B}[32m20%`
+            // would leave the red `10%` behind alongside the new green
+            // `20%` instead of overwriting it.
+            textBytes.removeAll(keepingCapacity: true)
+            currentLine.removeAll(keepingCapacity: true)
+            if emittedLineStart < emitted.count {
+                emitted.removeSubrange(emittedLineStart ..< emitted.count)
+            }
+        case 0x07, 0x08:                // BEL, BS — drop
+            return
+        case 0x0A:                      // LF — keep, commit line, advance marker
+            textBytes.append(b)
+            flushTextBytes()
+            flushCurrentLine()
+            emittedLineStart = emitted.count
+        case 0x09, 0x20 ... 0x7E:       // TAB, printable ASCII
+            textBytes.append(b)
+        default:                        // UTF-8 lead / continuation byte
+            textBytes.append(b)
+        }
+    }
+
+    /// Decode the buffered UTF-8 bytes up to the last complete codepoint
+    /// and append them to `currentLine`. Any trailing partial sequence
+    /// remains in `textBytes` so the next `feed()` can complete it.
+    private mutating func flushTextBytes() {
+        guard !textBytes.isEmpty else { return }
+        let safe = safeUTF8Prefix(textBytes)
+        if safe > 0 {
+            currentLine.append(String(decoding: textBytes.prefix(safe), as: UTF8.self))
+            textBytes.removeFirst(safe)
+        }
+    }
+
+    /// Returns the number of leading bytes in `bytes` that form complete
+    /// UTF-8 codepoints. A trailing incomplete sequence (lead byte
+    /// without enough continuation bytes yet) is left for the next feed.
+    private func safeUTF8Prefix(_ bytes: [UInt8]) -> Int {
+        if bytes.isEmpty { return 0 }
+        // Scan back from the end through continuation bytes (10xxxxxx) to
+        // find the last lead byte. Then check whether enough continuation
+        // bytes are present for it.
+        var lead = bytes.count - 1
+        while lead > 0, (bytes[lead] & 0xC0) == 0x80 {
+            lead -= 1
+        }
+        let leadByte = bytes[lead]
+        let needed: Int
+        switch leadByte {
+        case 0x00...0x7F: needed = 1
+        case 0xC0...0xDF: needed = 2
+        case 0xE0...0xEF: needed = 3
+        case 0xF0...0xF7: needed = 4
+        default:          needed = 1  // invalid lead — treat as single (will become U+FFFD)
+        }
+        let available = bytes.count - lead
+        return available >= needed ? bytes.count : lead
+    }
+
+    private mutating func handleEscByte(_ b: UInt8) {
+        switch b {
+        case 0x5B:                      // '['  CSI introducer
+            paramBuf = ""
+            state = .csiParams
+        case 0x5D:                      // ']'  OSC introducer
+            paramBuf = ""
+            state = .oscString
+        default:
+            // Two-character ESC sequence (e.g. ESC c), discard and resume.
+            state = .text
+        }
+    }
+
+    private mutating func handleCsiParamByte(_ b: UInt8) {
+        // CSI = ESC '[' params final.  Params are 0x30..0x3F (digits + ;:<=>?).
+        // Intermediates 0x20..0x2F are accepted-and-discarded for forward
+        // compatibility; final byte is 0x40..0x7E.
+        switch b {
+        case 0x30...0x3F:               // param
+            paramBuf.append(Character(UnicodeScalar(b)))
+        case 0x40...0x7E:               // final
+            if b == 0x6D {              // 'm' → SGR
+                applySGR(paramBuf)
+            }
+            // All other finals (cursor moves, scroll, erase, …) are silently consumed.
+            paramBuf = ""
+            state = .text
+        default:
+            // 0x20..0x2F intermediates: accept and continue.
+            break
+        }
+    }
+
+    private mutating func handleOscByte(_ b: UInt8) {
+        // OSC terminator is BEL (0x07) or ST (ESC \).
+        if b == 0x07 {
+            state = .text
+        } else if b == 0x1B {
+            state = .oscST
+        }
+    }
+
+    private mutating func handleOscSTByte(_ b: UInt8) {
+        // After ESC inside OSC: '\' completes ST and is consumed; any other
+        // byte is treated as the start of fresh text.
+        if b == 0x5C {
+            state = .text
+        } else {
+            state = .text
+            handleTextByte(b)
+        }
+    }
+
+    private mutating func flushCurrentLine() {
+        flushTextBytes()
+        if !currentLine.isEmpty {
+            emitted.append(AttributedRun(text: currentLine, attributes: attributes))
+            currentLine.removeAll(keepingCapacity: true)
+        }
+    }
+
+    // MARK: - SGR
+
+    private mutating func applySGR(_ raw: String) {
+        let parts = raw.split(separator: ";", omittingEmptySubsequences: false).map { Int($0) ?? 0 }
+        var i = 0
+        // Treat empty SGR as reset (ANSI convention).
+        if parts.isEmpty || (parts.count == 1 && parts[0] == 0) {
+            attributes = ANSIAttributes()
+            return
+        }
+        while i < parts.count {
+            let n = parts[i]
+            switch n {
+            case 0:
+                attributes = ANSIAttributes()
+            case 1:  attributes.bold = true
+            case 2:  attributes.dim = true
+            case 3:  attributes.italic = true
+            case 4:  attributes.underline = true
+            case 22:
+                attributes.bold = false
+                attributes.dim = false
+            case 23: attributes.italic = false
+            case 24: attributes.underline = false
+            case 30...37: attributes.foreground = ANSIColor.basic(n - 30)
+            case 39:      attributes.foreground = .default
+            case 40...47: attributes.background = ANSIColor.basic(n - 40)
+            case 49:      attributes.background = .default
+            case 90...97:   attributes.foreground = ANSIColor.bright(n - 90)
+            case 100...107: attributes.background = ANSIColor.bright(n - 100)
+            case 38, 48:
+                let isFg = (n == 38)
+                guard i + 1 < parts.count else {
+                    i += 1
+                    continue
+                }
+                let mode = parts[i + 1]
+                if mode == 5, i + 2 < parts.count {
+                    let palette = parts[i + 2]
+                    let c = ANSIColor.xterm256(palette)
+                    if isFg { attributes.foreground = c } else { attributes.background = c }
+                    i += 2
+                } else if mode == 2, i + 4 < parts.count {
+                    let r = parts[i + 2], g = parts[i + 3], b = parts[i + 4]
+                    let c = ANSIColor.rgb(red: r, green: g, blue: b)
+                    if isFg { attributes.foreground = c } else { attributes.background = c }
+                    i += 4
+                }
+            default:
+                break
+            }
+            i += 1
+        }
+    }
+}
+
+extension ANSIColor {
+    fileprivate static func basic(_ index: Int) -> ANSIColor {
+        switch index {
+        case 0: return .black
+        case 1: return .red
+        case 2: return .green
+        case 3: return .yellow
+        case 4: return .blue
+        case 5: return .magenta
+        case 6: return .cyan
+        case 7: return .white
+        default: return .default
+        }
+    }
+
+    fileprivate static func bright(_ index: Int) -> ANSIColor {
+        switch index {
+        case 0: return .brightBlack
+        case 1: return .brightRed
+        case 2: return .brightGreen
+        case 3: return .brightYellow
+        case 4: return .brightBlue
+        case 5: return .brightMagenta
+        case 6: return .brightCyan
+        case 7: return .brightWhite
+        default: return .default
+        }
+    }
+
+    fileprivate static func xterm256(_ n: Int) -> ANSIColor {
+        // 0..15 map to basic/bright, 16..231 to a 6×6×6 RGB cube,
+        // 232..255 to a 24-step grayscale ramp.
+        switch n {
+        case 0...7:   return .basic(n)
+        case 8...15:  return .bright(n - 8)
+        case 16...231:
+            let i = n - 16
+            let r = (i / 36) % 6
+            let g = (i / 6) % 6
+            let b = i % 6
+            let scale = { (x: Int) -> Int in x == 0 ? 0 : 55 + x * 40 }
+            return .rgb(red: scale(r), green: scale(g), blue: scale(b))
+        case 232...255:
+            let level = 8 + (n - 232) * 10
+            return .rgb(red: level, green: level, blue: level)
+        default:
+            return .default
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -283,6 +283,7 @@ struct ACPMessageList: View {
             ACPThoughtView(buffer: buf)
         case .toolCall(let tc):
             ACPToolCallCard(toolCall: tc)
+                .environment(\.acpTerminalHost, session.terminalHost)
         case .fileEdit(_, let edit):
             ACPFileEditCard(edit: edit, onOpenDiff: { onOpenDiff(edit.path) })
         case .plan:

--- a/Alas/Sources/ACP/UI/ACPTerminalTailView.swift
+++ b/Alas/Sources/ACP/UI/ACPTerminalTailView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// Bottom-anchored live tail of a single ACP terminal. Subscribed via
+/// `@ObservedObject` so it re-renders on every buffer flush. Max
+/// height is 300 px; the user can scroll up to see earlier output.
+struct ACPTerminalTailView: View {
+    let terminalId: String
+    let host: ACPTerminalHost
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        if let terminal = host.terminal(id: terminalId) {
+            TerminalLiveBody(terminal: terminal)
+        } else {
+            Text("Terminal output not retained across restart.")
+                .font(.system(size: 11))
+                .foregroundStyle(theme.color("fg-faint"))
+                .padding(.horizontal, 12).padding(.vertical, 8)
+        }
+    }
+}
+
+private struct TerminalLiveBody: View {
+    @ObservedObject var terminal: ACPTerminal
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    Text(parsedAttributed())
+                        .font(.system(size: 11.5, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12).padding(.vertical, 8)
+                        .id("BOTTOM")
+                }
+                .frame(maxHeight: 300)
+                .onChange(of: terminal.buffer) { _, _ in
+                    proxy.scrollTo("BOTTOM", anchor: .bottom)
+                }
+            }
+            if let s = terminal.exitStatus {
+                exitFooter(s)
+            }
+        }
+        .background(theme.color("bg-0").opacity(0.55))
+    }
+
+    private func parsedAttributed() -> AttributedString {
+        var stream = ANSIStream()
+        let runs = stream.feed(terminal.buffer)
+        var out = AttributedString()
+        for run in runs {
+            var s = AttributedString(run.text)
+            s.font = .system(size: 11.5, design: .monospaced)
+            if let c = run.attributes.foreground.swiftUIColor(theme: theme) {
+                s.foregroundColor = c
+            } else {
+                s.foregroundColor = theme.color("fg-muted")
+            }
+            if let bg = run.attributes.background.swiftUIColor(theme: theme) {
+                s.backgroundColor = bg
+            }
+            if run.attributes.bold { s.font = .system(size: 11.5, weight: .bold, design: .monospaced) }
+            if run.attributes.italic { s.font = (s.font ?? .system(size: 11.5, design: .monospaced)).italic() }
+            if run.attributes.underline { s.underlineStyle = .single }
+            out += s
+        }
+        return out
+    }
+
+    @ViewBuilder
+    private func exitFooter(_ s: ACPTerminalExitStatus) -> some View {
+        HStack(spacing: 6) {
+            if let sig = s.signal {
+                Text("Killed (\(sig))")
+                    .foregroundStyle(theme.color("fg-faint"))
+            } else if let code = s.exitCode {
+                Text("Exited \(code)")
+                    .foregroundStyle(code == 0 ? theme.color("add") : theme.color("del"))
+            }
+        }
+        .font(.system(size: 11))
+        .padding(.horizontal, 12).padding(.bottom, 6)
+    }
+}
+
+private extension ANSIColor {
+    func swiftUIColor(theme: Theme) -> Color? {
+        switch self {
+        case .default: return nil
+        case .black: return .black
+        case .red: return .red
+        case .green: return .green
+        case .yellow: return .yellow
+        case .blue: return .blue
+        case .magenta: return .purple
+        case .cyan: return .cyan
+        case .white: return .white
+        case .brightBlack: return .gray
+        case .brightRed: return Color(red: 1.0, green: 0.5, blue: 0.5)
+        case .brightGreen: return Color(red: 0.5, green: 1.0, blue: 0.5)
+        case .brightYellow: return Color(red: 1.0, green: 1.0, blue: 0.5)
+        case .brightBlue: return Color(red: 0.5, green: 0.5, blue: 1.0)
+        case .brightMagenta: return Color(red: 1.0, green: 0.5, blue: 1.0)
+        case .brightCyan: return Color(red: 0.5, green: 1.0, blue: 1.0)
+        case .brightWhite: return .white
+        case .rgb(let r, let g, let b):
+            return Color(red: Double(r) / 255.0, green: Double(g) / 255.0, blue: Double(b) / 255.0)
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -8,6 +8,7 @@ struct ACPToolCallCard: View {
     let toolCall: ACPMessage.ToolCall
     @State private var expanded = false
     @Environment(\.theme) private var theme
+    @Environment(\.acpTerminalHost) private var terminalHost
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -56,33 +57,42 @@ struct ACPToolCallCard: View {
 
     @ViewBuilder
     private var expandedBody: some View {
-        if toolCall.content.isEmpty {
-            HStack(spacing: 6) {
-                if toolCall.status == "in_progress" || toolCall.status == "pending" {
-                    Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10)
-                    Text("Working…")
-                } else if toolCall.status == "canceled" || toolCall.status == "cancelled" {
-                    Text("Canceled.")
-                } else {
-                    Text("No output.")
+        VStack(alignment: .leading, spacing: 0) {
+            if toolCall.content.isEmpty && toolCall.terminalIds.isEmpty {
+                HStack(spacing: 6) {
+                    if toolCall.status == "in_progress" || toolCall.status == "pending" {
+                        Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10)
+                        Text("Working…")
+                    } else if toolCall.status == "canceled" || toolCall.status == "cancelled" {
+                        Text("Canceled.")
+                    } else {
+                        Text("No output.")
+                    }
+                }
+                .font(.system(size: 11))
+                .foregroundStyle(theme.color("fg-faint"))
+                .padding(.horizontal, 12).padding(.vertical, 10)
+                .background(theme.color("bg-0").opacity(0.55))
+            } else {
+                if !toolCall.content.isEmpty {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        Text(toolCall.content)
+                            .font(.system(size: 11.5, design: .monospaced))
+                            .foregroundStyle(theme.color("fg-muted"))
+                            .lineSpacing(2)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 12).padding(.vertical, 10)
+                    }
+                    .background(theme.color("bg-0").opacity(0.55))
+                }
+                if let host = terminalHost {
+                    ForEach(toolCall.terminalIds, id: \.self) { tid in
+                        ACPTerminalTailView(terminalId: tid, host: host)
+                    }
                 }
             }
-            .font(.system(size: 11))
-            .foregroundStyle(theme.color("fg-faint"))
-            .padding(.horizontal, 12).padding(.vertical, 10)
-            .background(theme.color("bg-0").opacity(0.55))
-        } else {
-            ScrollView(.horizontal, showsIndicators: false) {
-                Text(toolCall.content)
-                    .font(.system(size: 11.5, design: .monospaced))
-                    .foregroundStyle(theme.color("fg-muted"))
-                    .lineSpacing(2)
-                    .textSelection(.enabled)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 12).padding(.vertical, 10)
-            }
-            .background(theme.color("bg-0").opacity(0.55))
         }
     }
 
@@ -147,5 +157,16 @@ struct ACPToolCallCard: View {
                 .foregroundStyle(theme.color("accent"))
         }
         .frame(width: 18, height: 18)
+    }
+}
+
+private struct ACPTerminalHostKey: EnvironmentKey {
+    static let defaultValue: ACPTerminalHost? = nil
+}
+
+extension EnvironmentValues {
+    var acpTerminalHost: ACPTerminalHost? {
+        get { self[ACPTerminalHostKey.self] }
+        set { self[ACPTerminalHostKey.self] = newValue }
     }
 }

--- a/AlasTests/ACP/Fixtures/initialize-request.json
+++ b/AlasTests/ACP/Fixtures/initialize-request.json
@@ -5,7 +5,8 @@
   "params": {
     "protocolVersion": 1,
     "clientCapabilities": {
-      "fs": { "readTextFile": true, "writeTextFile": true }
+      "fs": { "readTextFile": true, "writeTextFile": true },
+      "terminal": true
     }
   }
 }

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -13,6 +13,7 @@ struct ACPInitializeTests {
         #expect(env.params?.protocolVersion == 1)
         #expect(env.params?.clientCapabilities.fs.readTextFile == true)
         #expect(env.params?.clientCapabilities.fs.writeTextFile == true)
+        #expect(env.params?.clientCapabilities.terminal == true)
     }
 
     @Test("decodes an initialize response")

--- a/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioClientTests.swift
@@ -36,7 +36,9 @@ struct ACPStdioClientTests {
             method: "initialize",
             params: ACPInitializeParams(
                 protocolVersion: 1,
-                clientCapabilities: .init(fs: .init(readTextFile: true, writeTextFile: true)))
+                clientCapabilities: .init(
+                    fs: .init(readTextFile: true, writeTextFile: true),
+                    terminal: true))
         ))
         let init_ = try JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)
         #expect(init_.protocolVersion == 1)

--- a/AlasTests/ACP/Protocol/ACPStdioTerminalDispatchTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioTerminalDispatchTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPStdioClient terminal dispatch")
+struct ACPStdioTerminalDispatchTests {
+    @Test("terminal/create incoming frame yields ACPTerminalRequest.create")
+    func dispatchesCreate() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try client.start()
+        let json = #"""
+        {"jsonrpc":"2.0","id":42,"method":"terminal/create","params":{
+          "sessionId":"s","command":"echo","args":["hi"]
+        }}
+        """#
+        transport.send(frame: Data(json.utf8))
+        var it = client.terminalRequests.makeAsyncIterator()
+        let req = await it.next()
+        guard case .create(let id, let p) = req else {
+            Issue.record("expected .create, got \(String(describing: req))")
+            return
+        }
+        #expect(id == .number(42))
+        #expect(p.command == "echo")
+        #expect(p.args == ["hi"])
+    }
+}

--- a/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
+++ b/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
@@ -1,0 +1,34 @@
+import Foundation
+@testable import Alas
+
+/// Minimal in-process transport for `ACPStdioClient` tests.
+/// Call `send(frame:)` to inject a raw JSON frame as if the agent
+/// had written it to stdout.
+final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable {
+    private let cont: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation
+    let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
+
+    init() {
+        var c: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation!
+        self.incoming = AsyncStream { c = $0 }
+        self.cont = c
+    }
+
+    func start() throws {
+        // No subprocess to launch.
+    }
+
+    func send(_ data: Data) throws {
+        // Discard outbound bytes in tests (we only care about inbound dispatch).
+    }
+
+    func terminate() {
+        cont.yield(.exited(0))
+        cont.finish()
+    }
+
+    /// Inject an inbound JSON frame as if the agent sent it.
+    func send(frame: Data) {
+        cont.yield(.frame(frame))
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionTerminalRoutingTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTerminalRoutingTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP terminal routing")
+struct ACPSessionTerminalRoutingTests {
+    @Test("terminal/create routes to the session host and responds with an id")
+    func createRoundTrip() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.start()
+        defer { runner.stop() }
+
+        let params = ACPTerminalCreateParams(
+            sessionId: "s", command: "/bin/echo",
+            args: ["hi"], env: nil, cwd: nil, outputByteLimit: nil)
+        mock.emitTerminal(.create(id: .number(1), params: params))
+
+        for _ in 0..<50 {
+            if mock.terminalResponses[.number(1)] != nil { break }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .success(let body)? = mock.terminalResponses[.number(1)] else {
+            Issue.record("expected success response")
+            return
+        }
+        let res = try JSONDecoder().decode(ACPTerminalCreateResult.self, from: body)
+        #expect(!res.terminalId.isEmpty)
+        #expect(runner.session.terminalHost.terminal(id: res.terminalId) != nil)
+    }
+
+    @Test("terminal/output on unknown id responds with JSON-RPC error -32602")
+    func unknownTerminalErrors() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.start()
+        defer { runner.stop() }
+
+        mock.emitTerminal(.output(id: .number(2),
+            params: ACPTerminalOutputParams(sessionId: "s", terminalId: "nope")))
+        for _ in 0..<50 {
+            if mock.terminalResponses[.number(2)] != nil { break }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .failure(let err)? = mock.terminalResponses[.number(2)] else {
+            Issue.record("expected error response")
+            return
+        }
+        #expect(err.code == -32602)
+    }
+
+    @Test("runner seeds terminal host with the supplied agentEnv")
+    func runnerPropagatesAgentEnv() async throws {
+        let (runner, _) = try makeRunner(agentEnv: ["ALAS_TEST_TOKEN": "ok", "PATH": "/bin:/usr/bin"])
+        runner.start()
+        defer { runner.stop() }
+        // The same env was handed to the agent process; the terminal
+        // host should mirror it so agent-spawned commands see the same
+        // sanitized view (no CLAUDECODE/CLAUDE_SESSION_ID leakage).
+        let env = runner.session.terminalHost.sessionEnv
+        #expect(env["ALAS_TEST_TOKEN"] == "ok")
+        #expect(env["PATH"] == "/bin:/usr/bin")
+    }
+
+    @Test("runner.stop() kills agent-spawned terminals")
+    func stopKillsTerminals() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.start()
+
+        // Spawn a long-running terminal via the routing path.
+        mock.emitTerminal(.create(id: .number(7),
+            params: ACPTerminalCreateParams(
+                sessionId: "s", command: "/bin/sleep",
+                args: ["60"], env: nil, cwd: "/tmp", outputByteLimit: nil)))
+        for _ in 0..<50 {
+            if mock.terminalResponses[.number(7)] != nil { break }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        guard case .success(let body)? = mock.terminalResponses[.number(7)] else {
+            Issue.record("expected terminal/create success")
+            return
+        }
+        let res = try JSONDecoder().decode(ACPTerminalCreateResult.self, from: body)
+        let term = runner.session.terminalHost.terminal(id: res.terminalId)
+        #expect(term != nil)
+        #expect(term?.exitStatus == nil)
+
+        runner.stop()
+
+        // killAll → SIGTERM → process should exit within a couple seconds.
+        let status = await term!.waitForExit()
+        #expect(status.signal != nil || (status.exitCode ?? 0) != 0)
+    }
+
+    private func makeRunner(agentEnv: [String: String] = ProcessInfo.processInfo.environment)
+        throws -> (ACPSessionRunner, ACPMockClient)
+    {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path,
+            agentEnv: agentEnv)
+        return (runner, mock)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -141,4 +141,96 @@ struct ACPSessionTests {
             #expect(tc.content == "--- a.swift\n-let x = 1\n+let x = 2")
         } else { Issue.record("expected toolCall message") }
     }
+
+    @Test("terminal content records terminalIds and drops placeholder from content")
+    func toolCallUpdateTerminal() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-3", title: "run", kind: "execute", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-3", status: "in_progress",
+            content: [.terminal(terminalId: "term-42")],
+            rawOutput: nil)))
+        #expect(session.transcript.messages.count == 1)
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.terminalIds == ["term-42"])
+            #expect(tc.content == "")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("initial toolCall with terminal content records terminalIds")
+    func toolCallInitialTerminal() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-4", title: "run", kind: "execute", status: "in_progress",
+            content: [.terminal(terminalId: "term-99")],
+            locations: nil, rawInput: nil, rawOutput: nil)))
+        #expect(session.transcript.messages.count == 1)
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.terminalIds == ["term-99"])
+            #expect(tc.content == "")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("toolCallUpdate clears stale terminalIds when content has no terminals")
+    func toolCallUpdateClearsTerminalIds() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-clear", title: "run", kind: "execute", status: "in_progress",
+            content: [.terminal(terminalId: "term-x")],
+            locations: nil, rawInput: nil, rawOutput: nil)))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.terminalIds == ["term-x"])
+        } else { Issue.record("expected toolCall message") }
+        // Final replacement update carries text only — terminalIds must clear.
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-clear", status: "completed",
+            content: [.content(.text("final output"))],
+            rawOutput: nil)))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.terminalIds.isEmpty)
+            #expect(tc.content == "final output")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("completed toolCall strips wrapping markdown fences")
+    func toolCallStripsBothFences() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-5", title: "read", kind: "read", status: "in_progress",
+            content: nil, locations: nil, rawInput: nil, rawOutput: nil)))
+        session.apply(.toolCallUpdate(.init(
+            toolCallId: "tc-5", status: "completed",
+            content: [.content(.text("```swift\nlet x = 1\nlet y = 2\n```"))],
+            rawOutput: nil)))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "let x = 1\nlet y = 2")
+            #expect(tc.preview == "let x = 1")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("in-progress toolCall strips opening fence but keeps trailing line")
+    func toolCallKeepsTrailingMidStream() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-6", title: "read", kind: "read", status: "in_progress",
+            content: [.content(.text("```\npartial output"))],
+            locations: nil, rawInput: nil, rawOutput: nil)))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "partial output")
+        } else { Issue.record("expected toolCall message") }
+    }
+
+    @Test("toolCall without wrapping fences is left untouched")
+    func toolCallNoFencePassthrough() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.toolCall(.init(
+            toolCallId: "tc-7", title: "read", kind: "read", status: "completed",
+            content: [.content(.text("hello\n```\ninner\n```\nworld"))],
+            locations: nil, rawInput: nil, rawOutput: nil)))
+        if case .toolCall(let tc) = session.transcript.messages[0] {
+            #expect(tc.content == "hello\n```\ninner\n```\nworld")
+        } else { Issue.record("expected toolCall message") }
+    }
 }

--- a/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
+++ b/AlasTests/ACP/Terminal/ACPTerminalHostTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTerminalHost")
+struct ACPTerminalHostTests {
+    @Test("create returns a unique terminalId and stores the terminal")
+    func createStores() throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        let p = ACPTerminalCreateParams(
+            sessionId: "s", command: "/bin/echo",
+            args: ["x"], env: nil, cwd: nil, outputByteLimit: nil)
+        let r1 = try host.create(p)
+        let r2 = try host.create(p)
+        #expect(r1.terminalId != r2.terminalId)
+        #expect(host.terminal(id: r1.terminalId) != nil)
+    }
+
+    @Test("output on unknown id throws 'terminal not found'")
+    func unknownOutput() {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        let p = ACPTerminalOutputParams(sessionId: "s", terminalId: "nope")
+        #expect(throws: ACPTerminalHostError.notFound("nope")) {
+            _ = try host.output(p)
+        }
+    }
+
+    @Test("release retains the entry but invalidates the id for protocol calls")
+    func releaseRetainsForUI() async throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        let p = ACPTerminalCreateParams(
+            sessionId: "s", command: "/bin/echo",
+            args: ["y"], env: nil, cwd: nil, outputByteLimit: nil)
+        let r = try host.create(p)
+        // Let echo finish so the buffer has something to retain.
+        if let term = host.terminal(id: r.terminalId) { _ = await term.waitForExit() }
+
+        try host.release(.init(sessionId: "s", terminalId: r.terminalId))
+
+        // UI lookup still returns the terminal so the tool card keeps rendering.
+        let retained = host.terminal(id: r.terminalId)
+        #expect(retained != nil)
+        #expect(retained?.released == true)
+        #expect(retained?.snapshot(byteLimit: 1024).text.contains("y") == true)
+
+        // Protocol methods reject the released id with notFound.
+        #expect(throws: ACPTerminalHostError.notFound(r.terminalId)) {
+            _ = try host.output(.init(sessionId: "s", terminalId: r.terminalId))
+        }
+        #expect(throws: ACPTerminalHostError.notFound(r.terminalId)) {
+            try host.kill(.init(sessionId: "s", terminalId: r.terminalId))
+        }
+        #expect(throws: ACPTerminalHostError.notFound(r.terminalId)) {
+            try host.release(.init(sessionId: "s", terminalId: r.terminalId))
+        }
+    }
+
+    @Test("releasing a live terminal still publishes exitStatus")
+    func releaseLiveStillFinalizes() async throws {
+        // Releasing a running command kills it. The terminal must still
+        // finalize (`exitStatus` published) so it stops counting as live
+        // against maxLiveTerminals — otherwise repeated releases starve
+        // future `terminal/create` calls.
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        let r = try host.create(.init(
+            sessionId: "s", command: "/bin/sleep",
+            args: ["60"], env: nil, cwd: nil, outputByteLimit: nil))
+        let term = host.terminal(id: r.terminalId)
+        #expect(term != nil)
+        try host.release(.init(sessionId: "s", terminalId: r.terminalId))
+        let status = await term!.waitForExit()
+        #expect(status.signal != nil || (status.exitCode ?? 0) != 0)
+        // The released entry no longer counts as live, so we can create
+        // up to the cap fresh.
+        let live = host.terminal(id: r.terminalId)?.exitStatus
+        #expect(live != nil)
+    }
+
+    @Test("waitForExit result encodes {exitCode, signal} at the top level")
+    func waitForExitWireShape() async throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        let r = try host.create(.init(
+            sessionId: "s", command: "/bin/sh",
+            args: ["-c", "exit 0"], env: nil, cwd: nil, outputByteLimit: nil))
+        let status = try await host.waitForExit(.init(sessionId: "s", terminalId: r.terminalId))
+        let json = try JSONEncoder().encode(status)
+        let obj = try JSONSerialization.jsonObject(with: json) as? [String: Any]
+        // Per ACP spec WaitForTerminalExitResponse: exitCode and signal sit
+        // at the top level — there must be no `exitStatus` wrapper key.
+        #expect(obj?["exitCode"] as? Int == 0)
+        #expect(obj?.keys.contains("exitStatus") == false)
+    }
+
+    @Test("killAll terminates every live terminal")
+    func killAllTerminates() async throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        let p = ACPTerminalCreateParams(
+            sessionId: "s", command: "/bin/sleep",
+            args: ["60"], env: nil, cwd: nil, outputByteLimit: nil)
+        let r = try host.create(p)
+        host.killAll()
+        // The terminal should observe exit shortly.
+        let term = host.terminal(id: r.terminalId)
+        #expect(term != nil)
+        let status = await term!.waitForExit()
+        #expect(status.exitCode != 0 || status.signal != nil)
+    }
+
+    @Test("create errors after 32 live terminals")
+    func tooManyLive() async throws {
+        let host = ACPTerminalHost(sessionCwd: "/tmp", sessionEnv: [:])
+        var ids: [String] = []
+        for _ in 0 ..< 32 {
+            let p = ACPTerminalCreateParams(
+                sessionId: "s", command: "/bin/sleep",
+                args: ["60"], env: nil, cwd: nil, outputByteLimit: nil)
+            ids.append(try host.create(p).terminalId)
+        }
+        let p = ACPTerminalCreateParams(
+            sessionId: "s", command: "/bin/echo",
+            args: ["x"], env: nil, cwd: nil, outputByteLimit: nil)
+        #expect(throws: ACPTerminalHostError.tooManyTerminals) {
+            _ = try host.create(p)
+        }
+        host.killAll()
+        // Wait for every spawned terminal to actually exit so we don't
+        // leak 32 `sleep 60` processes when the suite is run on CI.
+        await withTaskGroup(of: Void.self) { group in
+            for id in ids {
+                if let term = host.terminal(id: id) {
+                    group.addTask { _ = await term.waitForExit() }
+                }
+            }
+        }
+    }
+}

--- a/AlasTests/ACP/Terminal/ACPTerminalTests.swift
+++ b/AlasTests/ACP/Terminal/ACPTerminalTests.swift
@@ -1,0 +1,316 @@
+import Darwin
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTerminal")
+struct ACPTerminalTests {
+    @Test("echo captures stdout and reports exit 0")
+    func captureEcho() async throws {
+        let t = try ACPTerminal(
+            id: "t1",
+            command: "/bin/echo",
+            args: ["hello"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 1024
+        )
+        let status = await t.waitForExit()
+        #expect(status.exitCode == 0)
+        let snap = t.snapshot(byteLimit: 1024)
+        #expect(snap.text.contains("hello"))
+        #expect(snap.truncated == false)
+    }
+
+    @Test("non-zero exit code is captured")
+    func nonZeroExit() async throws {
+        let t = try ACPTerminal(
+            id: "t2",
+            command: "/bin/sh",
+            args: ["-c", "exit 7"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 1024
+        )
+        let status = await t.waitForExit()
+        #expect(status.exitCode == 7)
+    }
+
+    @Test("snapshot after waitForExit on a fast command sees the full output")
+    func fastExitOutputDrained() async throws {
+        // Repeatedly run a short-lived `echo` and verify wait_for_exit
+        // returns ONLY after the output has landed in the buffer. The
+        // race Codex flagged: terminationHandler resumes waiters before
+        // the readability handler's dispatched appendChunk Task runs.
+        for i in 0..<20 {
+            let t = try ACPTerminal(
+                id: "tfast-\(i)",
+                command: "/bin/echo",
+                args: ["mark-\(i)"],
+                env: [:],
+                cwd: "/tmp",
+                outputByteLimit: 1024
+            )
+            _ = await t.waitForExit()
+            let snap = t.snapshot(byteLimit: 1024).text
+            #expect(snap.contains("mark-\(i)"))
+        }
+    }
+
+    @Test("release reaches a backgrounded descendant after root exited")
+    func releaseReachesOrphans() async throws {
+        // Backgrounded sleep inherits the pipe write end, so the root
+        // can exit but the EOF on our read end never fires. The parent
+        // stays alive for ~3 s after the fork so the periodic
+        // descendant tracker can capture the BG sleep before exit; once
+        // the root exits, kill() relies on that captured set to reach
+        // the orphan and let EOF finally arrive.
+        let t = try ACPTerminal(
+            id: "torphan",
+            command: "/bin/sh",
+            args: ["-c", "sleep 60 & echo $!; sleep 3"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 1024
+        )
+        var sleepPid: pid_t = 0
+        for _ in 0..<50 {
+            try await Task.sleep(nanoseconds: 40_000_000)
+            let snap = t.snapshot(byteLimit: 1024).text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let pid = pid_t(snap) {
+                sleepPid = pid
+                break
+            }
+        }
+        #expect(sleepPid != 0)
+        // Wait long enough for sh to finish its `sleep 3` and exit, so
+        // we're genuinely in the orphaned-pipe state when release runs.
+        try await Task.sleep(nanoseconds: 3_500_000_000)
+        #expect(t.exitStatus == nil)
+        t.release()
+        _ = await t.waitForExit()
+        var reaped = false
+        for _ in 0..<100 {
+            try await Task.sleep(nanoseconds: 40_000_000)
+            if Darwin.kill(sleepPid, 0) != 0 {
+                reaped = true
+                break
+            }
+        }
+        #expect(reaped)
+    }
+
+    @Test("kill escalates to SIGKILL when a descendant traps SIGTERM")
+    func killEscalatesToSigkill() async throws {
+        // Shell forks a SIGTERM-trapping sleep, prints its PID, waits.
+        // The root shell exits on SIGTERM, but the trapped child should
+        // survive SIGTERM and only die at the 2 s SIGKILL escalation.
+        let t = try ACPTerminal(
+            id: "ttrap",
+            command: "/bin/sh",
+            args: ["-c", "(trap '' TERM; sleep 30) & echo $! ; wait"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 1024
+        )
+        var trappedPid: pid_t = 0
+        for _ in 0..<50 {
+            try await Task.sleep(nanoseconds: 40_000_000)
+            let snap = t.snapshot(byteLimit: 1024).text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let pid = pid_t(snap) {
+                trappedPid = pid
+                break
+            }
+        }
+        #expect(trappedPid != 0)
+        t.kill()
+        _ = await t.waitForExit()
+        // Poll up to ~4 s for the trapped child to die under SIGKILL.
+        var reaped = false
+        for _ in 0..<100 {
+            try await Task.sleep(nanoseconds: 40_000_000)
+            if Darwin.kill(trappedPid, 0) != 0 {
+                reaped = true
+                break
+            }
+        }
+        #expect(reaped)
+    }
+
+    @Test("kill terminates the whole process group")
+    func killReachesGrandchildren() async throws {
+        // Shell forks a `sleep 30` background child, prints its PID,
+        // then waits. After we kill the shell's process group, the
+        // grandchild sleep should also exit — verified by polling
+        // kill(grandchildPid, 0) until it returns ESRCH.
+        let t = try ACPTerminal(
+            id: "tpgkill",
+            command: "/bin/sh",
+            args: ["-c", "sleep 30 & echo $! ; wait"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 1024
+        )
+        // Wait until the shell has printed the grandchild PID.
+        var grandchildPid: pid_t = 0
+        for _ in 0..<50 {
+            try await Task.sleep(nanoseconds: 40_000_000)
+            let snap = t.snapshot(byteLimit: 1024).text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let pid = pid_t(snap) {
+                grandchildPid = pid
+                break
+            }
+        }
+        #expect(grandchildPid != 0)
+        t.kill()
+        _ = await t.waitForExit()
+        // Poll for grandchild death — SIGTERM → process group → child.
+        var reaped = false
+        for _ in 0..<50 {
+            try await Task.sleep(nanoseconds: 40_000_000)
+            if Darwin.kill(grandchildPid, 0) != 0 {
+                reaped = true
+                break
+            }
+        }
+        #expect(reaped)
+    }
+
+    @Test("kill terminates a long-running process within 3 s")
+    func killTerminates() async throws {
+        let t = try ACPTerminal(
+            id: "t3",
+            command: "/bin/sleep",
+            args: ["60"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 1024
+        )
+        defer { t.release() }
+        // Give the process a moment to actually start.
+        try await Task.sleep(nanoseconds: 100_000_000)
+        t.kill()
+        let start = Date()
+        let status = await t.waitForExit()
+        #expect(Date().timeIntervalSince(start) < 3.0)
+        // Foundation reports termination by signal; we just want NOT zero-exit-success.
+        #expect(status.signal != nil || (status.exitCode ?? 0) != 0)
+    }
+
+    @Test("snapshot honors a sub-1024 outputByteLimit")
+    func smallByteLimit() async throws {
+        let t = try ACPTerminal(
+            id: "tsmall",
+            command: "/bin/sh",
+            args: ["-c", "printf 'abcdefghij'"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 4
+        )
+        _ = await t.waitForExit()
+        let snap = t.snapshot(byteLimit: 4)
+        #expect(snap.text.count == 4)
+        #expect(snap.truncated == true)
+        #expect(snap.text == "ghij")
+    }
+
+    @Test("snapshot lookback resyncs into a cut ANSI escape")
+    func snapshotResyncsEscape() async throws {
+        // Output is `prefix\u{1B}[31mHELLO`; cut at limit=8 lands
+        // mid-CSI (suffix would start at `m`/`HELLO` or earlier).
+        // The lookback must extend the slice start back to the ESC
+        // so the parser strips the escape instead of emitting `mHELLO`
+        // or similar garbage. Resulting text must be a clean `HELLO`
+        // with no escape fragments.
+        let t = try ACPTerminal(
+            id: "tcut",
+            command: "/bin/sh",
+            args: ["-c", "printf 'prefix\\033[31mHELLO'"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 8
+        )
+        _ = await t.waitForExit()
+        let snap = t.snapshot(byteLimit: 8)
+        #expect(snap.truncated == true)
+        #expect(snap.text == "HELLO")
+    }
+
+    @Test("snapshot tail starts at a UTF-8 codepoint boundary")
+    func snapshotUTF8Boundary() async throws {
+        // 4 × 🎉 = 16 bytes (each 4 bytes). Limit to 9: naive byte
+        // suffix would start with two continuation bytes of the second
+        // codepoint and corrupt the decode. The fix advances past them.
+        let t = try ACPTerminal(
+            id: "tutf",
+            command: "/bin/sh",
+            args: ["-c", "printf '🎉🎉🎉🎉'"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 9
+        )
+        _ = await t.waitForExit()
+        let snap = t.snapshot(byteLimit: 9)
+        // We expect 2 complete 🎉 (8 bytes) — never a replacement char.
+        #expect(!snap.text.contains("\u{FFFD}"))
+        #expect(snap.text == "🎉🎉")
+        #expect(snap.truncated == true)
+    }
+
+    @Test("bare command name resolves through PATH")
+    func bareCommandPATH() async throws {
+        // `echo` (no leading slash) must spawn via /usr/bin/env so PATH
+        // is consulted. Foundation's Process would otherwise fail.
+        let t = try ACPTerminal(
+            id: "tpath",
+            command: "echo",
+            args: ["resolved"],
+            env: ["PATH": "/bin:/usr/bin"],
+            cwd: "/tmp",
+            outputByteLimit: 1024
+        )
+        let status = await t.waitForExit()
+        #expect(status.exitCode == 0)
+        #expect(t.snapshot(byteLimit: 1024).text.contains("resolved"))
+    }
+
+    @Test("rolling-buffer rollover starts on a UTF-8 boundary")
+    func rolloverUTF8Boundary() async throws {
+        // Emit ~1.6 MiB of 🎉 (4 bytes each) so the 1 MiB rolling cap
+        // kicks in and almost certainly trims mid-codepoint. The cap
+        // path must advance past any leading continuation bytes, so a
+        // full-cap snapshot must contain zero replacement chars.
+        let t = try ACPTerminal(
+            id: "troll",
+            command: "/usr/bin/perl",
+            args: ["-e", "print \"\\xf0\\x9f\\x8e\\x89\" x 400000"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 1 << 20
+        )
+        _ = await t.waitForExit()
+        let snap = t.snapshot(byteLimit: 1 << 20)
+        #expect(snap.truncated == true)
+        #expect(!snap.text.contains("\u{FFFD}"))
+        // Every retained codepoint should be 🎉.
+        #expect(snap.text.unicodeScalars.allSatisfy { $0 == "\u{1F389}" })
+    }
+
+    @Test("buffer rolls past 1 MiB and sets truncated sticky")
+    func rollingBuffer() async throws {
+        let t = try ACPTerminal(
+            id: "t4",
+            // Print ~1.2 MiB so we exceed the 1 MiB cap.
+            command: "/bin/sh",
+            args: ["-c", "yes x | head -c 1258291"],
+            env: [:],
+            cwd: "/tmp",
+            outputByteLimit: 2048
+        )
+        _ = await t.waitForExit()
+        let snap = t.snapshot(byteLimit: 2048)
+        #expect(snap.truncated == true)
+        #expect(snap.text.count <= 2048)
+    }
+}

--- a/AlasTests/ACP/Terminal/ANSIStreamTests.swift
+++ b/AlasTests/ACP/Terminal/ANSIStreamTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite("ANSIStream")
+struct ANSIStreamTests {
+    @Test("plain text passes through with default attributes")
+    func plainText() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("hello world".utf8))
+        #expect(runs.count == 1)
+        #expect(runs[0].text == "hello world")
+        #expect(runs[0].attributes == .default)
+    }
+
+    @Test("SGR red foreground produces a red run")
+    func redForeground() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("\u{1B}[31mred\u{1B}[0m".utf8))
+        let red = runs.first { $0.text == "red" }
+        #expect(red?.attributes.foreground == .red)
+    }
+
+    @Test("partial escape split across feeds produces correct output")
+    func partialEscape() {
+        var s = ANSIStream()
+        var runs = s.feed(Data("\u{1B}[3".utf8))
+        runs += s.feed(Data("1mhi\u{1B}[0m".utf8))
+        #expect(runs.contains { $0.text == "hi" && $0.attributes.foreground == .red })
+    }
+
+    @Test("non-SGR CSI is consumed silently")
+    func cursorMoveStripped() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("a\u{1B}[2Jb".utf8))
+        let text = runs.map(\.text).joined()
+        #expect(text == "ab")
+    }
+
+    @Test("OSC sequence is consumed silently")
+    func oscStripped() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("\u{1B}]0;title\u{07}body".utf8))
+        let text = runs.map(\.text).joined()
+        #expect(text == "body")
+    }
+
+    @Test("OSC sequence terminated by ESC \\ is consumed silently")
+    func oscSTStripped() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("\u{1B}]0;title\u{1B}\\body".utf8))
+        let text = runs.map(\.text).joined()
+        #expect(text == "body")
+    }
+
+    @Test("CR causes line restart")
+    func carriageReturnRestartsLine() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("downloading 10%\rdownloading 50%\rdownloading 99%\n".utf8))
+        let text = runs.map(\.text).joined()
+        #expect(text == "downloading 99%\n")
+    }
+
+    @Test("256-color SGR uses xterm 256 palette")
+    func xterm256() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("\u{1B}[38;5;196mX\u{1B}[0m".utf8))
+        let x = runs.first { $0.text == "X" }
+        // 196 is bright red in the xterm-256 palette
+        #expect(x?.attributes.foreground != nil)
+        #expect(x?.attributes.foreground != .default)
+    }
+
+    @Test("truecolor SGR carries exact RGB")
+    func truecolor() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("\u{1B}[38;2;10;20;30mY\u{1B}[0m".utf8))
+        let y = runs.first { $0.text == "Y" }
+        #expect(y?.attributes.foreground == .rgb(red: 10, green: 20, blue: 30))
+    }
+
+    @Test("BEL and other C0 controls are dropped")
+    func c0Stripped() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("a\u{07}b".utf8))
+        let text = runs.map(\.text).joined()
+        #expect(text == "ab")
+    }
+
+    @Test("multibyte UTF-8 decodes to the correct scalar")
+    func multibyteUTF8() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("café 日本語 🎉".utf8))
+        let text = runs.map(\.text).joined()
+        #expect(text == "café 日本語 🎉")
+    }
+
+    @Test("UTF-8 codepoint split across feeds reassembles")
+    func splitMultibyteUTF8() {
+        var s = ANSIStream()
+        // 🎉 is F0 9F 8E 89; split at the 3-byte mark.
+            let full = Array("🎉".utf8)
+        var runs = s.feed(Data(full.prefix(3)))
+        runs += s.feed(Data(full.suffix(from: 3)))
+        let text = runs.map(\.text).joined()
+        #expect(text == "🎉")
+    }
+
+    @Test("CR truncation still works after a prior feed emitted an LF")
+    func crAcrossFeedsAfterLF() {
+        var s = ANSIStream()
+        _ = s.feed(Data("ok\n".utf8))
+        // Second feed starts a fresh logical line; emittedLineStart must
+        // reset to 0 so CR can still truncate the colored prefix.
+        let runs = s.feed(Data("\u{1B}[31m10\u{1B}[33m%\r\u{1B}[32m20%".utf8))
+        let text = runs.map(\.text).joined()
+        #expect(text == "20%")
+        #expect(runs.allSatisfy { $0.attributes.foreground == .green })
+    }
+
+    @Test("CR drops previously emitted colored runs on the same line")
+    func crDropsColoredPrefix() {
+        var s = ANSIStream()
+        // Red "10%" is flushed when the second ESC arrives, then CR
+        // should discard it before the new green "20%" is emitted.
+        let runs = s.feed(Data("\u{1B}[31m10\u{1B}[33m%\r\u{1B}[32m20%".utf8))
+        let text = runs.map(\.text).joined()
+        #expect(text == "20%")
+        #expect(runs.allSatisfy { $0.attributes.foreground == .green })
+    }
+
+    @Test("multibyte UTF-8 colored by SGR carries the right text")
+    func multibyteWithSGR() {
+        var s = ANSIStream()
+        let runs = s.feed(Data("\u{1B}[31mé\u{1B}[0m".utf8))
+        let e = runs.first { $0.text == "é" }
+        #expect(e?.attributes.foreground == .red)
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for the ACP `terminal/*` RPC family so agents can run processes through the host and stream output back into the UI.

- **Protocol**: `ACPTerminalMessages` + dispatcher for `terminal/create`, `terminal/output`, `terminal/wait_for_exit`, `terminal/kill`, `terminal/release` on the stdio client.
- **Runtime**: `ACPTerminal` process wrapper with rolling buffer + `ANSIStream` SGR parser. `ACPTerminalHost` is a per-session registry; the session runner routes `terminal/*` RPCs through it.
- **Model**: `ACPMessage.ToolCall` now carries `terminalIds`. The tool-call card renders the live tail structurally via `ACPTerminalTailView` (bottom-anchored, max 300 px, scroll-up for history, exit-status footer).
- **Polish**: best-effort strip of wrapping markdown code fences in tool output, so Claude's ` ``` `-wrapped responses render as plain monospaced text like Codex's raw output.

## Test plan

- [x] `xcodebuild build` succeeds on macOS
- [x] All ACP terminal-related test suites pass: `ACPSessionTests`, `ACPTerminalTests`, `ACPTerminalHostTests`, `ANSIStreamTests`, `ACPSessionTerminalRoutingTests`, `ACPStdioTerminalDispatchTests`
- [ ] Manual: run a long-output shell command through Claude and Codex agents; confirm live tail updates, fence-strip behavior, and exit footer