### PR TITLE
feat(acp): off-main session hydration + windowed transcript render

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */; };
 		3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64C0B7363363C77718B446C /* CopilotInstaller.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
+		4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */; };
 		40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */; };
 		412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
@@ -303,6 +304,7 @@
 		603D2F40A0368A139822CE80 /* ACPLaunchCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */; };
 		604E881461FC839C4233B0AF /* LSPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D394D40BC9060833DD640A /* LSPInstaller.swift */; };
 		6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */; };
+		61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D30693F45966ED1456811E /* ACPSessionHydrator.swift */; };
 		6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1874031C788ADB4398151FF1 /* StageChip.swift */; };
 		6291072E82FC282625FD1617 /* GitServiceCommitEditingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB3D6DF4A23648F0C45AC5 /* GitServiceCommitEditingTests.swift */; };
 		629B98E07ED9A159A695707D /* JetBrainsMonoNerdFont-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9110E0F4F4EF24444FA0BE3A /* JetBrainsMonoNerdFont-Regular.ttf */; };
@@ -470,6 +472,7 @@
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
 		9D2E53FB0A57BC38C146EA5E /* WorktreeLaunchSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941BC60920D6A87164610273 /* WorktreeLaunchSurface.swift */; };
 		9D439D5F19ACEB5A39B7CB68 /* CodexACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3985F2F58DB6E3BBF3520EFD /* CodexACPInstaller.swift */; };
+		9D4F9F5CE9FF51C33E32703C /* ACPMessageWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21F30DB5A812E396262A926 /* ACPMessageWire.swift */; };
 		9D6FE5A4589D73A7480CE2B2 /* IndentationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */; };
 		9DF0D37CE59DF8AAD7172443 /* ACPSetupChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */; };
 		9E302329243407946D47DC91 /* BranchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */; };
@@ -490,6 +493,7 @@
 		A2E0A755C2854FE489530FE3 /* ImageDiffDifferenceComputer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881B46F8FCAF830239357372 /* ImageDiffDifferenceComputer.swift */; };
 		A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */; };
 		A3EE2DE5C01EB87DE7BCC801 /* ACPStdioClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */; };
+		A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */; };
 		A4AB930CA0EEA2CEF0302646 /* ImageCheckerboardBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */; };
 		A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */; };
 		A58568C1EFF4A274FBDC83A4 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CA3930F30444A51FB2393D /* Theme.swift */; };
@@ -556,6 +560,7 @@
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
+		BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */; };
 		BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */; };
 		BD1CDAECF2D1928C95796F63 /* ACPSessionStoreQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */; };
 		BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */; };
@@ -632,11 +637,13 @@
 		D1C14B54BE27D97E354F448B /* ProcessGitDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */; };
 		D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F198697EB5305E5ECE97BC61 /* HarnessDetectorTests.swift */; };
 		D1FF11465D1309A56FCFFAF0 /* AppConfigCodeInstallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */; };
+		D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */; };
 		D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB58175A9A39073E9D73F85 /* GitIgnoreServiceTests.swift */; };
 		D2B345D1AEB1D5CEF48354C3 /* HoverHighlightFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */; };
 		D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */; };
 		D397C3E94E3F00F012CBE5AE /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27595490B7D883CF5D9FFD5 /* Tab.swift */; };
 		D3EAFAA986CE4441B7F103F9 /* HookCommandShellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */; };
+		D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */; };
 		D46F8DF1FB66AD0ED92F3DF0 /* ChangesTreeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910CB5077C8E89A778F1E896 /* ChangesTreeBuilder.swift */; };
 		D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DC5DBEC068EB1BFDBB7F59 /* GitEventFilterTests.swift */; };
 		D51AC3D5B34A566A90C923BB /* AgentRunnerInvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */; };
@@ -845,6 +852,7 @@
 		1B0785F1FFC8008C74009584 /* session-update-available-models.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-available-models.json"; sourceTree = "<group>"; };
 		1D3505FB870FA22C9C0FDB26 /* RightPaneStateSyncStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateSyncStatusTests.swift; sourceTree = "<group>"; };
 		1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservationsTests.swift; sourceTree = "<group>"; };
+		1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrationStateTests.swift; sourceTree = "<group>"; };
 		1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptStatusTests.swift; sourceTree = "<group>"; };
 		1EC659A56A08A30F7784428D /* ACPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPClient.swift; sourceTree = "<group>"; };
 		1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouterTests.swift; sourceTree = "<group>"; };
@@ -865,6 +873,7 @@
 		23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextView.swift; sourceTree = "<group>"; };
 		2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBindingTests.swift; sourceTree = "<group>"; };
 		2463B784210156F489A13FAC /* initialize-response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "initialize-response.json"; sourceTree = "<group>"; };
+		2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageWireTests.swift; sourceTree = "<group>"; };
 		25493E3B18A1AB94EA6985C3 /* EventHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHolder.swift; sourceTree = "<group>"; };
 		256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayoutTests.swift; sourceTree = "<group>"; };
 		25C1AD69581AAE3D34624F23 /* AgentAutoLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunch.swift; sourceTree = "<group>"; };
@@ -977,6 +986,7 @@
 		45D8B88C4D4837376C123D45 /* AgentLauncherModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModelTests.swift; sourceTree = "<group>"; };
 		45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPHarnessBridge.swift; sourceTree = "<group>"; };
 		46554893BA6205CD856B99B5 /* AppStateKeepSessionsAliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateKeepSessionsAliveTests.swift; sourceTree = "<group>"; };
+		472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerHydrationTests.swift; sourceTree = "<group>"; };
 		4749A35B3BEF89C8E7B92CD7 /* PiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstallerTests.swift; sourceTree = "<group>"; };
 		4865995B2D4B92166321201F /* CommitContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilder.swift; sourceTree = "<group>"; };
 		489C9B383554D7DAB170C2F8 /* Seg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Seg.swift; sourceTree = "<group>"; };
@@ -1125,6 +1135,7 @@
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
 		7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointingHandCursor.swift; sourceTree = "<group>"; };
 		7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCacheTests.swift; sourceTree = "<group>"; };
+		7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptWindowTests.swift; sourceTree = "<group>"; };
 		7DD6C7F7A898CE1A030F28C3 /* MergeWordDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWordDiff.swift; sourceTree = "<group>"; };
 		7E39F15B0B7395FB81D2C9D0 /* AlasApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasApp.swift; sourceTree = "<group>"; };
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
@@ -1158,6 +1169,7 @@
 		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
 		8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictColumnView.swift; sourceTree = "<group>"; };
 		8CFED7F76987C01213CB68A9 /* TabActivityPulse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulse.swift; sourceTree = "<group>"; };
+		8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydratorTests.swift; sourceTree = "<group>"; };
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
 		8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcherTests.swift; sourceTree = "<group>"; };
@@ -1185,6 +1197,7 @@
 		9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitInfoTests.swift; sourceTree = "<group>"; };
 		949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailability.swift; sourceTree = "<group>"; };
 		94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibility.swift; sourceTree = "<group>"; };
+		94D30693F45966ED1456811E /* ACPSessionHydrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrator.swift; sourceTree = "<group>"; };
 		9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAction.swift; sourceTree = "<group>"; };
 		95DA6BFFE45ED25669869C76 /* CommitMessageEditorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitMessageEditorViewTests.swift; sourceTree = "<group>"; };
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
@@ -1348,6 +1361,7 @@
 		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
 		D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftTests.swift; sourceTree = "<group>"; };
 		D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSettingsVisibilityTests.swift; sourceTree = "<group>"; };
+		D21F30DB5A812E396262A926 /* ACPMessageWire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageWire.swift; sourceTree = "<group>"; };
 		D2935EB661338757C478CD86 /* SurfaceViewShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewShortcutTests.swift; sourceTree = "<group>"; };
 		D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeWatcher.swift; sourceTree = "<group>"; };
 		D2F90D03073708AA01531533 /* GitService+Staging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+Staging.swift"; sourceTree = "<group>"; };
@@ -2116,7 +2130,9 @@
 				DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */,
 				A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */,
 				321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */,
+				D21F30DB5A812E396262A926 /* ACPMessageWire.swift */,
 				BBBEFD27FD7013D458435779 /* ACPSession.swift */,
+				94D30693F45966ED1456811E /* ACPSessionHydrator.swift */,
 				7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */,
 				F332906E17C5865856DBB90B /* ACPSessionRunner.swift */,
 				E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */,
@@ -2460,6 +2476,10 @@
 				D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */,
 				6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */,
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
+				2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */,
+				1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */,
+				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
+				472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */,
 				547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */,
@@ -2471,6 +2491,7 @@
 				F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */,
 				26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */,
 				EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */,
+				7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */,
 				FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */,
 			);
 			path = Session;
@@ -3096,6 +3117,7 @@
 				2B823A7361BB54D8D93D7C99 /* ACPMentionPicker.swift in Sources */,
 				94354D17B0FEF3F0046B452A /* ACPMessage.swift in Sources */,
 				37DD3F3B818131973DAA2B9B /* ACPMessageList.swift in Sources */,
+				9D4F9F5CE9FF51C33E32703C /* ACPMessageWire.swift in Sources */,
 				B8412B44C090B4AA6A892D25 /* ACPMessages.swift in Sources */,
 				552EBB79C20E7D939C7015A1 /* ACPMockClient.swift in Sources */,
 				E4C6E2BE1C7F20AD29C66DF0 /* ACPPermissionDecisionLog.swift in Sources */,
@@ -3110,6 +3132,7 @@
 				518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */,
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
+				61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
 				1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */,
 				027A326E7DAB6C6E133E5FD3 /* ACPSessionStore.swift in Sources */,
@@ -3495,12 +3518,16 @@
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */,
 				D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */,
+				BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */,
 				395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */,
 				4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */,
 				57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */,
 				8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */,
 				97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */,
+				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
+				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,
 				C51451EC8E103EB5FEF82EFE /* ACPSessionLifecycleTests.swift in Sources */,
+				D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
 				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,
 				D56C78F4D6A2BDFDF5A05B55 /* ACPSessionRunnerQueueTests.swift in Sources */,
@@ -3516,6 +3543,7 @@
 				D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */,
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
 				4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */,
+				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,
 				FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */,
 				7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -35,10 +35,12 @@ enum ACPMessage: Equatable {
         }
     }
 
-    struct Attachment: Codable, Equatable, Hashable { let uri: String
-    let name: String? }
+    struct Attachment: Codable, Equatable, Hashable, Sendable {
+        let uri: String
+        let name: String?
+    }
 
-    struct ToolCall: Codable, Equatable, Hashable {
+    struct ToolCall: Codable, Equatable, Hashable, Sendable {
         let toolCallId: String
         var title: String
         var kind: String?
@@ -95,13 +97,13 @@ enum ACPMessage: Equatable {
         }
     }
 
-    struct FileEdit: Codable, Equatable, Hashable {
+    struct FileEdit: Codable, Equatable, Hashable, Sendable {
         let path: String
         var added: Int
         var removed: Int
     }
 
-    struct PlanItem: Codable, Equatable, Hashable {
+    struct PlanItem: Codable, Equatable, Hashable, Sendable {
         let content: String
         var status: String   // "pending" | "in_progress" | "completed"
     }

--- a/Alas/Sources/ACP/Session/ACPMessageWire.swift
+++ b/Alas/Sources/ACP/Session/ACPMessageWire.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Sendable, isolation-free intermediate between persisted message bytes
+/// and the main-actor `ACPMessage` used by views. The hydrator decodes
+/// payloads into `ACPMessageWire` on a background actor; the main hop
+/// converts each variant into a full `ACPMessage`, which is the only
+/// place we allocate `StreamingText` (a `@MainActor` class).
+enum ACPMessageWire: Sendable {
+    case user(text: String, attachments: [ACPMessage.Attachment])
+    case agent(text: String)
+    case thought(text: String)
+    case toolCall(ACPMessage.ToolCall)
+    case fileEdit(ACPMessage.FileEdit)
+    case plan([ACPMessage.PlanItem])
+    case systemNotice(text: String)
+
+    /// Decode a persisted `(kind, payload)` pair into the matching wire variant.
+    /// Mirrors `ACPMessageCodec.decode` but produces Sendable values and is
+    /// safe to call from any isolation domain. Unknown kinds become system
+    /// notices (matching the legacy fallback).
+    ///
+    /// `decoder` may be a shared instance reused across many calls (e.g. by
+    /// `ACPSessionHydrator` when decoding an entire transcript); defaults to
+    /// a per-call instance when callers don't care.
+    static func decode(
+        kind: String,
+        payload: Data,
+        decoder: JSONDecoder = JSONDecoder()
+    ) throws -> ACPMessageWire {
+        switch kind {
+        case "user":
+            let p = try decoder.decode(UserPayload.self, from: payload)
+            return .user(text: p.text, attachments: p.attachments)
+        case "agent":
+            return .agent(text: try decoder.decode(TextPayload.self, from: payload).text)
+        case "thought":
+            return .thought(text: try decoder.decode(TextPayload.self, from: payload).text)
+        case "tool_call":
+            return .toolCall(try decoder.decode(ACPMessage.ToolCall.self, from: payload))
+        case "file_edit":
+            return .fileEdit(try decoder.decode(ACPMessage.FileEdit.self, from: payload))
+        case "plan":
+            return .plan(try decoder.decode(PlanPayload.self, from: payload).items)
+        case "system":
+            return .systemNotice(text: try decoder.decode(TextPayload.self, from: payload).text)
+        default:
+            return .systemNotice(text: "(unknown message kind: \(kind))")
+        }
+    }
+
+    /// Convert to a full `ACPMessage`. Must run on the main actor because
+    /// `StreamingText` is `@MainActor`-isolated.
+    @MainActor
+    func toMessage() -> ACPMessage {
+        switch self {
+        case .user(let text, let attachments):
+            return .user(id: UUID(), text: text, attachments: attachments)
+        case .agent(let text):
+            return .agent(id: UUID(), StreamingText(text))
+        case .thought(let text):
+            return .thought(id: UUID(), StreamingText(text))
+        case .toolCall(let tc):
+            return .toolCall(tc)
+        case .fileEdit(let fe):
+            return .fileEdit(id: UUID(), fe)
+        case .plan(let items):
+            return .plan(id: UUID(), items)
+        case .systemNotice(let text):
+            return .systemNotice(id: UUID(), text: text)
+        }
+    }
+
+    private struct TextPayload: Decodable { let text: String }
+    private struct UserPayload: Decodable {
+        let text: String
+        let attachments: [ACPMessage.Attachment]
+    }
+    private struct PlanPayload: Decodable { let items: [ACPMessage.PlanItem] }
+}

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -34,6 +34,12 @@ final class ACPSession: ObservableObject, Identifiable {
     /// composer's send button watches this so users can't queue prompts
     /// against a not-yet-attached agent.
     @Published var attached: Bool = false
+    /// Tracks whether the session's persisted state (messages, queue, draft,
+    /// row fields) has been loaded from SQLite. `.loading` is the initial
+    /// state for sessions returned by `placeholderSession`; `.ready` is the
+    /// initial state for sessions returned by `createSession`. `.failed`
+    /// surfaces a hydration error to the view.
+    @Published var hydrationState: HydrationState
     /// ACP session id assigned by the agent on `session/new` (or the
     /// id we passed to `session/load`). Used for every subsequent
     /// protocol call (`session/prompt`, `session/cancel`, etc).
@@ -57,6 +63,11 @@ final class ACPSession: ObservableObject, Identifiable {
         composerDraftRevision += 1
     }
 
+    enum HydrationState: Equatable {
+        case loading
+        case ready
+        case failed(String)
+    }
     enum StreamingState: Equatable { case idle, sending, streaming, awaitingPermission }
     enum SetupState: Equatable {
         case checking
@@ -68,12 +79,15 @@ final class ACPSession: ObservableObject, Identifiable {
         let params: ACPPermissionRequestParams
     }
 
-    init(id: ID, agentId: String, worktreeId: String, title: String, createdAt: Date = Date()) {
+    init(id: ID, agentId: String, worktreeId: String, title: String,
+         createdAt: Date = Date(),
+         hydrationState: HydrationState = .ready) {
         self.id = id
         self.agentId = agentId
         self.worktreeId = worktreeId
         self.title = title
         self.createdAt = createdAt
+        self.hydrationState = hydrationState
     }
 
     func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {

--- a/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Off-main hydration of an ACP session's persisted state. Owns its own
+/// `SQLiteDatabase` handle on the manager's underlying store path; safe
+/// to run concurrently with main-thread writes via SQLite's WAL mode and
+/// `SQLITE_OPEN_FULLMUTEX` (set by `SQLiteDatabase.init`).
+///
+/// Returns a Sendable `HydrationResult`; the caller converts `wireMessages`
+/// to `[ACPMessage]` on the main actor (where `StreamingText` can be
+/// allocated).
+actor ACPSessionHydrator {
+    enum Error: Swift.Error, Equatable {
+        case sessionNotFound(String)
+    }
+
+    private let store: ACPSessionStore
+    private let decoder = JSONDecoder()
+
+    init(path: String) throws {
+        self.store = try ACPSessionStore(path: path)
+    }
+
+    func hydrate(sessionId: String) async throws -> HydrationResult {
+        guard let row = try store.loadSession(id: sessionId) else {
+            throw Error.sessionNotFound(sessionId)
+        }
+
+        // Decode every stored message into a Sendable wire variant.
+        // Malformed payloads are skipped (matching the legacy try? in
+        // openSession) rather than failing the whole hydration.
+        let stored = try store.loadMessages(sessionId: sessionId)
+        var wire: [ACPMessageWire] = []
+        wire.reserveCapacity(stored.count)
+        for m in stored {
+            if let w = try? ACPMessageWire.decode(kind: m.kind, payload: m.payload, decoder: decoder) {
+                wire.append(w)
+            }
+        }
+
+        let queue = (try? store.loadQueue(sessionId: sessionId)) ?? []
+        let draft = try? store.loadComposerDraft(sessionId: sessionId)
+
+        // Post-load side effect: bump `last_opened_at` so the recents
+        // list orders this session to the top. Use the narrow UPDATE
+        // helper instead of `upsertSession` — the latter would resurrect
+        // a row the user deleted between our `loadSession` read and now,
+        // and would also rewrite `archived` back to whatever we captured.
+        let now = Int64(Date().timeIntervalSince1970)
+        try? store.touchLastOpenedAt(id: sessionId, at: now)
+        let touched = ACPSessionRow(
+            id: row.id, agentId: row.agentId, title: row.title,
+            currentModel: row.currentModel, currentMode: row.currentMode,
+            autoRun: row.autoRun,
+            createdAt: row.createdAt, updatedAt: row.updatedAt,
+            lastOpenedAt: now,
+            archived: row.archived)
+        let recent = (try? store.recentSessions()) ?? []
+
+        return HydrationResult(
+            row: touched,
+            wireMessages: wire,
+            queue: queue,
+            draft: draft,
+            recent: recent)
+    }
+}
+
+/// Sendable snapshot returned by the hydrator. The main actor unwraps
+/// `wireMessages` into full `ACPMessage` values (which contain
+/// `StreamingText`, a `@MainActor` class).
+struct HydrationResult: Sendable {
+    let row: ACPSessionRow
+    let wireMessages: [ACPMessageWire]
+    let queue: [QueuedPrompt]
+    let draft: ACPComposerDraft?
+    let recent: [ACPSessionRow]
+}

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -23,8 +23,11 @@ final class ACPSessionManager: ObservableObject {
     /// further keystroke so a typing burst produces one write.
     private var pendingDraftWrites: [ACPSession.ID: Task<Void, Never>] = [:]
     private static let draftDebounceNanos: UInt64 = 300_000_000
+    private let hydrator: ACPSessionHydrator?
+    private var inFlightHydrations: [ACPSession.ID: Task<Void, Never>] = [:]
 
     init(worktreeId: String, worktreePath: String, store: ACPSessionStore,
+         hydratorPath: String? = nil,
          onDirtyCheck: ((String) -> Bool)? = nil,
          onLiveBufferRead: ((String) -> String?)? = nil)
     {
@@ -33,6 +36,7 @@ final class ACPSessionManager: ObservableObject {
         self.store = store
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
+        self.hydrator = hydratorPath.flatMap { try? ACPSessionHydrator(path: $0) }
         self.recent = (try? store.recentSessions()) ?? []
     }
 
@@ -44,38 +48,142 @@ final class ACPSessionManager: ObservableObject {
             currentModel: nil, currentMode: nil, autoRun: false,
             createdAt: now, updatedAt: now, lastOpenedAt: now, archived: false)
         try? store.upsertSession(row)
-        let session = ACPSession(id: id, agentId: agentId, worktreeId: worktreeId, title: row.title)
+        let session = ACPSession(
+            id: id, agentId: agentId, worktreeId: worktreeId,
+            title: row.title, hydrationState: .ready)
         sessions[id] = session
         refreshRecent()
         return session
     }
 
-    func openSession(id: ACPSession.ID) -> ACPSession? {
+    /// Returns a cached session or a `.loading` placeholder. Cache hits
+    /// are O(1); cache misses do a single indexed `loadSession` query
+    /// against SQLite so we don't insert orphan loading entries for
+    /// typo'd ids. The heavy work (loading every message, decoding,
+    /// reading the queue + draft) is deferred to `hydrateIfNeeded`.
+    func placeholderSession(id: ACPSession.ID) -> ACPSession? {
         if let s = sessions[id] { return s }
+        // Verify the session exists before allocating a placeholder so we
+        // don't insert orphan loading entries for typo'd ids.
         guard let row = try? store.loadSession(id: id) else { return nil }
-        let session = ACPSession(id: row.id, agentId: row.agentId, worktreeId: worktreeId, title: row.title)
-        // Restore transcript
-        if let stored = try? store.loadMessages(sessionId: id) {
-            for m in stored {
-                if let decoded = try? ACPMessageCodec.decode(kind: m.kind, payload: m.payload) {
-                    session.transcript.messages.append(decoded)
-                }
+        let session = ACPSession(
+            id: row.id, agentId: row.agentId, worktreeId: worktreeId,
+            title: row.title, hydrationState: .loading)
+        sessions[id] = session
+        return session
+    }
+
+    /// Drives a session from `.loading` to `.ready` (or `.failed`). Safe to
+    /// call multiple times concurrently — duplicate callers await the same
+    /// in-flight task. No-op when the session is already `.ready` or
+    /// `.failed`.
+    func hydrateIfNeeded(id: ACPSession.ID) async {
+        guard let session = sessions[id] else { return }
+        guard session.hydrationState == .loading else { return }
+        if let existing = inFlightHydrations[id] {
+            await existing.value
+            // The in-flight task captured an earlier session instance; if
+            // it was closed + reopened while we awaited, the new placeholder
+            // (still `.loading`) needs its own hydration pass. Recurse once
+            // so the visible session reaches `.ready`. The guards at the
+            // top prevent runaway recursion — they'll see the just-applied
+            // `.ready` from a happy-path completion and exit. The task body
+            // clears `inFlightHydrations[id]` before returning, so the
+            // recursive call won't re-await the completed task.
+            await hydrateIfNeeded(id: id)
+            return
+        }
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.runHydration(id: id, session: session)
+            // Clear the map from inside the task body so any waiter that
+            // resumes from `await existing.value` observes a clean slate
+            // and can spawn a fresh hydration for a reopened placeholder
+            // rather than re-awaiting this completed task.
+            self.inFlightHydrations[id] = nil
+        }
+        inFlightHydrations[id] = task
+        await task.value
+    }
+
+    private func runHydration(id: ACPSession.ID, session: ACPSession) async {
+        do {
+            let result: HydrationResult
+            if let hydrator {
+                result = try await hydrator.hydrate(sessionId: id)
+            } else {
+                // No off-main hydrator (test fallback): perform the same
+                // work synchronously via the manager's store.
+                result = try synchronousHydrate(id: id)
+            }
+            // Drop the result if the captured session was closed (or closed
+            // and reopened — the cached entry now points to a different
+            // ACPSession instance) while we awaited. The fresh placeholder
+            // will be hydrated by the recursive call in `hydrateIfNeeded`.
+            guard sessions[id] === session else { return }
+            applyHydration(result, to: session)
+        } catch {
+            guard sessions[id] === session else { return }
+            session.hydrationState = .failed(error.localizedDescription)
+        }
+    }
+
+    /// Synchronous hydration fallback used when no hydrator was wired in
+    /// (tests that construct the manager without a path). Same data, same
+    /// shape — just on the main thread.
+    private func synchronousHydrate(id: ACPSession.ID) throws -> HydrationResult {
+        guard let row = try store.loadSession(id: id) else {
+            throw ACPSessionHydrator.Error.sessionNotFound(id)
+        }
+        let stored = (try? store.loadMessages(sessionId: id)) ?? []
+        var wire: [ACPMessageWire] = []
+        wire.reserveCapacity(stored.count)
+        let decoder = JSONDecoder()
+        for m in stored {
+            if let w = try? ACPMessageWire.decode(kind: m.kind, payload: m.payload, decoder: decoder) {
+                wire.append(w)
             }
         }
-        // Restore queue
-        if let queue = try? store.loadQueue(sessionId: id) {
-            session.restoreQueue(queue)
+        let queue = (try? store.loadQueue(sessionId: id)) ?? []
+        let draft = try? store.loadComposerDraft(sessionId: id)
+        let now = Int64(Date().timeIntervalSince1970)
+        try? store.touchLastOpenedAt(id: id, at: now)
+        let touched = ACPSessionRow(
+            id: row.id, agentId: row.agentId, title: row.title,
+            currentModel: row.currentModel, currentMode: row.currentMode,
+            autoRun: row.autoRun,
+            createdAt: row.createdAt, updatedAt: row.updatedAt,
+            lastOpenedAt: now,
+            archived: row.archived)
+        let recent = (try? store.recentSessions()) ?? []
+        return HydrationResult(row: touched, wireMessages: wire,
+                               queue: queue, draft: draft, recent: recent)
+    }
+
+    private func applyHydration(_ result: HydrationResult, to session: ACPSession) {
+        // Convert wire variants into full ACPMessages (allocates StreamingText
+        // for agent/thought) in one main-actor pass.
+        session.transcript.messages = result.wireMessages.map { $0.toMessage() }
+        session.transcript.resetWindowToTail()
+        session.restoreQueue(result.queue)
+        // The composer is rendered (and focused) the moment the placeholder
+        // appears, so the user can start typing before hydration finishes.
+        // Only restore the persisted draft when the live composer is still
+        // pristine (revision == 0); an intentional clear still bumps the
+        // revision, so it's distinguishable from "never edited" even though
+        // both leave `composerDraft.isEmpty == true`.
+        if let draft = result.draft, session.composerDraftRevision == 0 {
+            session.replaceComposerDraft(draft)
         }
-        session.currentModel = row.currentModel
-        session.currentMode = row.currentMode
-        session.autoRunEnabled = row.autoRun
-        if let loadedDraft = try? store.loadComposerDraft(sessionId: id) {
-            session.replaceComposerDraft(loadedDraft)
-        }
-        sessions[id] = session
-        try? store.upsertSession(touch(row))
-        refreshRecent()
-        return session
+        session.currentModel = result.row.currentModel
+        session.currentMode = result.row.currentMode
+        session.autoRunEnabled = result.row.autoRun
+        // Title intentionally NOT overwritten: `placeholderSession` already
+        // seeded it from the same row, and a rename made through the
+        // toolbar during the hydration window should win against the value
+        // we captured before the user typed it.
+        session.hydrationState = .ready
+        self.recent = result.recent
     }
 
     func closeSession(id: ACPSession.ID) {
@@ -224,12 +332,6 @@ final class ACPSessionManager: ObservableObject {
     func refreshRecent() {
         recent = (try? store.recentSessions()) ?? []
     }
-
-    private func touch(_ row: ACPSessionRow) -> ACPSessionRow {
-        var r = row
-        r.lastOpenedAt = Int64(Date().timeIntervalSince1970)
-        return r
-    }
 }
 
 // MARK: - Process lifecycle
@@ -289,8 +391,8 @@ extension ACPSessionManager {
             // server doesn't know about our local UUID, and `remoteSessionId`
             // (the id `session/new` previously returned) isn't persisted.
             // Most ACP agents also don't implement `session/load`. The user-
-            // visible history comes from the local SQLite store, loaded in
-            // `openSession`; the server just gets a fresh conversation.
+            // visible history comes from the local SQLite store, loaded via
+            // `hydrateIfNeeded`; the server just gets a fresh conversation.
             let result = try await connection.newSession(cwd: worktreePath)
             session.remoteSessionId = result.sessionId
             session.availableModels = result.availableModels
@@ -334,10 +436,10 @@ extension ACPSessionManager {
             // owned it is gone with the runner, so the next attach must
             // see a `.pending` head to be able to flush it. Without this,
             // closing a tab mid-flush leaves the cached session's head
-            // as `.sending`; the next openSession returns the cached
-            // object (skipping `restoreQueue`), the post-attach flush
-            // sees `.sending`, and the queue stays stuck until a full
-            // app restart reloads from SQLite.
+            // as `.sending`; the next `placeholderSession` returns the
+            // cached object (skipping `restoreQueue`), the post-attach
+            // flush sees `.sending`, and the queue stays stuck until a
+            // full app restart reloads from SQLite.
             session.restoreQueue(session.queue)
         }
         if let runner = runners.removeValue(forKey: sessionId) {

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -149,6 +149,17 @@ extension ACPSessionStore {
         return rows.first.map(Self.rowToSession)
     }
 
+    /// Bump `last_opened_at` for an existing row without touching any
+    /// other field. No-op if the row is gone (the user deleted the
+    /// session) — unlike `upsertSession`, this never resurrects a
+    /// deleted row or flips `archived` back to false.
+    func touchLastOpenedAt(id: String, at timestamp: Int64) throws {
+        try db.exec(
+            "UPDATE sessions SET last_opened_at = ? WHERE id = ?",
+            bindings: [timestamp, id]
+        )
+    }
+
     func recentSessions(limit: Int = 50) throws -> [ACPSessionRow] {
         let rows = try db.query("""
         SELECT * FROM sessions WHERE archived = 0 ORDER BY last_opened_at DESC LIMIT ?

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -21,6 +21,18 @@ final class ACPTranscript: ObservableObject {
     /// tree stable across ticks.
     @Published var streamingTick: UInt32 = 0
 
+    /// Render window: `ACPMessageList` draws `messages[visibleHead...]`.
+    /// Reset to `max(0, messages.count - tailWindow)` after hydration so
+    /// long transcripts paint quickly; user can scroll up or click the
+    /// "Earlier messages…" affordance to reveal older rows in chunks of
+    /// `tailWindow`.
+    @Published var visibleHead: Int = 0
+
+    /// Number of rows revealed per backfill step. Tuned for chat-style
+    /// content where a screenful is a few rows; bigger steps feel like
+    /// loading state, smaller steps require too many clicks.
+    static let tailWindow: Int = 30
+
     // MARK: - Per-message markdown caches
 
     private var markdownCaches: [String: ACPMarkdownBlockCache] = [:]
@@ -53,5 +65,20 @@ final class ACPTranscript: ObservableObject {
             if case .plan(_, let items) = m { return items }
         }
         return nil
+    }
+
+    // MARK: - Render window helpers
+
+    /// Reset `visibleHead` to show the last `tailWindow` messages. Call
+    /// after hydration applies a transcript. No-op for transcripts shorter
+    /// than `tailWindow`.
+    func resetWindowToTail() {
+        visibleHead = max(0, messages.count - Self.tailWindow)
+    }
+
+    /// Reveal one more `tailWindow`-sized chunk of older messages.
+    /// Clamps at zero. Idempotent at the head.
+    func stepHeadBack() {
+        visibleHead = max(0, visibleHead - Self.tailWindow)
     }
 }

--- a/Alas/Sources/ACP/UI/ACPHistorySidebar.swift
+++ b/Alas/Sources/ACP/UI/ACPHistorySidebar.swift
@@ -27,7 +27,7 @@ struct ACPHistorySidebar: View {
 
     private func rowView(_ row: ACPSessionRow) -> some View {
         Button {
-            _ = manager.openSession(id: row.id)
+            _ = manager.placeholderSession(id: row.id)
         } label: {
             HStack(spacing: 8) {
                 if let agent = agentLookup(row.agentId) {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -19,6 +19,8 @@ struct ACPMessageList: View {
     @State private var tailFrame: CGRect = .zero
     @State private var isRestoringTail = false
     @State private var userInterruptedTailRestore = false
+    @State private var headFrame: CGRect = .zero
+    @State private var lastHeadStepAt: Date = .distantPast
 
     /// Height of an invisible spacer at the tail of the VStack. The
     /// composer pill plus its outer padding occupies roughly this much
@@ -27,7 +29,26 @@ struct ACPMessageList: View {
     /// above the composer instead of behind it.
     private let composerSpacerHeight: CGFloat = 220
     private let tailTolerance: CGFloat = 36
+    /// Step the visible head back when the "Earlier messages…" marker
+    /// crosses this many points from the top edge during scroll.
+    private let headStepScrollThreshold: CGFloat = 200
+    /// Minimum gap between automatic head-back steps so a single scroll
+    /// doesn't decrement multiple times before layout settles.
+    private let headStepDebounceInterval: TimeInterval = 0.3
     private var scrollSpaceName: String { "acp-message-list-\(session.id)" }
+
+    /// Window-sliced, plan-filtered list of rows to render. The slice
+    /// bounds first-paint cost on long transcripts (`visibleHead` is
+    /// reset to `max(0, count - tailWindow)` after hydration); the
+    /// filter drops `.plan` entries because the toolbar pill renders
+    /// the current turn's plan instead of an inline card.
+    private var visibleMessages: [ACPMessage] {
+        let head = min(transcript.visibleHead, transcript.messages.count)
+        return transcript.messages[head...].filter {
+            if case .plan = $0 { return false }
+            return true
+        }
+    }
 
     /// Cheap signature of the entire transcript. SwiftUI re-evaluates when
     /// any cell mutates (e.g. an agent_message_chunk merging into the
@@ -63,21 +84,35 @@ struct ACPMessageList: View {
         return hasher.finalize()
     }
 
-    /// Messages excluding plan entries — the plan now lives in the
-    /// toolbar pill, not in the transcript scroll list.
-    private var displayedMessages: [ACPMessage] {
-        transcript.messages.filter {
-            if case .plan = $0 { return false }
-            return true
-        }
-    }
-
     var body: some View {
         ScrollViewReader { proxy in
             GeometryReader { viewport in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
-                        ForEach(displayedMessages, id: \.stableId) { message in
+                        if transcript.visibleHead > 0 {
+                            Button {
+                                transcript.stepHeadBack()
+                            } label: {
+                                Text("Earlier messages\u{2026}")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(theme.color("fg-muted"))
+                                    .padding(.horizontal, 10).padding(.vertical, 4)
+                                    .background(theme.color("bg-1").opacity(0.6))
+                                    .clipShape(Capsule())
+                            }
+                            .buttonStyle(.plain)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.bottom, 4)
+                            .background(
+                                GeometryReader { headGeom in
+                                    Color.clear.preference(
+                                        key: ACPHeadFramePreferenceKey.self,
+                                        value: headGeom.frame(in: .named(scrollSpaceName))
+                                    )
+                                }
+                            )
+                        }
+                        ForEach(visibleMessages, id: \.stableId) { message in
                             row(for: message)
                         }
                         if transcript.pendingPermission != nil, let policy = policy {
@@ -145,6 +180,26 @@ struct ACPMessageList: View {
                 }
                 .onPreferenceChange(ACPTailFramePreferenceKey.self) { frame in
                     tailFrame = frame
+                }
+                .onPreferenceChange(ACPHeadFramePreferenceKey.self) { frame in
+                    headFrame = frame
+                    // Step back when the head marker enters the threshold
+                    // band at the top of the viewport; debounce so a single
+                    // scroll doesn't decrement multiple times before SwiftUI
+                    // lays out the newly-revealed rows.
+                    // `frame.maxY > 0` ensures the marker is actually
+                    // visible — without it, restoring to the tail of a
+                    // long transcript puts the marker far above the
+                    // viewport (negative minY *and* negative maxY) and the
+                    // initial preference fire would still satisfy
+                    // `minY < threshold`, defeating the window before the
+                    // user scrolled.
+                    guard transcript.visibleHead > 0 else { return }
+                    guard frame.minY < headStepScrollThreshold, frame.maxY > 0 else { return }
+                    let now = Date()
+                    guard now.timeIntervalSince(lastHeadStepAt) > headStepDebounceInterval else { return }
+                    lastHeadStepAt = now
+                    transcript.stepHeadBack()
                 }
                 .onChange(of: scrollSignature) { _, _ in
                     if session.followsTranscriptTail {
@@ -241,6 +296,13 @@ struct ACPMessageList: View {
 private struct ACPTailFramePreferenceKey: PreferenceKey {
     static let defaultValue: CGRect = .zero
 
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        value = nextValue()
+    }
+}
+
+private struct ACPHeadFramePreferenceKey: PreferenceKey {
+    static let defaultValue: CGRect = .zero
     static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
         value = nextValue()
     }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -7,7 +7,7 @@ struct ACPTabView: View {
 
     var body: some View {
         if let manager = state.acpManager(for: worktree),
-           let session = manager.openSession(id: sessionId) {
+           let session = manager.placeholderSession(id: sessionId) {
             ACPSessionView(
                 sessionId: sessionId,
                 state: state,
@@ -70,11 +70,13 @@ private struct ACPSessionView: View {
             if let err = session.lastError {
                 errorBanner(err)
             }
+            if case .failed(let msg) = session.hydrationState {
+                hydrationFailureBanner(message: msg)
+            }
             transcriptAndComposer
         }
         .task(id: sessionId) {
-            let freshlyCreated = manager.runners[sessionId] == nil && session.transcript.messages.isEmpty
-            await manager.attach(to: sessionId, freshlyCreated: freshlyCreated)
+            await hydrateAndAttach()
         }
         .focusable()
         .onKeyPress(.escape) {
@@ -100,6 +102,7 @@ private struct ACPSessionView: View {
     /// fresh open. Don't show the empty transcript or "agent not yet
     /// attached" warning during this — render a skeleton instead.
     private var isConnecting: Bool {
+        if session.hydrationState == .loading { return true }
         guard manager.runners[sessionId] == nil else { return false }
         if case .needsSetup = session.setupState { return false }
         if session.lastError != nil { return false }
@@ -251,6 +254,47 @@ private struct ACPSessionView: View {
         .background(theme.color("bg-1").opacity(0.6))
         .overlay(alignment: .bottom) {
             Rectangle().fill(theme.color("line")).frame(height: 0.5)
+        }
+    }
+
+    /// Drive a session from `.loading` through `.ready` (or `.failed`)
+    /// and, on success, attach the runner. Used by both the initial
+    /// `.task(id:)` and the failure banner's Retry button so a successful
+    /// retry doesn't leave the session unattached with a disabled composer.
+    private func hydrateAndAttach() async {
+        await manager.hydrateIfNeeded(id: sessionId)
+        if case .failed = session.hydrationState { return }
+        let freshlyCreated = manager.runners[sessionId] == nil
+            && session.transcript.messages.isEmpty
+        await manager.attach(to: sessionId, freshlyCreated: freshlyCreated)
+    }
+
+    private func hydrationFailureBanner(message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(theme.color("del"))
+            Text("Failed to load session history: \(message)")
+                .font(.system(size: 12))
+                .foregroundStyle(theme.color("fg"))
+                .textSelection(.enabled)
+            Spacer()
+            Button("Retry") {
+                session.hydrationState = .loading
+                // Mirror the initial `.task(id:)` so a successful retry
+                // continues into `attach`. Without this, the runner stays
+                // nil and the composer can't send.
+                Task { await hydrateAndAttach() }
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: 11, weight: .medium))
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(theme.color("del").opacity(0.18))
+            .clipShape(Capsule())
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(theme.color("del").opacity(0.10))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(theme.color("del").opacity(0.3)).frame(height: 0.5)
         }
     }
 

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2338,6 +2338,7 @@ final class AppState {
                 worktreeId: worktree.id,
                 worktreePath: worktree.path.path,
                 store: store,
+                hydratorPath: dbURL.path,
                 onDirtyCheck: { [weak self] path in
                     self?.editorHasDirtyBuffer(for: path, worktreeId: worktree.id) ?? false
                 },
@@ -2416,7 +2417,7 @@ final class AppState {
         } else {
             title = "ACP session"
         }
-        _ = mgr.openSession(id: sessionId)
+        _ = mgr.placeholderSession(id: sessionId)
         let state = ACPSessionTabState(sessionId: sessionId, title: title)
         tabs.append(acpSession: state, to: worktree.id)
     }

--- a/AlasTests/ACP/Session/ACPMessageWireTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageWireTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPMessageWire")
+struct ACPMessageWireTests {
+    @Test("decode round-trips user payload")
+    func userRoundTrip() throws {
+        let original: ACPMessage = .user(
+            id: UUID(),
+            text: "hello",
+            attachments: [.init(uri: "file:///x.txt", name: "x.txt")])
+        let payload = try ACPMessageCodec.encode(original)
+        let wire = try ACPMessageWire.decode(kind: "user", payload: payload)
+        guard case let .user(text, attachments) = wire else {
+            #expect(Bool(false), "expected .user, got \(wire)")
+            return
+        }
+        #expect(text == "hello")
+        #expect(attachments == [.init(uri: "file:///x.txt", name: "x.txt")])
+    }
+
+    @Test("decode round-trips agent text")
+    func agentRoundTrip() throws {
+        let original: ACPMessage = .agent(id: UUID(), StreamingText("agent prose"))
+        let payload = try ACPMessageCodec.encode(original)
+        let wire = try ACPMessageWire.decode(kind: "agent", payload: payload)
+        guard case let .agent(text) = wire else {
+            #expect(Bool(false), "expected .agent, got \(wire)")
+            return
+        }
+        #expect(text == "agent prose")
+    }
+
+    @Test("decode round-trips tool call")
+    func toolCallRoundTrip() throws {
+        let tc = ACPMessage.ToolCall(
+            toolCallId: "tc1", title: "read",
+            kind: "fs.read", status: "completed",
+            content: "abc", preview: "abc",
+            locations: ["/a"])
+        let original: ACPMessage = .toolCall(tc)
+        let payload = try ACPMessageCodec.encode(original)
+        let wire = try ACPMessageWire.decode(kind: "tool_call", payload: payload)
+        guard case let .toolCall(decoded) = wire else {
+            #expect(Bool(false), "expected .toolCall, got \(wire)")
+            return
+        }
+        #expect(decoded == tc)
+    }
+
+    @Test("unknown kind decodes to system notice")
+    func unknownKind() throws {
+        let wire = try ACPMessageWire.decode(kind: "mystery", payload: Data())
+        guard case let .systemNotice(text) = wire else {
+            #expect(Bool(false), "expected .systemNotice, got \(wire)")
+            return
+        }
+        #expect(text.contains("unknown message kind"))
+    }
+
+    @Test("toMessage produces ACPMessage with fresh ids")
+    func toMessage() throws {
+        let wire: ACPMessageWire = .agent(text: "x")
+        let m1 = wire.toMessage()
+        let m2 = wire.toMessage()
+        // Same wire, different UUIDs each call (matches existing decode behavior).
+        guard case let .agent(id1, _) = m1, case let .agent(id2, _) = m2 else {
+            #expect(Bool(false))
+            return
+        }
+        #expect(id1 != id2)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionHydrationStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionHydrationStateTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSession.HydrationState")
+struct ACPSessionHydrationStateTests {
+    @Test("init defaults to .ready")
+    func defaultsToReady() {
+        let s = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
+        #expect(s.hydrationState == .ready)
+    }
+
+    @Test("explicit loading init")
+    func explicitLoading() {
+        let s = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt",
+                           title: "t", hydrationState: .loading)
+        #expect(s.hydrationState == .loading)
+    }
+
+    @Test("state transitions")
+    func transitions() {
+        let s = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt",
+                           title: "t", hydrationState: .loading)
+        s.hydrationState = .ready
+        #expect(s.hydrationState == .ready)
+        s.hydrationState = .failed("boom")
+        if case .failed(let m) = s.hydrationState { #expect(m == "boom") }
+        else { #expect(Bool(false), "expected .failed") }
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionHydratorTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionHydratorTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPSessionHydrator")
+struct ACPSessionHydratorTests {
+    private func tmpStorePath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("hydrator-\(UUID()).sqlite").path
+    }
+
+    @Test("hydrates row, messages, queue, draft")
+    func happyPath() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "demo",
+            currentModel: "sonnet", currentMode: "agent",
+            autoRun: true,
+            createdAt: 1, updatedAt: 1, lastOpenedAt: 1, archived: false))
+
+        // Seed three messages of different kinds. ACPMessage construction
+        // and ACPMessageCodec.encode are @MainActor, so we hop.
+        let payloads: [(String, Data)] = try await MainActor.run {
+            let user: ACPMessage = .user(id: UUID(), text: "hi", attachments: [])
+            let agent: ACPMessage = .agent(id: UUID(), StreamingText("yo"))
+            let tool: ACPMessage = .toolCall(.init(
+                toolCallId: "tc", title: "read", status: "completed",
+                content: "abc", preview: "abc", locations: []))
+            return try [user, agent, tool].map { ($0.kind, try ACPMessageCodec.encode($0)) }
+        }
+        for (i, p) in payloads.enumerated() {
+            try store.appendMessage(
+                sessionId: "s", id: "m\(i)", kind: p.0,
+                seq: Int64(i), payload: p.1, createdAt: Int64(i))
+        }
+
+        // Seed queue + draft.
+        try store.upsertQueue(sessionId: "s", items: [
+            QueuedPrompt(blocks: [.text("queued")])
+        ])
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: ACPComposerDraft(segments: [.text("draft")]),
+            updatedAt: 2)
+
+        let hydrator = try ACPSessionHydrator(path: path)
+        let result = try await hydrator.hydrate(sessionId: "s")
+
+        #expect(result.row.id == "s")
+        #expect(result.row.title == "demo")
+        #expect(result.row.currentModel == "sonnet")
+        #expect(result.row.autoRun == true)
+        #expect(result.wireMessages.count == 3)
+        #expect(result.queue.count == 1)
+        #expect(result.draft != nil)
+        #expect(result.recent.contains(where: { $0.id == "s" }))
+    }
+
+    @Test("missing session throws")
+    func missingSession() async throws {
+        let path = tmpStorePath()
+        _ = try ACPSessionStore(path: path) // create schema
+        let hydrator = try ACPSessionHydrator(path: path)
+        await #expect(throws: ACPSessionHydrator.Error.self) {
+            _ = try await hydrator.hydrate(sessionId: "missing")
+        }
+    }
+
+    @Test("malformed payload is skipped, others survive")
+    func malformedSkip() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        // One good message + one corrupt payload.
+        let goodPayload = try await MainActor.run {
+            let m: ACPMessage = .user(id: UUID(), text: "ok", attachments: [])
+            return try ACPMessageCodec.encode(m)
+        }
+        try store.appendMessage(sessionId: "s", id: "g", kind: "user",
+                                seq: 0, payload: goodPayload, createdAt: 0)
+        try store.appendMessage(sessionId: "s", id: "bad", kind: "user",
+                                seq: 1, payload: Data([0xFF, 0xFE]), createdAt: 1)
+
+        let hydrator = try ACPSessionHydrator(path: path)
+        let result = try await hydrator.hydrate(sessionId: "s")
+        #expect(result.wireMessages.count == 1)
+    }
+
+    @Test("hydrate bumps lastOpenedAt via touch(row)")
+    func touchesLastOpenedAt() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 100, updatedAt: 100, lastOpenedAt: 100, archived: false
+        ))
+
+        let hydrator = try ACPSessionHydrator(path: path)
+        _ = try await hydrator.hydrate(sessionId: "s")
+
+        // touch() rewrites lastOpenedAt to now (a recent unix timestamp).
+        let row = try #require(try store.loadSession(id: "s"))
+        #expect(row.lastOpenedAt > 100)
+    }
+
+    @Test("hydrate of a deleted session does not resurrect it")
+    func deletedSessionStaysDeleted() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false
+        ))
+        let hydrator = try ACPSessionHydrator(path: path)
+        // Delete the row through the manager's store handle while the
+        // hydrator still holds its own snapshot. With the old
+        // `upsertSession` touch the hydrator would re-insert the row.
+        try store.deleteSession(id: "s")
+        _ = try? await hydrator.hydrate(sessionId: "s")
+        #expect(try store.loadSession(id: "s") == nil)
+    }
+
+    @Test("hydrate of an archived session does not un-archive it")
+    func archivedSessionStaysArchived() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false
+        ))
+        let hydrator = try ACPSessionHydrator(path: path)
+        try store.setArchived(id: "s", archived: true)
+        _ = try await hydrator.hydrate(sessionId: "s")
+        let row = try #require(try store.loadSession(id: "s"))
+        #expect(row.archived == true)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -1,0 +1,254 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSessionManager hydration")
+struct ACPSessionManagerHydrationTests {
+    private func tmpStorePath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-hydration-\(UUID()).sqlite").path
+    }
+
+    @Test("placeholderSession returns .loading session synchronously")
+    func placeholderSync() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        #expect(s.hydrationState == .loading)
+        #expect(s.transcript.messages.isEmpty)
+        #expect(mgr.sessions["s"] === s)
+    }
+
+    @Test("placeholderSession returns nil for unknown session")
+    func placeholderNil() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        #expect(mgr.placeholderSession(id: "ghost") == nil)
+    }
+
+    @Test("placeholderSession is idempotent for cached sessions")
+    func placeholderCached() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let created = mgr.createSession(agentId: "claude")
+        let again = try #require(mgr.placeholderSession(id: created.id))
+        #expect(again === created)
+        #expect(again.hydrationState == .ready) // created sessions start ready
+    }
+
+    @Test("hydrateIfNeeded flips state to .ready and populates transcript")
+    func hydrateReady() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let userMsg: ACPMessage = .user(id: UUID(), text: "hi", attachments: [])
+        let payload = try ACPMessageCodec.encode(userMsg)
+        try store.appendMessage(sessionId: "s", id: "m0", kind: "user",
+                                seq: 0, payload: payload, createdAt: 0)
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.transcript.messages.count == 1)
+        if case .user(_, let text, _) = s.transcript.messages.first! {
+            #expect(text == "hi")
+        } else {
+            #expect(Bool(false), "expected user message")
+        }
+    }
+
+    @Test("hydrateIfNeeded short-circuits when already ready")
+    func hydrateShortCircuit() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let created = mgr.createSession(agentId: "claude")
+        // No await needed because state == .ready short-circuits before any work.
+        await mgr.hydrateIfNeeded(id: created.id)
+        #expect(created.hydrationState == .ready)
+    }
+
+    @Test("hydrateIfNeeded resets transcript visibleHead to tail")
+    func hydrateResetsWindow() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        // Seed 40 user messages so the tail window kicks in.
+        for i in 0..<40 {
+            let m: ACPMessage = .user(id: UUID(), text: "m\(i)", attachments: [])
+            let payload = try ACPMessageCodec.encode(m)
+            try store.appendMessage(sessionId: "s", id: "m\(i)", kind: "user",
+                                    seq: Int64(i), payload: payload, createdAt: 0)
+        }
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        await mgr.hydrateIfNeeded(id: "s")
+        #expect(s.transcript.messages.count == 40)
+        #expect(s.transcript.visibleHead == 10) // 40 - 30
+    }
+
+    @Test("concurrent hydrateIfNeeded calls coalesce")
+    func hydrateCoalesce() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        _ = mgr.placeholderSession(id: "s")
+
+        async let a: Void = mgr.hydrateIfNeeded(id: "s")
+        async let b: Void = mgr.hydrateIfNeeded(id: "s")
+        async let c: Void = mgr.hydrateIfNeeded(id: "s")
+        _ = await (a, b, c)
+
+        #expect(mgr.sessions["s"]?.hydrationState == .ready)
+    }
+
+    @Test("hydrateIfNeeded sets .failed for unknown id")
+    func hydrateFailure() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        // Insert a row, then drop it from the store but keep a placeholder so
+        // hydrate can target the cached session id and surface its failure.
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        try store.deleteSession(id: "s")
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        if case .failed = s.hydrationState {} else {
+            #expect(Bool(false), "expected .failed hydration state")
+        }
+    }
+
+    @Test("hydrateIfNeeded does not overwrite a draft typed during hydration")
+    func hydratePreservesInProgressDraft() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: ACPComposerDraft(segments: [.text("old persisted")]),
+            updatedAt: 1
+        )
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        // Simulate the user typing into the composer before hydration lands.
+        let inFlight = ACPComposerDraft(segments: [.text("user is typing")])
+        s.replaceComposerDraft(inFlight)
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == inFlight)
+    }
+
+    @Test("hydrateIfNeeded does not restore a draft after a deliberate clear")
+    func hydrateRespectsDeliberateClear() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        try store.upsertComposerDraft(
+            sessionId: "s",
+            draft: ACPComposerDraft(segments: [.text("old persisted")]),
+            updatedAt: 1
+        )
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        // User types and then deletes — composer ends up empty, but the
+        // revision counter records that they touched it on purpose.
+        s.replaceComposerDraft(ACPComposerDraft(segments: [.text("typed then deleted")]))
+        s.replaceComposerDraft(.empty)
+        #expect(s.composerDraftRevision == 2)
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.composerDraft == .empty)
+    }
+
+    @Test("hydrateIfNeeded does not overwrite a title renamed during hydration")
+    func hydratePreservesInProgressTitleEdit() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "Old title",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false
+        ))
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        // User renames via the toolbar while hydration is in flight.
+        s.title = "Renamed by user"
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.title == "Renamed by user")
+    }
+
+    @Test("hydrateIfNeeded re-hydrates after close + reopen during in-flight hydration")
+    func hydrateAfterCloseReopen() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let m: ACPMessage = .user(id: UUID(), text: "hi", attachments: [])
+        try store.appendMessage(
+            sessionId: "s", id: "m0", kind: "user",
+            seq: 0, payload: ACPMessageCodec.encode(m), createdAt: 0
+        )
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let first = try #require(mgr.placeholderSession(id: "s"))
+        // Kick off hydration without awaiting yet.
+        async let firstHydrate: Void = mgr.hydrateIfNeeded(id: "s")
+        // Simulate the user closing the tab while hydration is in flight,
+        // then reopening it. The reopened session must end up `.ready`.
+        mgr.closeSession(id: "s")
+        let second = try #require(mgr.placeholderSession(id: "s"))
+        #expect(second !== first)
+        async let secondHydrate: Void = mgr.hydrateIfNeeded(id: "s")
+        _ = await (firstHydrate, secondHydrate)
+
+        #expect(second.hydrationState == .ready)
+        #expect(second.transcript.messages.count == 1)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -27,8 +27,8 @@ struct ACPSessionManagerTests {
         try store.upsertComposerDraft(sessionId: "s", draft: draft, updatedAt: 123)
 
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
-        let session = try #require(mgr.openSession(id: "s"))
-
+        let session = try #require(mgr.placeholderSession(id: "s"))
+        await mgr.hydrateIfNeeded(id: "s")
         #expect(session.composerDraft == draft)
     }
 

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -461,7 +461,8 @@ struct ACPSessionRunnerQueueTests {
         let mock2 = ACPMockClient()
         mock2.script(method: "session/prompt") { _ in Data("null".utf8) }
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: FileManager.default.temporaryDirectory.path, store: store)
-        let session2 = mgr.openSession(id: "rt")!
+        let session2 = mgr.placeholderSession(id: "rt")!
+        await mgr.hydrateIfNeeded(id: "rt")
         #expect(session2.queue.count == 2)
         // .sending was normalized to .pending on restore.
         #expect(session2.queue[0].status == .pending)

--- a/AlasTests/ACP/Session/ACPSessionStoreQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreQueueTests.swift
@@ -64,7 +64,7 @@ struct ACPSessionStoreQueueTests {
 @Suite("ACPSessionManager queue restore")
 struct ACPSessionManagerQueueRestoreTests {
     @Test("openSession restores persisted queue, flipping .sending to .pending")
-    func restoreNormalizes() throws {
+    func restoreNormalizes() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-q-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
         try store.upsertSession(.init(
@@ -77,7 +77,8 @@ struct ACPSessionManagerQueueRestoreTests {
         ])
 
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp", store: store)
-        let session = mgr.openSession(id: "sm")
+        let session = mgr.placeholderSession(id: "sm")
+        await mgr.hydrateIfNeeded(id: "sm")
         #expect(session != nil)
         #expect(session?.queue.count == 2)
         #expect(session?.queue[0].status == .pending)   // was .sending

--- a/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptWindowTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscript window")
+struct ACPTranscriptWindowTests {
+    @Test("tailWindow is 30")
+    func tailWindowConstant() {
+        #expect(ACPTranscript.tailWindow == 30)
+    }
+
+    @Test("visibleHead defaults to zero")
+    func defaultHead() {
+        let t = ACPTranscript()
+        #expect(t.visibleHead == 0)
+    }
+
+    @Test("resetWindowToTail computes initial head")
+    func resetForLongTranscript() {
+        let t = ACPTranscript()
+        for _ in 0..<50 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.resetWindowToTail()
+        #expect(t.visibleHead == 20) // 50 - 30
+    }
+
+    @Test("resetWindowToTail clamps to zero for short transcripts")
+    func resetForShortTranscript() {
+        let t = ACPTranscript()
+        for _ in 0..<5 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.resetWindowToTail()
+        #expect(t.visibleHead == 0)
+    }
+
+    @Test("stepHeadBack decrements by tailWindow, clamped at zero")
+    func stepBack() {
+        let t = ACPTranscript()
+        for _ in 0..<100 {
+            t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        }
+        t.resetWindowToTail()
+        #expect(t.visibleHead == 70)
+        t.stepHeadBack()
+        #expect(t.visibleHead == 40)
+        t.stepHeadBack()
+        #expect(t.visibleHead == 10)
+        t.stepHeadBack()
+        #expect(t.visibleHead == 0) // clamped
+        t.stepHeadBack()
+        #expect(t.visibleHead == 0) // still clamped
+    }
+}


### PR DESCRIPTION
## Summary

Opening a worktree whose active tab is an ACP session — or switching to an ACP tab for the first time in this app launch — used to freeze the UI while `ACPSessionManager` loaded the row, read every persisted message from SQLite, JSON-decoded each one with a fresh decoder, and rendered the entire historical transcript on the first paint. The freeze grew linearly with transcript length.

This PR moves the heavy work off the main thread and bounds first-paint cost on long sessions.

**Hydration off main:**
- New `ACPSessionHydrator` actor owns its own `SQLiteDatabase` handle and runs the whole hydration pass (`loadMessages`, `loadQueue`, `loadComposerDraft`, `upsertSession` touch, `recentSessions` refresh) off main.
- New `ACPMessageWire` is a `Sendable` mirror of `ACPMessage` that crosses the actor boundary; the main hop converts wire variants into full `ACPMessage`s and is the only place `StreamingText` gets allocated.
- `ACPSession` gains a `HydrationState` flag; `ACPTabView` reuses the existing `ACPConnectingPlaceholder` while loading, runs hydrate before attach, and surfaces a Retry banner on failure.
- `ACPSessionManager.openSession` splits into a sync `placeholderSession` (cache hit O(1); cache miss is a single indexed `loadSession`) plus an async `hydrateIfNeeded` that coalesces concurrent callers via an in-flight map.

**Windowed transcript render:**
- `ACPTranscript` gains `visibleHead` + `tailWindow = 30`. After hydration applies, the head is reset to `max(0, count - 30)` so long sessions paint immediately.
- `ACPMessageList` slices to `messages[visibleHead...]` and shows an "Earlier messages…" capsule above the rendered range. Scrolling the marker within ~200pt of the top steps back another 30 rows (debounced 300ms).

**Tests:** 30 new tests across 5 new suites cover the wire round-trip, hydration state, transcript window math, hydrator I/O (happy path / missing session / malformed payload skip / `lastOpenedAt` touch), and manager hydration paths (placeholder semantics, `.ready`/`.failed` transitions, window reset, concurrent call coalescing).

## Test plan

- [x] Full ACP suite: 71/71 green across the 9 affected suites.
- [x] Manual: cold open of a worktree with an active ACP tab pointing at a long-history session shows the placeholder immediately, then the windowed transcript, with no perceptible main-thread stall.
- [x] Manual: switching between ACP tabs is instant on subsequent activations (hydration cache hit).
- [x] Manual: new session creation unchanged — placeholder during `attach`, composer accepts input as soon as setup succeeds.
- [ ] CI green.