### PR TITLE
Render inline diffs in ACP file edit cards

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		295EF629FAAA46FCD6802F4E /* ScrollEventCapturingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22E44126BAFC8F3B515BAC0 /* ScrollEventCapturingView.swift */; };
 		29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */; };
 		2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */; };
+		2A19A7B4B392979989E25EC0 /* ACPDiffGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */; };
 		2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9E3F080F847EF069137844 /* ShortcutBinding.swift */; };
 		2B823A7361BB54D8D93D7C99 /* ACPMentionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
@@ -206,6 +207,7 @@
 		3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64C0B7363363C77718B446C /* CopilotInstaller.swift */; };
 		40450134EBF5CCD5CD667327 /* ChangeSummaryVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */; };
 		4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */; };
+		40A21E55EB86B5F3D42AEFF2 /* InlineDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */; };
 		40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */; };
 		412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
@@ -234,6 +236,7 @@
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
 		474DF7FE50CB6146644B2450 /* ImageDiffEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */; };
 		476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */; };
+		47789166FA5C563AE2F550ED /* ACPDiffGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */; };
 		4781661414034F09EA02E0BC /* CommitsOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8673293AD419AA36F7DF02A9 /* CommitsOlderTests.swift */; };
 		478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */; };
 		48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */; };
@@ -785,6 +788,7 @@
 		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
 		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
 		05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
+		05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDiffGeneratorTests.swift; sourceTree = "<group>"; };
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
 		06375E561569DA36EC289C6F /* JSONRPCNewlineFramer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCNewlineFramer.swift; sourceTree = "<group>"; };
 		074A17527610230DCFBEA13C /* ACPMockClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClient.swift; sourceTree = "<group>"; };
@@ -1023,6 +1027,7 @@
 		5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioClientTests.swift; sourceTree = "<group>"; };
 		530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighter.swift; sourceTree = "<group>"; };
 		5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolver.swift; sourceTree = "<group>"; };
+		531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineDiffView.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
@@ -1272,6 +1277,7 @@
 		B65018D176CD2E52A3999CF0 /* AlasTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlasTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B6F6E707551671670D8CBA38 /* AgentLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLogoView.swift; sourceTree = "<group>"; };
 		B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSidebarContrastTests.swift; sourceTree = "<group>"; };
+		B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPDiffGenerator.swift; sourceTree = "<group>"; };
 		B77927262BEAF31E39CE6698 /* RecommendedLanguageCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedLanguageCatalogTests.swift; sourceTree = "<group>"; };
 		B78414C2E79104BC6218B1F4 /* ACPPermissionPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionPolicy.swift; sourceTree = "<group>"; };
 		B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTests.swift; sourceTree = "<group>"; };
@@ -2004,6 +2010,7 @@
 		3FEAE3661475B1EF994B8D45 /* ACP */ = {
 			isa = PBXGroup;
 			children = (
+				B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */,
 				45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */,
 				0A9B6A8C7372DB9E6C627A0E /* Adapter */,
 				22693797F2929554193802B2 /* FileWriter */,
@@ -2252,6 +2259,7 @@
 		6C8726781C7EE2E64AE25E56 /* ACP */ = {
 			isa = PBXGroup;
 			children = (
+				05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */,
 				1A5A3E6B2F9AC2CBB1CDA78E /* ACPHarnessBridgeTests.swift */,
 				C1CE17139DAF0E60FE9D92C2 /* Adapter */,
 				E6055B84E3F6E5717B873689 /* E2E */,
@@ -2310,6 +2318,7 @@
 				0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */,
 				E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */,
 				CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */,
+				531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -3102,6 +3111,7 @@
 				1298147855092677E3184AC2 /* ACPConfigOption.swift in Sources */,
 				809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */,
 				C7EC6D85810513194F831F13 /* ACPConnection.swift in Sources */,
+				2A19A7B4B392979989E25EC0 /* ACPDiffGenerator.swift in Sources */,
 				7FFC3D96011714F0A131FAB8 /* ACPFileChip.swift in Sources */,
 				DB305015BF666EEE0F9C7BAB /* ACPFileEditCard.swift in Sources */,
 				FF23739CD41997C6DD44E18B /* ACPFileWriter.swift in Sources */,
@@ -3327,6 +3337,7 @@
 				1B9CC3C13E96290B391E7C26 /* ImagePreviewTabView.swift in Sources */,
 				9D6FE5A4589D73A7480CE2B2 /* IndentationHelper.swift in Sources */,
 				709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */,
+				40A21E55EB86B5F3D42AEFF2 /* InlineDiffView.swift in Sources */,
 				BC98C2BCDB4F6C88C66117A6 /* InlineErrorStrip.swift in Sources */,
 				B614CD7F894DD6908C903254 /* InstallNudgeBanner.swift in Sources */,
 				0237F9775763E3C43D2D849A /* InstallNudgeResolver.swift in Sources */,
@@ -3509,6 +3520,7 @@
 				3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,
+				47789166FA5C563AE2F550ED /* ACPDiffGeneratorTests.swift in Sources */,
 				B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */,
 				43CB2A054DED7568A583822E /* ACPGeminiE2ETests.swift in Sources */,
 				01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */,

--- a/Alas/Sources/ACP/ACPDiffGenerator.swift
+++ b/Alas/Sources/ACP/ACPDiffGenerator.swift
@@ -3,15 +3,14 @@ import Foundation
 enum ACPDiffGenerator {
     static func generate(oldText: String?, newText: String) async throws -> ParsedDiff {
         let old = oldText ?? ""
-        let new = newText
 
-        if oldText == nil && new.isEmpty {
+        if oldText == nil && newText.isEmpty {
             return ParsedDiff(hunks: [])
         }
 
         if oldText == nil {
-            let hasTrailingNewline = new.hasSuffix("\n")
-            var lines = new.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            let hasTrailingNewline = newText.hasSuffix("\n")
+            var lines = newText.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
             if let last = lines.last, last.isEmpty { _ = lines.popLast() }
             let hunkLines = lines.enumerated().map { (i, text) in
                 ParsedDiff.Hunk.Line(
@@ -31,7 +30,7 @@ enum ACPDiffGenerator {
             return ParsedDiff(hunks: [hunk])
         }
 
-        if old == new {
+        if old == newText {
             return ParsedDiff(hunks: [])
         }
 
@@ -42,7 +41,7 @@ enum ACPDiffGenerator {
         let oldPath = tmpDir.appendingPathComponent("a")
         let newPath = tmpDir.appendingPathComponent("b")
         try old.write(to: oldPath, atomically: true, encoding: .utf8)
-        try new.write(to: newPath, atomically: true, encoding: .utf8)
+        try newText.write(to: newPath, atomically: true, encoding: .utf8)
 
         let result = try await Process.git(
             ["diff", "--no-index", "--", oldPath.path, newPath.path],

--- a/Alas/Sources/ACP/ACPDiffGenerator.swift
+++ b/Alas/Sources/ACP/ACPDiffGenerator.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+enum ACPDiffGenerator {
+    static func generate(oldText: String?, newText: String) async throws -> ParsedDiff {
+        let old = oldText ?? ""
+        let new = newText
+
+        if old.isEmpty && new.isEmpty {
+            return ParsedDiff(hunks: [])
+        }
+
+        if oldText == nil {
+            var lines = new.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            if let last = lines.last, last.isEmpty { _ = lines.popLast() }
+            let hunkLines = lines.enumerated().map { (i, text) in
+                ParsedDiff.Hunk.Line(
+                    kind: .add,
+                    text: text,
+                    oldNumber: nil,
+                    newNumber: i + 1
+                )
+            }
+            let hunk = ParsedDiff.Hunk(
+                header: "@@ -0,0 +1,\(lines.count) @@",
+                oldStart: 0,
+                newStart: 1,
+                lines: hunkLines
+            )
+            return ParsedDiff(hunks: [hunk])
+        }
+
+        if old == new {
+            return ParsedDiff(hunks: [])
+        }
+
+        let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("acp-diff-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        let oldPath = tmpDir.appendingPathComponent("a")
+        let newPath = tmpDir.appendingPathComponent("b")
+        try old.write(to: oldPath, atomically: true, encoding: .utf8)
+        try new.write(to: newPath, atomically: true, encoding: .utf8)
+
+        let result = try await Process.git(
+            ["diff", "--no-index", "--", oldPath.path, newPath.path],
+            cwd: tmpDir
+        )
+        return DiffParser.parse(result.stdout)
+    }
+}

--- a/Alas/Sources/ACP/ACPDiffGenerator.swift
+++ b/Alas/Sources/ACP/ACPDiffGenerator.swift
@@ -5,11 +5,12 @@ enum ACPDiffGenerator {
         let old = oldText ?? ""
         let new = newText
 
-        if old.isEmpty && new.isEmpty {
+        if oldText == nil && new.isEmpty {
             return ParsedDiff(hunks: [])
         }
 
         if oldText == nil {
+            let hasTrailingNewline = new.hasSuffix("\n")
             var lines = new.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
             if let last = lines.last, last.isEmpty { _ = lines.popLast() }
             let hunkLines = lines.enumerated().map { (i, text) in
@@ -17,7 +18,8 @@ enum ACPDiffGenerator {
                     kind: .add,
                     text: text,
                     oldNumber: nil,
-                    newNumber: i + 1
+                    newNumber: i + 1,
+                    noTrailingNewline: !hasTrailingNewline && i == lines.count - 1
                 )
             }
             let hunk = ParsedDiff.Hunk(

--- a/Alas/Sources/ACP/ACPDiffGenerator.swift
+++ b/Alas/Sources/ACP/ACPDiffGenerator.swift
@@ -47,6 +47,9 @@ enum ACPDiffGenerator {
             ["diff", "--no-color", "--no-index", "--", oldPath.path, newPath.path],
             cwd: tmpDir
         )
-        return DiffParser.parse(result.stdout)
+        let stdout = result.stdout
+        return await Task.detached(priority: .userInitiated) {
+            DiffParser.parse(stdout)
+        }.value
     }
 }

--- a/Alas/Sources/ACP/ACPDiffGenerator.swift
+++ b/Alas/Sources/ACP/ACPDiffGenerator.swift
@@ -44,7 +44,7 @@ enum ACPDiffGenerator {
         try newText.write(to: newPath, atomically: true, encoding: .utf8)
 
         let result = try await Process.git(
-            ["diff", "--no-index", "--", oldPath.path, newPath.path],
+            ["diff", "--no-color", "--no-index", "--", oldPath.path, newPath.path],
             cwd: tmpDir
         )
         return DiffParser.parse(result.stdout)

--- a/Alas/Sources/ACP/FileWriter/ACPFileWriter.swift
+++ b/Alas/Sources/ACP/FileWriter/ACPFileWriter.swift
@@ -10,7 +10,7 @@ struct ACPFileWriter {
         let removed: Int
         let path: String
         let oldText: String?
-        let newText: String?
+        let newText: String
     }
 
     func write(path: String, content: String) throws -> Result {

--- a/Alas/Sources/ACP/FileWriter/ACPFileWriter.swift
+++ b/Alas/Sources/ACP/FileWriter/ACPFileWriter.swift
@@ -5,19 +5,24 @@ struct ACPFileWriter {
 
     enum Error: Swift.Error, Equatable { case outsideWorktree(path: String) }
 
-    struct Result: Equatable { let added: Int
-    let removed: Int
-    let path: String }
+    struct Result: Equatable {
+        let added: Int
+        let removed: Int
+        let path: String
+        let oldText: String?
+        let newText: String?
+    }
 
     func write(path: String, content: String) throws -> Result {
         let target = try resolveInsideWorktree(path: path)
 
-        let pre = (try? String(contentsOf: target, encoding: .utf8)) ?? ""
+        let pre = try? String(contentsOf: target, encoding: .utf8)
         try FileManager.default.createDirectory(at: target.deletingLastPathComponent(),
                                                 withIntermediateDirectories: true)
         try content.write(to: target, atomically: true, encoding: .utf8)
-        let (added, removed) = Self.diffLineCount(pre: pre, post: content)
-        return Result(added: added, removed: removed, path: target.path)
+        let (added, removed) = Self.diffLineCount(pre: pre ?? "", post: content)
+        return Result(added: added, removed: removed, path: target.path,
+                      oldText: pre, newText: content)
     }
 
     /// Throws `outsideWorktree` if `path` resolves outside the

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -101,6 +101,29 @@ enum ACPMessage: Equatable {
         let path: String
         var added: Int
         var removed: Int
+        var oldText: String?
+        var newText: String
+
+        init(path: String, added: Int, removed: Int, oldText: String? = nil, newText: String = "") {
+            self.path = path
+            self.added = added
+            self.removed = removed
+            self.oldText = oldText
+            self.newText = newText
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case path, added, removed, oldText, newText
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            path = try c.decode(String.self, forKey: .path)
+            added = try c.decode(Int.self, forKey: .added)
+            removed = try c.decode(Int.self, forKey: .removed)
+            oldText = try c.decodeIfPresent(String.self, forKey: .oldText)
+            newText = try c.decodeIfPresent(String.self, forKey: .newText) ?? ""
+        }
     }
 
     struct PlanItem: Codable, Equatable, Hashable, Sendable {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -161,7 +161,7 @@ final class ACPSessionRunner {
                         // path). Storing the absolute path silently
                         // produced empty diffs.
                         let storedPath = self.relativeToWorktree(params.path) ?? params.path
-                        self.appendAndPersistFileEdit(.init(path: storedPath, added: res.added, removed: res.removed))
+                        self.appendAndPersistFileEdit(.init(path: storedPath, added: res.added, removed: res.removed, oldText: res.oldText, newText: res.newText))
                         // ACP `fs/write_text_file` is defined as
                         // returning `result: null`. Encoding an empty
                         // Swift struct produced `{}`, which spec-strict

--- a/Alas/Sources/ACP/UI/ACPFileEditCard.swift
+++ b/Alas/Sources/ACP/UI/ACPFileEditCard.swift
@@ -1,45 +1,131 @@
 import SwiftUI
 
-/// Compact card that announces a file edit landed in the worktree, with
-/// a click target that opens the existing diff tab against HEAD.
 struct ACPFileEditCard: View {
     let edit: ACPMessage.FileEdit
     let onOpenDiff: () -> Void
     @Environment(\.theme) private var theme
+    @State private var expanded = false
+
+    private var hasDiffContent: Bool {
+        edit.oldText != nil || edit.newText != ""
+    }
 
     var body: some View {
-        HStack(spacing: 8) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(theme.color("accent").opacity(0.18))
-                Image(systemName: "pencil")
-                    .font(.system(size: 10))
-                    .foregroundStyle(theme.color("accent"))
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            if expanded, hasDiffContent {
+                diffPanel
             }
-            .frame(width: 18, height: 18)
-
-            Text("Edit")
-                .font(.system(size: 10.5, weight: .semibold))
-                .tracking(0.6)
-                .textCase(.uppercase)
-                .foregroundStyle(theme.color("accent"))
-
-            FileChip(path: edit.path, lines: nil, iconSystemName: nil)
-
-            Text("+\(edit.added) −\(edit.removed)")
-                .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(theme.color("fg-faint"))
-
-            Spacer(minLength: 6)
-
-            Button("Open diff", action: onOpenDiff)
-                .buttonStyle(.plain)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(theme.color("accent"))
         }
-        .padding(.horizontal, 10).padding(.vertical, 8)
-        .background(theme.color("bg-1").opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(theme.color("line"), lineWidth: 0.5))
+    }
+
+    private var header: some View {
+        Button(action: {
+            if hasDiffContent {
+                withAnimation(.easeOut(duration: 0.12)) {
+                    expanded.toggle()
+                }
+            }
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(theme.color("fg-faint"))
+                    .frame(width: 12)
+                    .opacity(hasDiffContent ? 1 : 0.3)
+
+                ZStack {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(theme.color("accent").opacity(0.18))
+                    Image(systemName: "pencil")
+                        .font(.system(size: 10))
+                        .foregroundStyle(theme.color("accent"))
+                }
+                .frame(width: 18, height: 18)
+
+                Text("Edit")
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .tracking(0.6)
+                    .textCase(.uppercase)
+                    .foregroundStyle(theme.color("accent"))
+
+                FileChip(path: edit.path, lines: nil, iconSystemName: nil)
+
+                Text("+\(edit.added) -\(edit.removed)")
+                    .font(.system(size: 10.5, design: .monospaced))
+                    .foregroundStyle(theme.color("fg-faint"))
+
+                Spacer(minLength: 6)
+
+                Button("Open diff", action: onOpenDiff)
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(theme.color("accent"))
+            }
+            .padding(.horizontal, 10).padding(.vertical, 8)
+            .background(theme.color("bg-1").opacity(0.5))
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var diffPanel: some View {
+        _InlineDiffPanel(
+            oldText: edit.oldText,
+            newText: edit.newText,
+            relativePath: edit.path,
+            onShowAll: onOpenDiff
+        )
+    }
+}
+
+private struct _InlineDiffPanel: View {
+    let oldText: String?
+    let newText: String
+    let relativePath: String
+    let onShowAll: () -> Void
+    @Environment(\.theme) private var theme
+    @State private var diff: ParsedDiff?
+    @State private var loading = true
+
+    var body: some View {
+        Group {
+            if loading {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .scaleEffect(0.5)
+                        .frame(width: 16, height: 16)
+                    Spacer()
+                }
+                .padding(12)
+                .background(theme.color("bg-2"))
+            } else if let diff, !diff.hunks.isEmpty {
+                InlineDiffView(
+                    diff: diff,
+                    relativePath: relativePath,
+                    maxLines: 15,
+                    onShowAll: onShowAll
+                )
+            } else {
+                Text("No changes")
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("fg-dim"))
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .background(theme.color("bg-2"))
+            }
+        }
+        .overlay(Divider().opacity(0.5), alignment: .top)
+        .task {
+            loading = true
+            diff = try? await ACPDiffGenerator.generate(
+                oldText: oldText,
+                newText: newText
+            )
+            loading = false
+        }
     }
 }

--- a/Alas/Sources/ACP/UI/ACPFileEditCard.swift
+++ b/Alas/Sources/ACP/UI/ACPFileEditCard.swift
@@ -22,52 +22,56 @@ struct ACPFileEditCard: View {
     }
 
     private var header: some View {
-        Button(action: {
-            if hasDiffContent {
-                withAnimation(.easeOut(duration: 0.12)) {
-                    expanded.toggle()
+        HStack(spacing: 8) {
+            Button(action: {
+                if hasDiffContent {
+                    withAnimation(.easeOut(duration: 0.12)) {
+                        expanded.toggle()
+                    }
                 }
-            }
-        }) {
-            HStack(spacing: 8) {
-                Image(systemName: expanded ? "chevron.down" : "chevron.right")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(theme.color("fg-faint"))
-                    .frame(width: 12)
-                    .opacity(hasDiffContent ? 1 : 0.3)
+            }) {
+                HStack(spacing: 8) {
+                    Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(theme.color("fg-faint"))
+                        .frame(width: 12)
+                        .opacity(hasDiffContent ? 1 : 0.3)
 
-                ZStack {
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(theme.color("accent").opacity(0.18))
-                    Image(systemName: "pencil")
-                        .font(.system(size: 10))
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(theme.color("accent").opacity(0.18))
+                        Image(systemName: "pencil")
+                            .font(.system(size: 10))
+                            .foregroundStyle(theme.color("accent"))
+                    }
+                    .frame(width: 18, height: 18)
+
+                    Text("Edit")
+                        .font(.system(size: 10.5, weight: .semibold))
+                        .tracking(0.6)
+                        .textCase(.uppercase)
                         .foregroundStyle(theme.color("accent"))
+
+                    FileChip(path: edit.path, lines: nil, iconSystemName: nil)
+
+                    Text("+\(edit.added) -\(edit.removed)")
+                        .font(.system(size: 10.5, design: .monospaced))
+                        .foregroundStyle(theme.color("fg-faint"))
+
+                    Spacer(minLength: 6)
                 }
-                .frame(width: 18, height: 18)
-
-                Text("Edit")
-                    .font(.system(size: 10.5, weight: .semibold))
-                    .tracking(0.6)
-                    .textCase(.uppercase)
-                    .foregroundStyle(theme.color("accent"))
-
-                FileChip(path: edit.path, lines: nil, iconSystemName: nil)
-
-                Text("+\(edit.added) -\(edit.removed)")
-                    .font(.system(size: 10.5, design: .monospaced))
-                    .foregroundStyle(theme.color("fg-faint"))
-
-                Spacer(minLength: 6)
-
-                Button("Open diff", action: onOpenDiff)
-                    .buttonStyle(.plain)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(theme.color("accent"))
+                .padding(.horizontal, 10).padding(.vertical, 8)
+                .background(theme.color("bg-1").opacity(0.5))
             }
-            .padding(.horizontal, 10).padding(.vertical, 8)
-            .background(theme.color("bg-1").opacity(0.5))
+            .buttonStyle(.plain)
+
+            Button("Open diff", action: onOpenDiff)
+                .buttonStyle(.plain)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(theme.color("accent"))
+                .padding(.horizontal, 10).padding(.vertical, 8)
         }
-        .buttonStyle(.plain)
+        .background(theme.color("bg-1").opacity(0.5))
     }
 
     @ViewBuilder

--- a/Alas/Sources/ACP/UI/InlineDiffView.swift
+++ b/Alas/Sources/ACP/UI/InlineDiffView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct InlineDiffView: View {
+    let diff: ParsedDiff
+    let relativePath: String
+    let maxLines: Int
+    let onShowAll: () -> Void
+    @Environment(\.theme) private var theme
+
+    private static let codeFontSize: CGFloat = 11
+    private static let codeFontFamily: String = ""
+
+    private var allLines: [ParsedDiff.Hunk.Line] {
+        diff.hunks.flatMap(\.lines)
+    }
+
+    private var truncated: Bool {
+        allLines.count > maxLines
+    }
+
+    private var visibleHunks: [ParsedDiff.Hunk] {
+        guard truncated else { return diff.hunks }
+
+        var remaining = maxLines
+        var result: [ParsedDiff.Hunk] = []
+
+        for hunk in diff.hunks {
+            if remaining <= 0 { break }
+            if hunk.lines.count <= remaining {
+                result.append(hunk)
+                remaining -= hunk.lines.count
+            } else {
+                let trimmed = ParsedDiff.Hunk(
+                    header: hunk.header,
+                    oldStart: hunk.oldStart,
+                    newStart: hunk.newStart,
+                    lines: Array(hunk.lines.prefix(remaining))
+                )
+                result.append(trimmed)
+                remaining = 0
+            }
+        }
+        return result
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(visibleHunks.enumerated()), id: \.offset) { (_, hunk) in
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(hunk.header)
+                        .font(.system(size: Self.codeFontSize * 0.85, design: .monospaced))
+                        .foregroundStyle(theme.color("fg-dim"))
+                        .padding(.horizontal, 14).padding(.vertical, 4)
+                        .background(theme.color("bg-2"))
+                        .overlay(Divider().opacity(0.5), alignment: .bottom)
+
+                    DiffSelectableTextView(
+                        hunk: hunk,
+                        fileExtension: fileExtension,
+                        codeFontFamily: Self.codeFontFamily,
+                        codeFontSize: Self.codeFontSize,
+                        theme: theme
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if truncated {
+                Button(action: onShowAll) {
+                    HStack(spacing: 4) {
+                        Text("Show all \(allLines.count) lines")
+                        Image(systemName: "arrow.forward")
+                    }
+                    .font(.system(size: 11))
+                    .foregroundStyle(theme.color("accent"))
+                    .padding(.horizontal, 14).padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .buttonStyle(.plain)
+                .background(theme.color("bg-2"))
+                .overlay(Divider().opacity(0.5), alignment: .top)
+            }
+        }
+    }
+
+    private var fileExtension: String {
+        (relativePath as NSString).pathExtension
+    }
+}

--- a/AlasTests/ACP/ACPDiffGeneratorTests.swift
+++ b/AlasTests/ACP/ACPDiffGeneratorTests.swift
@@ -44,6 +44,18 @@ struct ACPDiffGeneratorTests {
         #expect(dels.contains { $0.text == "beta" })
     }
 
+    @Test("new file without trailing newline sets noTrailingNewline on last line")
+    func newFileNoTrailingNewline() async throws {
+        let diff = try await ACPDiffGenerator.generate(
+            oldText: nil,
+            newText: "line1\nline2\nline3"
+        )
+        #expect(diff.hunks.count == 1)
+        let hunk = diff.hunks[0]
+        #expect(hunk.lines.count == 3)
+        #expect(hunk.lines.last?.noTrailingNewline == true)
+    }
+
     @Test("new empty file produces empty diff")
     func newEmptyFile() async throws {
         let diff = try await ACPDiffGenerator.generate(

--- a/AlasTests/ACP/ACPDiffGeneratorTests.swift
+++ b/AlasTests/ACP/ACPDiffGeneratorTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPDiffGenerator")
+struct ACPDiffGeneratorTests {
+
+    @Test("new file produces all-additions hunk")
+    func newFile() async throws {
+        let diff = try await ACPDiffGenerator.generate(
+            oldText: nil,
+            newText: "line1\nline2\nline3\n"
+        )
+        #expect(diff.hunks.count == 1)
+        let hunk = diff.hunks[0]
+        #expect(hunk.header == "@@ -0,0 +1,3 @@")
+        #expect(hunk.lines.allSatisfy { $0.kind == .add })
+        #expect(hunk.lines.count == 3)
+        #expect(hunk.lines[0].text == "line1")
+        #expect(hunk.lines[0].newNumber == 1)
+        #expect(hunk.lines[0].oldNumber == nil)
+    }
+
+    @Test("identical texts produce empty diff")
+    func identical() async throws {
+        let diff = try await ACPDiffGenerator.generate(
+            oldText: "abc\ndef\n",
+            newText: "abc\ndef\n"
+        )
+        #expect(diff.hunks.isEmpty)
+    }
+
+    @Test("modified file returns hunks from git diff --no-index")
+    func modified() async throws {
+        let diff = try await ACPDiffGenerator.generate(
+            oldText: "alpha\nbeta\ngamma\n",
+            newText: "alpha\ndelta\ngamma\n"
+        )
+        #expect(diff.hunks.count == 1)
+        let hunk = diff.hunks[0]
+        let adds = hunk.lines.filter { $0.kind == .add }
+        let dels = hunk.lines.filter { $0.kind == .delete }
+        #expect(adds.contains { $0.text == "delta" })
+        #expect(dels.contains { $0.text == "beta" })
+    }
+
+    @Test("new empty file produces empty diff")
+    func newEmptyFile() async throws {
+        let diff = try await ACPDiffGenerator.generate(
+            oldText: nil,
+            newText: ""
+        )
+        #expect(diff.hunks.isEmpty)
+    }
+
+    @Test("deleting all content shows deletions")
+    func deleteAll() async throws {
+        let diff = try await ACPDiffGenerator.generate(
+            oldText: "abc\ndef\n",
+            newText: ""
+        )
+        #expect(!diff.hunks.isEmpty)
+        let hunk = diff.hunks[0]
+        #expect(hunk.lines.allSatisfy { $0.kind == .delete })
+    }
+}

--- a/AlasTests/ACP/ACPDiffGeneratorTests.swift
+++ b/AlasTests/ACP/ACPDiffGeneratorTests.swift
@@ -4,7 +4,6 @@ import Testing
 
 @Suite("ACPDiffGenerator")
 struct ACPDiffGeneratorTests {
-
     @Test("new file produces all-additions hunk")
     func newFile() async throws {
         let diff = try await ACPDiffGenerator.generate(

--- a/AlasTests/ACP/FileWriter/ACPFileWriterTests.swift
+++ b/AlasTests/ACP/FileWriter/ACPFileWriterTests.swift
@@ -19,6 +19,8 @@ struct ACPFileWriterTests {
                                       content: "one\ntwo\nthree\n")
         #expect(result.added == 3)
         #expect(result.removed == 0)
+        #expect(result.oldText == nil)
+        #expect(result.newText == "one\ntwo\nthree\n")
         #expect(FileManager.default.fileExists(atPath: wt.appendingPathComponent("a.txt").path))
     }
 
@@ -30,8 +32,10 @@ struct ACPFileWriterTests {
         try "alpha\nbeta\ngamma\n".write(to: p, atomically: true, encoding: .utf8)
         let writer = ACPFileWriter(worktreeRoot: wt)
         let result = try writer.write(path: p.path, content: "alpha\nGAMMA\ndelta\n")
-        #expect(result.added == 2)   // GAMMA, delta
-        #expect(result.removed == 2) // beta, gamma
+        #expect(result.added == 2)
+        #expect(result.removed == 2)
+        #expect(result.oldText == "alpha\nbeta\ngamma\n")
+        #expect(result.newText == "alpha\nGAMMA\ndelta\n")
     }
 
     @Test("rejects writes outside the worktree")

--- a/AlasTests/ACP/Session/ACPMessageTests.swift
+++ b/AlasTests/ACP/Session/ACPMessageTests.swift
@@ -41,7 +41,10 @@ struct ACPMessageTests {
     }
     @Test("file edit round-trips")
     func editRoundtrip() throws {
-        let m = ACPMessage.fileEdit(id: UUID(), .init(path: "x.swift", added: 4, removed: 1))
+        let m = ACPMessage.fileEdit(id: UUID(), .init(
+            path: "x.swift", added: 4, removed: 1,
+            oldText: "abc\ndef\n", newText: "abc\nGHI\ndef\n"
+        ))
         let payload = try ACPMessageCodec.encode(m)
         let back = try ACPMessageCodec.decode(kind: m.kind, payload: payload)
         guard case .fileEdit(_, let edit) = back else {
@@ -51,5 +54,26 @@ struct ACPMessageTests {
         #expect(edit.path == "x.swift")
         #expect(edit.added == 4)
         #expect(edit.removed == 1)
+        #expect(edit.oldText == "abc\ndef\n")
+        #expect(edit.newText == "abc\nGHI\ndef\n")
+    }
+
+    @Test("file edit decodes with nil oldText for backward compat")
+    func editRoundtripBackwardCompat() throws {
+        let payload = try JSONEncoder().encode(OldFormat(path: "y.swift", added: 1, removed: 0))
+        let back = try ACPMessageCodec.decode(kind: "file_edit", payload: payload)
+        guard case .fileEdit(_, let edit) = back else {
+            Issue.record("expected file edit")
+            return
+        }
+        #expect(edit.path == "y.swift")
+        #expect(edit.oldText == nil)
+        #expect(edit.newText == "")
+    }
+
+    private struct OldFormat: Codable {
+        let path: String
+        let added: Int
+        let removed: Int
     }
 }


### PR DESCRIPTION
## Summary

- ACP file edit cards in the transcript are now expandable — clicking the header toggles an inline diff rendered with the same `DiffSelectableTextView` used in the full diff tab
- Diffs are capped at 15 lines; larger diffs show a "Show all N lines →" button that opens the dedicated `DiffTab`
- `ACPFileWriter` now captures the file's content before overwriting, and `ACPMessage.FileEdit` stores `oldText`/`newText` for diff generation
- New `ACPDiffGenerator` converts text pairs into `ParsedDiff` — synthesizes an all-additions hunk for new files, uses `git diff --no-index` for modified files
- Backward compatible: older persisted sessions without `oldText`/`newText` render the card non-expandable, with the "Open diff" button working as before

## Files changed

| File | Change |
|---|---|
| `ACPFileWriter.swift` | Add `oldText`/`newText` to `Result` |
| `ACPMessage.swift` | Add `oldText`/`newText` to `FileEdit` with backward-compat decoder |
| `ACPSessionRunner.swift` | Thread fields through in write handler |
| `ACPDiffGenerator.swift` | New — text-to-`ParsedDiff` conversion |
| `ACPFileEditCard.swift` | Refactored to expandable card with inline diff panel |
| `InlineDiffView.swift` | New — truncated diff hunk rendering |