### PR TITLE
feat(terminal): auto-close pane when shell exits

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -944,6 +944,10 @@ final class AppState {
         terminal.socketReleaseHandler = { [weak self] leafId in
             self?.harness.socketServer.unlinkSession(leafId: leafId)
         }
+        terminal.onSessionProcessExited = { [weak self] leafId, worktreeId, processAlive in
+            guard !processAlive else { return }
+            self?.closePaneForProcessExit(worktreeId: worktreeId, leafId: leafId)
+        }
         harness.socketServer.onCLIRequest = { [weak self] request in
             await MainActor.run {
                 guard let self else { return .error("Alas is not available.") }
@@ -1174,6 +1178,35 @@ final class AppState {
             )
         } catch {
             AlasGhostty.logger.error("splitFocusedPane failed: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Called when Ghostty reports that the shell in `leafId` has exited.
+    /// Locates the owning tab, removes the leaf from the pane tree, and
+    /// either closes the tab (when it was the last leaf) or tears down the
+    /// dead session and lets the sibling collapse take over the freed space.
+    /// Idempotent: if the leaf is no longer in any tab (manual close raced
+    /// ahead), returns without side effects.
+    func closePaneForProcessExit(worktreeId: String, leafId: String) {
+        let owningTabId = tabs.tabs(forWorktree: worktreeId).first { tab in
+            guard case .terminal(let state) = tab else { return false }
+            return state.root.find(leafId: leafId) != nil
+        }?.id
+        guard let tabId = owningTabId else { return }
+        guard let outcome = tabs.removeLeaf(
+            worktreeId: worktreeId, tabId: tabId, leafId: leafId
+        ) else { return }
+        switch outcome {
+        case .tabRemoved:
+            closeTab(worktreeId: worktreeId, tabId: tabId)
+        case .leafRemoved:
+            terminal.closeSession(
+                id: leafId,
+                worktreeId: worktreeId,
+                projectPath: projectPath(forWorktreeId: worktreeId)
+            )
+            harness.detector.unregister(sessionId: leafId)
+            harness.forgetSession(leafId)
         }
     }
 

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -254,10 +254,10 @@ final class TabsManager {
         return tab
     }
 
-    enum RemoveFocusedLeafOutcome {
-        /// A non-focused-leaf sibling collapsed up; the tab persists.
+    enum RemoveLeafOutcome {
+        /// A sibling collapsed up; the tab persists.
         case leafRemoved(tab: Tab, closedLeafId: String)
-        /// The focused leaf was the last leaf; caller must run the regular close-tab path.
+        /// The removed leaf was the last leaf; caller must run the regular close-tab path.
         case tabRemoved(closedLeafId: String)
 
         var closedLeafId: String {
@@ -267,20 +267,27 @@ final class TabsManager {
         }
     }
 
-    /// Remove the focused leaf. If it was the last leaf, the tab is removed via
-    /// the regular close-tab path and `tabRemoved` is true. Otherwise the sibling
-    /// collapses up and a sensible focus replacement is picked (first leaf in the
-    /// remaining tree).
+    typealias RemoveFocusedLeafOutcome = RemoveLeafOutcome
+
+    /// Remove the leaf identified by `leafId` from `tabId` in `worktreeId`. If the
+    /// leaf is part of a split, the sibling collapses up; focus only moves when
+    /// the removed leaf was itself focused (then to the first leaf in the
+    /// remaining tree). Returns `.tabRemoved` when the leaf was the last in the
+    /// tab — the tab stays in the list so callers can run the regular close-tab
+    /// path. Returns `nil` when the worktree, tab, or leaf is missing, so the
+    /// process-exit handler can race manual close as a quiet no-op.
     @discardableResult
-    func removeFocusedLeaf(worktreeId: String, tabId: TabID) -> RemoveFocusedLeafOutcome? {
+    func removeLeaf(worktreeId: String, tabId: TabID, leafId: String) -> RemoveLeafOutcome? {
         guard var file = byWorktree[worktreeId],
               let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
               case .terminal(var state) = file.tabs[idx],
-              let focused = state.root.find(leafId: state.focusedLeafId)?.leaf else { return nil }
-        let closedLeafId = focused.id
-        if let newRoot = state.root.removingLeaf(id: state.focusedLeafId) {
+              state.root.find(leafId: leafId) != nil else { return nil }
+        let closedLeafId = leafId
+        if let newRoot = state.root.removingLeaf(id: leafId) {
             state.root = newRoot
-            state.focusedLeafId = newRoot.firstLeaf().id
+            if state.root.find(leafId: state.focusedLeafId) == nil {
+                state.focusedLeafId = newRoot.firstLeaf().id
+            }
             let tab = Tab.terminal(state)
             file.tabs[idx] = tab
             byWorktree[worktreeId] = file
@@ -289,6 +296,15 @@ final class TabsManager {
         } else {
             return .tabRemoved(closedLeafId: closedLeafId)
         }
+    }
+
+    /// Remove the focused leaf. Thin wrapper around `removeLeaf(worktreeId:tabId:leafId:)`.
+    @discardableResult
+    func removeFocusedLeaf(worktreeId: String, tabId: TabID) -> RemoveLeafOutcome? {
+        guard let file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .terminal(let state) = file.tabs[idx] else { return nil }
+        return removeLeaf(worktreeId: worktreeId, tabId: tabId, leafId: state.focusedLeafId)
     }
 
     @discardableResult

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -267,8 +267,6 @@ final class TabsManager {
         }
     }
 
-    typealias RemoveFocusedLeafOutcome = RemoveLeafOutcome
-
     /// Remove the leaf identified by `leafId` from `tabId` in `worktreeId`. If the
     /// leaf is part of a split, the sibling collapses up; focus only moves when
     /// the removed leaf was itself focused (then to the first leaf in the

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
@@ -210,6 +210,8 @@ private func alasGhosttyAction(
 
     case GHOSTTY_ACTION_CLOSE_WINDOW, GHOSTTY_ACTION_CLOSE_TAB:
         guard let sv = surfaceView else { return true }
+        // Shell may still be running (user hit cmd-W inside Ghostty); we pass
+        // false to signal "dismiss the pane regardless," not as a liveness claim.
         DispatchQueue.main.async { sv.processExitHandler?(false) }
         return true
 

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.App.swift
@@ -210,7 +210,7 @@ private func alasGhosttyAction(
 
     case GHOSTTY_ACTION_CLOSE_WINDOW, GHOSTTY_ACTION_CLOSE_TAB:
         guard let sv = surfaceView else { return true }
-        DispatchQueue.main.async { sv.processExitHandler?() }
+        DispatchQueue.main.async { sv.processExitHandler?(false) }
         return true
 
     case GHOSTTY_ACTION_QUIT:
@@ -247,7 +247,7 @@ private func alasGhosttyAction(
 
     case GHOSTTY_ACTION_SHOW_CHILD_EXITED:
         guard let sv = surfaceView else { return false }
-        DispatchQueue.main.async { sv.processExitHandler?() }
+        DispatchQueue.main.async { sv.processExitHandler?(false) }
         return true
 
     default:
@@ -333,5 +333,5 @@ private func alasGhosttyCloseSurface(
     guard let ud = userdata else { return }
     let sv = Unmanaged<AlasGhostty.SurfaceView>.fromOpaque(ud).takeUnretainedValue()
     AlasGhostty.logger.info("close_surface_cb processAlive=\(processAlive)")
-    DispatchQueue.main.async { sv.processExitHandler?() }
+    DispatchQueue.main.async { sv.processExitHandler?(processAlive) }
 }

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -78,7 +78,12 @@ extension AlasGhostty {
         var titleHandler: ((String) -> Void)?
 
         /// Called (on main thread) when the child process exits or the surface is closed.
-        var processExitHandler: (() -> Void)?
+        /// `processAlive` reflects the value Ghostty supplied via `close_surface_cb`:
+        /// `false` means the shell process is gone and the UI should dismiss the pane;
+        /// `true` means Ghostty asked us to tear down a surface whose shell is still
+        /// running (e.g. an internal close request), which the manual-close paths
+        /// already handle. Receivers should no-op when `processAlive == true`.
+        var processExitHandler: ((_ processAlive: Bool) -> Void)?
 
         // Current working directory, derived from Ghostty's GHOSTTY_ACTION_PWD events
         // (which fire when the shell emits OSC 7). Nil until the shell reports one.

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -77,12 +77,14 @@ extension AlasGhostty {
         /// Called (on main thread) whenever the terminal title changes.
         var titleHandler: ((String) -> Void)?
 
-        /// Called (on main thread) when the child process exits or the surface is closed.
-        /// `processAlive` reflects the value Ghostty supplied via `close_surface_cb`:
-        /// `false` means the shell process is gone and the UI should dismiss the pane;
-        /// `true` means Ghostty asked us to tear down a surface whose shell is still
-        /// running (e.g. an internal close request), which the manual-close paths
-        /// already handle. Receivers should no-op when `processAlive == true`.
+        /// Called (on main thread) when the pane should be dismissed.
+        /// `processAlive == false` is the dismiss signal — emitted authoritatively
+        /// by `close_surface_cb` when the shell exits, and conventionally by the
+        /// `CLOSE_WINDOW`/`CLOSE_TAB`/`SHOW_CHILD_EXITED` Ghostty actions to mean
+        /// "Alas should tear down this pane regardless of shell liveness."
+        /// `processAlive == true` only arrives from `close_surface_cb` when Ghostty
+        /// is tearing down a surface whose shell is still running because we asked
+        /// it to (manual-close path); receivers should no-op in that case.
         var processExitHandler: ((_ processAlive: Bool) -> Void)?
 
         // Current working directory, derived from Ghostty's GHOSTTY_ACTION_PWD events

--- a/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
+++ b/Alas/Sources/Terminal/Ghostty/AlasGhostty.SurfaceView.swift
@@ -85,6 +85,8 @@ extension AlasGhostty {
         /// `processAlive == true` only arrives from `close_surface_cb` when Ghostty
         /// is tearing down a surface whose shell is still running because we asked
         /// it to (manual-close path); receivers should no-op in that case.
+        /// May fire more than once for a single shell exit (e.g. `SHOW_CHILD_EXITED`
+        /// followed by `close_surface_cb`); receivers must be idempotent.
         var processExitHandler: ((_ processAlive: Bool) -> Void)?
 
         // Current working directory, derived from Ghostty's GHOSTTY_ACTION_PWD events

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -26,6 +26,12 @@ final class TerminalService {
     /// Called when a session is closed so the provider can release any
     /// per-session state (e.g. unlink the symlink).
     @ObservationIgnored var socketReleaseHandler: ((String) -> Void)?
+    /// Fires when the shell process inside a session exits, as reported by
+    /// Ghostty's `close_surface_cb`. `processAlive == false` is the dismiss
+    /// signal (shell is gone — or a Ghostty action requested teardown);
+    /// `processAlive == true` means a manual-close path is already in flight
+    /// and the receiver should no-op. Always invoked on the main thread.
+    @ObservationIgnored var onSessionProcessExited: ((_ leafId: String, _ worktreeId: String, _ processAlive: Bool) -> Void)?
     @ObservationIgnored let zmxClient: ZmxClient
 
     /// Default initializer used by production code paths (AppState).
@@ -130,6 +136,11 @@ final class TerminalService {
             app: app,
             configuration: surfaceConfig
         )
+        let capturedLeafId = sessionId
+        let capturedWorktreeId = worktree.id
+        surface.processExitHandler = { [weak self] processAlive in
+            self?.onSessionProcessExited?(capturedLeafId, capturedWorktreeId, processAlive)
+        }
         let session = TerminalSession(
             id: sessionId,
             worktreeId: worktree.id,

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -658,7 +658,8 @@ struct TabsManagerPaneTests {
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
         guard case .terminal(let initial) = tab,
               case .leaf(let originalLeaf) = initial.root else {
-            Issue.record("expected single-leaf terminal tab"); return
+            Issue.record("expected single-leaf terminal tab")
+            return
         }
         _ = mgr.splitFocusedLeaf(
             worktreeId: "wt", tabId: tab.id, axis: .vertical,
@@ -669,7 +670,8 @@ struct TabsManagerPaneTests {
             worktreeId: "wt", tabId: tab.id, leafId: originalLeaf.id
         ))
         guard case .leafRemoved(let outcomeTab, let closedLeafId) = outcome else {
-            Issue.record("expected .leafRemoved"); return
+            Issue.record("expected .leafRemoved")
+            return
         }
         #expect(closedLeafId == originalLeaf.id)
         if case .terminal(let s) = outcomeTab, case .leaf(let l) = s.root {
@@ -685,7 +687,8 @@ struct TabsManagerPaneTests {
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
         guard case .terminal(let initial) = tab,
               case .leaf(let originalLeaf) = initial.root else {
-            Issue.record("expected single-leaf terminal tab"); return
+            Issue.record("expected single-leaf terminal tab")
+            return
         }
         _ = mgr.splitFocusedLeaf(
             worktreeId: "wt", tabId: tab.id, axis: .vertical,
@@ -696,12 +699,14 @@ struct TabsManagerPaneTests {
             worktreeId: "wt", tabId: tab.id, leafId: "new"
         ))
         guard case .leafRemoved(_, let closedLeafId) = outcome else {
-            Issue.record("expected .leafRemoved"); return
+            Issue.record("expected .leafRemoved")
+            return
         }
         #expect(closedLeafId == "new")
         guard case .terminal(let persisted) = (mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id })!),
               case .leaf(let persistedLeaf) = persisted.root else {
-            Issue.record("expected single-leaf root"); return
+            Issue.record("expected single-leaf root")
+            return
         }
         #expect(persistedLeaf.id == originalLeaf.id)
         #expect(persisted.focusedLeafId == originalLeaf.id)
@@ -712,13 +717,15 @@ struct TabsManagerPaneTests {
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
         guard case .terminal(let initial) = tab,
               case .leaf(let onlyLeaf) = initial.root else {
-            Issue.record("expected single-leaf terminal tab"); return
+            Issue.record("expected single-leaf terminal tab")
+            return
         }
         let outcome = try #require(mgr.removeLeaf(
             worktreeId: "wt", tabId: tab.id, leafId: onlyLeaf.id
         ))
         guard case .tabRemoved(let closedLeafId) = outcome else {
-            Issue.record("expected .tabRemoved"); return
+            Issue.record("expected .tabRemoved")
+            return
         }
         #expect(closedLeafId == onlyLeaf.id)
     }
@@ -752,7 +759,8 @@ struct TabsManagerPaneTests {
             worktreeId: "wt", tabId: tab.id, leafId: "new"
         ))
         guard case .leafRemoved = first else {
-            Issue.record("expected .leafRemoved"); return
+            Issue.record("expected .leafRemoved")
+            return
         }
         // Second removal of the same leaf must be a quiet no-op — the
         // process-exit handler relies on this to race manual close.

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -653,6 +653,93 @@ struct TabsManagerPaneTests {
         #expect(closedLeafId == expectedLeafId)
     }
 
+    @Test func removeLeafBySpecificIdCollapsesSibling() throws {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        guard case .terminal(let initial) = tab,
+              case .leaf(let originalLeaf) = initial.root else {
+            Issue.record("expected single-leaf terminal tab"); return
+        }
+        _ = mgr.splitFocusedLeaf(
+            worktreeId: "wt", tabId: tab.id, axis: .vertical,
+            newLeafId: "new", newSessionId: "s2"
+        )
+        // Remove the ORIGINAL (non-focused) leaf by id. Focus is currently on "new".
+        let outcome = try #require(mgr.removeLeaf(
+            worktreeId: "wt", tabId: tab.id, leafId: originalLeaf.id
+        ))
+        guard case .leafRemoved(let outcomeTab, let closedLeafId) = outcome else {
+            Issue.record("expected .leafRemoved"); return
+        }
+        #expect(closedLeafId == originalLeaf.id)
+        if case .terminal(let s) = outcomeTab, case .leaf(let l) = s.root {
+            #expect(l.id == "new")
+            #expect(s.focusedLeafId == "new")
+        } else {
+            Issue.record("expected leaf root after collapse")
+        }
+    }
+
+    @Test func removeLeafResetsFocusWhenFocusedLeafRemoved() throws {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        guard case .terminal(let initial) = tab,
+              case .leaf(let originalLeaf) = initial.root else {
+            Issue.record("expected single-leaf terminal tab"); return
+        }
+        _ = mgr.splitFocusedLeaf(
+            worktreeId: "wt", tabId: tab.id, axis: .vertical,
+            newLeafId: "new", newSessionId: "s2"
+        )
+        // Remove the FOCUSED leaf ("new"). Focus must move to the surviving leaf.
+        let outcome = try #require(mgr.removeLeaf(
+            worktreeId: "wt", tabId: tab.id, leafId: "new"
+        ))
+        guard case .leafRemoved(_, let closedLeafId) = outcome else {
+            Issue.record("expected .leafRemoved"); return
+        }
+        #expect(closedLeafId == "new")
+        guard case .terminal(let persisted) = (mgr.tabs(forWorktree: "wt").first(where: { $0.id == tab.id })!),
+              case .leaf(let persistedLeaf) = persisted.root else {
+            Issue.record("expected single-leaf root"); return
+        }
+        #expect(persistedLeaf.id == originalLeaf.id)
+        #expect(persisted.focusedLeafId == originalLeaf.id)
+    }
+
+    @Test func removeLeafReturnsTabRemovedForLastLeaf() throws {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        guard case .terminal(let initial) = tab,
+              case .leaf(let onlyLeaf) = initial.root else {
+            Issue.record("expected single-leaf terminal tab"); return
+        }
+        let outcome = try #require(mgr.removeLeaf(
+            worktreeId: "wt", tabId: tab.id, leafId: onlyLeaf.id
+        ))
+        guard case .tabRemoved(let closedLeafId) = outcome else {
+            Issue.record("expected .tabRemoved"); return
+        }
+        #expect(closedLeafId == onlyLeaf.id)
+    }
+
+    @Test func removeLeafReturnsNilForUnknownLeaf() {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        let outcome = mgr.removeLeaf(
+            worktreeId: "wt", tabId: tab.id, leafId: "nope"
+        )
+        #expect(outcome == nil)
+    }
+
+    @Test func removeLeafReturnsNilForUnknownTab() {
+        let mgr = TabsManager()
+        let outcome = mgr.removeLeaf(
+            worktreeId: "wt", tabId: "ghost-tab", leafId: "any"
+        )
+        #expect(outcome == nil)
+    }
+
     @Test func setSplitFractionClampsBetween0_1And0_9() {
         let mgr = TabsManager()
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")

--- a/AlasTests/TabsManagerTests.swift
+++ b/AlasTests/TabsManagerTests.swift
@@ -740,6 +740,28 @@ struct TabsManagerPaneTests {
         #expect(outcome == nil)
     }
 
+    @Test func removeLeafTwiceIsNoOp() throws {
+        let mgr = TabsManager()
+        let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")
+        _ = mgr.splitFocusedLeaf(
+            worktreeId: "wt", tabId: tab.id, axis: .vertical,
+            newLeafId: "new", newSessionId: "s2"
+        )
+        // First removal succeeds.
+        let first = try #require(mgr.removeLeaf(
+            worktreeId: "wt", tabId: tab.id, leafId: "new"
+        ))
+        guard case .leafRemoved = first else {
+            Issue.record("expected .leafRemoved"); return
+        }
+        // Second removal of the same leaf must be a quiet no-op — the
+        // process-exit handler relies on this to race manual close.
+        let second = mgr.removeLeaf(
+            worktreeId: "wt", tabId: tab.id, leafId: "new"
+        )
+        #expect(second == nil)
+    }
+
     @Test func setSplitFractionClampsBetween0_1And0_9() {
         let mgr = TabsManager()
         let tab = mgr.appendTerminal(worktreeId: "wt", title: "t", sessionId: "s1")


### PR DESCRIPTION
## Summary

When a shell process inside a terminal pane exits (e.g. the user runs `exit`), the pane now closes automatically. Panes are only closed on a real process exit — tab switches, app teardown, and other "view disappeared" events do not trigger close.

- Threads Ghostty's `processAlive` flag through `SurfaceView.processExitHandler` so receivers can distinguish a real shell exit (`processAlive == false`) from a teardown of a still-live surface (`processAlive == true`).
- Adds `TerminalService.onSessionProcessExited` injection point and `TabsManager.removeLeaf(worktreeId:tabId:leafId:)` API.
- `AppState.closePaneForProcessExit` wires the two together and is idempotent so duplicate fires (`SHOW_CHILD_EXITED` + `close_surface_cb`) race manual close as a quiet no-op.
- Unit tests cover `removeLeaf` happy paths, focus reset, last-leaf → `.tabRemoved`, unknown-leaf/tab → `nil`, and the documented idempotency contract.

## Test plan

- [x] `xcodebuild test -only-testing:AlasTests/TabsManagerTests` — all 37 tests pass
- [ ] `exit` inside a single-pane terminal tab closes the tab
- [ ] `exit` inside one half of a split collapses the sibling up
- [ ] Switching tabs does not close panes