### PR TITLE
fix(acp): hide queued bubble while head is .sending

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -393,6 +393,7 @@
 		82E9F713C1BFF433E540314C /* AgentLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F6E707551671670D8CBA38 /* AgentLogoView.swift */; };
 		8312A5067AD6E0143FA83023 /* JSONRPCStdioTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A1EB96EBED0DEDCA5CD094 /* JSONRPCStdioTransport.swift */; };
 		832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */; };
+		2122969A246641F59AA155F1 /* ACPSessionVisibleQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2158E6144CBD436EBE0EB89B /* ACPSessionVisibleQueueTests.swift */; };
 		8352A6C0D7AE371907E50217 /* TreeSitterPython in Frameworks */ = {isa = PBXBuildFile; productRef = 7D55FFC5D9F65DAD0178FB0E /* TreeSitterPython */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
@@ -802,6 +803,7 @@
 		0AF8152B18C9D6290724122F /* HoverFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeature.swift; sourceTree = "<group>"; };
 		0B0317FF3C6E6D3F149FB4F5 /* ACPTranscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscript.swift; sourceTree = "<group>"; };
 		0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionQueueAPITests.swift; sourceTree = "<group>"; };
+		2158E6144CBD436EBE0EB89B /* ACPSessionVisibleQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionVisibleQueueTests.swift; sourceTree = "<group>"; };
 		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
 		0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionPrompt.swift; sourceTree = "<group>"; };
 		0C5373F76231F229D3F96AF3 /* session-update-config-option.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-option.json"; sourceTree = "<group>"; };
@@ -2482,6 +2484,7 @@
 				472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */,
+				2158E6144CBD436EBE0EB89B /* ACPSessionVisibleQueueTests.swift */,
 				547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */,
 				B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */,
 				45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */,
@@ -3530,6 +3533,7 @@
 				D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
 				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,
+				2122969A246641F59AA155F1 /* ACPSessionVisibleQueueTests.swift in Sources */,
 				D56C78F4D6A2BDFDF5A05B55 /* ACPSessionRunnerQueueTests.swift in Sources */,
 				57A5A3F4F14E75F6C00A2DC0 /* ACPSessionRunnerTests.swift in Sources */,
 				20096441D4850614A3CB8187 /* ACPSessionStoreCRUDTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -222,6 +222,16 @@ final class ACPSession: ObservableObject, Identifiable {
         queue.insert(contentsOf: snapshot, at: insertAt)
     }
 
+    /// Number of queue items that should render as bubbles below the
+    /// transcript. Excludes the `.sending` head because its prompt has
+    /// already been appended to the transcript by `ACPSessionRunner.sendNow`
+    /// (and the composer's Stop pill conveys the in-flight state). Without
+    /// this, the user sees the same message twice — once in the transcript,
+    /// once as a "Sending" queued bubble.
+    var visibleQueueCount: Int {
+        queue.reduce(0) { $0 + ($1.status == .sending ? 0 : 1) }
+    }
+
     /// Mark the head item `.sending`. Called by the flusher right before
     /// it spawns the prompt RPC. Clears any previous `lastError` so a
     /// retried item displays cleanly while in-flight.

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -58,6 +58,7 @@ struct ACPMessageList: View {
         var hasher = Hasher()
         hasher.combine(transcript.messages.count)
         hasher.combine(session.queue.count)
+        hasher.combine(session.queue.first?.status)
         // Streaming chunks mutate the buffer in place without re-publishing
         // the transcript array; the tick gives the body a reason to re-eval
         // so this signature changes and the tail-scroll fires per chunk.
@@ -123,26 +124,28 @@ struct ACPMessageList: View {
                             StreamingCaret().frame(width: 8, height: 14)
                                 .id("__streaming_caret__")
                         }
-                        if session.queue.count > 1 {
-                            ACPQueueHeader(count: session.queue.count, onClear: onQueueClearAll)
+                        if session.visibleQueueCount > 1 {
+                            ACPQueueHeader(count: session.visibleQueueCount, onClear: onQueueClearAll)
                                 .id("__queue_header__")
                         }
                         ForEach(Array(session.queue.enumerated()), id: \.element.id) { idx, item in
-                            ACPQueuedBubble(
-                                item: item,
-                                onEdit: { onQueueEdit(item) },
-                                onRemove: { onQueueRemove(item.id) },
-                                onRetry: { onQueueRetry(item.id) }
-                            )
-                            .dropDestination(for: String.self) { items, _ in
-                                guard let s = items.first,
-                                      let uuid = UUID(uuidString: s),
-                                      let src = session.queue.firstIndex(where: { $0.id == uuid })
-                                else { return false }
-                                onQueueReorder(src, idx)
-                                return true
+                            if item.status != .sending {
+                                ACPQueuedBubble(
+                                    item: item,
+                                    onEdit: { onQueueEdit(item) },
+                                    onRemove: { onQueueRemove(item.id) },
+                                    onRetry: { onQueueRetry(item.id) }
+                                )
+                                .dropDestination(for: String.self) { items, _ in
+                                    guard let s = items.first,
+                                          let uuid = UUID(uuidString: s),
+                                          let src = session.queue.firstIndex(where: { $0.id == uuid })
+                                    else { return false }
+                                    onQueueReorder(src, idx)
+                                    return true
+                                }
+                                .id("__queue_\(item.id)")
                             }
-                            .id("__queue_\(item.id)")
                         }
                         // Invisible tail spacer that the auto-scroll pins to
                         // the viewport bottom; this guarantees the streaming

--- a/AlasTests/ACP/Session/ACPSessionVisibleQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionVisibleQueueTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSession visibleQueueCount")
+struct ACPSessionVisibleQueueTests {
+    private func mkSession() -> ACPSession {
+        ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+    }
+
+    @Test("empty queue → 0 visible")
+    func empty() {
+        #expect(mkSession().visibleQueueCount == 0)
+    }
+
+    @Test("single .pending → 1 visible")
+    func singlePending() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        #expect(s.visibleQueueCount == 1)
+    }
+
+    @Test("single .sending head → 0 visible")
+    func singleSending() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.markQueueHeadSending()
+        #expect(s.visibleQueueCount == 0)
+    }
+
+    @Test(".sending head + two .pending → 2 visible")
+    func sendingPlusPending() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.enqueue(blocks: [.text("b")])
+        s.enqueue(blocks: [.text("c")])
+        s.markQueueHeadSending()
+        #expect(s.queue.count == 3)
+        #expect(s.visibleQueueCount == 2)
+    }
+
+    @Test("retry-eligible .pending with lastError stays visible")
+    func pendingWithErrorStaysVisible() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.markQueueHeadSending()
+        s.setQueueHeadError("boom")
+        #expect(s.queue[0].status == .pending)
+        #expect(s.queue[0].lastError == "boom")
+        #expect(s.visibleQueueCount == 1)
+    }
+}


### PR DESCRIPTION
## Summary

- When a queued ACP prompt promoted to `.sending`, the runner recorded its text in the transcript AND the queue still owned the item until the RPC resolved, so the same message appeared twice — once as a transcript user-bubble, once as a "Sending" queued bubble below.
- Add `ACPSession.visibleQueueCount` (excludes `.sending` items) and use it to gate both the queue header and the `ForEach` rendering in `ACPMessageList`, so the in-flight head is hidden until it's popped (or rolls back to `.pending` on failure with a Retry button).
- Fold `session.queue.first?.status` into `scrollSignature` so SwiftUI re-evaluates the body at promotion time.

## Test plan

- [x] `xcodebuild … -only-testing:AlasTests/ACPSessionVisibleQueueTests test` (5 new tests, all green)
- [x] Broader run: `ACPSessionVisibleQueueTests + ACPSessionQueueAPITests + ACPSessionRunnerQueueTests` (41 tests, all green)
- [x] `xcodebuild … build` clean on Debug
- [ ] Manual: queue a prompt while a turn is in flight, wait for it to promote, confirm only one user bubble appears (no "Sending" duplicate below)
- [ ] Manual regression: `[sending, pending, pending]` shows header "2 queued" with two bubbles
- [ ] Manual regression: a failed queued send still shows the bubble with Retry (status flips back to `.pending`)