### PR TITLE
feat(acp): inline plan sidebar in ACP pane on wide layouts

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */; };
 		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
 		5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */; };
+		5BCB202710E37EA60DCC91F0 /* ACPPlanSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */; };
 		5C86AEAEA5497DBF5FD7D604 /* initialize-response.json in Resources */ = {isa = PBXBuildFile; fileRef = 2463B784210156F489A13FAC /* initialize-response.json */; };
 		5C9791E96E80858B5A037941 /* session-update-agent-chunk.json in Resources */ = {isa = PBXBuildFile; fileRef = 4D63B166AF2C533BE6E59365 /* session-update-agent-chunk.json */; };
 		5C9EB59AAA68656BD7190044 /* DiffOpenFileAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */; };
@@ -390,6 +391,7 @@
 		7DFE8DCEA8A4BABF51F54215 /* GitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A92711BC1D9A78D8A80561 /* GitTypes.swift */; };
 		7E56D356C235F59E1CE24210 /* AgentBuiltinsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */; };
 		7EB64E55CE27886D660C5D0C /* DefinitionSnippetCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */; };
+		7EC95A2AAEFE78B51D9F599A /* ACPPlanSidebarVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */; };
 		7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */; };
 		7FFC3D96011714F0A131FAB8 /* ACPFileChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */; };
 		8035C82C1C3F79801A0F2F39 /* ImageDiffPairKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */; };
@@ -519,11 +521,13 @@
 		A75289A4560BCA2DACA0760B /* AppStateCreateWorktreeSymlinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */; };
 		A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7AEB9E8D83B610E291BAE1 /* ContentSearcher.swift */; };
 		A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */; };
+		A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */; };
 		A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */; };
 		A9AD5B31C3A9FCBE76A15179 /* BlockedLanguageServerNudgeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD723B8C15EF2413C5D935D /* BlockedLanguageServerNudgeResolver.swift */; };
 		A9D0D8D94E1D46F35D17DDBA /* CodeEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC93F4FB957C2CCD4E1E2326 /* CodeEditorView.swift */; };
 		AA3024661C46385700D8B3A6 /* TitlelessWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */; };
 		AA8FEF94B861001AB643E005 /* FontFamilyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */; };
+		AB81A1DA27A87F7C7E49D9CF /* ACPPlanChecklist.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */; };
 		AB8B755B315E94BDF0BD937B /* TreeSitterBash in Frameworks */ = {isa = PBXBuildFile; productRef = 0714DCAA9EC181C239773440 /* TreeSitterBash */; };
 		ABB5595A9A39C8AF203B5873 /* AppStateOverlayFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6612D1543C76A6EAF38A14F4 /* AppStateOverlayFocusTests.swift */; };
 		AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490AFAD12616D61858A19A31 /* ACPSetupCheckerTests.swift */; };
@@ -744,6 +748,7 @@
 		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
+		F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */; };
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
 		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
 		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
@@ -833,6 +838,7 @@
 		0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonospaceFontCatalog.swift; sourceTree = "<group>"; };
 		0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionPrompt.swift; sourceTree = "<group>"; };
 		0C5373F76231F229D3F96AF3 /* session-update-config-option.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-option.json"; sourceTree = "<group>"; };
+		0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptLatestPlanTests.swift; sourceTree = "<group>"; };
 		0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabLoadingIndicatorTests.swift; sourceTree = "<group>"; };
 		0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewController.swift; sourceTree = "<group>"; };
 		0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationStateTests.swift; sourceTree = "<group>"; };
@@ -1241,6 +1247,7 @@
 		94D30693F45966ED1456811E /* ACPSessionHydrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionHydrator.swift; sourceTree = "<group>"; };
 		9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAction.swift; sourceTree = "<group>"; };
 		95DA6BFFE45ED25669869C76 /* CommitMessageEditorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitMessageEditorViewTests.swift; sourceTree = "<group>"; };
+		96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanSidebarVisibilityTests.swift; sourceTree = "<group>"; };
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
 		97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroupViewTests.swift; sourceTree = "<group>"; };
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
@@ -1398,6 +1405,7 @@
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstaller.swift; sourceTree = "<group>"; };
 		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
+		CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanChecklist.swift; sourceTree = "<group>"; };
 		CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModel.swift; sourceTree = "<group>"; };
 		CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRendererTests.swift; sourceTree = "<group>"; };
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
@@ -1425,6 +1433,7 @@
 		D65BEFA85B6671FDE505A30D /* CommitMessageEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitMessageEditorView.swift; sourceTree = "<group>"; };
 		D6A9977C979705A40595FD5E /* TabsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerTests.swift; sourceTree = "<group>"; };
 		D7268D601058775FE02B6B06 /* CommitEditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitEditorTabView.swift; sourceTree = "<group>"; };
+		D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanSidebarVisibility.swift; sourceTree = "<group>"; };
 		D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailability.swift; sourceTree = "<group>"; };
 		D8ACFACD788DF2035534F62E /* AppConfigCodeInstallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigCodeInstallTests.swift; sourceTree = "<group>"; };
 		D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStore.swift; sourceTree = "<group>"; };
@@ -1489,6 +1498,7 @@
 		EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTextStorage.swift; sourceTree = "<group>"; };
 		EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigFilesTests.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
+		EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanSidebar.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
 		EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptCurrentPlanTests.swift; sourceTree = "<group>"; };
 		EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTerminalTests.swift; sourceTree = "<group>"; };
@@ -2159,6 +2169,7 @@
 				85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */,
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
+				96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */,
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
 			);
 			path = UI;
@@ -2356,8 +2367,11 @@
 				E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */,
 				3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */,
 				0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */,
+				CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */,
 				B7AAAEB5A9C69FC459AAD70B /* ACPPlanPill.swift */,
 				2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */,
+				EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */,
+				D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */,
 				987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */,
 				10602801D3FA990E60CB072D /* ACPQueueHeader.swift */,
 				B5E898E9F7E2680132FF54D4 /* ACPSelectChip.swift */,
@@ -2565,6 +2579,7 @@
 				F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */,
 				26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */,
 				EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */,
+				0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */,
 				7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */,
 				FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */,
 			);
@@ -3217,8 +3232,11 @@
 				0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */,
 				52A5CDD852333A0C4BDC6995 /* ACPPermissionRequest.swift in Sources */,
 				823AA3E801A11C535C9438BD /* ACPPermissionScope.swift in Sources */,
+				AB81A1DA27A87F7C7E49D9CF /* ACPPlanChecklist.swift in Sources */,
 				B055F47062645975A500E2EF /* ACPPlanPill.swift in Sources */,
 				CF6CC4CD0C7841CA79DB0E4E /* ACPPlanPillState.swift in Sources */,
+				5BCB202710E37EA60DCC91F0 /* ACPPlanSidebar.swift in Sources */,
+				7EC95A2AAEFE78B51D9F599A /* ACPPlanSidebarVisibility.swift in Sources */,
 				7556121D51C54458FCAFED2A /* ACPProtocolVersion.swift in Sources */,
 				F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */,
 				518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */,
@@ -3628,6 +3646,7 @@
 				57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */,
 				8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */,
 				97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */,
+				F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,
 				C51451EC8E103EB5FEF82EFE /* ACPSessionLifecycleTests.swift in Sources */,
@@ -3653,6 +3672,7 @@
 				89F58C7178B661EAE0057622 /* ACPTerminalTests.swift in Sources */,
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
 				4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */,
+				A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
 				E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */,
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -59,10 +59,35 @@ final class ACPTranscript: ObservableObject {
     /// when no plan has arrived for this turn yet, even if an older turn
     /// left a plan behind. The toolbar pill renders the *current* turn's
     /// work, not stale progress from a previous prompt.
+    /// (See also `latestPlan`, which is turn-stable and treats an empty plan as nil.)
     var currentPlan: [ACPMessage.PlanItem]? {
         for m in messages.reversed() {
             if case .user = m { return nil }
             if case .plan(_, let items) = m { return items }
+        }
+        return nil
+    }
+
+    /// The most recent plan emitted in this session, ignoring turn
+    /// boundaries. Unlike `currentPlan`, this survives the gap between
+    /// a fresh user prompt and the next `.plan` arrival — so the sidebar
+    /// can stay visible across turns per spec §6 ("stays until the next
+    /// plan or session reset").
+    ///
+    /// Returns nil when no plan message has ever arrived, or when the
+    /// most recent plan is empty. Note: unlike `currentPlan`, which returns an empty array for an empty current-turn plan, `latestPlan` normalises empty to nil — the sidebar uses this to decide whether to render at all.
+    ///
+    /// **Sidebar-only intent.** The toolbar pill deliberately keeps reading
+    /// `currentPlan` so it reflects the *active* turn — a per-turn signal
+    /// matches the pill's "what's the agent doing right now" framing. The
+    /// turn-stable semantics here exist only because the sidebar wants the
+    /// previous plan to linger across the brief gap when a new user prompt
+    /// has landed but the next `.plan` hasn't yet arrived.
+    var latestPlan: [ACPMessage.PlanItem]? {
+        for m in messages.reversed() {
+            if case .plan(_, let items) = m {
+                return items.isEmpty ? nil : items
+            }
         }
         return nil
     }

--- a/Alas/Sources/ACP/UI/ACPPlanChecklist.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanChecklist.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// Shared body of the plan UI — header (`done / total`) plus the list
+/// of rows with completed / in-progress / pending marks. Used by both
+/// `ACPPlanPill`'s popover (sub-threshold) and `ACPPlanSidebar`
+/// (wide-pane). 320pt content width; the host frames it.
+///
+/// Spec: `docs/superpowers/specs/2026-05-29-acp-plan-sidebar-design.md`
+struct ACPPlanChecklist: View {
+    let items: [ACPMessage.PlanItem]
+    @Environment(\.theme) private var theme
+
+    private var done: Int { items.filter { $0.status == "completed" }.count }
+    private var total: Int { items.count }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider().background(theme.color("line"))
+            VStack(alignment: .leading, spacing: 1) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    row(item: item)
+                }
+            }
+            .padding(.vertical, 6)
+        }
+        .background(theme.color("bg-1"))
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 10))
+                .foregroundStyle(theme.color("accent"))
+            Text("Plan")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.5)
+                .textCase(.uppercase)
+                .foregroundStyle(theme.color("accent"))
+            Text("\(done) / \(total)")
+                .font(.system(size: 10.5, design: .monospaced))
+                .foregroundStyle(theme.color("fg-faint"))
+            Spacer()
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .background(theme.color("bg-2").opacity(0.4))
+    }
+
+    @ViewBuilder
+    private func row(item: ACPMessage.PlanItem) -> some View {
+        HStack(spacing: 10) {
+            mark(for: item)
+            Text(item.content)
+                .font(.system(size: 12))
+                .foregroundStyle(item.status == "completed" ? theme.color("fg-faint") : theme.color("fg"))
+                .strikethrough(item.status == "completed", color: theme.color("fg-faint").opacity(0.5))
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 5)
+        .background(item.status == "in_progress" ? theme.color("accent").opacity(0.10) : Color.clear)
+    }
+
+    @ViewBuilder
+    private func mark(for item: ACPMessage.PlanItem) -> some View {
+        switch item.status {
+        case "completed":
+            Image(systemName: "checkmark")
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(theme.color("add"))
+                .frame(width: 12)
+        case "in_progress":
+            Spinner(lineWidth: 1.5, duration: 0.7)
+                .frame(width: 10, height: 10)
+                .frame(width: 12)
+        default:
+            Circle()
+                .fill(theme.color("fg-faint").opacity(0.6))
+                .frame(width: 5, height: 5)
+                .frame(width: 12)
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPPlanPill.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanPill.swift
@@ -1,5 +1,21 @@
 import SwiftUI
 
+/// Environment flag set by `ACPSessionView` when the inline plan
+/// sidebar is currently visible. The toolbar pill reads this and
+/// renders nothing when true (the sidebar is the canonical surface).
+///
+/// Spec §3 / §4a — pill and sidebar are mutually exclusive.
+private struct ACPPlanSidebarVisibleKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var acpPlanSidebarVisible: Bool {
+        get { self[ACPPlanSidebarVisibleKey.self] }
+        set { self[ACPPlanSidebarVisibleKey.self] = newValue }
+    }
+}
+
 /// Floaty pill that lives in the ACP toolbar and surfaces the latest
 /// plan from the session's transcript. Shows `done / total`, the current
 /// step name, a slim progress bar, and an "animated snake" border that
@@ -13,10 +29,11 @@ import SwiftUI
 struct ACPPlanPill: View {
     @ObservedObject var transcript: ACPTranscript
     @Environment(\.theme) private var theme
+    @Environment(\.acpPlanSidebarVisible) private var sidebarVisible
     @State private var popoverOpen = false
 
     var body: some View {
-        if let state = ACPPlanPillState(items: transcript.currentPlan) {
+        if !sidebarVisible, let state = ACPPlanPillState(items: transcript.currentPlan) {
             pill(state: state)
         } else {
             EmptyView()
@@ -54,10 +71,16 @@ struct ACPPlanPill: View {
         .buttonStyle(.plain)
         .help("Plan — click to view all steps")
         .popover(isPresented: $popoverOpen, arrowEdge: .top) {
-            let items = transcript.currentPlan ?? []
-            if let popoverState = ACPPlanPillState(items: items) {
-                ACPPlanPopover(items: items, state: popoverState)
+            if let items = transcript.currentPlan, !items.isEmpty {
+                ACPPlanChecklist(items: items)
+                    .frame(width: 320)
             }
+        }
+        // The body gate hides the pill once the sidebar appears, but a
+        // popover attached to a view that leaves the tree is not
+        // guaranteed to auto-dismiss on macOS — explicitly close it.
+        .onChange(of: sidebarVisible) { _, nowVisible in
+            if nowVisible { popoverOpen = false }
         }
     }
 
@@ -132,80 +155,5 @@ struct ACPPlanPill: View {
             }
         }
         .frame(width: 48, height: 4)
-    }
-}
-
-/// Popover body: full plan checklist, current step highlighted.
-private struct ACPPlanPopover: View {
-    let items: [ACPMessage.PlanItem]
-    let state: ACPPlanPillState
-    @Environment(\.theme) private var theme
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            header
-            Divider().background(theme.color("line"))
-            VStack(alignment: .leading, spacing: 1) {
-                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                    row(item: item)
-                }
-            }
-            .padding(.vertical, 6)
-        }
-        .frame(width: 320)
-        .background(theme.color("bg-1"))
-    }
-
-    private var header: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 10))
-                .foregroundStyle(theme.color("accent"))
-            Text("Plan")
-                .font(.system(size: 10.5, weight: .semibold))
-                .tracking(0.5)
-                .textCase(.uppercase)
-                .foregroundStyle(theme.color("accent"))
-            Text("\(state.done) / \(state.total)")
-                .font(.system(size: 10.5, design: .monospaced))
-                .foregroundStyle(theme.color("fg-faint"))
-            Spacer()
-        }
-        .padding(.horizontal, 12).padding(.vertical, 8)
-        .background(theme.color("bg-2").opacity(0.4))
-    }
-
-    @ViewBuilder
-    private func row(item: ACPMessage.PlanItem) -> some View {
-        HStack(spacing: 10) {
-            mark(for: item)
-            Text(item.content)
-                .font(.system(size: 12))
-                .foregroundStyle(item.status == "completed" ? theme.color("fg-faint") : theme.color("fg"))
-                .strikethrough(item.status == "completed", color: theme.color("fg-faint").opacity(0.5))
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 12).padding(.vertical, 5)
-        .background(item.status == "in_progress" ? theme.color("accent").opacity(0.10) : Color.clear)
-    }
-
-    @ViewBuilder
-    private func mark(for item: ACPMessage.PlanItem) -> some View {
-        switch item.status {
-        case "completed":
-            Image(systemName: "checkmark")
-                .font(.system(size: 9, weight: .bold))
-                .foregroundStyle(theme.color("add"))
-                .frame(width: 12)
-        case "in_progress":
-            Spinner(lineWidth: 1.5, duration: 0.7)
-                .frame(width: 10, height: 10)
-                .frame(width: 12)
-        default:
-            Circle()
-                .fill(theme.color("fg-faint").opacity(0.6))
-                .frame(width: 5, height: 5)
-                .frame(width: 12)
-        }
     }
 }

--- a/Alas/Sources/ACP/UI/ACPPlanPill.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanPill.swift
@@ -33,10 +33,19 @@ struct ACPPlanPill: View {
     @State private var popoverOpen = false
 
     var body: some View {
-        if !sidebarVisible, let state = ACPPlanPillState(items: transcript.currentPlan) {
-            pill(state: state)
-        } else {
-            EmptyView()
+        // .onChange lives on the outer Group so it keeps firing even
+        // when the gate below collapses to EmptyView — without that, a
+        // popover open at the moment the sidebar appears would never
+        // be told to close, and would linger next to the sidebar.
+        Group {
+            if !sidebarVisible, let state = ACPPlanPillState(items: transcript.currentPlan) {
+                pill(state: state)
+            } else {
+                EmptyView()
+            }
+        }
+        .onChange(of: sidebarVisible) { _, nowVisible in
+            if nowVisible { popoverOpen = false }
         }
     }
 
@@ -75,12 +84,6 @@ struct ACPPlanPill: View {
                 ACPPlanChecklist(items: items)
                     .frame(width: 320)
             }
-        }
-        // The body gate hides the pill once the sidebar appears, but a
-        // popover attached to a view that leaves the tree is not
-        // guaranteed to auto-dismiss on macOS — explicitly close it.
-        .onChange(of: sidebarVisible) { _, nowVisible in
-            if nowVisible { popoverOpen = false }
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPPlanSidebar.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanSidebar.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// Inline right-side plan surface. Shown by `ACPSessionView` when the
+/// pane is wide enough (see `ACPPlanSidebarVisibility`). Mirrors the
+/// pill's popover content via the shared `ACPPlanChecklist`, just
+/// hosted in a fixed 320pt column with a left divider and an outer
+/// scroll view.
+///
+/// Observes `ACPTranscript` directly so plan updates re-render here
+/// (same reason `ACPPlanPill` observes it directly — `ACPSession`
+/// doesn't forward transcript changes).
+///
+/// Spec: `docs/superpowers/specs/2026-05-29-acp-plan-sidebar-design.md` (§3)
+struct ACPPlanSidebar: View {
+    @ObservedObject var transcript: ACPTranscript
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        let items = transcript.latestPlan ?? []
+        HStack(spacing: 0) {
+            Rectangle()
+                .fill(theme.color("line"))
+                .frame(width: 0.5)
+            ScrollView(.vertical, showsIndicators: false) {
+                if !items.isEmpty {
+                    ACPPlanChecklist(items: items)
+                } else {
+                    // The caller gates rendering on hasPlan, so we
+                    // shouldn't be visible without a plan; render an
+                    // empty placeholder rather than crashing if items
+                    // race to nil before the visibility flips.
+                    Color.clear.frame(height: 1)
+                }
+            }
+            .frame(maxHeight: .infinity)
+            .background(theme.color("bg-1"))
+        }
+        .frame(width: 320)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel(for: items))
+    }
+
+    private func accessibilityLabel(for items: [ACPMessage.PlanItem]) -> String {
+        guard let state = ACPPlanPillState(items: items) else { return "Plan" }
+        return "Plan, \(state.done) of \(state.total) complete — \(state.currentStep)"
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPPlanSidebarVisibility.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanSidebarVisibility.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Pure decision function for whether the inline plan sidebar should
+/// be shown. Hysteresis (820/900 dead band) prevents flicker when the
+/// user drags a pane divider near the boundary, or when the right pane
+/// animates open/closed.
+///
+/// Spec: `docs/superpowers/specs/2026-05-29-acp-plan-sidebar-design.md`
+enum ACPPlanSidebarVisibility {
+    /// Width at or above which a hidden sidebar appears.
+    static let showThreshold: CGFloat = 900
+
+    /// Width strictly below which a shown sidebar hides.
+    static let hideThreshold: CGFloat = 820
+
+    /// Returns the next visibility given the current pane width, whether
+    /// a plan is available, and whether the sidebar is currently shown.
+    ///
+    /// - If no plan: always hidden (the sidebar has no empty state).
+    /// - If width ≥ `showThreshold`: shown.
+    /// - If width < `hideThreshold`: hidden.
+    /// - Otherwise (dead band): keep `current`.
+    static func next(paneWidth: CGFloat, hasPlan: Bool, current: Bool) -> Bool {
+        guard hasPlan else { return false }
+        if paneWidth >= showThreshold { return true }
+        if paneWidth < hideThreshold { return false }
+        return current
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -45,6 +45,29 @@ private struct ACPSessionView: View {
     @State private var updateState: AdapterUpdateState?
     @State private var dismissedLatest: String?
     @Environment(\.theme) private var theme
+    @State private var showPlanSidebar: Bool = false
+
+    /// Re-evaluated on every width / plan change. Pure call into the
+    /// hysteresis reducer; the `.spring` wrap lives at the call site.
+    ///
+    /// Intentionally not debounced. Spec §5 mentioned an ~80ms debounce
+    /// against divider-drag thrash, but the 80pt hysteresis dead band +
+    /// the spring animation absorb that case in practice — and the
+    /// per-tick work here is just an isEmpty check, a Bool compare, and
+    /// an equality test. Revisit if profiling shows otherwise.
+    private func updatePlanSidebar(paneWidth: CGFloat) {
+        let hasPlan = (session.transcript.latestPlan?.isEmpty == false)
+        let next = ACPPlanSidebarVisibility.next(
+            paneWidth: paneWidth,
+            hasPlan: hasPlan,
+            current: showPlanSidebar
+        )
+        if next != showPlanSidebar {
+            withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
+                showPlanSidebar = next
+            }
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -64,6 +87,7 @@ private struct ACPSessionView: View {
             }
             transcriptAndComposer
         }
+        .environment(\.acpPlanSidebarVisible, showPlanSidebar)
         .task(id: sessionId) {
             await hydrateAndAttach()
         }
@@ -100,110 +124,127 @@ private struct ACPSessionView: View {
     }
 
     private var transcriptAndComposer: some View {
-        ZStack(alignment: .bottom) {
-            if isConnecting {
-                ACPConnectingPlaceholder(
-                    agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId
-                )
-            } else {
-                ACPMessageList(
-                    session: session,
-                    transcript: session.transcript,
-                    onOpenDiff: { relativePath in
-                        state.openDiffTab(forFileInWorktree: worktree, relativePath: relativePath)
-                    },
-                    // Use the runner's policy (where the agent's continuation
-                    // lives) — otherwise the user's click can't resolve the
-                    // pending permission request.
-                    policy: manager.runners[sessionId]?.policy,
-                    scopeKey: scopeKey(for: session.transcript.pendingPermission),
-                    onQueueEdit: { item in
-                        // Inline editor is a future enhancement (see plan §4.4).
-                        // For v1, clicking the pencil removes the item from
-                        // the queue so the user can re-type in the composer.
-                        session.removeFromQueue(id: item.id)
-                        manager.persistQueue(for: session)
-                        // Discarding the head can unblock a successor
-                        // that was waiting behind a `lastError` head.
-                        manager.runners[sessionId]?.flushQueueIfIdle()
-                    },
-                    onQueueRemove: { id in
-                        session.removeFromQueue(id: id)
-                        manager.persistQueue(for: session)
-                        manager.runners[sessionId]?.flushQueueIfIdle()
-                    },
-                    onQueueRetry: { id in
-                        guard let idx = session.queue.firstIndex(where: { $0.id == id }) else { return }
-                        session.queue[idx].lastError = nil
-                        manager.persistQueue(for: session)
-                        manager.runners[sessionId]?.flushQueueIfIdle()
-                    },
-                    onQueueReorder: { src, dst in
-                        session.moveInQueue(from: src, to: dst)
-                        manager.persistQueue(for: session)
-                        // Reordering can move a clean prompt to the head
-                        // where it can finally drain.
-                        manager.runners[sessionId]?.flushQueueIfIdle()
-                    },
-                    onQueueClearAll: {
-                        session.clearPendingQueue()
-                        manager.persistQueue(for: session)
-                        // No-op if the queue is now empty, but if a
-                        // `.sending` head survives the clear and the
-                        // user re-enqueues, the next idle drain still
-                        // needs to fire from this path.
-                        manager.runners[sessionId]?.flushQueueIfIdle()
-                    }
-                )
-            }
-
-            ACPComposer(
-                session: session,
-                manager: manager,
-                worktreeRoot: worktree.path,
-                agentLookup: { state.agent(id: $0) },
-                sendOnEnter: state.config.harness.acpSendOnEnter
-            ) { text, attachments, intent, draft, onPromptFinished -> Bool in
-                guard session.attached, !session.disconnected,
-                      let runner = manager.runners[sessionId] else { return false }
-                // `intent` is already resolved by the composer for keyboard
-                // submits; the toolbar send button bypasses the keyboard
-                // inversion and supplies its own intent directly. No
-                // further resolution here.
-                let draftRevision = session.composerDraftRevision
-                runner.send(text: text, attachments: attachments, intent: intent) { succeeded in
-                    if succeeded {
-                        manager.clearComposerDraft(
-                            for: session,
-                            ifCurrentDraftEquals: draft,
-                            revision: draftRevision
+        GeometryReader { proxy in
+            HStack(spacing: 0) {
+                ZStack(alignment: .bottom) {
+                    if isConnecting {
+                        ACPConnectingPlaceholder(
+                            agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId
                         )
                     } else {
-                        manager.persistComposerDraft(
-                            draft,
-                            for: session,
-                            ifCurrentDraftEquals: draft,
-                            revision: draftRevision
+                        ACPMessageList(
+                            session: session,
+                            transcript: session.transcript,
+                            onOpenDiff: { relativePath in
+                                state.openDiffTab(forFileInWorktree: worktree, relativePath: relativePath)
+                            },
+                            // Use the runner's policy (where the agent's continuation
+                            // lives) — otherwise the user's click can't resolve the
+                            // pending permission request.
+                            policy: manager.runners[sessionId]?.policy,
+                            scopeKey: scopeKey(for: session.transcript.pendingPermission),
+                            onQueueEdit: { item in
+                                // Inline editor is a future enhancement (see plan §4.4).
+                                // For v1, clicking the pencil removes the item from
+                                // the queue so the user can re-type in the composer.
+                                session.removeFromQueue(id: item.id)
+                                manager.persistQueue(for: session)
+                                // Discarding the head can unblock a successor
+                                // that was waiting behind a `lastError` head.
+                                manager.runners[sessionId]?.flushQueueIfIdle()
+                            },
+                            onQueueRemove: { id in
+                                session.removeFromQueue(id: id)
+                                manager.persistQueue(for: session)
+                                manager.runners[sessionId]?.flushQueueIfIdle()
+                            },
+                            onQueueRetry: { id in
+                                guard let idx = session.queue.firstIndex(where: { $0.id == id }) else { return }
+                                session.queue[idx].lastError = nil
+                                manager.persistQueue(for: session)
+                                manager.runners[sessionId]?.flushQueueIfIdle()
+                            },
+                            onQueueReorder: { src, dst in
+                                session.moveInQueue(from: src, to: dst)
+                                manager.persistQueue(for: session)
+                                // Reordering can move a clean prompt to the head
+                                // where it can finally drain.
+                                manager.runners[sessionId]?.flushQueueIfIdle()
+                            },
+                            onQueueClearAll: {
+                                session.clearPendingQueue()
+                                manager.persistQueue(for: session)
+                                // No-op if the queue is now empty, but if a
+                                // `.sending` head survives the clear and the
+                                // user re-enqueues, the next idle drain still
+                                // needs to fire from this path.
+                                manager.runners[sessionId]?.flushQueueIfIdle()
+                            }
                         )
                     }
-                    onPromptFinished(succeeded)
-                }
-                return true
-            }
 
-            if let undo = session.steerUndo, !undo.snapshot.isEmpty {
-                VStack {
-                    Spacer()
-                    ACPSteerUndoToast(
-                        discardedCount: undo.snapshot.count,
-                        onUndo: { manager.runners[sessionId]?.steerUndo() },
-                        onDismiss: { session.steerUndo = nil }
-                    )
-                    .id(undo.id)
-                    .padding(.bottom, 200)
+                    ACPComposer(
+                        session: session,
+                        manager: manager,
+                        worktreeRoot: worktree.path,
+                        agentLookup: { state.agent(id: $0) },
+                        sendOnEnter: state.config.harness.acpSendOnEnter
+                    ) { text, attachments, intent, draft, onPromptFinished -> Bool in
+                        guard session.attached, !session.disconnected,
+                              let runner = manager.runners[sessionId] else { return false }
+                        // `intent` is already resolved by the composer for keyboard
+                        // submits; the toolbar send button bypasses the keyboard
+                        // inversion and supplies its own intent directly. No
+                        // further resolution here.
+                        let draftRevision = session.composerDraftRevision
+                        runner.send(text: text, attachments: attachments, intent: intent) { succeeded in
+                            if succeeded {
+                                manager.clearComposerDraft(
+                                    for: session,
+                                    ifCurrentDraftEquals: draft,
+                                    revision: draftRevision
+                                )
+                            } else {
+                                manager.persistComposerDraft(
+                                    draft,
+                                    for: session,
+                                    ifCurrentDraftEquals: draft,
+                                    revision: draftRevision
+                                )
+                            }
+                            onPromptFinished(succeeded)
+                        }
+                        return true
+                    }
+
+                    if let undo = session.steerUndo, !undo.snapshot.isEmpty {
+                        VStack {
+                            Spacer()
+                            ACPSteerUndoToast(
+                                discardedCount: undo.snapshot.count,
+                                onUndo: { manager.runners[sessionId]?.steerUndo() },
+                                onDismiss: { session.steerUndo = nil }
+                            )
+                            .id(undo.id)
+                            .padding(.bottom, 200)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .transition(.opacity)
+                    }
                 }
-                .frame(maxWidth: .infinity)
-                .transition(.opacity)
+
+                if showPlanSidebar {
+                    ACPPlanSidebar(transcript: session.transcript)
+                        .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height)
+            .onAppear { updatePlanSidebar(paneWidth: proxy.size.width) }
+            .onChange(of: proxy.size.width) { _, newWidth in
+                updatePlanSidebar(paneWidth: newWidth)
+            }
+            .onChange(of: session.transcript.latestPlan) { _, _ in
+                updatePlanSidebar(paneWidth: proxy.size.width)
             }
         }
     }

--- a/AlasTests/ACP/Session/ACPTranscriptLatestPlanTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptLatestPlanTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscript.latestPlan")
+struct ACPTranscriptLatestPlanTests {
+    private typealias Item = ACPMessage.PlanItem
+
+    private func makeSession() -> ACPSession {
+        ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
+    }
+
+    @Test("nil when no plan has ever arrived")
+    func nilWhenNoPlan() {
+        let session = makeSession()
+        session.transcript.messages = [.user(id: UUID(), text: "hi", attachments: [])]
+        #expect(session.transcript.latestPlan == nil)
+    }
+
+    @Test("returns the most recent plan in the current turn")
+    func returnsCurrentTurnPlan() {
+        let items: [Item] = [.init(content: "Read", status: "in_progress")]
+        let session = makeSession()
+        session.transcript.messages = [
+            .user(id: UUID(), text: "hi", attachments: []),
+            .plan(id: UUID(), items)
+        ]
+        #expect(session.transcript.latestPlan == items)
+    }
+
+    @Test("survives a new user prompt after a plan (unlike currentPlan)")
+    func survivesNewUserPrompt() {
+        let oldItems: [Item] = [.init(content: "Done step", status: "completed")]
+        let session = makeSession()
+        session.transcript.messages = [
+            .user(id: UUID(), text: "first", attachments: []),
+            .plan(id: UUID(), oldItems),
+            .user(id: UUID(), text: "second", attachments: [])
+        ]
+        #expect(session.transcript.currentPlan == nil)     // turn-scoped, unchanged
+        #expect(session.transcript.latestPlan == oldItems) // turn-stable
+    }
+
+    @Test("returns the latest plan when multiple plans exist across turns")
+    func returnsLatestAcrossTurns() {
+        let oldItems: [Item] = [.init(content: "Old", status: "completed")]
+        let newItems: [Item] = [.init(content: "New", status: "in_progress")]
+        let session = makeSession()
+        session.transcript.messages = [
+            .user(id: UUID(), text: "first", attachments: []),
+            .plan(id: UUID(), oldItems),
+            .user(id: UUID(), text: "second", attachments: []),
+            .plan(id: UUID(), newItems)
+        ]
+        #expect(session.transcript.latestPlan == newItems)
+    }
+
+    @Test("returns nil when latest plan items are empty")
+    func nilForEmptyLatest() {
+        let session = makeSession()
+        session.transcript.messages = [
+            .user(id: UUID(), text: "hi", attachments: []),
+            .plan(id: UUID(), [])
+        ]
+        #expect(session.transcript.latestPlan == nil)
+    }
+}

--- a/AlasTests/ACP/UI/ACPPlanSidebarVisibilityTests.swift
+++ b/AlasTests/ACP/UI/ACPPlanSidebarVisibilityTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPPlanSidebarVisibility")
+struct ACPPlanSidebarVisibilityTests {
+
+    @Test("no plan → hidden regardless of width")
+    func hiddenWithoutPlan() {
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 2000, hasPlan: false, current: false) == false)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 2000, hasPlan: false, current: true)  == false)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 500,  hasPlan: false, current: false) == false)
+    }
+
+    @Test("width ≥ 900 with plan → shown")
+    func showsAtOrAboveShowThreshold() {
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 900,  hasPlan: true, current: false) == true)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 1200, hasPlan: true, current: false) == true)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 900,  hasPlan: true, current: true)  == true)
+    }
+
+    @Test("width < 820 with plan → hidden")
+    func hidesBelowHideThreshold() {
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 819, hasPlan: true, current: true)  == false)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 500, hasPlan: true, current: true)  == false)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 819, hasPlan: true, current: false) == false)
+    }
+
+    @Test("dead band 820–900 with plan → keep current")
+    func deadBandLatches() {
+        // Currently shown → stays shown
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 850, hasPlan: true, current: true)  == true)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 820, hasPlan: true, current: true)  == true)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 899, hasPlan: true, current: true)  == true)
+        // Currently hidden → stays hidden
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 850, hasPlan: true, current: false) == false)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 820, hasPlan: true, current: false) == false)
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 899, hasPlan: true, current: false) == false)
+    }
+
+    @Test("crossing up from below to ≥ 900 shows")
+    func crossingUpShows() {
+        var v = false
+        v = ACPPlanSidebarVisibility.next(paneWidth: 700, hasPlan: true, current: v) // hidden
+        #expect(v == false)
+        v = ACPPlanSidebarVisibility.next(paneWidth: 850, hasPlan: true, current: v) // dead band, stays hidden
+        #expect(v == false)
+        v = ACPPlanSidebarVisibility.next(paneWidth: 920, hasPlan: true, current: v) // crosses up
+        #expect(v == true)
+    }
+
+    @Test("crossing down from above to < 820 hides")
+    func crossingDownHides() {
+        var v = true
+        v = ACPPlanSidebarVisibility.next(paneWidth: 1000, hasPlan: true, current: v) // shown
+        #expect(v == true)
+        v = ACPPlanSidebarVisibility.next(paneWidth: 850, hasPlan: true, current: v) // dead band, stays shown
+        #expect(v == true)
+        v = ACPPlanSidebarVisibility.next(paneWidth: 700, hasPlan: true, current: v) // crosses down
+        #expect(v == false)
+    }
+
+    @Test("plan disappears mid-shown → hides immediately")
+    func planRemovalForcesHide() {
+        #expect(ACPPlanSidebarVisibility.next(paneWidth: 1500, hasPlan: false, current: true) == false)
+    }
+
+    @Test("thresholds are 900 show / 820 hide")
+    func thresholdConstants() {
+        #expect(ACPPlanSidebarVisibility.showThreshold == 900)
+        #expect(ACPPlanSidebarVisibility.hideThreshold == 820)
+    }
+}

--- a/AlasTests/ACP/UI/ACPPlanSidebarVisibilityTests.swift
+++ b/AlasTests/ACP/UI/ACPPlanSidebarVisibilityTests.swift
@@ -4,7 +4,6 @@ import Testing
 
 @Suite("ACPPlanSidebarVisibility")
 struct ACPPlanSidebarVisibilityTests {
-
     @Test("no plan → hidden regardless of width")
     func hiddenWithoutPlan() {
         #expect(ACPPlanSidebarVisibility.next(paneWidth: 2000, hasPlan: false, current: false) == false)


### PR DESCRIPTION
## Summary

- Render the current plan as a 320pt-wide right-side sidebar inside the ACP pane when it is ≥ 900pt wide and a plan exists; hide below 820pt (80pt hysteresis dead band). Below threshold the existing toolbar pill + popover still applies.
- When the sidebar is up, the toolbar pill hides via a SwiftUI `EnvironmentValue` so the two surfaces never duplicate.
- New `ACPTranscript.latestPlan` accessor is turn-stable, so the sidebar survives the brief gap between a new user prompt and the next `.plan` emission. `currentPlan` stays per-turn for the pill.
- Pure `ACPPlanSidebarVisibility.next(paneWidth:hasPlan:current:)` reducer (Foundation only, no SwiftUI) drives the show/hide decision. Shared `ACPPlanChecklist` is now consumed by both the popover and the new `ACPPlanSidebar` host.

## Why this shape

The layout split lives inside `ACPSessionView.transcriptAndComposer`: `GeometryReader → HStack { transcript ZStack; optional sidebar }`. Measuring the outer `HStack` (not the inner column) avoids a layout loop where the sidebar's own width would oscillate the threshold. The sidebar slides in from the trailing edge with a spring + opacity transition; the toolbar pill fades.

## Out of scope (deferred)

- User-controllable show/hide toggle
- Drag-to-resize sidebar
- Persisted per-session sidebar state
- Multi-pane sidebar content (e.g., plan + diff)
- Snake-border animation on the sidebar's in-progress row

## Test plan

- [x] 13 new unit tests (5 for `latestPlan`, 8 for the visibility reducer)
- [x] Full test suite green (2350 tests, 301 suites) on the squashed branch
- [ ] Manual: drag the ACP pane through 820/900pt with a live plan — sidebar slides in/out, pill hides/appears, no flicker in the dead band
- [ ] Manual: send a new prompt mid-session — sidebar stays visible (`latestPlan`) until the next plan arrives
- [ ] Manual: plan completes — sidebar stays visible until session reset
- [ ] Manual: narrow the pane below 820pt while the popover is open — popover dismisses cleanly