### PR TITLE
feat(acp): agent recovery via AgentState state machine

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
 		3E46667F7AA794E24B04BC7F /* TerminalCLIInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013AF8211B98BD98B65DF632 /* TerminalCLIInjection.swift */; };
+		3E4934D7DC18EB748B81436F /* ACPSessionRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B69601924624FFE573EBA /* ACPSessionRecoveryTests.swift */; };
 		3E4C896D74C96DE0BFCAE2A5 /* ShortcutReservationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A5200C6EBB6434DD6B8BD /* ShortcutReservationsTests.swift */; };
 		3E9B50F3BA9D7273EBA50445 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */; };
 		3E9F2C02A264024FC020172D /* EditorFindBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 679E62B501E0490F48CCA830 /* EditorFindBarView.swift */; };
@@ -455,6 +456,7 @@
 		90B09645EB794C287B95A5AD /* HarnessService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 155B35EBCCE7F2CA1A0E5DE5 /* HarnessService.swift */; };
 		90BB0EFFD7E0EF8DE64296E6 /* ShortcutAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */; };
 		90F619F67402DB675E2614CC /* TabActivityPulseTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F650CFAC8E61B1EC99CD04A /* TabActivityPulseTransitionTests.swift */; };
+		9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */; };
 		91BA613AFD278AF56168EB22 /* LSPURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C69060B922A729DD807920 /* LSPURI.swift */; };
 		929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */; };
 		92EEAFAEFB3E637FB72174A8 /* TreeSitterYAML in Frameworks */ = {isa = PBXBuildFile; productRef = 2B4C3DD473FF121828FD3CA5 /* TreeSitterYAML */; };
@@ -625,7 +627,9 @@
 		C7AACF777FF0DAD9ACA426F3 /* AgentLifecycleEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */; };
 		C7EC6D85810513194F831F13 /* ACPConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C4BEC7F392AF938F468B1F /* ACPConnection.swift */; };
 		C82A2082E6E61069068B8FAB /* SQLiteStatement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A442AC7909A919582DF4372 /* SQLiteStatement.swift */; };
+		C85FF0853DE69CE2EB59633E /* ACPRecoveryPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */; };
 		C893CA3167A5CC6637FCD8C8 /* light.json in Resources */ = {isa = PBXBuildFile; fileRef = 1688AB1B49758FAB5BF0AF2F /* light.json */; };
+		C9004250BC974548165BE5B3 /* ACPSessionRecoveryIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */; };
 		C91AE8901B9D4B16A1EE67FB /* EditorBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */; };
 		C9BC01285F80FB20F665A765 /* CodeTextViewMultiCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */; };
 		C9DAC0F907752F6D3B955DD8 /* HoverFeatureRenderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */; };
@@ -845,6 +849,7 @@
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
 		0E6600436B01C75D85C01FFA /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
+		0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionAgentStateTests.swift; sourceTree = "<group>"; };
 		0F68A9692F85197ED9E16262 /* WorktreesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreesPane.swift; sourceTree = "<group>"; };
 		0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThoughtView.swift; sourceTree = "<group>"; };
 		100091C8ABC3F3FA66C744E9 /* HoverHighlightFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverHighlightFeatureTests.swift; sourceTree = "<group>"; };
@@ -998,6 +1003,7 @@
 		3D105CB2C185958ED23164D1 /* IndentationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationMode.swift; sourceTree = "<group>"; };
 		3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
 		3DCEFADD952DB870B8BAB890 /* CommitRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRow.swift; sourceTree = "<group>"; };
+		3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryIntegrationTests.swift; sourceTree = "<group>"; };
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
 		3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupChecker.swift; sourceTree = "<group>"; };
 		3F1D8FEB5416139D8B2BA780 /* HoverFeatureRenderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverFeatureRenderingTests.swift; sourceTree = "<group>"; };
@@ -1103,6 +1109,7 @@
 		620C4A708CD1013DE2736A00 /* AppIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconTests.swift; sourceTree = "<group>"; };
 		626DBFF220D347A36859AB17 /* ZmxSessionNameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionNameTests.swift; sourceTree = "<group>"; };
 		638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffEndToEndTests.swift; sourceTree = "<group>"; };
+		639B69601924624FFE573EBA /* ACPSessionRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryTests.swift; sourceTree = "<group>"; };
 		64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvBuilderTests.swift; sourceTree = "<group>"; };
 		64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBuffer.swift; sourceTree = "<group>"; };
 		650B300A5337E2A9149CF083 /* UnionCanvasGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometry.swift; sourceTree = "<group>"; };
@@ -1305,6 +1312,7 @@
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometryTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
+		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
 		B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
@@ -2374,6 +2382,7 @@
 				D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */,
 				987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */,
 				10602801D3FA990E60CB072D /* ACPQueueHeader.swift */,
+				AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */,
 				B5E898E9F7E2680132FF54D4 /* ACPSelectChip.swift */,
 				7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */,
 				6791BB640C39115289BF6D07 /* ACPSetupNudgeBanner.swift */,
@@ -2563,11 +2572,14 @@
 				6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */,
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
 				2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */,
+				0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */,
 				1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */,
 				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
 				472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */,
+				3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */,
+				639B69601924624FFE573EBA /* ACPSessionRecoveryTests.swift */,
 				547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */,
 				B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */,
 				45D7C5464CA7B663A9A7BBFF /* ACPSessionStoreCRUDTests.swift */,
@@ -3240,6 +3252,7 @@
 				7556121D51C54458FCAFED2A /* ACPProtocolVersion.swift in Sources */,
 				F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */,
 				518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */,
+				C85FF0853DE69CE2EB59633E /* ACPRecoveryPill.swift in Sources */,
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
 				61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */,
@@ -3647,12 +3660,15 @@
 				8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */,
 				97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */,
 				F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */,
+				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,
 				C51451EC8E103EB5FEF82EFE /* ACPSessionLifecycleTests.swift in Sources */,
 				D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
 				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,
+				C9004250BC974548165BE5B3 /* ACPSessionRecoveryIntegrationTests.swift in Sources */,
+				3E4934D7DC18EB748B81436F /* ACPSessionRecoveryTests.swift in Sources */,
 				D56C78F4D6A2BDFDF5A05B55 /* ACPSessionRunnerQueueTests.swift in Sources */,
 				57A5A3F4F14E75F6C00A2DC0 /* ACPSessionRunnerTests.swift in Sources */,
 				20096441D4850614A3CB8187 /* ACPSessionStoreCRUDTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -24,17 +24,25 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published private(set) var composerDraftRevision: Int = 0
     @Published var setupState: SetupState = .checking
     @Published var lastError: String?
-    @Published var disconnected: Bool = false
     /// Runtime-only transcript scroll intent. When true, the ACP message
     /// list follows new content and restores to the latest bottom after
     /// returning to this session. Set false when the user scrolls upward.
     @Published var followsTranscriptTail: Bool = true
-    /// True once a runner has been started for this session — meaning
-    /// `initialize` + `session/new` succeeded and we have a live agent on
-    /// stdio. Reset to false on detach or when the process exits. The
-    /// composer's send button watches this so users can't queue prompts
-    /// against a not-yet-attached agent.
-    @Published var attached: Bool = false
+    /// Lifecycle state of the agent process backing this session.
+    /// Single source of truth for the composer, header pill, and runner
+    /// registry checks.
+    /// Note: `AgentState.idle` means "no runner spawned yet" (process
+    /// lifecycle), distinct from `StreamingState.idle` which means
+    /// "runner is attached but not currently mid-prompt" (turn lifecycle).
+    @Published var agentState: AgentState = .idle
+
+    enum AgentState: Equatable {
+        case idle
+        case spawning
+        case ready
+        case disconnected
+        case failed(String)
+    }
     /// Tracks whether the session's persisted state (messages, queue, draft,
     /// row fields) has been loaded from SQLite. `.loading` is the initial
     /// state for sessions returned by `placeholderSession`; `.ready` is the

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -343,11 +343,20 @@ extension ACPSessionManager {
     /// and calls `session/new` (new sessions) or `session/load` (reopened).
     func attach(to sessionId: ACPSession.ID, freshlyCreated: Bool) async {
         guard let session = sessions[sessionId] else { return }
-        if runners[sessionId] != nil { return }
         switch session.agentState {
         case .spawning, .ready: return
         case .idle, .disconnected, .failed: break
         }
+        // Drop any stale runner left over from a prior process (e.g. the
+        // runner's stream-end branch flipped agentState to .disconnected
+        // but did not unregister itself). The .ready/.spawning early-return
+        // above already covers the live-runner case — a runner is only
+        // registered AFTER state flips to .ready — so anything still here
+        // is a zombie whose update task already exited.
+        if let stale = runners[sessionId] {
+            stale.stop()
+        }
+        runners[sessionId] = nil
         session.agentState = .spawning
 
         guard let spec = ACPLaunchCatalog.spec(for: session.agentId) else {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -344,15 +344,23 @@ extension ACPSessionManager {
     func attach(to sessionId: ACPSession.ID, freshlyCreated: Bool) async {
         guard let session = sessions[sessionId] else { return }
         if runners[sessionId] != nil { return }
+        switch session.agentState {
+        case .spawning, .ready: return
+        case .idle, .disconnected, .failed: break
+        }
+        session.agentState = .spawning
 
         guard let spec = ACPLaunchCatalog.spec(for: session.agentId) else {
-            session.setupState = .needsSetup(reason: "No ACP launch spec for \(session.agentId)")
+            let reason = "No ACP launch spec for \(session.agentId)"
+            session.setupState = .needsSetup(reason: reason)
+            session.agentState = .failed(reason)
             return
         }
         let checker = ACPSetupChecker(env: ProcessInfo.processInfo.environment)
         let setup = await checker.evaluate(spec.setupCheck)
         guard case .ready = setup else {
             session.setupState = .needsSetup(reason: setup.reasonText)
+            session.agentState = .failed(setup.reasonText)
             return
         }
         session.setupState = .ready
@@ -372,7 +380,9 @@ extension ACPSessionManager {
             }
             try client.start()
         } catch {
-            session.lastError = "Failed to launch agent: \(error.localizedDescription)"
+            let msg = "Failed to launch agent: \(error.localizedDescription)"
+            session.lastError = msg
+            session.agentState = .failed(msg)
             return
         }
         let connection = ACPConnection(client: client)
@@ -409,7 +419,7 @@ extension ACPSessionManager {
                                           onLiveBufferRead: onLiveBufferRead)
             runner.start()
             runners[sessionId] = runner
-            session.attached = true
+            session.agentState = .ready
             runner.flushQueueIfIdle()
             stderrTask.cancel()
         } catch {
@@ -418,20 +428,116 @@ extension ACPSessionManager {
             stderrTask.cancel()
             let tail = stderrBuffer.tail()
             let base = "ACP initialize/new failed: \(error.localizedDescription)"
-            session.lastError = tail.isEmpty ? base : base + "\nstderr: " + tail
+            let full = tail.isEmpty ? base : base + "\nstderr: " + tail
+            session.lastError = full
+            session.agentState = .failed(full)
             await connection.shutdown()
+        }
+    }
+
+    /// Idempotent recovery entry point. Called by the composer when the
+    /// user submits into a pane whose agent isn't `.ready`. A no-op for
+    /// states that already represent in-flight or live agents.
+    func reattach(to sessionId: ACPSession.ID) async {
+        guard let session = sessions[sessionId] else { return }
+        switch session.agentState {
+        case .spawning, .ready: return
+        case .idle, .disconnected, .failed:
+            await attach(to: sessionId, freshlyCreated: false)
+        }
+    }
+
+    /// Enqueue a prompt into a session whose agent isn't `.ready` yet.
+    /// Mirrors `ACPSessionRunner`'s `.enqueue` intent so the persisted
+    /// queue looks identical regardless of which side wrote it. The
+    /// existing `flushQueueIfIdle()` call inside `attach()` will drain
+    /// these items once the agent becomes `.ready`.
+    func enqueueWhileRecovering(
+        text: String,
+        attachments: [ACPMessage.Attachment],
+        into sessionId: ACPSession.ID
+    ) {
+        guard let session = sessions[sessionId] else { return }
+        let blocks = ACPSessionRunner.blocks(text: text, attachments: attachments)
+        session.enqueue(blocks: blocks)
+        do {
+            try store.upsertQueue(sessionId: sessionId, items: session.queue)
+        } catch {
+            session.lastError = "Failed to persist queued prompt: \(error.localizedDescription)"
+        }
+    }
+
+    /// Composer submit. Returns `true` if the prompt was accepted (either
+    /// sent immediately or queued for delivery once the agent is ready).
+    /// `onCompleted` fires once the underlying send/enqueue resolves; the
+    /// composer uses it to decide whether to clear or re-persist the draft.
+    ///
+    /// Branches on `session.agentState`:
+    /// - `.ready`: dispatch via the runner as before.
+    /// - `.spawning`: enqueue only — an `attach` is already in flight and
+    ///   the post-attach `flushQueueIfIdle()` will drain the head.
+    /// - `.idle` / `.disconnected` / `.failed`: enqueue AND kick `reattach`
+    ///   so the user's prompt is what brings the agent back online.
+    ///
+    @discardableResult
+    func submit(
+        sessionId: ACPSession.ID,
+        text: String,
+        attachments: [ACPMessage.Attachment],
+        intent: ACPSubmitIntent,
+        onCompleted: @escaping @MainActor (Bool) -> Void
+    ) -> Bool {
+        guard let session = sessions[sessionId] else { return false }
+
+        switch session.agentState {
+        case .ready:
+            guard let runner = runners[sessionId] else {
+                // State and registry disagree — treat as not-ready so the
+                // prompt isn't dropped. Enqueue and kick recovery. The
+                // prompt is already accepted at this point; fire
+                // `onCompleted` synchronously so the composer can clear
+                // its draft instead of waiting on the full reattach
+                // handshake (which can take seconds).
+                enqueueWhileRecovering(text: text, attachments: attachments, into: sessionId)
+                onCompleted(true)
+                Task { @MainActor in await reattach(to: sessionId) }
+                return true
+            }
+            runner.send(text: text, attachments: attachments, intent: intent) { succeeded in
+                onCompleted(succeeded)
+            }
+            return true
+
+        case .spawning:
+            // An attach is in flight; the post-attach `flushQueueIfIdle()`
+            // will pick up the freshly enqueued head.
+            enqueueWhileRecovering(text: text, attachments: attachments, into: sessionId)
+            Task { @MainActor in onCompleted(true) }
+            return true
+
+        case .idle, .disconnected, .failed:
+            // Prompt is accepted the moment it lands in the queue; fire
+            // `onCompleted` before awaiting reattach so the composer
+            // clears its draft immediately rather than after the full
+            // attach handshake completes.
+            enqueueWhileRecovering(text: text, attachments: attachments, into: sessionId)
+            onCompleted(true)
+            Task { @MainActor in await reattach(to: sessionId) }
+            return true
         }
     }
 
     func detach(sessionId: ACPSession.ID) async {
         // Reset transient session state SYNCHRONOUSLY before any await.
         // The steer task is unstructured and can resume during the
-        // `connection.shutdown()` await below — if `session.attached`
-        // is still true at that point, its post-`userCancel` liveness
+        // `connection.shutdown()` await below — if `agentState` is still
+        // `.ready` at that point, its post-`userCancel` liveness
         // check passes and it dispatches `sendNow` against a connection
-        // being torn down. Flipping the flag here closes that window.
+        // being torn down. Flipping the state here closes that window.
         if let session = sessions[sessionId] {
-            session.attached = false
+            // .idle (user-initiated teardown), not .disconnected — the latter
+            // is reserved for the runner's unexpected stream-end branch.
+            session.agentState = .idle
             session.transcript.streamingState = .idle
             // Normalize any in-flight queue head: the sendNow task that
             // owned it is gone with the runner, so the next attach must

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -501,12 +501,16 @@ extension ACPSessionManager {
         switch session.agentState {
         case .ready:
             guard let runner = runners[sessionId] else {
-                // State and registry disagree — treat as not-ready so the
-                // prompt isn't dropped. Enqueue and kick recovery. The
-                // prompt is already accepted at this point; fire
-                // `onCompleted` synchronously so the composer can clear
-                // its draft instead of waiting on the full reattach
-                // handshake (which can take seconds).
+                // State and registry disagree — somehow we lost the runner
+                // without the stream-end branch flipping agentState. Reflect
+                // reality (`.disconnected`, same surface as the runner's
+                // stream-end branch) so `reattach()` actually fires a fresh
+                // attach instead of no-opping on `.ready`. The prompt is
+                // already accepted at this point; fire `onCompleted`
+                // synchronously so the composer can clear its draft instead
+                // of waiting on the full reattach handshake (which can take
+                // seconds).
+                session.agentState = .disconnected
                 enqueueWhileRecovering(text: text, attachments: attachments, into: sessionId)
                 onCompleted(true)
                 Task { @MainActor in await reattach(to: sessionId) }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -357,6 +357,11 @@ extension ACPSessionManager {
             stale.stop()
         }
         runners[sessionId] = nil
+        // Clear any error from the prior attempt so the UI doesn't keep
+        // showing a stale failure banner while we spawn fresh. If this
+        // attempt also fails, the catch branches below will repopulate
+        // `lastError` with the new reason.
+        session.lastError = nil
         session.agentState = .spawning
 
         guard let spec = ACPLaunchCatalog.spec(for: session.agentId) else {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -505,14 +505,13 @@ extension ACPSessionManager {
                 // without the stream-end branch flipping agentState. Reflect
                 // reality (`.disconnected`, same surface as the runner's
                 // stream-end branch) so `reattach()` actually fires a fresh
-                // attach instead of no-opping on `.ready`. The prompt is
-                // already accepted at this point; fire `onCompleted`
-                // synchronously so the composer can clear its draft instead
-                // of waiting on the full reattach handshake (which can take
-                // seconds).
+                // attach instead of no-opping on `.ready`. Defer `onCompleted`
+                // to the next tick so it runs after the composer's submit
+                // closure returns and registers its pending id (without the
+                // hop the completion fires too early and gets ignored).
                 session.agentState = .disconnected
                 enqueueWhileRecovering(text: text, attachments: attachments, into: sessionId)
-                onCompleted(true)
+                Task { @MainActor in onCompleted(true) }
                 Task { @MainActor in await reattach(to: sessionId) }
                 return true
             }
@@ -529,12 +528,13 @@ extension ACPSessionManager {
             return true
 
         case .idle, .disconnected, .failed:
-            // Prompt is accepted the moment it lands in the queue; fire
-            // `onCompleted` before awaiting reattach so the composer
-            // clears its draft immediately rather than after the full
-            // attach handshake completes.
+            // Prompt is accepted the moment it lands in the queue. Defer
+            // `onCompleted` to the next tick so it runs after the composer's
+            // submit closure returns and registers its pending id — firing
+            // synchronously here would race the composer's bookkeeping and
+            // get ignored, leaving the persisted draft uncleared.
             enqueueWhileRecovering(text: text, attachments: attachments, into: sessionId)
-            onCompleted(true)
+            Task { @MainActor in onCompleted(true) }
             Task { @MainActor in await reattach(to: sessionId) }
             return true
         }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -98,8 +98,7 @@ final class ACPSessionRunner {
             // the unexpected stream-end.
             if Task.isCancelled { return }
             await MainActor.run {
-                self.session.disconnected = true
-                self.session.attached = false
+                self.session.agentState = .disconnected
                 self.session.transcript.streamingState = .idle
                 // No flushQueueIfIdle() here: the connection is dead, so
                 // the next prompt would just fail. The queue stays put
@@ -469,11 +468,24 @@ extension ACPSessionRunner {
         intent: ACPSubmitIntent,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
+        let blocks = Self.blocks(text: text, attachments: attachments)
+        send(blocks: blocks, intent: intent, onPromptFinished: onPromptFinished)
+    }
+
+    /// Build the canonical `[ACPContentBlock]` array from a composer-shaped
+    /// `(text, attachments)` pair: leading text block followed by one
+    /// `.resourceLink` per attachment. Shared with
+    /// `ACPSessionManager.enqueueWhileRecovering` so prompts persisted before
+    /// the runner exists look identical on the wire to ones the runner enqueues.
+    static func blocks(
+        text: String,
+        attachments: [ACPMessage.Attachment]
+    ) -> [ACPContentBlock] {
         var blocks: [ACPContentBlock] = [.text(text)]
         for a in attachments {
             blocks.append(.resourceLink(uri: a.uri, name: a.name))
         }
-        send(blocks: blocks, intent: intent, onPromptFinished: onPromptFinished)
+        return blocks
     }
 
     /// Primary entry. Resolves the routing then dispatches to one of:
@@ -593,7 +605,7 @@ extension ACPSessionRunner {
                 // a `lastError` against the dead connection. Bail out
                 // and tell the composer the submit didn't land so its
                 // draft stays put.
-                guard self.session.attached, !self.session.disconnected else {
+                guard self.session.agentState == .ready else {
                     onPromptFinished?(false)
                     return
                 }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -384,10 +384,18 @@ struct ACPComposer: View {
         .help(sendHelpText)
     }
 
-    /// Disabled only when the agent isn't reachable. State.streaming /
-    /// .sending no longer disable — they queue.
+    // TODO(harness): SwiftUI rendering test for `sendDisabled` requires
+    // snapshot infrastructure we don't have; the invariant we care about
+    // (button enabled whenever `manager.submit` would accept the prompt
+    // — i.e. for all agent states, including .disconnected / .failed /
+    // .idle so mouse-only users can drive recovery) is inspection-
+    // verifiable here and exercised by the `submit` tests above.
     private var sendDisabled: Bool {
-        session.agentState != .ready
+        // Intentionally NOT gated on `agentState`: `manager.submit(...)`
+        // accepts prompts in every state (queueing + kicking reattach
+        // when not `.ready`). The send button must mirror Enter-to-submit
+        // so mouse-only users can recover a disconnected session.
+        false
     }
 
     private var sendHelpText: String {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -118,7 +118,7 @@ struct ACPComposer: View {
             // Pulse + agent identity (icon + ACP label). Pulse moved here
             // from the toolbar so the "live agent" cue sits next to the
             // composer where focus is.
-            ACPPulseDot(color: session.disconnected ? theme.color("del") : theme.color("add"))
+            ACPPulseDot(color: session.agentState == .disconnected ? theme.color("del") : theme.color("add"))
             if let agent = agentLookup(session.agentId) {
                 AgentLogoView(agent: agent).frame(width: 14, height: 14)
             }
@@ -177,7 +177,7 @@ struct ACPComposer: View {
         if session.chipState.autoRun == .ignored { return true }
         switch session.transcript.streamingState {
         case .streaming, .sending: return true
-        default: return !session.attached || session.disconnected
+        default: return session.agentState != .ready
         }
     }
 
@@ -187,8 +187,9 @@ struct ACPComposer: View {
         }
         if case .streaming = session.transcript.streamingState { return "Auto-run cannot be changed while streaming" }
         if case .sending = session.transcript.streamingState { return "Auto-run cannot be changed while sending" }
-        if !session.attached { return "Agent connecting…" }
-        if session.disconnected { return "Agent disconnected" }
+        // .disconnected wins over "connecting" — it's a terminal state.
+        if session.agentState == .disconnected { return "Agent disconnected" }
+        if session.agentState != .ready { return "Agent connecting…" }
         return session.autoRunEnabled
             ? "Auto-run is ON — agent runs tools without asking"
             : "Click to skip permission prompts"
@@ -386,12 +387,12 @@ struct ACPComposer: View {
     /// Disabled only when the agent isn't reachable. State.streaming /
     /// .sending no longer disable — they queue.
     private var sendDisabled: Bool {
-        !session.attached || session.disconnected
+        session.agentState != .ready
     }
 
     private var sendHelpText: String {
-        if session.disconnected { return "Agent disconnected" }
-        if !session.attached    { return "Agent connecting…" }
+        if session.agentState == .disconnected { return "Agent disconnected" }
+        if session.agentState != .ready        { return "Agent connecting…" }
         if session.transcript.streamingState == .idle, session.queue.isEmpty {
             return "Send (⏎). Hold ⌥ to steer."
         }

--- a/Alas/Sources/ACP/UI/ACPRecoveryPill.swift
+++ b/Alas/Sources/ACP/UI/ACPRecoveryPill.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// Toolbar pill that surfaces the ACP agent process lifecycle. Renders
+/// nothing while the runner is `.idle` or `.ready` and a labeled chip
+/// otherwise (spawning / disconnected / failed). Styled to sit next to
+/// `ACPPlanPill` without clashing.
+struct ACPRecoveryPill: View {
+    @ObservedObject var session: ACPSession
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        if let label = label(for: session.agentState) {
+            HStack(spacing: 6) {
+                statusDot(animating: isAnimating(session.agentState))
+                Text(label)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 22)
+            .background(
+                RoundedRectangle(cornerRadius: 11, style: .continuous)
+                    .fill(theme.color("bg-1"))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 11, style: .continuous)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+            .help(helpText(for: session.agentState))
+            .transition(.opacity)
+        }
+    }
+
+    private func label(for state: ACPSession.AgentState) -> String? {
+        switch state {
+        case .idle, .ready: return nil
+        case .spawning: return "Reconnecting…"
+        case .disconnected: return "Disconnected"
+        case .failed: return "Failed"
+        }
+    }
+
+    private func helpText(for state: ACPSession.AgentState) -> String {
+        switch state {
+        case .spawning: return "Bringing the agent process back up…"
+        case .disconnected: return "Agent process exited. Will reconnect on next send."
+        case .failed(let reason): return "Failed: \(reason)"
+        default: return ""
+        }
+    }
+
+    private func isAnimating(_ state: ACPSession.AgentState) -> Bool {
+        if case .spawning = state { return true }
+        return false
+    }
+
+    @ViewBuilder
+    private func statusDot(animating: Bool) -> some View {
+        Circle()
+            .fill(theme.color("accent"))
+            .frame(width: 6, height: 6)
+            .opacity(animating ? 0.4 : 1.0)
+            .animation(animating
+                ? .easeInOut(duration: 1.2).repeatForever(autoreverses: true)
+                : .default,
+                value: animating)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPSessionsButton.swift
+++ b/Alas/Sources/ACP/UI/ACPSessionsButton.swift
@@ -31,7 +31,7 @@ struct ACPSessionsButton: View {
                     .background(theme.color("bg-3").opacity(0.5))
                     .clipShape(RoundedRectangle(cornerRadius: 5))
                     .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(theme.color("line"), lineWidth: 0.5))
-                if session.disconnected {
+                if session.agentState == .disconnected {
                     Circle()
                         .fill(theme.color("del"))
                         .frame(width: 6, height: 6)
@@ -67,7 +67,7 @@ private struct SessionsPopover: View {
     var body: some View {
         VStack(spacing: 0) {
             currentSessionHeader
-            if session.disconnected {
+            if session.agentState == .disconnected {
                 disconnectedBanner
             }
             Divider().background(theme.color("line"))
@@ -190,7 +190,6 @@ private struct SessionsPopover: View {
         Task {
             await manager.detach(sessionId: session.id)
             await manager.attach(to: session.id, freshlyCreated: false)
-            await MainActor.run { session.disconnected = false }
         }
     }
 }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -119,7 +119,7 @@ private struct ACPSessionView: View {
         guard manager.runners[sessionId] == nil else { return false }
         if case .needsSetup = session.setupState { return false }
         if session.lastError != nil { return false }
-        if session.disconnected { return false }
+        if session.agentState == .disconnected { return false }
         return session.transcript.messages.isEmpty
     }
 
@@ -190,14 +190,17 @@ private struct ACPSessionView: View {
                         agentLookup: { state.agent(id: $0) },
                         sendOnEnter: state.config.harness.acpSendOnEnter
                     ) { text, attachments, intent, draft, onPromptFinished -> Bool in
-                        guard session.attached, !session.disconnected,
-                              let runner = manager.runners[sessionId] else { return false }
                         // `intent` is already resolved by the composer for keyboard
                         // submits; the toolbar send button bypasses the keyboard
                         // inversion and supplies its own intent directly. No
                         // further resolution here.
                         let draftRevision = session.composerDraftRevision
-                        runner.send(text: text, attachments: attachments, intent: intent) { succeeded in
+                        return manager.submit(
+                            sessionId: sessionId,
+                            text: text,
+                            attachments: attachments,
+                            intent: intent
+                        ) { succeeded in
                             if succeeded {
                                 manager.clearComposerDraft(
                                     for: session,
@@ -214,7 +217,6 @@ private struct ACPSessionView: View {
                             }
                             onPromptFinished(succeeded)
                         }
-                        return true
                     }
 
                     if let undo = session.steerUndo, !undo.snapshot.isEmpty {

--- a/Alas/Sources/ACP/UI/ACPToolbar.swift
+++ b/Alas/Sources/ACP/UI/ACPToolbar.swift
@@ -17,6 +17,7 @@ struct ACPToolbar: View {
                 worktree: worktree,
                 agentLookup: agentLookup
             )
+            ACPRecoveryPill(session: session)
             ACPPlanPill(transcript: session.transcript)
                 .layoutPriority(1)
         }

--- a/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
@@ -94,6 +94,29 @@ struct ACPSessionManagerAttachStateTests {
         #expect(session.agentState == .spawning)
         #expect(mgr.runners[session.id] == nil)
     }
+
+    /// Stale lastError from a prior failed attempt must not leak through to
+    /// the recovery banner once the user retries — the next attach clears it
+    /// upfront so a successful retry doesn't show a phantom failure.
+    @Test("attach clears stale lastError before spawning")
+    func attachClearsStaleLastError() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-attach-clear-err-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        // Bogus agentId so attach() hits the spec-missing branch (which
+        // repopulates lastError with its own message — but the clear at
+        // the top of attach should happen first).
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        session.lastError = "previous failure that should not leak"
+        session.agentState = .disconnected
+
+        await mgr.attach(to: session.id, freshlyCreated: false)
+
+        // After attach: lastError reflects THIS attempt's failure, not the
+        // stale one. (The spec-missing branch doesn't set lastError, so
+        // it should now be nil — only the agentState carries the failure.)
+        #expect(session.lastError == nil || session.lastError?.contains("previous failure") == false)
+    }
 }
 
 @MainActor

--- a/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionAgentStateTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSession agentState")
+struct ACPSessionAgentStateTests {
+    @Test("default state is .idle")
+    func defaultIsIdle() {
+        let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
+        #expect(session.agentState == .idle)
+    }
+
+    @Test("AgentState.failed equality compares reason")
+    func failedEquality() {
+        #expect(ACPSession.AgentState.failed("a") == ACPSession.AgentState.failed("a"))
+        #expect(ACPSession.AgentState.failed("a") != ACPSession.AgentState.failed("b"))
+    }
+
+    @Test("all transitions are assignable")
+    func transitionsAssignable() {
+        let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .spawning
+        #expect(session.agentState == .spawning)
+        session.agentState = .ready
+        #expect(session.agentState == .ready)
+        session.agentState = .disconnected
+        #expect(session.agentState == .disconnected)
+        session.agentState = .failed("boom")
+        #expect(session.agentState == .failed("boom"))
+    }
+}
+
+@MainActor
+@Suite("ACPSessionRunner agentState transitions")
+struct ACPSessionRunnerAgentStateTests {
+    @Test("runner flips agentState to .disconnected when updates stream ends")
+    func runnerFlipsToDisconnectedOnStreamEnd() async throws {
+        // Drive the runner's `incomingUpdates` for-await loop to natural
+        // end-of-stream by calling `mock.shutdown()`. The runner's exit
+        // branch (not the Task-cancelled branch) should fire and set
+        // `agentState = .disconnected`.
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-state-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        runner.start()
+
+        await mock.shutdown()
+
+        // Wait for the runner's MainActor.run cleanup to land.
+        for _ in 0..<50 where session.agentState != .disconnected {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        #expect(session.agentState == .disconnected)
+    }
+}
+
+@MainActor
+@Suite("ACPSessionManager attach state transitions")
+struct ACPSessionManagerAttachStateTests {
+    @Test("attach while .spawning is a no-op")
+    func attachDoubleNoop() async throws {
+        // Construct a manager + session against the real APIs. The point
+        // of this test is to prove the early-return guard fires before
+        // any spawn work — so the test doesn't need a working agent.
+        // Pre-set agentState to .spawning and call attach; expect the
+        // state to stay .spawning and no runner to be registered.
+        //
+        // TODO(harness): Once Task 10 lands a real test harness with
+        // injectable agent specs, restore the attachSuccess and
+        // attachSpawnFailure tests from the plan and remove this comment.
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-attach-noop-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        session.agentState = .spawning
+
+        await mgr.attach(to: session.id, freshlyCreated: true)
+
+        #expect(session.agentState == .spawning)
+        #expect(mgr.runners[session.id] == nil)
+    }
+}
+
+@MainActor
+@Suite("ACPSessionManager reattach")
+struct ACPSessionManagerReattachTests {
+    /// `.ready` is the steady state — reattach must not poke `attach()` and
+    /// must leave the runner registry untouched.
+    @Test("reattach while .ready is a no-op")
+    func noopWhileReady() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-reattach-ready-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        session.agentState = .ready
+        let runnersBefore = mgr.runners
+
+        await mgr.reattach(to: session.id)
+
+        #expect(session.agentState == .ready)
+        // Runner map must be identical (no new entry, no removal).
+        #expect(mgr.runners.keys == runnersBefore.keys)
+    }
+
+    /// `.spawning` means an attach is in flight — reattach must defer to it.
+    @Test("reattach while .spawning is a no-op")
+    func noopWhileSpawning() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-reattach-spawning-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        session.agentState = .spawning
+
+        await mgr.reattach(to: session.id)
+
+        #expect(session.agentState == .spawning)
+        #expect(mgr.runners[session.id] == nil)
+    }
+
+    /// `.disconnected` should delegate to `attach()`. Without an agent
+    /// harness, `attach()` bounces off the spec-missing / setup-not-ready
+    /// branch and lands on `.failed(reason)` (per Task 2's failure-path
+    /// behavior). Observing the transition out of `.disconnected` proves
+    /// the delegation fired without needing a working agent.
+    @Test("reattach while .disconnected delegates to attach")
+    func reattachFromDisconnected() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-reattach-disc-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        // Use an agentId with no launch spec so attach takes the
+        // "no ACP launch spec" branch and lands at .failed.
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        session.agentState = .disconnected
+
+        await mgr.reattach(to: session.id)
+
+        #expect(session.agentState != .disconnected)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionRecoveryIntegrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRecoveryIntegrationTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import Testing
+@testable import Alas
+
+// TODO(harness): end-to-end .ready + drain coverage requires a stub ACP
+// agent target — out of scope for this refactor. The full happy path
+// (persist → fresh manager → attach() → session/new → .ready → queue
+// drain) cannot be exercised without either a fake agent CLI on $PATH
+// or a factory-injection seam in `ACPSessionManager.attach()`. The
+// tests below exercise everything *up to* the actual subprocess
+// handshake: persistence round-trip, hydration, the reattach state
+// machine via the spec-missing branch, and queue ordering invariants.
+
+@MainActor
+@Suite("ACPSessionManager recovery round-trip")
+struct ACPSessionRecoveryIntegrationTests {
+    private func tmpStorePath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-recover-int-\(UUID()).sqlite").path
+    }
+
+    /// Scenario 1: write a session with a transcript message and a queued
+    /// item directly to SQLite, tear down the manager, spin up a fresh
+    /// `ACPSessionManager` against the same store, hydrate, and verify the
+    /// transcript / queue / metadata are intact. Then call `attach()` with
+    /// an agentId that has no launch spec to walk the state machine
+    /// (.idle → .spawning → .idle via the spec-missing branch) without
+    /// losing the persisted queue.
+    @Test("persistence round-trip survives manager teardown and reattach")
+    func persistenceRoundTripWithReattach() async throws {
+        let path = tmpStorePath()
+        let sessionId = "round-trip-\(UUID().uuidString)"
+        let agentId = "no-such-agent-\(UUID().uuidString)"
+
+        // --- Phase 1: seed the store directly, then drop everything. ---
+        do {
+            let store = try ACPSessionStore(path: path)
+            try store.upsertSession(.init(
+                id: sessionId, agentId: agentId, title: "Original title",
+                currentModel: "model-x", currentMode: "mode-y", autoRun: true,
+                createdAt: 100, updatedAt: 200, lastOpenedAt: 300,
+                archived: false))
+
+            // Hand-rolled user message payload — same shape ACPMessageCodec
+            // writes on the live path (see ACPSessionManagerHydrationTests
+            // .hydrateReady for the established pattern).
+            let userMsg: ACPMessage = .user(
+                id: UUID(), text: "persisted hello", attachments: [])
+            let payload = try ACPMessageCodec.encode(userMsg)
+            try store.appendMessage(
+                sessionId: sessionId, id: "m0", kind: "user",
+                seq: 0, payload: payload, createdAt: 100)
+
+            // Hand-rolled queue item — matches the QueuedPrompt shape used
+            // by ACPSessionStoreQueueTests.
+            let queued = QueuedPrompt(
+                blocks: [.text("queued before crash")],
+                status: .pending)
+            try store.upsertQueue(sessionId: sessionId, items: [queued])
+        }
+
+        // --- Phase 2: fresh manager against the same on-disk store. ---
+        let store = try ACPSessionStore(path: path)
+        let mgr = ACPSessionManager(
+            worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = try #require(mgr.placeholderSession(id: sessionId))
+        // Initial agentState is .idle — no spawn has happened on the
+        // fresh manager regardless of what the prior process was doing.
+        #expect(session.agentState == .idle)
+        #expect(session.hydrationState == .loading)
+
+        await mgr.hydrateIfNeeded(id: sessionId)
+
+        #expect(session.hydrationState == .ready)
+        #expect(session.transcript.messages.count == 1)
+        if case .user(_, let text, _) = session.transcript.messages.first! {
+            #expect(text == "persisted hello")
+        } else {
+            Issue.record("expected hydrated transcript head to be a user message")
+        }
+        #expect(session.queue.count == 1)
+        #expect(session.queue.first?.blocks == [.text("queued before crash")])
+        #expect(session.currentModel == "model-x")
+        #expect(session.currentMode == "mode-y")
+        #expect(session.autoRunEnabled == true)
+
+        // --- Phase 3: drive attach() through the state machine. ---
+        // The no-spec branch flips .idle → .spawning, then lands at
+        // .failed(reason) with setupState = .needsSetup. The persisted
+        // queue must survive that transition.
+        await mgr.attach(to: sessionId, freshlyCreated: false)
+
+        if case .failed = session.agentState {
+            // success — attach() ran the spec-missing branch
+        } else {
+            Issue.record("expected agentState = .failed after spec-missing attach, got \(session.agentState)")
+        }
+        if case .needsSetup = session.setupState {
+            // success — attach() ran the spec-missing branch
+        } else {
+            Issue.record("expected setupState = .needsSetup after spec-missing attach, got \(session.setupState)")
+        }
+        // Queue must NOT have been clobbered by the failed attach.
+        #expect(session.queue.count == 1)
+        let persistedAfter = try store.loadQueue(sessionId: sessionId)
+        #expect(persistedAfter.count == 1)
+        #expect(persistedAfter.first?.blocks == [.text("queued before crash")])
+    }
+
+    /// Scenario 2: submit-during-recovery. Start from a hydrated session
+    /// at .idle, call `manager.submit(...)` with text — assert the prompt
+    /// lands in `session.queue`, round-trips through SQLite, AND that the
+    /// reattach-driven attempt fires (state transitions out of .idle and
+    /// returns via the spec-missing branch).
+    @Test("submit during recovery enqueues, persists, and triggers reattach")
+    func submitDuringRecoveryRoundTrip() async throws {
+        let path = tmpStorePath()
+        let sessionId = "submit-recover-\(UUID().uuidString)"
+        let agentId = "no-such-agent-\(UUID().uuidString)"
+
+        // Seed an empty session row directly; no transcript, no queue.
+        do {
+            let store = try ACPSessionStore(path: path)
+            try store.upsertSession(.init(
+                id: sessionId, agentId: agentId, title: "t",
+                currentModel: nil, currentMode: nil, autoRun: false,
+                createdAt: 0, updatedAt: 0, lastOpenedAt: 0,
+                archived: false))
+        }
+
+        let store = try ACPSessionStore(path: path)
+        let mgr = ACPSessionManager(
+            worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = try #require(mgr.placeholderSession(id: sessionId))
+        await mgr.hydrateIfNeeded(id: sessionId)
+        #expect(session.hydrationState == .ready)
+        #expect(session.agentState == .idle)
+
+        // Submit from the recovery state — the .idle branch enqueues
+        // and kicks reattach.
+        let accepted = mgr.submit(
+            sessionId: sessionId,
+            text: "submitted during recovery",
+            attachments: [],
+            intent: .auto
+        ) { _ in }
+
+        #expect(accepted == true)
+        #expect(session.queue.count == 1)
+        if case .text(let s) = session.queue.first?.blocks.first {
+            #expect(s == "submitted during recovery")
+        } else {
+            Issue.record("expected first block to be .text, got \(String(describing: session.queue.first?.blocks.first))")
+        }
+
+        // The prompt must round-trip through SQLite — a fresh load
+        // against the same path returns the same head.
+        let persisted = try store.loadQueue(sessionId: sessionId)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.id == session.queue.first?.id)
+
+        // Wait for the reattach's awaited attach() to evaluate the spec.
+        // The spec-missing branch lands setupState = .needsSetup; that's
+        // our observable proof that reattach actually fired.
+        for _ in 0..<50 {
+            if case .needsSetup = session.setupState { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        if case .needsSetup = session.setupState {
+            // success — submit kicked reattach, which kicked attach,
+            // which walked the spec-missing branch.
+        } else {
+            Issue.record("submit-during-recovery did not invoke attach(): setupState=\(session.setupState)")
+        }
+        // attach lands at .failed(reason) for the spec-missing branch —
+        // queue is preserved across the round-trip.
+        if case .failed = session.agentState {
+            // success
+        } else {
+            Issue.record("expected agentState = .failed after spec-missing attach, got \(session.agentState)")
+        }
+        #expect(session.queue.count == 1)
+    }
+
+    /// Scenario 3: queue ordering invariant. Enqueue two items via
+    /// `enqueueWhileRecovering` AND one via `submit` while in .spawning.
+    /// Assert all three end up in `session.queue` in the order they
+    /// were enqueued.
+    @Test("queue preserves enqueue order across enqueueWhileRecovering and submit")
+    func queueOrderingInvariant() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        let mgr = ACPSessionManager(
+            worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        // createSession produces a .ready hydrationState with .idle
+        // agentState; agentId is irrelevant here — we never call attach.
+        let session = mgr.createSession(agentId: "claude")
+
+        // Two items via the recovery enqueue path.
+        mgr.enqueueWhileRecovering(
+            text: "first", attachments: [], into: session.id)
+        mgr.enqueueWhileRecovering(
+            text: "second", attachments: [], into: session.id)
+
+        // Flip to .spawning so submit takes the enqueue-only branch
+        // (no reattach kick — an attach is conceptually in flight).
+        session.agentState = .spawning
+
+        let accepted = mgr.submit(
+            sessionId: session.id,
+            text: "third",
+            attachments: [],
+            intent: .auto
+        ) { _ in }
+        #expect(accepted == true)
+
+        // All three in original enqueue order.
+        #expect(session.queue.count == 3)
+        let texts: [String] = session.queue.compactMap { item in
+            if case .text(let s) = item.blocks.first { return s }
+            return nil
+        }
+        #expect(texts == ["first", "second", "third"])
+
+        // SQLite agrees — order survives the persistence path.
+        let persisted = try store.loadQueue(sessionId: session.id)
+        #expect(persisted.count == 3)
+        let persistedTexts: [String] = persisted.compactMap { item in
+            if case .text(let s) = item.blocks.first { return s }
+            return nil
+        }
+        #expect(persistedTexts == ["first", "second", "third"])
+
+        // Submit during .spawning must NOT trigger reattach (avoids a
+        // racing second attach against the in-flight one).
+        #expect(session.agentState == .spawning)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionRecoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRecoveryTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+@testable import Alas
+
+// TODO(harness): drain-on-attach test deferred to Task 10 integration coverage.
+// The second half of the plan (enqueue two, attach, assert the head promotes
+// to .sending) needs a working end-to-end attach() path which requires a real
+// agent process; covered by the recovery round-trip integration test.
+
+@MainActor
+@Suite("ACPSessionManager.enqueueWhileRecovering")
+struct ACPSessionEnqueueWhileRecoveringTests {
+    @Test("enqueueWhileRecovering appends to session.queue and persists")
+    func enqueueAppends() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-recover-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+
+        #expect(session.queue.isEmpty)
+
+        mgr.enqueueWhileRecovering(text: "hello", attachments: [], into: session.id)
+
+        #expect(session.queue.count == 1)
+        let head = try #require(session.queue.first)
+        #expect(head.status == .pending)
+        // The blocks-builder mirrors ACPSessionRunner.send(text:attachments:):
+        // the first block is the text payload.
+        if case .text(let s) = head.blocks.first {
+            #expect(s == "hello")
+        } else {
+            Issue.record("expected first block to be .text(\"hello\"), got \(String(describing: head.blocks.first))")
+        }
+
+        let persisted = try store.loadQueue(sessionId: session.id)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.id == head.id)
+    }
+
+    @Test("enqueueWhileRecovering preserves attachments as resource links")
+    func enqueueWithAttachments() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-recover-att-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+
+        let attachment = ACPMessage.Attachment(uri: "file:///a.txt", name: "a.txt")
+        mgr.enqueueWhileRecovering(
+            text: "see this", attachments: [attachment], into: session.id)
+
+        let head = try #require(session.queue.first)
+        #expect(head.blocks.count == 2)
+        if case .resourceLink(let uri, let name) = head.blocks.last {
+            #expect(uri == "file:///a.txt")
+            #expect(name == "a.txt")
+        } else {
+            Issue.record("expected last block to be .resourceLink, got \(String(describing: head.blocks.last))")
+        }
+    }
+
+    @Test("enqueueWhileRecovering is a no-op when the session id is unknown")
+    func unknownSessionIsNoOp() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-recover-noop-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+
+        mgr.enqueueWhileRecovering(text: "hi", attachments: [], into: "missing-id")
+
+        let persisted = try store.loadQueue(sessionId: "missing-id")
+        #expect(persisted.isEmpty)
+    }
+}
+
+// TODO(harness): the `.ready`-with-runner happy path for `submit(...)` needs a
+// test harness that can stand up a fake runner and observe `runner.send`. That
+// harness doesn't exist today; coverage lives in Task 10's recovery
+// round-trip integration test. The cases below preset `agentState` and
+// observe the queue / state transitions, which doesn't need the harness.
+@MainActor
+@Suite("ACPSessionManager.submit")
+struct ACPSessionManagerSubmitTests {
+    @Test("submit while .spawning enqueues and returns true")
+    func submitWhileSpawningEnqueues() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-submit-spawn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        session.agentState = .spawning
+
+        let accepted = mgr.submit(
+            sessionId: session.id,
+            text: "queued during spawn",
+            attachments: [],
+            intent: .auto
+        ) { _ in }
+
+        #expect(accepted == true)
+        #expect(session.queue.count == 1)
+        let head = try #require(session.queue.first)
+        if case .text(let s) = head.blocks.first {
+            #expect(s == "queued during spawn")
+        } else {
+            Issue.record("expected first block to be .text, got \(String(describing: head.blocks.first))")
+        }
+
+        let persisted = try store.loadQueue(sessionId: session.id)
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.id == head.id)
+
+        // Spawning must NOT trigger reattach — an attach is already in
+        // flight; a second one would race or no-op against itself.
+        #expect(session.agentState == .spawning)
+    }
+
+    @Test("submit while .disconnected enqueues and triggers reattach")
+    func submitWhileDisconnectedReattaches() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-submit-disc-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        // Use an agentId with no launch spec so the reattach-triggered
+        // attach takes the "no ACP launch spec" branch and lands on .failed
+        // (mirrors ACPSessionManagerReattachTests.reattachFromDisconnected).
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        session.agentState = .disconnected
+
+        let accepted = mgr.submit(
+            sessionId: session.id,
+            text: "trying again",
+            attachments: [],
+            intent: .auto
+        ) { _ in }
+
+        #expect(accepted == true)
+        #expect(session.queue.count == 1)
+
+        // Wait for the reattach's awaited attach() to land.
+        for _ in 0..<50 where session.agentState == .disconnected {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(session.agentState != .disconnected)
+    }
+
+    @Test("submit while .idle enqueues and triggers reattach")
+    func submitWhileIdleReattaches() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-submit-idle-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        // createSession leaves the session at the default .idle state;
+        // re-asserting here makes the precondition explicit.
+        session.agentState = .idle
+
+        let accepted = mgr.submit(
+            sessionId: session.id,
+            text: "kick attach",
+            attachments: [],
+            intent: .auto
+        ) { _ in }
+
+        #expect(accepted == true)
+        #expect(session.queue.count == 1)
+
+        // attach() from .idle flips to .spawning, then lands on .failed on
+        // the spec-missing branch. By the time reattach's awaited attach()
+        // returns, the session has been touched. Poll until either a
+        // runner appears or we see the setupState set by the spec-missing
+        // branch.
+        for _ in 0..<50 {
+            if mgr.runners[session.id] != nil { break }
+            // The spec-missing branch sets setupState to .needsSetup and
+            // agentState to .failed — that's our observable signal.
+            if case .needsSetup = session.setupState { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        if case .needsSetup = session.setupState {
+            // success — reattach drove attach() far enough to evaluate spec
+        } else {
+            Issue.record("reattach from .idle did not invoke attach(): setupState=\(session.setupState)")
+        }
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionRecoveryTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRecoveryTests.swift
@@ -190,4 +190,48 @@ struct ACPSessionManagerSubmitTests {
             Issue.record("reattach from .idle did not invoke attach(): setupState=\(session.setupState)")
         }
     }
+
+    @Test("submit with state/registry desync (.ready but no runner) self-heals")
+    func submitReadyButNoRunnerSelfHeals() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-submit-desync-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(
+            worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        // Use an agentId with no launch spec so the reattach-triggered
+        // attach lands on .failed via the spec-missing branch.
+        let session = mgr.createSession(agentId: "no-such-agent-\(UUID().uuidString)")
+        // Pre-set the desync state directly. runners[session.id] is already
+        // nil for a freshly created session — that's the desync we're
+        // testing: state says .ready, registry says no runner.
+        session.agentState = .ready
+
+        let accepted = mgr.submit(
+            sessionId: session.id,
+            text: "wake up",
+            attachments: [],
+            intent: .auto
+        ) { _ in }
+
+        #expect(accepted == true)
+        #expect(session.queue.count == 1)
+        // Fix invariant: state must transition off .ready synchronously so
+        // reattach actually fires instead of no-opping.
+        #expect(session.agentState != .ready)
+
+        // Poll for the post-reattach state (spec-missing branch → .failed
+        // observable via setupState == .needsSetup, matching the .idle test
+        // above).
+        for _ in 0..<50 {
+            if mgr.runners[session.id] != nil { break }
+            if case .needsSetup = session.setupState { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        if case .needsSetup = session.setupState {
+            // success — desync was recovered: reattach drove attach() far
+            // enough to evaluate spec.
+        } else {
+            Issue.record("reattach from desync did not invoke attach(): setupState=\(session.setupState), agentState=\(session.agentState)")
+        }
+    }
 }

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -144,7 +144,7 @@ struct ACPSessionRunnerQueueTests {
         let (runner, mock, session, store) = try mkRunner()
         mock.script(method: "session/prompt") { _ in Data("null".utf8) }
         // Pre-seed queue + put session in streaming.
-        session.attached = true
+        session.agentState = .ready
         session.transcript.streamingState = .streaming
         session.enqueue(blocks: [.text("stale-a")])
         session.enqueue(blocks: [.text("stale-b")])
@@ -172,18 +172,18 @@ struct ACPSessionRunnerQueueTests {
         // Regression: the unstructured steer Task survives the runner +
         // connection it was spawned in. If the user closes the tab while
         // we're awaiting `userCancel`, `ACPSessionManager.detach` flips
-        // `session.attached = false` and shuts down the connection but
-        // doesn't cancel this task. Without a liveness check, the trailing
-        // `sendNow` would append the redirect prompt and persist a
-        // `lastError` on the detached session.
+        // `session.agentState` away from `.ready` and shuts down the
+        // connection but doesn't cancel this task. Without a liveness
+        // check, the trailing `sendNow` would append the redirect prompt
+        // and persist a `lastError` on the detached session.
         let (runner, mock, session, _) = try mkRunner()
         mock.script(method: "session/prompt") { _ in Data("null".utf8) }
-        session.attached = true
+        session.agentState = .ready
         session.transcript.streamingState = .streaming
 
         runner.send(blocks: [.text("redirect")], intent: .steer)
         // Simulate the detach landing while userCancel is still in flight.
-        session.attached = false
+        session.agentState = .idle
 
         try await Task.sleep(nanoseconds: 250_000_000)
 
@@ -198,7 +198,7 @@ struct ACPSessionRunnerQueueTests {
     func steerUndoRestores() async throws {
         let (runner, mock, session, store) = try mkRunner()
         mock.script(method: "session/prompt") { _ in Data("null".utf8) }
-        session.attached = true
+        session.agentState = .ready
         session.transcript.streamingState = .streaming
         session.enqueue(blocks: [.text("a")])
         runner.send(blocks: [.text("redirect")], intent: .steer)
@@ -295,7 +295,7 @@ struct ACPSessionRunnerQueueTests {
         // behind the steer.
         let (runner, mock, session, store) = try mkRunner()
         mock.script(method: "session/prompt") { _ in Data("null".utf8) }
-        session.attached = true
+        session.agentState = .ready
         // Simulate: flusher already promoted the head to .sending; a
         // pending tail is sitting behind it.
         session.enqueue(blocks: [.text("in-flight")])


### PR DESCRIPTION
## Summary

Replaces the trio of readiness signals on `ACPSession` (`attached`, `disconnected`, `manager.runners[id] != nil`) with a single `AgentState` enum, so opening a recovered ACP pane after relaunch reliably respawns the agent process and surfaces the recovery status in the toolbar. Submits during the recovery window persist into the existing session queue and drain the moment the agent reaches `.ready`.

Before: the visual transcript hydrated on pane open, but the agent was dead — the first Send was silently dropped because the boolean cocktail returned `false` with no UI feedback.

After: the composer routes through a single `manager.submit(...)` path that branches on `agentState`. A new `ACPRecoveryPill` in the toolbar shows `Reconnecting…` / `Disconnected` / `Failed` with the reason in the tooltip.

### What changed

- New `AgentState` enum on `ACPSession`: `.idle / .spawning / .ready / .disconnected / .failed(reason)`.
- `ACPSessionManager.attach()` drives the state machine with an idempotency guard. Spec-missing, setup-not-ready, spawn, and RPC failures all land at `.failed(reason)` so the pill renders accurately.
- `reattach(to:)` — idempotent self-heal entry point used by `submit` when the user types into a non-`.ready` pane.
- `enqueueWhileRecovering(...)` + extracted `ACPSessionRunner.blocks(text:attachments:)` so manager-side and runner-side enqueue paths produce byte-identical persisted queues. The existing `flushQueueIfIdle()` drains both.
- `submit(...)` — composer dispatch that branches on `agentState`. `onCompleted(true)` fires synchronously the moment the prompt is queued, so the draft clears without waiting for the spawn handshake.
- `ACPRecoveryPill` SwiftUI view bound to `agentState`, wired into `ACPToolbar` next to `ACPPlanPill`.
- Legacy `attached`/`disconnected` booleans removed across 6 production + 2 test files; readers migrated to `agentState`.

### Out of scope

- Preserving prior conversation context in the respawned agent (would require `session/load` + persisted `remoteSessionId`).
- Eager respawn of all sessions on app launch (recovery is lazy on pane open or submit).
- Manual "Reconnect" button (the state machine has a seam for it, deferred).
- A fake ACP CLI test target or factory-injection seam in `attach()`. Without one, the end-to-end `.ready` + drain path can't run in automated tests. Coverage stops at the spec-missing branch, which exercises the full state machine including `.failed → .spawning` via `reattach`. Documented inline with `TODO(harness):` markers.

## Test plan

- [x] 2354 / 306 suites pass (`xcodebuild ... test`)
- [x] New unit coverage: state machine transitions, idempotency, reattach delegation, enqueueWhileRecovering, submit branching
- [x] New integration test: persistence round-trip with hydration + reattach + queue preservation; submit-during-recovery; queue ordering across enqueueWhileRecovering + submit
- [ ] Manual smoke: relaunch Alas with an open ACP pane, confirm "Reconnecting…" pill appears briefly then clears, first Send goes through
- [ ] Manual smoke: configure a session with a missing CLI, open the pane, confirm "Failed" pill with reason on hover