### PR TITLE
perf(acp): in-app memory accounting + capped retain surfaces

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */; };
 		08DF3AC4BA50775940371445 /* ACPSessionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */; };
 		095A19B85DFA5EBA5A24786D /* AdvancedPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16C4F54FB3E390F80208DA1 /* AdvancedPane.swift */; };
+		095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */; };
 		0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F90D03073708AA01531533 /* GitService+Staging.swift */; };
 		0B11B8038CBA3A6F05E34895 /* GatekeeperAssessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137E9C84D7F32E747F0AF4C0 /* GatekeeperAssessorTests.swift */; };
 		0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */; };
@@ -174,6 +175,7 @@
 		376A08C73011C5CA9E445C4B /* ImageDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7D83CD76ABF9FED3B29F62 /* ImageDiffView.swift */; };
 		37DD3F3B818131973DAA2B9B /* ACPMessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */; };
 		387EF12B6875648E422956F7 /* Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E8A2A1A02BD06F4B782D03 /* Highlighted.swift */; };
+		38B6857CDB7D094A46F653E2 /* ACPSessionByteAccounting.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */; };
 		38DCAD9DA4B9418906700A25 /* MergeView3Way.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695C887147631ACF1FA73C3F /* MergeView3Way.swift */; };
 		38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */; };
 		395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */; };
@@ -260,6 +262,7 @@
 		4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */; };
 		4BDE8C92734D3A60645C0500 /* PaneLeafEncodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */; };
 		4C31A14595F4AE906BFE67D2 /* ACPAgentProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3692D5EB4BCA66AB702D43 /* ACPAgentProfiles.swift */; };
+		4CFC511BB3BEFB139BDF66F6 /* MemoryReportWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3E23DCE2A602A87915ECE /* MemoryReportWindow.swift */; };
 		4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */; };
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
 		4E352BDC87A204DE2912F54F /* ACPHarnessBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */; };
@@ -280,6 +283,7 @@
 		52A5CDD852333A0C4BDC6995 /* ACPPermissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */; };
 		5426DC977050AACBCBDA37E9 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */; };
 		542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */; };
+		551C15188490062DFC77A479 /* MemorySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */; };
 		552EBB79C20E7D939C7015A1 /* ACPMockClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074A17527610230DCFBEA13C /* ACPMockClient.swift */; };
 		5585C223E2CB23CD8650A5DC /* MergeActionGutter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56780EE994E2CA14A3ABBA7B /* MergeActionGutter.swift */; };
 		55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */; };
@@ -403,6 +407,7 @@
 		8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		823AA3E801A11C535C9438BD /* ACPPermissionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */; };
+		82544FFCF9960E0BA0FD2C7F /* ProcessMemoryProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */; };
 		82D3560952F0B800F56377D7 /* AgentHookInstallNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */; };
 		82E9F713C1BFF433E540314C /* AgentLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F6E707551671670D8CBA38 /* AgentLogoView.swift */; };
 		8312A5067AD6E0143FA83023 /* JSONRPCStdioTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A1EB96EBED0DEDCA5CD094 /* JSONRPCStdioTransport.swift */; };
@@ -465,8 +470,10 @@
 		94354D17B0FEF3F0046B452A /* ACPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */; };
 		950C937884477417569DC20B /* EmptyTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008E982C8526670670425AB8 /* EmptyTabView.swift */; };
 		956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */; };
+		960593EAB0380436038D1400 /* ACPSessionToolCallTruncationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */; };
 		9624AE35A36692177C9EBD38 /* ACPSubmitIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */; };
 		9707DC02317F0E92AB06196B /* ImageDiffModeApplicabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE911B77AC087704180BDB5 /* ImageDiffModeApplicabilityTests.swift */; };
+		970B6BCA824C6AF4DA812946 /* ProcessMemoryProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AA350F5909E28954C623B7 /* ProcessMemoryProbe.swift */; };
 		9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */; };
 		9782C5866410EFE13E670AFF /* FilesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4A3B9B1103346242438940 /* FilesTabView.swift */; };
 		97D86F05B3993A61A0302B97 /* DefinitionSnippetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0326789AA29BD63CC1B8F81F /* DefinitionSnippetCache.swift */; };
@@ -499,6 +506,7 @@
 		9E4B32E154B18BD2285F0D34 /* CommitDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */; };
 		9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */; };
 		9FD539228216762192A02C69 /* DialogChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEDACEB27E6AF219054496E /* DialogChrome.swift */; };
+		9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */; };
 		A03338AC85E6EC8201D56F95 /* TreeSitterJavaScript in Frameworks */ = {isa = PBXBuildFile; productRef = B3568F495249430FBBE2FCCF /* TreeSitterJavaScript */; };
 		A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E96E26D5F53F217BFD1F49 /* EditorBuffer.swift */; };
 		A0B5074B10E732616C917D10 /* DragHandleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1379AD82025AFEABD37EFC42 /* DragHandleTests.swift */; };
@@ -575,6 +583,7 @@
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
 		B834ADF0BB988121361AF334 /* tool-call-content-blocks.json in Resources */ = {isa = PBXBuildFile; fileRef = F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */; };
 		B8412B44C090B4AA6A892D25 /* ACPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B68FD01B15E3EEA09CB79 /* ACPMessages.swift */; };
+		B8492C38E81BB859B4B7BFA4 /* MemoryDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D223B9B905C2BBEFDE50E36 /* MemoryDiagnostics.swift */; };
 		B87B51AC9B374F318CCF1F08 /* AppStateKeepSessionsAliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46554893BA6205CD856B99B5 /* AppStateKeepSessionsAliveTests.swift */; };
 		B884D1257E321D543B5BC670 /* ShortcutBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */; };
 		B8B0B60C8096F691F8401D31 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */; };
@@ -732,6 +741,7 @@
 		E6CB573877637461E11CACAF /* InstallRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */; };
 		E6F317EB2FF5522C77B30B62 /* ACPMarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */; };
 		E703B4895A0337310A17FED6 /* GitService+ImageDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8EFC853C0D2EB4AC2B01D9E /* GitService+ImageDiff.swift */; };
+		E77C416471C1AAADF35EE085 /* MemorySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */; };
 		E7C047F37A5C7100149FED4A /* ImageDiffPairResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76942B028C3CBAED16BC4CC1 /* ImageDiffPairResolverTests.swift */; };
 		E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A9977C979705A40595FD5E /* TabsManagerTests.swift */; };
 		E83BA776F26C011D034CAE18 /* HoverHighlightFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019A03B92542169A6595D432 /* HoverHighlightFeature.swift */; };
@@ -744,6 +754,7 @@
 		EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */; };
 		EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82387CFDFFBF52E639095C65 /* GitServiceBehindStatusTests.swift */; };
 		EC3209AD2538061259084545 /* ACPTerminalMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */; };
+		EC9A9B3211CFE0B652F5CA83 /* MemoryDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */; };
 		ECEE8511CA84DF4A15F01DC1 /* AppConfigTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */; };
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
@@ -754,6 +765,7 @@
 		F078F588859E4B2E906D704A /* AlasToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1841997CCBDB9611576B930C /* AlasToggle.swift */; };
 		F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */; };
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
+		F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */; };
 		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
 		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
@@ -924,6 +936,7 @@
 		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
 		26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntentTests.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
+		2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionToolCallTruncationTests.swift; sourceTree = "<group>"; };
 		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
 		27A92711BC1D9A78D8A80561 /* GitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypes.swift; sourceTree = "<group>"; };
 		27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitFilesListView.swift; sourceTree = "<group>"; };
@@ -944,6 +957,7 @@
 		2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconTests.swift; sourceTree = "<group>"; };
 		2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficLights.swift; sourceTree = "<group>"; };
 		2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPillState.swift; sourceTree = "<group>"; };
+		2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnosticsTests.swift; sourceTree = "<group>"; };
 		2E669FEBE09BC250B477B335 /* ACPLaunchCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalog.swift; sourceTree = "<group>"; };
 		2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLifecycleTests.swift; sourceTree = "<group>"; };
 		2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDiffView.swift; sourceTree = "<group>"; };
@@ -976,6 +990,7 @@
 		36992F601C8EB6C3D45B584F /* SearchKbd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKbd.swift; sourceTree = "<group>"; };
 		36B06AE8BA5FBDEAD4586616 /* SearchKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchKind.swift; sourceTree = "<group>"; };
 		36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentAutoLaunchTests.swift; sourceTree = "<group>"; };
+		3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdownCacheEvictionTests.swift; sourceTree = "<group>"; };
 		3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerWorktreeOrderingTests.swift; sourceTree = "<group>"; };
 		373D587E3153D902EB10208B /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
 		37987D5884297401F95478D3 /* AgentPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPathTests.swift; sourceTree = "<group>"; };
@@ -1066,6 +1081,7 @@
 		519CFB3707E8DDBDECD6C5D1 /* Alas.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Alas.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5210D5B1E2FD2EF68139506E /* ProcessGitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitTests.swift; sourceTree = "<group>"; };
 		524926F2D16B1AD83FC234AB /* ChangeSummaryVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryVisibility.swift; sourceTree = "<group>"; };
+		52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionByteAccountingTests.swift; sourceTree = "<group>"; };
 		52C55C85672956E1340B03B1 /* MergeSidePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeSidePane.swift; sourceTree = "<group>"; };
 		5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioClientTests.swift; sourceTree = "<group>"; };
 		530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighter.swift; sourceTree = "<group>"; };
@@ -1075,6 +1091,7 @@
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
 		542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationState.swift; sourceTree = "<group>"; };
+		5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySnapshotTests.swift; sourceTree = "<group>"; };
 		547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunnerQueueTests.swift; sourceTree = "<group>"; };
 		54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallContentTests.swift; sourceTree = "<group>"; };
 		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
@@ -1139,6 +1156,7 @@
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
 		6CA51D49B1AE4C4E10D450C6 /* ACPFileWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileWriterTests.swift; sourceTree = "<group>"; };
 		6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBranchSelectorTests.swift; sourceTree = "<group>"; };
+		6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRetentionTests.swift; sourceTree = "<group>"; };
 		6D46BDE72E52818061452ECB /* CommitRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRowTests.swift; sourceTree = "<group>"; };
 		6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagingTests.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1183,6 +1201,7 @@
 		7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionsButton.swift; sourceTree = "<group>"; };
 		7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewAutoPairTests.swift; sourceTree = "<group>"; };
 		7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeatureTests.swift; sourceTree = "<group>"; };
+		7D223B9B905C2BBEFDE50E36 /* MemoryDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnostics.swift; sourceTree = "<group>"; };
 		7D398D06BDFFA5EDC24D3E6A /* DragHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragHandle.swift; sourceTree = "<group>"; };
 		7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointingHandCursor.swift; sourceTree = "<group>"; };
 		7D6BC5CC26EC6A242C2FDDDA /* DefinitionSnippetCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionSnippetCacheTests.swift; sourceTree = "<group>"; };
@@ -1219,6 +1238,7 @@
 		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
 		89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionName.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
+		8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySnapshot.swift; sourceTree = "<group>"; };
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
 		8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictColumnView.swift; sourceTree = "<group>"; };
@@ -1298,6 +1318,7 @@
 		A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntent.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimer.swift; sourceTree = "<group>"; };
+		A6C3E23DCE2A602A87915ECE /* MemoryReportWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryReportWindow.swift; sourceTree = "<group>"; };
 		A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailView.swift; sourceTree = "<group>"; };
 		A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigAgentsCodingTests.swift; sourceTree = "<group>"; };
 		A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommandTests.swift; sourceTree = "<group>"; };
@@ -1344,6 +1365,7 @@
 		B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunnerTests.swift; sourceTree = "<group>"; };
 		B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftBridgeTests.swift; sourceTree = "<group>"; };
 		B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceMergeTests.swift; sourceTree = "<group>"; };
+		B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbeTests.swift; sourceTree = "<group>"; };
 		BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileChip.swift; sourceTree = "<group>"; };
 		BAE3E5634CC9BA68765EA539 /* ANSIStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSIStream.swift; sourceTree = "<group>"; };
 		BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPromptEditorWindow.swift; sourceTree = "<group>"; };
@@ -1435,6 +1457,7 @@
 		D510DACCD80A328B2DFABDC0 /* CompletionFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionFeature.swift; sourceTree = "<group>"; };
 		D568D53950A3CA2CD1F4EECB /* ImageDiffPairResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairResolver.swift; sourceTree = "<group>"; };
 		D5825E49F6DC54DC35132D2F /* MergeConflictTabModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModelTests.swift; sourceTree = "<group>"; };
+		D5AA350F5909E28954C623B7 /* ProcessMemoryProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessMemoryProbe.swift; sourceTree = "<group>"; };
 		D5BAC2BE2CEAFDD462D9116F /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		D60051A6C7BEE35773F3FBB9 /* tool-call-content-terminal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-terminal.json"; sourceTree = "<group>"; };
 		D64C0B7363363C77718B446C /* CopilotInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstaller.swift; sourceTree = "<group>"; };
@@ -1505,6 +1528,7 @@
 		EBBBF87CC508451B2C0F3A66 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		EBBFE202A6AB6F0EFB46EB5D /* MergeConflictTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTextStorage.swift; sourceTree = "<group>"; };
 		EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigFilesTests.swift; sourceTree = "<group>"; };
+		EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionByteAccounting.swift; sourceTree = "<group>"; };
 		EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerConfigMasonPrefill.swift; sourceTree = "<group>"; };
 		EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanSidebar.swift; sourceTree = "<group>"; };
 		EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewProjectDialog.swift; sourceTree = "<group>"; };
@@ -1624,6 +1648,17 @@
 				6CA51D49B1AE4C4E10D450C6 /* ACPFileWriterTests.swift */,
 			);
 			path = FileWriter;
+			sourceTree = "<group>";
+		};
+		07E359D8B18600D505C1B4C1 /* Diagnostics */ = {
+			isa = PBXGroup;
+			children = (
+				7D223B9B905C2BBEFDE50E36 /* MemoryDiagnostics.swift */,
+				A6C3E23DCE2A602A87915ECE /* MemoryReportWindow.swift */,
+				8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */,
+				D5AA350F5909E28954C623B7 /* ProcessMemoryProbe.swift */,
+			);
+			path = Diagnostics;
 			sourceTree = "<group>";
 		};
 		08AFF75AE216ACC5E010B709 /* Highlight */ = {
@@ -1890,6 +1925,7 @@
 				E0E5107A10052A150DD8DE02 /* ZmxSunPathBudgetTests.swift */,
 				6C8726781C7EE2E64AE25E56 /* ACP */,
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
+				EAD92DAB367A7F31FF1223D1 /* Diagnostics */,
 				08BD96F4379A0D250DE4303C /* JSONRPC */,
 				5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */,
 			);
@@ -2052,6 +2088,7 @@
 				FAE46B7EB9FF647CE1B2E166 /* App */,
 				5E838E5E31D2C1A333F73943 /* Center */,
 				4884B807E1962E6CAE50F20D /* Code */,
+				07E359D8B18600D505C1B4C1 /* Diagnostics */,
 				1B7FB431695F35CED973CDD2 /* Dialogs */,
 				2DC32361E466DA20E974D106 /* Git */,
 				B4091CAB7D0E176C8D1E112C /* Harness */,
@@ -2209,6 +2246,7 @@
 				321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */,
 				D21F30DB5A812E396262A926 /* ACPMessageWire.swift */,
 				BBBEFD27FD7013D458435779 /* ACPSession.swift */,
+				EBF4DE84207D33D518DD7D3E /* ACPSessionByteAccounting.swift */,
 				94D30693F45966ED1456811E /* ACPSessionHydrator.swift */,
 				7615FEA1F225EBDE52CF5E14 /* ACPSessionManager.swift */,
 				F332906E17C5865856DBB90B /* ACPSessionRunner.swift */,
@@ -2573,9 +2611,11 @@
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
 				2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */,
 				0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */,
+				52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */,
 				1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */,
 				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
 				472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */,
+				6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */,
 				3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */,
@@ -2587,11 +2627,13 @@
 				F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */,
 				9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */,
 				1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */,
+				2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */,
 				EAA78FF7BA562DC4423AC35D /* ACPSessionVisibleQueueTests.swift */,
 				F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */,
 				26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */,
 				EC7FA2ABE27A4CC2EB0BCA18 /* ACPTranscriptCurrentPlanTests.swift */,
 				0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */,
+				3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */,
 				7DCF803DF778CF9C06AC1579 /* ACPTranscriptWindowTests.swift */,
 				FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */,
 			);
@@ -2872,6 +2914,16 @@
 				BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */,
 			);
 			path = Commit;
+			sourceTree = "<group>";
+		};
+		EAD92DAB367A7F31FF1223D1 /* Diagnostics */ = {
+			isa = PBXGroup;
+			children = (
+				2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */,
+				5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */,
+				B9830BAAE86AA0A20A77731D /* ProcessMemoryProbeTests.swift */,
+			);
+			path = Diagnostics;
 			sourceTree = "<group>";
 		};
 		F180B48403645336DCF3A60B /* res */ = {
@@ -3255,6 +3307,7 @@
 				C85FF0853DE69CE2EB59633E /* ACPRecoveryPill.swift in Sources */,
 				900A70EF9D41AEF3953CABBB /* ACPSelectChip.swift in Sources */,
 				8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */,
+				38B6857CDB7D094A46F653E2 /* ACPSessionByteAccounting.swift in Sources */,
 				61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */,
 				209FB0AAF20BDE5850A139F4 /* ACPSessionManager.swift in Sources */,
 				1F89B774F2DC7DD818AD4E5B /* ACPSessionRunner.swift in Sources */,
@@ -3489,6 +3542,9 @@
 				6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */,
 				A98F3436BE8AB680178B341C /* MarkdownViewMode.swift in Sources */,
 				F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */,
+				B8492C38E81BB859B4B7BFA4 /* MemoryDiagnostics.swift in Sources */,
+				4CFC511BB3BEFB139BDF66F6 /* MemoryReportWindow.swift in Sources */,
+				E77C416471C1AAADF35EE085 /* MemorySnapshot.swift in Sources */,
 				5585C223E2CB23CD8650A5DC /* MergeActionGutter.swift in Sources */,
 				4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */,
 				2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */,
@@ -3529,6 +3585,7 @@
 				1B1A33B610D29116A1D08A74 /* PointingHandCursor.swift in Sources */,
 				C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */,
 				106120CBE8107E0AC4EA353A /* ProcessKiller.swift in Sources */,
+				970B6BCA824C6AF4DA812946 /* ProcessMemoryProbe.swift in Sources */,
 				1DCE55DBA4A9DC466D817D22 /* ProjectConfig.swift in Sources */,
 				F88FD8BE546E36A0E3BF2594 /* ProjectGitWatcher.swift in Sources */,
 				E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */,
@@ -3661,10 +3718,12 @@
 				97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */,
 				F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */,
 				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,
+				9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,
 				C51451EC8E103EB5FEF82EFE /* ACPSessionLifecycleTests.swift in Sources */,
 				D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */,
+				095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
 				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,
 				C9004250BC974548165BE5B3 /* ACPSessionRecoveryIntegrationTests.swift in Sources */,
@@ -3676,6 +3735,7 @@
 				08DF3AC4BA50775940371445 /* ACPSessionStoreTests.swift in Sources */,
 				48AD9728403D96C9C5958AC6 /* ACPSessionTerminalRoutingTests.swift in Sources */,
 				B472D692A8D8D1C664EAC467 /* ACPSessionTests.swift in Sources */,
+				960593EAB0380436038D1400 /* ACPSessionToolCallTruncationTests.swift in Sources */,
 				33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */,
 				A4476A509577896F9DADE5CB /* ACPSessionVisibleQueueTests.swift in Sources */,
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
@@ -3689,6 +3749,7 @@
 				E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */,
 				4B8BD1280C2DFF3CE1FD3C4B /* ACPTranscriptCurrentPlanTests.swift in Sources */,
 				A8EE9207A828D4D1BAF1C1C1 /* ACPTranscriptLatestPlanTests.swift in Sources */,
+				F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
 				E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */,
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,
@@ -3851,6 +3912,8 @@
 				8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */,
 				8B0F53A453343AF8DA0B4C0C /* MarkdownViewModeTests.swift in Sources */,
 				EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */,
+				EC9A9B3211CFE0B652F5CA83 /* MemoryDiagnosticsTests.swift in Sources */,
+				551C15188490062DFC77A479 /* MemorySnapshotTests.swift in Sources */,
 				85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */,
 				98ED89EA20255EBB9D186AD5 /* MergeConflictBinaryDetectionTests.swift in Sources */,
 				04C778DB96502CD36E4C031B /* MergeConflictTabModelTests.swift in Sources */,
@@ -3872,6 +3935,7 @@
 				04EC051D5AEE99A4841B29C7 /* PiInstallerTests.swift in Sources */,
 				D1C14B54BE27D97E354F448B /* ProcessGitDataTests.swift in Sources */,
 				7FC2A96DE87638A594DD8B61 /* ProcessGitTests.swift in Sources */,
+				82544FFCF9960E0BA0FD2C7F /* ProcessMemoryProbeTests.swift in Sources */,
 				636ED129478744F9169AD774 /* ProjectConfigAgentOverrideTests.swift in Sources */,
 				D13AFC98364971915782491C /* ProjectConfigTests.swift in Sources */,
 				2A18F8265F467BF33AD69159 /* ProjectGitWatcherTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -60,6 +60,27 @@ enum ACPMessage: Equatable {
         /// content the agent emitted.
         var terminalIds: [String]
 
+        /// Set when `content` has been truncated to save memory. The full
+        /// content is still in SQLite (`ACPSessionStore.loadMessages`) and
+        /// can be refetched on demand for an expanded card.
+        var isContentTruncated: Bool = false
+
+        /// How many characters of `content` we keep in memory for an
+        /// off-window completed tool call. Tuned to fit the collapsed-card
+        /// teaser + a small head of context — the rest is paged in if the
+        /// user expands.
+        static let truncatedTailBytes: Int = 4096
+
+        /// Replace `content` with its first `truncatedTailBytes` characters
+        /// and mark the message as truncated. No-op if already truncated.
+        mutating func truncateForOffWindow() {
+            guard !isContentTruncated else { return }
+            if content.count > Self.truncatedTailBytes {
+                content = String(content.prefix(Self.truncatedTailBytes))
+            }
+            isContentTruncated = true
+        }
+
         init(toolCallId: String, title: String, kind: String? = nil,
              status: String, content: String = "", preview: String? = nil,
              locations: [String] = [], terminalIds: [String] = [])
@@ -103,6 +124,30 @@ enum ACPMessage: Equatable {
             try c.encodeIfPresent(preview, forKey: .preview)
             try c.encode(locations, forKey: .locations)
             try c.encode(terminalIds, forKey: .terminalIds)
+        }
+
+        // Manual Equatable/Hashable: `isContentTruncated` is an in-memory-only
+        // flag that flips when off-window content is truncated. Two tool calls
+        // representing the same logical row must remain equal across that
+        // boundary, so we exclude the flag from both conformances.
+        static func == (lhs: Self, rhs: Self) -> Bool {
+            lhs.toolCallId == rhs.toolCallId
+                && lhs.title == rhs.title
+                && lhs.kind == rhs.kind
+                && lhs.status == rhs.status
+                && lhs.content == rhs.content
+                && lhs.preview == rhs.preview
+                && lhs.locations == rhs.locations
+        }
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(toolCallId)
+            hasher.combine(title)
+            hasher.combine(kind)
+            hasher.combine(status)
+            hasher.combine(content)
+            hasher.combine(preview)
+            hasher.combine(locations)
         }
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionByteAccounting.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionByteAccounting.swift
@@ -1,0 +1,42 @@
+#if DEBUG
+import Foundation
+
+@MainActor
+extension ACPSession {
+    /// Sum of approximate UTF-8 byte sizes across every message in the transcript.
+    /// Tool-call `content` and `preview` are counted in full; locations are
+    /// counted by their joined path length.
+    func transcriptByteEstimate() -> UInt64 {
+        var total: UInt64 = 0
+        for m in transcript.messages {
+            switch m {
+            case .user(_, let text, let atts):
+                total &+= UInt64(text.utf8.count)
+                for a in atts {
+                    total &+= UInt64(a.uri.utf8.count)
+                    total &+= UInt64(a.name?.utf8.count ?? 0)
+                }
+            case .agent(_, let buf), .thought(_, let buf):
+                total &+= UInt64(buf.value.utf8.count)
+            case .toolCall(let tc):
+                total &+= UInt64(tc.content.utf8.count)
+                total &+= UInt64(tc.preview?.utf8.count ?? 0)
+                total &+= UInt64(tc.title.utf8.count)
+                for path in tc.locations { total &+= UInt64(path.utf8.count) }
+            case .fileEdit(_, let edit):
+                total &+= UInt64(edit.path.utf8.count)
+            case .plan(_, let items):
+                for item in items { total &+= UInt64(item.content.utf8.count) }
+            case .systemNotice(_, let text):
+                total &+= UInt64(text.utf8.count)
+            }
+        }
+        return total
+    }
+
+    /// Forwards to `ACPTranscript.markdownCacheByteEstimate`.
+    func markdownCacheByteEstimate() -> UInt64 {
+        transcript.markdownCacheByteEstimate
+    }
+}
+#endif

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -16,6 +16,11 @@ final class ACPSessionManager: ObservableObject {
     @Published private(set) var sessions: [ACPSession.ID: ACPSession] = [:]
     @Published private(set) var recent: [ACPSessionRow] = []
     private(set) var runners: [ACPSession.ID: ACPSessionRunner] = [:]
+    #if DEBUG
+    /// Number of attached runners. Public-but-namespaced read accessor for
+    /// `MemoryDiagnostics`; we don't expose the runner instances themselves.
+    var runnerCountForDiagnostics: Int { runners.count }
+    #endif
     /// Per-session debounced write tasks for `composer_drafts`. The
     /// in-memory `session.composerDraft` updates on every keystroke;
     /// the SQLite write only fires after a brief idle (or a forced
@@ -25,6 +30,12 @@ final class ACPSessionManager: ObservableObject {
     private static let draftDebounceNanos: UInt64 = 300_000_000
     private let hydrator: ACPSessionHydrator?
     private var inFlightHydrations: [ACPSession.ID: Task<Void, Never>] = [:]
+
+    /// Per-session UI refcount. When this drops to zero AND the session is
+    /// not `attached`, the cached `ACPSession` is evicted from `sessions`.
+    /// Re-opening through `placeholderSession` + `hydrateIfNeeded` recreates
+    /// it cleanly from SQLite.
+    private var sessionRefCounts: [ACPSession.ID: Int] = [:]
 
     init(worktreeId: String, worktreePath: String, store: ACPSessionStore,
          hydratorPath: String? = nil,
@@ -191,14 +202,61 @@ final class ACPSessionManager: ObservableObject {
         // session reference — otherwise a tab-switch-while-typing
         // window can lose the last ~300ms of input.
         flushPendingDraftWrite(for: id)
+        sessions[id]?.transcript.resetMarkdownCaches()
         sessions[id] = nil
+        sessionRefCounts.removeValue(forKey: id)
     }
 
     func deleteSession(id: ACPSession.ID) {
         cancelPendingDraftWrite(for: id)
+        sessions[id]?.transcript.resetMarkdownCaches()
         sessions[id] = nil
+        sessionRefCounts.removeValue(forKey: id)
         try? store.deleteSession(id: id)
         refreshRecent()
+    }
+
+    /// Increment the UI refcount for `id`. No-op if the session isn't
+    /// currently cached (e.g. typo'd id, or already evicted by a prior
+    /// release). Callers must pair every retain with exactly one release.
+    func retainSession(id: ACPSession.ID) {
+        guard sessions[id] != nil else { return }
+        sessionRefCounts[id, default: 0] += 1
+    }
+
+    /// Decrement the UI refcount for `id`. When it reaches zero AND the
+    /// session is not `attached`, the cached `ACPSession` is evicted
+    /// (markdown caches torn down). Releases beyond the retain count are
+    /// silently ignored so a missed retain (e.g. id-typo) can't underflow.
+    func releaseSession(id: ACPSession.ID) {
+        guard let current = sessionRefCounts[id], current > 0 else { return }
+        let next = current - 1
+        if next == 0 {
+            sessionRefCounts.removeValue(forKey: id)
+            evictIfIdle(id: id)
+        } else {
+            sessionRefCounts[id] = next
+        }
+    }
+
+    /// Drops the cached `ACPSession` when its refcount is zero AND no live
+    /// runner is attached. Sessions whose agent process is spawning or ready
+    /// stay resident so in-flight streaming still has somewhere to land.
+    private func evictIfIdle(id: ACPSession.ID) {
+        guard let session = sessions[id] else { return }
+        switch session.agentState {
+        case .spawning, .ready: return
+        case .idle, .disconnected, .failed: break
+        }
+        guard (sessionRefCounts[id] ?? 0) == 0 else { return }
+        // Flush the debounced composer-draft write SYNCHRONOUSLY before
+        // dropping the in-memory session. Otherwise a typing burst that
+        // ends within the 300ms debounce window loses its tail when the
+        // session is evicted — the timer task fires on a nil `sessions[id]`
+        // and silently returns.
+        flushPendingDraftWrite(for: id)
+        session.transcript.resetMarkdownCaches()
+        sessions[id] = nil
     }
 
     func setArchived(id: ACPSession.ID, archived: Bool) {
@@ -331,6 +389,21 @@ final class ACPSessionManager: ObservableObject {
 
     func refreshRecent() {
         recent = (try? store.recentSessions()) ?? []
+    }
+
+    /// Loads the full persisted `content` for a tool call. Used by the
+    /// tool-call card when expanding a message whose in-memory content
+    /// was truncated to save memory. Returns nil if the row is gone or
+    /// the payload can't be decoded.
+    func reloadFullToolCallContent(sessionId: ACPSession.ID, toolCallId: String) -> String? {
+        guard let stored = try? store.loadMessages(sessionId: sessionId) else { return nil }
+        for row in stored where row.kind == "tool_call" {
+            if let tc = try? JSONDecoder().decode(ACPMessage.ToolCall.self, from: row.payload),
+               tc.toolCallId == toolCallId {
+                return tc.content
+            }
+        }
+        return nil
     }
 }
 
@@ -578,6 +651,12 @@ extension ACPSessionManager {
             runner.stop()
             await runner.connection.shutdown()
         }
+        // SwiftUI's `.onDisappear` retain release for a closing tab can
+        // arrive BEFORE this async detach starts, so the release runs while
+        // agentState is still `.ready` and short-circuits eviction. Re-check
+        // now that state is `.idle` so a closed-while-attached session
+        // doesn't keep its transcript + caches resident indefinitely.
+        evictIfIdle(id: sessionId)
     }
 
     private static func mergeEnv(extra: [String: String]) -> [String: String] {

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -48,6 +48,14 @@ final class ACPTranscript: ObservableObject {
         markdownCaches.removeValue(forKey: id)
     }
 
+    #if DEBUG
+    /// Sum of `byteEstimate` over every retained cache. Bounded by the number
+    /// of messages with at least one render pass.
+    var markdownCacheByteEstimate: UInt64 {
+        markdownCaches.values.reduce(0) { $0 + $1.byteEstimate }
+    }
+    #endif
+
     /// Clear all per-message caches; call when the transcript itself is
     /// discarded (e.g. session close).
     func resetMarkdownCaches() {
@@ -98,7 +106,7 @@ final class ACPTranscript: ObservableObject {
     /// after hydration applies a transcript. No-op for transcripts shorter
     /// than `tailWindow`.
     func resetWindowToTail() {
-        visibleHead = max(0, messages.count - Self.tailWindow)
+        setVisibleHead(max(0, messages.count - Self.tailWindow))
     }
 
     /// Reveal one more `tailWindow`-sized chunk of older messages.
@@ -106,4 +114,33 @@ final class ACPTranscript: ObservableObject {
     func stepHeadBack() {
         visibleHead = max(0, visibleHead - Self.tailWindow)
     }
+
+    /// Move the render window head, dropping markdown caches for any message
+    /// whose index is now below the new head. No-op if `newHead` is not greater
+    /// than the current `visibleHead`. Use this instead of writing
+    /// `visibleHead` directly when advancing the window.
+    func setVisibleHead(_ newHead: Int) {
+        let clamped = max(0, min(newHead, messages.count))
+        guard clamped > visibleHead else {
+            visibleHead = clamped
+            return
+        }
+        for i in visibleHead..<clamped {
+            markdownCaches.removeValue(forKey: messages[i].stableId)
+            if case .toolCall(var tc) = messages[i] {
+                if tc.status != "in_progress", tc.status != "pending" {
+                    tc.truncateForOffWindow()
+                    messages[i] = .toolCall(tc)
+                }
+            }
+        }
+        visibleHead = clamped
+    }
+
+    #if DEBUG
+    var markdownCacheCountForTests: Int { markdownCaches.count }
+    func hasMarkdownCacheForTests(messageId: String) -> Bool {
+        markdownCaches[messageId] != nil
+    }
+    #endif
 }

--- a/Alas/Sources/ACP/UI/ACPHistorySidebar.swift
+++ b/Alas/Sources/ACP/UI/ACPHistorySidebar.swift
@@ -4,6 +4,12 @@ struct ACPHistorySidebar: View {
     @ObservedObject var manager: ACPSessionManager
     let agentLookup: (String) -> AgentDefinition?
     @State private var search: String = ""
+    /// Ids materialized through this sidebar's row taps. We retain on
+    /// materialization so the placeholder doesn't sit forever in the
+    /// manager dict, then release everything en masse when the sidebar
+    /// goes away — letting any id NOT independently retained by another
+    /// surface (e.g. the active tab) get evicted.
+    @State private var retainedIds: Set<ACPSession.ID> = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -18,6 +24,12 @@ struct ACPHistorySidebar: View {
                 }
             }
         }
+        .onDisappear {
+            for id in retainedIds {
+                manager.releaseSession(id: id)
+            }
+            retainedIds.removeAll()
+        }
     }
 
     private var filtered: [ACPSessionRow] {
@@ -27,7 +39,10 @@ struct ACPHistorySidebar: View {
 
     private func rowView(_ row: ACPSessionRow) -> some View {
         Button {
-            _ = manager.placeholderSession(id: row.id)
+            if manager.placeholderSession(id: row.id) != nil,
+               retainedIds.insert(row.id).inserted {
+                manager.retainSession(id: row.id)
+            }
         } label: {
             HStack(spacing: 8) {
                 if let agent = agentLookup(row.agentId) {

--- a/Alas/Sources/ACP/UI/ACPMarkdownBlockCache.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownBlockCache.swift
@@ -16,6 +16,14 @@ final class ACPMarkdownBlockCache {
     private var stablePrefixLength: Int = 0
     private var lastFullText: String = ""
 
+    #if DEBUG
+    /// Approximate UTF-8 byte size of the retained text + a small per-stable-block
+    /// constant covering the parsed AST overhead. Used by `MemoryDiagnostics`.
+    var byteEstimate: UInt64 {
+        UInt64(lastFullText.utf8.count) + UInt64(stableBlocks.count) * 128
+    }
+    #endif
+
     func update(with full: String) {
         // Detect non-extending updates and reset.
         if !full.hasPrefix(lastFullText) {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -14,6 +14,11 @@ struct ACPMessageList: View {
     let onQueueRetry: (UUID) -> Void
     let onQueueReorder: (Int, Int) -> Void
     let onQueueClearAll: () -> Void
+    /// Resolves the full persisted content of a tool call by id when an
+    /// expanded card's in-memory content was truncated. Wired by the host
+    /// to `ACPSessionManager.reloadFullToolCallContent`. Returns nil when
+    /// the row is gone or the payload is undecodable.
+    let onLoadFullToolCallContent: (String) -> String?
     @Environment(\.theme) private var theme
     @State private var viewportHeight: CGFloat = 0
     @State private var tailFrame: CGRect = .zero
@@ -285,7 +290,11 @@ struct ACPMessageList: View {
         case .thought(_, let buf):
             ACPThoughtView(buffer: buf)
         case .toolCall(let tc):
-            ACPToolCallCard(toolCall: tc)
+            ACPToolCallCard(
+                toolCall: tc,
+                loadFullContent: tc.isContentTruncated
+                    ? { [tcid = tc.toolCallId] in onLoadFullToolCallContent(tcid) }
+                    : nil)
                 .environment(\.acpTerminalHost, session.terminalHost)
         case .fileEdit(_, let edit):
             ACPFileEditCard(edit: edit, onOpenDiff: { onOpenDiff(edit.path) })

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -16,6 +16,13 @@ struct ACPTabView: View {
                 session: session,
                 transcript: session.transcript
             )
+            // Refcount this tab's hold on the cached `ACPSession`. When the
+            // tab is dismissed (worktree switch, tab close, window close)
+            // and no other UI surface still retains the same id, the manager
+            // evicts it from `sessions` so its transcript + markdown caches
+            // can be reclaimed. Reopening rehydrates from SQLite.
+            .onAppear { manager.retainSession(id: sessionId) }
+            .onDisappear { manager.releaseSession(id: sessionId) }
         } else {
             VStack {
                 Spacer()
@@ -179,6 +186,10 @@ private struct ACPSessionView: View {
                                 // user re-enqueues, the next idle drain still
                                 // needs to fire from this path.
                                 manager.runners[sessionId]?.flushQueueIfIdle()
+                            },
+                            onLoadFullToolCallContent: { toolCallId in
+                                manager.reloadFullToolCallContent(
+                                    sessionId: sessionId, toolCallId: toolCallId)
                             }
                         )
                     }

--- a/Alas/Sources/ACP/UI/ACPToolCallCard.swift
+++ b/Alas/Sources/ACP/UI/ACPToolCallCard.swift
@@ -6,13 +6,29 @@ import SwiftUI
 /// renders an animated spinner instead of a static glyph.
 struct ACPToolCallCard: View {
     let toolCall: ACPMessage.ToolCall
+    /// Closure that returns the full persisted `content` for the tool call
+    /// whose in-memory `content` was truncated when its row left the render
+    /// window. Invoked the first time the card expands; the result is cached
+    /// in `expandedContent` and rendered in place of the truncated copy.
+    /// Optional — when nil (or when the lookup returns nil) the card falls
+    /// back to the in-memory `toolCall.content`.
+    var loadFullContent: (() -> String?)? = nil
     @State private var expanded = false
+    @State private var expandedContent: String? = nil
     @Environment(\.theme) private var theme
     @Environment(\.acpTerminalHost) private var terminalHost
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Button { expanded.toggle() } label: {
+            Button {
+                expanded.toggle()
+                if expanded, toolCall.isContentTruncated, expandedContent == nil {
+                    // First expand of an off-window truncated card: page the
+                    // full content back in from SQLite via the host-provided
+                    // loader. Subsequent toggles reuse the cached string.
+                    expandedContent = loadFullContent?()
+                }
+            } label: {
                 HStack(spacing: 8) {
                     glyph
                     Text(verb)
@@ -53,12 +69,29 @@ struct ACPToolCallCard: View {
         .background(theme.color("bg-1").opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(borderColor, lineWidth: 0.5))
+        // `expandedContent` is keyed to SwiftUI view identity, not to the
+        // tool call's id. If SwiftUI recycles this card for a different
+        // tool call at the same position (e.g. during prepend / reorder),
+        // we must drop the cached full content so we don't render a stale
+        // body from the previous tool call.
+        .onChange(of: toolCall.toolCallId) { _, _ in
+            expandedContent = nil
+        }
+    }
+
+    /// What to draw inside the expanded card. Prefers the just-fetched
+    /// full SQLite content (set on first expand for truncated rows) and
+    /// falls back to the in-memory `toolCall.content` otherwise. Live
+    /// rows (`in_progress`, `pending`) are never truncated, so they
+    /// always render straight from `toolCall.content`.
+    private var displayContent: String {
+        expandedContent ?? toolCall.content
     }
 
     @ViewBuilder
     private var expandedBody: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if toolCall.content.isEmpty && toolCall.terminalIds.isEmpty {
+            if displayContent.isEmpty && toolCall.terminalIds.isEmpty {
                 HStack(spacing: 6) {
                     if toolCall.status == "in_progress" || toolCall.status == "pending" {
                         Spinner(lineWidth: 1.5, duration: 0.7).frame(width: 10, height: 10)
@@ -74,9 +107,9 @@ struct ACPToolCallCard: View {
                 .padding(.horizontal, 12).padding(.vertical, 10)
                 .background(theme.color("bg-0").opacity(0.55))
             } else {
-                if !toolCall.content.isEmpty {
+                if !displayContent.isEmpty {
                     ScrollView(.horizontal, showsIndicators: false) {
-                        Text(toolCall.content)
+                        Text(displayContent)
                             .font(.system(size: 11.5, design: .monospaced))
                             .foregroundStyle(theme.color("fg-muted"))
                             .lineSpacing(2)

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -312,5 +312,13 @@ struct AlasApp: App {
             }
             .keyboardShortcut(state.shortcut(for: .resetFontSize))
         }
+        #if DEBUG
+        CommandMenu("Debug") {
+            Button("Memory Report…") {
+                openMemoryReport(state: state)
+            }
+            .keyboardShortcut("M", modifiers: [.command, .shift, .control])
+        }
+        #endif
     }
 }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2337,6 +2337,15 @@ final class AppState {
     @ObservationIgnored
     private lazy var acpHarnessBridge = ACPHarnessBridge(harness: harness)
 
+    #if DEBUG
+    @ObservationIgnored
+    lazy var memoryDiagnostics: MemoryDiagnostics = {
+        let d = MemoryDiagnostics()
+        d.startTicker(interval: 30)
+        return d
+    }()
+    #endif
+
     /// Returns `true` when the editor has a live, dirty (unsaved) buffer for
     /// the given absolute path within the given worktree.
     func editorHasDirtyBuffer(for absolutePath: String, worktreeId: String) -> Bool {
@@ -2382,6 +2391,9 @@ final class AppState {
             )
             acpManagers[worktree.id] = mgr
             acpHarnessBridge.attach(manager: mgr)
+            #if DEBUG
+            memoryDiagnostics.attach(manager: mgr)
+            #endif
             return mgr
         } catch {
             return nil
@@ -2401,6 +2413,9 @@ final class AppState {
         // manager down — otherwise the last ~300ms of typing in any
         // composer for this worktree never reaches SQLite.
         manager.flushPendingDraftWrites()
+        #if DEBUG
+        memoryDiagnostics.detach(worktreeId: worktreeId)
+        #endif
         acpHarnessBridge.detach(worktreeId: worktreeId)
         let sessionIds = Array(manager.runners.keys)
         // Synchronously cancel the runner's async loops so they stop

--- a/Alas/Sources/Diagnostics/MemoryDiagnostics.swift
+++ b/Alas/Sources/Diagnostics/MemoryDiagnostics.swift
@@ -1,0 +1,102 @@
+#if DEBUG
+import Combine
+import Foundation
+import os
+
+/// Aggregates per-subsystem memory accounting across all attached
+/// `ACPSessionManager`s. Pull-model: the snapshot walks live state when
+/// asked; nothing tracked per mutation.
+///
+/// The tick timer (debug builds only) calls `snapshot()` periodically and
+/// emits the one-line summary via `os.Logger`. The `latest` publisher feeds
+/// the debug "Memory report…" window.
+@MainActor
+final class MemoryDiagnostics: ObservableObject {
+    @Published private(set) var latest: MemorySnapshot?
+
+    private var managers: [String: ACPSessionManager] = [:]
+    private var timer: Timer?
+    private let logger = Logger(subsystem: "io.nlopez.alas", category: "mem")
+
+    func attach(manager: ACPSessionManager) {
+        managers[manager.worktreeId] = manager
+    }
+
+    func detach(worktreeId: String) {
+        managers.removeValue(forKey: worktreeId)
+    }
+
+    func snapshot() -> MemorySnapshot {
+        var perSession: [MemorySnapshot.PerSession] = []
+        var transcriptBytes: UInt64 = 0
+        var markdownCacheBytes: UInt64 = 0
+        var sessionCount = 0
+        var runnerCount = 0
+        for (worktreeId, manager) in managers {
+            runnerCount += manager.runnerCountForDiagnostics
+            for session in manager.sessions.values {
+                let tx = session.transcriptByteEstimate()
+                let md = session.markdownCacheByteEstimate()
+                transcriptBytes &+= tx
+                markdownCacheBytes &+= md
+                sessionCount += 1
+                perSession.append(.init(
+                    sessionId: session.id,
+                    worktreeId: worktreeId,
+                    transcriptBytes: tx,
+                    markdownCacheBytes: md,
+                    messageCount: session.transcript.messages.count,
+                    attached: Self.isAttached(state: session.agentState)))
+            }
+        }
+        let terminalBytes: UInt64 = 0
+        return MemorySnapshot(
+            timestamp: Date(),
+            physFootprint: ProcessMemoryProbe.physFootprint(),
+            transcriptBytes: transcriptBytes,
+            markdownCacheBytes: markdownCacheBytes,
+            terminalBytes: terminalBytes,
+            sessionCount: sessionCount,
+            runnerCount: runnerCount,
+            perSession: perSession)
+    }
+
+    /// Start a repeating tick. Pass `nil` to stop. Safe to call multiple times.
+    func startTicker(interval: TimeInterval = 30) {
+        timer?.invalidate()
+        let t = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+    }
+
+    func stopTicker() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func tick() {
+        let snap = snapshot()
+        latest = snap
+        logger.log("\(snap.oneLineLog(), privacy: .public)")
+    }
+
+    /// Force an immediate sample and publish. Used by the debug
+    /// "Refresh now" button. Does NOT emit an os_log line, so manual
+    /// refreshes don't pollute the tick stream.
+    func refreshNow() {
+        latest = snapshot()
+    }
+
+    /// True when a runner is live (or being spawned) — these sessions
+    /// pin themselves into `ACPSessionManager.sessions` until the agent
+    /// process exits or detaches.
+    private static func isAttached(state: ACPSession.AgentState) -> Bool {
+        switch state {
+        case .spawning, .ready: return true
+        case .idle, .disconnected, .failed: return false
+        }
+    }
+}
+#endif

--- a/Alas/Sources/Diagnostics/MemoryReportWindow.swift
+++ b/Alas/Sources/Diagnostics/MemoryReportWindow.swift
@@ -1,0 +1,96 @@
+#if DEBUG
+import AppKit
+import SwiftUI
+
+/// Debug-only window showing the most recent MemoryDiagnostics snapshot, sorted
+/// by transcript bytes descending. Refreshes whenever `diagnostics.latest`
+/// publishes — i.e. every tick.
+@MainActor
+struct MemoryReportView: View {
+    @ObservedObject var diagnostics: MemoryDiagnostics
+
+    /// Row wrapper to give `PerSession` an Identifiable conformance for `Table`.
+    /// The `sessionId` alone may not be unique across worktrees, so the id
+    /// composites the worktree id and the session id.
+    private struct Row: Identifiable {
+        let inner: MemorySnapshot.PerSession
+        var id: String { "\(inner.worktreeId)|\(inner.sessionId)" }
+    }
+
+    private var rows: [Row] {
+        (diagnostics.latest?.perSession ?? [])
+            .sorted { $0.transcriptBytes > $1.transcriptBytes }
+            .map { Row(inner: $0) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let snap = diagnostics.latest {
+                Text(snap.oneLineLog())
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                Divider()
+                Table(rows) {
+                    TableColumn("Worktree") { Text($0.inner.worktreeId).font(.system(.body, design: .monospaced)) }
+                    TableColumn("Session") { Text($0.inner.sessionId.prefix(8) + "…").font(.system(.body, design: .monospaced)) }
+                    TableColumn("Tx") { Text(MemorySnapshot.formatBinary($0.inner.transcriptBytes)) }
+                    TableColumn("Md") { Text(MemorySnapshot.formatBinary($0.inner.markdownCacheBytes)) }
+                    TableColumn("Msgs") { Text("\($0.inner.messageCount)") }
+                    TableColumn("Attached") { Text($0.inner.attached ? "yes" : "no") }
+                }
+            } else {
+                Text("Awaiting first tick…")
+                    .foregroundStyle(.secondary)
+            }
+            HStack {
+                Button("Refresh now") {
+                    diagnostics.refreshNow()
+                }
+                Spacer()
+                Text("Updates every ~30s")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 720, minHeight: 480)
+    }
+}
+
+@MainActor
+final class MemoryReportWindowController: NSObject, NSWindowDelegate {
+    static let shared = MemoryReportWindowController()
+    private var window: NSWindow?
+
+    func show(diagnostics: MemoryDiagnostics) {
+        if let win = window {
+            win.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        let win = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 480),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered, defer: false)
+        win.title = "Memory report"
+        win.isReleasedWhenClosed = false
+        win.contentView = NSHostingView(rootView: MemoryReportView(diagnostics: diagnostics))
+        win.center()
+        win.delegate = self
+        win.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        window = win
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        if let closing = notification.object as? NSWindow, closing === window {
+            window = nil
+        }
+    }
+}
+
+@MainActor
+func openMemoryReport(state: AppState) {
+    MemoryReportWindowController.shared.show(diagnostics: state.memoryDiagnostics)
+}
+#endif

--- a/Alas/Sources/Diagnostics/MemorySnapshot.swift
+++ b/Alas/Sources/Diagnostics/MemorySnapshot.swift
@@ -1,0 +1,69 @@
+#if DEBUG
+import Foundation
+
+/// One pull-tick of memory accounting for the Alas process.
+///
+/// Each byte field is an *estimate* — Swift's `String` byte cost is approximated as
+/// UTF-8 length, attributed strings as their plain text byte length plus a per-block
+/// constant, etc. The deltas between ticks are the load-bearing signal; absolute
+/// values are bounded by `physFootprint`.
+struct MemorySnapshot {
+    let timestamp: Date
+    let physFootprint: UInt64
+    let transcriptBytes: UInt64
+    let markdownCacheBytes: UInt64
+    let terminalBytes: UInt64
+    let sessionCount: Int
+    let runnerCount: Int
+    let perSession: [PerSession]
+
+    struct PerSession: Equatable {
+        let sessionId: String
+        let worktreeId: String
+        let transcriptBytes: UInt64
+        let markdownCacheBytes: UInt64
+        let messageCount: Int
+        let attached: Bool
+    }
+
+    var accountedBytes: UInt64 {
+        transcriptBytes &+ markdownCacheBytes &+ terminalBytes
+    }
+
+    var unattributedBytes: UInt64 {
+        physFootprint > accountedBytes ? physFootprint - accountedBytes : 0
+    }
+
+    func oneLineLog() -> String {
+        "mem:" +
+        " phys=\(Self.formatBinary(physFootprint))" +
+        " acp.tx=\(Self.formatBinary(transcriptBytes))" +
+        " acp.md=\(Self.formatBinary(markdownCacheBytes))" +
+        " term=\(Self.formatBinary(terminalBytes))" +
+        " sessions=\(sessionCount)" +
+        " runners=\(runnerCount)" +
+        " unattributed=\(Self.formatBinary(unattributedBytes))"
+    }
+
+    /// Compact binary-units formatter: `1.42G`, `412M`, `2.0K`, `512B`.
+    /// Uses 1024-based units, rounded to the precision of each unit.
+    static func formatBinary(_ bytes: UInt64) -> String {
+        let kb: UInt64 = 1024
+        let mb = kb * 1024
+        let gb = mb * 1024
+        if bytes >= gb {
+            let value = Double(bytes) / Double(gb)
+            return String(format: "%.2fG", value)
+        }
+        if bytes >= mb {
+            let value = Double(bytes) / Double(mb)
+            return String(format: "%.0fM", value)
+        }
+        if bytes >= kb {
+            let value = Double(bytes) / Double(kb)
+            return String(format: "%.1fK", value)
+        }
+        return "\(bytes)B"
+    }
+}
+#endif

--- a/Alas/Sources/Diagnostics/ProcessMemoryProbe.swift
+++ b/Alas/Sources/Diagnostics/ProcessMemoryProbe.swift
@@ -1,0 +1,23 @@
+#if DEBUG
+import Darwin
+import Foundation
+
+/// Reads the kernel-reported `phys_footprint` for the current process. This is
+/// the same number Activity Monitor displays as "Memory" and Xcode shows as
+/// "Memory Use" — the most faithful single-number representation of the
+/// process's memory pressure.
+enum ProcessMemoryProbe {
+    /// Returns 0 if the syscall fails (rare; logged at the call site if needed).
+    static func physFootprint() -> UInt64 {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.stride / MemoryLayout<integer_t>.stride)
+        let result = withUnsafeMutablePointer(to: &info) { ptr -> kern_return_t in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { reboundPtr in
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), reboundPtr, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return 0 }
+        return UInt64(info.phys_footprint)
+    }
+}
+#endif

--- a/AlasTests/ACP/Session/ACPSessionByteAccountingTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionByteAccountingTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSession byte accounting")
+struct ACPSessionByteAccountingTests {
+    @Test("transcriptByteEstimate sums utf8 bytes across all message kinds")
+    func transcriptSums() {
+        let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "w1", title: "t")
+        session.transcript.messages.append(.user(id: UUID(), text: "hello", attachments: []))
+        session.transcript.messages.append(.agent(id: UUID(), StreamingText("world!")))
+        session.transcript.messages.append(.systemNotice(id: UUID(), text: "x"))
+        #expect(session.transcriptByteEstimate() == 12)
+    }
+
+    @Test("transcriptByteEstimate counts toolCall content, preview, title, locations")
+    func toolCallBytes() {
+        let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "w1", title: "t")
+        let tc = ACPMessage.ToolCall(
+            toolCallId: "tc1", title: "read",
+            status: "completed", content: "0123456789",
+            preview: "0…", locations: ["/a/b"])
+        session.transcript.messages.append(.toolCall(tc))
+        let expected: UInt64 = UInt64(
+            "0123456789".utf8.count
+            + "0…".utf8.count
+            + "read".utf8.count
+            + "/a/b".utf8.count
+        )
+        #expect(session.transcriptByteEstimate() == expected)
+    }
+
+    @Test("markdownCacheByteEstimate sums lastFullText across caches")
+    func markdownCacheSums() {
+        let session = ACPSession(id: "s1", agentId: "claude", worktreeId: "w1", title: "t")
+        let cacheA = session.transcript.markdownCache(forMessage: "a")
+        cacheA.update(with: String(repeating: "x", count: 1000))
+        let cacheB = session.transcript.markdownCache(forMessage: "b")
+        cacheB.update(with: String(repeating: "y", count: 500))
+        let bytes = session.markdownCacheByteEstimate()
+        #expect(bytes >= 1500)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerRetentionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerRetentionTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSessionManager idle eviction")
+struct ACPSessionManagerRetentionTests {
+    private func makeManager() -> ACPSessionManager {
+        let path = NSTemporaryDirectory() + "retain-\(UUID()).sqlite"
+        let store = try! ACPSessionStore(path: path)
+        return ACPSessionManager(worktreeId: "w1", worktreePath: "/tmp", store: store)
+    }
+
+    @Test("placeholderSession increments refcount; release evicts on zero")
+    func evictOnZero() {
+        let mgr = makeManager()
+        let created = mgr.createSession(agentId: "claude")
+        let id = created.id
+        mgr.retainSession(id: id)
+        #expect(mgr.sessions[id] != nil)
+        mgr.releaseSession(id: id)
+        #expect(mgr.sessions[id] == nil)
+    }
+
+    @Test("multiple retains require matching releases")
+    func balancedReleases() {
+        let mgr = makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        let id = s.id
+        mgr.retainSession(id: id)
+        mgr.retainSession(id: id)
+        mgr.releaseSession(id: id)
+        #expect(mgr.sessions[id] != nil)
+        mgr.releaseSession(id: id)
+        #expect(mgr.sessions[id] == nil)
+    }
+
+    @Test("retain on a deleted session id is a no-op")
+    func retainUnknownIsNoOp() {
+        let mgr = makeManager()
+        mgr.retainSession(id: "does-not-exist")
+        #expect(mgr.sessions["does-not-exist"] == nil)
+    }
+
+    @Test("attached sessions are NOT evicted on zero refcount")
+    func attachedSticky() {
+        let mgr = makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        s.agentState = .ready
+        let id = s.id
+        mgr.retainSession(id: id)
+        mgr.releaseSession(id: id)
+        #expect(mgr.sessions[id] != nil)
+    }
+
+    @Test("closeSession overrides retention and tears down")
+    func closeOverrides() {
+        let mgr = makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        let id = s.id
+        mgr.retainSession(id: id)
+        mgr.retainSession(id: id)
+        mgr.closeSession(id: id)
+        #expect(mgr.sessions[id] == nil)
+    }
+
+    @Test("detach evicts a session whose refcount already hit zero while attached")
+    func detachEvictsAfterAsyncRelease() async {
+        let mgr = makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        let id = s.id
+        s.agentState = .ready
+        mgr.retainSession(id: id)
+        // Simulate SwiftUI's .onDisappear firing before AppState's async
+        // cleanupACPSession got around to invoking detach: refcount drops
+        // to zero while agentState is still .ready, so eviction is skipped.
+        mgr.releaseSession(id: id)
+        #expect(mgr.sessions[id] != nil)
+        // Now the async detach completes: agentState flips out of .ready
+        // and the session must finally evict because refcount is zero.
+        await mgr.detach(sessionId: id)
+        #expect(mgr.sessions[id] == nil)
+    }
+
+    @Test("evicting a session flushes its pending composer draft")
+    func evictionFlushesDraft() async throws {
+        let mgr = makeManager()
+        let s = mgr.createSession(agentId: "claude")
+        let id = s.id
+        let draft = ACPComposerDraft(segments: [.text("unsaved tail")])
+        // Persist via the debounced path so the 300ms timer is in flight.
+        // Without the flush-before-evict, the eviction below races the timer.
+        mgr.persistComposerDraft(draft, for: s)
+        mgr.retainSession(id: id)
+        mgr.releaseSession(id: id)
+        // Session is idle by default; release should trigger eviction.
+        #expect(mgr.sessions[id] == nil)
+        // The store must contain the draft — flushPendingDraftWrite was
+        // called inline by evictIfIdle.
+        let loaded = try mgr.store.loadComposerDraft(sessionId: id)
+        #expect(loaded == draft)
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionToolCallTruncationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionToolCallTruncationTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ToolCall in-memory truncation")
+struct ACPSessionToolCallTruncationTests {
+    private func bigContent() -> String { String(repeating: "a", count: 32_768) }
+
+    @Test("setVisibleHead truncates completed tool calls below the new head")
+    func truncatesCompleted() {
+        let t = ACPTranscript()
+        let tc = ACPMessage.ToolCall(
+            toolCallId: "tc1", title: "read",
+            status: "completed", content: bigContent(),
+            preview: "aaa…", locations: [])
+        t.messages.append(.toolCall(tc))
+        t.messages.append(.systemNotice(id: UUID(), text: "later"))
+
+        t.setVisibleHead(1)
+
+        if case .toolCall(let after) = t.messages[0] {
+            #expect(after.content.utf8.count <= ACPMessage.ToolCall.truncatedTailBytes + 64)
+            #expect(after.isContentTruncated)
+            #expect(after.preview == "aaa…")
+        } else {
+            Issue.record("expected toolCall at index 0")
+        }
+    }
+
+    @Test("setVisibleHead does NOT truncate in-progress or pending tool calls")
+    func skipsLive() {
+        let t = ACPTranscript()
+        let live = ACPMessage.ToolCall(
+            toolCallId: "tc1", title: "run",
+            status: "in_progress", content: bigContent(),
+            preview: "…", locations: [])
+        let pending = ACPMessage.ToolCall(
+            toolCallId: "tc2", title: "run",
+            status: "pending", content: bigContent(),
+            preview: "…", locations: [])
+        t.messages.append(.toolCall(live))
+        t.messages.append(.toolCall(pending))
+        t.messages.append(.systemNotice(id: UUID(), text: "tail"))
+
+        t.setVisibleHead(2)
+
+        if case .toolCall(let liveAfter) = t.messages[0] {
+            #expect(liveAfter.content.utf8.count == 32_768)
+            #expect(!liveAfter.isContentTruncated)
+        } else { Issue.record("expected toolCall live") }
+        if case .toolCall(let pendingAfter) = t.messages[1] {
+            #expect(pendingAfter.content.utf8.count == 32_768)
+            #expect(!pendingAfter.isContentTruncated)
+        } else { Issue.record("expected toolCall pending") }
+    }
+
+    @Test("truncate() keeps the first truncatedTailBytes (character-wise) and sets the flag")
+    func truncateMethod() {
+        var tc = ACPMessage.ToolCall(
+            toolCallId: "x", title: "t",
+            status: "completed", content: String(repeating: "x", count: 100_000),
+            preview: "x…", locations: [])
+        tc.truncateForOffWindow()
+        // We truncate by character count; for ASCII this equals byte count.
+        #expect(tc.content.count == ACPMessage.ToolCall.truncatedTailBytes)
+        #expect(tc.isContentTruncated)
+    }
+
+    @Test("two ToolCalls are equal even if one has been truncated")
+    func equalityIgnoresTruncationFlag() {
+        let original = ACPMessage.ToolCall(
+            toolCallId: "tc1", title: "read",
+            status: "completed", content: "0123456789",
+            preview: "0…", locations: [])
+        var truncated = original
+        // Force the flag without changing content (or use the API and then put content back)
+        truncated.truncateForOffWindow()
+        // Re-equalize content so only the flag differs:
+        truncated.content = "0123456789"
+        #expect(original == truncated)
+        #expect(original.hashValue == truncated.hashValue)
+    }
+
+    @Test("two ToolCalls remain unequal if content differs (truncated or not)")
+    func contentStillDistinguishesEquality() {
+        let a = ACPMessage.ToolCall(
+            toolCallId: "tc1", title: "read",
+            status: "completed", content: "abc",
+            preview: "a", locations: [])
+        let b = ACPMessage.ToolCall(
+            toolCallId: "tc1", title: "read",
+            status: "completed", content: "xyz",
+            preview: "a", locations: [])
+        #expect(a != b)
+    }
+}

--- a/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
+++ b/AlasTests/ACP/Session/ACPTranscriptMarkdownCacheEvictionTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPTranscript markdown cache eviction")
+struct ACPTranscriptMarkdownCacheEvictionTests {
+    @Test("advancing visibleHead drops caches for messages now below head")
+    func dropsBelowHead() {
+        let t = ACPTranscript()
+        for i in 0..<10 {
+            t.messages.append(.systemNotice(id: UUID(), text: "n\(i)"))
+        }
+        let ids = t.messages.map(\.stableId)
+        for id in ids {
+            t.markdownCache(forMessage: id).update(with: "body for \(id)")
+        }
+        #expect(t.markdownCacheCountForTests == 10)
+
+        t.setVisibleHead(5)
+        #expect(t.markdownCacheCountForTests == 5)
+        for id in ids[0..<5] {
+            #expect(!t.hasMarkdownCacheForTests(messageId: id))
+        }
+        for id in ids[5..<10] {
+            #expect(t.hasMarkdownCacheForTests(messageId: id))
+        }
+    }
+
+    @Test("setVisibleHead is idempotent at the same value")
+    func idempotent() {
+        let t = ACPTranscript()
+        for i in 0..<4 { t.messages.append(.systemNotice(id: UUID(), text: "\(i)")) }
+        for id in t.messages.map(\.stableId) {
+            t.markdownCache(forMessage: id).update(with: id)
+        }
+        t.setVisibleHead(2)
+        let countAfterFirst = t.markdownCacheCountForTests
+        t.setVisibleHead(2)
+        #expect(t.markdownCacheCountForTests == countAfterFirst)
+    }
+
+    @Test("setVisibleHead does not drop caches above the head")
+    func keepsAboveHead() {
+        let t = ACPTranscript()
+        for i in 0..<6 { t.messages.append(.systemNotice(id: UUID(), text: "\(i)")) }
+        for id in t.messages.map(\.stableId) {
+            t.markdownCache(forMessage: id).update(with: id)
+        }
+        t.setVisibleHead(2)
+        let after = t.markdownCacheCountForTests
+        t.setVisibleHead(0)
+        #expect(t.markdownCacheCountForTests == after)
+    }
+
+    @Test("resetMarkdownCaches empties the cache map")
+    func resetClears() {
+        let t = ACPTranscript()
+        t.messages.append(.systemNotice(id: UUID(), text: "x"))
+        t.markdownCache(forMessage: t.messages[0].stableId).update(with: "x")
+        #expect(t.markdownCacheCountForTests == 1)
+        t.resetMarkdownCaches()
+        #expect(t.markdownCacheCountForTests == 0)
+    }
+}

--- a/AlasTests/Diagnostics/MemoryDiagnosticsTests.swift
+++ b/AlasTests/Diagnostics/MemoryDiagnosticsTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("MemoryDiagnostics")
+struct MemoryDiagnosticsTests {
+    @Test("snapshot rolls up per-session accounting across managers")
+    func rollup() {
+        let store1 = try? ACPSessionStore(path: NSTemporaryDirectory() + "diag1-\(UUID()).sqlite")
+        let store2 = try? ACPSessionStore(path: NSTemporaryDirectory() + "diag2-\(UUID()).sqlite")
+        let m1 = ACPSessionManager(worktreeId: "w1", worktreePath: "/tmp", store: store1!)
+        let m2 = ACPSessionManager(worktreeId: "w2", worktreePath: "/tmp", store: store2!)
+        let s1 = m1.createSession(agentId: "claude")
+        s1.transcript.messages.append(.user(id: UUID(), text: "abc", attachments: []))
+        let s2 = m2.createSession(agentId: "claude")
+        s2.transcript.messages.append(.agent(id: UUID(), StreamingText("hello world")))
+
+        let diag = MemoryDiagnostics()
+        diag.attach(manager: m1)
+        diag.attach(manager: m2)
+
+        let snap = diag.snapshot()
+        #expect(snap.sessionCount == 2)
+        #expect(snap.transcriptBytes == 14)
+        #expect(snap.perSession.count == 2)
+        #expect(snap.physFootprint > 0)
+    }
+
+    @Test("detach removes the manager from rollup")
+    func detach() {
+        let store = try? ACPSessionStore(path: NSTemporaryDirectory() + "diag3-\(UUID()).sqlite")
+        let m = ACPSessionManager(worktreeId: "w1", worktreePath: "/tmp", store: store!)
+        _ = m.createSession(agentId: "claude")
+        let diag = MemoryDiagnostics()
+        diag.attach(manager: m)
+        diag.detach(worktreeId: "w1")
+        #expect(diag.snapshot().sessionCount == 0)
+    }
+}

--- a/AlasTests/Diagnostics/MemorySnapshotTests.swift
+++ b/AlasTests/Diagnostics/MemorySnapshotTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("MemorySnapshot")
+struct MemorySnapshotTests {
+    @Test("oneLineLog formats bytes with binary suffixes and includes unattributed bucket")
+    func oneLineLogFormatsBytes() {
+        let snap = MemorySnapshot(
+            timestamp: Date(timeIntervalSince1970: 0),
+            physFootprint: 2_482_311_167,
+            transcriptBytes: 1_524_000_000,
+            markdownCacheBytes: 432_000_000,
+            terminalBytes: 125_829_120,
+            sessionCount: 14,
+            runnerCount: 4,
+            perSession: [])
+        let line = snap.oneLineLog()
+        #expect(line.hasPrefix("mem:"))
+        #expect(line.contains("phys=2.31G"))
+        #expect(line.contains("acp.tx=1.42G"))
+        #expect(line.contains("acp.md=412M"))
+        #expect(line.contains("term=120M"))
+        #expect(line.contains("sessions=14"))
+        #expect(line.contains("runners=4"))
+        #expect(line.contains("unattributed="))
+    }
+
+    @Test("unattributed bucket equals phys minus accounted, floored at zero")
+    func unattributedBucket() {
+        let snap = MemorySnapshot(
+            timestamp: Date(),
+            physFootprint: 1_000_000_000,
+            transcriptBytes: 100_000_000,
+            markdownCacheBytes: 50_000_000,
+            terminalBytes: 50_000_000,
+            sessionCount: 0, runnerCount: 0, perSession: [])
+        #expect(snap.unattributedBytes == 800_000_000)
+    }
+
+    @Test("unattributed clamps to zero when accounting overshoots phys")
+    func unattributedFloor() {
+        let snap = MemorySnapshot(
+            timestamp: Date(),
+            physFootprint: 100,
+            transcriptBytes: 200,
+            markdownCacheBytes: 0,
+            terminalBytes: 0,
+            sessionCount: 0, runnerCount: 0, perSession: [])
+        #expect(snap.unattributedBytes == 0)
+    }
+}

--- a/AlasTests/Diagnostics/ProcessMemoryProbeTests.swift
+++ b/AlasTests/Diagnostics/ProcessMemoryProbeTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ProcessMemoryProbe")
+struct ProcessMemoryProbeTests {
+    @Test("physFootprint returns a non-zero kernel-reported value")
+    func nonZero() {
+        let bytes = ProcessMemoryProbe.physFootprint()
+        #expect(bytes > 0)
+    }
+
+    @Test("physFootprint grows after we allocate a large buffer")
+    func growsAfterAllocation() {
+        let before = ProcessMemoryProbe.physFootprint()
+        var ballast = [UInt8](repeating: 0xAB, count: 64 * 1024 * 1024)
+        for i in stride(from: 0, to: ballast.count, by: 4096) {
+            ballast[i] = 0xCD
+        }
+        let after = ProcessMemoryProbe.physFootprint()
+        #expect(after > before)
+        _ = ballast.count
+    }
+}


### PR DESCRIPTION
## Summary
- **Motivation**: under a 6-worktree / 2–3 ACP-pane daily workload, Alas grew unbounded to ~8 GB and was OOM-killed. Smoking gun: `ACPTranscript.markdownCaches` retained every streaming reply's full text + parsed AST forever (`dropMarkdownCache` / `resetMarkdownCaches` were defined but never called). Tool-call `content` (whole file reads, command output) also lived in memory indefinitely.
- **What this lands**: in-app per-subsystem memory accounting (debug-only) + four targeted caps on the retain surfaces flagged by the spec, with the test infra to verify them.

### Diagnostics (debug-only)
- `MemoryDiagnostics`: pull-model rollup of per-session transcript bytes, markdown-cache bytes, runner counts, plus kernel `phys_footprint` via `task_info(TASK_VM_INFO)`.
- 30s tick emits a one-line `mem: phys=… acp.tx=… acp.md=… term=… sessions=… runners=… unattributed=…` via `os.Logger`.
- ⌘⇧⌃M opens a "Memory report…" window showing per-session breakdown sorted by transcript bytes desc; "Refresh now" pulls a fresh sample.
- Entire layer compiled out of release builds (no `task_info` syscall, no metering types).

### Retain surface caps
1. **Markdown cache eviction.** `ACPTranscript.setVisibleHead` is the single funnel that advances the render window head AND drops markdown caches for messages dropped below it. Retreating writes leave caches intact. `closeSession` / `deleteSession` also reset all caches.
2. **Tool-call content truncation.** When the window advances, completed (non-`in_progress` / non-`pending`) tool calls whose index drops below the head are truncated in-memory to 4 KB; `isContentTruncated` is excluded from `Equatable` / `Hashable` / `Codable` (in-memory only). Full content stays in SQLite and is refetched via `ACPSessionManager.reloadFullToolCallContent` when the user expands an old card. `ACPToolCallCard` resets its `@State` cache on `toolCallId` change so view recycling can't show stale content.
3. **Idle session eviction.** `ACPSessionManager` tracks a per-session UI refcount via `retainSession` / `releaseSession`. When refcount hits zero AND the session's `agentState` is not `.spawning` / `.ready`, the cached `ACPSession` is dropped from the in-memory map. Re-opening re-hydrates through the existing placeholder + hydrate path. Tabs and the history sidebar retain on materialization, release on dismiss.
4. **Runner audit.** `ACPSessionRunner` inspected end-to-end — all unstructured `Task` blocks use `[weak self]` and are cancelled in `stop()`; the three stored `for await` loops exit on cancel; no Combine sinks; no closures stored on `ACPConnection` that point back at the runner. Clean.

### Out of scope (deferred per the spec)
- Soft cap on individual `StreamingText` buffers (only matters if a single agent reply exceeds a few MB; instrumentation will surface this).
- Lower terminal scrollback default (already bounded at 10K lines/pane; only adjust if metering shows it's a meaningful contributor under the workload).

## Test plan
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` — full suite passes (2503 tests, 0 failures)
- [x] 17 new Swift Testing cases covering: snapshot formatting & unattributed clamp, `phys_footprint` probe non-zero + grows-after-allocation, per-session byte sums per message kind, markdown cache eviction including idempotence + retreat-keeps + reset-clears, tool-call truncation including live/pending skip + equality round-trip + flag exclusion, refcount eviction including attached-stickiness + unknown-id no-op + closeSession override
- [x] Release build (`-configuration Release`) compiles cleanly — confirms the DEBUG gate is correct
- [ ] Run the user's real-workload reproduction (6 worktrees, 2–3 ACP panes, long sessions over several hours): `phys_footprint` should stabilise under ~2 GB; `acp.tx` and `acp.md` should not trend upward across hours; `unattributed` bucket should not grow