### PR TITLE
perf(acp): debounce textDidChange restyler + draft extraction by 500ms

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -130,12 +130,15 @@ struct ACPInputField: NSViewRepresentable {
         private var nextSubmitID = 0
         private var pendingSubmitID: Int?
         private var pendingRestyleWork: DispatchWorkItem?
+        private var pendingRestyleGeneration = 0
+        private var pendingRestyleRange: NSRange?
         private static let restyleDebounceInterval: Double = 0.5
 
         func flushPendingRestyleNow() {
             guard let work = pendingRestyleWork else { return }
             pendingRestyleWork = nil
             work.perform()
+            pendingRestyleGeneration += 1
             work.cancel()
         }
 
@@ -201,13 +204,21 @@ struct ACPInputField: NSViewRepresentable {
             else { return }
             guard !restoringDraft else { return }
             pendingSubmitID = nil
+            let draft = Self.draft(from: storage)
+            lastSyncedDraft = draft
+            onDraftChange(draft)
+            pendingRestyleRange = pendingRestyleRange.map { existing in
+                NSUnionRange(existing, ACPMarkdownLiveStyler.editedLineRange(in: storage) ?? existing)
+            } ?? ACPMarkdownLiveStyler.editedLineRange(in: storage)
             pendingRestyleWork?.cancel()
+            pendingRestyleGeneration += 1
+            let generation = pendingRestyleGeneration
             let work = DispatchWorkItem { [weak self] in
                 guard let self else { return }
-                ACPMarkdownLiveStyler.restyle(storage)
-                let draft = Self.draft(from: storage)
-                self.lastSyncedDraft = draft
-                self.onDraftChange(draft)
+                guard self.pendingRestyleGeneration == generation else { return }
+                ACPMarkdownLiveStyler.restyle(storage, in: self.pendingRestyleRange)
+                self.pendingRestyleRange = nil
+                self.pendingRestyleWork = nil
             }
             pendingRestyleWork = work
             DispatchQueue.main.asyncAfter(

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -76,6 +76,10 @@ struct ACPInputField: NSViewRepresentable {
         }
     }
 
+    static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
+        coordinator.flushPendingRestyleNow()
+    }
+
     /// When busy, the placeholder advertises whichever action ⏎ will
     /// trigger under the current settings — so a user who inverted the
     /// shortcut (sendOnEnter = false) sees "Steer the agent…" instead of
@@ -125,6 +129,15 @@ struct ACPInputField: NSViewRepresentable {
         private var lastSyncedDraft: ACPComposerDraft
         private var nextSubmitID = 0
         private var pendingSubmitID: Int?
+        private var pendingRestyleWork: DispatchWorkItem?
+        private static let restyleDebounceInterval: Double = 0.5
+
+        func flushPendingRestyleNow() {
+            guard let work = pendingRestyleWork else { return }
+            pendingRestyleWork = nil
+            work.perform()
+            work.cancel()
+        }
 
         init(
             worktreeRoot: URL,
@@ -186,15 +199,25 @@ struct ACPInputField: NSViewRepresentable {
             guard let tv = notification.object as? NSTextView,
                   let storage = tv.textStorage
             else { return }
-            ACPMarkdownLiveStyler.restyle(storage)
             guard !restoringDraft else { return }
             pendingSubmitID = nil
-            let draft = Self.draft(from: storage)
-            lastSyncedDraft = draft
-            onDraftChange(draft)
+            pendingRestyleWork?.cancel()
+            let work = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                ACPMarkdownLiveStyler.restyle(storage)
+                let draft = Self.draft(from: storage)
+                self.lastSyncedDraft = draft
+                self.onDraftChange(draft)
+            }
+            pendingRestyleWork = work
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + Self.restyleDebounceInterval,
+                execute: work
+            )
         }
 
         func submit(_ textView: NSTextView, intent: ACPSubmitIntent = .auto) {
+            flushPendingRestyleNow()
             let attributed = textView.attributedString()
             let (text, attachments) = Self.extract(attributed)
             guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }

--- a/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
@@ -28,6 +28,10 @@ enum ACPMarkdownLiveStyler {
     }()
 
     static func restyle(_ storage: NSTextStorage) {
+        restyle(storage, in: nil)
+    }
+
+    static func restyle(_ storage: NSTextStorage, in requestedRange: NSRange?) {
         guard storage.length > 0 else { return }
 
         // Restrict the styling work to the line(s) touched by the latest
@@ -39,14 +43,10 @@ enum ACPMarkdownLiveStyler {
         // the start would miss the freshly-orphaned line below. On a
         // fresh restyle with no edit info, fall back to full storage.
         let target: NSRange
-        let edited = storage.editedRange
-        if edited.location != NSNotFound, edited.location <= storage.length {
-            let nsString = storage.string as NSString
-            let startLoc = min(edited.location, storage.length)
-            let endLoc = min(edited.location + edited.length, storage.length)
-            let startLine = nsString.lineRange(for: NSRange(location: startLoc, length: 0))
-            let endLine = nsString.lineRange(for: NSRange(location: endLoc, length: 0))
-            target = NSUnionRange(startLine, endLine)
+        if let requestedRange {
+            target = lineRangeCovering(requestedRange, in: storage)
+        } else if let edited = editedLineRange(in: storage) {
+            target = edited
         } else {
             target = NSRange(location: 0, length: storage.length)
         }
@@ -81,6 +81,23 @@ enum ACPMarkdownLiveStyler {
             .foregroundColor: NSColor(calibratedRed: 0.78, green: 0.86, blue: 0.92, alpha: 1),
             .backgroundColor: NSColor.white.withAlphaComponent(0.06),
         ])
+    }
+
+    static func editedLineRange(in storage: NSTextStorage) -> NSRange? {
+        let edited = storage.editedRange
+        guard edited.location != NSNotFound, edited.location <= storage.length else {
+            return nil
+        }
+        return lineRangeCovering(edited, in: storage)
+    }
+
+    private static func lineRangeCovering(_ range: NSRange, in storage: NSTextStorage) -> NSRange {
+        let nsString = storage.string as NSString
+        let startLoc = min(range.location, storage.length)
+        let endLoc = min(range.location + range.length, storage.length)
+        let startLine = nsString.lineRange(for: NSRange(location: startLoc, length: 0))
+        let endLine = nsString.lineRange(for: NSRange(location: endLoc, length: 0))
+        return NSUnionRange(startLine, endLine)
     }
 
     private static func apply(regex: NSRegularExpression,

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -106,6 +106,7 @@ struct ACPComposerDraftBridgeTests {
         coordinator.submit(textView)
         textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: newerDraft))
         coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        coordinator.flushPendingRestyleNow()
         completion?(true)
 
         #expect(changedDrafts == [newerDraft])
@@ -143,6 +144,7 @@ struct ACPComposerDraftBridgeTests {
         coordinator.submit(textView)
         textView.textStorage?.setAttributedString(ACPInputField.Coordinator.attributedString(from: newerDraft))
         coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        coordinator.flushPendingRestyleNow()
         completion?(false)
 
         #expect(changedDrafts == [newerDraft])

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -76,6 +76,94 @@ struct ACPComposerDraftBridgeTests {
         #expect(textView.string.isEmpty)
     }
 
+    @Test("submit flushes pending draft before accepting")
+    func submitFlushesPendingDraftBeforeAccepting() {
+        let draft = ACPComposerDraft(segments: [.text("hello")])
+        let textView = NSTextView()
+        textView.string = "hello"
+        var events: [String] = []
+
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            sendOnEnter: true,
+            onDraftChange: {
+                #expect($0 == draft)
+                events.append("draft")
+            },
+            onDraftClear: { events.append("clear") },
+            onSubmit: { _, _, _, submittedDraft, _ in
+                #expect(submittedDraft == draft)
+                events.append("submit")
+                return true
+            }
+        )
+        coordinator.textView = textView
+
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        #expect(events == ["draft"])
+        coordinator.submit(textView)
+
+        #expect(events == ["draft", "submit"])
+    }
+
+    @Test("flushed pending restyle does not publish again after visible draft clears")
+    func flushedPendingRestyleDoesNotPublishAgainAfterVisibleDraftClears() async throws {
+        let draft = ACPComposerDraft(segments: [.text("hello")])
+        let textView = NSTextView()
+        textView.string = "hello"
+        var changedDrafts: [ACPComposerDraft] = []
+        var completion: (@MainActor (Bool) -> Void)?
+
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            sendOnEnter: true,
+            onDraftChange: { changedDrafts.append($0) },
+            onDraftClear: {},
+            onSubmit: { _, _, _, _, onFinished in
+                completion = onFinished
+                return true
+            }
+        )
+        coordinator.textView = textView
+
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        coordinator.flushPendingRestyleNow()
+        coordinator.submit(textView)
+        completion?(true)
+        try await Task.sleep(nanoseconds: 650_000_000)
+
+        #expect(changedDrafts == [draft])
+    }
+
+    @Test("debounced restyle includes every line dirtied during the debounce")
+    func debouncedRestyleIncludesEveryDirtyLine() {
+        let textView = NSTextView()
+        textView.string = "one\ntwo"
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            sendOnEnter: true,
+            onDraftChange: { _ in },
+            onDraftClear: {},
+            onSubmit: { _, _, _, _, _ in true }
+        )
+        coordinator.textView = textView
+
+        textView.textStorage?.replaceCharacters(in: NSRange(location: 0, length: 3), with: "**one**")
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        textView.textStorage?.replaceCharacters(in: NSRange(location: 8, length: 3), with: "**two**")
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+        coordinator.flushPendingRestyleNow()
+
+        let attributed = textView.attributedString()
+        let firstFont = attributed.attribute(.font, at: 2, effectiveRange: nil) as? NSFont
+        let secondFont = attributed.attribute(.font, at: 10, effectiveRange: nil) as? NSFont
+        #expect(firstFont?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+        #expect(secondFont?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+    }
+
     @Test("successful completion does not clear newer draft after intervening edit")
     func successfulCompletionDoesNotClearNewerDraftAfterInterveningEdit() {
         let submittedDraft = ACPComposerDraft(segments: [.text("hello")])


### PR DESCRIPTION
## Summary
- Debounces ACPMarkdownLiveStyler.restyle() and draft extraction in textDidChange by 500ms to fix visual typing lag
- Synchronous regex + NSTextStorage attribute walking on every keystroke was the culprit, not the existing SQLite persistence debounce
- Adds `flushPendingRestyleNow()` for test determinism

## Test Plan
- [x] All existing tests pass (including ACPComposerDraftBridgeTests)
- [ ] Manual test: type fast in the ACP composer — characters should appear immediately, markdown styling catches up after pause