### PR TITLE
refactor(settings): move chat queue/steer toggle to Agents > Chat

### DIFF
--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -68,6 +68,17 @@ struct AgentsPane: View {
                     }
                 }
 
+                SettingsGroup(title: "Chat") {
+                    SettingsRow(name: "While busy, ⏎ queues; ⌥⏎ steers",
+                                desc: "Turn off to swap — ⏎ steers and ⌥⏎ queues. Steering cancels the running turn and discards any pending queue items.") {
+                        AlasToggle(on: Binding(
+                            get: { state.config.harness.acpSendOnEnter },
+                            set: { state.config.harness.acpSendOnEnter = $0
+                            state.saveConfig() }
+                        ))
+                    }
+                }
+
                 SettingsGroup(title: "Harness") {
                     HStack(alignment: .top, spacing: 16) {
                         VStack(alignment: .leading, spacing: 2) {

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -126,14 +126,6 @@ struct TerminalPane: View {
                                 desc: "Show a clickable notification when a detected harness is waiting for input.") {
                         AlasToggle(on: state.bind(\.harness.notifyOnAwaiting))
                     }
-                    SettingsRow(name: "While busy, ⏎ queues; ⌥⏎ steers",
-                                desc: "Turn off to swap — ⏎ steers and ⌥⏎ queues. Steering cancels the running turn and discards any pending queue items.") {
-                        AlasToggle(on: Binding(
-                            get: { state.config.harness.acpSendOnEnter },
-                            set: { state.config.harness.acpSendOnEnter = $0
-                            state.saveConfig() }
-                        ))
-                    }
                     ForEach(installerRegistry.supportedAgents) { agent in
                         SettingsRow(name: agent.displayName) {
                             HStack {


### PR DESCRIPTION
## What

Moves the chat queue/steer toggle ("While busy, ⏎ queues; ⌥⏎ steers") out of **Settings → Terminal → Harness** and into a new **Chat** group under **Settings → Agents**.

## Why

The toggle governs ACP chat behavior (how ⏎ / ⌥⏎ queue vs. steer a running turn), not the embedded terminal. It read as out of place under Terminal. Agents is its natural home.

## Details

- `TerminalPane.swift` — remove the queue/steer row from the Harness group; notification toggles and per-agent installer rows are unchanged.
- `AgentsPane.swift` — add a new `SettingsGroup(title: "Chat")` holding the same toggle, placed after the Launcher group.
- The stored config key stays `harness.acpSendOnEnter` — UI-only move, no migration, runtime read sites untouched.

## Testing

- `xcodebuild -scheme Alas -destination 'platform=macOS' build` → **BUILD SUCCEEDED**
