### PR TITLE
feat(repo-selector): surface current worktree's repo first in cmd+K

### DIFF
--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -80,7 +80,8 @@ final class RepoSelectorModel {
         let projectOrder = orderedProjects(
             projects: projects,
             worktreesByProject: worktreesByProject,
-            recents: recents
+            recents: recents,
+            currentId: currentId
         )
         for project in projectOrder {
             rows.append(.projectHeader(projectId: project.id))
@@ -181,13 +182,21 @@ final class RepoSelectorModel {
         return refs
     }
 
-    /// Projects ordered by the recency of their most-recently-touched
-    /// worktree. Projects with no recents fall back to alpha order on name.
+    /// Projects ordered with the current worktree's project first (switching
+    /// usually means jumping within the same repo), then by the recency of
+    /// their most-recently-touched worktree. Projects with no recents fall
+    /// back to alpha order on name.
     private func orderedProjects(
         projects: [ProjectConfig],
         worktreesByProject: [String: [Worktree]],
-        recents: RepoSelectorRecents
+        recents: RepoSelectorRecents,
+        currentId: String?
     ) -> [ProjectConfig] {
+        // The project owning the currently-selected worktree always sorts
+        // first, regardless of recency or alpha.
+        let currentProjectId = currentId.flatMap { id in
+            worktreesByProject.first { $0.value.contains { $0.id == id } }?.key
+        }
         // Build a "most-recent index" per project: lower = more recent.
         // Projects with no recents get .max so they sort to the back.
         let validProjectIds = Set(projects.map(\.id))
@@ -196,6 +205,15 @@ final class RepoSelectorModel {
             uniqueKeysWithValues: recentProjectIds.enumerated().map { ($0.element, $0.offset) }
         )
         return projects.sorted { a, b in
+            if let currentProjectId {
+                let aCurrent = a.id == currentProjectId
+                let bCurrent = b.id == currentProjectId
+                // Only decide on current-project priority when exactly one of
+                // them is the current project — returning `true` when both are
+                // (i.e. comparing the element with itself) would break the
+                // strict-weak-ordering contract of `sorted(by:)`.
+                if aCurrent != bCurrent { return aCurrent }
+            }
             let ai = projectRecencyIndex[a.id] ?? Int.max
             let bi = projectRecencyIndex[b.id] ?? Int.max
             if ai != bi { return ai < bi }

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -291,6 +291,37 @@ struct RepoSelectorModelTests {
         #expect(inSection == [wb, wa, wc])
     }
 
+    @Test func emptyQueryPutsCurrentWorktreesProjectFirst() {
+        // Switching usually means jumping to another worktree in the same
+        // repo, so the project owning the current worktree sorts first —
+        // ahead of more-recent and alphabetically-earlier projects.
+        let model = RepoSelectorModel()
+        let acme = project("p-acme", name: "acme")
+        let beta = project("p-beta", name: "beta")
+        let alas = project("p-alas", name: "alas")
+        let acmeW = worktree("acme-w", projectId: "p-acme", branch: "main")
+        let betaW = worktree("beta-w", projectId: "p-beta", branch: "main")
+        let alasW = worktree("alas-w", projectId: "p-alas", branch: "main")
+        var r = RepoSelectorRecents()
+        r.bumpProject("p-acme")  // acme is the most-recently-touched project
+        let e = env(
+            projects: [acme, beta, alas],
+            worktrees: [
+                "p-acme": [acmeW],
+                "p-beta": [betaW],
+                "p-alas": [alasW]
+            ],
+            recents: r,
+            currentWorktreeId: "beta-w"  // current lives in beta
+        )
+        let rows = model.rows(environment: e)
+        let headerOrder = rows.compactMap { row -> String? in
+            if case .projectHeader(let pid) = row { return pid } else { return nil }
+        }
+        // beta first (owns current), then recency (acme), then alpha (alas).
+        #expect(headerOrder == ["p-beta", "p-acme", "p-alas"])
+    }
+
     @Test func emptyQueryProjectWithZeroWorktreesStillShowsHeaderAndNewWorktreeAction() {
         let model = RepoSelectorModel()
         let e = env(


### PR DESCRIPTION
## What

In the cmd+K worktree selector, the project (repo) that owns the **currently selected worktree** now sorts to the top of the project sections.

## Why

Switching worktrees almost always means jumping to another worktree in the same repo, so showing that repo first saves scrolling/searching.

## Details

- `orderedProjects(...)` now resolves the project owning the current worktree (via `worktreesByProject`) and forces it first; the rest keep the existing recency-then-alphabetical order.
- Only the empty-query project-section ordering changes. The cross-project RECENT section and the filtered/fuzzy-search view are untouched (the current worktree is already marked there via `isCurrent`).

## Test

Added `emptyQueryPutsCurrentWorktreesProjectFirst`: three projects where the current worktree's repo is neither most-recent nor alphabetically first; asserts header order is `[current, recent, alpha]`. Full `RepoSelectorModelTests` suite passes (23/23).