### PR TITLE
fix(git): force LC_ALL=C so worktree-remove works in non-English locales

### DIFF
--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -168,6 +168,12 @@ extension Process {
     static func gitEnv() -> [String: String] {
         var env = ProcessInfo.processInfo.environment
         env["GIT_OPTIONAL_LOCKS"] = "0"
+        // Force git to emit messages in English. We parse stderr in several
+        // places (e.g. WorktreeService submodule/dirty/LFS matchers) and those
+        // matchers are English-only; a user with `LANG=es_ES.UTF-8` would
+        // otherwise hit translated errors that no matcher recognizes. POSIX:
+        // LC_ALL overrides LC_MESSAGES and LANG, so this is sufficient.
+        env["LC_ALL"] = "C"
         if let shellPath = ShellEnvResolver.shared.resolvedPath {
             env["PATH"] = shellPath
         }

--- a/AlasTests/ProcessGitTests.swift
+++ b/AlasTests/ProcessGitTests.swift
@@ -79,6 +79,37 @@ struct ProcessGitTests {
         #expect(env["GIT_OPTIONAL_LOCKS"] == "0")
     }
 
+    @Test func gitEnvForcesCLocale() {
+        // Stderr matchers in WorktreeService etc. only recognize English git
+        // messages. Without LC_ALL=C, a user with a non-English shell locale
+        // (e.g. es_ES.UTF-8) hits localized errors like "árboles de trabajo
+        // conteniendo submódulos…" and the auto-force-remove path never fires.
+        let env = Process.gitEnv()
+        #expect(env["LC_ALL"] == "C")
+    }
+
+    @Test func gitEmitsEnglishMessagesUnderForeignLocale() async throws {
+        // End-to-end check: gitEnv() must override an inherited foreign LANG
+        // so git still emits English. We can't mutate ProcessInfo, but we can
+        // run /usr/bin/env git directly with the env gitEnv() produces and
+        // confirm the message is English even if LANG would request Spanish.
+        var env = Process.gitEnv()
+        env["LANG"] = "es_ES.UTF-8"
+        // Trigger any error: `git` with no args in a non-repo cwd emits the
+        // usage hint, which is locale-sensitive. Easier: ask for a config key
+        // that doesn't exist and check stderr/stdout aren't Spanish.
+        let result = try await Process.run(
+            "/usr/bin/env",
+            args: ["git", "help", "-a"],
+            env: env
+        )
+        // "The common Git" / "available" appears verbatim in English `git help -a`
+        // output; Spanish translation would not contain these tokens.
+        #expect(result.exitCode == 0)
+        #expect(result.stdout.lowercased().contains("available")
+            || result.stdout.lowercased().contains("commands"))
+    }
+
     @Test func gitEnvInheritsPath() {
         // The parent process always has PATH set (xcodebuild guarantees this).
         // If we accidentally clear inherited env when adding overrides, git
@@ -99,12 +130,13 @@ struct ProcessGitTests {
         // Stronger than the keyed tests above: a broken implementation that
         // returned a hardcoded minimal dict (PATH/HOME only) would pass the
         // single-key checks. Verify the whole parent env round-trips, with
-        // the deliberate exceptions of GIT_OPTIONAL_LOCKS (always overridden)
-        // and PATH (overridden when ShellEnvResolver discovered a login-shell
-        // PATH, which happens in integration test environments).
+        // the deliberate exceptions of GIT_OPTIONAL_LOCKS (always overridden),
+        // PATH (overridden when ShellEnvResolver discovered a login-shell
+        // PATH, which happens in integration test environments), and LC_ALL
+        // (always pinned to "C" so git emits English-parseable messages).
         let parent = ProcessInfo.processInfo.environment
         let env = Process.gitEnv()
-        for (key, value) in parent where key != "GIT_OPTIONAL_LOCKS" && key != "PATH" {
+        for (key, value) in parent where !["GIT_OPTIONAL_LOCKS", "PATH", "LC_ALL"].contains(key) {
             #expect(env[key] == value, "key \(key) was dropped or changed")
         }
     }


### PR DESCRIPTION
## Summary
- `WorktreeService` parses git stderr (English-only substrings) to detect submodule / dirty / missing-LFS errors and trigger the auto-force-remove path. Under a non-English shell locale git emits translated messages, none of the matchers fire, and the user sees the raw error instead of the intended recovery — reported as `fatal: árboles de trabajo conteniendo submódulos no pueden ser movidos o eliminados` when trying to delete a worktree containing submodules.
- Fix: pin `LC_ALL=C` in `Process.gitEnv()` so every git invocation emits parseable English regardless of the user's environment. POSIX guarantees `LC_ALL` overrides `LANG` and `LC_MESSAGES`.

## Test plan
- [x] Shell-level repro: `LANG=es_ES.UTF-8 git worktree remove …` → Spanish; same with `LC_ALL=C` → English (exact string the matcher checks)
- [x] `ProcessGitTests.gitEnvForcesCLocale` — asserts `gitEnv()["LC_ALL"] == "C"`
- [x] `ProcessGitTests.gitEmitsEnglishMessagesUnderForeignLocale` — runs `git help -a` with an injected `LANG=es_ES.UTF-8` and verifies English output
- [x] `ProcessGitTests.gitEnvPreservesAllParentVariables` updated to include `LC_ALL` in the override exception list
- [x] All 44 affected tests pass (`ProcessGitTests` + `WorktreeServiceTests`, incl. existing submodule scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)