### PR TITLE
style(acp): floaty card + laser border for plan sidebar

### DIFF
--- a/Alas/Sources/ACP/UI/ACPPlanSidebar.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanSidebar.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 /// Inline right-side plan surface. Shown by `ACPSessionView` when the
 /// pane is wide enough (see `ACPPlanSidebarVisibility`). Mirrors the
-/// pill's popover content via the shared `ACPPlanChecklist`, just
-/// hosted in a fixed 320pt column with a left divider and an outer
-/// scroll view.
+/// pill's popover content via the shared `ACPPlanChecklist`, hosted in
+/// a 320pt column as a floaty rounded card with the same animated
+/// laser border the toolbar pill uses while a step is in progress.
 ///
 /// Observes `ACPTranscript` directly so plan updates re-render here
 /// (same reason `ACPPlanPill` observes it directly — `ACPSession`
@@ -15,29 +15,64 @@ struct ACPPlanSidebar: View {
     @ObservedObject var transcript: ACPTranscript
     @Environment(\.theme) private var theme
 
+    private let cornerRadius: CGFloat = 12
+
     var body: some View {
         let items = transcript.latestPlan ?? []
-        HStack(spacing: 0) {
-            Rectangle()
-                .fill(theme.color("line"))
-                .frame(width: 0.5)
-            ScrollView(.vertical, showsIndicators: false) {
-                if !items.isEmpty {
-                    ACPPlanChecklist(items: items)
-                } else {
-                    // The caller gates rendering on hasPlan, so we
-                    // shouldn't be visible without a plan; render an
-                    // empty placeholder rather than crashing if items
-                    // race to nil before the visibility flips.
-                    Color.clear.frame(height: 1)
-                }
+        let animating = items.contains { $0.status == "in_progress" }
+        ScrollView(.vertical, showsIndicators: false) {
+            if !items.isEmpty {
+                ACPPlanChecklist(items: items)
+                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                    .overlay(laserBorder(animating: animating))
+                    .shadow(color: .black.opacity(0.28), radius: 8, y: 2)
+                    .padding(12)
+            } else {
+                // The caller gates rendering on hasPlan, so we
+                // shouldn't be visible without a plan; render an
+                // empty placeholder rather than crashing if items
+                // race to nil before the visibility flips.
+                Color.clear.frame(height: 1)
             }
-            .frame(maxHeight: .infinity)
-            .background(theme.color("bg-1"))
         }
         .frame(width: 320)
+        .frame(maxHeight: .infinity)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(accessibilityLabel(for: items))
+    }
+
+    @ViewBuilder
+    private func laserBorder(animating: Bool) -> some View {
+        if animating {
+            TimelineView(.animation) { context in
+                let cycleSeconds: Double = 2.2
+                let now = context.date.timeIntervalSinceReferenceDate
+                let phase = (now.truncatingRemainder(dividingBy: cycleSeconds)) / cycleSeconds
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(snakeGradient(phase: phase), lineWidth: 1.25)
+            }
+        } else {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(theme.color("accent").opacity(0.35), lineWidth: 1)
+        }
+    }
+
+    private func snakeGradient(phase: Double) -> AngularGradient {
+        let accent = theme.color("accent")
+        let start = Angle.degrees(phase * 360.0)
+        return AngularGradient(
+            stops: [
+                .init(color: .clear,              location: 0.00),
+                .init(color: .clear,              location: 0.60),
+                .init(color: accent.opacity(0.4), location: 0.75),
+                .init(color: accent,              location: 0.88),
+                .init(color: accent.opacity(0.4), location: 0.96),
+                .init(color: .clear,              location: 1.00)
+            ],
+            center: .center,
+            startAngle: start,
+            endAngle: start + .degrees(360)
+        )
     }
 
     private func accessibilityLabel(for items: [ACPMessage.PlanItem]) -> String {


### PR DESCRIPTION
## Summary
- Wraps `ACPPlanChecklist` inside `ACPPlanSidebar` in a rounded squircle (continuous corner radius 12) with a soft drop shadow so the inline plan reads as a floating card instead of a flat strip glued to the pane edge.
- Adds the same animated snake/laser `strokeBorder` the toolbar pill uses (verbatim cycle, gradient stops, line width), gated on any `in_progress` item; idle plans fall back to the static `accent.opacity(0.35)` border.
- Drops the old left-edge divider rectangle — the floating card now provides its own boundary.

## Test plan
- [ ] Open an ACP session, widen the pane past 900pt so the sidebar appears
- [ ] Confirm idle plan shows a static accent border, rounded card, visible elevation
- [ ] Run an agent task with an in-progress step and confirm the snake animation matches the toolbar pill's
- [ ] Narrow the pane below 820pt and confirm the sidebar collapses cleanly (pill returns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)