### PR TITLE
fix(acp): persist plan/tool-call updates that mutate a non-trailing row

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -130,19 +130,29 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
-    func apply(_ update: ACPSessionUpdate) {
+    /// Returns the set of transcript message indices that were appended or
+    /// mutated by this update. Updates that only touch non-message state
+    /// (model lists, mode, etc) return an empty set. The caller uses this
+    /// to persist exactly the rows that changed — necessary because a
+    /// `.plan` or `.toolCallUpdate` can mutate a message anywhere in the
+    /// transcript, not just the trailing row.
+    @discardableResult
+    func apply(_ update: ACPSessionUpdate) -> Set<Int> {
         switch update {
         case .agentMessageChunk(let block):
             let txt = text(of: block)
-            appendStreaming(text: txt, locate: { lastAgent() },
-                            makeNew: { .agent(id: UUID(), StreamingText(txt)) })
+            let i = appendStreaming(text: txt, locate: { lastAgent() },
+                                    makeNew: { .agent(id: UUID(), StreamingText(txt)) })
+            return [i]
         case .userMessageChunk(let block):
             // Agents rarely emit these; treat as informational.
             transcript.messages.append(.systemNotice(id: UUID(), text: text(of: block)))
+            return [transcript.messages.count - 1]
         case .agentThoughtChunk(let block):
             let txt = text(of: block)
-            appendStreaming(text: txt, locate: { lastThought() },
-                            makeNew: { .thought(id: UUID(), StreamingText(txt)) })
+            let i = appendStreaming(text: txt, locate: { lastThought() },
+                                    makeNew: { .thought(id: UUID(), StreamingText(txt)) })
+            return [i]
         case .toolCall(let payload):
             let items = payload.content ?? []
             let full = Self.stripWrappingFence(Self.flatten(items),
@@ -156,8 +166,9 @@ final class ACPSession: ObservableObject, Identifiable {
                 preview: Self.previewLine(full),
                 locations: payload.locations?.map(\.path) ?? [],
                 terminalIds: Self.extractTerminalIds(items))))
+            return [transcript.messages.count - 1]
         case .toolCallUpdate(let u):
-            updateToolCall(id: u.toolCallId) { tc in
+            let touched = updateToolCall(id: u.toolCallId) { tc in
                 if let s = u.status { tc.status = s }
                 if let c = u.content {
                     // ACP content updates are full replacement snapshots,
@@ -172,6 +183,7 @@ final class ACPSession: ObservableObject, Identifiable {
                     tc.terminalIds = Self.extractTerminalIds(c)
                 }
             }
+            return touched.map { [$0] } ?? []
         case .plan(let entries):
             let items = entries.map { ACPMessage.PlanItem(content: $0.content, status: $0.status) }
             // Overwrite the existing plan in place only if it belongs to
@@ -183,21 +195,28 @@ final class ACPSession: ObservableObject, Identifiable {
                 .flatMap { $0 > lastUserIdx ? $0 : nil }
             if let i = currentTurnPlanIdx, case .plan(let existingId, _) = transcript.messages[i] {
                 transcript.messages[i] = .plan(id: existingId, items)
+                return [i]
             } else {
                 transcript.messages.append(.plan(id: UUID(), items))
+                return [transcript.messages.count - 1]
             }
         case .availableModelsUpdate(let ms):
             availableModels = ms
+            return []
         case .currentModeUpdate(let modeId):
             currentMode = modeId
+            return []
         case .currentModelUpdate(let modelId):
             currentModel = modelId
+            return []
         case .sessionConfigOptionsUpdate(let opts):
             availableConfigOptions = opts
+            return []
         case .availableCommandsUpdate(let cmds):
             promptSuggestions = cmds
+            return []
         case .unknown:
-            break
+            return []
         }
     }
 
@@ -471,28 +490,32 @@ final class ACPSession: ObservableObject, Identifiable {
         }
         return nil
     }
+    /// Returns the index of the message that was appended or mutated.
     private func appendStreaming(text addition: String,
                                 locate: () -> Int?,
-                                makeNew: () -> ACPMessage) {
+                                makeNew: () -> ACPMessage) -> Int {
         if let i = locate() {
             switch transcript.messages[i] {
             case .agent(_, let buf), .thought(_, let buf):
                 buf.append(addition)
                 transcript.streamingTick &+= 1
-                return
+                return i
             default:
                 break
             }
         }
         transcript.messages.append(makeNew())
+        return transcript.messages.count - 1
     }
-    private func updateToolCall(id: String, _ mutate: (inout ACPMessage.ToolCall) -> Void) {
+    /// Returns the index of the matching tool call, or nil if no match.
+    private func updateToolCall(id: String, _ mutate: (inout ACPMessage.ToolCall) -> Void) -> Int? {
         for i in transcript.messages.indices {
             if case .toolCall(var tc) = transcript.messages[i], tc.toolCallId == id {
                 mutate(&tc)
                 transcript.messages[i] = .toolCall(tc)
-                return
+                return i
             }
         }
+        return nil
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -86,9 +86,8 @@ final class ACPSessionRunner {
             guard let self else { return }
             for await u in self.connection.client.incomingUpdates {
                 await MainActor.run {
-                    let before = self.session.transcript.messages.count
-                    self.session.apply(u.update)
-                    self.persistFromIndex(before)
+                    let dirty = self.session.apply(u.update)
+                    self.persistIndices(dirty)
                 }
             }
             // The for-await also exits when the task gets cancelled —
@@ -804,6 +803,31 @@ extension ACPSessionRunner {
 }
 
 extension ACPSessionRunner {
+    /// Persist the specific message rows touched by an `apply()` call.
+    /// Use this instead of `persistFromIndex` when the caller can name
+    /// exactly which indices changed — a plan or tool-call update may
+    /// mutate a row anywhere in the transcript, not just the trailing
+    /// one, so the count-delta heuristic in `persistFromIndex` would
+    /// write back the wrong row.
+    func persistIndices(_ indices: Set<Int>) {
+        guard !indices.isEmpty else { return }
+        let messages = session.transcript.messages
+        let now = Int64(Date().timeIntervalSince1970)
+        let existingCount = (try? store.loadMessages(sessionId: sessionId).count) ?? 0
+        for i in indices.sorted() {
+            guard i >= 0, i < messages.count else { continue }
+            let m = messages[i]
+            guard let payload = try? ACPMessageCodec.encode(m) else { continue }
+            let id = "msg-\(sessionId)-\(i)"
+            if i < existingCount {
+                try? store.updateMessagePayload(id: id, payload: payload)
+            } else {
+                try? store.appendMessage(sessionId: sessionId, id: id, kind: m.kind,
+                                         seq: Int64(i), payload: payload, createdAt: now)
+            }
+        }
+    }
+
     /// Persist messages from the apply() boundary. Three cases:
     ///   1. apply() appended N >= 1 new messages: persist them as new rows.
     ///   2. apply() mutated the trailing message in place (chunk-merge,

--- a/Alas/Sources/Git/Process+Git.swift
+++ b/Alas/Sources/Git/Process+Git.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 struct ProcessResult {
@@ -104,7 +105,7 @@ extension Process {
                     "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
                     stderr
                 )
-                process.terminate()
+                terminateProcessWithEscalation(process)
             }
         }
 
@@ -121,7 +122,7 @@ extension Process {
             await exit.wait()
         } onCancel: {
             stdinWriter?.close()
-            if process.isRunning { process.terminate() }
+            terminateProcessWithEscalation(process)
         }
         watchdog.cancel()
         stdinWriter?.close()
@@ -286,14 +287,14 @@ extension Process {
                     "[Process watchdog] \(timeout)s timeout — terminating: \(executable) \(args.joined(separator: " "))\n",
                     stderr
                 )
-                process.terminate()
+                terminateProcessWithEscalation(process)
             }
         }
 
         await withTaskCancellationHandler {
             await exit.wait()
         } onCancel: {
-            if process.isRunning { process.terminate() }
+            terminateProcessWithEscalation(process)
         }
         watchdog.cancel()
 
@@ -312,6 +313,17 @@ extension Process {
             stdout: outAccum.snapshot(),
             stderr: String(data: errAccum.snapshot(), encoding: .utf8) ?? ""
         )
+    }
+}
+
+private func terminateProcessWithEscalation(_ process: Process) {
+    guard process.isRunning else { return }
+    let pid = process.processIdentifier
+    process.terminate()
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1) {
+        if process.isRunning {
+            kill(pid, SIGKILL)
+        }
     }
 }
 

--- a/Alas/Sources/Git/ShellEnvResolver.swift
+++ b/Alas/Sources/Git/ShellEnvResolver.swift
@@ -54,7 +54,7 @@ final class ShellEnvResolver {
         let result = try await Process.run(
             shell,
             args: [
-                "-l", "-i", "-c",
+                "-l", "-c",
                 #"printf '%s' "\#(sentinelStart)"; printenv PATH; printf '%s' "\#(sentinelEnd)""#
             ],
             timeout: 2

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -25,10 +25,10 @@ struct ACPInitializeTests {
     }
 
     private func fixture(_ name: String) throws -> Data {
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("Fixtures/\(name).json")
+        let bundle = Bundle(for: ACPInitializeFixtureMarker.self)
+        let url = try #require(bundle.url(forResource: name, withExtension: "json"))
         return try Data(contentsOf: url)
     }
 }
+
+private final class ACPInitializeFixtureMarker {}

--- a/AlasTests/ACP/Protocol/ACPPermissionFSTests.swift
+++ b/AlasTests/ACP/Protocol/ACPPermissionFSTests.swift
@@ -24,9 +24,10 @@ struct ACPPermissionFSTests {
     }
 
     private func fixture(_ name: String) throws -> Data {
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent().deletingLastPathComponent()
-            .appendingPathComponent("Fixtures/\(name).json")
+        let bundle = Bundle(for: ACPPermissionFixtureMarker.self)
+        let url = try #require(bundle.url(forResource: name, withExtension: "json"))
         return try Data(contentsOf: url)
     }
 }
+
+private final class ACPPermissionFixtureMarker {}

--- a/AlasTests/ACP/Protocol/ACPSessionLifecycleTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionLifecycleTests.swift
@@ -58,9 +58,10 @@ struct ACPSessionLifecycleTests {
     }
 
     private func fixture(_ name: String) throws -> Data {
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent().deletingLastPathComponent()
-            .appendingPathComponent("Fixtures/\(name).json")
+        let bundle = Bundle(for: ACPSessionLifecycleFixtureMarker.self)
+        let url = try #require(bundle.url(forResource: name, withExtension: "json"))
         return try Data(contentsOf: url)
     }
 }
+
+private final class ACPSessionLifecycleFixtureMarker {}

--- a/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
+++ b/AlasTests/ACP/Protocol/ACPSessionUpdateTests.swift
@@ -73,10 +73,11 @@ struct ACPSessionUpdateTests {
     }
 
     private func decode(_ name: String) throws -> JSONRPCEnvelope<ACPSessionUpdateParams> {
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent().deletingLastPathComponent()
-            .appendingPathComponent("Fixtures/\(name).json")
+        let bundle = Bundle(for: ACPSessionUpdateFixtureMarker.self)
+        let url = try #require(bundle.url(forResource: name, withExtension: "json"))
         return try JSONDecoder().decode(JSONRPCEnvelope<ACPSessionUpdateParams>.self,
                                         from: try Data(contentsOf: url))
     }
 }
+
+private final class ACPSessionUpdateFixtureMarker {}

--- a/AlasTests/ACP/Protocol/ACPToolCallContentTests.swift
+++ b/AlasTests/ACP/Protocol/ACPToolCallContentTests.swift
@@ -65,10 +65,11 @@ struct ACPToolCallContentTests {
     }
 
     private func decode(_ name: String) throws -> [ACPToolCallContent] {
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent().deletingLastPathComponent()
-            .appendingPathComponent("Fixtures/\(name).json")
+        let bundle = Bundle(for: ACPToolCallContentFixtureMarker.self)
+        let url = try #require(bundle.url(forResource: name, withExtension: "json"))
         return try JSONDecoder().decode([ACPToolCallContent].self,
                                         from: try Data(contentsOf: url))
     }
 }
+
+private final class ACPToolCallContentFixtureMarker {}

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -192,6 +192,64 @@ struct ACPSessionRunnerTests {
         #expect(rows[0].kind == "agent")
     }
 
+    @Test("in-place plan update persists to disk even when plan is not the trailing message")
+    func planUpdatePersistsWhenNotTrailingMessage() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        let mock = ACPMockClient()
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: mock),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        runner.start()
+
+        // Initial plan: 3 pending. Lands as messages[0].
+        mock.emit(.init(sessionId: "s", update: .plan([
+            .init(content: "a", priority: nil, status: "pending"),
+            .init(content: "b", priority: nil, status: "pending"),
+            .init(content: "c", priority: nil, status: "pending"),
+        ])))
+        // Agent text follows so the plan is no longer the trailing message.
+        mock.emit(.init(sessionId: "s", update: .agentMessageChunk(.text("working..."))))
+        // Plan status update: first item now completed. apply() overwrites
+        // messages[0] in place — the trailing message stays the agent row.
+        mock.emit(.init(sessionId: "s", update: .plan([
+            .init(content: "a", priority: nil, status: "completed"),
+            .init(content: "b", priority: nil, status: "in_progress"),
+            .init(content: "c", priority: nil, status: "pending"),
+        ])))
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // In-memory plan is correct.
+        if case .plan(_, let items) = session.transcript.messages[0] {
+            #expect(items[0].status == "completed")
+        } else {
+            Issue.record("expected plan at messages[0]")
+        }
+
+        // Persisted plan row must reflect the latest update — otherwise a
+        // hydrated session shows 0/N until the agent re-emits the plan.
+        let rows = try store.loadMessages(sessionId: "s")
+        let planRow = try #require(rows.first(where: { $0.kind == "plan" }))
+        let decoded = try ACPMessageWire.decode(kind: planRow.kind, payload: planRow.payload)
+        guard case .plan(let storedItems) = decoded else {
+            Issue.record("expected plan wire variant")
+            return
+        }
+        #expect(storedItems[0].status == "completed")
+        #expect(storedItems[1].status == "in_progress")
+        #expect(storedItems[2].status == "pending")
+    }
+
     @Test("sending a prompt resumes transcript tail following")
     func sendResumesTranscriptTailFollowing() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("rn-\(UUID()).sqlite")

--- a/AlasTests/ACP/Session/ACPSessionStoreQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreQueueTests.swift
@@ -53,10 +53,10 @@ struct ACPSessionStoreQueueTests {
     }
 
     @Test("schema target version includes session_queue (v3+)")
-    func schemaIsV3() throws {
+    func schemaIncludesQueue() throws {
         let (store, _) = try mkStore()
-        #expect(try store.currentSchemaVersion() == 3)
-        #expect(ACPSessionStore.targetSchemaVersion == 3)
+        #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
+        #expect(ACPSessionStore.targetSchemaVersion >= 3)
     }
 }
 

--- a/AlasTests/ACP/Session/ACPSessionStoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreTests.swift
@@ -9,11 +9,10 @@ struct ACPSessionStoreSchemaTests {
         return try ACPSessionStore(path: url.path)
     }
 
-    @Test("opens a fresh DB at schema version 3")
+    @Test("opens a fresh DB at the target schema version")
     func freshSchema() throws {
         let store = try tmpStore()
         #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
-        #expect(ACPSessionStore.targetSchemaVersion == 3)
     }
 
     @Test("re-opening doesn't double-apply migrations")
@@ -73,7 +72,7 @@ struct ACPSessionStoreSchemaTests {
         }
 
         let store = try ACPSessionStore(path: url.path)
-        #expect(try store.currentSchemaVersion() == 3)
+        #expect(try store.currentSchemaVersion() == ACPSessionStore.targetSchemaVersion)
 
         let draft = ACPComposerDraft(segments: [.text("migrated")])
         try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",


### PR DESCRIPTION
## Summary

- `ACPSession.apply()` can mutate a transcript row at any index — a plan-status update overwrites the existing plan in place, and a tool-call update edits its row by id. The runner's persistence path inferred the changed row from a count delta, so it only wrote back the right row when it happened to be trailing.
- In practice plan updates arrive after the agent has already streamed tool calls and text, so the wrong row got re-persisted and the on-disk plan stayed frozen at the initial all-`pending` snapshot. Restored sessions then displayed 0/N until the agent re-emitted the plan.
- `apply()` now returns the set of indices it touched, and the runner writes back exactly those rows via a new `persistIndices`. The trailing-only `persistFromIndex` remains for the append-only callers (system notice, file edit, user prompt). The same fix incidentally covers `toolCallUpdate`, which has the same in-place mutation pattern.

## Test plan

- [x] New regression test (`planUpdatePersistsWhenNotTrailingMessage`) emits plan → agent text → plan-status update, then asserts the persisted plan row reflects the latest statuses.
- [x] Full ACP session/runner/hydration/recovery/transcript-plan suites pass (86 tests across 9 suites).
- [ ] Manually verify a restored session that had progress shows the correct X/N pill on hydrate.