### PR TITLE
feat(alas): default code and terminal fonts to JetBrainsMono Nerd Font

### DIFF
--- a/Alas/Sources/Center/CenterTypography.swift
+++ b/Alas/Sources/Center/CenterTypography.swift
@@ -43,9 +43,15 @@ enum CenterTypography {
                 return font
             }
         }
-        if let font = NSFont(name: family, size: size) { return font }
+        if let font = NSFont(name: family, size: size),
+           font.familyName == family || font.fontName == family {
+            return font
+        }
         let descriptor = NSFontDescriptor(fontAttributes: [.family: family])
-        if let font = NSFont(descriptor: descriptor, size: size) { return font }
+        if let font = NSFont(descriptor: descriptor, size: size),
+           font.familyName == family {
+            return font
+        }
         return .monospacedSystemFont(ofSize: size, weight: .regular)
     }
 

--- a/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
+++ b/Alas/Sources/Code/Editor/CodeEditorCoordinator.swift
@@ -125,7 +125,7 @@ final class CodeEditorCoordinator {
                 return root.appendingPathComponent(rel).lspURI
             },
             getTheme: { [weak self] in self?.currentTheme ?? (try? ThemeStore().current) ?? (try? Theme.loadBundled(id: "cool-slate")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:]) },
-            getMonoFontFamily: { [weak self] in self?.currentFontFamily ?? self?.appState.config.code.fontFamily ?? "SF Mono" },
+            getMonoFontFamily: { [weak self] in self?.currentFontFamily ?? self?.appState.config.code.fontFamily ?? "JetBrainsMono Nerd Font" },
             getMonoFontSize: { [weak self] in self?.currentFontSize.map(Int.init) ?? self?.appState.config.code.fontSize ?? 13 }
         )
         installHoverObservers(textView: textView)
@@ -244,7 +244,7 @@ final class CodeEditorCoordinator {
                 return true
             },
             getTheme: { [weak self] in self?.currentTheme ?? (try? ThemeStore().current) ?? (try? Theme.loadBundled(id: "cool-slate")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:]) },
-            getMonoFontFamily: { [weak self] in self?.currentFontFamily ?? self?.appState.config.code.fontFamily ?? "SF Mono" },
+            getMonoFontFamily: { [weak self] in self?.currentFontFamily ?? self?.appState.config.code.fontFamily ?? "JetBrainsMono Nerd Font" },
             getMonoFontSize: { [weak self] in self?.currentFontSize.map(Int.init) ?? self?.appState.config.code.fontSize ?? 13 },
             prepareForCompletionRequest: { [weak self] in
                 await self?.flushPendingLSPDidChangeForCompletion()

--- a/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
+++ b/Alas/Sources/Code/LSP/Features/CompletionFeature.swift
@@ -34,7 +34,7 @@ final class CompletionFeature {
         getTheme: @escaping () -> Theme = {
             (try? Theme.loadBundled(id: "cool-slate")) ?? Theme(id: "fallback", name: "Fallback", tokens: [:])
         },
-        getMonoFontFamily: @escaping () -> String = { "SF Mono" },
+        getMonoFontFamily: @escaping () -> String = { "JetBrainsMono Nerd Font" },
         getMonoFontSize: @escaping () -> Int = { 13 },
         prepareForCompletionRequest: @escaping @MainActor () async -> Void = {}
     ) {

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -26,7 +26,7 @@ final class MarkdownRenderer {
     private var anchorRanges: [String: NSRange] = [:]
     private var remoteImages: [RemoteImageReference] = []
     private var theme: Theme!
-    private var monoFamily: String = "SF Mono"
+    private var monoFamily: String = "JetBrainsMono Nerd Font"
     private var monoSize: CGFloat = 13
     private var baseDirectory: URL = URL(fileURLWithPath: "/")
     /// Optional worktree root, used to resolve markdown-style root-relative

--- a/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+++ b/Alas/Sources/Code/Markdown/MarkdownRenderer.swift
@@ -664,7 +664,7 @@ final class MarkdownRenderer {
     }
 
     private func monospaceFont(size: CGFloat) -> NSFont {
-        NSFont(name: monoFamily, size: size) ?? NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+        CenterTypography.resolveCodeFont(family: monoFamily, size: size)
     }
 
     // MARK: - Append helpers

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -325,7 +325,7 @@ struct AppConfig: Codable, Equatable {
             startupScript: "",
             worktreeCreateScript: "",
             inheritParentEnv: true,
-            fontFamily: "JetBrains Mono",
+            fontFamily: "JetBrainsMono Nerd Font",
             fontSize: 13,
             cursorStyle: "beam",
             cursorBlink: true,
@@ -336,7 +336,7 @@ struct AppConfig: Codable, Equatable {
         ),
         harness: Harness(notifyOnFinish: true, notifyOnAwaiting: true),
         code: Code(
-            fontFamily: "SF Mono",
+            fontFamily: "JetBrainsMono Nerd Font",
             fontSize: 13,
             formatOnSave: false,
             showLineNumbers: true,
@@ -463,7 +463,7 @@ extension AppConfig {
             let startupScript = (try? termContainer.decode(String.self, forKey: .startupScript)) ?? ""
             let worktreeCreateScript = (try? termContainer.decode(String.self, forKey: .worktreeCreateScript)) ?? ""
             let inheritParentEnv = (try? termContainer.decode(Bool.self, forKey: .inheritParentEnv)) ?? true
-            let fontFamily = (try? termContainer.decode(String.self, forKey: .fontFamily)) ?? "JetBrains Mono"
+            let fontFamily = (try? termContainer.decode(String.self, forKey: .fontFamily)) ?? "JetBrainsMono Nerd Font"
             let fontSize = (try? termContainer.decode(Int.self, forKey: .fontSize)) ?? 13
             let cursorStyle = (try? termContainer.decode(String.self, forKey: .cursorStyle)) ?? "beam"
             let cursorBlink = (try? termContainer.decode(Bool.self, forKey: .cursorBlink)) ?? true
@@ -493,7 +493,7 @@ extension AppConfig {
                 startupScript: "",
                 worktreeCreateScript: "",
                 inheritParentEnv: true,
-                fontFamily: "JetBrains Mono",
+                fontFamily: "JetBrainsMono Nerd Font",
                 fontSize: 13,
                 cursorStyle: "beam",
                 cursorBlink: true,
@@ -505,7 +505,7 @@ extension AppConfig {
         }
         harness = try c.decode(Harness.self, forKey: .harness)
         if let codeContainer = try? c.nestedContainer(keyedBy: AppConfig.Code.CodingKeys.self, forKey: .code) {
-            let fontFamily = (try? codeContainer.decode(String.self, forKey: .fontFamily)) ?? "SF Mono"
+            let fontFamily = (try? codeContainer.decode(String.self, forKey: .fontFamily)) ?? "JetBrainsMono Nerd Font"
             let rawSize = (try? codeContainer.decode(Int.self, forKey: .fontSize)) ?? 13
             let fontSize = max(8, min(64, rawSize))
             let formatOnSave = (try? codeContainer.decode(Bool.self, forKey: .formatOnSave)) ?? false
@@ -524,7 +524,7 @@ extension AppConfig {
             )
         } else {
             code = Code(
-                fontFamily: "SF Mono",
+                fontFamily: "JetBrainsMono Nerd Font",
                 fontSize: 13,
                 formatOnSave: false,
                 showLineNumbers: true,

--- a/AlasTests/EditorBufferTests.swift
+++ b/AlasTests/EditorBufferTests.swift
@@ -544,6 +544,10 @@ struct EditorBufferTests {
         let root = tempWorktree()
         _ = try writeFile(root, "a.swift", "let answer = 42\n")
         let appState = AppState()
+        // Use a guaranteed-available system monospace font so the test
+        // doesn't depend on whether the bundled Nerd Font is registered
+        // in the test process.
+        appState.config.code.fontFamily = "Menlo"
         let buffer = appState.tabs.buffer(
             worktreeId: "wt",
             tabId: "tab",
@@ -583,6 +587,7 @@ struct EditorBufferTests {
         _ = try writeFile(root, "a.md", "alpha\n")
         _ = try writeFile(root, "b.swift", "let beta = 1\n")
         let appState = AppState()
+        appState.config.code.fontFamily = "Menlo"
         let bufferA = appState.tabs.buffer(
             worktreeId: "wt",
             tabId: "tab-a",


### PR DESCRIPTION
## Summary
- Default editor, diff, markdown code, completion, and terminal font settings to JetBrainsMono Nerd Font.
- Keep decoding compatibility for existing config values.
- Add coverage for default code font settings.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` started and passed many suites, but was interrupted after no output for about 90 seconds while reproducing the local hang seen by the runner.