### PR TITLE
feat(acp): auto-paginate older messages with scroll preservation

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -23,7 +23,7 @@ struct ACPMessageList: View {
     @State private var isRestoringTail = false
     @State private var headFrame: CGRect = .zero
     @State private var lastHeadStepAt: Date = .distantPast
-    @State private var nsScrollView: NSScrollView?
+    @State private var scrollViewRef = ACPWeakScrollViewRef()
 
     /// Height of an invisible spacer at the tail of the VStack. The
     /// composer pill plus its outer padding occupies roughly this much
@@ -162,7 +162,7 @@ struct ACPMessageList: View {
                             setFollowsTranscriptTail(true)
                         },
                         isRestoring: { isRestoringTail },
-                        onScrollViewResolved: { nsScrollView = $0 }
+                        onScrollViewResolved: { scrollViewRef.scrollView = $0 }
                     )
                 )
                 .onAppear {
@@ -252,7 +252,7 @@ struct ACPMessageList: View {
     /// prepends rows, then adjusts the clip-view origin by the delta so
     /// the user's reading position doesn't jump.
     private func stepHeadBackPreservingScroll() {
-        guard let scrollView = nsScrollView else {
+        guard let scrollView = scrollViewRef.scrollView else {
             transcript.stepHeadBack()
             return
         }
@@ -302,6 +302,10 @@ struct ACPMessageList: View {
             ACPSystemNoticeView(text: text)
         }
     }
+}
+
+private final class ACPWeakScrollViewRef {
+    weak var scrollView: NSScrollView?
 }
 
 private struct ACPHeadFramePreferenceKey: PreferenceKey {

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -362,7 +362,10 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
         }
 
         func observe(scrollView: NSScrollView) {
-            guard observedScrollView !== scrollView else { return }
+            guard observedScrollView !== scrollView else {
+                onScrollViewResolved?(scrollView)
+                return
+            }
             if let observer {
                 NotificationCenter.default.removeObserver(observer)
             }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -23,6 +23,7 @@ struct ACPMessageList: View {
     @State private var isRestoringTail = false
     @State private var headFrame: CGRect = .zero
     @State private var lastHeadStepAt: Date = .distantPast
+    @State private var nsScrollView: NSScrollView?
 
     /// Height of an invisible spacer at the tail of the VStack. The
     /// composer pill plus its outer padding occupies roughly this much
@@ -92,27 +93,18 @@ struct ACPMessageList: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
                         if transcript.visibleHead > 0 {
-                            Button {
-                                transcript.stepHeadBack()
-                            } label: {
-                                Text("Earlier messages\u{2026}")
-                                    .font(.system(size: 11, weight: .medium))
-                                    .foregroundStyle(theme.color("fg-muted"))
-                                    .padding(.horizontal, 10).padding(.vertical, 4)
-                                    .background(theme.color("bg-1").opacity(0.6))
-                                    .clipShape(Capsule())
-                            }
-                            .buttonStyle(.plain)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                            .padding(.bottom, 4)
-                            .background(
-                                GeometryReader { headGeom in
-                                    Color.clear.preference(
-                                        key: ACPHeadFramePreferenceKey.self,
-                                        value: headGeom.frame(in: .named(scrollSpaceName))
-                                    )
-                                }
-                            )
+                            ProgressView()
+                                .controlSize(.small)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.bottom, 4)
+                                .background(
+                                    GeometryReader { headGeom in
+                                        Color.clear.preference(
+                                            key: ACPHeadFramePreferenceKey.self,
+                                            value: headGeom.frame(in: .named(scrollSpaceName))
+                                        )
+                                    }
+                                )
                         }
                         ForEach(visibleMessages, id: \.stableId) { message in
                             row(for: message)
@@ -169,7 +161,8 @@ struct ACPMessageList: View {
                         onAtBottom: {
                             setFollowsTranscriptTail(true)
                         },
-                        isRestoring: { isRestoringTail }
+                        isRestoring: { isRestoringTail },
+                        onScrollViewResolved: { nsScrollView = $0 }
                     )
                 )
                 .onAppear {
@@ -180,13 +173,13 @@ struct ACPMessageList: View {
                 }
                 .onPreferenceChange(ACPHeadFramePreferenceKey.self) { frame in
                     headFrame = frame
-                    // Step back when the head marker enters the threshold
-                    // band at the top of the viewport; debounce so a single
-                    // scroll doesn't decrement multiple times before SwiftUI
-                    // lays out the newly-revealed rows.
-                    // `frame.maxY > 0` ensures the marker is actually
+                    // Auto-paginate: step back when the sentinel enters the
+                    // threshold band at the top of the viewport; debounce so
+                    // a single scroll doesn't decrement multiple times before
+                    // SwiftUI lays out the newly-revealed rows.
+                    // `frame.maxY > 0` ensures the sentinel is actually
                     // visible — without it, restoring to the tail of a
-                    // long transcript puts the marker far above the
+                    // long transcript puts the sentinel far above the
                     // viewport (negative minY *and* negative maxY) and the
                     // initial preference fire would still satisfy
                     // `minY < threshold`, defeating the window before the
@@ -196,7 +189,7 @@ struct ACPMessageList: View {
                     let now = Date()
                     guard now.timeIntervalSince(lastHeadStepAt) > headStepDebounceInterval else { return }
                     lastHeadStepAt = now
-                    transcript.stepHeadBack()
+                    stepHeadBackPreservingScroll()
                 }
                 .onChange(of: scrollSignature) { _, _ in
                     if session.followsTranscriptTail {
@@ -254,6 +247,37 @@ struct ACPMessageList: View {
         session.followsTranscriptTail = follows
     }
 
+    /// Reveal older messages while keeping the viewport anchored to the
+    /// same content. Captures the content height before `stepHeadBack()`
+    /// prepends rows, then adjusts the clip-view origin by the delta so
+    /// the user's reading position doesn't jump.
+    private func stepHeadBackPreservingScroll() {
+        guard let scrollView = nsScrollView else {
+            transcript.stepHeadBack()
+            return
+        }
+        let clipView = scrollView.contentView
+        let oldOffset = clipView.bounds.origin.y
+        let oldContentHeight = scrollView.documentView?.bounds.height ?? 0
+
+        isRestoringTail = true
+        transcript.stepHeadBack()
+
+        // After SwiftUI lays out the prepended rows, compute the content
+        // height delta and shift the clip-view origin so the viewport
+        // stays anchored to the same messages.
+        DispatchQueue.main.async {
+            let newContentHeight = scrollView.documentView?.bounds.height ?? 0
+            let delta = newContentHeight - oldContentHeight
+            if delta > 0 {
+                clipView.setBoundsOrigin(NSPoint(x: clipView.bounds.origin.x, y: oldOffset + delta))
+            }
+            DispatchQueue.main.async {
+                isRestoringTail = false
+            }
+        }
+    }
+
     @ViewBuilder
     private func row(for m: ACPMessage) -> some View {
         switch m {
@@ -291,6 +315,7 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
     let onPaused: () -> Void
     let onAtBottom: () -> Void
     let isRestoring: () -> Bool
+    var onScrollViewResolved: ((NSScrollView) -> Void)?
 
     func makeCoordinator() -> Coordinator {
         Coordinator(onPaused: onPaused, onAtBottom: onAtBottom, isRestoring: isRestoring)
@@ -308,6 +333,7 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
         context.coordinator.onPaused = onPaused
         context.coordinator.onAtBottom = onAtBottom
         context.coordinator.isRestoring = isRestoring
+        context.coordinator.onScrollViewResolved = onScrollViewResolved
         nsView.resolve()
     }
 
@@ -316,6 +342,7 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
         var onPaused: () -> Void
         var onAtBottom: () -> Void
         var isRestoring: () -> Bool
+        var onScrollViewResolved: ((NSScrollView) -> Void)?
         private weak var observedScrollView: NSScrollView?
         private var observer: NSObjectProtocol?
         private var lastOffsetY: CGFloat?
@@ -340,6 +367,7 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
                 NotificationCenter.default.removeObserver(observer)
             }
             observedScrollView = scrollView
+            onScrollViewResolved?(scrollView)
             lastOffsetY = scrollView.contentView.bounds.origin.y
             scrollView.contentView.postsBoundsChangedNotifications = true
             observer = NotificationCenter.default.addObserver(


### PR DESCRIPTION
## Summary

- Replaced the manual "Earlier messages..." capsule button with automatic infinite-scroll pagination
- Older messages now load automatically when the user scrolls within ~3-4 messages of the top boundary
- A small `ProgressView` spinner shows at the top while older messages are available
- Scroll position is preserved when rows prepend by capturing NSScrollView content height delta and restoring the clip-view origin after layout

## Changes

**Single file:** `Alas/Sources/ACP/UI/ACPMessageList.swift` (+57, -29)

- **Sentinel + spinner** — Button replaced by `ProgressView(.controlSize(.small))`, visible while `visibleHead > 0`
- **Auto-trigger preserved** — Existing `GeometryReader` + `ACPHeadFramePreferenceKey` mechanism (200pt threshold, 0.3s debounce) now calls scroll-preserving variant
- **Scroll preservation** — New `stepHeadBackPreservingScroll()` captures content height before `stepHeadBack()`, adjusts clip-view origin by delta after layout via `DispatchQueue.main.async`
- **NSScrollView plumbing** — Coordinator exposes resolved `NSScrollView` via `onScrollViewResolved` callback
- **Stability** — `isRestoringTail` flag suppresses scroll-direction classifier during offset restoration

## Test plan

- [ ] Open ACP pane with a long transcript (50+ messages)
- [ ] Scroll up — verify older messages auto-load with spinner, no viewport jump
- [ ] Scroll back down — verify tail-following resumes
- [ ] Rapid scroll wheel up — verify no double-load or jank
- [ ] Short session (<30 messages) — verify no spinner shown, no auto-step triggered