### PR TITLE
fix(ACP): tail scroll pause threshold

### DIFF
--- a/Alas/Sources/ACP/UI/ACPScrollDirectionClassifier.swift
+++ b/Alas/Sources/ACP/UI/ACPScrollDirectionClassifier.swift
@@ -11,12 +11,17 @@ enum ACPScrollDecision: Equatable {
 /// AppKit/SwiftUI so it can be exercised in unit tests.
 enum ACPScrollDirectionClassifier {
     /// Sub-pixel jitter is ignored. 0.5pt comfortably covers Retina rounding
-    /// noise; anything larger is treated as user intent.
+    /// noise; anything larger can be treated as deliberate direction.
     static let upwardEpsilon: CGFloat = 0.5
 
     /// Distance from the bottom of the document at which the user is
     /// considered to be "at the tail." Matches the prior `tailTolerance`.
     static let bottomTolerance: CGFloat = 36
+
+    /// Distance from the bottom before an upward scroll pauses tail following.
+    /// Roughly eight transcript text lines: enough to filter trackpad/layout
+    /// micro-hops while still respecting a deliberate scroll away.
+    static let pauseTolerance: CGFloat = 160
 
     static func decide(
         previousOffsetY: CGFloat?,
@@ -26,13 +31,12 @@ enum ACPScrollDirectionClassifier {
         isRestoring: Bool,
         isUserDriven: Bool = false
     ) -> ACPScrollDecision {
-        if isRestoring {
-            return isUserDriven ? .userScrolledUp : .noChange
-        }
         let distanceFromBottom = max(0, contentHeight - viewportHeight - newOffsetY)
         if distanceFromBottom <= bottomTolerance { return .userAtBottom }
         guard let prev = previousOffsetY else { return .noChange }
-        if newOffsetY < prev - upwardEpsilon { return .userScrolledUp }
-        return .noChange
+        let movedUp = newOffsetY < prev - upwardEpsilon
+        guard distanceFromBottom > pauseTolerance, movedUp else { return .noChange }
+        if isRestoring && !isUserDriven { return .noChange }
+        return .userScrolledUp
     }
 }

--- a/Alas/Sources/ACP/UI/ACPScrollDirectionClassifier.swift
+++ b/Alas/Sources/ACP/UI/ACPScrollDirectionClassifier.swift
@@ -32,11 +32,11 @@ enum ACPScrollDirectionClassifier {
         isUserDriven: Bool = false
     ) -> ACPScrollDecision {
         let distanceFromBottom = max(0, contentHeight - viewportHeight - newOffsetY)
+        if isRestoring && !isUserDriven { return .noChange }
         if distanceFromBottom <= bottomTolerance { return .userAtBottom }
         guard let prev = previousOffsetY else { return .noChange }
         let movedUp = newOffsetY < prev - upwardEpsilon
         guard distanceFromBottom > pauseTolerance, movedUp else { return .noChange }
-        if isRestoring && !isUserDriven { return .noChange }
         return .userScrolledUp
     }
 }

--- a/AlasTests/ACPScrollDirectionClassifierTests.swift
+++ b/AlasTests/ACPScrollDirectionClassifierTests.swift
@@ -37,7 +37,7 @@ struct ACPScrollDirectionClassifierTests {
         #expect(decision == .userScrolledUp)
     }
 
-    @Test func isRestoringUserInputPausesEvenWhenOffsetMovesDownward() {
+    @Test func isRestoringUserInputMovingDownwardDoesNotPause() {
         let decision = ACPScrollDirectionClassifier.decide(
             previousOffsetY: 4300,
             newOffsetY: 4400,
@@ -46,7 +46,7 @@ struct ACPScrollDirectionClassifierTests {
             isRestoring: true,
             isUserDriven: true
         )
-        #expect(decision == .userScrolledUp)
+        #expect(decision == .userAtBottom)
     }
 
     @Test func isRestoringIgnoresProgrammaticUpwardRestores() {
@@ -143,6 +143,50 @@ struct ACPScrollDirectionClassifierTests {
         #expect(decision == .userAtBottom)
     }
 
+    @Test func upwardMoveNearTailDoesNotPause() {
+        // A small upward hop near the tail should not latch auto-scroll off.
+        let viewportH: CGFloat = 600
+        let contentH: CGFloat = 5000
+        let newY = contentH - viewportH - 80
+        let decision = ACPScrollDirectionClassifier.decide(
+            previousOffsetY: newY + 20,
+            newOffsetY: newY,
+            viewportHeight: viewportH,
+            contentHeight: contentH,
+            isRestoring: false
+        )
+        #expect(decision == .noChange)
+    }
+
+    @Test func upwardMoveMeaningfullyAwayFromTailPauses() {
+        let viewportH: CGFloat = 600
+        let contentH: CGFloat = 5000
+        let newY = contentH - viewportH - 180
+        let decision = ACPScrollDirectionClassifier.decide(
+            previousOffsetY: newY + 20,
+            newOffsetY: newY,
+            viewportHeight: viewportH,
+            contentHeight: contentH,
+            isRestoring: false
+        )
+        #expect(decision == .userScrolledUp)
+    }
+
+    @Test func restoringUserInputNearTailDoesNotPause() {
+        let viewportH: CGFloat = 600
+        let contentH: CGFloat = 5000
+        let newY = contentH - viewportH - 80
+        let decision = ACPScrollDirectionClassifier.decide(
+            previousOffsetY: newY + 20,
+            newOffsetY: newY,
+            viewportHeight: viewportH,
+            contentHeight: contentH,
+            isRestoring: true,
+            isUserDriven: true
+        )
+        #expect(decision == .noChange)
+    }
+
     @Test func contentShorterThanViewportIsAtBottom() {
         // contentH < viewportH (short transcript): distanceFromBottom clamps to 0.
         let decision = ACPScrollDirectionClassifier.decide(
@@ -167,7 +211,7 @@ struct ACPScrollDirectionClassifierTests {
         #expect(decision == .noChange)
     }
 
-    // MARK: - Boundary tests pinning upwardEpsilon and bottomTolerance
+    // MARK: - Boundary tests pinning upwardEpsilon, bottomTolerance, and pauseTolerance
     //
     // Derive values from the classifier's constants so the tests track
     // any retune of the thresholds instead of silently passing.
@@ -224,5 +268,35 @@ struct ACPScrollDirectionClassifierTests {
             isRestoring: false
         )
         #expect(decision == .noChange)
+    }
+
+    @Test func atExactPauseToleranceBoundaryDoesNotPause() {
+        // distanceFromBottom == pauseTolerance → strict `>` means noChange.
+        let viewportH: CGFloat = 600
+        let contentH: CGFloat = 5000
+        let newY = contentH - viewportH - ACPScrollDirectionClassifier.pauseTolerance
+        let decision = ACPScrollDirectionClassifier.decide(
+            previousOffsetY: newY + 10,
+            newOffsetY: newY,
+            viewportHeight: viewportH,
+            contentHeight: contentH,
+            isRestoring: false
+        )
+        #expect(decision == .noChange)
+    }
+
+    @Test func justOutsidePauseTolerancePausesOnUpwardMove() {
+        // distanceFromBottom == pauseTolerance + 1 and moving up → userScrolledUp.
+        let viewportH: CGFloat = 600
+        let contentH: CGFloat = 5000
+        let newY = contentH - viewportH - ACPScrollDirectionClassifier.pauseTolerance - 1
+        let decision = ACPScrollDirectionClassifier.decide(
+            previousOffsetY: newY + 10,
+            newOffsetY: newY,
+            viewportHeight: viewportH,
+            contentHeight: contentH,
+            isRestoring: false
+        )
+        #expect(decision == .userScrolledUp)
     }
 }


### PR DESCRIPTION
## Summary

Fixes ACP transcript tail-follow behavior so auto-scroll is not disabled by tiny upward hops near the bottom of the pane.

## Root Cause

The scroll classifier paused tail-following on any upward offset change larger than sub-pixel jitter once the viewport was outside the 36pt bottom resume tolerance. That made small trackpad/layout hops near the tail latch turn auto-scroll off while agents continued streaming.

## Changes

- Add a separate 160pt pause tolerance before upward movement can disable tail-following.
- Keep the existing 36pt bottom tolerance for resuming tail-following.
- Preserve restore-time protection so programmatic restore movement is ignored, while meaningful user upward movement can still pause.
- Add classifier tests for near-tail hops, meaningful-away upward movement, restore-time near-tail input, and pause boundary behavior.

## Validation

- `xcodegen` passed.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build` passed.
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPScrollDirectionClassifierTests` passed: 23 tests.
- GitHub Actions `Build / build-test` passed on commit `15125ff`.