### PR TITLE
fix(acp): clear in-memory composer draft eagerly on accepted submit

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -378,27 +378,64 @@ final class ACPSessionManager: ObservableObject {
         try? store.upsertQueue(sessionId: session.id, items: session.queue)
     }
 
-    func clearComposerDraft(
-        for session: ACPSession,
-        ifCurrentDraftEquals expected: ACPComposerDraft,
-        revision expectedRevision: Int
-    ) {
-        guard session.composerDraft == expected,
-              session.composerDraftRevision == expectedRevision
-        else { return }
-        clearComposerDraft(for: session)
+    /// Eager-clear hook for an accepted composer submission. Synchronously
+    /// flushes the submitted draft to SQLite (so a crash or detach before
+    /// the prompt is recorded can still recover the user's text on next
+    /// hydration), cancels the debounced timer so a delayed wake-up can't
+    /// overwrite the suspended row, then clears the in-memory draft.
+    ///
+    /// Eager in-memory clearing prevents the ACP composer from re-showing
+    /// the sent text when its NSView is dismantled and re-mounted while
+    /// the agent's RPC is still in flight (e.g. user switches worktrees
+    /// and comes back). Pair with `purgeSuspendedComposerDraft` on success
+    /// or `reinstateSuspendedComposerDraft` on failure.
+    ///
+    /// Returns the post-clear revision; the completion handler uses it as
+    /// the conditional token so a draft the user has typed since the
+    /// suspension survives untouched.
+    @discardableResult
+    func suspendComposerDraftForSubmission(
+        _ submitted: ACPComposerDraft, for session: ACPSession
+    ) -> Int {
+        let sid = session.id
+        pendingDraftWrites[sid]?.cancel()
+        pendingDraftWrites[sid] = nil
+        if !submitted.isEmpty {
+            let now = Int64(Date().timeIntervalSince1970)
+            try? store.upsertComposerDraft(sessionId: sid, draft: submitted, updatedAt: now)
+        }
+        session.replaceComposerDraft(.empty)
+        return session.composerDraftRevision
     }
 
-    func persistComposerDraft(
-        _ draft: ACPComposerDraft,
-        for session: ACPSession,
-        ifCurrentDraftEquals expected: ACPComposerDraft,
-        revision expectedRevision: Int
+    /// Delete the SQLite row left by `suspendComposerDraftForSubmission`
+    /// once the prompt has been durably recorded. Guarded on the post-
+    /// suspend revision so a draft the user has typed since the suspension
+    /// (which is now what `composerDraft` holds) survives untouched.
+    func purgeSuspendedComposerDraft(
+        for session: ACPSession, suspendedRevision: Int
     ) {
-        guard session.composerDraft == expected,
-              session.composerDraftRevision == expectedRevision
+        guard session.composerDraftRevision == suspendedRevision,
+              session.composerDraft.isEmpty
         else { return }
-        persistComposerDraft(draft, for: session)
+        try? store.deleteComposerDraft(sessionId: session.id)
+    }
+
+    /// Restore the suspended draft back into memory when the prompt
+    /// failed to record. SQLite already holds the suspended row, so this
+    /// only needs to bring the in-memory state back into agreement so the
+    /// composer (if still mounted, or on next mount) shows the text.
+    /// Guarded on the post-suspend revision so a draft the user has typed
+    /// since the suspension wins.
+    func reinstateSuspendedComposerDraft(
+        _ submitted: ACPComposerDraft,
+        for session: ACPSession,
+        suspendedRevision: Int
+    ) {
+        guard session.composerDraftRevision == suspendedRevision,
+              session.composerDraft.isEmpty
+        else { return }
+        session.replaceComposerDraft(submitted)
     }
 
     func refreshRecent() {

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -205,29 +205,44 @@ private struct ACPSessionView: View {
                         // submits; the toolbar send button bypasses the keyboard
                         // inversion and supplies its own intent directly. No
                         // further resolution here.
-                        let draftRevision = session.composerDraftRevision
-                        return manager.submit(
+                        //
+                        // The eager in-memory clear happens AFTER `manager.submit`
+                        // returns but BEFORE the completion closure can run (the
+                        // submit's completion is always dispatched via a Task,
+                        // so it runs on a later main-actor tick). The
+                        // suspendedRevision captured below identifies the post-
+                        // clear state — if the user has typed a new draft by the
+                        // time the completion fires, the conditional checks in
+                        // purge/reinstate skip and the new draft survives.
+                        var suspendedRevision: Int = -1
+                        let accepted = manager.submit(
                             sessionId: sessionId,
                             text: text,
                             attachments: attachments,
                             intent: intent
                         ) { succeeded in
-                            if succeeded {
-                                manager.clearComposerDraft(
-                                    for: session,
-                                    ifCurrentDraftEquals: draft,
-                                    revision: draftRevision
-                                )
-                            } else {
-                                manager.persistComposerDraft(
-                                    draft,
-                                    for: session,
-                                    ifCurrentDraftEquals: draft,
-                                    revision: draftRevision
-                                )
+                            if suspendedRevision >= 0 {
+                                if succeeded {
+                                    manager.purgeSuspendedComposerDraft(
+                                        for: session,
+                                        suspendedRevision: suspendedRevision
+                                    )
+                                } else {
+                                    manager.reinstateSuspendedComposerDraft(
+                                        draft,
+                                        for: session,
+                                        suspendedRevision: suspendedRevision
+                                    )
+                                }
                             }
                             onPromptFinished(succeeded)
                         }
+                        if accepted {
+                            suspendedRevision = manager.suspendComposerDraftForSubmission(
+                                draft, for: session
+                            )
+                        }
+                        return accepted
                     }
 
                     if let undo = session.steerUndo, !undo.snapshot.isEmpty {

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -67,47 +67,99 @@ struct ACPSessionManagerTests {
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
     }
 
-    @Test("conditional composer draft clear only clears the submitted draft")
-    func conditionalComposerDraftClear() async throws {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-conditional-clear-\(UUID()).sqlite")
+    @Test("suspendComposerDraftForSubmission empties memory and durably saves SQLite")
+    func suspendComposerDraftForSubmissionFlushesAndClears() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-suspend-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
         let session = mgr.createSession(agentId: "claude")
         let submitted = ACPComposerDraft(segments: [.text("sent")])
-        let newer = ACPComposerDraft(segments: [.text("newer")])
+
+        // Schedule a debounced write but DO NOT flush — simulates the
+        // common path where the user types and immediately submits before
+        // the 300ms timer fires.
+        mgr.persistComposerDraft(submitted, for: session)
+
+        let suspendedRevision = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+        #expect(session.composerDraft == .empty)
+        #expect(session.composerDraftRevision == suspendedRevision)
+        // SQLite was written synchronously by suspend, no flush needed.
+        #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
+    }
+
+    @Test("purgeSuspendedComposerDraft deletes SQLite only when revision matches")
+    func purgeSuspendedComposerDraftRespectsRevision() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-purge-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let submitted = ACPComposerDraft(segments: [.text("sent")])
 
         mgr.persistComposerDraft(submitted, for: session)
-        let submittedRevision = session.composerDraftRevision
-        mgr.clearComposerDraft(for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
-        #expect(session.composerDraft == .empty)
+        let suspendedRevision = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+
+        // Success path with no intervening typing: SQLite row is purged.
+        mgr.purgeSuspendedComposerDraft(for: session, suspendedRevision: suspendedRevision)
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
 
+        // Re-suspend, then simulate the user typing while the prompt is
+        // in flight: the new draft must survive a late completion's purge.
+        mgr.persistComposerDraft(submitted, for: session)
+        let suspendedAgain = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+        let newer = ACPComposerDraft(segments: [.text("newer")])
         mgr.persistComposerDraft(newer, for: session)
-        mgr.clearComposerDraft(for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
+        mgr.purgeSuspendedComposerDraft(for: session, suspendedRevision: suspendedAgain)
         #expect(session.composerDraft == newer)
         mgr.flushPendingDraftWrites()
         #expect(try store.loadComposerDraft(sessionId: session.id) == newer)
     }
 
-    @Test("conditional composer draft persist does not overwrite a newer draft revision")
-    func conditionalComposerDraftPersistByRevision() async throws {
-        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-conditional-persist-\(UUID()).sqlite")
+    @Test("reinstateSuspendedComposerDraft restores memory only when revision matches")
+    func reinstateSuspendedComposerDraftRespectsRevision() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-reinstate-\(UUID()).sqlite")
         let store = try ACPSessionStore(path: url.path)
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
         let session = mgr.createSession(agentId: "claude")
         let submitted = ACPComposerDraft(segments: [.text("sent")])
 
+        // Failure with no intervening typing: in-memory draft is restored
+        // so a still-mounted composer (or next re-mount) shows the text.
         mgr.persistComposerDraft(submitted, for: session)
-        let submittedRevision = session.composerDraftRevision
-        mgr.persistComposerDraft(submitted, for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
+        let suspendedRevision = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+        mgr.reinstateSuspendedComposerDraft(submitted, for: session, suspendedRevision: suspendedRevision)
         #expect(session.composerDraft == submitted)
-        mgr.flushPendingDraftWrites()
-        #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
+
+        // Re-suspend, then simulate the user typing a new draft while the
+        // prompt is in flight — a late failure must not stomp it.
+        let suspendedAgain = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+        let newer = ACPComposerDraft(segments: [.text("newer")])
+        mgr.persistComposerDraft(newer, for: session)
+        mgr.reinstateSuspendedComposerDraft(submitted, for: session, suspendedRevision: suspendedAgain)
+        #expect(session.composerDraft == newer)
+    }
+
+    @Test("re-mounting the composer after submit reads an empty initial draft")
+    func remountAfterSubmitSeesEmptyDraft() async throws {
+        // Regression for #353 follow-up: the second commit of #353 deferred
+        // the in-memory draft clear to onPromptFinished. While the agent's
+        // prompt RPC is in flight, a worktree switch dismantles the ACP
+        // composer; re-mounting reads `session.composerDraft`, which was
+        // never cleared, and the sent text reappears in the input. The new
+        // suspend hook clears in-memory eagerly so a fresh coordinator
+        // sees an empty initial draft.
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-remount-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let submitted = ACPComposerDraft(segments: [.text("hello")])
 
         mgr.persistComposerDraft(submitted, for: session)
-        mgr.persistComposerDraft(.empty, for: session, ifCurrentDraftEquals: submitted, revision: submittedRevision)
-        #expect(session.composerDraft == submitted)
-        mgr.flushPendingDraftWrites()
+        _ = mgr.suspendComposerDraftForSubmission(submitted, for: session)
+
+        // What `ACPInputField.makeCoordinator()` reads as `initialDraft`.
+        #expect(session.composerDraft.isEmpty)
+        // …while the persisted row is still durable for crash recovery
+        // until the prompt is recorded and the completion fires.
         #expect(try store.loadComposerDraft(sessionId: session.id) == submitted)
     }
 


### PR DESCRIPTION
## Summary
- Closes the regression where a sent ACP message reappears in the composer after switching worktrees and coming back: #353's second commit deferred the in-memory clear to `onPromptFinished`, so during the prompt RPC `session.composerDraft` still held the sent text and a re-mounted composer read it as `initialDraft`.
- `suspendComposerDraftForSubmission` synchronously flushes the submitted draft to SQLite (cancelling the debounced timer first so it can't overwrite the row), then clears `session.composerDraft` in-memory and returns the post-clear revision.
- `purgeSuspendedComposerDraft` / `reinstateSuspendedComposerDraft` finalize on success / failure, both guarded on the post-suspend revision so a draft typed while the prompt was in flight survives untouched. SQLite retains the suspended row until success, preserving #353's crash/detach recovery guarantee.
- Removes the now-unused `clearComposerDraft(_:ifCurrentDraftEquals:revision:)` / `persistComposerDraft(_:for:ifCurrentDraftEquals:revision:)` helpers; ACPTabView's submit closure uses the new suspend/purge/reinstate API.

## Test plan
- [x] `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- [x] `xcodebuild test -only-testing:AlasTests/ACPSessionManagerTests` — 10/10 pass, including new regression `re-mounting the composer after submit reads an empty initial draft`
- [ ] Manual: ACP pane → send message → switch worktree → switch back → composer stays empty
- [ ] Manual: ACP pane → send message → type a new draft mid-RPC → confirm new draft survives both success and failure