### PR TITLE
fix: select new worktrees immediately

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -494,6 +494,7 @@ final class AppState {
         )
         projectsManager.insertOptimisticWorktree(optimistic)
         projectsManager.setOperationState(id: optimistic.id, state: .creating)
+        selectedWorktreeId = optimistic.id
 
         let repoPath = URL(fileURLWithPath: project.path)
         let startupScript = StartupScriptResolver.worktreeCreateScript(

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -187,6 +187,32 @@ struct AppStateCleanupTests {
         #expect(state.projectsManager.worktrees(projectId: project.id).contains { $0.id == id })
     }
 
+    @Test func createWorktreeSelectsOptimisticRowImmediately() async throws {
+        let repo = try await makeRepo(name: "create-select-opt")
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let state = AppState()
+        let project = try await state.projectsManager.addProject(path: repo, displayName: "create-select-opt", color: "#5fb7c4")
+        try await state.projectsManager.refreshWorktrees(projectId: project.id)
+        let existing = try #require(state.projectsManager.worktrees(projectId: project.id).first)
+        state.selectedWorktreeId = existing.id
+
+        let dest = repo.appendingPathComponent("wt-select-opt")
+        let id = state.createWorktree(
+            projectId: project.id,
+            base: "main",
+            branch: "select-opt-b",
+            destination: dest,
+            runStartup: false,
+            launchSurface: .none
+        )
+
+        #expect(!id.isEmpty)
+        #expect(state.projectsManager.operationState(for: id) == .creating)
+        #expect(state.selectedWorktreeId == id)
+
+        try await waitForOperationState(state.projectsManager, id: id, equals: nil)
+    }
+
     @Test func createWorktreeRejectsExistingDestination() async throws {
         let repo = try await makeRepo(name: "create-existing-destination")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/GitServiceBehindStatusTests.swift
+++ b/AlasTests/GitServiceBehindStatusTests.swift
@@ -17,6 +17,7 @@ struct GitServiceBehindStatusTests {
         _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
         _ = try await Process.git(["remote", "add", "origin", remote.path], cwd: repo)
         _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: repo)
+        _ = try await Process.git(["--git-dir", remote.path, "symbolic-ref", "HEAD", "refs/heads/main"], cwd: nil)
         return (repo, remote)
     }
 

--- a/AlasTests/RightPaneStateSyncStatusTests.swift
+++ b/AlasTests/RightPaneStateSyncStatusTests.swift
@@ -167,6 +167,7 @@ struct RightPaneStateSyncStatusTests {
         _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
         _ = try await Process.git(["remote", "add", "origin", remote.path], cwd: publisher)
         _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: publisher)
+        _ = try await Process.git(["--git-dir", remote.path, "symbolic-ref", "HEAD", "refs/heads/main"], cwd: nil)
 
         let consumer = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-sync-cons-\(UUID().uuidString)")
@@ -245,6 +246,7 @@ struct RightPaneStateSyncStatusTests {
         _ = try await Process.git(["checkout", "-q", "-b", "main"], cwd: cloneA)
         _ = try await Process.git(["commit", "-q", "--allow-empty", "-m", "seed"], cwd: cloneA)
         _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: cloneA)
+        _ = try await Process.git(["--git-dir", remote.path, "symbolic-ref", "HEAD", "refs/heads/main"], cwd: nil)
         // cloneB clones at the same SHA.
         _ = try await Process.git(["clone", "-q", remote.path, cloneB.path], cwd: nil)
         _ = try await Process.git(["config", "user.email", "b@e"], cwd: cloneB)
@@ -281,6 +283,7 @@ struct RightPaneStateSyncStatusTests {
         _ = try await Process.git(["init", "--bare", "-q", remote.path], cwd: nil)
         _ = try await Process.git(["remote", "add", "origin", remote.path], cwd: repo)
         _ = try await Process.git(["push", "-q", "-u", "origin", "main"], cwd: repo)
+        _ = try await Process.git(["--git-dir", remote.path, "symbolic-ref", "HEAD", "refs/heads/main"], cwd: nil)
 
         // Create feature behind origin/main by one commit.
         _ = try await Process.git(["checkout", "-q", "-b", "feature"], cwd: repo)


### PR DESCRIPTION
## Summary

- Select the optimistic worktree row as soon as worktree creation starts.
- Add coverage for the immediate selection behavior.
- Stabilize local git sync-status test fixtures by explicitly pointing bare remote HEAD at `main`.

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`