### PR TITLE
Improve worktree delete preflight

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -1197,7 +1197,7 @@
 		76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeEditorLineNumberRulerView.swift; sourceTree = "<group>"; };
 		76F2498E56CBAF84CB67166C /* HarnessKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessKind.swift; sourceTree = "<group>"; };
 		781B8F6F0A3085FEBFC615C2 /* DefinitionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefinitionPicker.swift; sourceTree = "<group>"; };
-		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = "$(SRCROOT)/.build/ghostty/GhosttyKit.xcframework"; sourceTree = "<group>"; };
+		7831AEE2807254F6BCC5B65B /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GhosttyKit.xcframework; path = .build/ghostty/GhosttyKit.xcframework; sourceTree = "<group>"; };
 		784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecentsTests.swift; sourceTree = "<group>"; };
 		7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstaller.swift; sourceTree = "<group>"; };
 		795056B6AD803D2B555FC866 /* RightPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStore.swift; sourceTree = "<group>"; };
@@ -4174,7 +4174,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/.build/ghostty\"",
+					"\".build/ghostty\"",
 				);
 				INFOPLIST_FILE = Alas/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4216,7 +4216,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/.build/ghostty\"",
+					"\".build/ghostty\"",
 				);
 				INFOPLIST_FILE = Alas/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -234,6 +234,18 @@ final class AppState {
     }
     var pendingForceDeleteWorktree: PendingForceDeleteWorktree?
 
+    struct WorktreeDeleteConfirmation: Equatable {
+        let title: String
+        let message: String
+        let buttonTitle: String
+        let force: Bool
+    }
+
+    struct WorktreeDeleteDecision: Equatable {
+        let confirmation: WorktreeDeleteConfirmation
+        let force: Bool
+    }
+
     @ObservationIgnored
     lazy var search: SearchModel = SearchModel(environment: makeSearchEnvironment())
     @ObservationIgnored
@@ -2117,7 +2129,6 @@ final class AppState {
         let dirty = dirtyEditorTabIds(worktreeId: worktree.id)
         let saveBuffersFirst: Bool
         if dirty.isEmpty {
-            guard confirmDeleteWorktree(branch: worktree.branch, keepBranch: keepBranch) else { return }
             saveBuffersFirst = false
         } else {
             switch promptForDirtyBuffers(
@@ -2148,15 +2159,26 @@ final class AppState {
         let siblingsBefore = projectsManager.visibleWorktrees(projectId: worktree.projectId)
         let removedIndex = siblingsBefore.firstIndex(where: { $0.id == worktree.id }) ?? 0
 
-        // Mark deleting immediately so the UI dims the row.
-        projectsManager.setOperationState(id: worktree.id, state: .deleting)
-
         Task { @MainActor in
+            let preflight = await Self.performDeletePreflight(worktreePath: worktree.path)
+            let confirmation = Self.deleteConfirmation(
+                branch: worktree.branch,
+                keepBranch: keepBranch,
+                preflight: preflight
+            )
+            guard let decision = Self.resolveDeleteDecision(
+                branch: worktree.branch,
+                keepBranch: keepBranch,
+                preflight: preflight,
+                userConfirmed: confirmDeleteWorktree(confirmation)
+            ) else { return }
+
+            projectsManager.setOperationState(id: worktree.id, state: .deleting)
             await performDeleteWorktree(
                 worktree: worktree,
                 repoPath: repoPath,
                 deleteBranchIfMerged: deleteBranch,
-                force: false,
+                force: decision.force,
                 removedIndex: removedIndex
             )
         }
@@ -2180,19 +2202,17 @@ final class AppState {
                 force: force
             )
         } catch let WorktreeService.WorktreeError.gitFailed(stderr) {
-            if !force, let reason = Self.forceDeleteReason(for: stderr) {
-                // Clear deleting so the user can see the row again while deciding.
-                projectsManager.setOperationState(id: worktree.id, state: nil)
-                pendingForceDeleteWorktree = PendingForceDeleteWorktree(
-                    id: worktree.id,
-                    branch: worktree.branch,
-                    projectId: worktree.projectId,
+            if !force,
+               let pending = Self.pendingForceDelete(
+                    for: worktree,
                     repoPath: repoPath,
-                    worktreePath: worktree.path,
                     deleteBranchIfMerged: deleteBranchIfMerged,
                     removedIndex: removedIndex,
-                    reason: reason
-                )
+                    stderr: stderr
+               ) {
+                // Clear deleting so the user can see the row again while deciding.
+                projectsManager.setOperationState(id: worktree.id, state: nil)
+                pendingForceDeleteWorktree = pending
                 return
             } else {
                 projectsManager.setOperationState(
@@ -2277,6 +2297,16 @@ final class AppState {
         }.value
     }
 
+    nonisolated private static func performDeletePreflight(worktreePath: URL) async -> WorktreeDeletePreflight {
+        do {
+            return try await Task.detached {
+                try await WorktreeService().deletePreflight(worktreePath: worktreePath)
+            }.value
+        } catch {
+            return WorktreeDeletePreflight(reasons: [], submoduleLocalState: .unknown)
+        }
+    }
+
     /// Resolve whether `git branch -d` should run after `git worktree remove`.
     /// `keepBranch == true` (a per-operation override) always wins — the local
     /// branch is preserved regardless of the global setting.
@@ -2285,6 +2315,82 @@ final class AppState {
         keepBranch: Bool
     ) -> Bool {
         globalDeleteOnRemove && !keepBranch
+    }
+
+    nonisolated static func deleteConfirmation(
+        branch: String,
+        keepBranch: Bool,
+        preflight: WorktreeDeletePreflight
+    ) -> WorktreeDeleteConfirmation {
+        var messageParts = [
+            keepBranch
+                ? "This removes its files from disk. The local branch will be kept."
+                : "This removes its files from disk. The local branch will be deleted if merged."
+        ]
+
+        if preflight.reasons.contains(.dirty) {
+            messageParts.append("This worktree has modified or untracked files. Force delete will permanently remove them from disk.")
+        }
+        let containsInitializedSubmodules = preflight.reasons.contains(.containsInitializedSubmodules)
+        if containsInitializedSubmodules {
+            messageParts.append("This worktree contains initialized submodules. Git requires force delete to remove it.")
+        }
+
+        if containsInitializedSubmodules {
+            switch preflight.submoduleLocalState {
+            case .none:
+                break
+            case .present:
+                messageParts.append("Preflight found local-only submodule state that may only exist inside this worktree.")
+            case .unknown:
+                messageParts.append("Alas could not verify whether the initialized submodules contain local-only state.")
+            }
+        }
+
+        return WorktreeDeleteConfirmation(
+            title: "Delete worktree '\(branch)'?",
+            message: messageParts.joined(separator: " "),
+            buttonTitle: preflight.requiresForce ? "Force Delete" : "Delete",
+            force: preflight.requiresForce
+        )
+    }
+
+    nonisolated static func resolveDeleteDecision(
+        branch: String,
+        keepBranch: Bool,
+        preflight: WorktreeDeletePreflight,
+        userConfirmed: Bool
+    ) -> WorktreeDeleteDecision? {
+        guard userConfirmed else { return nil }
+        let confirmation = deleteConfirmation(
+            branch: branch,
+            keepBranch: keepBranch,
+            preflight: preflight
+        )
+        return WorktreeDeleteDecision(
+            confirmation: confirmation,
+            force: confirmation.force
+        )
+    }
+
+    nonisolated static func pendingForceDelete(
+        for worktree: Worktree,
+        repoPath: URL,
+        deleteBranchIfMerged: Bool,
+        removedIndex: Int,
+        stderr: String
+    ) -> PendingForceDeleteWorktree? {
+        guard let reason = forceDeleteReason(for: stderr) else { return nil }
+        return PendingForceDeleteWorktree(
+            id: worktree.id,
+            branch: worktree.branch,
+            projectId: worktree.projectId,
+            repoPath: repoPath,
+            worktreePath: worktree.path,
+            deleteBranchIfMerged: deleteBranchIfMerged,
+            removedIndex: removedIndex,
+            reason: reason
+        )
     }
 
     /// Permissive substring check: git's exact wording around dirty/submodule
@@ -2307,14 +2413,12 @@ final class AppState {
         return nil
     }
 
-    private func confirmDeleteWorktree(branch: String, keepBranch: Bool) -> Bool {
+    private func confirmDeleteWorktree(_ confirmation: WorktreeDeleteConfirmation) -> Bool {
         let alert = NSAlert()
-        alert.messageText = "Delete worktree '\(branch)'?"
-        alert.informativeText = keepBranch
-            ? "This removes its files from disk. The local branch will be kept."
-            : "This removes its files from disk. The local branch will be deleted if merged."
+        alert.messageText = confirmation.title
+        alert.informativeText = confirmation.message
         alert.alertStyle = .warning
-        let deleteButton = alert.addButton(withTitle: "Delete")
+        let deleteButton = alert.addButton(withTitle: confirmation.buttonTitle)
         alert.addButton(withTitle: "Cancel")
         deleteButton.hasDestructiveAction = true
         return alert.runModal() == .alertFirstButtonReturn

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -1,6 +1,23 @@
 import CryptoKit
 import Foundation
 
+struct WorktreeDeletePreflight: Equatable {
+    var requiresForce: Bool { reasons.isEmpty == false }
+    var reasons: Set<WorktreeDeletePreflightReason>
+    var submoduleLocalState: SubmoduleLocalState
+}
+
+enum WorktreeDeletePreflightReason: Equatable, Hashable {
+    case dirty
+    case containsInitializedSubmodules
+}
+
+enum SubmoduleLocalState: Equatable {
+    case none
+    case present
+    case unknown
+}
+
 struct WorktreeService {
     enum WorktreeError: Error, LocalizedError {
         case gitFailed(String)
@@ -152,41 +169,57 @@ struct WorktreeService {
             }
         }
         if result.exitCode != 0 {
-            // Treat any thrown helper error (timeout, malformed submodule,
-            // etc.) as "couldn't verify clean" so we propagate the original
-            // stderr from `git worktree remove` instead of surfacing the
-            // helper's internal failure to the user. Sequential bindings
-            // because `&&` autoclosures don't propagate `async`.
-            let okToForce: Bool
-            do {
-                let workClean = try await isWorktreeClean(worktree.path)
-                let subsClean = workClean
-                    ? try await areInitializedSubmodulesClean(worktree.path)
-                    : false
-                let subsNoLocal = subsClean
-                    ? try await initializedSubmodulesHaveNoLocalState(worktree.path)
-                    : false
-                okToForce = subsNoLocal
-            } catch {
-                okToForce = false
-            }
-            guard !force,
-                  Self.looksLikeSubmoduleWorktreeRemoveError(result.stderr),
-                  okToForce
-            else {
-                throw WorktreeError.gitFailed(result.stderr)
-            }
-
-            let forceResult = try await Process.git(
-                ["worktree", "remove", worktree.path.path, "--force"],
-                cwd: repoPath
-            )
-            guard forceResult.exitCode == 0 else { throw WorktreeError.gitFailed(forceResult.stderr) }
+            throw WorktreeError.gitFailed(result.stderr)
         }
         if deleteBranchIfMerged && worktree.branch != "(detached)" {
             // Best-effort delete. -d only succeeds if merged; ignore failures.
             _ = try? await Process.git(["branch", "-d", worktree.branch], cwd: repoPath)
         }
+    }
+
+    func deletePreflight(worktreePath: URL) async throws -> WorktreeDeletePreflight {
+        var reasons: Set<WorktreeDeletePreflightReason> = []
+
+        let hasInitializedSubmodules = try await containsInitializedSubmodules(worktreePath)
+        if hasInitializedSubmodules {
+            reasons.insert(.containsInitializedSubmodules)
+        }
+
+        let worktreeClean: Bool?
+        do {
+            worktreeClean = try await isWorktreeClean(worktreePath)
+        } catch {
+            guard hasInitializedSubmodules else { throw error }
+            worktreeClean = nil
+        }
+
+        if worktreeClean == false {
+            reasons.insert(.dirty)
+        }
+
+        let submoduleLocalState: SubmoduleLocalState
+        if hasInitializedSubmodules {
+            do {
+                if worktreeClean == nil {
+                    submoduleLocalState = .unknown
+                } else if try await areInitializedSubmodulesClean(worktreePath) {
+                    submoduleLocalState = try await initializedSubmodulesHaveNoLocalState(
+                        worktreePath,
+                        timeout: 10
+                    )
+                        ? .none
+                        : .present
+                } else {
+                    submoduleLocalState = .present
+                }
+            } catch {
+                submoduleLocalState = .unknown
+            }
+        } else {
+            submoduleLocalState = .none
+        }
+
+        return WorktreeDeletePreflight(reasons: reasons, submoduleLocalState: submoduleLocalState)
     }
 
     func prune(repoPath: URL) async throws {
@@ -218,10 +251,35 @@ struct WorktreeService {
             || lower.contains("dirty worktree")
     }
 
-    private static func looksLikeSubmoduleWorktreeRemoveError(_ stderr: String) -> Bool {
-        let lower = stderr.lowercased()
-        return lower.contains("working trees containing submodules")
-            && lower.contains("cannot be moved or removed")
+    private func containsInitializedSubmodules(_ path: URL) async throws -> Bool {
+        let result = try await Process.git(["submodule", "status", "--recursive"], cwd: path)
+        guard result.exitCode == 0 else {
+            let paths = try await submodulePathsFromGitmodules(path)
+            return paths.contains { relativePath in
+                FileManager.default.fileExists(
+                    atPath: path.appendingPathComponent(relativePath).appendingPathComponent(".git").path
+                )
+            }
+        }
+        return result.stdout.split(separator: "\n").contains { line in
+            guard let first = line.first else { return false }
+            return first != "-"
+        }
+    }
+
+    private func submodulePathsFromGitmodules(_ path: URL) async throws -> [String] {
+        let result = try await Process.git(
+            ["config", "--file", ".gitmodules", "--get-regexp", "path"],
+            cwd: path
+        )
+        if result.exitCode != 0 {
+            return []
+        }
+        return result.stdout
+            .split(separator: "\n")
+            .compactMap { line in
+                line.split(separator: " ", maxSplits: 1).dropFirst().first.map(String.init)
+            }
     }
 
     private func isWorktreeClean(_ path: URL) async throws -> Bool {
@@ -245,7 +303,10 @@ struct WorktreeService {
         return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private func initializedSubmodulesHaveNoLocalState(_ path: URL) async throws -> Bool {
+    private func initializedSubmodulesHaveNoLocalState(
+        _ path: URL,
+        timeout: TimeInterval = 120
+    ) async throws -> Bool {
         // Reachability set arithmetic for reflog and notes/stash (the
         // perf-critical fix — replaces an O(reflog × remotes) shell loop
         // that timed out on submodules with non-trivial reflogs).
@@ -301,7 +362,7 @@ struct WorktreeService {
         let result = try await Process.git(
             ["submodule", "foreach", "--quiet", "--recursive", localStateScript],
             cwd: path,
-            timeout: 120
+            timeout: timeout
         )
         guard result.exitCode == 0 else { throw WorktreeError.gitFailed(result.stderr) }
         return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty

--- a/AlasTests/AppStateCleanupTests.swift
+++ b/AlasTests/AppStateCleanupTests.swift
@@ -341,6 +341,147 @@ struct AppStateCleanupTests {
         #expect(AppState.resolveDeleteBranchIfMerged(globalDeleteOnRemove: false, keepBranch: true) == false)
     }
 
+    @Test func deleteConfirmationForCleanPreflightUsesDeleteAndBranchDeletionCopy() {
+        let confirmation = AppState.deleteConfirmation(
+            branch: "feature/clean",
+            keepBranch: false,
+            preflight: WorktreeDeletePreflight(reasons: [], submoduleLocalState: .none)
+        )
+
+        #expect(confirmation == AppState.WorktreeDeleteConfirmation(
+            title: "Delete worktree 'feature/clean'?",
+            message: "This removes its files from disk. The local branch will be deleted if merged.",
+            buttonTitle: "Delete",
+            force: false
+        ))
+    }
+
+    @Test func deleteConfirmationForDirtyPreflightUsesForceAndKeepBranchCopy() {
+        let confirmation = AppState.deleteConfirmation(
+            branch: "feature/dirty",
+            keepBranch: true,
+            preflight: WorktreeDeletePreflight(reasons: [.dirty], submoduleLocalState: .none)
+        )
+
+        #expect(confirmation.title == "Delete worktree 'feature/dirty'?")
+        #expect(confirmation.buttonTitle == "Force Delete")
+        #expect(confirmation.force == true)
+        #expect(confirmation.message.contains("This removes its files from disk."))
+        #expect(confirmation.message.contains("The local branch will be kept."))
+        #expect(confirmation.message.contains("This worktree has modified or untracked files. Force delete will permanently remove them from disk."))
+    }
+
+    @Test func deleteConfirmationForSubmoduleLocalStateIncludesSubmoduleWarnings() {
+        let confirmation = AppState.deleteConfirmation(
+            branch: "feature/submodule",
+            keepBranch: false,
+            preflight: WorktreeDeletePreflight(
+                reasons: [.containsInitializedSubmodules],
+                submoduleLocalState: .present
+            )
+        )
+
+        #expect(confirmation.buttonTitle == "Force Delete")
+        #expect(confirmation.force == true)
+        #expect(confirmation.message.contains("This worktree contains initialized submodules. Git requires force delete to remove it."))
+        #expect(confirmation.message.contains("Preflight found local-only submodule state that may only exist inside this worktree."))
+    }
+
+    @Test func deleteConfirmationForUnknownWithoutSubmoduleReasonUsesNormalCopy() {
+        let confirmation = AppState.deleteConfirmation(
+            branch: "feature/unknown",
+            keepBranch: false,
+            preflight: WorktreeDeletePreflight(reasons: [], submoduleLocalState: .unknown)
+        )
+
+        #expect(confirmation.buttonTitle == "Delete")
+        #expect(confirmation.force == false)
+        #expect(!confirmation.message.contains("initialized submodules"))
+        #expect(!confirmation.message.contains("could not verify"))
+    }
+
+    @Test func deleteConfirmationForDirtyAndSubmodulePreflightIncludesBothWarnings() {
+        let confirmation = AppState.deleteConfirmation(
+            branch: "feature/combined",
+            keepBranch: false,
+            preflight: WorktreeDeletePreflight(
+                reasons: [.dirty, .containsInitializedSubmodules],
+                submoduleLocalState: .none
+            )
+        )
+
+        #expect(confirmation.buttonTitle == "Force Delete")
+        #expect(confirmation.force == true)
+        #expect(confirmation.message.contains("This worktree has modified or untracked files. Force delete will permanently remove them from disk."))
+        #expect(confirmation.message.contains("This worktree contains initialized submodules. Git requires force delete to remove it."))
+    }
+
+    @Test func resolveDeleteDecisionReturnsForceDecisionWhenConfirmed() {
+        let preflight = WorktreeDeletePreflight(
+            reasons: [.containsInitializedSubmodules],
+            submoduleLocalState: .none
+        )
+
+        let decision = AppState.resolveDeleteDecision(
+            branch: "feature/submodule",
+            keepBranch: false,
+            preflight: preflight,
+            userConfirmed: true
+        )
+
+        #expect(decision == AppState.WorktreeDeleteDecision(
+            confirmation: AppState.deleteConfirmation(
+                branch: "feature/submodule",
+                keepBranch: false,
+                preflight: preflight
+            ),
+            force: true
+        ))
+        #expect(decision?.confirmation.buttonTitle == "Force Delete")
+    }
+
+    @Test func resolveDeleteDecisionReturnsNilWhenCancelled() {
+        let decision = AppState.resolveDeleteDecision(
+            branch: "feature/cancel",
+            keepBranch: false,
+            preflight: WorktreeDeletePreflight(reasons: [.dirty], submoduleLocalState: .none),
+            userConfirmed: false
+        )
+
+        #expect(decision == nil)
+    }
+
+    @Test func submoduleRemoveErrorBuildsPendingForceDeleteFallback() {
+        let repoPath = URL(fileURLWithPath: "/tmp/repo")
+        let worktreePath = URL(fileURLWithPath: "/tmp/repo-worktree")
+        let worktree = Worktree(
+            id: "wt-submodule",
+            projectId: "project",
+            name: "feature/submodule",
+            branch: "feature/submodule",
+            path: worktreePath,
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+
+        let pending = AppState.pendingForceDelete(
+            for: worktree,
+            repoPath: repoPath,
+            deleteBranchIfMerged: true,
+            removedIndex: 2,
+            stderr: "fatal: working trees containing submodules cannot be moved or removed"
+        )
+
+        #expect(pending?.id == worktree.id)
+        #expect(pending?.branch == worktree.branch)
+        #expect(pending?.projectId == worktree.projectId)
+        #expect(pending?.repoPath == repoPath)
+        #expect(pending?.worktreePath == worktreePath)
+        #expect(pending?.deleteBranchIfMerged == true)
+        #expect(pending?.removedIndex == 2)
+        #expect(pending?.reason == .containsSubmodules)
+    }
+
     @Test func cancelForceDeleteClearsPendingState() async throws {
         let repo = try await makeRepo(name: "cancel-force")
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/WorktreeServiceTests.swift
+++ b/AlasTests/WorktreeServiceTests.swift
@@ -84,6 +84,92 @@ struct WorktreeServiceTests {
 }
 
 extension WorktreeServiceTests {
+    @Test func deletePreflightReportsCleanForCleanWorktree() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let dest = repo.deletingLastPathComponent().appendingPathComponent("\(repo.lastPathComponent)-preflight-clean")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/preflight-clean",
+            destination: dest, projectId: "p"
+        )
+
+        let preflight = try await svc.deletePreflight(worktreePath: wt.path)
+
+        #expect(preflight.requiresForce == false)
+        #expect(preflight.reasons.isEmpty)
+        #expect(preflight.submoduleLocalState == .none)
+    }
+
+    @Test func deletePreflightReportsDirtyForUntrackedFile() async throws {
+        let repo = try await makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        let dest = repo.deletingLastPathComponent().appendingPathComponent("\(repo.lastPathComponent)-preflight-dirty")
+        defer { try? FileManager.default.removeItem(at: dest) }
+        let svc = WorktreeService()
+        let wt = try await svc.add(
+            repoPath: repo, base: "main", branch: "feat/preflight-dirty",
+            destination: dest, projectId: "p"
+        )
+        try "local".write(to: dest.appendingPathComponent("local.txt"), atomically: true, encoding: .utf8)
+
+        let preflight = try await svc.deletePreflight(worktreePath: wt.path)
+
+        #expect(preflight.requiresForce == true)
+        #expect(preflight.reasons == [.dirty])
+        #expect(preflight.submoduleLocalState == .none)
+    }
+
+    @Test func deletePreflightReportsInitializedSubmodulesWithoutLocalState() async throws {
+        let fixture = try await makeRepoWithInitializedSubmodule(suffix: "preflight-submodule-clean")
+        defer {
+            try? FileManager.default.removeItem(at: fixture.repo)
+            try? FileManager.default.removeItem(at: fixture.submoduleRepo)
+            try? FileManager.default.removeItem(at: fixture.worktree.path)
+        }
+
+        let preflight = try await fixture.service.deletePreflight(worktreePath: fixture.worktree.path)
+
+        #expect(preflight.requiresForce == true)
+        #expect(preflight.reasons == [.containsInitializedSubmodules])
+        #expect(preflight.submoduleLocalState == .none)
+    }
+
+    @Test func deletePreflightReportsInitializedSubmoduleWithLocalOnlyBranch() async throws {
+        let fixture = try await makeRepoWithInitializedSubmodule(suffix: "preflight-submodule-local-branch")
+        defer {
+            try? FileManager.default.removeItem(at: fixture.repo)
+            try? FileManager.default.removeItem(at: fixture.submoduleRepo)
+            try? FileManager.default.removeItem(at: fixture.worktree.path)
+        }
+        let submodulePath = fixture.worktree.path.appendingPathComponent("Deps/Submodule")
+        _ = try await Process.git(["branch", "local-only", "HEAD"], cwd: submodulePath)
+
+        let preflight = try await fixture.service.deletePreflight(worktreePath: fixture.worktree.path)
+
+        #expect(preflight.requiresForce == true)
+        #expect(preflight.reasons == [.containsInitializedSubmodules])
+        #expect(preflight.submoduleLocalState == .present)
+    }
+
+    @Test func deletePreflightReportsUnknownSubmoduleLocalStateWhenCheckFails() async throws {
+        let fixture = try await makeRepoWithInitializedSubmodule(suffix: "preflight-submodule-broken")
+        defer {
+            try? FileManager.default.removeItem(at: fixture.repo)
+            try? FileManager.default.removeItem(at: fixture.submoduleRepo)
+            try? FileManager.default.removeItem(at: fixture.worktree.path)
+        }
+        let gitfile = fixture.worktree.path.appendingPathComponent("Deps/Submodule/.git")
+        try "gitdir: /nonexistent/broken/path\n".write(to: gitfile, atomically: true, encoding: .utf8)
+
+        let preflight = try await fixture.service.deletePreflight(worktreePath: fixture.worktree.path)
+
+        #expect(preflight.requiresForce == true)
+        #expect(preflight.reasons == [.containsInitializedSubmodules])
+        #expect(preflight.submoduleLocalState == .unknown)
+    }
+
     @Test func removeFailsOnDirtyWorktreeWithoutForce() async throws {
         let repo = try await makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -318,13 +404,18 @@ extension WorktreeServiceTests {
 }
 
 extension WorktreeServiceTests {
-    @Test func removeDeletesCleanWorktreeContainingSubmodule() async throws {
+    private struct InitializedSubmoduleFixture {
+        let repo: URL
+        let submoduleRepo: URL
+        let service: WorktreeService
+        let worktree: Worktree
+    }
+
+    private func makeRepoWithInitializedSubmodule(suffix: String) async throws -> InitializedSubmoduleFixture {
         let repo = try await makeRepo()
-        defer { try? FileManager.default.removeItem(at: repo) }
 
         let submoduleRepo = FileManager.default.temporaryDirectory
             .appendingPathComponent("alas-submodule-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: submoduleRepo) }
         try FileManager.default.createDirectory(at: submoduleRepo, withIntermediateDirectories: true)
         _ = try await Process.git(["init", "-q", "-b", "main"], cwd: submoduleRepo)
         try "initial".write(
@@ -341,11 +432,10 @@ extension WorktreeServiceTests {
         )
         _ = try await Process.git(["commit", "-q", "-am", "add submodule"], cwd: repo)
 
-        let dest = repo.deletingLastPathComponent().appendingPathComponent("\(repo.lastPathComponent)-submodule")
-        defer { try? FileManager.default.removeItem(at: dest) }
+        let dest = repo.deletingLastPathComponent().appendingPathComponent("\(repo.lastPathComponent)-\(suffix)")
         let svc = WorktreeService()
         let wt = try await svc.add(
-            repoPath: repo, base: "main", branch: "feat/submodule",
+            repoPath: repo, base: "main", branch: "feat/\(suffix)",
             destination: dest, projectId: "p"
         )
         _ = try await Process.git(
@@ -353,11 +443,47 @@ extension WorktreeServiceTests {
             cwd: dest
         )
 
-        try await svc.remove(repoPath: repo, worktree: wt, deleteBranchIfMerged: false)
+        return InitializedSubmoduleFixture(repo: repo, submoduleRepo: submoduleRepo, service: svc, worktree: wt)
+    }
 
-        let listed = try await svc.list(repoPath: repo, projectId: "p")
+    @Test func removeWithoutForceFailsForCleanInitializedSubmodule() async throws {
+        let fixture = try await makeRepoWithInitializedSubmodule(suffix: "submodule-no-force")
+        defer {
+            try? FileManager.default.removeItem(at: fixture.repo)
+            try? FileManager.default.removeItem(at: fixture.submoduleRepo)
+            try? FileManager.default.removeItem(at: fixture.worktree.path)
+        }
+
+        await #expect(throws: WorktreeService.WorktreeError.self) {
+            try await fixture.service.remove(
+                repoPath: fixture.repo,
+                worktree: fixture.worktree,
+                deleteBranchIfMerged: false,
+                force: false
+            )
+        }
+
+        #expect(FileManager.default.fileExists(atPath: fixture.worktree.path.path))
+    }
+
+    @Test func removeWithForceDeletesCleanInitializedSubmodule() async throws {
+        let fixture = try await makeRepoWithInitializedSubmodule(suffix: "submodule-force")
+        defer {
+            try? FileManager.default.removeItem(at: fixture.repo)
+            try? FileManager.default.removeItem(at: fixture.submoduleRepo)
+            try? FileManager.default.removeItem(at: fixture.worktree.path)
+        }
+
+        try await fixture.service.remove(
+            repoPath: fixture.repo,
+            worktree: fixture.worktree,
+            deleteBranchIfMerged: false,
+            force: true
+        )
+
+        let listed = try await fixture.service.list(repoPath: fixture.repo, projectId: "p")
         #expect(listed.count == 1)
-        #expect(!FileManager.default.fileExists(atPath: dest.path))
+        #expect(!FileManager.default.fileExists(atPath: fixture.worktree.path.path))
     }
 
     @Test func removeDoesNotForceDeleteIgnoredDirtySubmodule() async throws {

--- a/docs/superpowers/specs/2026-05-30-worktree-delete-preflight-design.md
+++ b/docs/superpowers/specs/2026-05-30-worktree-delete-preflight-design.md
@@ -1,0 +1,182 @@
+# Worktree Delete Preflight – Design
+
+**Date:** 2026-05-30
+**Status:** Design approved, ready for implementation plan
+
+## Problem
+
+Deleting a worktree currently starts with a generic confirmation. Alas then
+tries `git worktree remove` without `--force`; if Git rejects the remove
+because the worktree is dirty or contains initialized submodules, Alas shows a
+second "Force Delete" confirmation.
+
+That reactive flow is correct, but it makes the first confirmation incomplete:
+the user is asked to delete before Alas tells them that the delete may require
+force or may remove uncommitted/untracked files.
+
+## Goal
+
+Move the force-delete decision ahead of the first confirmation whenever Alas
+can safely classify the worktree. The user should see one context-aware delete
+confirmation that explains why `--force` is required before any remove attempt
+runs.
+
+This also makes the proposed Worktrees preference unnecessary for the normal
+path: submodule-only deletes are confirmed once with accurate copy instead of
+being confirmed once generically and once reactively.
+
+## Non-Goals
+
+- Do not weaken the existing dirty-worktree protections.
+- Do not force-delete submodules merely because submodules exist.
+- Do not remove the current reactive fallback; Git state can change after the
+  preflight, and Git error wording can vary by version.
+- Do not change branch deletion semantics.
+
+## User-Facing Behavior
+
+Before showing the delete confirmation, Alas runs a delete preflight for the
+selected worktree and classifies it as:
+
+- `clean`: show the existing normal delete copy and remove without force.
+- `dirty`: show destructive copy that says the worktree has modified or
+  untracked files and force delete will remove them; remove with force after
+  confirmation.
+- `containsInitializedSubmodules`: show copy that says initialized submodules
+  require force delete; include an extra warning if preflight found local-only
+  submodule state; remove with force after confirmation.
+- `dirtyAndContainsSubmodules`: show copy that includes the dirty/untracked
+  warning and the submodule warning; remove with force after confirmation.
+- `unknown`: show the existing normal confirmation, then rely on the current
+  reactive failure path if Git later requires force.
+
+This makes the proposed "skip submodule force-delete confirmation" setting
+unnecessary for the normal path. If Alas can safely know that initialized
+submodules are the only reason force is required, the first dialog says so and
+the confirmed delete proceeds with force. Dirty/untracked worktrees get their
+own destructive first-confirmation copy.
+
+## Architecture
+
+### Delete preflight
+
+Add a small preflight API near `WorktreeService`:
+
+```swift
+struct WorktreeDeletePreflight: Equatable {
+    var requiresForce: Bool
+    var reasons: Set<WorktreeDeletePreflightReason>
+    var submoduleLocalState: SubmoduleLocalState
+}
+
+enum WorktreeDeletePreflightReason: Equatable {
+    case dirty
+    case containsInitializedSubmodules
+}
+
+enum SubmoduleLocalState: Equatable {
+    case none
+    case present
+    case unknown
+}
+```
+
+Implementation can reuse the existing helper logic in `WorktreeService`:
+
+- worktree clean check: `git status --porcelain --ignore-submodules=none
+  --untracked-files=all`
+- initialized submodule presence check: `git submodule status --recursive`,
+  treating entries not prefixed by `-` as initialized
+- initialized submodule cleanliness:
+  `areInitializedSubmodulesClean`
+- initialized submodule local-state check:
+  `initializedSubmodulesHaveNoLocalState`
+
+Submodule local-state checks should inform the first confirmation copy. They do
+not block force delete after an explicit user confirmation; they replace the
+current generic first confirmation plus second force confirmation with one
+better-informed destructive confirmation.
+
+### AppState delete flow
+
+`AppState.deleteWorktree(_:keepBranch:)` becomes an async state-driven flow:
+
+1. Save or discard dirty editor buffers using the existing in-app buffer prompt.
+2. Resolve project, repo path, branch deletion behavior, and removed index.
+3. Run `WorktreeService` delete preflight off the main actor.
+4. Show a single `NSAlert` whose title, message, and destructive button copy
+   reflect the preflight result.
+5. If confirmed, call `performDeleteWorktree(... force: preflight.requiresForce)`.
+
+If the preflight is `unknown`, keep the existing non-force attempt and reactive
+fallback.
+
+### Reactive fallback
+
+Keep `pendingForceDeleteWorktree` and the SwiftUI alert in `RootView`.
+
+This remains necessary for:
+
+- Git state changing between preflight and removal.
+- Git failures not detectable by preflight.
+- Git versions whose stderr does not match the preflight assumptions.
+- Unknown preflight results where the user still chose the normal delete path
+  and Git later reports a force-delete requirement.
+
+There is no new config field or Settings UI in this design. The simplified UX
+comes from preflight detection, not from a preference.
+
+## Alert Copy
+
+Use one delete confirmation path with copy derived from the preflight:
+
+- Clean: existing copy.
+- Dirty: "This worktree has modified or untracked files. Force delete will
+  permanently remove them from disk."
+- Submodules: "This worktree contains initialized submodules. Git requires
+  force delete to remove it."
+- Dirty + submodules: include both sentences.
+
+The destructive button can remain `Delete` for clean deletes and become
+`Force Delete` when preflight requires force.
+
+## Error Handling & Edge Cases
+
+- **Preflight throws:** classify as `unknown`; continue with the existing
+  delete confirmation and reactive fallback.
+- **Submodule local-state check fails:** set `submoduleLocalState` to
+  `.unknown` and include conservative copy. If the user confirms, proceed with
+  force just as the current second confirmation would.
+- **Dirty editor buffers:** keep the existing prompt first. It protects unsaved
+  in-app buffers before Git status is meaningful.
+- **Branch deletion:** continue using
+  `resolveDeleteBranchIfMerged(globalDeleteOnRemove:keepBranch:)`.
+- **Main worktree:** no behavior change beyond improved copy if the delete path
+  reaches preflight.
+
+## Testing
+
+Unit/integration tests should cover:
+
+- Preflight reports `clean` for a clean worktree.
+- Preflight reports `dirty` for modified or untracked files.
+- Preflight reports `containsInitializedSubmodules` when initialized
+  submodules are present.
+- Preflight distinguishes clean submodules from submodules with local-only
+  state, and from unknown local-state checks.
+- `AppState` resolves first-confirmation copy and force behavior for clean,
+  dirty, submodule-only, and combined cases.
+- Reactive `forceDeleteReason(for:)` still handles dirty and submodule Git
+  stderr.
+- Submodule-only preflight shows one context-aware confirmation and then deletes
+  with force when confirmed.
+- Unknown or raced submodule-only fallback still presents the second
+  confirmation.
+
+## Files Touched
+
+- `Alas/Sources/Git/WorktreeService.swift`
+- `Alas/Sources/App/AppState.swift`
+- `Alas/Sources/App/RootView.swift`
+- `AlasTests/WorktreeServiceTests.swift`
+- `AlasTests/AppStateCleanupTests.swift`

--- a/project.yml
+++ b/project.yml
@@ -105,7 +105,7 @@ targets:
         CFBundleIconFile: AppIcon
         CFBundleIconName: AppIcon
     dependencies:
-      - framework: $(SRCROOT)/.build/ghostty/GhosttyKit.xcframework
+      - framework: .build/ghostty/GhosttyKit.xcframework
         embed: false
         link: true
         codeSign: false


### PR DESCRIPTION
## Summary
- add a worktree delete preflight that classifies dirty worktrees, initialized submodules, and submodule local state
- move AppState delete confirmation after preflight so force-required deletes get one context-aware prompt
- preserve the reactive force-delete fallback for raced or unknown Git failures
- update GhosttyKit project path handling so Xcode resolves the local XCFramework reliably

## Validation
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS,arch=arm64' -only-testing:AlasTests/WorktreeServiceTests -only-testing:AlasTests/AppStateCleanupTests test`

## Notes
- A local full-suite `xcodebuild ... test` run was interrupted after hanging without additional output for roughly fifteen minutes. CI should provide the authoritative full-suite result.