### PR TITLE
fix(acp): lossless queued-prompt edit-restore + atomic edit-take

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -231,8 +231,8 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Append a new pending item to the tail of the queue. Used by the
     /// runner when the user submits while the agent is busy (or while
     /// the queue is already non-empty — see ACPSubmitRoute).
-    func enqueue(blocks: [ACPContentBlock]) {
-        queue.append(QueuedPrompt(blocks: blocks))
+    func enqueue(blocks: [ACPContentBlock], draft: ACPComposerDraft? = nil) {
+        queue.append(QueuedPrompt(blocks: blocks, draft: draft))
     }
 
     /// Remove a specific item by id. The drag-handle X on the bubble
@@ -242,6 +242,20 @@ final class ACPSession: ObservableObject, Identifiable {
         guard let idx = queue.firstIndex(where: { $0.id == id }) else { return }
         if queue[idx].status == .sending { return }
         queue.remove(at: idx)
+    }
+
+    /// Pull a queued item back into the composer for editing: remove it and
+    /// return its restorable draft — but ONLY if it's still `.pending`.
+    /// Returns `nil` if the item is gone or already `.sending` (mid-RPC), so
+    /// the caller never restores a prompt that's still in flight. This is the
+    /// atomic replacement for "check status, then removeFromQueue, then
+    /// restore" — collapsing the time-of-check/time-of-use window that let a
+    /// flusher-promoted item be duplicated into the composer.
+    func takeForEditing(id: UUID) -> ACPComposerDraft? {
+        guard let idx = queue.firstIndex(where: { $0.id == id }) else { return nil }
+        guard queue[idx].status == .pending else { return nil }
+        let item = queue.remove(at: idx)
+        return item.restorableDraft
     }
 
     /// Reorder within the queue. Refuses to move a `.sending` head — the
@@ -257,10 +271,14 @@ final class ACPSession: ObservableObject, Identifiable {
     }
 
     /// Edit the prompt blocks of a `.pending` item. No-op for `.sending`.
+    /// Clears any captured draft — the old segments no longer describe the
+    /// new blocks, so a later edit falls back to the heuristic on the
+    /// current blocks rather than restoring stale structure.
     func editQueueItem(id: UUID, blocks: [ACPContentBlock]) {
         guard let idx = queue.firstIndex(where: { $0.id == id }) else { return }
         if queue[idx].status == .sending { return }
         queue[idx].blocks = blocks
+        queue[idx].draft = nil
     }
 
     /// Remove all `.pending` items; return the snapshot in original order so

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -274,6 +274,10 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Clears any captured draft — the old segments no longer describe the
     /// new blocks, so a later edit falls back to the heuristic on the
     /// current blocks rather than restoring stale structure.
+    ///
+    /// This is the only correct path to mutate a queued item's `blocks` —
+    /// call it rather than writing `queue[idx].blocks` directly, otherwise a
+    /// now-stale `draft` survives and mis-restores on the next edit.
     func editQueueItem(id: UUID, blocks: [ACPContentBlock]) {
         guard let idx = queue.firstIndex(where: { $0.id == id }) else { return }
         if queue[idx].status == .sending { return }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -593,11 +593,12 @@ extension ACPSessionManager {
     func enqueueWhileRecovering(
         text: String,
         attachments: [ACPMessage.Attachment],
+        draft: ACPComposerDraft? = nil,
         into sessionId: ACPSession.ID
     ) {
         guard let session = sessions[sessionId] else { return }
         let blocks = ACPSessionRunner.blocks(text: text, attachments: attachments)
-        session.enqueue(blocks: blocks)
+        session.enqueue(blocks: blocks, draft: draft)
         do {
             try store.upsertQueue(sessionId: sessionId, items: session.queue)
         } catch {
@@ -623,6 +624,7 @@ extension ACPSessionManager {
         text: String,
         attachments: [ACPMessage.Attachment],
         intent: ACPSubmitIntent,
+        draft: ACPComposerDraft? = nil,
         onCompleted: @escaping @MainActor (Bool) -> Void
     ) -> Bool {
         guard let session = sessions[sessionId] else { return false }
@@ -639,12 +641,12 @@ extension ACPSessionManager {
                 // closure returns and registers its pending id (without the
                 // hop the completion fires too early and gets ignored).
                 session.agentState = .disconnected
-                enqueueWhileRecovering(text: text, attachments: attachments, into: sessionId)
+                enqueueWhileRecovering(text: text, attachments: attachments, draft: draft, into: sessionId)
                 Task { @MainActor in onCompleted(true) }
                 Task { @MainActor in await reattach(to: sessionId) }
                 return true
             }
-            runner.send(text: text, attachments: attachments, intent: intent) { succeeded in
+            runner.send(text: text, attachments: attachments, intent: intent, draft: draft) { succeeded in
                 onCompleted(succeeded)
             }
             return true
@@ -652,7 +654,7 @@ extension ACPSessionManager {
         case .spawning:
             // An attach is in flight; the post-attach `flushQueueIfIdle()`
             // will pick up the freshly enqueued head.
-            enqueueWhileRecovering(text: text, attachments: attachments, into: sessionId)
+            enqueueWhileRecovering(text: text, attachments: attachments, draft: draft, into: sessionId)
             Task { @MainActor in onCompleted(true) }
             return true
 
@@ -662,7 +664,7 @@ extension ACPSessionManager {
             // submit closure returns and registers its pending id — firing
             // synchronously here would race the composer's bookkeeping and
             // get ignored, leaving the persisted draft uncleared.
-            enqueueWhileRecovering(text: text, attachments: attachments, into: sessionId)
+            enqueueWhileRecovering(text: text, attachments: attachments, draft: draft, into: sessionId)
             Task { @MainActor in onCompleted(true) }
             Task { @MainActor in await reattach(to: sessionId) }
             return true

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -466,10 +466,11 @@ extension ACPSessionRunner {
         text: String,
         attachments: [ACPMessage.Attachment],
         intent: ACPSubmitIntent,
+        draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
         let blocks = Self.blocks(text: text, attachments: attachments)
-        send(blocks: blocks, intent: intent, onPromptFinished: onPromptFinished)
+        send(blocks: blocks, intent: intent, draft: draft, onPromptFinished: onPromptFinished)
     }
 
     /// Build the canonical `[ACPContentBlock]` array from a composer-shaped
@@ -493,9 +494,13 @@ extension ACPSessionRunner {
     ///   - enqueue  → appends to queue + persists
     ///   - steer    → cancels in-flight + clears queue + sends (Task 8)
     ///   - noOp     → empty composer, ignore
+    /// `draft` is the structured composer state for lossless edit-restore;
+    /// it's consumed only on the `enqueue` route and ignored on the others
+    /// (sendNow/steer have no queued item to annotate).
     func send(
         blocks: [ACPContentBlock],
         intent: ACPSubmitIntent,
+        draft: ACPComposerDraft? = nil,
         onPromptFinished: (@MainActor (_ succeeded: Bool) -> Void)? = nil
     ) {
         let route = ACPSubmitRoute.resolve(
@@ -513,7 +518,7 @@ extension ACPSessionRunner {
         case .sendNow:
             sendNow(blocks: blocks, queuedItemId: nil, onPromptFinished: onPromptFinished)
         case .enqueue:
-            session.enqueue(blocks: blocks)
+            session.enqueue(blocks: blocks, draft: draft)
             persistQueue()
             // The user's prompt was accepted into the queue — from the
             // composer's perspective this is a successful submission so

--- a/Alas/Sources/ACP/Session/QueuedPrompt.swift
+++ b/Alas/Sources/ACP/Session/QueuedPrompt.swift
@@ -14,12 +14,20 @@ struct QueuedPrompt: Identifiable, Equatable, Codable {
     /// user bubble per retry. Persisted so a relaunch-mid-attempt
     /// doesn't double-record either.
     var transcriptRecorded: Bool
+    /// Structured composer state captured at enqueue time, so editing a
+    /// queued prompt restores the EXACT original draft instead of inverting
+    /// the lossy `blocks` serialization. `nil` for block-only origins
+    /// (items persisted before this field existed, recovery-path enqueues,
+    /// rolled-back direct sends) — those fall back to the heuristic via
+    /// `restorableDraft`. Not sent to the agent; `blocks` remains the wire form.
+    var draft: ACPComposerDraft?
 
     init(id: UUID = UUID(),
          blocks: [ACPContentBlock],
          enqueuedAt: Date = Date(),
          status: Status = .pending,
          lastError: String? = nil,
+         draft: ACPComposerDraft? = nil,
          transcriptRecorded: Bool = false)
     {
         self.id = id
@@ -27,11 +35,12 @@ struct QueuedPrompt: Identifiable, Equatable, Codable {
         self.enqueuedAt = enqueuedAt
         self.status = status
         self.lastError = lastError
+        self.draft = draft
         self.transcriptRecorded = transcriptRecorded
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, blocks, enqueuedAt, status, lastError, transcriptRecorded
+        case id, blocks, enqueuedAt, status, lastError, draft, transcriptRecorded
     }
 
     init(from decoder: Decoder) throws {
@@ -41,6 +50,7 @@ struct QueuedPrompt: Identifiable, Equatable, Codable {
         enqueuedAt = try c.decode(Date.self, forKey: .enqueuedAt)
         status = try c.decode(Status.self, forKey: .status)
         lastError = try? c.decode(String.self, forKey: .lastError)
+        draft = try? c.decode(ACPComposerDraft.self, forKey: .draft)
         transcriptRecorded = (try? c.decode(Bool.self, forKey: .transcriptRecorded)) ?? false
     }
 
@@ -53,5 +63,12 @@ struct QueuedPrompt: Identifiable, Equatable, Codable {
         var copy = self
         copy.status = .pending
         return copy
+    }
+
+    /// The draft to load back into the composer when this item is edited:
+    /// the structured `draft` when captured, otherwise the heuristic inverse
+    /// of `blocks`. See the `draft` field for why the fallback is lossy.
+    var restorableDraft: ACPComposerDraft {
+        draft ?? ACPComposerDraft(blocks: blocks)
     }
 }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -153,12 +153,15 @@ private struct ACPSessionView: View {
                             onQueueEdit: { item in
                                 // Pull the queued prompt back into the composer
                                 // for editing — appended after any text the user
-                                // has already typed so nothing is clobbered — then
-                                // drop it from the queue.
-                                let restored = session.composerDraft.appending(
-                                    ACPComposerDraft(blocks: item.blocks))
-                                manager.persistComposerDraft(restored, for: session)
-                                session.removeFromQueue(id: item.id)
+                                // has already typed so nothing is clobbered.
+                                // `takeForEditing` removes the item and returns
+                                // its draft ONLY if it's still `.pending`; a
+                                // `.sending` item (promoted by the flusher
+                                // between render and click) returns nil and is
+                                // left in flight, so it can't be duplicated.
+                                guard let restored = session.takeForEditing(id: item.id) else { return }
+                                manager.persistComposerDraft(
+                                    session.composerDraft.appending(restored), for: session)
                                 manager.persistQueue(for: session)
                                 // Discarding the head can unblock a successor
                                 // that was waiting behind a `lastError` head.
@@ -223,7 +226,8 @@ private struct ACPSessionView: View {
                             sessionId: sessionId,
                             text: text,
                             attachments: attachments,
-                            intent: intent
+                            intent: intent,
+                            draft: draft
                         ) { succeeded in
                             if suspendedRevision >= 0 {
                                 if succeeded {

--- a/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
+++ b/AlasTests/ACP/Session/ACPSessionQueueAPITests.swift
@@ -159,4 +159,92 @@ struct ACPSessionQueueAPITests {
         #expect(s.queue[0].blocks == [.text("restored")])
         #expect(s.queue[1].blocks == [.text("existing-pending")])
     }
+
+    @Test("enqueue(blocks:draft:) stores the structured draft on the item")
+    func enqueueWithDraft() {
+        let s = mkSession()
+        let draft = ACPComposerDraft(segments: [.text("hi")])
+        s.enqueue(blocks: [.text("hi")], draft: draft)
+        #expect(s.queue[0].draft == draft)
+    }
+
+    @Test("takeForEditing removes a pending item and returns its restorable draft")
+    func takeForEditingPending() {
+        let s = mkSession()
+        let draft = ACPComposerDraft(segments: [.text("edit me")])
+        s.enqueue(blocks: [.text("edit me")], draft: draft)
+        let id = s.queue[0].id
+        let restored = s.takeForEditing(id: id)
+        #expect(restored == draft)
+        #expect(s.queue.isEmpty)
+    }
+
+    @Test("takeForEditing refuses a .sending item and leaves the queue intact")
+    func takeForEditingSendingNoop() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        s.markQueueHeadSending()
+        let id = s.queue[0].id
+        #expect(s.takeForEditing(id: id) == nil)
+        #expect(s.queue.count == 1)
+        #expect(s.queue[0].status == .sending)
+    }
+
+    @Test("takeForEditing returns nil for an unknown id")
+    func takeForEditingUnknown() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("a")])
+        #expect(s.takeForEditing(id: UUID()) == nil)
+        #expect(s.queue.count == 1)
+    }
+
+    @Test("takeForEditing is lossless where the blocks heuristic would misclaim a literal @name")
+    func takeForEditingLossless() {
+        let s = mkSession()
+        // Draft: a literal "@here" the user typed, then a real chip for a file named "here".
+        let draft = ACPComposerDraft(segments: [
+            .text("ping @here and "),
+            .mention(displayName: "here", uri: "file:///here")
+        ])
+        // The lossy wire form `extract`+`blocks` would produce for that draft.
+        let blocks: [ACPContentBlock] = [
+            .text("ping @here and @here "),
+            .resourceLink(uri: "file:///here", name: "here")
+        ]
+        // Heuristic inverse misclaims the FIRST "@here " (the literal) — the bug.
+        #expect(ACPComposerDraft(blocks: blocks) != draft)
+        // With the stored draft, restore is exact — the fix.
+        s.enqueue(blocks: blocks, draft: draft)
+        #expect(s.takeForEditing(id: s.queue[0].id) == draft)
+    }
+
+    @Test("editQueueItem clears the stored draft so a later edit reflects the new blocks")
+    func editQueueItemClearsDraft() {
+        let s = mkSession()
+        s.enqueue(blocks: [.text("old")],
+                  draft: ACPComposerDraft(segments: [.text("old")]))
+        let id = s.queue[0].id
+        s.editQueueItem(id: id, blocks: [.text("new")])
+        #expect(s.queue[0].draft == nil)
+        // With the draft cleared, restorableDraft is the heuristic over the new
+        // blocks. Assert the concrete expected segments (not the same
+        // initializer) so this proves the structure rather than Equatable reflexivity.
+        #expect(s.queue[0].restorableDraft == ACPComposerDraft(segments: [.text("new")]))
+    }
+
+    @Test("takeForEditing on a draft-less pending item returns the blocks heuristic")
+    func takeForEditingFallsBackWhenNoDraft() {
+        let s = mkSession()
+        // Enqueued without a draft (legacy/recovery path): restore must fall
+        // back to the heuristic inverse of the blocks.
+        let blocks: [ACPContentBlock] = [.text("see @File.swift "),
+                                         .resourceLink(uri: "file:///File.swift", name: "File.swift")]
+        s.enqueue(blocks: blocks)
+        let restored = s.takeForEditing(id: s.queue[0].id)
+        #expect(restored == ACPComposerDraft(segments: [
+            .text("see "),
+            .mention(displayName: "File.swift", uri: "file:///File.swift"),
+        ]))
+        #expect(s.queue.isEmpty)
+    }
 }

--- a/AlasTests/ACP/Session/QueuedPromptTests.swift
+++ b/AlasTests/ACP/Session/QueuedPromptTests.swift
@@ -46,7 +46,9 @@ struct QueuedPromptTests {
         ])
         let original = QueuedPrompt(
             id: UUID(),
-            // The "@File.swift " marker consumes one trailing space; " please" remains.
+            // `extract` emits "review " + "@File.swift " (the marker adds its own
+            // trailing space) and the following text keeps its leading space in
+            // " please" — hence the double space before "please".
             blocks: [.text("review @File.swift  please"),
                      .resourceLink(uri: "file:///tmp/File.swift", name: "File.swift")],
             enqueuedAt: Date(timeIntervalSince1970: 1_700_000_000),

--- a/AlasTests/ACP/Session/QueuedPromptTests.swift
+++ b/AlasTests/ACP/Session/QueuedPromptTests.swift
@@ -36,4 +36,55 @@ struct QueuedPromptTests {
         let json = String(data: try JSONEncoder().encode(q), encoding: .utf8)!
         #expect(json.contains("\"status\":\"sending\""))
     }
+
+    @Test("draft round-trips through JSON when present")
+    func draftRoundTrip() throws {
+        let draft = ACPComposerDraft(segments: [
+            .text("review "),
+            .mention(displayName: "File.swift", uri: "file:///tmp/File.swift"),
+            .text(" please")
+        ])
+        let original = QueuedPrompt(
+            id: UUID(),
+            // The "@File.swift " marker consumes one trailing space; " please" remains.
+            blocks: [.text("review @File.swift  please"),
+                     .resourceLink(uri: "file:///tmp/File.swift", name: "File.swift")],
+            enqueuedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            draft: draft
+        )
+        let decoded = try JSONDecoder().decode(
+            QueuedPrompt.self, from: try JSONEncoder().encode(original))
+        #expect(decoded == original)
+        #expect(decoded.draft == draft)
+    }
+
+    @Test("legacy JSON without a draft key decodes to nil")
+    func legacyNoDraftKey() throws {
+        let legacy = QueuedPrompt(
+            id: UUID(), blocks: [.text("hi")],
+            enqueuedAt: Date(timeIntervalSince1970: 1), status: .pending)
+        let json = String(data: try JSONEncoder().encode(legacy), encoding: .utf8)!
+        #expect(!json.contains("\"draft\""))   // nil optional is omitted on encode
+        let decoded = try JSONDecoder().decode(
+            QueuedPrompt.self, from: Data(json.utf8))
+        #expect(decoded.draft == nil)
+    }
+
+    @Test("restorableDraft prefers the stored draft, else falls back to the blocks heuristic")
+    func restorableDraftFallback() {
+        let draft = ACPComposerDraft(segments: [.text("kept")])
+        let withDraft = QueuedPrompt(id: UUID(), blocks: [.text("ignored")],
+                                     enqueuedAt: .init(), draft: draft)
+        #expect(withDraft.restorableDraft == draft)
+
+        let blocks: [ACPContentBlock] = [.text("hello @File.swift "),
+                                         .resourceLink(uri: "file:///File.swift", name: "File.swift")]
+        let noDraft = QueuedPrompt(id: UUID(), blocks: blocks, enqueuedAt: .init())
+        // Spell out the heuristic's expected output so this asserts a concrete
+        // value, not a tautology against the same initializer.
+        #expect(noDraft.restorableDraft == ACPComposerDraft(segments: [
+            .text("hello "),
+            .mention(displayName: "File.swift", uri: "file:///File.swift"),
+        ]))
+    }
 }


### PR DESCRIPTION
## What & why

Follow-up to #378 ("A"), addressing the two threads of Codex feedback that were deferred there.

### 1. Lossless queued-prompt round-trip
The composer holds structured state (`ACPComposerDraft.segments`: `.text`/`.mention`). On submit it's flattened to wire `blocks` (`[.text(wholeString), .resourceLink…]`), which loses the chip-vs-literal distinction — so editing a queued prompt had to invert it with a heuristic forward-scan (`ACPComposerDraft(blocks:)`) that could misclaim a literal `@name` the user typed. In #378 I accepted that as a limitation, noting a lossless fix needs to stop relying on inverting the lossy serialization.

**Fix:** capture the structured draft on the queued item — `QueuedPrompt.draft` (optional, persisted, tolerant decode) — and restore from it exactly via `restorableDraft`. The wire `blocks` are **unchanged**; `draft` is additive and read only on edit-restore. The heuristic survives solely as a fallback for draft-less items (pre-upgrade persisted, recovery-path, rolled-back sends).

### 2. Queue-edit race (the unaddressed thread on #378)
`removeFromQueue(id:)` no-ops once an item is `.sending`, but `onQueueEdit` restored into the composer **then** removed — so a flusher promoting the item between render and click could duplicate an in-flight prompt.

**Fix:** `ACPSession.takeForEditing(id:)` atomically removes-and-returns the restorable draft **only if still `.pending`** (nil otherwise). `@MainActor`-confined, so the check/remove can't interleave. The UI restores only on non-nil.

## How
- `QueuedPrompt.draft: ACPComposerDraft?` + `restorableDraft` (prefers draft, else heuristic).
- `ACPSession`: `enqueue(blocks:draft:)`, atomic `takeForEditing(id:)`, `editQueueItem` clears the stale draft when blocks change.
- Thread optional `draft` through `ACPSessionManager.submit` / `enqueueWhileRecovering` / `ACPSessionRunner.send` to the `.enqueue` route (ignored on `sendNow`/`steer`).
- `ACPTabView`: `onQueueEdit` → `takeForEditing`; submit forwards `draft`.

## Tests
- `QueuedPrompt`: draft codable round-trip, legacy JSON (no draft key) → nil, `restorableDraft` fallback.
- `ACPSession` queue API: `enqueue(draft:)`, `takeForEditing` for pending/sending/unknown/no-draft, the **lossless `@name`-collision** proof (heuristic misclaims vs stored-draft exact), `editQueueItem` clears draft.
- 44 tests across the ACP session/composer/manager/store suites pass; app target builds.

## Test plan (manual UI)
- [ ] Mid-text mention round-trips on edit (chip stays a chip, no duplicate)
- [ ] Literal `@name` + a chip for a same-named file both restore correctly
- [ ] Clicking edit on a `.sending` item does nothing (no duplication)
- [ ] Non-empty composer: queued item appends after typed text without clobbering
- [ ] Mention restores correctly after app relaunch (persistence path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)