### PR TITLE
fix(ACP): only pause tail-follow on user-driven scroll

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -414,13 +414,7 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
         }
 
         private static var isUserDrivenScrollEvent: Bool {
-            guard let event = NSApp.currentEvent else { return false }
-            switch event.type {
-            case .scrollWheel, .leftMouseDragged, .gesture, .magnify, .swipe:
-                return true
-            default:
-                return false
-            }
+            ACPUserScrollEvent.isUserDriven(NSApp.currentEvent?.type)
         }
     }
 
@@ -444,6 +438,33 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
                     ancestor = view.superview
                 }
             }
+        }
+    }
+}
+
+/// Maps an `NSEvent.EventType` to whether it represents a live user scroll
+/// gesture, used by `ACPScrollEventObserver` to decide if an upward bounds
+/// change is deliberate. Extracted as a pure function so the mapping is unit
+/// testable without a running event loop.
+///
+/// `.keyDown` is deliberately excluded: the transcript `ScrollView` is never
+/// the first responder here (the composer owns focus), so keyboard paging
+/// can't scroll it — and because `NSApp.currentEvent` reports the most recent
+/// app-wide event, accepting `.keyDown` would misread composer typing during
+/// streaming as a scroll and falsely pause tail-following.
+enum ACPUserScrollEvent {
+    static func isUserDriven(_ type: NSEvent.EventType?) -> Bool {
+        guard let type else { return false }
+        switch type {
+        case .scrollWheel, .leftMouseDragged, .leftMouseDown, .gesture, .magnify, .swipe:
+            // scrollWheel/gesture/magnify/swipe: trackpad. leftMouseDragged:
+            // dragging the scroller knob. leftMouseDown: clicking the scrollbar
+            // track to page — held while the scroll happens, so its staleness
+            // window is bounded (unlike leftMouseUp/keyDown, which linger after
+            // any click or keystroke).
+            return true
+        default:
+            return false
         }
     }
 }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -447,21 +447,23 @@ private struct ACPScrollEventObserver: NSViewRepresentable {
 /// change is deliberate. Extracted as a pure function so the mapping is unit
 /// testable without a running event loop.
 ///
-/// `.keyDown` is deliberately excluded: the transcript `ScrollView` is never
-/// the first responder here (the composer owns focus), so keyboard paging
-/// can't scroll it — and because `NSApp.currentEvent` reports the most recent
-/// app-wide event, accepting `.keyDown` would misread composer typing during
-/// streaming as a scroll and falsely pause tail-following.
+/// The set is deliberately narrow. `NSApp.currentEvent` reports the most
+/// recent app-wide event, not the cause of the bounds change, so any event
+/// type that also occurs away from scrolling would misattribute layout reflow
+/// during streaming and re-latch the false pause this guards against:
+///   - `.keyDown`: the transcript `ScrollView` never holds key focus here (the
+///     composer owns it), so keyboard paging can't scroll it; accepting it
+///     would catch composer typing during streaming.
+///   - `.leftMouseDown` / `.leftMouseUp`: a bare click can't be told apart from
+///     clicking a transcript control (expanding a card, the copy button) by
+///     type alone, so it would catch reflow that coincides with such a click.
+/// The covered cases (trackpad and dragging the scroller knob) only fire while
+/// actually scrolling, so they can't be confused with idle layout reflow.
 enum ACPUserScrollEvent {
     static func isUserDriven(_ type: NSEvent.EventType?) -> Bool {
         guard let type else { return false }
         switch type {
-        case .scrollWheel, .leftMouseDragged, .leftMouseDown, .gesture, .magnify, .swipe:
-            // scrollWheel/gesture/magnify/swipe: trackpad. leftMouseDragged:
-            // dragging the scroller knob. leftMouseDown: clicking the scrollbar
-            // track to page — held while the scroll happens, so its staleness
-            // window is bounded (unlike leftMouseUp/keyDown, which linger after
-            // any click or keystroke).
+        case .scrollWheel, .leftMouseDragged, .gesture, .magnify, .swipe:
             return true
         default:
             return false

--- a/Alas/Sources/ACP/UI/ACPScrollDirectionClassifier.swift
+++ b/Alas/Sources/ACP/UI/ACPScrollDirectionClassifier.swift
@@ -36,7 +36,14 @@ enum ACPScrollDirectionClassifier {
         if distanceFromBottom <= bottomTolerance { return .userAtBottom }
         guard let prev = previousOffsetY else { return .noChange }
         let movedUp = newOffsetY < prev - upwardEpsilon
-        guard distanceFromBottom > pauseTolerance, movedUp else { return .noChange }
+        // Only a live scroll gesture pauses tail-following. Bounds changes
+        // with no current input event are layout, not intent: a tool card
+        // above the fold finishing async layout, streaming content reflow, or
+        // animated-restore lag can shift the viewport upward past
+        // `pauseTolerance` on their own. Treating those as "user scrolled up"
+        // is what made the transcript jump up a few lines and stop following
+        // while agents were still streaming.
+        guard isUserDriven, movedUp, distanceFromBottom > pauseTolerance else { return .noChange }
         return .userScrolledUp
     }
 }

--- a/AlasTests/ACPScrollDirectionClassifierTests.swift
+++ b/AlasTests/ACPScrollDirectionClassifierTests.swift
@@ -79,7 +79,8 @@ struct ACPScrollDirectionClassifierTests {
             newOffsetY: 900,
             viewportHeight: 600,
             contentHeight: 5000,
-            isRestoring: false
+            isRestoring: false,
+            isUserDriven: true
         )
         #expect(decision == .userScrolledUp)
     }
@@ -167,9 +168,29 @@ struct ACPScrollDirectionClassifierTests {
             newOffsetY: newY,
             viewportHeight: viewportH,
             contentHeight: contentH,
-            isRestoring: false
+            isRestoring: false,
+            isUserDriven: true
         )
         #expect(decision == .userScrolledUp)
+    }
+
+    @Test func layoutInducedUpwardMoveAwayFromTailDoesNotPause() {
+        // The classic "jumps up a few lines on its own" failure: a tool card
+        // above the fold finishing async layout (or restore lag) shifts the
+        // viewport past pauseTolerance with NO live scroll gesture. Without a
+        // user event this must not latch auto-scroll off.
+        let viewportH: CGFloat = 600
+        let contentH: CGFloat = 5000
+        let newY = contentH - viewportH - 180
+        let decision = ACPScrollDirectionClassifier.decide(
+            previousOffsetY: newY + 20,
+            newOffsetY: newY,
+            viewportHeight: viewportH,
+            contentHeight: contentH,
+            isRestoring: false,
+            isUserDriven: false
+        )
+        #expect(decision == .noChange)
     }
 
     @Test func restoringUserInputNearTailDoesNotPause() {
@@ -235,7 +256,8 @@ struct ACPScrollDirectionClassifierTests {
             newOffsetY: 1000 - ACPScrollDirectionClassifier.upwardEpsilon - 0.01,
             viewportHeight: 600,
             contentHeight: 5000,
-            isRestoring: false
+            isRestoring: false,
+            isUserDriven: true
         )
         #expect(decision == .userScrolledUp)
     }
@@ -295,7 +317,8 @@ struct ACPScrollDirectionClassifierTests {
             newOffsetY: newY,
             viewportHeight: viewportH,
             contentHeight: contentH,
-            isRestoring: false
+            isRestoring: false,
+            isUserDriven: true
         )
         #expect(decision == .userScrolledUp)
     }

--- a/AlasTests/ACPUserScrollEventTests.swift
+++ b/AlasTests/ACPUserScrollEventTests.swift
@@ -15,11 +15,15 @@ struct ACPUserScrollEventTests {
         #expect(ACPUserScrollEvent.isUserDriven(.leftMouseDragged))
     }
 
-    @Test func scrollbarTrackClickIsUserDriven() {
-        // Clicking the scrollbar track to page arrives as a button-held
-        // leftMouseDown rather than a scrollWheel; it is still a deliberate
-        // user scroll and must be allowed to pause tail-following.
-        #expect(ACPUserScrollEvent.isUserDriven(.leftMouseDown))
+    @Test func plainMouseDownIsNotScrollIntent() {
+        // A bare leftMouseDown is "any left click" — it can't be distinguished
+        // from clicking a transcript control (expanding/collapsing a card, the
+        // copy button) by event type alone. If such a click coincides with a
+        // streaming/layout reflow that shifts the clip view upward, treating it
+        // as a scroll would re-latch the false pause this change prevents. Only
+        // the knob drag (leftMouseDragged) counts; track-click paging is a rare
+        // interaction not worth that regression.
+        #expect(!ACPUserScrollEvent.isUserDriven(.leftMouseDown))
     }
 
     @Test func keyboardIsNotTreatedAsScroll() {

--- a/AlasTests/ACPUserScrollEventTests.swift
+++ b/AlasTests/ACPUserScrollEventTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import AppKit
+@testable import Alas
+
+struct ACPUserScrollEventTests {
+    @Test func trackpadScrollIsUserDriven() {
+        #expect(ACPUserScrollEvent.isUserDriven(.scrollWheel))
+        #expect(ACPUserScrollEvent.isUserDriven(.gesture))
+        #expect(ACPUserScrollEvent.isUserDriven(.magnify))
+        #expect(ACPUserScrollEvent.isUserDriven(.swipe))
+    }
+
+    @Test func scrollerKnobDragIsUserDriven() {
+        // Dragging the scrollbar knob arrives as leftMouseDragged.
+        #expect(ACPUserScrollEvent.isUserDriven(.leftMouseDragged))
+    }
+
+    @Test func scrollbarTrackClickIsUserDriven() {
+        // Clicking the scrollbar track to page arrives as a button-held
+        // leftMouseDown rather than a scrollWheel; it is still a deliberate
+        // user scroll and must be allowed to pause tail-following.
+        #expect(ACPUserScrollEvent.isUserDriven(.leftMouseDown))
+    }
+
+    @Test func keyboardIsNotTreatedAsScroll() {
+        // The transcript ScrollView never holds key focus (the composer does),
+        // and currentEvent is app-wide, so keyDown would misattribute composer
+        // typing during streaming. It must not count as a user scroll.
+        #expect(!ACPUserScrollEvent.isUserDriven(.keyDown))
+    }
+
+    @Test func incidentalEventsAreNotUserDriven() {
+        #expect(!ACPUserScrollEvent.isUserDriven(.mouseMoved))
+        #expect(!ACPUserScrollEvent.isUserDriven(.leftMouseUp))
+        #expect(!ACPUserScrollEvent.isUserDriven(nil))
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #375. Auto-scroll still latched off — the transcript would jump up a few lines on its own and stop following — especially while many tools stream into the ACP chat.

## Root Cause

`ACPScrollDirectionClassifier.decide` computes `isUserDriven` (from `NSApp.currentEvent`) but only used it to override the `isRestoring` early-return. The pause decision itself never required it, so **any** upward bounds change beyond `pauseTolerance` disabled tail-following — even one with no live scroll gesture.

While many tools stream, two things combine:

1. Animated `scrollToTail` lags behind large/frequent content jumps and async card layout, so the viewport drifts past the 160pt tolerance while still following (pure content growth doesn't move the clip origin, so the classifier isn't re-invoked to re-pin).
2. A tool card above the fold then finishes async layout / status reflow and shifts everything down a few lines. That layout-induced upward move (`isUserDriven == false`) satisfied `distanceFromBottom > pauseTolerance && movedUp` and was misread as a deliberate scroll-up → auto-scroll latched off.

The prior test `upwardMoveMeaningfullyAwayFromTailPauses` encoded the bug: `isUserDriven` defaulted to false yet expected `.userScrolledUp`.

## Changes

- Require `isUserDriven` to emit `.userScrolledUp`. A bounds change with no current input event is layout, never intent — so streaming reflow, content growth, and restore lag never pause tail-following.
- Resume-at-bottom and user-interrupt-during-restore paths are unchanged.
- Add `layoutInducedUpwardMoveAwayFromTailDoesNotPause`; update the user-scroll tests to pass `isUserDriven: true` (their actual intent).

## Validation

- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPScrollDirectionClassifierTests` passed: 24 tests.
- Full project compiled clean.