### PR TITLE
feat(acp): allow minimizing task sidebar

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -35,6 +35,10 @@ final class ACPSession: ObservableObject, Identifiable {
     /// list follows new content and restores to the latest bottom after
     /// returning to this session. Set false when the user scrolls upward.
     @Published var followsTranscriptTail: Bool = true
+    /// Runtime-only user override for the inline plan sidebar. This is
+    /// deliberately not persisted; it only survives while this in-memory
+    /// ACP session object is retained.
+    @Published var planSidebarMinimized: Bool = false
     /// Lifecycle state of the agent process backing this session.
     /// Single source of truth for the composer, header pill, and runner
     /// registry checks.

--- a/Alas/Sources/ACP/UI/ACPPlanChecklist.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanChecklist.swift
@@ -8,6 +8,7 @@ import SwiftUI
 /// Spec: `docs/superpowers/specs/2026-05-29-acp-plan-sidebar-design.md`
 struct ACPPlanChecklist: View {
     let items: [ACPMessage.PlanItem]
+    var onMinimize: (() -> Void)? = nil
     @Environment(\.theme) private var theme
 
     private var done: Int { items.filter { $0.status == "completed" }.count }
@@ -41,6 +42,18 @@ struct ACPPlanChecklist: View {
                 .font(.system(size: 10.5, design: .monospaced))
                 .foregroundStyle(theme.color("fg-faint"))
             Spacer()
+            if let onMinimize {
+                Button(action: onMinimize) {
+                    Image(systemName: "minus")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(theme.color("fg-faint"))
+                        .frame(width: 20, height: 18)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Minimize tasks to toolbar")
+                .accessibilityLabel("Minimize tasks")
+            }
         }
         .padding(.horizontal, 12).padding(.vertical, 8)
         .background(theme.color("bg-2").opacity(0.4))

--- a/Alas/Sources/ACP/UI/ACPPlanPill.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanPill.swift
@@ -28,6 +28,8 @@ extension EnvironmentValues {
 /// `transcript.objectWillChange`).
 struct ACPPlanPill: View {
     @ObservedObject var transcript: ACPTranscript
+    var sidebarUserMinimized: Bool = false
+    var onRestoreSidebar: () -> Void = {}
     @Environment(\.theme) private var theme
     @Environment(\.acpPlanSidebarVisible) private var sidebarVisible
     @State private var popoverOpen = false
@@ -38,7 +40,14 @@ struct ACPPlanPill: View {
         // popover open at the moment the sidebar appears would never
         // be told to close, and would linger next to the sidebar.
         Group {
-            if !sidebarVisible, let state = ACPPlanPillState(items: transcript.currentPlan) {
+            if sidebarUserMinimized,
+               ACPPlanSidebarVisibility.restorePillVisible(
+                    hasPlan: transcript.latestPlan?.isEmpty == false,
+                    userMinimized: sidebarUserMinimized
+               ),
+               let state = ACPPlanPillState(items: transcript.latestPlan) {
+                pill(state: state, mode: .restore)
+            } else if !sidebarVisible, let state = ACPPlanPillState(items: transcript.currentPlan) {
                 pill(state: state)
             } else {
                 EmptyView()
@@ -49,10 +58,21 @@ struct ACPPlanPill: View {
         }
     }
 
+    private enum Mode {
+        case popover
+        case restore
+    }
+
     @ViewBuilder
-    private func pill(state: ACPPlanPillState) -> some View {
+    private func pill(state: ACPPlanPillState, mode: Mode = .popover) -> some View {
         Button {
-            popoverOpen.toggle()
+            switch mode {
+            case .popover:
+                popoverOpen.toggle()
+            case .restore:
+                popoverOpen = false
+                onRestoreSidebar()
+            }
         } label: {
             HStack(spacing: 8) {
                 statusDot(animating: state.isAnimating)
@@ -66,7 +86,7 @@ struct ACPPlanPill: View {
                     .truncationMode(.tail)
                 Spacer(minLength: 8)
                 progressBar(done: state.done, total: state.total)
-                Image(systemName: popoverOpen ? "chevron.up" : "chevron.down")
+                Image(systemName: accessoryIconName(mode: mode))
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(theme.color("fg-faint"))
             }
@@ -78,11 +98,13 @@ struct ACPPlanPill: View {
             .shadow(color: .black.opacity(0.18), radius: 4, y: 1)
         }
         .buttonStyle(.plain)
-        .help("Plan — click to view all steps")
+        .help(mode == .restore ? "Restore tasks sidebar" : "Plan — click to view all steps")
         .popover(isPresented: $popoverOpen, arrowEdge: .top) {
-            if let items = transcript.currentPlan, !items.isEmpty {
-                ACPPlanChecklist(items: items)
-                    .frame(width: 320)
+            if mode == .popover {
+                if let items = transcript.currentPlan, !items.isEmpty {
+                    ACPPlanChecklist(items: items)
+                        .frame(width: 320)
+                }
             }
         }
     }
@@ -95,6 +117,15 @@ struct ACPPlanPill: View {
             ],
             startPoint: .top, endPoint: .bottom
         )
+    }
+
+    private func accessoryIconName(mode: Mode) -> String {
+        switch mode {
+        case .restore:
+            return "sidebar.right"
+        case .popover:
+            return popoverOpen ? "chevron.up" : "chevron.down"
+        }
     }
 
     @ViewBuilder

--- a/Alas/Sources/ACP/UI/ACPPlanSidebar.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanSidebar.swift
@@ -13,6 +13,7 @@ import SwiftUI
 /// Spec: `docs/superpowers/specs/2026-05-29-acp-plan-sidebar-design.md` (§3)
 struct ACPPlanSidebar: View {
     @ObservedObject var transcript: ACPTranscript
+    let onMinimize: () -> Void
     @Environment(\.theme) private var theme
 
     private let cornerRadius: CGFloat = 12
@@ -22,7 +23,7 @@ struct ACPPlanSidebar: View {
         let animating = items.contains { $0.status == "in_progress" }
         ScrollView(.vertical, showsIndicators: false) {
             if !items.isEmpty {
-                ACPPlanChecklist(items: items)
+                ACPPlanChecklist(items: items, onMinimize: onMinimize)
                     .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
                     .overlay(laserBorder(animating: animating))
                     .shadow(color: .black.opacity(0.28), radius: 8, y: 2)

--- a/Alas/Sources/ACP/UI/ACPPlanSidebarVisibility.swift
+++ b/Alas/Sources/ACP/UI/ACPPlanSidebarVisibility.swift
@@ -16,14 +16,26 @@ enum ACPPlanSidebarVisibility {
     /// Returns the next visibility given the current pane width, whether
     /// a plan is available, and whether the sidebar is currently shown.
     ///
+    /// - If user-minimized: always hidden until the restore action clears
+    ///   the override.
     /// - If no plan: always hidden (the sidebar has no empty state).
     /// - If width ≥ `showThreshold`: shown.
     /// - If width < `hideThreshold`: hidden.
     /// - Otherwise (dead band): keep `current`.
-    static func next(paneWidth: CGFloat, hasPlan: Bool, current: Bool) -> Bool {
+    static func next(
+        paneWidth: CGFloat,
+        hasPlan: Bool,
+        current: Bool,
+        userMinimized: Bool = false
+    ) -> Bool {
+        guard !userMinimized else { return false }
         guard hasPlan else { return false }
         if paneWidth >= showThreshold { return true }
         if paneWidth < hideThreshold { return false }
         return current
+    }
+
+    static func restorePillVisible(hasPlan: Bool, userMinimized: Bool) -> Bool {
+        hasPlan && userMinimized
     }
 }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -67,7 +67,8 @@ private struct ACPSessionView: View {
         let next = ACPPlanSidebarVisibility.next(
             paneWidth: paneWidth,
             hasPlan: hasPlan,
-            current: showPlanSidebar
+            current: showPlanSidebar,
+            userMinimized: session.planSidebarMinimized
         )
         if next != showPlanSidebar {
             withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
@@ -83,7 +84,11 @@ private struct ACPSessionView: View {
                 manager: manager,
                 agentLookup: { state.agent(id: $0) },
                 state: state,
-                worktree: worktree
+                worktree: worktree,
+                planSidebarUserMinimized: session.planSidebarMinimized,
+                onRestorePlanSidebar: {
+                    session.planSidebarMinimized = false
+                }
             )
             adapterBanner()
             if let err = session.lastError {
@@ -270,7 +275,10 @@ private struct ACPSessionView: View {
                 }
 
                 if showPlanSidebar {
-                    ACPPlanSidebar(transcript: session.transcript)
+                    ACPPlanSidebar(
+                        transcript: session.transcript,
+                        onMinimize: { session.planSidebarMinimized = true }
+                    )
                         .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
             }
@@ -280,6 +288,9 @@ private struct ACPSessionView: View {
                 updatePlanSidebar(paneWidth: newWidth)
             }
             .onChange(of: session.transcript.latestPlan) { _, _ in
+                updatePlanSidebar(paneWidth: proxy.size.width)
+            }
+            .onChange(of: session.planSidebarMinimized) { _, _ in
                 updatePlanSidebar(paneWidth: proxy.size.width)
             }
         }

--- a/Alas/Sources/ACP/UI/ACPToolbar.swift
+++ b/Alas/Sources/ACP/UI/ACPToolbar.swift
@@ -6,6 +6,8 @@ struct ACPToolbar: View {
     let agentLookup: (String) -> AgentDefinition?
     let state: AppState
     let worktree: Worktree
+    let planSidebarUserMinimized: Bool
+    let onRestorePlanSidebar: () -> Void
     @Environment(\.theme) private var theme
 
     var body: some View {
@@ -18,7 +20,11 @@ struct ACPToolbar: View {
                 agentLookup: agentLookup
             )
             ACPRecoveryPill(session: session)
-            ACPPlanPill(transcript: session.transcript)
+            ACPPlanPill(
+                transcript: session.transcript,
+                sidebarUserMinimized: planSidebarUserMinimized,
+                onRestoreSidebar: onRestorePlanSidebar
+            )
                 .layoutPriority(1)
         }
         .padding(.horizontal, 12)

--- a/AlasTests/ACP/UI/ACPPlanSidebarVisibilityTests.swift
+++ b/AlasTests/ACP/UI/ACPPlanSidebarVisibilityTests.swift
@@ -64,6 +64,39 @@ struct ACPPlanSidebarVisibilityTests {
         #expect(ACPPlanSidebarVisibility.next(paneWidth: 1500, hasPlan: false, current: true) == false)
     }
 
+    @Test("user-minimized override hides even when wide")
+    func userMinimizedOverrideHides() {
+        #expect(ACPPlanSidebarVisibility.next(
+            paneWidth: 1500,
+            hasPlan: true,
+            current: true,
+            userMinimized: true
+        ) == false)
+    }
+
+    @Test("clearing user-minimized override restores normal width rules")
+    func clearingUserMinimizedOverrideRestoresWidthRules() {
+        #expect(ACPPlanSidebarVisibility.next(
+            paneWidth: 1500,
+            hasPlan: true,
+            current: false,
+            userMinimized: false
+        ) == true)
+        #expect(ACPPlanSidebarVisibility.next(
+            paneWidth: 500,
+            hasPlan: true,
+            current: false,
+            userMinimized: false
+        ) == false)
+    }
+
+    @Test("restore pill only appears while user-minimized with a plan")
+    func restorePillVisibility() {
+        #expect(ACPPlanSidebarVisibility.restorePillVisible(hasPlan: true, userMinimized: true) == true)
+        #expect(ACPPlanSidebarVisibility.restorePillVisible(hasPlan: false, userMinimized: true) == false)
+        #expect(ACPPlanSidebarVisibility.restorePillVisible(hasPlan: true, userMinimized: false) == false)
+    }
+
     @Test("thresholds are 900 show / 820 hide")
     func thresholdConstants() {
         #expect(ACPPlanSidebarVisibility.showThreshold == 900)


### PR DESCRIPTION
## Summary
- add session-scoped ACP plan sidebar minimization state
- show a toolbar restore pill when the task sidebar is user-minimized
- cover minimized override, restore, and restore-pill visibility in reducer tests

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test (fails in unrelated ACPComposerDraftBridgeTests/mentionRoundTrip())
- focused ACPPlanSidebarVisibilityTests