### PR TITLE
fix(acp): move focus outline to composer

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -14,6 +14,7 @@ struct ACPInputField: NSViewRepresentable {
     @ObservedObject var session: ACPSession
     let worktreeRoot: URL
     let actions: ACPComposerActions
+    @Binding var isFocused: Bool
     /// True when ⏎ should submit with `.auto` intent (the default mapping
     /// — queue while busy). False when the user inverted the setting so
     /// ⏎ steers; the placeholder reverses accordingly while busy.
@@ -66,6 +67,7 @@ struct ACPInputField: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
+        context.coordinator.isFocused = $isFocused
         context.coordinator.promptSuggestions = session.promptSuggestions
         context.coordinator.theme = context.environment.theme
         context.coordinator.sendOnEnter = sendOnEnter
@@ -77,6 +79,7 @@ struct ACPInputField: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
+        coordinator.isFocused.wrappedValue = false
         coordinator.flushPendingRestyleNow()
     }
 
@@ -99,6 +102,7 @@ struct ACPInputField: NSViewRepresentable {
         Coordinator(
             worktreeRoot: worktreeRoot,
             initialDraft: session.composerDraft,
+            isFocused: $isFocused,
             sendOnEnter: sendOnEnter,
             onDraftChange: onDraftChange,
             onDraftClear: onDraftClear,
@@ -109,6 +113,7 @@ struct ACPInputField: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         let worktreeRoot: URL
         let initialDraft: ACPComposerDraft
+        var isFocused: Binding<Bool>
         /// Keyboard-only inversion flag. The coordinator resolves the
         /// raw modifier-derived intent (`.auto` for ⏎, `.steer` for ⌥⏎)
         /// against this and emits a FINAL intent to `onSubmit`. The
@@ -145,6 +150,7 @@ struct ACPInputField: NSViewRepresentable {
         init(
             worktreeRoot: URL,
             initialDraft: ACPComposerDraft,
+            isFocused: Binding<Bool> = .constant(false),
             sendOnEnter: Bool,
             onDraftChange: @escaping (ACPComposerDraft) -> Void,
             onDraftClear: @escaping () -> Void,
@@ -152,11 +158,20 @@ struct ACPInputField: NSViewRepresentable {
         ) {
             self.worktreeRoot = worktreeRoot
             self.initialDraft = initialDraft
+            self.isFocused = isFocused
             self.sendOnEnter = sendOnEnter
             self.lastSyncedDraft = initialDraft
             self.onDraftChange = onDraftChange
             self.onDraftClear = onDraftClear
             self.onSubmit = onSubmit
+        }
+
+        func textDidBeginEditing(_ notification: Notification) {
+            isFocused.wrappedValue = true
+        }
+
+        func textDidEndEditing(_ notification: Notification) {
+            isFocused.wrappedValue = false
         }
 
         func textView(_ textView: NSTextView, doCommandBy selector: Selector) -> Bool {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -15,7 +15,7 @@ struct ACPComposer: View {
     let onSubmit: ACPComposerSubmitHandler
 
     @Environment(\.theme) private var theme
-    @FocusState private var inputFocused: Bool
+    @State private var inputFocused = false
     @StateObject private var actions = ACPComposerActions()
     @State private var hasText: Bool = false
 
@@ -54,6 +54,7 @@ struct ACPComposer: View {
                 session: session,
                 worktreeRoot: worktreeRoot,
                 actions: actions,
+                isFocused: $inputFocused,
                 sendOnEnter: sendOnEnter,
                 onDraftChange: { draft in
                     manager.persistComposerDraft(draft, for: session)

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -158,7 +158,7 @@ struct ACPComposer: View {
     }
 
     private var borderColor: Color {
-        inputFocused ? theme.color("accent").opacity(0.7) : theme.color("line")
+        inputFocused ? theme.color("add").opacity(0.7) : theme.color("line")
     }
 
     // MARK: - Auto-run pill (was in the toolbar)

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -103,11 +103,8 @@ private struct ACPSessionView: View {
         .task(id: sessionId) {
             await hydrateAndAttach()
         }
-        .focusable()
-        .focusEffectDisabled()
-        .onKeyPress(.escape) {
+        .onExitCommand {
             handleEscape()
-            return .handled
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -104,6 +104,7 @@ private struct ACPSessionView: View {
             await hydrateAndAttach()
         }
         .focusable()
+        .focusEffectDisabled()
         .onKeyPress(.escape) {
             handleEscape()
             return .handled

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -1,11 +1,35 @@
 import AppKit
 import Foundation
+import SwiftUI
 import Testing
 @testable import Alas
 
 @MainActor
 @Suite("ACP composer draft bridge")
 struct ACPComposerDraftBridgeTests {
+    @Test("editing lifecycle updates composer focus binding")
+    func editingLifecycleUpdatesFocusBinding() {
+        var focused = false
+        let coordinator = ACPInputField.Coordinator(
+            worktreeRoot: URL(fileURLWithPath: "/tmp"),
+            initialDraft: .empty,
+            isFocused: Binding(
+                get: { focused },
+                set: { focused = $0 }
+            ),
+            sendOnEnter: true,
+            onDraftChange: { _ in },
+            onDraftClear: {},
+            onSubmit: { _, _, _, _, _ in true }
+        )
+
+        coordinator.textDidBeginEditing(Notification(name: NSText.didBeginEditingNotification))
+        #expect(focused)
+
+        coordinator.textDidEndEditing(Notification(name: NSText.didEndEditingNotification))
+        #expect(!focused)
+    }
+
     @Test("accepted submit restores structured draft when async completion fails")
     func acceptedSubmitRestoresDraftWhenCompletionFails() {
         let draft = ACPComposerDraft(segments: [


### PR DESCRIPTION
## Summary
- suppress the ACP pane-level focus effect while keeping keyboard focusability
- use the green add token for the focused ACP composer outline
- leave existing composer button focus styling unchanged

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- git diff --check

Full xcodebuild test was attempted during implementation but could not complete because the system volume ran out of space, then Xcode test orchestration stalled after moving DerivedData/TMPDIR to the external volume.