### PR TITLE
Restore ACP composer split action button

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		13E762EA8D84EFE6F0228806 /* AgentTerminalLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C3EC94DBE871DFC45C7D25 /* AgentTerminalLaunchTests.swift */; };
 		13FF5AC96D9F0C14264096D9 /* ImageDiffSideBySideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379D90AD620EAF6E84A04902 /* ImageDiffSideBySideView.swift */; };
 		14775ED3C1BC3A084B2147C1 /* HeadReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2EB554CB6AF797545DB95D /* HeadReader.swift */; };
+		14BC25FE7259A545420F28AA /* ComposerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */; };
 		162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */; };
 		165300DDFFB445D8AAE7A5E5 /* MarkdownFileTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */; };
 		16F5212404948970EAFCFE62 /* MarkdownPreviewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */; };
@@ -364,6 +365,7 @@
 		70FCC2B12AE446728EE7CF8D /* LSPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38499AFE31188908546EE222 /* LSPTransport.swift */; };
 		7146CECD7FE56140D7A7AF50 /* MergeConflictTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAC89A6B9D5DC926AC18E13 /* MergeConflictTabView.swift */; };
 		71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */; };
+		724CD1B1450DEC33DE6B0DE3 /* ComposerActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
 		7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */; };
@@ -1544,6 +1546,7 @@
 		EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigTerminalTests.swift; sourceTree = "<group>"; };
 		ECB537B70B998A15B81BCBF7 /* CodeTextViewIndentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewIndentationTests.swift; sourceTree = "<group>"; };
 		ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRenderer.swift; sourceTree = "<group>"; };
+		EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerActionTests.swift; sourceTree = "<group>"; };
 		EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileWriter.swift; sourceTree = "<group>"; };
 		EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffParserTests.swift; sourceTree = "<group>"; };
 		EE607EE1ACDE73C1DB0FCA00 /* SettingsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRow.swift; sourceTree = "<group>"; };
@@ -1589,6 +1592,7 @@
 		FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstaller.swift; sourceTree = "<group>"; };
 		FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipeTests.swift; sourceTree = "<group>"; };
 		FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceUpstreamTests.swift; sourceTree = "<group>"; };
+		FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerAction.swift; sourceTree = "<group>"; };
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
 		FEB2EC20D23F9A4F50B1A6E3 /* TerminalPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPane.swift; sourceTree = "<group>"; };
 		FEC68B05B719B9235865027F /* ThreePaneSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizing.swift; sourceTree = "<group>"; };
@@ -2225,6 +2229,7 @@
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
 				96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */,
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
+				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -2443,6 +2448,7 @@
 				0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */,
 				E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */,
 				CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */,
+				FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */,
 				531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */,
 			);
 			path = UI;
@@ -3432,6 +3438,7 @@
 				D2D5D79EE8DE82FC44C2D36A /* CompletionFeature.swift in Sources */,
 				FFC747D542D806E6CF6FCD03 /* CompletionPopup.swift in Sources */,
 				412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */,
+				14BC25FE7259A545420F28AA /* ComposerAction.swift in Sources */,
 				C2EDB6A5E6149758C4A0051E /* ConflictMarkerParser.swift in Sources */,
 				FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */,
 				A8A433243C4567927739F249 /* ContentResultGroup.swift in Sources */,
@@ -3838,6 +3845,7 @@
 				DEC1744FA9C8A26294FF0671 /* CompletionEngineTests.swift in Sources */,
 				CDE156FA8E19E85437E79908 /* CompletionFeatureTests.swift in Sources */,
 				B5E38A6134CDE9F8D5EA76D1 /* CompletionWindowControllerTests.swift in Sources */,
+				724CD1B1450DEC33DE6B0DE3 /* ComposerActionTests.swift in Sources */,
 				B54B0BFA87B2566DB59C3D59 /* ConflictMarkerParserTests.swift in Sources */,
 				5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */,
 				2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -500,6 +500,7 @@
 		9C73FEDF9B7B93D60FA3B51F /* ZmxClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47AF847BD698EAB373D128B /* ZmxClient.swift */; };
 		9C9EC609F3ED8EFF1151D611 /* JSONRPCFramerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
+		9CF6B43A0B19392A597A53EC /* ACPComposerActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */; };
 		9D2E53FB0A57BC38C146EA5E /* WorktreeLaunchSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941BC60920D6A87164610273 /* WorktreeLaunchSurface.swift */; };
 		9D439D5F19ACEB5A39B7CB68 /* CodexACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3985F2F58DB6E3BBF3520EFD /* CodexACPInstaller.swift */; };
 		9D4F9F5CE9FF51C33E32703C /* ACPMessageWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21F30DB5A812E396262A926 /* ACPMessageWire.swift */; };
@@ -1519,6 +1520,7 @@
 		E504D11F9B69ACCE7B8E5CA4 /* ACPTerminalHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalHost.swift; sourceTree = "<group>"; };
 		E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictMinimap.swift; sourceTree = "<group>"; };
 		E63FA8816D43E1A08AE8164B /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActionButton.swift; sourceTree = "<group>"; };
 		E6CA3930F30444A51FB2393D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolbar.swift; sourceTree = "<group>"; };
 		E7C070765F0474DF1C4ACEF0 /* session-new-response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-new-response.json"; sourceTree = "<group>"; };
@@ -2415,6 +2417,7 @@
 				D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */,
 				530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */,
 				C496549308D5C3DD20E988AD /* ACPComposer.swift */,
+				E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */,
 				2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */,
 				906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */,
 				DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */,
@@ -3284,6 +3287,7 @@
 				A70A62FDF7EA38F99D9E2B06 /* ACPClient.swift in Sources */,
 				EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */,
 				34F18AB368DC5D93196056CA /* ACPComposer.swift in Sources */,
+				9CF6B43A0B19392A597A53EC /* ACPComposerActionButton.swift in Sources */,
 				1C5D64F032EAD5EA28B2482B /* ACPComposerActions.swift in Sources */,
 				E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */,
 				C04150547C17399FA9D7947C /* ACPComposerShell.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -418,6 +418,7 @@
 		832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */; };
 		8352A6C0D7AE371907E50217 /* TreeSitterPython in Frameworks */ = {isa = PBXBuildFile; productRef = 7D55FFC5D9F65DAD0178FB0E /* TreeSitterPython */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
+		83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
 		8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */; };
 		8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */; };
@@ -837,6 +838,7 @@
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
 		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
 		04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdown.swift; sourceTree = "<group>"; };
+		0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserScrollEventTests.swift; sourceTree = "<group>"; };
 		0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessPill.swift; sourceTree = "<group>"; };
 		0594E7E039B5FC403783C6E8 /* ACPTerminal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminal.swift; sourceTree = "<group>"; };
 		05B122F66B2DEA7853804624 /* ShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorder.swift; sourceTree = "<group>"; };
@@ -1717,6 +1719,7 @@
 			children = (
 				3A110966FCF7EA47C18BE71A /* ACPAgentProfilesTests.swift */,
 				3D0190EE078ADB537982F7DC /* ACPScrollDirectionClassifierTests.swift */,
+				0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */,
 				D1CD33324CA36118FCEA2BE2 /* AdvancedSettingsVisibilityTests.swift */,
 				36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */,
 				4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */,
@@ -3778,6 +3781,7 @@
 				F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */,
 				6682233134C258D81E22D7AD /* ACPTranscriptMarkdownTests.swift in Sources */,
 				A3F27DE52BAC71EFFA69938A /* ACPTranscriptWindowTests.swift in Sources */,
+				83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */,
 				E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */,
 				162A6ABEAE92BB3AD1511567 /* AdvancedSettingsVisibilityTests.swift in Sources */,
 				FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPComposerDraft.swift
+++ b/Alas/Sources/ACP/Session/ACPComposerDraft.swift
@@ -16,6 +16,20 @@ struct ACPComposerDraft: Codable, Equatable {
         }
     }
 
+    /// True when the draft has any non-whitespace text or any mention.
+    /// Distinct from `isEmpty` (which is strictly structural) — use this
+    /// when deciding whether the user has typed something meaningful.
+    var hasContent: Bool {
+        segments.contains { segment in
+            switch segment {
+            case .text(let value):
+                return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .mention:
+                return true
+            }
+        }
+    }
+
     enum Segment: Codable, Equatable {
         case text(String)
         case mention(displayName: String, uri: String)

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -41,7 +41,7 @@ struct ACPComposerActionButton: View {
             .background(
                 RoundedRectangle(cornerRadius: 7).fill(theme.color("accent"))
             )
-            .overlay(badgeOverlay)
+            .overlay(alignment: .topTrailing) { badgeOverlay }
         }
         .buttonStyle(.plain)
         .help("Send (⏎)")
@@ -87,7 +87,7 @@ struct ACPComposerActionButton: View {
                 .padding(.horizontal, 11)
                 .frame(height: 26)
                 .background(theme.color("bg-3"))
-                .overlay(badgeOverlay)
+                .overlay(alignment: .topTrailing) { badgeOverlay }
             }
             .buttonStyle(.plain)
             .help("Queue (⏎). Hold ⌥ to steer.")
@@ -151,7 +151,6 @@ struct ACPComposerActionButton: View {
                 .background(Capsule().fill(theme.color("warn")))
                 .overlay(Capsule().strokeBorder(theme.color("bg-0"), lineWidth: 1))
                 .offset(x: 6, y: -6)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
                 .allowsHitTesting(false)
         }
     }

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+/// Single state-driven button that replaces the composer's separate Send
+/// and Stop affordances. Pure render of a `ComposerAction` — knows nothing
+/// about `ACPSession` or the runner. The shell wires `onPrimary` / `onMenu`
+/// to the appropriate `submitWithIntent` / `userCancel` calls.
+struct ACPComposerActionButton: View {
+    let action: ComposerAction
+    let onPrimary: () -> Void
+    let onMenu: (ComposerMenuItem) -> Void
+    let queueBadgeCount: Int
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        switch action {
+        case .hidden:
+            EmptyView()
+        case .send:
+            sendCapsule
+        case .stop:
+            stopCapsule
+        case .queue(let menu):
+            queueSplitCapsule(menu: menu)
+        }
+    }
+
+    // MARK: - Send (single capsule, accent-colored)
+
+    private var sendCapsule: some View {
+        Button(action: onPrimary) {
+            HStack(spacing: 5) {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 12, weight: .bold))
+                Text("Send")
+                    .font(.system(size: 11.5, weight: .semibold))
+            }
+            .foregroundStyle(theme.color("bg-0"))
+            .padding(.horizontal, 11)
+            .frame(height: 26)
+            .background(
+                RoundedRectangle(cornerRadius: 7).fill(theme.color("accent"))
+            )
+            .overlay(badgeOverlay)
+        }
+        .buttonStyle(.plain)
+        .help("Send (⏎)")
+    }
+
+    // MARK: - Stop (single capsule, destructive treatment)
+
+    private var stopCapsule: some View {
+        Button(action: onPrimary) {
+            HStack(spacing: 5) {
+                Image(systemName: "stop.fill")
+                    .font(.system(size: 10, weight: .bold))
+                Text("Stop")
+                    .font(.system(size: 11.5, weight: .semibold))
+            }
+            .foregroundStyle(theme.color("del"))
+            .padding(.horizontal, 11)
+            .frame(height: 26)
+            .background(
+                RoundedRectangle(cornerRadius: 7).fill(theme.color("del").opacity(0.15))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 7)
+                    .strokeBorder(theme.color("del").opacity(0.45), lineWidth: 0.75)
+            )
+        }
+        .buttonStyle(.plain)
+        .help("Stop the running turn (Esc)")
+    }
+
+    // MARK: - Queue (split capsule, primary + chevron menu)
+
+    private func queueSplitCapsule(menu: [ComposerMenuItem]) -> some View {
+        HStack(spacing: 1) {
+            Button(action: onPrimary) {
+                HStack(spacing: 5) {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 12, weight: .bold))
+                    Text("Queue")
+                        .font(.system(size: 11.5, weight: .semibold))
+                }
+                .foregroundStyle(theme.color("fg"))
+                .padding(.horizontal, 11)
+                .frame(height: 26)
+                .background(theme.color("bg-3"))
+                .overlay(badgeOverlay)
+            }
+            .buttonStyle(.plain)
+            .help("Queue (⏎). Hold ⌥ to steer.")
+
+            Menu {
+                ForEach(menu, id: \.self) { item in
+                    menuButton(for: item)
+                    if item == .steer, menu.contains(.stop) {
+                        Divider()
+                    }
+                }
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(theme.color("fg"))
+                    .padding(.horizontal, 7)
+                    .frame(height: 26)
+                    .background(theme.color("bg-3"))
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("More actions")
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .strokeBorder(theme.color("line"), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 7))
+    }
+
+    @ViewBuilder
+    private func menuButton(for item: ComposerMenuItem) -> some View {
+        switch item {
+        case .steer:
+            Button {
+                onMenu(.steer)
+            } label: {
+                Label("Steer running turn (⌥⏎)", systemImage: "arrow.turn.up.right")
+            }
+        case .stop:
+            Button(role: .destructive) {
+                onMenu(.stop)
+            } label: {
+                Label("Stop running turn (Esc)", systemImage: "stop.fill")
+            }
+        }
+    }
+
+    // MARK: - Queue count badge (rendered on Send & Queue primary halves)
+
+    @ViewBuilder
+    private var badgeOverlay: some View {
+        if queueBadgeCount > 0 {
+            Text("\(queueBadgeCount)")
+                .font(.system(size: 9, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(theme.color("bg-0"))
+                .padding(.horizontal, 4)
+                .frame(minWidth: 16, minHeight: 14)
+                .background(Capsule().fill(theme.color("warn")))
+                .overlay(Capsule().strokeBorder(theme.color("bg-0"), lineWidth: 1))
+                .offset(x: 6, y: -6)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+                .allowsHitTesting(false)
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -66,6 +66,9 @@ struct ACPComposer: View {
             .onAppear {
                 hasText = session.composerDraft.hasContent
             }
+            .onChange(of: session.composerDraftRevision) { _, _ in
+                hasText = session.composerDraft.hasContent
+            }
 
             HStack(spacing: 8) {
                 hint
@@ -317,13 +320,6 @@ struct ACPComposer: View {
                     manager.persist(session)
                 }
             }
-        }
-    }
-
-    private var isBusy: Bool {
-        switch session.transcript.streamingState {
-        case .streaming, .sending, .awaitingPermission: return true
-        case .idle: return false
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -340,8 +340,7 @@ struct ACPComposer: View {
         composerAction(
             streamingState: session.transcript.streamingState,
             hasText: hasText,
-            attached: session.attached,
-            disconnected: session.disconnected
+            agentState: session.agentState
         )
     }
 

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -17,6 +17,7 @@ struct ACPComposer: View {
     @Environment(\.theme) private var theme
     @FocusState private var inputFocused: Bool
     @StateObject private var actions = ACPComposerActions()
+    @State private var hasText: Bool = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -54,16 +55,21 @@ struct ACPComposer: View {
                 worktreeRoot: worktreeRoot,
                 actions: actions,
                 sendOnEnter: sendOnEnter,
-                onDraftChange: { draft in manager.persistComposerDraft(draft, for: session) },
+                onDraftChange: { draft in
+                    manager.persistComposerDraft(draft, for: session)
+                    hasText = !draft.isEmpty
+                },
                 onDraftClear: { manager.clearComposerDraft(for: session) },
                 onSubmit: onSubmit
             )
             .frame(minHeight: 44, maxHeight: 140)
+            .onAppear {
+                hasText = !session.composerDraft.isEmpty
+            }
 
             HStack(spacing: 8) {
                 hint
                 Spacer()
-                stopPill
                 autoRunToggle
                 if let thinking = session.chipState.thinking {
                     thinkingChip(thinking)
@@ -74,7 +80,12 @@ struct ACPComposer: View {
                 if let models = session.chipState.models {
                     modelChip(models)
                 }
-                sendButton
+                ACPComposerActionButton(
+                    action: currentAction,
+                    onPrimary: handlePrimary,
+                    onMenu: handleMenu,
+                    queueBadgeCount: session.queue.count
+                )
             }
             .padding(.horizontal, 2)
         }
@@ -309,35 +320,6 @@ struct ACPComposer: View {
         }
     }
 
-    // MARK: - Stop pill (separate from send; visible only while busy)
-
-    @ViewBuilder
-    private var stopPill: some View {
-        if isBusy {
-            Button {
-                stopTapped()
-            } label: {
-                HStack(spacing: 5) {
-                    Image(systemName: "stop.fill")
-                        .font(.system(size: 10, weight: .bold))
-                    Text("Stop")
-                        .font(.system(size: 11, weight: .medium))
-                }
-                .foregroundStyle(theme.color("del"))
-                .padding(.horizontal, 8)
-                .frame(height: 24)
-                .background(
-                    RoundedRectangle(cornerRadius: 6).fill(theme.color("del").opacity(0.15))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("del").opacity(0.45), lineWidth: 0.75)
-                )
-            }
-            .buttonStyle(.plain)
-            .help("Stop the running turn (Esc)")
-        }
-    }
-
     private var isBusy: Bool {
         switch session.transcript.streamingState {
         case .streaming, .sending, .awaitingPermission: return true
@@ -356,90 +338,34 @@ struct ACPComposer: View {
         }
     }
 
-    // MARK: - Send button
+    // MARK: - Unified action button wiring
 
-    private var sendButton: some View {
-        Button {
-            sendButtonTapped()
-        } label: {
-            ZStack(alignment: .topTrailing) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 7).fill(buttonBg)
-                    Image(systemName: "arrow.up")
-                        .font(.system(size: 12, weight: .bold))
-                        .foregroundStyle(buttonFg)
-                }
-                .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(buttonBorder, lineWidth: 0.5))
-                .frame(width: 28, height: 28)
-                if session.queue.count > 0 {
-                    queueBadge
-                        .offset(x: 6, y: -6)
-                }
-            }
-            .contentShape(Rectangle())
+    private var currentAction: ComposerAction {
+        composerAction(
+            streamingState: session.transcript.streamingState,
+            hasText: hasText,
+            attached: session.attached,
+            disconnected: session.disconnected
+        )
+    }
+
+    private func handlePrimary() {
+        switch currentAction {
+        case .send, .queue:
+            actions.submitWithIntent?(.auto)
+        case .stop:
+            stopTapped()
+        case .hidden:
+            break
         }
-        .buttonStyle(.plain)
-        .disabled(sendDisabled)
-        .opacity(sendDisabled ? 0.7 : 1.0)
-        .help(sendHelpText)
     }
 
-    // TODO(harness): SwiftUI rendering test for `sendDisabled` requires
-    // snapshot infrastructure we don't have; the invariant we care about
-    // (button enabled whenever `manager.submit` would accept the prompt
-    // — i.e. for all agent states, including .disconnected / .failed /
-    // .idle so mouse-only users can drive recovery) is inspection-
-    // verifiable here and exercised by the `submit` tests above.
-    private var sendDisabled: Bool {
-        // Intentionally NOT gated on `agentState`: `manager.submit(...)`
-        // accepts prompts in every state (queueing + kicking reattach
-        // when not `.ready`). The send button must mirror Enter-to-submit
-        // so mouse-only users can recover a disconnected session.
-        false
-    }
-
-    private var sendHelpText: String {
-        if session.agentState == .disconnected { return "Agent disconnected" }
-        if session.agentState != .ready        { return "Agent connecting…" }
-        if session.transcript.streamingState == .idle, session.queue.isEmpty {
-            return "Send (⏎). Hold ⌥ to steer."
+    private func handleMenu(_ item: ComposerMenuItem) {
+        switch item {
+        case .steer:
+            actions.submitWithIntent?(.steer)
+        case .stop:
+            stopTapped()
         }
-        return "Queue (⏎). Hold ⌥ to steer."
-    }
-
-    /// Always submit; the runner's routing decides queue vs send vs steer.
-    private func sendButtonTapped() {
-        guard !sendDisabled else { return }
-        let option = NSApp.currentEvent?.modifierFlags.contains(.option) == true
-        actions.submitWithIntent?(option ? .steer : .auto)
-    }
-
-    private var buttonBg: Color {
-        sendDisabled
-            ? theme.color("bg-3").opacity(0.7)
-            : theme.color("accent")
-    }
-    private var buttonFg: Color {
-        sendDisabled ? theme.color("fg-dim") : theme.color("bg-0")
-    }
-    private var buttonBorder: Color {
-        sendDisabled
-            ? theme.color("line")
-            : theme.color("accent").opacity(0.7)
-    }
-
-    /// Small badge with the queue count, sitting at the top-right of
-    /// the send button.
-    private var queueBadge: some View {
-        Text("\(session.queue.count)")
-            .font(.system(size: 9, weight: .bold, design: .rounded))
-            .monospacedDigit()
-            .foregroundStyle(theme.color("bg-0"))
-            .padding(.horizontal, 4)
-            .frame(minWidth: 16, minHeight: 14)
-            .background(
-                Capsule().fill(theme.color("warn"))
-            )
-            .overlay(Capsule().strokeBorder(theme.color("bg-0"), lineWidth: 1))
     }
 }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -345,14 +345,21 @@ struct ACPComposer: View {
     }
 
     private func handlePrimary() {
+        if let intent = primarySubmitIntent(for: currentAction, optionPressed: optionPressed) {
+            actions.submitWithIntent?(intent)
+            return
+        }
+
         switch currentAction {
-        case .send, .queue:
-            actions.submitWithIntent?(.auto)
         case .stop:
             stopTapped()
-        case .hidden:
+        case .send, .queue, .hidden:
             break
         }
+    }
+
+    private var optionPressed: Bool {
+        NSApp.currentEvent?.modifierFlags.contains(.option) == true
     }
 
     private func handleMenu(_ item: ComposerMenuItem) {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -57,14 +57,14 @@ struct ACPComposer: View {
                 sendOnEnter: sendOnEnter,
                 onDraftChange: { draft in
                     manager.persistComposerDraft(draft, for: session)
-                    hasText = !draft.isEmpty
+                    hasText = draft.hasContent
                 },
                 onDraftClear: { manager.clearComposerDraft(for: session) },
                 onSubmit: onSubmit
             )
             .frame(minHeight: 44, maxHeight: 140)
             .onAppear {
-                hasText = !session.composerDraft.isEmpty
+                hasText = session.composerDraft.hasContent
             }
 
             HStack(spacing: 8) {

--- a/Alas/Sources/ACP/UI/ComposerAction.swift
+++ b/Alas/Sources/ACP/UI/ComposerAction.swift
@@ -1,5 +1,5 @@
 /// Mutually-exclusive states the composer's single action button can be in.
-/// Derived from `(streamingState, hasText, attached, disconnected)` via
+/// Derived from `(streamingState, hasText, agentState)` via
 /// `composerAction(...)`. The view layer renders one capsule per case.
 enum ComposerAction: Equatable {
     /// Nothing to do — render nothing. Composer toolbar reflows naturally.
@@ -23,18 +23,18 @@ enum ComposerMenuItem: Hashable {
 /// Pure derive — no SwiftUI imports, no session/runner references.
 /// Exhaustively unit-tested in `ComposerActionTests`.
 ///
-/// Priority:
-/// 1. `disconnected` dominates everything → `.hidden`.
-/// 2. `attached == false` (connecting) → `.hidden`.
-/// 3. Otherwise dispatch on `(streamingState, hasText)`.
+/// The agent lifecycle intentionally does not disable or hide a non-empty
+/// composer: `ACPSessionManager.submit` accepts prompts while disconnected,
+/// failed, idle, or spawning so the user's prompt can kick recovery.
 func composerAction(
     streamingState: ACPSession.StreamingState,
     hasText: Bool,
-    attached: Bool,
-    disconnected: Bool
+    agentState: ACPSession.AgentState
 ) -> ComposerAction {
-    if disconnected { return .hidden }
-    if !attached    { return .hidden }
+    switch agentState {
+    case .idle, .spawning, .ready, .disconnected, .failed(_):
+        break
+    }
 
     switch streamingState {
     case .idle:

--- a/Alas/Sources/ACP/UI/ComposerAction.swift
+++ b/Alas/Sources/ACP/UI/ComposerAction.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Mutually-exclusive states the composer's single action button can be in.
 /// Derived from `(streamingState, hasText, attached, disconnected)` via
 /// `composerAction(...)`. The view layer renders one capsule per case.
@@ -17,7 +15,7 @@ enum ComposerAction: Equatable {
 
 /// Items that appear in the chevron menu when `ComposerAction == .queue`.
 /// Ordered as they appear top-to-bottom in the menu.
-enum ComposerMenuItem: Equatable {
+enum ComposerMenuItem: Hashable {
     case steer
     case stop
 }

--- a/Alas/Sources/ACP/UI/ComposerAction.swift
+++ b/Alas/Sources/ACP/UI/ComposerAction.swift
@@ -43,3 +43,12 @@ func composerAction(
         return hasText ? .queue(menu: [.steer, .stop]) : .stop
     }
 }
+
+func primarySubmitIntent(for action: ComposerAction, optionPressed: Bool) -> ACPSubmitIntent? {
+    switch action {
+    case .send, .queue:
+        optionPressed ? .steer : .auto
+    case .stop, .hidden:
+        nil
+    }
+}

--- a/Alas/Sources/ACP/UI/ComposerAction.swift
+++ b/Alas/Sources/ACP/UI/ComposerAction.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Mutually-exclusive states the composer's single action button can be in.
+/// Derived from `(streamingState, hasText, attached, disconnected)` via
+/// `composerAction(...)`. The view layer renders one capsule per case.
+enum ComposerAction: Equatable {
+    /// Nothing to do — render nothing. Composer toolbar reflows naturally.
+    case hidden
+    /// Idle agent + non-empty composer. Tapping submits the prompt.
+    case send
+    /// Busy agent + non-empty composer. Primary action enqueues the prompt;
+    /// the menu exposes steer and stop.
+    case queue(menu: [ComposerMenuItem])
+    /// Busy agent + empty composer. Tapping cancels the in-flight turn.
+    case stop
+}
+
+/// Items that appear in the chevron menu when `ComposerAction == .queue`.
+/// Ordered as they appear top-to-bottom in the menu.
+enum ComposerMenuItem: Equatable {
+    case steer
+    case stop
+}
+
+/// Pure derive — no SwiftUI imports, no session/runner references.
+/// Exhaustively unit-tested in `ComposerActionTests`.
+///
+/// Priority:
+/// 1. `disconnected` dominates everything → `.hidden`.
+/// 2. `attached == false` (connecting) → `.hidden`.
+/// 3. Otherwise dispatch on `(streamingState, hasText)`.
+func composerAction(
+    streamingState: ACPSession.StreamingState,
+    hasText: Bool,
+    attached: Bool,
+    disconnected: Bool
+) -> ComposerAction {
+    if disconnected { return .hidden }
+    if !attached    { return .hidden }
+
+    switch streamingState {
+    case .idle:
+        return hasText ? .send : .hidden
+    case .sending, .streaming, .awaitingPermission:
+        return hasText ? .queue(menu: [.steer, .stop]) : .stop
+    }
+}

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -574,11 +574,9 @@ struct ACPComposerDraftBridgeTests {
         // position with text on both sides — no doubled mention, no dropped
         // one (the codex P2 findings).
         //
-        // `extract` always emits `@name ` with a trailing space, so the
-        // chip's separator ends up as a leading space on the following text
-        // (`"now"` → `" now"`). That one-space shift is inherent to the
-        // lossy serialization; the user's content and the mention position
-        // survive intact, which is what matters here.
+        // `extract` emits `@name ` with a trailing space, and the inverse
+        // consumes that marker separator when replacing it with the mention
+        // chip. The user's following text remains unchanged.
         let original = ACPComposerDraft(segments: [
             .text("please review "),
             .mention(displayName: "File.swift", uri: "file:///tmp/File.swift"),
@@ -593,7 +591,7 @@ struct ACPComposerDraftBridgeTests {
         #expect(restored == ACPComposerDraft(segments: [
             .text("please review "),
             .mention(displayName: "File.swift", uri: "file:///tmp/File.swift"),
-            .text(" now"),
+            .text("now"),
         ]))
     }
 

--- a/AlasTests/ACP/UI/ComposerActionTests.swift
+++ b/AlasTests/ACP/UI/ComposerActionTests.swift
@@ -3,7 +3,6 @@ import Testing
 
 @Suite("ComposerAction derive function")
 struct ComposerActionTests {
-
     // MARK: - Agent lifecycle
 
     @Test("idle streaming + text shows Send for every agent lifecycle state")

--- a/AlasTests/ACP/UI/ComposerActionTests.swift
+++ b/AlasTests/ACP/UI/ComposerActionTests.swift
@@ -78,6 +78,20 @@ struct ComposerActionTests {
         }
     }
 
+    @Test("primary submit intent preserves Option-click steer shortcut")
+    func primarySubmitIntentPreservesOptionClickSteer() {
+        #expect(primarySubmitIntent(for: .send, optionPressed: false) == .auto)
+        #expect(primarySubmitIntent(for: .send, optionPressed: true) == .steer)
+        #expect(primarySubmitIntent(for: .queue(menu: [.steer, .stop]), optionPressed: false) == .auto)
+        #expect(primarySubmitIntent(for: .queue(menu: [.steer, .stop]), optionPressed: true) == .steer)
+    }
+
+    @Test("primary submit intent is absent for non-submit actions")
+    func primarySubmitIntentAbsentForNonSubmitActions() {
+        #expect(primarySubmitIntent(for: .stop, optionPressed: true) == nil)
+        #expect(primarySubmitIntent(for: .hidden, optionPressed: true) == nil)
+    }
+
     private var busyStates: [ACPSession.StreamingState] {
         [.sending, .streaming, .awaitingPermission]
     }

--- a/AlasTests/ACP/UI/ComposerActionTests.swift
+++ b/AlasTests/ACP/UI/ComposerActionTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ComposerAction derive function")
+struct ComposerActionTests {
+
+    // MARK: - .hidden cases
+
+    @Test("disconnected hides the button regardless of any other state")
+    func disconnectedAlwaysHidden() {
+        let states: [ACPSession.StreamingState] = [.idle, .sending, .streaming, .awaitingPermission]
+        for state in states {
+            for hasText in [false, true] {
+                for attached in [false, true] {
+                    let action = composerAction(
+                        streamingState: state,
+                        hasText: hasText,
+                        attached: attached,
+                        disconnected: true
+                    )
+                    #expect(action == .hidden,
+                            "expected .hidden for state=\(state), hasText=\(hasText), attached=\(attached), disconnected=true")
+                }
+            }
+        }
+    }
+
+    @Test("connecting (attached==false) hides the button regardless of any other state")
+    func connectingAlwaysHidden() {
+        let states: [ACPSession.StreamingState] = [.idle, .sending, .streaming, .awaitingPermission]
+        for state in states {
+            for hasText in [false, true] {
+                let action = composerAction(
+                    streamingState: state,
+                    hasText: hasText,
+                    attached: false,
+                    disconnected: false
+                )
+                #expect(action == .hidden,
+                        "expected .hidden for state=\(state), hasText=\(hasText), attached=false")
+            }
+        }
+    }
+
+    @Test("idle + empty composer shows nothing")
+    func idleEmptyHidden() {
+        let action = composerAction(streamingState: .idle, hasText: false, attached: true, disconnected: false)
+        #expect(action == .hidden)
+    }
+
+    // MARK: - .send
+
+    @Test("idle + has text shows Send")
+    func idleWithTextSends() {
+        let action = composerAction(streamingState: .idle, hasText: true, attached: true, disconnected: false)
+        #expect(action == .send)
+    }
+
+    // MARK: - .stop
+
+    @Test("busy + empty composer shows Stop, for every busy state")
+    func busyEmptyStops() {
+        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission] {
+            let action = composerAction(streamingState: state, hasText: false, attached: true, disconnected: false)
+            #expect(action == .stop, "expected .stop for state=\(state)")
+        }
+    }
+
+    // MARK: - .queue
+
+    @Test("busy + has text shows Queue with Steer and Stop menu items, for every busy state")
+    func busyWithTextQueuesWithSteerAndStopMenu() {
+        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission] {
+            let action = composerAction(streamingState: state, hasText: true, attached: true, disconnected: false)
+            #expect(action == .queue(menu: [.steer, .stop]),
+                    "expected .queue([.steer, .stop]) for state=\(state)")
+        }
+    }
+}

--- a/AlasTests/ACP/UI/ComposerActionTests.swift
+++ b/AlasTests/ACP/UI/ComposerActionTests.swift
@@ -1,51 +1,40 @@
-import Foundation
 import Testing
 @testable import Alas
 
 @Suite("ComposerAction derive function")
 struct ComposerActionTests {
 
-    // MARK: - .hidden cases
+    // MARK: - Agent lifecycle
 
-    @Test("disconnected hides the button regardless of any other state")
-    func disconnectedAlwaysHidden() {
-        let states: [ACPSession.StreamingState] = [.idle, .sending, .streaming, .awaitingPermission]
-        for state in states {
-            for hasText in [false, true] {
-                for attached in [false, true] {
-                    let action = composerAction(
-                        streamingState: state,
-                        hasText: hasText,
-                        attached: attached,
-                        disconnected: true
-                    )
-                    #expect(action == .hidden,
-                            "expected .hidden for state=\(state), hasText=\(hasText), attached=\(attached), disconnected=true")
-                }
-            }
+    @Test("idle streaming + text shows Send for every agent lifecycle state")
+    func idleWithTextSendsForEveryAgentState() {
+        for agentState in agentStates {
+            let action = composerAction(
+                streamingState: .idle,
+                hasText: true,
+                agentState: agentState
+            )
+            #expect(action == .send, "expected .send for agentState=\(agentState)")
         }
     }
 
-    @Test("connecting (attached==false) hides the button regardless of any other state")
-    func connectingAlwaysHidden() {
-        let states: [ACPSession.StreamingState] = [.idle, .sending, .streaming, .awaitingPermission]
-        for state in states {
-            for hasText in [false, true] {
-                let action = composerAction(
-                    streamingState: state,
-                    hasText: hasText,
-                    attached: false,
-                    disconnected: false
-                )
-                #expect(action == .hidden,
-                        "expected .hidden for state=\(state), hasText=\(hasText), attached=false")
-            }
+    @Test("idle streaming + empty composer hides the action for every agent lifecycle state")
+    func idleEmptyHiddenForEveryAgentState() {
+        for agentState in agentStates {
+            let action = composerAction(
+                streamingState: .idle,
+                hasText: false,
+                agentState: agentState
+            )
+            #expect(action == .hidden, "expected .hidden for agentState=\(agentState)")
         }
     }
+
+    // MARK: - .hidden
 
     @Test("idle + empty composer shows nothing")
     func idleEmptyHidden() {
-        let action = composerAction(streamingState: .idle, hasText: false, attached: true, disconnected: false)
+        let action = composerAction(streamingState: .idle, hasText: false, agentState: .ready)
         #expect(action == .hidden)
     }
 
@@ -53,7 +42,7 @@ struct ComposerActionTests {
 
     @Test("idle + has text shows Send")
     func idleWithTextSends() {
-        let action = composerAction(streamingState: .idle, hasText: true, attached: true, disconnected: false)
+        let action = composerAction(streamingState: .idle, hasText: true, agentState: .ready)
         #expect(action == .send)
     }
 
@@ -61,9 +50,15 @@ struct ComposerActionTests {
 
     @Test("busy + empty composer shows Stop, for every busy state")
     func busyEmptyStops() {
-        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission] {
-            let action = composerAction(streamingState: state, hasText: false, attached: true, disconnected: false)
-            #expect(action == .stop, "expected .stop for state=\(state)")
+        for state in busyStates {
+            for agentState in agentStates {
+                let action = composerAction(
+                    streamingState: state,
+                    hasText: false,
+                    agentState: agentState
+                )
+                #expect(action == .stop, "expected .stop for state=\(state), agentState=\(agentState)")
+            }
         }
     }
 
@@ -71,10 +66,24 @@ struct ComposerActionTests {
 
     @Test("busy + has text shows Queue with Steer and Stop menu items, for every busy state")
     func busyWithTextQueuesWithSteerAndStopMenu() {
-        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission] {
-            let action = composerAction(streamingState: state, hasText: true, attached: true, disconnected: false)
-            #expect(action == .queue(menu: [.steer, .stop]),
-                    "expected .queue([.steer, .stop]) for state=\(state)")
+        for state in busyStates {
+            for agentState in agentStates {
+                let action = composerAction(
+                    streamingState: state,
+                    hasText: true,
+                    agentState: agentState
+                )
+                #expect(action == .queue(menu: [.steer, .stop]),
+                        "expected .queue([.steer, .stop]) for state=\(state), agentState=\(agentState)")
+            }
         }
+    }
+
+    private var busyStates: [ACPSession.StreamingState] {
+        [.sending, .streaming, .awaitingPermission]
+    }
+
+    private var agentStates: [ACPSession.AgentState] {
+        [.idle, .spawning, .ready, .disconnected, .failed("boom")]
     }
 }


### PR DESCRIPTION
## Summary

Restores the ACP composer split action button work onto current `main`.

- Adds a unified composer action model for Send, Queue, Stop, and hidden states.
- Adds the split capsule action button with a chevron menu for alternate actions.
- Wires the composer shell to current agent lifecycle state so disconnected/failed sessions still allow recovery submits.
- Keeps generated Xcode project metadata current after rebasing and aligns the composer draft bridge test with the existing round-trip behavior.

## Validation

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`

## Notes

The app was launched locally from the Debug build and the split button was manually checked before the rebase.