### PR TITLE
fix(acp): improve composer chip contrast

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
 		6FA1659F464BE9C03C90F787 /* GitService+CommitEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */; };
 		7028C08DE3F176175CA1FC20 /* MergeConflictResolvedEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */; };
+		702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */; };
 		709F5006202FA86C750BBB69 /* IndentationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D105CB2C185958ED23164D1 /* IndentationMode.swift */; };
 		70F0096BEEECA74B24A3BF70 /* session-update-config-option.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C5373F76231F229D3F96AF3 /* session-update-config-option.json */; };
 		70FCC2B12AE446728EE7CF8D /* LSPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38499AFE31188908546EE222 /* LSPTransport.swift */; };
@@ -1296,6 +1297,7 @@
 		987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueuedBubble.swift; sourceTree = "<group>"; };
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
 		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
+		98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSelectChipTests.swift; sourceTree = "<group>"; };
 		9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HunkPatchBuilder.swift; sourceTree = "<group>"; };
 		9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-diff.json"; sourceTree = "<group>"; };
 		9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTerminalRoutingTests.swift; sourceTree = "<group>"; };
@@ -2233,6 +2235,7 @@
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
 				96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */,
+				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
 			);
@@ -3746,6 +3749,7 @@
 				97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */,
 				F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */,
 				A383F1C9B0B00B2805576209 /* ACPScrollDirectionClassifierTests.swift in Sources */,
+				702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */,
 				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,
 				9FDF577BDD6D5C47635229DE /* ACPSessionByteAccountingTests.swift in Sources */,
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPSelectChip.swift
+++ b/Alas/Sources/ACP/UI/ACPSelectChip.swift
@@ -36,7 +36,7 @@ struct ACPSelectChip: View {
                     .shadow(color: accent.opacity(0.7), radius: 3)
                 Text(label.isEmpty ? placeholder : label)
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(Color.blend(accent, .white, t: 0.55))
+                    .foregroundStyle(Self.labelForeground(accent: accent, theme: theme))
                     .lineLimit(1)
                 Image(systemName: "chevron.down")
                     .font(.system(size: 8, weight: .bold))
@@ -67,6 +67,10 @@ struct ACPSelectChip: View {
             )
             .environment(\.theme, theme)
         }
+    }
+
+    static func labelForeground(accent: Color, theme: Theme) -> Color {
+        Color.blend(accent, theme.darkMode ? .white : .black, t: theme.darkMode ? 0.55 : 0.30)
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPSelectChip.swift
+++ b/Alas/Sources/ACP/UI/ACPSelectChip.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Styled chip + custom popover dropdown used for the composer's model and
@@ -70,7 +71,73 @@ struct ACPSelectChip: View {
     }
 
     static func labelForeground(accent: Color, theme: Theme) -> Color {
-        Color.blend(accent, theme.darkMode ? .white : .black, t: theme.darkMode ? 0.55 : 0.30)
+        if theme.darkMode {
+            return Color.blend(accent, .white, t: 0.55)
+        }
+
+        let chipBackground = composited(foreground: accent, alpha: 0.18, over: theme.color("bg-1"))
+        let minimumContrast = 4.5
+        let preferredBlend = Color.blend(accent, .black, t: 0.30)
+        if contrastRatio(preferredBlend, chipBackground) >= minimumContrast {
+            return preferredBlend
+        }
+
+        var lower = 0.30
+        var upper = 1.0
+        for _ in 0..<12 {
+            let midpoint = (lower + upper) / 2
+            let candidate = Color.blend(accent, .black, t: midpoint)
+            if contrastRatio(candidate, chipBackground) >= minimumContrast {
+                upper = midpoint
+            } else {
+                lower = midpoint
+            }
+        }
+        return Color.blend(accent, .black, t: upper)
+    }
+
+    private struct ColorComponents {
+        let red: Double
+        let green: Double
+        let blue: Double
+        let alpha: Double
+    }
+
+    private static func colorComponents(_ color: Color) -> ColorComponents {
+        let nsColor = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(color)
+        return ColorComponents(
+            red: Double(nsColor.redComponent),
+            green: Double(nsColor.greenComponent),
+            blue: Double(nsColor.blueComponent),
+            alpha: Double(nsColor.alphaComponent)
+        )
+    }
+
+    private static func composited(foreground: Color, alpha: Double, over background: Color) -> Color {
+        let fg = colorComponents(foreground)
+        let bg = colorComponents(background)
+        let a = max(0, min(1, alpha))
+        return Color(
+            .sRGB,
+            red: fg.red * a + bg.red * (1 - a),
+            green: fg.green * a + bg.green * (1 - a),
+            blue: fg.blue * a + bg.blue * (1 - a),
+            opacity: fg.alpha * a + bg.alpha * (1 - a)
+        )
+    }
+
+    private static func contrastRatio(_ lhs: Color, _ rhs: Color) -> Double {
+        let l1 = relativeLuminance(lhs)
+        let l2 = relativeLuminance(rhs)
+        return (max(l1, l2) + 0.05) / (min(l1, l2) + 0.05)
+    }
+
+    private static func relativeLuminance(_ color: Color) -> Double {
+        let c = colorComponents(color)
+        func channel(_ value: Double) -> Double {
+            value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(c.red) + 0.7152 * channel(c.green) + 0.0722 * channel(c.blue)
     }
 }
 

--- a/AlasTests/ACP/UI/ACPSelectChipTests.swift
+++ b/AlasTests/ACP/UI/ACPSelectChipTests.swift
@@ -1,0 +1,78 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite("ACP select chip")
+struct ACPSelectChipTests {
+    @Test func labelForegroundPreservesDarkModeTreatment() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let accent = theme.color("accent")
+        let foreground = ACPSelectChip.labelForeground(accent: accent, theme: theme)
+        let existing = Color.blend(accent, .white, t: 0.55)
+
+        #expect(Self.colorComponents(foreground).isClose(to: Self.colorComponents(existing)))
+    }
+
+    @Test func labelForegroundImprovesLightModeContrast() throws {
+        let theme = try Theme.loadBundled(id: "light")
+        let accent = theme.color("accent")
+        let chipBackground = Self.composited(foreground: accent, alpha: 0.18, over: theme.color("bg-1"))
+        let previousForeground = Color.blend(accent, .white, t: 0.55)
+        let foreground = ACPSelectChip.labelForeground(accent: accent, theme: theme)
+
+        #expect(Self.contrastRatio(foreground, chipBackground) > Self.contrastRatio(previousForeground, chipBackground))
+        #expect(Self.contrastRatio(foreground, chipBackground) >= 4.5)
+    }
+
+    private struct Components {
+        let red: Double
+        let green: Double
+        let blue: Double
+        let alpha: Double
+
+        func isClose(to other: Components, tolerance: Double = 0.001) -> Bool {
+            abs(red - other.red) <= tolerance
+                && abs(green - other.green) <= tolerance
+                && abs(blue - other.blue) <= tolerance
+                && abs(alpha - other.alpha) <= tolerance
+        }
+    }
+
+    private static func colorComponents(_ color: Color) -> Components {
+        let nsColor = NSColor(color).usingColorSpace(.sRGB) ?? NSColor(color)
+        return Components(
+            red: Double(nsColor.redComponent),
+            green: Double(nsColor.greenComponent),
+            blue: Double(nsColor.blueComponent),
+            alpha: Double(nsColor.alphaComponent)
+        )
+    }
+
+    private static func composited(foreground: Color, alpha: Double, over background: Color) -> Color {
+        let fg = colorComponents(foreground)
+        let bg = colorComponents(background)
+        let a = max(0, min(1, alpha))
+        return Color(
+            .sRGB,
+            red: fg.red * a + bg.red * (1 - a),
+            green: fg.green * a + bg.green * (1 - a),
+            blue: fg.blue * a + bg.blue * (1 - a),
+            opacity: fg.alpha * a + bg.alpha * (1 - a)
+        )
+    }
+
+    private static func contrastRatio(_ lhs: Color, _ rhs: Color) -> Double {
+        let l1 = relativeLuminance(lhs)
+        let l2 = relativeLuminance(rhs)
+        return (max(l1, l2) + 0.05) / (min(l1, l2) + 0.05)
+    }
+
+    private static func relativeLuminance(_ color: Color) -> Double {
+        let c = colorComponents(color)
+        func channel(_ value: Double) -> Double {
+            value <= 0.03928 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(c.red) + 0.7152 * channel(c.green) + 0.0722 * channel(c.blue)
+    }
+}

--- a/AlasTests/ACP/UI/ACPSelectChipTests.swift
+++ b/AlasTests/ACP/UI/ACPSelectChipTests.swift
@@ -14,6 +14,20 @@ struct ACPSelectChipTests {
         #expect(Self.colorComponents(foreground).isClose(to: Self.colorComponents(existing)))
     }
 
+    @Test func labelForegroundPreservesDarkModeTreatmentForAccentOverrides() throws {
+        let baseTheme = try Theme.loadBundled(id: "cool-slate")
+
+        for hex in Theme.accentHexById.values {
+            var theme = baseTheme
+            theme.accentOverrideHex = hex
+            let accent = theme.color("accent")
+            let foreground = ACPSelectChip.labelForeground(accent: accent, theme: theme)
+            let existing = Color.blend(accent, .white, t: 0.55)
+
+            #expect(Self.colorComponents(foreground).isClose(to: Self.colorComponents(existing)))
+        }
+    }
+
     @Test func labelForegroundImprovesLightModeContrast() throws {
         let theme = try Theme.loadBundled(id: "light")
         let accent = theme.color("accent")
@@ -23,6 +37,22 @@ struct ACPSelectChipTests {
 
         #expect(Self.contrastRatio(foreground, chipBackground) > Self.contrastRatio(previousForeground, chipBackground))
         #expect(Self.contrastRatio(foreground, chipBackground) >= 4.5)
+    }
+
+    @Test func labelForegroundMeetsLightModeContrastForAccentOverrides() throws {
+        let baseTheme = try Theme.loadBundled(id: "light")
+
+        for (id, hex) in Theme.accentHexById {
+            var theme = baseTheme
+            theme.accentOverrideHex = hex
+            let accent = theme.color("accent")
+            let chipBackground = Self.composited(foreground: accent, alpha: 0.18, over: theme.color("bg-1"))
+            let previousForeground = Color.blend(accent, .white, t: 0.55)
+            let foreground = ACPSelectChip.labelForeground(accent: accent, theme: theme)
+
+            #expect(Self.contrastRatio(foreground, chipBackground) > Self.contrastRatio(previousForeground, chipBackground), "\(id) should improve contrast over the previous dark-mode treatment")
+            #expect(Self.contrastRatio(foreground, chipBackground) >= 4.5, "\(id) should meet AA contrast")
+        }
     }
 
     private struct Components {


### PR DESCRIPTION
## Summary
- improve ACP composer chip label contrast in light mode using the existing accent blend system
- preserve the existing dark-mode color treatment
- add focused Swift Testing coverage for dark-mode preservation and light-mode contrast

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- focused ACPSelectChipTests

Note: the full xcodebuild test run was attempted locally but hung with Alas.app still alive after about 10 minutes.