### PR TITLE
Gate ACP code block syntax highlighting

### DIFF
--- a/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
+++ b/Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift
@@ -44,13 +44,17 @@ enum ACPCodeLanguage {
         case "cc": return "cc"
         case "cxx": return "cxx"
         case "hpp": return "hpp"
-        case "diff", "patch": return "diff"
+        case "hh": return "hh"
+        case "hxx": return "hxx"
+        case "diff": return "diff"
+        case "patch": return "patch"
         case "html": return "html"
         case "xml": return "xml"
         case "css": return "css"
         case "scss": return "scss"
         case "sass": return "sass"
-        case "sql": return "sql"
+        case "sql", "rb", "ruby", "php", "pl", "perl", "lua", "ex", "exs", "elixir", "dockerfile", "ini":
+            return nil
         default: return nil
         }
     }

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -5,6 +5,35 @@ import Testing
 @MainActor
 @Suite("ACP code block highlighter")
 struct ACPCodeBlockHighlighterTests {
+    private func foregroundColor(
+        for needle: String,
+        in attributed: NSAttributedString
+    ) throws -> NSColor {
+        let range = (attributed.string as NSString).range(of: needle)
+        try #require(range.location != NSNotFound)
+        let color = attributed.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+        return try #require(color)
+    }
+
+    private func allForegroundColors(
+        in attributed: NSAttributedString,
+        equal expected: NSColor
+    ) -> Bool {
+        guard attributed.length > 0 else { return true }
+        var matches = true
+        attributed.enumerateAttribute(
+            .foregroundColor,
+            in: NSRange(location: 0, length: attributed.length)
+        ) { value, _, stop in
+            guard let color = value as? NSColor, color == expected else {
+                matches = false
+                stop.pointee = true
+                return
+            }
+        }
+        return matches
+    }
+
     @Test("maps common ACP fence labels to highlighter extensions")
     func mapsFenceLabels() {
         #expect(ACPCodeLanguage.highlighterExtension(for: "swift") == "swift")
@@ -49,6 +78,46 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(for: "elixir") == nil)
         #expect(ACPCodeLanguage.highlighterExtension(for: "dockerfile") == nil)
         #expect(ACPCodeLanguage.highlighterExtension(for: "ini") == nil)
+    }
+
+    @Test("regex fallback labels apply non-default ACP syntax colors")
+    func regexFallbackLabelsApplySyntaxColors() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let editorTheme = EditorTheme(theme: theme)
+
+        let diff = ACPCodeBlockHighlighter.attributedString(
+            code: "@@ -1 +1 @@\n-old\n+new",
+            language: "diff",
+            theme: theme
+        )
+        let html = ACPCodeBlockHighlighter.attributedString(
+            code: #"<button disabled class="primary">Save</button>"#,
+            language: "html",
+            theme: theme
+        )
+        let css = ACPCodeBlockHighlighter.attributedString(
+            code: #".primary { display: flex; color: #fff; }"#,
+            language: "css",
+            theme: theme
+        )
+
+        #expect(try foregroundColor(for: "@@", in: diff) != editorTheme.defaultFG)
+        #expect(try foregroundColor(for: "<button", in: html) != editorTheme.defaultFG)
+        #expect(try foregroundColor(for: "display", in: css) != editorTheme.defaultFG)
+    }
+
+    @Test("future-known unsupported ACP labels keep attributed output plain")
+    func futureKnownUnsupportedAttributedOutputRemainsPlain() throws {
+        let theme = try Theme.loadBundled(id: "cool-slate")
+        let editorTheme = EditorTheme(theme: theme)
+        let attributed = ACPCodeBlockHighlighter.attributedString(
+            code: "SELECT id FROM users WHERE active = true;",
+            language: "sql",
+            theme: theme
+        )
+
+        #expect(attributed.string == "SELECT id FROM users WHERE active = true;")
+        #expect(allForegroundColors(in: attributed, equal: editorTheme.defaultFG))
     }
 
     @Test("Swift code applies syntax color while preserving monospaced font")

--- a/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+++ b/AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
@@ -27,6 +27,30 @@ struct ACPCodeBlockHighlighterTests {
         #expect(ACPCodeLanguage.highlighterExtension(for: "not-a-language") == nil)
     }
 
+    @Test("maps regex-backed ACP fence labels to fallback extensions")
+    func mapsRegexBackedFenceLabels() {
+        #expect(ACPCodeLanguage.highlighterExtension(for: "diff") == "diff")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "patch") == "patch")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "html") == "html")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "xml") == "xml")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "css") == "css")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "scss") == "scss")
+        #expect(ACPCodeLanguage.highlighterExtension(for: "sass") == "sass")
+    }
+
+    @Test("future-known unsupported ACP fence labels remain plain")
+    func futureKnownUnsupportedFenceLabelsRemainPlain() {
+        #expect(ACPCodeLanguage.highlighterExtension(for: "sql") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "ruby") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "rb") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "php") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "perl") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "lua") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "elixir") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "dockerfile") == nil)
+        #expect(ACPCodeLanguage.highlighterExtension(for: "ini") == nil)
+    }
+
     @Test("Swift code applies syntax color while preserving monospaced font")
     func swiftCodeAppliesSyntaxColor() throws {
         let theme = try Theme.loadBundled(id: "cool-slate")

--- a/docs/superpowers/plans/2026-05-30-acp-code-block-syntax-coloring.md
+++ b/docs/superpowers/plans/2026-05-30-acp-code-block-syntax-coloring.md
@@ -1,0 +1,298 @@
+# ACP Code Block Syntax Coloring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align ACP fenced code block highlighting with the approved ACP-only design: Tree-sitter plus existing regex fallback for supported labels, with future-known unsupported labels remaining plain.
+
+**Architecture:** Keep `ACPCodeBlockHighlighter` as the ACP-local adapter between chat fence labels and the shared `TreeSitterHighlighter`. The shared highlighter can keep its broader capabilities, but ACP must only request highlighting for labels approved in the ACP spec. `CodeBlockView` continues to render the original visible label and copied code unchanged.
+
+**Tech Stack:** Swift 5.9+, SwiftUI/AppKit attributed strings, Swift Testing, existing `TreeSitterHighlighter`, `EditorTheme`, and `Theme`.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift`
+  - Responsibility: normalize ACP fence labels into currently supported highlighter extensions and build attributed strings for ACP code blocks.
+- Modify `AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift`
+  - Responsibility: test ACP label mapping, supported regex fallback routing, unsupported future labels, default/plain output, and string preservation.
+- No changes to `Alas/Sources/Code/Markdown/MarkdownRenderer.swift`
+  - Markdown preview mapping is a fast follow and remains out of scope.
+- No changes to `Alas/Sources/Code/Highlight/TreeSitterHighlighter.swift`
+  - Existing shared fallback behavior remains available to other callers.
+
+---
+
+### Task 1: Gate ACP Fence Labels To Supported ACP Highlighting
+
+**Files:**
+- Modify: `AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift`
+
+- [ ] **Step 1: Write failing label mapping tests**
+
+Add these test methods to `ACPCodeBlockHighlighterTests`:
+
+```swift
+@Test("maps regex-backed ACP fence labels to fallback extensions")
+func mapsRegexBackedFenceLabels() {
+    #expect(ACPCodeLanguage.highlighterExtension(for: "diff") == "diff")
+    #expect(ACPCodeLanguage.highlighterExtension(for: "patch") == "patch")
+    #expect(ACPCodeLanguage.highlighterExtension(for: "html") == "html")
+    #expect(ACPCodeLanguage.highlighterExtension(for: "xml") == "xml")
+    #expect(ACPCodeLanguage.highlighterExtension(for: "css") == "css")
+    #expect(ACPCodeLanguage.highlighterExtension(for: "scss") == "scss")
+    #expect(ACPCodeLanguage.highlighterExtension(for: "sass") == "sass")
+}
+
+@Test("future-known unsupported ACP fence labels remain plain")
+func futureKnownUnsupportedFenceLabelsRemainPlain() {
+    #expect(ACPCodeLanguage.highlighterExtension(for: "sql") == nil)
+    #expect(ACPCodeLanguage.highlighterExtension(for: "ruby") == nil)
+    #expect(ACPCodeLanguage.highlighterExtension(for: "rb") == nil)
+    #expect(ACPCodeLanguage.highlighterExtension(for: "php") == nil)
+    #expect(ACPCodeLanguage.highlighterExtension(for: "perl") == nil)
+    #expect(ACPCodeLanguage.highlighterExtension(for: "lua") == nil)
+    #expect(ACPCodeLanguage.highlighterExtension(for: "elixir") == nil)
+    #expect(ACPCodeLanguage.highlighterExtension(for: "dockerfile") == nil)
+    #expect(ACPCodeLanguage.highlighterExtension(for: "ini") == nil)
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPCodeBlockHighlighterTests test
+```
+
+Expected: the new unsupported-label test fails because `sql` currently maps to `"sql"` or any newly tested future labels are not yet covered by the desired behavior.
+
+- [ ] **Step 3: Update `ACPCodeLanguage` mapping**
+
+In `ACPCodeLanguage.highlighterExtension(for:)`, keep supported Tree-sitter and regex-backed labels returning extensions, remove ACP `sql` highlighting, and explicitly keep future-known unsupported labels plain.
+
+The switch should include this shape:
+
+```swift
+switch normalized {
+case "swift": return "swift"
+case "py", "python": return "py"
+case "js", "javascript", "mjs", "cjs": return "js"
+case "jsx": return "jsx"
+case "ts", "typescript": return "ts"
+case "tsx": return "tsx"
+case "sh", "bash", "shell", "zsh", "console", "terminal": return "sh"
+case "md", "markdown": return "md"
+case "json": return "json"
+case "yaml", "yml": return "yaml"
+case "toml": return "toml"
+case "rs", "rust": return "rs"
+case "go", "golang": return "go"
+case "java": return "java"
+case "kt", "kotlin": return "kt"
+case "kts": return "kts"
+case "c": return "c"
+case "h": return "h"
+case "cpp", "c++": return "cpp"
+case "cc": return "cc"
+case "cxx": return "cxx"
+case "hpp": return "hpp"
+case "hh": return "hh"
+case "hxx": return "hxx"
+case "diff": return "diff"
+case "patch": return "patch"
+case "html": return "html"
+case "xml": return "xml"
+case "css": return "css"
+case "scss": return "scss"
+case "sass": return "sass"
+case "sql", "rb", "ruby", "php", "pl", "perl", "lua", "ex", "exs", "elixir", "dockerfile", "ini":
+    return nil
+default:
+    return nil
+}
+```
+
+- [ ] **Step 4: Run focused tests and verify they pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPCodeBlockHighlighterTests test
+```
+
+Expected: `ACPCodeBlockHighlighterTests` pass.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+rtk git add Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+rtk git commit -m "fix(acp): gate code block language highlighting"
+```
+
+---
+
+### Task 2: Verify ACP Attributed Output For Fallback And Plain Paths
+
+**Files:**
+- Modify: `AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift` only if the tests expose a defect.
+
+- [ ] **Step 1: Add failing attributed-output tests**
+
+Add these helpers and tests to `ACPCodeBlockHighlighterTests`:
+
+```swift
+private func foregroundColor(
+    for needle: String,
+    in attributed: NSAttributedString
+) throws -> NSColor {
+    let range = (attributed.string as NSString).range(of: needle)
+    #expect(range.location != NSNotFound)
+    let color = attributed.attribute(.foregroundColor, at: range.location, effectiveRange: nil) as? NSColor
+    return try #require(color)
+}
+
+@Test("regex fallback labels apply non-default ACP syntax colors")
+func regexFallbackLabelsApplySyntaxColors() throws {
+    let theme = try Theme.loadBundled(id: "cool-slate")
+    let editorTheme = EditorTheme(theme: theme)
+
+    let diff = ACPCodeBlockHighlighter.attributedString(
+        code: "@@ -1 +1 @@\n-old\n+new",
+        language: "diff",
+        theme: theme
+    )
+    let html = ACPCodeBlockHighlighter.attributedString(
+        code: #"<button disabled class="primary">Save</button>"#,
+        language: "html",
+        theme: theme
+    )
+    let css = ACPCodeBlockHighlighter.attributedString(
+        code: #".primary { display: flex; color: #fff; }"#,
+        language: "css",
+        theme: theme
+    )
+
+    #expect(try foregroundColor(for: "@@", in: diff) != editorTheme.defaultFG)
+    #expect(try foregroundColor(for: "<button", in: html) != editorTheme.defaultFG)
+    #expect(try foregroundColor(for: "display", in: css) != editorTheme.defaultFG)
+}
+
+@Test("future-known unsupported ACP labels keep attributed output plain")
+func futureKnownUnsupportedAttributedOutputRemainsPlain() throws {
+    let theme = try Theme.loadBundled(id: "cool-slate")
+    let editorTheme = EditorTheme(theme: theme)
+    let attributed = ACPCodeBlockHighlighter.attributedString(
+        code: "SELECT id FROM users WHERE active = true;",
+        language: "sql",
+        theme: theme
+    )
+
+    #expect(attributed.string == "SELECT id FROM users WHERE active = true;")
+    #expect(try foregroundColor(for: "SELECT", in: attributed) == editorTheme.defaultFG)
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail if implementation is incomplete**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPCodeBlockHighlighterTests test
+```
+
+Expected before Task 1 implementation: the SQL plain-output assertion fails. Expected after Task 1 implementation: these tests pass.
+
+- [ ] **Step 3: Fix only defects exposed by the tests**
+
+If the tests fail after Task 1, update `ACPCodeBlockHighlighter.attributedString` so it returns the base attributed string whenever `ACPCodeLanguage.highlighterExtension(for:)` returns nil. Preserve the existing span bounds checks:
+
+```swift
+guard !code.isEmpty,
+      let ext = ACPCodeLanguage.highlighterExtension(for: language) else {
+    return attributed
+}
+```
+
+- [ ] **Step 4: Run focused tests and verify they pass**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPCodeBlockHighlighterTests test
+```
+
+Expected: `ACPCodeBlockHighlighterTests` pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+rtk git add Alas/Sources/ACP/UI/ACPCodeBlockHighlighter.swift AlasTests/ACP/UI/ACPCodeBlockHighlighterTests.swift
+rtk git commit -m "test(acp): cover code block fallback highlighting"
+```
+
+---
+
+### Task 3: Final Verification
+
+**Files:**
+- No intended source edits.
+
+- [ ] **Step 1: Confirm no unintended Markdown preview changes**
+
+Run:
+
+```bash
+rtk git diff origin/main -- Alas/Sources/Code/Markdown/MarkdownRenderer.swift
+```
+
+Expected: no diff.
+
+- [ ] **Step 2: Run project generation**
+
+Run:
+
+```bash
+rtk xcodegen
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 3: Run macOS build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 5: Commit verification-only generated changes if any**
+
+If `xcodegen` changes project files, inspect the diff and commit only those generated project changes:
+
+```bash
+rtk git status --short
+rtk git add Alas.xcodeproj project.yml
+rtk git commit -m "chore: regenerate Xcode project"
+```
+
+Expected: commit only if there are actual project-generation diffs.

--- a/docs/superpowers/specs/2026-05-28-acp-code-block-syntax-coloring-design.md
+++ b/docs/superpowers/specs/2026-05-28-acp-code-block-syntax-coloring-design.md
@@ -1,13 +1,13 @@
 # Design: ACP Code Block Syntax Coloring
 
 **Date:** 2026-05-28
-**Status:** Draft
+**Status:** Approved
 
 ## Problem
 
 ACP chat messages render fenced code blocks in `Alas/Sources/ACP/UI/ACPMarkdownText.swift` as plain monospaced text. This preserves content and copy behavior, but makes agent answers harder to scan when they include Swift, shell, JSON, TypeScript, or other code examples.
 
-The app already has a Tree-sitter backed highlighter in `TreeSitterHighlighter`, a regex fallback for supported-but-unavailable language paths, and theme-aware capture styling in `EditorTheme`. Markdown file preview already uses this path for fenced code blocks. ACP chat should reuse the same infrastructure instead of adding a second syntax coloring system.
+The app already has a Tree-sitter backed highlighter in `TreeSitterHighlighter`, a regex fallback for supported-but-unavailable language paths, and theme-aware capture styling in `EditorTheme`. Markdown file preview already uses this path for fenced code blocks. ACP chat should reuse the same infrastructure instead of adding a second syntax coloring system, while keeping this pass scoped to ACP rendering.
 
 ## Solution
 
@@ -16,8 +16,10 @@ Add syntax coloring to ACP fenced code blocks by converting each code fence lang
 The change is scoped to ACP chat rendering:
 
 - Existing code block layout, header, copy button, scrolling, selection, spacing, and background chrome stay unchanged.
+- The visible code fence label stays exactly as the agent wrote it; normalization only affects highlighting.
 - Supported Tree-sitter languages use the existing parser and query path.
-- Known labels with no parser package can use the existing regex fallback where possible or remain plain.
+- Labels supported by the existing regex fallback, such as `diff`, `patch`, `html`, `xml`, and `css`, can be highlighted without adding new parser packages.
+- Known labels with no useful parser or fallback coverage, such as `sql` in this pass, remain plain until support is added deliberately.
 - Unknown or missing language labels render as plain monospaced text.
 - Syntax colors come from `EditorTheme.attributes(for:)`, keeping ACP chat consistent with the editor and Markdown preview.
 
@@ -33,7 +35,11 @@ enum ACPCodeLanguage {
 }
 ```
 
-The mapper normalizes fence labels by lowercasing and trimming common Markdown fence metadata. Examples:
+The mapper normalizes fence labels by lowercasing and trimming common Markdown fence metadata, including labels such as `{.swift}`, `.swift`, and `swift title=Example.swift`.
+
+It should recognize common labels for languages supported today and typical labels expected in agent output. Recognition does not guarantee coloring: labels without highlighter support should return nil or otherwise be filtered out by the ACP helper so the body stays plain.
+
+Supported examples:
 
 | Labels | Extension |
 |--------|-----------|
@@ -53,15 +59,22 @@ The mapper normalizes fence labels by lowercasing and trimming common Markdown f
 | `kt`, `kotlin`, `kts` | `kt` / `kts` |
 | `c`, `h` | `c` / `h` |
 | `cpp`, `c++`, `cc`, `cxx`, `hpp` | `cpp` / matching C++ extension |
+| `diff`, `patch` | `diff` / `patch` |
+| `html`, `xml` | `html` / `xml` |
+| `css`, `scss`, `sass` | `css` / matching CSS-like extension |
 
 Common chat labels without current Tree-sitter coverage are allowed but should degrade predictably:
 
-- `diff`, `patch`
-- `html`, `xml`
-- `css`, `scss`, `sass`
 - `sql`
+- `rb`, `ruby`
+- `php`
+- `pl`, `perl`
+- `lua`
+- `ex`, `exs`, `elixir`
+- `dockerfile`
+- `ini`
 
-For these labels, the mapper may return a stable pseudo-extension only if the fallback path can color something useful. Otherwise it should return nil and render plain text. The implementation should not add new parser packages for this feature.
+For these labels, the mapper may recognize the label for future alignment, but ACP should only request highlighting when the existing highlighter can color something useful. Otherwise it should render plain text. The implementation should not add new parser packages for this feature.
 
 ### CodeBlockView
 
@@ -82,15 +95,24 @@ Behavior:
 
 Invalid spans should be ignored defensively. Highlighting should not change the copied text.
 
+### Streaming Behavior
+
+ACP may re-render a message while the agent is still streaming. Stable parsed code blocks can be highlighted immediately, but the active streaming tail may remain plain until its closing fence arrives or until the block is promoted into `ACPMarkdownBlockCache.stableBlocks`.
+
+This pass should not add a Tree-sitter incremental cache for chat. If repeated highlighting of unstable blocks becomes measurable later, add that as a separate performance change.
+
 ### Optional Regex Coverage
 
 If the current fallback does not color desired chat-only labels, extend `RegexFallbackHighlighter` conservatively for simple languages only. This is optional and should be limited to labels where a small keyword/string/comment pattern gives useful output without pretending to be a full parser.
+
+`sql` is explicitly out of the first pass unless a small SQL fallback is added intentionally with tests. A broad alias table may still know about `sql`, but SQL blocks should remain plain without fallback support.
 
 ## Error Handling
 
 - Empty code block: render an empty monospaced block as today.
 - Empty or missing language label: render plain monospaced text.
 - Unknown language label: render plain monospaced text.
+- Known-but-unsupported language label: render plain monospaced text.
 - Tree-sitter parser or query unavailable: use the existing highlighter fallback behavior.
 - Malformed source for a language: return whatever spans Tree-sitter produces; never hide or modify code text.
 - Span range outside the string: skip that span.
@@ -100,11 +122,20 @@ If the current fallback does not color desired chat-only labels, extend `RegexFa
 Add focused Swift Testing coverage:
 
 - `ACPCodeLanguage` maps common aliases such as `python`, `typescript`, `shell`, `zsh`, `javascript`, and `c++`.
-- Unknown labels map to nil.
+- Supported regex-backed labels such as `diff`, `patch`, `html`, `xml`, and `css` route through the shared highlighter path.
+- Known-but-unsupported future labels such as `sql`, `ruby`, and `php` do not apply syntax colors until support exists.
+- Unknown labels map to nil or produce plain attributed output.
 - The attributed code builder applies a non-default foreground color to `func` in a Swift code block.
 - Unknown-language code remains monospaced and default-colored.
+- Highlighting does not change the visible header label or copied code string.
 
 If direct SwiftUI `View` inspection is awkward, keep the highlight application in a pure helper and test that helper.
+
+## Fast Follow: Markdown Preview
+
+Markdown file preview already highlights fenced code blocks, but its label mapping should not be changed in this ACP-first pass. After ACP lands, extract the fence-label normalization into shared code and have both ACP chat and Markdown preview use it.
+
+That follow-up should compare ACP and Markdown preview behavior explicitly so the two renderers converge without surprising existing Markdown preview users.
 
 ## Out of Scope
 
@@ -113,3 +144,4 @@ If direct SwiftUI `View` inspection is awkward, keep the highlight application i
 - Syntax coloring inline code in ACP prose.
 - Highlighting code while the user types in the ACP composer.
 - Changing ACP message persistence or protocol handling.
+- Changing Markdown preview behavior in this pass.


### PR DESCRIPTION
## Summary
- Gate ACP fenced-code syntax highlighting to currently supported Tree-sitter and regex-backed labels.
- Keep SQL and future-known unsupported labels plain in ACP while preserving shared highlighter behavior for other callers.
- Add focused ACP highlighter tests and document the ACP-only scope plus Markdown preview fast follow.

## Test Plan
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPCodeBlockHighlighterTests test`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`