### PR TITLE
Preserve ACP transcript recovery state

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -504,6 +504,7 @@
 		9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */; };
 		9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */; };
 		9C73FEDF9B7B93D60FA3B51F /* ZmxClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47AF847BD698EAB373D128B /* ZmxClient.swift */; };
+		9C78AF82EA26A9928865C5C6 /* ACPSessionManagerAttachRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */; };
 		9C9EC609F3ED8EFF1151D611 /* JSONRPCFramerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */; };
 		9CCB74669051D30EF12FE306 /* AlasGhostty.App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2119507B66D09AF3DF347280 /* AlasGhostty.App.swift */; };
 		9CF6B43A0B19392A597A53EC /* ACPComposerActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69452CB123EB0AABB632F03 /* ACPComposerActionButton.swift */; };
@@ -1589,6 +1590,7 @@
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
 		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
+		F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerAttachRestoreTests.swift; sourceTree = "<group>"; };
 		F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceDiscardTests.swift; sourceTree = "<group>"; };
 		F97EB3FA3E3C1206D76A9668 /* FileSearchDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchDialog.swift; sourceTree = "<group>"; };
 		F9CA43B30C70A80245BE99CE /* HarnessServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessServiceTests.swift; sourceTree = "<group>"; };
@@ -2662,6 +2664,7 @@
 				52B5F3FFF8AEF13BC48DCFBD /* ACPSessionByteAccountingTests.swift */,
 				1DC1B975662D135B148443BC /* ACPSessionHydrationStateTests.swift */,
 				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
+				F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */,
 				472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */,
 				6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
@@ -3793,6 +3796,7 @@
 				4058A537B8CAE76FE7EFE184 /* ACPSessionHydrationStateTests.swift in Sources */,
 				D45D14487117192F9E5D7F0E /* ACPSessionHydratorTests.swift in Sources */,
 				C51451EC8E103EB5FEF82EFE /* ACPSessionLifecycleTests.swift in Sources */,
+				9C78AF82EA26A9928865C5C6 /* ACPSessionManagerAttachRestoreTests.swift in Sources */,
 				D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */,
 				095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -15,6 +15,7 @@ final class ACPSession: ObservableObject, Identifiable {
     let agentId: String
     let worktreeId: String
     let createdAt: Date
+    let restoredFromPersistence: Bool
     let transcript = ACPTranscript()
     let terminalHost: ACPTerminalHost = ACPTerminalHost(sessionCwd: "/", sessionEnv: [:])
 
@@ -31,6 +32,7 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published private(set) var composerDraftRevision: Int = 0
     @Published var setupState: SetupState = .checking
     @Published var lastError: String?
+    @Published var contextRestoreWarning: ContextRestoreWarning?
     /// Runtime-only transcript scroll intent. When true, the ACP message
     /// list follows new content and restores to the latest bottom after
     /// returning to this session. Set false when the user scrolls upward.
@@ -65,7 +67,8 @@ final class ACPSession: ObservableObject, Identifiable {
     /// protocol call (`session/prompt`, `session/cancel`, etc).
     /// Distinct from `id`, which is our locally-generated UUID used
     /// as the persistence key in `ACPSessionStore`.
-    /// Not persisted — recreated on each `attach()` if missing.
+    /// Persisted in `ACPSessionStore` and refreshed on each successful
+    /// `session/new` or `session/load`.
     var remoteSessionId: String?
     @Published var queue: [QueuedPrompt] = []
     @Published var steerUndo: SteerUndoState?
@@ -76,6 +79,24 @@ final class ACPSession: ObservableObject, Identifiable {
         /// the previous toast has expired.
         let id: UUID
         let snapshot: [QueuedPrompt]
+    }
+
+    struct ContextRestoreWarning: Equatable {
+        var message: String
+        var canSendTranscript: Bool
+    }
+
+    var hasConversationTranscript: Bool {
+        transcript.messages.contains { message in
+            switch message {
+            case .user(_, let text, _):
+                return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .agent(_, let buffer):
+                return !buffer.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            default:
+                return false
+            }
+        }
     }
 
     func replaceComposerDraft(_ draft: ACPComposerDraft) {
@@ -102,7 +123,8 @@ final class ACPSession: ObservableObject, Identifiable {
     init(id: ID, agentId: String, worktreeId: String, title: String,
          titleSource: ACPSessionTitleSource = .placeholder,
          createdAt: Date = Date(),
-         hydrationState: HydrationState = .ready) {
+         hydrationState: HydrationState = .ready,
+         restoredFromPersistence: Bool = false) {
         self.id = id
         self.agentId = agentId
         self.worktreeId = worktreeId
@@ -110,6 +132,7 @@ final class ACPSession: ObservableObject, Identifiable {
         self.titleSource = titleSource
         self.createdAt = createdAt
         self.hydrationState = hydrationState
+        self.restoredFromPersistence = restoredFromPersistence
     }
 
     deinit {

--- a/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionHydrator.swift
@@ -50,6 +50,8 @@ actor ACPSessionHydrator {
         let touched = ACPSessionRow(
             id: row.id, agentId: row.agentId, title: row.title,
             titleSource: row.titleSource,
+            remoteSessionId: row.remoteSessionId,
+            contextRecoveryPending: row.contextRecoveryPending,
             currentModel: row.currentModel, currentMode: row.currentMode,
             autoRun: row.autoRun,
             createdAt: row.createdAt, updatedAt: row.updatedAt,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -2,6 +2,9 @@ import Foundation
 
 @MainActor
 final class ACPSessionManager: ObservableObject {
+    typealias ACPSetupEvaluator = @MainActor (_ spec: ACPLaunchSpec) async -> ACPSetupResult
+    typealias ACPConnectionFactory = @MainActor (_ spec: ACPLaunchSpec) throws -> ACPConnection
+
     let worktreeId: String
     let worktreePath: String
     let store: ACPSessionStore
@@ -29,6 +32,8 @@ final class ACPSessionManager: ObservableObject {
     private var pendingDraftWrites: [ACPSession.ID: Task<Void, Never>] = [:]
     private static let draftDebounceNanos: UInt64 = 300_000_000
     private let hydrator: ACPSessionHydrator?
+    private let setupEvaluator: ACPSetupEvaluator
+    private let connectionFactory: ACPConnectionFactory
     private var inFlightHydrations: [ACPSession.ID: Task<Void, Never>] = [:]
 
     /// Per-session UI refcount. When this drops to zero AND the session is
@@ -40,7 +45,9 @@ final class ACPSessionManager: ObservableObject {
     init(worktreeId: String, worktreePath: String, store: ACPSessionStore,
          hydratorPath: String? = nil,
          onDirtyCheck: ((String) -> Bool)? = nil,
-         onLiveBufferRead: ((String) -> String?)? = nil)
+         onLiveBufferRead: ((String) -> String?)? = nil,
+         setupEvaluator: ACPSetupEvaluator? = nil,
+         connectionFactory: ACPConnectionFactory? = nil)
     {
         self.worktreeId = worktreeId
         self.worktreePath = worktreePath
@@ -48,6 +55,26 @@ final class ACPSessionManager: ObservableObject {
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
         self.hydrator = hydratorPath.flatMap { try? ACPSessionHydrator(path: $0) }
+        self.setupEvaluator = setupEvaluator ?? { spec in
+            let checker = ACPSetupChecker(env: ProcessInfo.processInfo.environment)
+            return await checker.evaluate(spec.setupCheck)
+        }
+        self.connectionFactory = connectionFactory ?? { spec in
+            let client: ACPStdioClient
+            if spec.command.hasPrefix("/") {
+                client = try ACPStdioClient(
+                    executable: URL(fileURLWithPath: spec.command),
+                    arguments: spec.arguments,
+                    environment: Self.mergeEnv(extra: spec.extraEnv))
+            } else {
+                client = try ACPStdioClient(
+                    executable: URL(fileURLWithPath: "/usr/bin/env"),
+                    arguments: [spec.command] + spec.arguments,
+                    environment: Self.mergeEnv(extra: spec.extraEnv))
+            }
+            try client.start()
+            return ACPConnection(client: client)
+        }
         self.recent = (try? store.recentSessions()) ?? []
     }
 
@@ -80,7 +107,9 @@ final class ACPSessionManager: ObservableObject {
         guard let row = try? store.loadSession(id: id) else { return nil }
         let session = ACPSession(
             id: row.id, agentId: row.agentId, worktreeId: worktreeId,
-            title: row.title, titleSource: row.titleSource, hydrationState: .loading)
+            title: row.title, titleSource: row.titleSource, hydrationState: .loading,
+            restoredFromPersistence: true)
+        session.remoteSessionId = row.remoteSessionId
         sessions[id] = session
         return session
     }
@@ -163,6 +192,8 @@ final class ACPSessionManager: ObservableObject {
         let touched = ACPSessionRow(
             id: row.id, agentId: row.agentId, title: row.title,
             titleSource: row.titleSource,
+            remoteSessionId: row.remoteSessionId,
+            contextRecoveryPending: row.contextRecoveryPending,
             currentModel: row.currentModel, currentMode: row.currentMode,
             autoRun: row.autoRun,
             createdAt: row.createdAt, updatedAt: row.updatedAt,
@@ -190,6 +221,15 @@ final class ACPSessionManager: ObservableObject {
         }
         session.currentModel = result.row.currentModel
         session.currentMode = result.row.currentMode
+        if session.remoteSessionId == nil || session.remoteSessionId == result.row.remoteSessionId {
+            session.remoteSessionId = result.row.remoteSessionId
+        }
+        if result.row.contextRecoveryPending {
+            session.contextRestoreWarning = .init(
+                message: "Agent context could not be restored.",
+                canSendTranscript: session.hasConversationTranscript
+            )
+        }
         session.autoRunEnabled = result.row.autoRun
         // Title intentionally NOT overwritten: `placeholderSession` already
         // seeded it from the same row, and a rename made through the
@@ -296,6 +336,29 @@ final class ACPSessionManager: ObservableObject {
             createdAt: row.createdAt, updatedAt: now,
             lastOpenedAt: row.lastOpenedAt, archived: row.archived))
         refreshRecent()
+    }
+
+    private func persistSessionRemoteId(_ s: ACPSession) {
+        guard let row = try? store.loadSession(id: s.id) else { return }
+        try? store.upsertSession(.init(
+            id: row.id,
+            agentId: row.agentId,
+            title: row.title,
+            titleSource: row.titleSource,
+            remoteSessionId: s.remoteSessionId,
+            contextRecoveryPending: row.contextRecoveryPending,
+            currentModel: row.currentModel,
+            currentMode: row.currentMode,
+            autoRun: row.autoRun,
+            createdAt: row.createdAt,
+            updatedAt: row.updatedAt,
+            lastOpenedAt: row.lastOpenedAt,
+            archived: row.archived
+        ))
+    }
+
+    private func persistContextRecoveryPending(sessionId: ACPSession.ID, pending: Bool) {
+        try? store.setContextRecoveryPending(sessionId: sessionId, pending: pending)
     }
 
     /// Rename a session with the given title and source. Updates both
@@ -481,11 +544,11 @@ extension ACPSessionManager {
             stale.stop()
         }
         runners[sessionId] = nil
-        // Clear any error from the prior attempt so the UI doesn't keep
-        // showing a stale failure banner while we spawn fresh. If this
-        // attempt also fails, the catch branches below will repopulate
+        // Clear stale failure UI from the prior attempt while we spawn fresh.
+        // If this attempt also fails, the catch branches below will repopulate
         // `lastError` with the new reason.
         session.lastError = nil
+        session.contextRestoreWarning = nil
         session.agentState = .spawning
 
         guard let spec = ACPLaunchCatalog.spec(for: session.agentId) else {
@@ -494,8 +557,7 @@ extension ACPSessionManager {
             session.agentState = .failed(reason)
             return
         }
-        let checker = ACPSetupChecker(env: ProcessInfo.processInfo.environment)
-        let setup = await checker.evaluate(spec.setupCheck)
+        let setup = await setupEvaluator(spec)
         guard case .ready = setup else {
             session.setupState = .needsSetup(reason: setup.reasonText)
             session.agentState = .failed(setup.reasonText)
@@ -503,31 +565,19 @@ extension ACPSessionManager {
         }
         session.setupState = .ready
 
-        let client: ACPStdioClient
+        let connection: ACPConnection
         do {
-            if spec.command.hasPrefix("/") {
-                client = try ACPStdioClient(
-                    executable: URL(fileURLWithPath: spec.command),
-                    arguments: spec.arguments,
-                    environment: Self.mergeEnv(extra: spec.extraEnv))
-            } else {
-                client = try ACPStdioClient(
-                    executable: URL(fileURLWithPath: "/usr/bin/env"),
-                    arguments: [spec.command] + spec.arguments,
-                    environment: Self.mergeEnv(extra: spec.extraEnv))
-            }
-            try client.start()
+            connection = try connectionFactory(spec)
         } catch {
             let msg = "Failed to launch agent: \(error.localizedDescription)"
             session.lastError = msg
             session.agentState = .failed(msg)
             return
         }
-        let connection = ACPConnection(client: client)
         // Collect a short tail of stderr so we can surface it when the
         // agent rejects initialize / new for protocol or auth reasons.
         let stderrBuffer = StderrBuffer()
-        let stderrTask = Task { [weak client] in
+        let stderrTask = Task { [weak client = connection.client] in
             guard let stream = (client as? ACPStdioClient)?.incomingStderr else { return }
             for await data in stream {
                 stderrBuffer.append(data)
@@ -535,13 +585,43 @@ extension ACPSessionManager {
         }
         do {
             try await connection.initialize()
-            // Always call `session/new` — even when reopening, because the
-            // server doesn't know about our local UUID, and `remoteSessionId`
-            // (the id `session/new` previously returned) isn't persisted.
-            // Most ACP agents also don't implement `session/load`. The user-
-            // visible history comes from the local SQLite store, loaded via
-            // `hydrateIfNeeded`; the server just gets a fresh conversation.
-            let result = try await connection.newSession(cwd: worktreePath)
+            let pendingRecovery = (try? store.loadSession(id: sessionId)?.contextRecoveryPending) == true
+            let result: ACPSessionNewResult
+            var restoreWarning: ACPSession.ContextRestoreWarning?
+            var shouldHoldQueueForRecovery = pendingRecovery && session.hasConversationTranscript
+            if freshlyCreated {
+                result = try await connection.newSession(cwd: worktreePath)
+            } else if let remoteId = session.remoteSessionId, !remoteId.isEmpty {
+                do {
+                    result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
+                } catch {
+                    result = try await connection.newSession(cwd: worktreePath)
+                    if session.hasConversationTranscript {
+                        shouldHoldQueueForRecovery = true
+                        persistContextRecoveryPending(sessionId: sessionId, pending: true)
+                    }
+                    restoreWarning = .init(
+                        message: "Agent context could not be restored.",
+                        canSendTranscript: session.hasConversationTranscript
+                    )
+                }
+            } else {
+                result = try await connection.newSession(cwd: worktreePath)
+                if session.hasConversationTranscript {
+                    shouldHoldQueueForRecovery = true
+                    persistContextRecoveryPending(sessionId: sessionId, pending: true)
+                }
+                restoreWarning = .init(
+                    message: "Agent context could not be restored.",
+                    canSendTranscript: session.hasConversationTranscript
+                )
+            }
+            if restoreWarning == nil, pendingRecovery {
+                restoreWarning = .init(
+                    message: "Agent context could not be restored.",
+                    canSendTranscript: session.hasConversationTranscript
+                )
+            }
             session.remoteSessionId = result.sessionId
             session.availableModels = result.availableModels
             session.availableModes = result.availableModes
@@ -549,6 +629,8 @@ extension ACPSessionManager {
             session.currentMode = result.currentMode
             session.promptSuggestions = result.promptSuggestions
             session.availableConfigOptions = result.configOptions
+            session.contextRestoreWarning = restoreWarning
+            persistSessionRemoteId(session)
             let runner = ACPSessionRunner(session: session, connection: connection,
                                           store: store, sessionId: sessionId,
                                           worktreePath: worktreePath,
@@ -558,7 +640,9 @@ extension ACPSessionManager {
             runner.start()
             runners[sessionId] = runner
             session.agentState = .ready
-            runner.flushQueueIfIdle()
+            if !shouldHoldQueueForRecovery {
+                runner.flushQueueIfIdle()
+            }
             stderrTask.cancel()
         } catch {
             // Give stderr a moment to drain so the message is the real cause.
@@ -583,6 +667,40 @@ extension ACPSessionManager {
         case .idle, .disconnected, .failed:
             await attach(to: sessionId, freshlyCreated: false)
         }
+    }
+
+    func transcriptContextPrompt(for session: ACPSession, agentName: String?) -> String? {
+        guard session.hasConversationTranscript else { return nil }
+        let markdown = ACPTranscriptMarkdown.document(
+            title: session.title,
+            agentName: agentName,
+            messages: session.transcript.messages
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !markdown.isEmpty else { return nil }
+        return """
+        The previous agent context for this pane could not be restored. Use the transcript below as background context for future turns. Do not summarize or repeat it back unless I ask.
+
+        \(markdown)
+        """
+    }
+
+    @discardableResult
+    func sendTranscriptAsContext(sessionId: ACPSession.ID, agentName: String?) -> Bool {
+        guard let session = sessions[sessionId],
+              let runner = runners[sessionId],
+              session.contextRestoreWarning?.canSendTranscript == true,
+              session.agentState == .ready,
+              session.transcript.streamingState == .idle,
+              let prompt = transcriptContextPrompt(for: session, agentName: agentName)
+        else { return false }
+
+        runner.sendRecoveryContext(prompt) { delivered in
+            if delivered {
+                self.persistContextRecoveryPending(sessionId: sessionId, pending: false)
+                session.contextRestoreWarning = nil
+            }
+        }
+        return true
     }
 
     /// Enqueue a prompt into a session whose agent isn't `.ready` yet.

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -768,6 +768,64 @@ extension ACPSessionRunner {
         }
     }
 
+    func sendRecoveryContext(
+        _ prompt: String,
+        onCompleted: (@MainActor (_ delivered: Bool) -> Void)? = nil
+    ) {
+        let promptID = nextPromptID
+        nextPromptID += 1
+        activePromptID = promptID
+        Task { [weak self, onCompleted] in
+            guard let self else {
+                await MainActor.run { onCompleted?(false) }
+                return
+            }
+            let proceeded = await MainActor.run { () -> Bool in
+                if self.activePromptID != promptID {
+                    self.cancelledPromptIDs.remove(promptID)
+                    return false
+                }
+                self.session.transcript.streamingState = .sending
+                return true
+            }
+            guard proceeded else {
+                await MainActor.run { onCompleted?(false) }
+                return
+            }
+            do {
+                let remoteId = self.session.remoteSessionId ?? self.sessionId
+                try await self.connection.prompt(sessionId: remoteId, blocks: [.text(prompt)])
+                await MainActor.run {
+                    let wasCancelled = self.cancelledPromptIDs.remove(promptID) != nil
+                    let isActivePrompt = self.activePromptID == promptID
+                    let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
+                    if isActivePrompt {
+                        self.activePromptID = nil
+                        self.session.transcript.streamingState = .idle
+                        self.flushQueueIfIdle()
+                    }
+                    if !hasNewerActivePrompt {
+                        onCompleted?(isActivePrompt && !wasCancelled)
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    _ = self.cancelledPromptIDs.remove(promptID)
+                    let isActivePrompt = self.activePromptID == promptID
+                    let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
+                    if isActivePrompt {
+                        self.activePromptID = nil
+                        self.session.transcript.streamingState = .idle
+                        self.flushQueueIfIdle()
+                    }
+                    if !hasNewerActivePrompt {
+                        onCompleted?(false)
+                    }
+                }
+            }
+        }
+    }
+
     /// First text block as the user-facing preview. Used when recording
     /// the queued item's bubble in the transcript on flush. Concatenating
     /// every text block matches the wire shape we already send.

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ACPSessionStore {
-    static let targetSchemaVersion = 4
+    static let targetSchemaVersion = 6
     let db: SQLiteDatabase
 
     init(path: String) throws {
@@ -29,6 +29,8 @@ final class ACPSessionStore {
         if current < 2 { try migrate_to_v2() }
         if current < 3 { try migrate_to_v3() }
         if current < 4 { try migrate_to_v4() }
+        if current < 5 { try migrate_to_v5() }
+        if current < 6 { try migrate_to_v6() }
         if current == 0 {
             try db.exec("INSERT INTO schema_version (version) VALUES (?)", bindings: [Int64(Self.targetSchemaVersion)])
         } else if current < Self.targetSchemaVersion {
@@ -114,6 +116,14 @@ final class ACPSessionStore {
         WHERE title = '' OR title = 'New session'
         """)
     }
+
+    private func migrate_to_v5() throws {
+        try db.exec("ALTER TABLE sessions ADD COLUMN remote_session_id TEXT")
+    }
+
+    private func migrate_to_v6() throws {
+        try db.exec("ALTER TABLE sessions ADD COLUMN context_recovery_pending INTEGER NOT NULL DEFAULT 0")
+    }
 }
 
 struct ACPSessionRow: Equatable {
@@ -121,6 +131,8 @@ struct ACPSessionRow: Equatable {
     let agentId: String
     var title: String
     var titleSource: ACPSessionTitleSource = .placeholder
+    var remoteSessionId: String? = nil
+    var contextRecoveryPending: Bool = false
     var currentModel: String?
     var currentMode: String?
     var autoRun: Bool
@@ -142,12 +154,14 @@ struct ACPStoredMessage: Equatable {
 extension ACPSessionStore {
     func upsertSession(_ s: ACPSessionRow) throws {
         try db.exec("""
-        INSERT INTO sessions (id, agent_id, title, title_source, current_model, current_mode, auto_run,
-                              created_at, updated_at, last_opened_at, archived)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?)
+        INSERT INTO sessions (id, agent_id, title, title_source, remote_session_id, context_recovery_pending,
+                              current_model, current_mode, auto_run, created_at, updated_at, last_opened_at, archived)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
         ON CONFLICT(id) DO UPDATE SET
             title = excluded.title,
             title_source = excluded.title_source,
+            remote_session_id = COALESCE(excluded.remote_session_id, sessions.remote_session_id),
+            context_recovery_pending = sessions.context_recovery_pending,
             current_model = excluded.current_model,
             current_mode = excluded.current_mode,
             auto_run = excluded.auto_run,
@@ -155,8 +169,8 @@ extension ACPSessionStore {
             last_opened_at = excluded.last_opened_at,
             archived = excluded.archived
         """, bindings: [
-            s.id, s.agentId, s.title, s.titleSource.rawValue, s.currentModel, s.currentMode,
-            s.autoRun ? 1 : 0,
+            s.id, s.agentId, s.title, s.titleSource.rawValue, s.remoteSessionId, s.contextRecoveryPending ? 1 : 0,
+            s.currentModel, s.currentMode, s.autoRun ? 1 : 0,
             s.createdAt, s.updatedAt, s.lastOpenedAt, s.archived ? 1 : 0
         ])
     }
@@ -174,6 +188,13 @@ extension ACPSessionStore {
         try db.exec(
             "UPDATE sessions SET last_opened_at = ? WHERE id = ?",
             bindings: [timestamp, id]
+        )
+    }
+
+    func setContextRecoveryPending(sessionId: String, pending: Bool) throws {
+        try db.exec(
+            "UPDATE sessions SET context_recovery_pending = ? WHERE id = ?",
+            bindings: [pending ? 1 : 0, sessionId]
         )
     }
 
@@ -249,6 +270,8 @@ extension ACPSessionStore {
             agentId: r["agent_id"] as? String ?? "",
             title: r["title"] as? String ?? "",
             titleSource: ACPSessionTitleSource(rawValue: rawSource) ?? .placeholder,
+            remoteSessionId: r["remote_session_id"] as? String,
+            contextRecoveryPending: ((r["context_recovery_pending"] as? Int64) ?? 0) != 0,
             currentModel: r["current_model"] as? String,
             currentMode: r["current_mode"] as? String,
             autoRun: ((r["auto_run"] as? Int64) ?? 0) != 0,

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+enum ACPSessionAttachFreshness {
+    static func isFresh(restoredFromPersistence: Bool, remoteSessionId: String?) -> Bool {
+        !restoredFromPersistence && (remoteSessionId?.isEmpty ?? true)
+    }
+}
+
 struct ACPTabView: View {
     let sessionId: ACPSession.ID
     let state: AppState
@@ -91,6 +97,7 @@ private struct ACPSessionView: View {
                 }
             )
             adapterBanner()
+            contextRestoreBanner()
             if let err = session.lastError {
                 errorBanner(err)
             }
@@ -332,6 +339,40 @@ private struct ACPSessionView: View {
         }
     }
 
+    @ViewBuilder
+    private func contextRestoreBanner() -> some View {
+        if let warning = session.contextRestoreWarning {
+            HStack(spacing: 8) {
+                Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+                    .foregroundStyle(theme.color("warn"))
+                Text(warning.message)
+                    .font(.system(size: 12))
+                    .foregroundStyle(theme.color("fg"))
+                Spacer()
+                if warning.canSendTranscript {
+                    Button("Send transcript as context") {
+                        _ = manager.sendTranscriptAsContext(
+                            sessionId: sessionId,
+                            agentName: state.agent(id: session.agentId)?.displayName
+                        )
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(
+                        session.agentState != .ready
+                            || session.transcript.streamingState != .idle
+                            || manager.runners[sessionId] == nil
+                    )
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(theme.color("bg-1").opacity(0.7))
+            .overlay(alignment: .bottom) {
+                Rectangle().fill(theme.color("line")).frame(height: 0.5)
+            }
+        }
+    }
+
     private func scopeKey(for pending: ACPSession.PendingPermission?) -> String {
         guard let p = pending else { return "" }
         return "tool:\(p.params.toolCall.title ?? p.params.toolCall.toolCallId)"
@@ -339,12 +380,14 @@ private struct ACPSessionView: View {
 
     private func reattach() async {
         // Drop any half-attached connection state, clear the prior error,
-        // then re-run attach with `freshlyCreated:` matching whether we have
-        // any messages yet (mirrors initial-mount logic).
+        // then re-run attach with the session's persisted-origin state.
         await manager.detach(sessionId: sessionId)
         session.lastError = nil
         session.setupState = .checking
-        let freshlyCreated = session.transcript.messages.isEmpty
+        let freshlyCreated = ACPSessionAttachFreshness.isFresh(
+            restoredFromPersistence: session.restoredFromPersistence,
+            remoteSessionId: session.remoteSessionId
+        )
         await manager.attach(to: sessionId, freshlyCreated: freshlyCreated)
     }
 
@@ -395,7 +438,10 @@ private struct ACPSessionView: View {
         await manager.hydrateIfNeeded(id: sessionId)
         if case .failed = session.hydrationState { return }
         let freshlyCreated = manager.runners[sessionId] == nil
-            && session.transcript.messages.isEmpty
+            && ACPSessionAttachFreshness.isFresh(
+                restoredFromPersistence: session.restoredFromPersistence,
+                remoteSessionId: session.remoteSessionId
+            )
         await manager.attach(to: sessionId, freshlyCreated: freshlyCreated)
         await refreshAdapterUpdateState()
     }

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -28,6 +28,32 @@ struct ACPConnectionTests {
         #expect(new.availableModes.first?.id == "agent")
     }
 
+    @Test("loadSession sends session/load with cwd and remote session id")
+    func loadSessionRPC() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "session/load") { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-restored",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+
+        let conn = ACPConnection(client: mock)
+        let result = try await conn.loadSession(cwd: "/tmp/wt", sessionId: "remote-old")
+
+        #expect(result.sessionId == "remote-restored")
+        let req = try #require(mock.sent.last)
+        #expect(req.method == "session/load")
+        let params = try #require(req.params as? ACPSessionLoadParams)
+        #expect(params.cwd == "/tmp/wt")
+        #expect(params.sessionId == "remote-old")
+        #expect(params.mcpServers.isEmpty)
+    }
+
     @Test("setConfigOption sends session/set_config_option with sessionId, configId, value")
     func setConfigOptionRPC() async throws {
         let mock = ACPMockClient()

--- a/AlasTests/ACP/Session/ACPSessionHydratorTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionHydratorTests.swift
@@ -57,6 +57,30 @@ struct ACPSessionHydratorTests {
         #expect(result.recent.contains(where: { $0.id == "s" }))
     }
 
+    @Test("hydrate preserves remote ACP session id in touched row")
+    func hydratePreservesRemoteSessionIdInTouchedRow() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "claude",
+            title: "t",
+            remoteSessionId: "remote-1",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 0,
+            updatedAt: 0,
+            lastOpenedAt: 0,
+            archived: false
+        ))
+
+        let hydrator = try ACPSessionHydrator(path: path)
+        let result = try await hydrator.hydrate(sessionId: "s")
+
+        #expect(result.row.remoteSessionId == "remote-1")
+    }
+
     @Test("missing session throws")
     func missingSession() async throws {
         let path = tmpStorePath()

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -1,0 +1,564 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSessionManager attach restore")
+struct ACPSessionManagerAttachRestoreTests {
+    @Test("reopened session uses session/load")
+    func reopenedSessionUsesLoad() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-restored")
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        let methods = client.sent.map(\.method)
+        #expect(methods == ["initialize", "session/load"])
+        #expect(session.remoteSessionId == "remote-restored")
+        #expect(session.contextRestoreWarning == nil)
+        #expect(try store.loadSession(id: "local")?.remoteSessionId == "remote-restored")
+    }
+
+    @Test("load failure falls back to session/new with transcript warning")
+    func loadFailureFallsBackToNewWithWarning() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        let priorPrompt: ACPMessage = .user(id: UUID(), text: "prior prompt", attachments: [])
+        try store.appendMessage(
+            sessionId: "local", id: "m0", kind: priorPrompt.kind, seq: 0,
+            payload: ACPMessageCodec.encode(priorPrompt), createdAt: 0
+        )
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            throw JSONRPCError(code: -32601, message: "Method not found", data: nil)
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        let methods = client.sent.map(\.method)
+        #expect(methods == ["initialize", "session/load", "session/new"])
+        #expect(session.remoteSessionId == "remote-new")
+        let warning = try #require(session.contextRestoreWarning)
+        #expect(warning.canSendTranscript)
+        let row = try #require(try store.loadSession(id: "local"))
+        #expect(row.remoteSessionId == "remote-new")
+        #expect(row.contextRecoveryPending)
+    }
+
+    @Test("pending queued prompt waits for transcript recovery after load fallback")
+    func queuedPromptWaitsForTranscriptRecoveryAfterLoadFallback() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        try appendMessage(
+            .user(id: UUID(), text: "Prior context", attachments: []),
+            to: store,
+            seq: 0
+        )
+        try store.upsertQueue(sessionId: "local", items: [
+            QueuedPrompt(blocks: [.text("queued prompt")])
+        ])
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            throw JSONRPCError(code: -32601, message: "Method not found", data: nil)
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/new"])
+        #expect(session.queue.count == 1)
+        #expect(session.contextRestoreWarning?.canSendTranscript == true)
+        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == true)
+
+        let accepted = manager.sendTranscriptAsContext(sessionId: session.id, agentName: "Agent")
+
+        #expect(accepted)
+        try await waitUntil {
+            client.sent.filter { $0.method == "session/prompt" }.count == 2
+                && session.queue.isEmpty
+                && session.contextRestoreWarning == nil
+        }
+        let prompts = client.sent.compactMap { $0.params as? ACPSessionPromptParams }
+        #expect(prompts.count == 2)
+        let firstBlock = try #require(prompts.first?.prompt.first)
+        guard case .text(let recovery) = firstBlock else {
+            Issue.record("Expected transcript recovery prompt first")
+            return
+        }
+        #expect(recovery.contains("Prior context"))
+        #expect(prompts.last?.prompt == [.text("queued prompt")])
+        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == false)
+    }
+
+    @Test("missing remote id falls back to session/new with no-transcript warning")
+    func missingRemoteIdFallsBackToNewWithWarning() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: nil))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        let methods = client.sent.map(\.method)
+        #expect(methods == ["initialize", "session/new"])
+        #expect(session.remoteSessionId == "remote-new")
+        let warning = try #require(session.contextRestoreWarning)
+        #expect(!warning.canSendTranscript)
+        let row = try #require(try store.loadSession(id: "local"))
+        #expect(row.remoteSessionId == "remote-new")
+        #expect(!row.contextRecoveryPending)
+    }
+
+    @Test("pending context recovery survives restart after fallback remote id is persisted")
+    func pendingContextRecoverySurvivesRestart() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-new"))
+        try store.setContextRecoveryPending(sessionId: "local", pending: true)
+        try appendMessage(
+            .user(id: UUID(), text: "Context before restart", attachments: []),
+            to: store,
+            seq: 0
+        )
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-new")
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load"])
+        let warning = try #require(session.contextRestoreWarning)
+        #expect(warning.canSendTranscript)
+        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == true)
+    }
+
+    @Test("attach retry clears stale warning before setup failure")
+    func attachRetryClearsStaleWarningBeforeSetupFailure() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .missing(reason: "missing") }
+        )
+        let session = manager.createSession(agentId: "claude")
+        session.contextRestoreWarning = .init(
+            message: "old warning",
+            canSendTranscript: true
+        )
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(session.setupState == .needsSetup(reason: "missing"))
+        #expect(session.agentState == .failed("missing"))
+        #expect(session.contextRestoreWarning == nil)
+    }
+
+    @Test("load failure followed by new failure leaves stale warning cleared")
+    func loadFailureFollowedByNewFailureLeavesStaleWarningCleared() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            throw JSONRPCError(code: -32601, message: "Method not found", data: nil)
+        }
+        client.script(method: "session/new") { _ in
+            throw JSONRPCError(code: -32000, message: "new failed", data: nil)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        session.contextRestoreWarning = .init(
+            message: "old warning",
+            canSendTranscript: true
+        )
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/new"])
+        #expect(session.remoteSessionId == "remote-old")
+        #expect(session.contextRestoreWarning == nil)
+        if case .failed(let message) = session.agentState {
+            #expect(message.contains("new failed"))
+        } else {
+            Issue.record("Expected failed agent state")
+        }
+        #expect(try store.loadSession(id: "local")?.remoteSessionId == "remote-old")
+    }
+
+    @Test("send transcript context clears warning")
+    func sendTranscriptContextClearsWarning() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-new"))
+        try appendMessage(
+            .user(id: UUID(), text: "What changed?", attachments: []),
+            to: store,
+            seq: 0
+        )
+        try appendMessage(
+            .agent(id: UUID(), StreamingText("We changed persistence.")),
+            to: store,
+            seq: 1
+        )
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-new")
+        client.script(method: "session/prompt") { request in
+            let params = try #require(request.params as? ACPSessionPromptParams)
+            #expect(params.sessionId == "remote-new")
+            #expect(params.prompt.count == 1)
+            let block = try #require(params.prompt.first)
+            guard case .text(let text) = block else {
+                Issue.record("Expected text prompt block")
+                return Data("null".utf8)
+            }
+            #expect(text.contains("The previous agent context for this pane could not be restored."))
+            #expect(text.contains("## You\n\nWhat changed?"))
+            #expect(text.contains("## Agent\n\nWe changed persistence."))
+            return Data("null".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+        session.contextRestoreWarning = .init(
+            message: "Agent context could not be restored.",
+            canSendTranscript: true
+        )
+        let messageCountBefore = session.transcript.messages.count
+
+        let accepted = manager.sendTranscriptAsContext(sessionId: session.id, agentName: "Agent")
+
+        #expect(accepted)
+        try await waitUntil { session.contextRestoreWarning == nil }
+        #expect(session.transcript.messages.count == messageCountBefore)
+        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/prompt"])
+    }
+
+    @Test("send transcript context clears persisted recovery pending flag")
+    func sendTranscriptContextClearsPersistedPendingFlag() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-new"))
+        try store.setContextRecoveryPending(sessionId: "local", pending: true)
+        try appendMessage(
+            .user(id: UUID(), text: "What changed?", attachments: []),
+            to: store,
+            seq: 0
+        )
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-new")
+        client.script(method: "session/prompt") { _ in Data("null".utf8) }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(session.contextRestoreWarning?.canSendTranscript == true)
+        #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: "Agent"))
+        try await waitUntil { session.contextRestoreWarning == nil }
+        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == false)
+    }
+
+    @Test("failed transcript context send keeps warning and transcript")
+    func failedTranscriptContextSendKeepsWarningAndTranscript() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-new"))
+        try appendMessage(
+            .user(id: UUID(), text: "What changed?", attachments: []),
+            to: store,
+            seq: 0
+        )
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-new")
+        client.script(method: "session/prompt") { _ in
+            throw ACPClientError.noScript(method: "session/prompt")
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+        let warning = ACPSession.ContextRestoreWarning(
+            message: "Agent context could not be restored.",
+            canSendTranscript: true
+        )
+        session.contextRestoreWarning = warning
+        let messageCountBefore = session.transcript.messages.count
+
+        let accepted = manager.sendTranscriptAsContext(sessionId: session.id, agentName: "Agent")
+
+        #expect(accepted)
+        try await waitUntil {
+            client.sent.filter { $0.method == "session/prompt" }.count == 1
+                && session.transcript.streamingState == .idle
+        }
+        #expect(session.contextRestoreWarning == warning)
+        #expect(session.transcript.messages.count == messageCountBefore)
+    }
+
+    @Test("cancelled recovery context send reports not delivered")
+    func cancelledRecoveryContextSendReportsNotDelivered() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-new"))
+        try appendMessage(
+            .user(id: UUID(), text: "What changed?", attachments: []),
+            to: store,
+            seq: 0
+        )
+        let client = ACPMockClient()
+        let gate = PromptGate()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-new")
+        client.scriptAsync(method: "session/prompt") { _ in
+            await gate.waitInPrompt()
+            return Data("null".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+        let runner = try #require(manager.runners[session.id])
+        let warning = ACPSession.ContextRestoreWarning(
+            message: "Agent context could not be restored.",
+            canSendTranscript: true
+        )
+        session.contextRestoreWarning = warning
+        var delivered: Bool?
+
+        runner.sendRecoveryContext("recovery context") { result in
+            delivered = result
+        }
+        try await waitUntilAsync { await gate.hasEntered }
+        await runner.userCancel()
+        await gate.release()
+        try await waitUntil { delivered != nil }
+        #expect(delivered == false)
+        #expect(session.transcript.streamingState == .idle)
+        #expect(session.contextRestoreWarning == warning)
+    }
+
+    @Test("recovery context completion drains queued prompt")
+    func recoveryContextCompletionDrainsQueuedPrompt() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-new"))
+        try appendMessage(
+            .user(id: UUID(), text: "What changed?", attachments: []),
+            to: store,
+            seq: 0
+        )
+        let client = ACPMockClient()
+        let gate = PromptGate()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-new")
+        client.scriptAsync(method: "session/prompt") { _ in
+            await gate.waitInPrompt()
+            return Data("null".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+        let runner = try #require(manager.runners[session.id])
+
+        runner.sendRecoveryContext("recovery context")
+        try await waitUntilAsync { await gate.hasEntered }
+        runner.send(blocks: [.text("normal prompt")], intent: .auto)
+
+        #expect(session.queue.count == 1)
+        await gate.release()
+        try await waitUntil {
+            client.sent.filter { $0.method == "session/prompt" }.count == 2
+                && session.queue.isEmpty
+                && session.transcript.streamingState == .idle
+        }
+
+        let prompts = client.sent.filter { $0.method == "session/prompt" }
+        let second = try #require(prompts.last?.params as? ACPSessionPromptParams)
+        #expect(second.prompt == [.text("normal prompt")])
+    }
+
+    @Test("transcript context prompt requires conversation")
+    func transcriptContextPromptRequiresConversation() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = manager.createSession(agentId: "claude")
+        session.appendSystemNotice("Agent context could not be restored.")
+
+        #expect(manager.transcriptContextPrompt(for: session, agentName: "Agent") == nil)
+        #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: "Agent") == false)
+    }
+
+    @Test("send transcript context rejects unavailable states")
+    func sendTranscriptContextRejectsUnavailableStates() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let manager = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = manager.createSession(agentId: "claude")
+        session.recordUserPrompt(text: "What changed?", attachments: [])
+
+        #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: nil) == false)
+
+        session.contextRestoreWarning = .init(message: "warning", canSendTranscript: false)
+        #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: nil) == false)
+
+        session.contextRestoreWarning = .init(message: "warning", canSendTranscript: true)
+        session.agentState = .ready
+        #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: nil) == false)
+
+        session.transcript.streamingState = .streaming
+        #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: nil) == false)
+
+        session.transcript.streamingState = .idle
+        session.enqueue(blocks: [.text("queued")])
+        #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: nil) == false)
+    }
+
+    private func tmpStorePath() -> String {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-attach-restore-\(UUID()).sqlite").path
+    }
+
+    private func appendMessage(
+        _ message: ACPMessage,
+        to store: ACPSessionStore,
+        seq: Int64
+    ) throws {
+        try store.appendMessage(
+            sessionId: "local",
+            id: "m\(seq)",
+            kind: message.kind,
+            seq: seq,
+            payload: ACPMessageCodec.encode(message),
+            createdAt: seq
+        )
+    }
+
+    private func waitUntil(
+        timeoutNanos: UInt64 = 500_000_000,
+        condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let start = DispatchTime.now().uptimeNanoseconds
+        while !condition() {
+            if DispatchTime.now().uptimeNanoseconds - start >= timeoutNanos {
+                Issue.record("Timed out waiting for condition")
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    private func waitUntilAsync(
+        timeoutNanos: UInt64 = 500_000_000,
+        condition: @escaping () async -> Bool
+    ) async throws {
+        let start = DispatchTime.now().uptimeNanoseconds
+        while !(await condition()) {
+            if DispatchTime.now().uptimeNanoseconds - start >= timeoutNanos {
+                Issue.record("Timed out waiting for condition")
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    private func row(remoteSessionId: String?) -> ACPSessionRow {
+        ACPSessionRow(
+            id: "local",
+            agentId: "claude",
+            title: "Stored session",
+            titleSource: .placeholder,
+            remoteSessionId: remoteSessionId,
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 0,
+            updatedAt: 0,
+            lastOpenedAt: 0,
+            archived: false
+        )
+    }
+
+    private func manager(store: ACPSessionStore, client: ACPMockClient) -> ACPSessionManager {
+        ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in .ready },
+            connectionFactory: { _ in ACPConnection(client: client) }
+        )
+    }
+
+    private func scriptInitialize(_ client: ACPMockClient) {
+        client.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: nil,
+                authMethods: []
+            ))
+        }
+    }
+
+    private func scriptSessionResult(_ client: ACPMockClient, method: String, sessionId: String) {
+        client.script(method: method) { _ in
+            try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: sessionId,
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+    }
+
+    private actor PromptGate {
+        private var entered = false
+        private var released = false
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        var hasEntered: Bool { entered }
+
+        func waitInPrompt() async {
+            if released { return }
+            entered = true
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func release() {
+            released = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+}

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -73,6 +73,63 @@ struct ACPSessionManagerHydrationTests {
         }
     }
 
+    @Test("hydrateIfNeeded restores persisted remote ACP session id")
+    func hydrateRestoresRemoteSessionId() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "claude",
+            title: "t",
+            remoteSessionId: "remote-1",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 0,
+            updatedAt: 0,
+            lastOpenedAt: 0,
+            archived: false
+        ))
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        #expect(s.remoteSessionId == "remote-1")
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.remoteSessionId == "remote-1")
+    }
+
+    @Test("hydrateIfNeeded does not overwrite a newer in-memory remote ACP session id")
+    func hydratePreservesNewerRemoteSessionId() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s",
+            agentId: "claude",
+            title: "t",
+            remoteSessionId: "remote-old",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 0,
+            updatedAt: 0,
+            lastOpenedAt: 0,
+            archived: false
+        ))
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        #expect(s.remoteSessionId == "remote-old")
+        s.remoteSessionId = "remote-new"
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        #expect(s.hydrationState == .ready)
+        #expect(s.remoteSessionId == "remote-new")
+    }
+
     @Test("hydrateIfNeeded short-circuits when already ready")
     func hydrateShortCircuit() async throws {
         let path = tmpStorePath()

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -12,8 +12,55 @@ struct ACPSessionManagerTests {
         let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
         let s = mgr.createSession(agentId: "claude")
         #expect(mgr.sessions[s.id] != nil)
+        #expect(!s.restoredFromPersistence)
         let row = try store.loadSession(id: s.id)
         #expect(row?.agentId == "claude")
+    }
+
+    @Test("placeholderSession marks store-backed sessions as restored from persistence")
+    func placeholderSessionMarksRestoredFromPersistence() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-restored-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(
+            id: "stored",
+            agentId: "claude",
+            title: "Stored",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 0,
+            updatedAt: 0,
+            lastOpenedAt: 0,
+            archived: false
+        ))
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+
+        let session = try #require(mgr.placeholderSession(id: "stored"))
+        let cached = try #require(mgr.placeholderSession(id: "stored"))
+
+        #expect(session.restoredFromPersistence)
+        #expect(cached === session)
+        #expect(cached.restoredFromPersistence)
+    }
+
+    @Test("attach freshness uses persisted origin and remote id")
+    func attachFreshnessUsesPersistedOriginAndRemoteId() {
+        #expect(ACPSessionAttachFreshness.isFresh(
+            restoredFromPersistence: false,
+            remoteSessionId: nil
+        ))
+        #expect(!ACPSessionAttachFreshness.isFresh(
+            restoredFromPersistence: false,
+            remoteSessionId: "remote"
+        ))
+        #expect(!ACPSessionAttachFreshness.isFresh(
+            restoredFromPersistence: true,
+            remoteSessionId: nil
+        ))
+        #expect(!ACPSessionAttachFreshness.isFresh(
+            restoredFromPersistence: true,
+            remoteSessionId: "remote"
+        ))
     }
 
     @Test("openSession restores persisted composer draft")

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -26,6 +26,111 @@ struct ACPSessionStoreCRUDTests {
         #expect(got == row)
     }
 
+    @Test("session row persists remote ACP session id")
+    func sessionRowPersistsRemoteSessionId() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Restored",
+            titleSource: .manual,
+            remoteSessionId: "remote-1",
+            currentModel: "sonnet",
+            currentMode: "agent",
+            autoRun: true,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        let row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.remoteSessionId == "remote-1")
+        #expect(row.currentModel == "sonnet")
+        #expect(row.currentMode == "agent")
+        #expect(row.autoRun == true)
+    }
+
+    @Test("session metadata updates preserve stored remote ACP session id")
+    func sessionMetadataUpdatesPreserveRemoteSessionId() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Restored",
+            titleSource: .manual,
+            remoteSessionId: "remote-1",
+            currentModel: "sonnet",
+            currentMode: "agent",
+            autoRun: true,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Updated",
+            titleSource: .manual,
+            currentModel: "opus",
+            currentMode: "agent",
+            autoRun: true,
+            createdAt: 1,
+            updatedAt: 4,
+            lastOpenedAt: 5,
+            archived: false
+        ))
+
+        let row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.remoteSessionId == "remote-1")
+        #expect(row.title == "Updated")
+        #expect(row.currentModel == "opus")
+    }
+
+    @Test("context recovery pending is stored separately from metadata upserts")
+    func contextRecoveryPendingRoundTrip() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Restored",
+            titleSource: .manual,
+            remoteSessionId: "remote-1",
+            currentModel: nil,
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 2,
+            lastOpenedAt: 3,
+            archived: false
+        ))
+
+        try store.setContextRecoveryPending(sessionId: "local-1", pending: true)
+        try store.upsertSession(.init(
+            id: "local-1",
+            agentId: "claude",
+            title: "Updated",
+            titleSource: .manual,
+            currentModel: "opus",
+            currentMode: nil,
+            autoRun: false,
+            createdAt: 1,
+            updatedAt: 4,
+            lastOpenedAt: 5,
+            archived: false
+        ))
+
+        var row = try #require(try store.loadSession(id: "local-1"))
+        #expect(row.contextRecoveryPending)
+        #expect(row.title == "Updated")
+
+        try store.setContextRecoveryPending(sessionId: "local-1", pending: false)
+        row = try #require(try store.loadSession(id: "local-1"))
+        #expect(!row.contextRecoveryPending)
+    }
+
     @Test("recent list orders by last_opened_at desc and skips archived")
     func recent() throws {
         let store = try tmp()

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -35,6 +35,62 @@ struct ACPSessionTests {
         #expect(!session.followsTranscriptTail)
     }
 
+    @Test("empty transcript has no conversation transcript")
+    func emptyTranscriptHasNoConversationTranscript() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+
+        #expect(!session.hasConversationTranscript)
+    }
+
+    @Test("system notice alone has no conversation transcript")
+    func systemNoticeHasNoConversationTranscript() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.appendSystemNotice("Agent disconnected")
+
+        #expect(!session.hasConversationTranscript)
+    }
+
+    @Test("non-empty user message has conversation transcript")
+    func userMessageHasConversationTranscript() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.recordUserPrompt(text: "hello", attachments: [])
+
+        #expect(session.hasConversationTranscript)
+    }
+
+    @Test("whitespace-only user message has no conversation transcript")
+    func whitespaceUserMessageHasNoConversationTranscript() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.recordUserPrompt(text: " \n\t ", attachments: [])
+
+        #expect(!session.hasConversationTranscript)
+    }
+
+    @Test("non-empty agent message has conversation transcript")
+    func agentMessageHasConversationTranscript() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("hello from agent")))
+
+        #expect(session.hasConversationTranscript)
+    }
+
+    @Test("context restore warning can be set and compared")
+    func contextRestoreWarningState() async {
+        let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")
+        let warning = ACPSession.ContextRestoreWarning(
+            message: "Context restore failed",
+            canSendTranscript: true
+        )
+
+        session.contextRestoreWarning = warning
+
+        #expect(session.contextRestoreWarning == warning)
+        #expect(warning == ACPSession.ContextRestoreWarning(
+            message: "Context restore failed",
+            canSendTranscript: true
+        ))
+    }
+
     @Test("plan update creates / replaces the plan message")
     func plan() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")


### PR DESCRIPTION
## Summary

- persist and hydrate ACP remote session identifiers so restored sessions can reattach to the original remote session
- send prior ACP transcripts as recovery context when restoring after app reopen, without recording that recovery payload back into the transcript
- surface and clear ACP context restore warnings in the tab UI, with coverage for hydration, attach restore, transcript recovery, and store behavior

## Validation

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` started locally but stalled without output after destination selection in this sandbox; PR CI should provide the full test result