### PR TITLE
fix(repo-selector): drop outer maxHeight that centered content

### DIFF
--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorDialog.swift
@@ -35,7 +35,6 @@ struct RepoSelectorDialog: View {
                     appState.repoSelector.setSelectedIndex(0, in: rows)
                 }
                 .frame(width: 720)
-                .frame(maxHeight: 520)
                 .background(theme.color("bg-1").opacity(0.92))
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                 .overlay(


### PR DESCRIPTION
## Summary
- The cmd-K (repo selector) dialog's outer `.frame(maxHeight: 520)` was larger than the VStack's natural max (~494pt: inputRow 42 + rowList 420 + footer 32), so the content was center-aligned inside the frame, producing a ~13pt empty band of `bg-1` above the search field and below the footer.
- FileSearchDialog (cmd-P) doesn't show this because its content (input + scope + list + footer) reaches/exceeds 520pt and fills the frame.
- Drop the outer cap on RepoSelector; the dialog now sizes to its content. The rowList's own `maxHeight: 420` still caps the variable part.

## Test plan
- [x] Build succeeds (Debug, macOS)
- [x] Manual: open cmd-K — search field is flush at top, footer flush at bottom, no `bg-1` band above/below
- [ ] Manual: cmd-K with single project / few worktrees — dialog shrinks to content cleanly