### PR TITLE
Add Xcode build-state remediation scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,36 @@ older than `ALAS_GHOSTTY_LOCK_STALE_SECS`) are reclaimed automatically.
 (`.build/ghostty/fingerprint` match) wins before the shared cache is even
 consulted, and CI uses `actions/cache` keyed off `.ghostty-pin` to restore
 `.build/ghostty` directly.
+
+## Xcode build-state remediation
+
+Alas worktree-heavy development can leave many stale Xcode DerivedData entries
+behind, especially for `Alas.xcodeproj` and the vendored Ghostty project. These
+entries are large because each Xcode project path gets its own SwiftPM checkout,
+build products, and index state.
+
+**Inspect stale Alas/Ghostty DerivedData entries:**
+
+```bash
+scripts/prune-xcode-state.sh
+```
+
+**Delete only stale Alas/Ghostty DerivedData entries:**
+
+```bash
+scripts/prune-xcode-state.sh --delete
+```
+
+The pruner only considers `Alas-*` and `Ghostty-*` directories under
+`~/Library/Developer/Xcode/DerivedData`. It keeps entries whose recorded
+`WorkspacePath` still exists and ignores unrelated projects.
+
+**Capture a memory/build snapshot during a bad episode:**
+
+```bash
+scripts/build-memory-snapshot.sh > /tmp/alas-build-memory.txt
+```
+
+The snapshot records VM pressure, top resident processes, Xcode/Swift/Zig build
+processes, Alas/Ghostty DerivedData sizes, local build caches, and active git
+worktrees.

--- a/scripts/build-memory-snapshot.sh
+++ b/scripts/build-memory-snapshot.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/build-memory-snapshot.sh
+
+Print a point-in-time snapshot useful when Xcode builds or Ghostty/Zig build
+steps appear to be starving the machine of memory.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    "")
+        ;;
+    *)
+        echo "build-memory-snapshot.sh: unknown argument: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+esac
+
+section() {
+    printf '\n== %s ==\n' "$1"
+}
+
+section "Time"
+date
+
+section "VM pressure"
+vm_stat
+sysctl hw.memsize
+
+section "Top resident processes"
+top_processes="$(mktemp -t alas-build-memory-processes.XXXXXX)"
+trap 'rm -f "${top_processes}"' EXIT
+ps -axo rss,pid,ppid,stat,comm,args | sort -nr > "${top_processes}"
+sed -n '1,40p' "${top_processes}"
+
+section "Build-related processes"
+ps -axo rss,pid,ppid,stat,comm,args \
+    | awk 'NR == 1 || /xcodebuild|swift-frontend|SourceKit|XCBBuildService|SWBBuildService|zig|build-ghostty|build-zmx|rsync/ { print }'
+
+section "Alas DerivedData roots"
+derived_data="${HOME}/Library/Developer/Xcode/DerivedData"
+if [ -d "${derived_data}" ]; then
+    find "${derived_data}" -maxdepth 1 -type d \( -name 'Alas-*' -o -name 'Ghostty-*' \) -print0 \
+        | while IFS= read -r -d '' dir; do
+            du -sh "${dir}" 2>/dev/null || true
+        done \
+        | sort
+    du -sh "${derived_data}/ModuleCache.noindex" 2>/dev/null || true
+else
+    echo "DerivedData root not found: ${derived_data}"
+fi
+
+section "Alas build caches"
+du -sh \
+    "${HOME}/Library/Caches/Alas" \
+    .build \
+    build \
+    2>/dev/null || true
+
+section "Current worktrees"
+git worktree list 2>/dev/null || true

--- a/scripts/prune-xcode-state.sh
+++ b/scripts/prune-xcode-state.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/prune-xcode-state.sh [--delete] [--derived-data PATH]
+
+Prune stale Xcode DerivedData directories for Alas and vendored Ghostty
+projects. By default this is a dry run; pass --delete to remove entries.
+
+Options:
+  --delete             Remove stale entries instead of only printing them.
+  --derived-data PATH  DerivedData root to scan.
+                       Default: ~/Library/Developer/Xcode/DerivedData
+  -h, --help           Show this help.
+EOF
+}
+
+delete=0
+derived_data="${HOME}/Library/Developer/Xcode/DerivedData"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --delete)
+            delete=1
+            shift
+            ;;
+        --derived-data)
+            [ "$#" -ge 2 ] || { echo "prune-xcode-state.sh: --derived-data requires a path" >&2; exit 2; }
+            derived_data="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "prune-xcode-state.sh: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ ! -d "${derived_data}" ]; then
+    echo "prune-xcode-state.sh: DerivedData root does not exist: ${derived_data}" >&2
+    exit 1
+fi
+
+read_workspace_path() {
+    local plist="$1"
+    /usr/libexec/PlistBuddy -c 'Print :WorkspacePath' "${plist}"
+}
+
+format_size() {
+    local path="$1"
+    du -sh "${path}" 2>/dev/null | awk '{print $1}'
+}
+
+scan_entry() {
+    local entry="$1"
+    local base plist workspace reason size action
+
+    base="$(basename "${entry}")"
+    case "${base}" in
+        Alas-*|Ghostty-*) ;;
+        *) return 0 ;;
+    esac
+
+    plist="${entry}/info.plist"
+    if [ ! -f "${plist}" ]; then
+        reason="missing-info-plist"
+        size="$(format_size "${entry}")"
+        [ -n "${size}" ] || size="unknown-size"
+        printf 'skip\t%s\t%s\t%s\n' "${size}" "${reason}" "${entry}"
+        return 0
+    else
+        if ! workspace="$(read_workspace_path "${plist}" 2>/dev/null)"; then
+            reason="unreadable-info-plist"
+            size="$(format_size "${entry}")"
+            [ -n "${size}" ] || size="unknown-size"
+            printf 'skip\t%s\t%s\t%s\n' "${size}" "${reason}" "${entry}"
+            return 0
+        elif [ -z "${workspace}" ]; then
+            reason="empty-workspace-path"
+            size="$(format_size "${entry}")"
+            [ -n "${size}" ] || size="unknown-size"
+            printf 'skip\t%s\t%s\t%s\n' "${size}" "${reason}" "${entry}"
+            return 0
+        elif [ ! -e "${workspace}" ]; then
+            reason="missing-workspace:${workspace}"
+        else
+            return 0
+        fi
+    fi
+
+    size="$(format_size "${entry}")"
+    [ -n "${size}" ] || size="unknown-size"
+
+    if [ "${delete}" -eq 1 ]; then
+        rm -rf "${entry}"
+        action="deleted"
+    else
+        action="delete"
+    fi
+
+    printf '%s\t%s\t%s\t%s\n' "${action}" "${size}" "${reason}" "${entry}"
+}
+
+delete_candidates=0
+skipped=0
+while IFS= read -r -d '' entry; do
+    if scan_output="$(scan_entry "${entry}")" && [ -n "${scan_output}" ]; then
+        printf '%s\n' "${scan_output}"
+        case "${scan_output}" in
+            delete*|deleted*) delete_candidates=$((delete_candidates + 1)) ;;
+            skip*) skipped=$((skipped + 1)) ;;
+        esac
+    fi
+done < <(/usr/bin/find "${derived_data}" -maxdepth 1 -mindepth 1 -type d -print0)
+
+if [ "${delete_candidates}" -eq 0 ] && [ "${skipped}" -eq 0 ]; then
+    echo "No stale Alas/Ghostty DerivedData entries found."
+elif [ "${delete}" -eq 0 ]; then
+    if [ "${delete_candidates}" -gt 0 ]; then
+        echo "Dry run only. Re-run with --delete to remove entries marked delete."
+    fi
+    if [ "${skipped}" -gt 0 ]; then
+        echo "Entries marked skip were not readable enough to classify safely."
+    fi
+fi

--- a/scripts/tests/xcode-state/run.sh
+++ b/scripts/tests/xcode-state/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+chmod +x test_*.sh
+
+fails=0
+for t in test_*.sh; do
+    printf '== %-50s ' "${t}"
+    if "./${t}" >"${t}.log" 2>&1; then
+        echo PASS
+    else
+        echo FAIL
+        sed 's/^/    /' "${t}.log"
+        fails=$((fails + 1))
+    fi
+done
+
+[ ${fails} -eq 0 ] || { echo "${fails} test(s) failed" >&2; exit 1; }
+echo "all tests passed"

--- a/scripts/tests/xcode-state/test_01_prune_xcode_state_dry_run.sh
+++ b/scripts/tests/xcode-state/test_01_prune_xcode_state_dry_run.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+this_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "${this_dir}/../../.." && pwd)"
+tmp="$(mktemp -d -t alas-xcode-state-test.XXXXXX)"
+trap 'rm -rf "${tmp}"' EXIT
+
+derived_data="${tmp}/DerivedData"
+live_workspace="${tmp}/live/Alas.xcodeproj"
+mkdir -p "${derived_data}" "$(dirname "${live_workspace}")"
+: > "${live_workspace}"
+
+write_info_plist() {
+    local dir="$1"
+    local workspace="$2"
+    mkdir -p "${dir}"
+    cat > "${dir}/info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>WorkspacePath</key>
+  <string>${workspace}</string>
+</dict>
+</plist>
+EOF
+}
+
+write_info_plist "${derived_data}/Alas-live" "${live_workspace}"
+write_info_plist "${derived_data}/Alas-stale" "${tmp}/missing/Alas.xcodeproj"
+write_info_plist "${derived_data}/Ghostty-stale" "${tmp}/missing/Ghostty.xcodeproj"
+mkdir -p "${derived_data}/Alas-missing-info"
+mkdir -p "${derived_data}/Alas-unreadable-info"
+printf 'not a plist\n' > "${derived_data}/Alas-unreadable-info/info.plist"
+mkdir -p "${derived_data}/Other-stale"
+
+output="$("${repo_root}/scripts/prune-xcode-state.sh" --derived-data "${derived_data}")"
+
+for expected in \
+    "delete	"*Alas-stale \
+    "delete	"*Ghostty-stale
+do
+    case "${output}" in
+        *${expected}*) ;;
+        *) echo "dry-run output did not list expected stale entry pattern: ${expected}"; echo "${output}"; exit 1 ;;
+    esac
+done
+
+case "${output}" in
+    *missing-workspace*) ;;
+    *) echo "dry-run output did not include expected stale reasons"; echo "${output}"; exit 1 ;;
+esac
+
+case "${output}" in
+    *"skip	"*missing-info-plist*Alas-missing-info*) ;;
+    *) echo "dry-run output should skip missing plist entries"; echo "${output}"; exit 1 ;;
+esac
+
+case "${output}" in
+    *"skip	"*unreadable-info-plist*Alas-unreadable-info*) ;;
+    *) echo "dry-run output should skip unreadable plist entries"; echo "${output}"; exit 1 ;;
+esac
+
+case "${output}" in
+    *Alas-live*) echo "dry-run output should not list live workspace"; echo "${output}"; exit 1 ;;
+esac
+case "${output}" in
+    *Other-stale*) echo "dry-run output should not list unrelated entries"; echo "${output}"; exit 1 ;;
+esac
+
+[ -d "${derived_data}/Alas-stale" ] || { echo "dry-run removed Alas-stale"; exit 1; }
+[ -d "${derived_data}/Ghostty-stale" ] || { echo "dry-run removed Ghostty-stale"; exit 1; }
+[ -d "${derived_data}/Alas-missing-info" ] || { echo "dry-run removed Alas-missing-info"; exit 1; }
+[ -d "${derived_data}/Alas-unreadable-info" ] || { echo "dry-run removed Alas-unreadable-info"; exit 1; }

--- a/scripts/tests/xcode-state/test_02_prune_xcode_state_delete.sh
+++ b/scripts/tests/xcode-state/test_02_prune_xcode_state_delete.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+this_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "${this_dir}/../../.." && pwd)"
+tmp="$(mktemp -d -t alas-xcode-state-test.XXXXXX)"
+trap 'rm -rf "${tmp}"' EXIT
+
+derived_data="${tmp}/DerivedData"
+live_workspace="${tmp}/live/Alas.xcodeproj"
+mkdir -p "${derived_data}" "$(dirname "${live_workspace}")"
+: > "${live_workspace}"
+
+write_info_plist() {
+    local dir="$1"
+    local workspace="$2"
+    mkdir -p "${dir}"
+    cat > "${dir}/info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>WorkspacePath</key>
+  <string>${workspace}</string>
+</dict>
+</plist>
+EOF
+}
+
+write_info_plist "${derived_data}/Alas-live" "${live_workspace}"
+write_info_plist "${derived_data}/Alas-stale" "${tmp}/missing/Alas.xcodeproj"
+write_info_plist "${derived_data}/Ghostty-stale" "${tmp}/missing/Ghostty.xcodeproj"
+mkdir -p "${derived_data}/Alas-missing-info"
+mkdir -p "${derived_data}/Alas-unreadable-info"
+printf 'not a plist\n' > "${derived_data}/Alas-unreadable-info/info.plist"
+mkdir -p "${derived_data}/Other-stale"
+
+"${repo_root}/scripts/prune-xcode-state.sh" --derived-data "${derived_data}" --delete >/tmp/alas-prune-test.out
+
+[ -d "${derived_data}/Alas-live" ] || { echo "deleted live workspace"; exit 1; }
+[ ! -e "${derived_data}/Alas-stale" ] || { echo "kept stale Alas entry"; exit 1; }
+[ ! -e "${derived_data}/Ghostty-stale" ] || { echo "kept stale Ghostty entry"; exit 1; }
+[ -d "${derived_data}/Alas-missing-info" ] || { echo "deleted missing-info Alas entry"; exit 1; }
+[ -d "${derived_data}/Alas-unreadable-info" ] || { echo "deleted unreadable plist entry"; exit 1; }
+[ -d "${derived_data}/Other-stale" ] || { echo "deleted unrelated entry"; exit 1; }


### PR DESCRIPTION
## Summary

Adds build-state remediation tooling for worktree-heavy Alas development:

- `scripts/prune-xcode-state.sh` safely dry-runs or deletes stale `Alas-*` and `Ghostty-*` DerivedData entries whose recorded `WorkspacePath` no longer exists.
- `scripts/build-memory-snapshot.sh` captures VM pressure, top resident processes, build-related processes, DerivedData sizes, local build cache sizes, and active worktrees during memory-pressure episodes.
- Adds shell tests for dry-run and delete behavior of the DerivedData pruner.
- Documents the cleanup and snapshot commands in `AGENTS.md`.

## Validation

- `bash -n scripts/prune-xcode-state.sh scripts/build-memory-snapshot.sh scripts/tests/xcode-state/*.sh`
- `bash scripts/tests/xcode-state/run.sh`
- `scripts/build-memory-snapshot.sh >/tmp/alas-build-memory-snapshot-check.txt`
- `scripts/prune-xcode-state.sh`
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`

## Caveat

A full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` run was attempted, but it hung for over 11 minutes in the existing `ACP terminal routing` test at `terminal/create routes to the session host and responds with an id`. The hung `xcodebuild` and test host were terminated after inspection.