### PR TITLE
fix(acp): separate completed output blocks

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPClient.swift
@@ -38,6 +38,10 @@ protocol ACPClient: AnyObject {
 
     /// Streaming `session/update` notifications.
     var incomingUpdates: AsyncStream<ACPSessionUpdateParams> { get }
+    /// Monotonic count of `session/update` notifications yielded to
+    /// `incomingUpdates`. Runners use this as a drain target when an RPC
+    /// response races ahead of already-yielded update notifications.
+    var yieldedUpdateCount: Int { get }
 
     /// Permission requests (`session/request_permission`). The client owner must
     /// call `respondToPermission(id:decision:)` exactly once per emitted request.

--- a/Alas/Sources/ACP/Protocol/ACPMockClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMockClient.swift
@@ -8,8 +8,15 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
     private let filesCont: AsyncStream<ACPFileRequest>.Continuation
     private let terminalsCont: AsyncStream<ACPTerminalRequest>.Continuation
+    private let updateCountLock = NSLock()
+    private var _yieldedUpdateCount = 0
 
     let incomingUpdates: AsyncStream<ACPSessionUpdateParams>
+    var yieldedUpdateCount: Int {
+        updateCountLock.lock()
+        defer { updateCountLock.unlock() }
+        return _yieldedUpdateCount
+    }
     let permissionRequests: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>
     let fileRequests: AsyncStream<ACPFileRequest>
     let terminalRequests: AsyncStream<ACPTerminalRequest>
@@ -49,7 +56,12 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
         sent.append(request)
     }
 
-    func emit(_ update: ACPSessionUpdateParams) { updatesCont.yield(update) }
+    func emit(_ update: ACPSessionUpdateParams) {
+        updateCountLock.lock()
+        _yieldedUpdateCount += 1
+        updateCountLock.unlock()
+        updatesCont.yield(update)
+    }
     func emitPermission(id: JSONRPCID, params: ACPPermissionRequestParams) { permsCont.yield((id, params)) }
     func emitFile(_ req: ACPFileRequest) { filesCont.yield(req) }
     func emitTerminal(_ req: ACPTerminalRequest) { terminalsCont.yield(req) }

--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -9,6 +9,11 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     private let stderrCont: AsyncStream<Data>.Continuation
 
     let incomingUpdates: AsyncStream<ACPSessionUpdateParams>
+    var yieldedUpdateCount: Int {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return _yieldedUpdateCount
+    }
     let permissionRequests: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>
     let fileRequests: AsyncStream<ACPFileRequest>
     let terminalRequests: AsyncStream<ACPTerminalRequest>
@@ -16,6 +21,7 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
 
     private let stateLock = NSLock()
     private var nextId: Int = 0
+    private var _yieldedUpdateCount = 0
     private var pending: [JSONRPCID: CheckedContinuation<Data, Error>] = [:]
     private var dispatchTask: Task<Void, Never>?
 
@@ -142,7 +148,12 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         switch method {
         case "session/update":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPSessionUpdateParams>.self, from: data),
-               let p = env.params { updatesCont.yield(p) }
+               let p = env.params {
+                stateLock.lock()
+                _yieldedUpdateCount += 1
+                stateLock.unlock()
+                updatesCont.yield(p)
+            }
         case "session/request_permission":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPPermissionRequestParams>.self, from: data),
                let id = env.id, let p = env.params { permsCont.yield((id, p)) }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -143,7 +143,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {
         transcript.messages.append(.user(id: UUID(), text: text, attachments: attachments))
-        transcript.completedOutputBoundaryMessageId = nil
+        transcript.completedOutputBoundaryMessageIds.removeAll()
         if titleSource == .placeholder {
             let candidate = text
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -175,7 +175,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case .userMessageChunk(let block):
             // Agents rarely emit these; treat as informational.
             transcript.messages.append(.systemNotice(id: UUID(), text: text(of: block)))
-            transcript.completedOutputBoundaryMessageId = nil
+            transcript.completedOutputBoundaryMessageIds.removeAll()
             return [transcript.messages.count - 1]
         case .agentThoughtChunk(let block):
             let txt = text(of: block)
@@ -195,7 +195,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 preview: Self.previewLine(full),
                 locations: payload.locations?.map(\.path) ?? [],
                 terminalIds: Self.extractTerminalIds(items))))
-            transcript.completedOutputBoundaryMessageId = nil
+            transcript.completedOutputBoundaryMessageIds.removeAll()
             return [transcript.messages.count - 1]
         case .toolCallUpdate(let u):
             let touched = updateToolCall(id: u.toolCallId) { tc in
@@ -228,7 +228,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 return [i]
             } else {
                 transcript.messages.append(.plan(id: UUID(), items))
-                transcript.completedOutputBoundaryMessageId = nil
+                transcript.completedOutputBoundaryMessageIds.removeAll()
                 return [transcript.messages.count - 1]
             }
         case .availableModelsUpdate(let ms):
@@ -257,23 +257,22 @@ final class ACPSession: ObservableObject, Identifiable {
 
     func appendFileEdit(_ edit: ACPMessage.FileEdit) {
         transcript.messages.append(.fileEdit(id: UUID(), edit))
-        transcript.completedOutputBoundaryMessageId = nil
+        transcript.completedOutputBoundaryMessageIds.removeAll()
     }
 
     func markCompletedOutputBoundary() {
+        transcript.completedOutputBoundaryMessageIds.removeAll()
         for message in transcript.messages.reversed() {
             switch message {
             case .agent, .thought:
-                transcript.completedOutputBoundaryMessageId = message.stableId
-                return
+                transcript.completedOutputBoundaryMessageIds.insert(message.stableId)
+                continue
             case .plan:
                 continue
             default:
-                transcript.completedOutputBoundaryMessageId = nil
                 return
             }
         }
-        transcript.completedOutputBoundaryMessageId = nil
     }
 
     /// Append a new pending item to the tail of the queue. Used by the
@@ -565,8 +564,8 @@ final class ACPSession: ObservableObject, Identifiable {
                                 locate: () -> Int?,
                                 makeNew: () -> ACPMessage) -> Int {
         if let i = locate() {
-            if transcript.completedOutputBoundaryMessageId == transcript.messages[i].stableId {
-                transcript.completedOutputBoundaryMessageId = nil
+            if transcript.completedOutputBoundaryMessageIds.contains(transcript.messages[i].stableId) {
+                transcript.completedOutputBoundaryMessageIds.removeAll()
             } else {
                 switch transcript.messages[i] {
                 case .agent(_, let buf), .thought(_, let buf):
@@ -579,7 +578,7 @@ final class ACPSession: ObservableObject, Identifiable {
             }
         }
         transcript.messages.append(makeNew())
-        transcript.completedOutputBoundaryMessageId = nil
+        transcript.completedOutputBoundaryMessageIds.removeAll()
         return transcript.messages.count - 1
     }
     /// Returns the index of the matching tool call, or nil if no match.

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -143,6 +143,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {
         transcript.messages.append(.user(id: UUID(), text: text, attachments: attachments))
+        transcript.completedOutputBoundaryMessageId = nil
         if titleSource == .placeholder {
             let candidate = text
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -174,6 +175,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case .userMessageChunk(let block):
             // Agents rarely emit these; treat as informational.
             transcript.messages.append(.systemNotice(id: UUID(), text: text(of: block)))
+            transcript.completedOutputBoundaryMessageId = nil
             return [transcript.messages.count - 1]
         case .agentThoughtChunk(let block):
             let txt = text(of: block)
@@ -193,6 +195,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 preview: Self.previewLine(full),
                 locations: payload.locations?.map(\.path) ?? [],
                 terminalIds: Self.extractTerminalIds(items))))
+            transcript.completedOutputBoundaryMessageId = nil
             return [transcript.messages.count - 1]
         case .toolCallUpdate(let u):
             let touched = updateToolCall(id: u.toolCallId) { tc in
@@ -225,6 +228,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 return [i]
             } else {
                 transcript.messages.append(.plan(id: UUID(), items))
+                transcript.completedOutputBoundaryMessageId = nil
                 return [transcript.messages.count - 1]
             }
         case .availableModelsUpdate(let ms):
@@ -253,6 +257,23 @@ final class ACPSession: ObservableObject, Identifiable {
 
     func appendFileEdit(_ edit: ACPMessage.FileEdit) {
         transcript.messages.append(.fileEdit(id: UUID(), edit))
+        transcript.completedOutputBoundaryMessageId = nil
+    }
+
+    func markCompletedOutputBoundary() {
+        for message in transcript.messages.reversed() {
+            switch message {
+            case .agent, .thought:
+                transcript.completedOutputBoundaryMessageId = message.stableId
+                return
+            case .plan:
+                continue
+            default:
+                transcript.completedOutputBoundaryMessageId = nil
+                return
+            }
+        }
+        transcript.completedOutputBoundaryMessageId = nil
     }
 
     /// Append a new pending item to the tail of the queue. Used by the
@@ -544,16 +565,21 @@ final class ACPSession: ObservableObject, Identifiable {
                                 locate: () -> Int?,
                                 makeNew: () -> ACPMessage) -> Int {
         if let i = locate() {
-            switch transcript.messages[i] {
-            case .agent(_, let buf), .thought(_, let buf):
-                buf.append(addition)
-                transcript.streamingTick &+= 1
-                return i
-            default:
-                break
+            if transcript.completedOutputBoundaryMessageId == transcript.messages[i].stableId {
+                transcript.completedOutputBoundaryMessageId = nil
+            } else {
+                switch transcript.messages[i] {
+                case .agent(_, let buf), .thought(_, let buf):
+                    buf.append(addition)
+                    transcript.streamingTick &+= 1
+                    return i
+                default:
+                    break
+                }
             }
         }
         transcript.messages.append(makeNew())
+        transcript.completedOutputBoundaryMessageId = nil
         return transcript.messages.count - 1
     }
     /// Returns the index of the matching tool call, or nil if no match.

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -564,8 +564,9 @@ final class ACPSession: ObservableObject, Identifiable {
                                 locate: () -> Int?,
                                 makeNew: () -> ACPMessage) -> Int {
         if let i = locate() {
-            if transcript.completedOutputBoundaryMessageIds.contains(transcript.messages[i].stableId) {
-                transcript.completedOutputBoundaryMessageIds.removeAll()
+            let stableId = transcript.messages[i].stableId
+            if transcript.completedOutputBoundaryMessageIds.contains(stableId) {
+                transcript.completedOutputBoundaryMessageIds.remove(stableId)
             } else {
                 switch transcript.messages[i] {
                 case .agent(_, let buf), .thought(_, let buf):
@@ -578,7 +579,6 @@ final class ACPSession: ObservableObject, Identifiable {
             }
         }
         transcript.messages.append(makeNew())
-        transcript.completedOutputBoundaryMessageIds.removeAll()
         return transcript.messages.count - 1
     }
     /// Returns the index of the matching tool call, or nil if no match.

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -51,6 +51,8 @@ final class ACPSessionRunner {
     private var nextPromptID = 0
     private var activePromptID: Int?
     private var cancelledPromptIDs: Set<Int> = []
+    private var appliedUpdateCount = 0
+    private var pendingCompletedOutputBoundaryUpdateCount: Int?
     /// Set while `steer` is between `userCancel` and the redirect's
     /// `sendNow`. `flushQueueIfIdle` no-ops while this is true so an
     /// Undo tapped during the cancel round-trip can't drain the just-
@@ -87,7 +89,11 @@ final class ACPSessionRunner {
             for await u in self.connection.client.incomingUpdates {
                 await MainActor.run {
                     let dirty = self.session.apply(u.update)
+                    self.appliedUpdateCount += 1
                     self.persistIndices(dirty)
+                    if self.applyPendingCompletedOutputBoundaryIfReady() {
+                        self.flushQueueIfIdle()
+                    }
                 }
             }
             // The for-await also exits when the task gets cancelled —
@@ -733,8 +739,9 @@ extension ACPSessionRunner {
                         }
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
-                        self.session.markCompletedOutputBoundary()
-                        self.flushQueueIfIdle()
+                        if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
+                            self.flushQueueIfIdle()
+                        }
                     }
                     self.cancelledPromptIDs.remove(promptID)
                     if !hasNewerActivePrompt {
@@ -759,8 +766,9 @@ extension ACPSessionRunner {
                         }
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
-                        self.session.markCompletedOutputBoundary()
-                        self.flushQueueIfIdle()
+                        if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
+                            self.flushQueueIfIdle()
+                        }
                     }
                     if !hasNewerActivePrompt {
                         onPromptFinished?(wasCancelled)
@@ -804,8 +812,9 @@ extension ACPSessionRunner {
                     if isActivePrompt {
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
-                        self.session.markCompletedOutputBoundary()
-                        self.flushQueueIfIdle()
+                        if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
+                            self.flushQueueIfIdle()
+                        }
                     }
                     if !hasNewerActivePrompt {
                         onCompleted?(isActivePrompt && !wasCancelled)
@@ -819,8 +828,9 @@ extension ACPSessionRunner {
                     if isActivePrompt {
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
-                        self.session.markCompletedOutputBoundary()
-                        self.flushQueueIfIdle()
+                        if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
+                            self.flushQueueIfIdle()
+                        }
                     }
                     if !hasNewerActivePrompt {
                         onCompleted?(false)
@@ -850,6 +860,24 @@ extension ACPSessionRunner {
             }
             return nil
         }
+    }
+
+    private func deferCompletedOutputBoundaryUntilUpdatesDrain() -> Bool {
+        let target = connection.client.yieldedUpdateCount
+        pendingCompletedOutputBoundaryUpdateCount = max(
+            pendingCompletedOutputBoundaryUpdateCount ?? target,
+            target
+        )
+        return applyPendingCompletedOutputBoundaryIfReady()
+    }
+
+    private func applyPendingCompletedOutputBoundaryIfReady() -> Bool {
+        guard let target = pendingCompletedOutputBoundaryUpdateCount,
+              appliedUpdateCount >= target
+        else { return false }
+        pendingCompletedOutputBoundaryUpdateCount = nil
+        session.markCompletedOutputBoundary()
+        return true
     }
 
     /// Append a system notice to the session AND persist it. Use this

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -733,6 +733,7 @@ extension ACPSessionRunner {
                         }
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
+                        self.session.markCompletedOutputBoundary()
                         self.flushQueueIfIdle()
                     }
                     self.cancelledPromptIDs.remove(promptID)
@@ -758,6 +759,7 @@ extension ACPSessionRunner {
                         }
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
+                        self.session.markCompletedOutputBoundary()
                         self.flushQueueIfIdle()
                     }
                     if !hasNewerActivePrompt {
@@ -802,6 +804,7 @@ extension ACPSessionRunner {
                     if isActivePrompt {
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
+                        self.session.markCompletedOutputBoundary()
                         self.flushQueueIfIdle()
                     }
                     if !hasNewerActivePrompt {
@@ -816,6 +819,7 @@ extension ACPSessionRunner {
                     if isActivePrompt {
                         self.activePromptID = nil
                         self.session.transcript.streamingState = .idle
+                        self.session.markCompletedOutputBoundary()
                         self.flushQueueIfIdle()
                     }
                     if !hasNewerActivePrompt {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -873,6 +873,7 @@ extension ACPSessionRunner {
         else { return false }
         pendingCompletedOutputBoundaryUpdateCount = nil
         session.markCompletedOutputBoundary()
+        guard activePromptID == nil else { return false }
         session.transcript.streamingState = .idle
         return true
     }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -738,7 +738,6 @@ extension ACPSessionRunner {
                             self.persistQueue()
                         }
                         self.activePromptID = nil
-                        self.session.transcript.streamingState = .idle
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
                             self.flushQueueIfIdle()
                         }
@@ -765,7 +764,6 @@ extension ACPSessionRunner {
                             self.session.lastError = "prompt failed: \(error.localizedDescription)"
                         }
                         self.activePromptID = nil
-                        self.session.transcript.streamingState = .idle
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
                             self.flushQueueIfIdle()
                         }
@@ -811,7 +809,6 @@ extension ACPSessionRunner {
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
                         self.activePromptID = nil
-                        self.session.transcript.streamingState = .idle
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
                             self.flushQueueIfIdle()
                         }
@@ -827,7 +824,6 @@ extension ACPSessionRunner {
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
                         self.activePromptID = nil
-                        self.session.transcript.streamingState = .idle
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
                             self.flushQueueIfIdle()
                         }
@@ -877,6 +873,7 @@ extension ACPSessionRunner {
         else { return false }
         pendingCompletedOutputBoundaryUpdateCount = nil
         session.markCompletedOutputBoundary()
+        session.transcript.streamingState = .idle
         return true
     }
 

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -33,6 +33,11 @@ final class ACPTranscript: ObservableObject {
     /// loading state, smaller steps require too many clicks.
     static let tailWindow: Int = 30
 
+    /// Stable id of the latest streaming text row whose prompt has
+    /// completed. A later ACP text chunk must start a fresh row instead
+    /// of appending directly to that completed output.
+    var completedOutputBoundaryMessageId: String?
+
     // MARK: - Per-message markdown caches
 
     private var markdownCaches: [String: ACPMarkdownBlockCache] = [:]

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -33,10 +33,10 @@ final class ACPTranscript: ObservableObject {
     /// loading state, smaller steps require too many clicks.
     static let tailWindow: Int = 30
 
-    /// Stable id of the latest streaming text row whose prompt has
-    /// completed. A later ACP text chunk must start a fresh row instead
-    /// of appending directly to that completed output.
-    var completedOutputBoundaryMessageId: String?
+    /// Stable ids of streaming text rows whose prompt has completed. A
+    /// later ACP text chunk must start a fresh row instead of appending
+    /// directly to any completed output.
+    var completedOutputBoundaryMessageIds: Set<String> = []
 
     // MARK: - Per-message markdown caches
 

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -61,7 +61,7 @@ struct ACPSessionRunnerTests {
         }
 
         try await waitUntil { completion == true }
-        #expect(session.transcript.completedOutputBoundaryMessageId == nil)
+        #expect(session.transcript.completedOutputBoundaryMessageIds.isEmpty)
 
         client.emitReserved(.agentMessageChunk(.text(" second")))
         try await waitUntil {
@@ -69,7 +69,7 @@ struct ACPSessionRunnerTests {
                   case .agent(_, let buffer) = session.transcript.messages[1]
             else { return false }
             return buffer.value == "first second"
-                && session.transcript.completedOutputBoundaryMessageId == session.transcript.messages[1].stableId
+                && session.transcript.completedOutputBoundaryMessageIds == [session.transcript.messages[1].stableId]
         }
 
         client.emitFresh(.agentMessageChunk(.text("next task")))

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -36,6 +36,53 @@ struct ACPSessionRunnerTests {
         #expect(runner.session.transcript.streamingState == .idle)
     }
 
+    @Test("prompt completion waits for yielded updates before marking output boundary")
+    func promptCompletionWaitsForYieldedUpdatesBeforeBoundary() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-runner-boundary-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "codex", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let client = BoundaryRaceClient()
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: client),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        runner.start()
+
+        var completion: Bool?
+        runner.send(text: "hello", attachments: []) { succeeded in
+            completion = succeeded
+        }
+
+        try await waitUntil { completion == true }
+        #expect(session.transcript.completedOutputBoundaryMessageId == nil)
+
+        client.emitReserved(.agentMessageChunk(.text(" second")))
+        try await waitUntil {
+            guard session.transcript.messages.count == 2,
+                  case .agent(_, let buffer) = session.transcript.messages[1]
+            else { return false }
+            return buffer.value == "first second"
+                && session.transcript.completedOutputBoundaryMessageId == session.transcript.messages[1].stableId
+        }
+
+        client.emitFresh(.agentMessageChunk(.text("next task")))
+        try await waitUntil { session.transcript.messages.count == 3 }
+        if case .agent(_, let first) = session.transcript.messages[1],
+           case .agent(_, let second) = session.transcript.messages[2] {
+            #expect(first.value == "first second")
+            #expect(second.value == "next task")
+        } else {
+            Issue.record("expected completed output and next output in separate agent messages")
+        }
+    }
+
     @Test("send treats user-cancelled prompt errors as accepted completion")
     func sendTreatsCancelledPromptErrorsAsAcceptedCompletion() async throws {
         let (runner, mock) = try makeRunner()
@@ -312,6 +359,77 @@ struct ACPSessionRunnerTests {
             worktreePath: FileManager.default.temporaryDirectory.path
         )
         return (runner, mock)
+    }
+
+    private func waitUntil(
+        timeoutNanoseconds: UInt64 = 1_000_000_000,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while !condition() {
+            if DispatchTime.now().uptimeNanoseconds >= deadline { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(condition())
+    }
+}
+
+private final class BoundaryRaceClient: ACPClient, @unchecked Sendable {
+    private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
+    private let updateCountLock = NSLock()
+    private var _yieldedUpdateCount = 0
+    private(set) var sent: [ACPRequest] = []
+
+    let incomingUpdates: AsyncStream<ACPSessionUpdateParams>
+    let permissionRequests = AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)> { $0.finish() }
+    let fileRequests = AsyncStream<ACPFileRequest> { $0.finish() }
+    let terminalRequests = AsyncStream<ACPTerminalRequest> { $0.finish() }
+
+    var yieldedUpdateCount: Int {
+        updateCountLock.lock()
+        defer { updateCountLock.unlock() }
+        return _yieldedUpdateCount
+    }
+
+    init() {
+        var updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation!
+        incomingUpdates = AsyncStream { updatesCont = $0 }
+        self.updatesCont = updatesCont
+    }
+
+    func send(_ request: ACPRequest) async throws -> ACPResponse {
+        sent.append(request)
+        guard request.method == "session/prompt" else {
+            throw ACPClientError.noScript(method: request.method)
+        }
+        updateCountLock.lock()
+        _yieldedUpdateCount += 2
+        updateCountLock.unlock()
+        updatesCont.yield(.init(sessionId: "s", update: .agentMessageChunk(.text("first"))))
+        return ACPResponse(body: Data("{}".utf8))
+    }
+
+    func notify(_ request: ACPRequest) async throws {
+        sent.append(request)
+    }
+
+    func emitReserved(_ update: ACPSessionUpdate) {
+        updatesCont.yield(.init(sessionId: "s", update: update))
+    }
+
+    func emitFresh(_ update: ACPSessionUpdate) {
+        updateCountLock.lock()
+        _yieldedUpdateCount += 1
+        updateCountLock.unlock()
+        updatesCont.yield(.init(sessionId: "s", update: update))
+    }
+
+    func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse) {}
+    func respondToFileRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {}
+    func respondToTerminalRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {}
+
+    func shutdown() async {
+        updatesCont.finish()
     }
 }
 

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -83,6 +83,57 @@ struct ACPSessionRunnerTests {
         }
     }
 
+    @Test("submits queue while completed output boundary is waiting for updates")
+    func submitQueuesWhileCompletedBoundaryWaitsForUpdates() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-runner-boundary-submit-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "codex", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let client = BoundaryRaceClient()
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: client),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        runner.start()
+
+        var firstCompletion: Bool?
+        runner.send(text: "hello", attachments: []) { succeeded in
+            firstCompletion = succeeded
+        }
+        try await waitUntil { firstCompletion == true }
+        #expect(session.transcript.streamingState == .sending)
+
+        var secondAccepted: Bool?
+        runner.send(blocks: [.text("next")], intent: .auto) { succeeded in
+            secondAccepted = succeeded
+        }
+        try await waitUntil { secondAccepted == true }
+        #expect(session.queue.count == 1)
+        #expect(client.sent.filter { $0.method == "session/prompt" }.count == 1)
+
+        client.emitReserved(.agentMessageChunk(.text(" second")))
+        try await waitUntil {
+            client.sent.filter { $0.method == "session/prompt" }.count == 2
+                && session.transcript.messages.count >= 3
+        }
+
+        if case .user(_, let firstUser, _) = session.transcript.messages[0],
+           case .agent(_, let firstAnswer) = session.transcript.messages[1],
+           case .user(_, let secondUser, _) = session.transcript.messages[2] {
+            #expect(firstUser == "hello")
+            #expect(firstAnswer.value == "first second")
+            #expect(secondUser == "next")
+        } else {
+            Issue.record("expected delayed chunk to land before the queued next prompt")
+        }
+    }
+
     @Test("send treats user-cancelled prompt errors as accepted completion")
     func sendTreatsCancelledPromptErrorsAsAcceptedCompletion() async throws {
         let (runner, mock) = try makeRunner()

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -134,6 +134,50 @@ struct ACPSessionRunnerTests {
         }
     }
 
+    @Test("stale completed boundary does not idle active steer replacement")
+    func staleCompletedBoundaryDoesNotIdleActiveSteerReplacement() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-runner-boundary-steer-\(UUID().uuidString).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        try store.upsertSession(.init(id: "s", agentId: "codex", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        let client = BoundaryRaceClient()
+        let replacementGate = AsyncGate()
+        client.holdSecondPrompt(until: replacementGate)
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        session.agentState = .ready
+        let runner = ACPSessionRunner(
+            session: session,
+            connection: ACPConnection(client: client),
+            store: store,
+            sessionId: "s",
+            worktreePath: FileManager.default.temporaryDirectory.path
+        )
+        runner.start()
+
+        var firstCompletion: Bool?
+        runner.send(text: "hello", attachments: []) { succeeded in
+            firstCompletion = succeeded
+        }
+        try await waitUntil { firstCompletion == true }
+        #expect(session.transcript.streamingState == .sending)
+
+        runner.send(blocks: [.text("replacement")], intent: .steer)
+        try await waitUntil {
+            client.sent.filter { $0.method == "session/prompt" }.count == 2
+                && session.transcript.streamingState == .sending
+        }
+
+        client.emitReserved(.agentMessageChunk(.text(" old-tail")))
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(session.transcript.streamingState == .sending)
+
+        await replacementGate.open()
+        client.emitReserved(.agentMessageChunk(.text(" replacement-tail")))
+        try await waitUntil { session.transcript.streamingState == .idle }
+    }
+
     @Test("send treats user-cancelled prompt errors as accepted completion")
     func sendTreatsCancelledPromptErrorsAsAcceptedCompletion() async throws {
         let (runner, mock) = try makeRunner()
@@ -429,6 +473,8 @@ private final class BoundaryRaceClient: ACPClient, @unchecked Sendable {
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let updateCountLock = NSLock()
     private var _yieldedUpdateCount = 0
+    private var promptCount = 0
+    private var secondPromptGate: AsyncGate?
     private(set) var sent: [ACPRequest] = []
 
     let incomingUpdates: AsyncStream<ACPSessionUpdateParams>
@@ -454,9 +500,15 @@ private final class BoundaryRaceClient: ACPClient, @unchecked Sendable {
             throw ACPClientError.noScript(method: request.method)
         }
         updateCountLock.lock()
+        promptCount += 1
+        let currentPromptCount = promptCount
         _yieldedUpdateCount += 2
+        let secondPromptGate = self.secondPromptGate
         updateCountLock.unlock()
         updatesCont.yield(.init(sessionId: "s", update: .agentMessageChunk(.text("first"))))
+        if currentPromptCount == 2 {
+            await secondPromptGate?.wait()
+        }
         return ACPResponse(body: Data("{}".utf8))
     }
 
@@ -473,6 +525,12 @@ private final class BoundaryRaceClient: ACPClient, @unchecked Sendable {
         _yieldedUpdateCount += 1
         updateCountLock.unlock()
         updatesCont.yield(.init(sessionId: "s", update: update))
+    }
+
+    func holdSecondPrompt(until gate: AsyncGate) {
+        updateCountLock.lock()
+        secondPromptGate = gate
+        updateCountLock.unlock()
     }
 
     func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse) {}

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -64,6 +64,26 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("completed output boundary tracks agent before trailing thought")
+    func completedOutputBoundaryTracksAgentBeforeTrailingThought() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("visible answer")))
+        session.apply(.agentThoughtChunk(.text("trailing thought")))
+        session.markCompletedOutputBoundary()
+        session.apply(.agentMessageChunk(.text("next task")))
+
+        #expect(session.transcript.messages.count == 3)
+        if case .agent(_, let first) = session.transcript.messages[0],
+           case .thought(_, let thought) = session.transcript.messages[1],
+           case .agent(_, let second) = session.transcript.messages[2] {
+            #expect(first.value == "visible answer")
+            #expect(thought.value == "trailing thought")
+            #expect(second.value == "next task")
+        } else {
+            Issue.record("expected agent, thought, agent")
+        }
+    }
+
     @Test("user prompt creates a user message")
     func userPrompt() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -15,6 +15,55 @@ struct ACPSessionTests {
         else { Issue.record("expected single agent message") }
     }
 
+    @Test("agent chunks after a completed output boundary start a new message")
+    func completedOutputBoundaryStartsNewMessage() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("first task output")))
+        session.markCompletedOutputBoundary()
+        session.apply(.agentMessageChunk(.text("next task output")))
+
+        #expect(session.transcript.messages.count == 2)
+        if case .agent(_, let first) = session.transcript.messages[0],
+           case .agent(_, let second) = session.transcript.messages[1] {
+            #expect(first.value == "first task output")
+            #expect(second.value == "next task output")
+        } else {
+            Issue.record("expected two agent messages")
+        }
+    }
+
+    @Test("completed output boundary does not alter existing message text")
+    func completedOutputBoundaryDoesNotAddBlankLines() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("line one\nline two")))
+        session.markCompletedOutputBoundary()
+
+        if case .agent(_, let buf) = session.transcript.messages[0] {
+            #expect(buf.value == "line one\nline two")
+        } else {
+            Issue.record("expected agent message")
+        }
+    }
+
+    @Test("completed output boundary skips trailing plan rows")
+    func completedOutputBoundarySkipsTrailingPlan() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("first task")))
+        session.apply(.plan([.init(content: "done", priority: nil, status: "completed")]))
+        session.markCompletedOutputBoundary()
+        session.apply(.agentMessageChunk(.text("second task")))
+
+        #expect(session.transcript.messages.count == 3)
+        if case .agent(_, let first) = session.transcript.messages[0],
+           case .plan = session.transcript.messages[1],
+           case .agent(_, let second) = session.transcript.messages[2] {
+            #expect(first.value == "first task")
+            #expect(second.value == "second task")
+        } else {
+            Issue.record("expected agent, plan, agent")
+        }
+    }
+
     @Test("user prompt creates a user message")
     func userPrompt() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -84,6 +84,29 @@ struct ACPSessionTests {
         }
     }
 
+    @Test("completed output boundary survives next task leading thought")
+    func completedOutputBoundarySurvivesNextTaskLeadingThought() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.apply(.agentMessageChunk(.text("first answer")))
+        session.apply(.agentThoughtChunk(.text("first thought")))
+        session.markCompletedOutputBoundary()
+        session.apply(.agentThoughtChunk(.text("next thought")))
+        session.apply(.agentMessageChunk(.text("second answer")))
+
+        #expect(session.transcript.messages.count == 4)
+        if case .agent(_, let first) = session.transcript.messages[0],
+           case .thought(_, let firstThought) = session.transcript.messages[1],
+           case .thought(_, let secondThought) = session.transcript.messages[2],
+           case .agent(_, let second) = session.transcript.messages[3] {
+            #expect(first.value == "first answer")
+            #expect(firstThought.value == "first thought")
+            #expect(secondThought.value == "next thought")
+            #expect(second.value == "second answer")
+        } else {
+            Issue.record("expected agent, thought, thought, agent")
+        }
+    }
+
     @Test("user prompt creates a user message")
     func userPrompt() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")


### PR DESCRIPTION
## Summary
- record a completed ACP output boundary so later streaming output starts as a new rendered message
- keep mid-task ACP chunk merging intact
- handle trailing plan rows that are filtered from the visible transcript

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test