### PR TITLE
feat(acp): paste and attach images in the composer

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		279BAFE41DCB69286B64CFB9 /* AdapterUpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */; };
 		281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
+		28F42E0137436A3B5F72CB85 /* ACPImageEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */; };
 		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
 		29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */; };
 		295EF629FAAA46FCD6802F4E /* ScrollEventCapturingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22E44126BAFC8F3B515BAC0 /* ScrollEventCapturingView.swift */; };
@@ -204,6 +205,7 @@
 		3CFC291E5868CCD147D573E7 /* ACPAdapterUpdateBannerDeciderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */; };
 		3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */; };
 		3D711A767050DB05E4C77548 /* SurfaceViewKeyboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */; };
+		3D98C4F5EE2C0B1203C76752 /* ACPImageChipAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */; };
 		3DB85FF0D4965BF78AD2B010 /* MergeSidePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C55C85672956E1340B03B1 /* MergeSidePane.swift */; };
 		3E0A4613EB8F41DA8C182C36 /* FormatOnSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEBDB5A6617C62D0F1C0D1 /* FormatOnSaveTests.swift */; };
 		3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */; };
@@ -246,6 +248,7 @@
 		45B3616A459480A78A5004E8 /* ImageDiffPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */; };
 		45EEE2F32712FDEE392A9707 /* ZmxEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E0BB32D1A3B26473464A0F /* ZmxEnv.swift */; };
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
+		46E3CCB2AC426BD5F8CB55DC /* ACPImageBlocksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */; };
 		474DF7FE50CB6146644B2450 /* ImageDiffEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */; };
 		476CE4945CF013F76A96AFC6 /* MergeConflictTabState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */; };
 		47789166FA5C563AE2F550ED /* ACPDiffGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C9583C0CA5EDE7D2A1B7DF /* ACPDiffGeneratorTests.swift */; };
@@ -271,6 +274,7 @@
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
 		4E352BDC87A204DE2912F54F /* ACPHarnessBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */; };
 		4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */; };
+		4E8C1689D341A429BA91D20C /* ACPImageEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1615F1953C6FE9D1A30A1A2 /* ACPImageEncoding.swift */; };
 		4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */; };
 		4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
@@ -306,6 +310,7 @@
 		599A6D9A3A1CCF1F618146C8 /* LegacyHookSweepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */; };
 		59AFC96BD543D2520DBE7BB0 /* ThemeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1003EEEA51DA385A0DD57CA0 /* ThemeStoreTests.swift */; };
 		59EFDD354514B21BBA4206AD /* AiSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */; };
+		59F39BAAD57023F090AEDA4F /* ACPImageStagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */; };
 		5B02C8E213F6EA67BEB7E5BA /* ContentResultGroupViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */; };
 		5B415F5F89EAE4B2EEA07046 /* ShortcutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4069925EE709DD18AEA810B3 /* ShortcutResolver.swift */; };
 		5BCB202710E37EA60DCC91F0 /* ACPPlanSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */; };
@@ -357,6 +362,7 @@
 		6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */; };
 		6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795056B6AD803D2B555FC866 /* RightPaneStore.swift */; };
 		6DDB5FC604A28D699350C3BD /* TabActivityIconTintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */; };
+		6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */; };
 		6E52521BCD52ED8DB496E74B /* CompletionDocumentationRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */; };
@@ -423,8 +429,10 @@
 		832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */; };
 		8352A6C0D7AE371907E50217 /* TreeSitterPython in Frameworks */ = {isa = PBXBuildFile; productRef = 7D55FFC5D9F65DAD0178FB0E /* TreeSitterPython */; };
 		835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */; };
+		839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */; };
 		83A76F6425CD1406DA85B0E9 /* ACPUserScrollEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */; };
 		84C505BF196A3BDA23C80235 /* LanguageServerConfigMasonPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC01D9A0927AF9DD7524CEB7 /* LanguageServerConfigMasonPrefill.swift */; };
+		84E96EB0EF4267784462B866 /* ACPComposerImageExtractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */; };
 		8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */; };
 		8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */; };
 		859AD39BA8D5A9FCC905648D /* ImageDiffViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */; };
@@ -432,6 +440,7 @@
 		85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */; };
 		864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */; };
 		86718F7E55531B8E4356D7D1 /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2943FBB1D6371EFAC9BBE68 /* PaneTree.swift */; };
+		86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */; };
 		873535DE3342024BD7AA057E /* ShortcutReservations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */; };
 		8744A1DB40A1EC0D01D4C895 /* AlasGhostty.Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */; };
 		8775C1FD6CE74B0555D778A3 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DD66F449B380BC74B373647 /* Carbon.framework */; };
@@ -577,6 +586,7 @@
 		B1665774383C03F0C0765A43 /* ACPMarkdownBlockCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70255847CE81CE85E0117A85 /* ACPMarkdownBlockCache.swift */; };
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
 		B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */; };
+		B339F5B376407CFD88B0E7B8 /* ACPAttachmentMimeTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */; };
 		B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46BDE72E52818061452ECB /* CommitRowTests.swift */; };
 		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
 		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
@@ -607,6 +617,7 @@
 		B9BEA46E818C321122713F41 /* EditorFindControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */; };
 		B9F3258E4AE2DB1E7481690A /* SubprocessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06BA06E4A620EEE773E1672 /* SubprocessRunner.swift */; };
 		BAE4D422FC3950E61FEE1D15 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
+		BAE6B1D93387807ADD7ED0CC /* ACPImageThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */; };
 		BB565B8EE9BA20EE961B32FB /* ThemeSidebarContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70ED4990428C46B69784970 /* ThemeSidebarContrastTests.swift */; };
 		BC19B95DAAC3943FF1BE5817 /* CommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DBB72EE97F0E906442919B /* CommitTabView.swift */; };
 		BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */; };
@@ -739,6 +750,7 @@
 		E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373D587E3153D902EB10208B /* MarkdownParserTests.swift */; };
 		E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */; };
 		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
+		E2A3B2DB4B1F9A7C318921D7 /* ACPImageStaging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98796FD86FE05979A2BCBCF3 /* ACPImageStaging.swift */; };
 		E2A49F787B3DC3F45E92854D /* AgentEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E480C05A2AA6FF8863B7C5 /* AgentEditView.swift */; };
 		E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */; };
 		E30832C33A680645C481826F /* ANSIStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86CB3F953562BAFB284B5DB7 /* ANSIStreamTests.swift */; };
@@ -1090,6 +1102,7 @@
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
 		4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioClient.swift; sourceTree = "<group>"; };
 		4D4A929D20297ED9DAB53982 /* TreeSitterYAML */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterYAML; path = ThirdParty/TreeSitterYAML; sourceTree = SOURCE_ROOT; };
+		4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContentBlockImageTests.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4D63B166AF2C533BE6E59365 /* session-update-agent-chunk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-agent-chunk.json"; sourceTree = "<group>"; };
 		4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLeafEncodeTests.swift; sourceTree = "<group>"; };
@@ -1237,6 +1250,7 @@
 		7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceStoreTests.swift; sourceTree = "<group>"; };
 		7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshot.swift; sourceTree = "<group>"; };
 		7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+CommitEditing.swift"; sourceTree = "<group>"; };
+		7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownLiveStylerImageChipTests.swift; sourceTree = "<group>"; };
 		7F8802F19E02CED256495755 /* ACPTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTerminalTests.swift; sourceTree = "<group>"; };
 		7FFC9539E615699AC90A7412 /* ProjectsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManager.swift; sourceTree = "<group>"; };
 		802EF6C18E2E27F68F6B770E /* ImageDiffSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSwipeView.swift; sourceTree = "<group>"; };
@@ -1306,6 +1320,7 @@
 		97DA8F50DDCDAA15CCEA2004 /* session-update-config-options.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-options.json"; sourceTree = "<group>"; };
 		97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasonSnapshotTests.swift; sourceTree = "<group>"; };
 		9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConfigOptionTests.swift; sourceTree = "<group>"; };
+		98796FD86FE05979A2BCBCF3 /* ACPImageStaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageStaging.swift; sourceTree = "<group>"; };
 		987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQueuedBubble.swift; sourceTree = "<group>"; };
 		987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigMarkdownTests.swift; sourceTree = "<group>"; };
 		98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarVisibilityTests.swift; sourceTree = "<group>"; };
@@ -1340,8 +1355,11 @@
 		A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraft.swift; sourceTree = "<group>"; };
 		A5069EF396F2CB8E81B2AD11 /* ACPTranscriptMarkdownTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdownTests.swift; sourceTree = "<group>"; };
 		A52FE6A88564AD523AC577CC /* CodeTextViewMultiCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewMultiCursorTests.swift; sourceTree = "<group>"; };
+		A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageStagingTests.swift; sourceTree = "<group>"; };
 		A5848B9AAD7985BF7BFB87F6 /* MergeConflictAnnotationStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAnnotationStrip.swift; sourceTree = "<group>"; };
 		A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionUpdateTests.swift; sourceTree = "<group>"; };
+		A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageThumbnail.swift; sourceTree = "<group>"; };
+		A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerImageExtractTests.swift; sourceTree = "<group>"; };
 		A655F5AA40CA10A7685794F7 /* ACPSubmitIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntent.swift; sourceTree = "<group>"; };
 		A6926DACD1903E1AAAF66F48 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		A6C0DDAE33A9928438C65182 /* DebounceTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceTimer.swift; sourceTree = "<group>"; };
@@ -1350,6 +1368,7 @@
 		A72E6086ED069AF65F890BBB /* AppConfigAgentsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigAgentsCodingTests.swift; sourceTree = "<group>"; };
 		A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasHookCommandTests.swift; sourceTree = "<group>"; };
 		A78C23951DE157A38A9ED899 /* AgentHookSocketServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServerTests.swift; sourceTree = "<group>"; };
+		A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageChipAttachment.swift; sourceTree = "<group>"; };
 		A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerAvailabilityTests.swift; sourceTree = "<group>"; };
 		A8EFC853C0D2EB4AC2B01D9E /* GitService+ImageDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ImageDiff.swift"; sourceTree = "<group>"; };
 		A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunner.swift; sourceTree = "<group>"; };
@@ -1359,10 +1378,12 @@
 		AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManagerStatusTests.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometryTests.swift; sourceTree = "<group>"; };
+		AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAttachmentMimeTypeTests.swift; sourceTree = "<group>"; };
 		AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindowTests.swift; sourceTree = "<group>"; };
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
+		B1615F1953C6FE9D1A30A1A2 /* ACPImageEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncoding.swift; sourceTree = "<group>"; };
 		B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
 		B27595490B7D883CF5D9FFD5 /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
@@ -1400,6 +1421,7 @@
 		BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftCommitTabView.swift; sourceTree = "<group>"; };
 		BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigBuilder.swift; sourceTree = "<group>"; };
 		BCA9015C063CDD90D021D928 /* TreeSitterCSS */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterCSS; path = ThirdParty/TreeSitterCSS; sourceTree = SOURCE_ROOT; };
+		BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageBlocksTests.swift; sourceTree = "<group>"; };
 		BD4A3B9B1103346242438940 /* FilesTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabView.swift; sourceTree = "<group>"; };
 		BD708EEB35D93A7E7150981D /* ProjectsManagerHeadUpdatesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerHeadUpdatesTests.swift; sourceTree = "<group>"; };
 		BD77FB052C8B5A937B14A4AE /* ProjectConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfig.swift; sourceTree = "<group>"; };
@@ -1421,6 +1443,7 @@
 		C204307EE573512D731B8307 /* ACPGeminiE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPGeminiE2ETests.swift; sourceTree = "<group>"; };
 		C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
 		C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagedTests.swift; sourceTree = "<group>"; };
+		C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPromptCapabilitiesTests.swift; sourceTree = "<group>"; };
 		C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextTests.swift; sourceTree = "<group>"; };
 		C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecTests.swift; sourceTree = "<group>"; };
 		C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSystemNoticeView.swift; sourceTree = "<group>"; };
@@ -1612,6 +1635,7 @@
 		FC961032C642C166F17EFD99 /* QueuedPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPromptTests.swift; sourceTree = "<group>"; };
 		FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstaller.swift; sourceTree = "<group>"; };
 		FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipeTests.swift; sourceTree = "<group>"; };
+		FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncodingTests.swift; sourceTree = "<group>"; };
 		FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceUpstreamTests.swift; sourceTree = "<group>"; };
 		FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerAction.swift; sourceTree = "<group>"; };
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
@@ -2012,9 +2036,11 @@
 			children = (
 				9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */,
 				701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */,
+				4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */,
 				9DF8B5E766D2B3649D2555ED /* ACPInitializeTests.swift */,
 				11BA9F25CB0A6A2BFDB390EE /* ACPMockClientTests.swift */,
 				2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */,
+				C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */,
 				2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */,
 				A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */,
 				5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */,
@@ -2254,9 +2280,13 @@
 			children = (
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
+				A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */,
 				85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */,
 				DC76F9150CC29A324D785C29 /* ACPDelayedHoverVisibilityTests.swift */,
+				FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */,
+				A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */,
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
+				7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */,
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
 				96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */,
 				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
@@ -2454,6 +2484,10 @@
 				BA6C7434D216D5C43A2FB921 /* ACPFileChip.swift */,
 				29D7631D754795D16E946440 /* ACPFileEditCard.swift */,
 				E2C5BD0110EB8EDE7BB4ED93 /* ACPHistorySidebar.swift */,
+				A7FB37A9430467B477E40819 /* ACPImageChipAttachment.swift */,
+				B1615F1953C6FE9D1A30A1A2 /* ACPImageEncoding.swift */,
+				98796FD86FE05979A2BCBCF3 /* ACPImageStaging.swift */,
+				A5E1462C85D0E49127BCED81 /* ACPImageThumbnail.swift */,
 				70255847CE81CE85E0117A85 /* ACPMarkdownBlockCache.swift */,
 				2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */,
 				DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */,
@@ -2658,8 +2692,10 @@
 		A72D9EE2C6FD478C41435DBA /* Session */ = {
 			isa = PBXGroup;
 			children = (
+				AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */,
 				239125BB939233233D405EB8 /* ACPChipStateTests.swift */,
 				D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */,
+				BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */,
 				6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */,
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
 				2468AD293C8215FAF390C907 /* ACPMessageWireTests.swift */,
@@ -3351,6 +3387,10 @@
 				DAA6F5DABE3214693628C730 /* ACPFilesystem.swift in Sources */,
 				4E352BDC87A204DE2912F54F /* ACPHarnessBridge.swift in Sources */,
 				F73063B2384B650C227BD09E /* ACPHistorySidebar.swift in Sources */,
+				3D98C4F5EE2C0B1203C76752 /* ACPImageChipAttachment.swift in Sources */,
+				4E8C1689D341A429BA91D20C /* ACPImageEncoding.swift in Sources */,
+				E2A3B2DB4B1F9A7C318921D7 /* ACPImageStaging.swift in Sources */,
+				BAE6B1D93387807ADD7ED0CC /* ACPImageThumbnail.swift in Sources */,
 				433EC05E13C676C1C2EB6888 /* ACPLaunchCatalog.swift in Sources */,
 				542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */,
 				B1665774383C03F0C0765A43 /* ACPMarkdownBlockCache.swift in Sources */,
@@ -3767,23 +3807,30 @@
 				BE7FA8E07C4A1FC48267C64D /* ACPAdapterUpdateStoreTests.swift in Sources */,
 				481DEBE64E91C54A81185D09 /* ACPAdapterVersionCheckerTests.swift in Sources */,
 				CC531074F02A34E48A1E6133 /* ACPAgentProfilesTests.swift in Sources */,
+				B339F5B376407CFD88B0E7B8 /* ACPAttachmentMimeTypeTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,
+				84E96EB0EF4267784462B866 /* ACPComposerImageExtractTests.swift in Sources */,
 				3FCC4EDA31A96BE121F45D44 /* ACPComposerPlaceholderTests.swift in Sources */,
 				FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */,
 				30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */,
+				839AF384DDFF728207769920 /* ACPContentBlockImageTests.swift in Sources */,
 				DADDDA3FA289B52415EF4379 /* ACPDelayedHoverVisibilityTests.swift in Sources */,
 				47789166FA5C563AE2F550ED /* ACPDiffGeneratorTests.swift in Sources */,
 				B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */,
 				43CB2A054DED7568A583822E /* ACPGeminiE2ETests.swift in Sources */,
 				01568CB821D2E938C51BBCAB /* ACPHarnessBridgeTests.swift in Sources */,
+				46E3CCB2AC426BD5F8CB55DC /* ACPImageBlocksTests.swift in Sources */,
+				28F42E0137436A3B5F72CB85 /* ACPImageEncodingTests.swift in Sources */,
+				59F39BAAD57023F090AEDA4F /* ACPImageStagingTests.swift in Sources */,
 				01C919A6F3868980D51539DD /* ACPInitializeTests.swift in Sources */,
 				603D2F40A0368A139822CE80 /* ACPLaunchCatalogTests.swift in Sources */,
 				864B31874E286ED036347975 /* ACPLaunchSpecNpmPackageTests.swift in Sources */,
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
+				6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */,
 				9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */,
 				D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */,
 				BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */,
@@ -3793,6 +3840,7 @@
 				8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */,
 				97E90C02DD115438B5E12DF2 /* ACPPlanPillStateTests.swift in Sources */,
 				F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */,
+				86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */,
 				A383F1C9B0B00B2805576209 /* ACPScrollDirectionClassifierTests.swift in Sources */,
 				702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */,
 				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -7,14 +7,18 @@ final class ACPConnection: @unchecked Sendable {
 
     init(client: ACPClient) { self.client = client }
 
-    func initialize() async throws {
+    /// Returns whether the agent advertises inline-image prompt capability.
+    @discardableResult
+    func initialize() async throws -> Bool {
         let req = ACPRequest(method: "initialize",
                              params: ACPInitializeParams(
                                 protocolVersion: ACPProtocolVersion.current,
                                 clientCapabilities: .init(
                                     fs: .init(readTextFile: true, writeTextFile: true),
                                     terminal: true)))
-        _ = try await client.send(req)
+        let resp = try await client.send(req)
+        let result = try? JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)
+        return result?.agentCapabilities?.promptCapabilities?.image ?? false
     }
 
     func newSession(cwd: String) async throws -> ACPSessionNewResult {

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -74,6 +74,21 @@ struct ACPInitializeResult: Codable, Equatable {
     struct ACPPromptCapabilities: Codable, Equatable {
         let image: Bool
         let audio: Bool
+
+        init(image: Bool = false, audio: Bool = false) {
+            self.image = image
+            self.audio = audio
+        }
+
+        // ACP defines each prompt capability as defaulting to false when
+        // omitted, so an agent advertising only `{ "image": true }` must still
+        // decode (a non-optional `audio` would otherwise fail the whole
+        // initialize result and silently drop image support).
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            image = try c.decodeIfPresent(Bool.self, forKey: .image) ?? false
+            audio = try c.decodeIfPresent(Bool.self, forKey: .audio) ?? false
+        }
     }
     struct ACPAuthMethod: Codable, Equatable {
         let id: String
@@ -333,9 +348,9 @@ struct ACPSessionPromptParams: Codable, Equatable {
 enum ACPContentBlock: Codable, Equatable {
     case text(String)
     case resourceLink(uri: String, name: String?)
-    case image(uri: String, mimeType: String?)
+    case image(data: String?, uri: String?, mimeType: String?)
 
-    private enum Keys: String, CodingKey { case type, text, uri, name, mimeType }
+    private enum Keys: String, CodingKey { case type, text, uri, name, mimeType, data }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: Keys.self)
@@ -348,7 +363,8 @@ enum ACPContentBlock: Codable, Equatable {
                 name: try? c.decode(String.self, forKey: .name))
         case "image":
             self = .image(
-                uri: try c.decode(String.self, forKey: .uri),
+                data: try? c.decode(String.self, forKey: .data),
+                uri: try? c.decode(String.self, forKey: .uri),
                 mimeType: try? c.decode(String.self, forKey: .mimeType))
         default:
             self = .text("")
@@ -364,9 +380,10 @@ enum ACPContentBlock: Codable, Equatable {
             try c.encode("resource_link", forKey: .type)
             try c.encode(uri, forKey: .uri)
             try c.encodeIfPresent(name, forKey: .name)
-        case .image(let uri, let mime):
+        case .image(let data, let uri, let mime):
             try c.encode("image", forKey: .type)
-            try c.encode(uri, forKey: .uri)
+            try c.encodeIfPresent(data, forKey: .data)
+            try c.encodeIfPresent(uri, forKey: .uri)
             try c.encodeIfPresent(mime, forKey: .mimeType)
         }
     }

--- a/Alas/Sources/ACP/Session/ACPComposerDraft.swift
+++ b/Alas/Sources/ACP/Session/ACPComposerDraft.swift
@@ -10,7 +10,7 @@ struct ACPComposerDraft: Codable, Equatable {
             switch segment {
             case .text(let value):
                 value.isEmpty
-            case .mention:
+            case .mention, .image:
                 false
             }
         }
@@ -24,7 +24,7 @@ struct ACPComposerDraft: Codable, Equatable {
             switch segment {
             case .text(let value):
                 return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            case .mention:
+            case .mention, .image:
                 return true
             }
         }
@@ -33,17 +33,20 @@ struct ACPComposerDraft: Codable, Equatable {
     enum Segment: Codable, Equatable {
         case text(String)
         case mention(displayName: String, uri: String)
+        case image(uri: String, mimeType: String)
 
         private enum CodingKeys: String, CodingKey {
             case type
             case text
             case displayName
             case uri
+            case mimeType
         }
 
         private enum SegmentType: String, Codable {
             case text
             case mention
+            case image
         }
 
         init(from decoder: Decoder) throws {
@@ -57,6 +60,10 @@ struct ACPComposerDraft: Codable, Equatable {
                     displayName: try container.decode(String.self, forKey: .displayName),
                     uri: try container.decode(String.self, forKey: .uri)
                 )
+            case .image:
+                self = .image(
+                    uri: try container.decode(String.self, forKey: .uri),
+                    mimeType: try container.decode(String.self, forKey: .mimeType))
             }
         }
 
@@ -70,6 +77,10 @@ struct ACPComposerDraft: Codable, Equatable {
                 try container.encode(SegmentType.mention, forKey: .type)
                 try container.encode(displayName, forKey: .displayName)
                 try container.encode(uri, forKey: .uri)
+            case .image(let uri, let mimeType):
+                try container.encode(SegmentType.image, forKey: .type)
+                try container.encode(uri, forKey: .uri)
+                try container.encode(mimeType, forKey: .mimeType)
             }
         }
     }
@@ -103,6 +114,7 @@ extension ACPComposerDraft {
     /// Declared in an extension so the compiler keeps synthesizing the
     /// memberwise `init(segments:)` that the rest of the codebase relies on.
     init(blocks: [ACPContentBlock]) {
+        var segments: [Segment] = []
         var text = ""
         var links: [(name: String, uri: String)] = []
         for block in blocks {
@@ -111,11 +123,17 @@ extension ACPComposerDraft {
                 text += value
             case .resourceLink(let uri, let name):
                 links.append((name ?? Self.displayName(forURI: uri), uri))
-            case .image(let uri, _):
-                links.append((Self.displayName(forURI: uri), uri))
+            case .image(_, let uri, let mimeType):
+                if let uri {
+                    segments.append(contentsOf: Self.rebuild(text: text, links: links))
+                    text = ""
+                    links = []
+                    segments.append(.image(uri: uri, mimeType: mimeType ?? "image/png"))
+                }
             }
         }
-        self.segments = Self.rebuild(text: text, links: links)
+        segments.append(contentsOf: Self.rebuild(text: text, links: links))
+        self.segments = segments
     }
 
     private static func displayName(forURI uri: String) -> String {

--- a/Alas/Sources/ACP/Session/ACPMessage.swift
+++ b/Alas/Sources/ACP/Session/ACPMessage.swift
@@ -38,6 +38,17 @@ enum ACPMessage: Equatable {
     struct Attachment: Codable, Equatable, Hashable, Sendable {
         let uri: String
         let name: String?
+        /// Image MIME type (e.g. `image/png`) when this attachment is an
+        /// image; `nil` for mention/resource-link attachments. Drives
+        /// thumbnail rendering in the user bubble. Synthesized Codable
+        /// decodes a missing key as nil, so legacy rows stay valid.
+        let mimeType: String?
+
+        init(uri: String, name: String?, mimeType: String? = nil) {
+            self.uri = uri
+            self.name = name
+            self.mimeType = mimeType
+        }
     }
 
     struct ToolCall: Codable, Equatable, Hashable, Sendable {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -48,6 +48,11 @@ final class ACPSession: ObservableObject, Identifiable {
     /// lifecycle), distinct from `StreamingState.idle` which means
     /// "runner is attached but not currently mid-prompt" (turn lifecycle).
     @Published var agentState: AgentState = .idle
+    /// Whether the connected agent accepts inline image content blocks
+    /// (`promptCapabilities.image`). Runtime-only: re-learned on each
+    /// `initialize`, never persisted. Drives the send-time hydration in
+    /// `ACPSessionRunner.hydrate`.
+    @Published var imageInputSupported: Bool = false
 
     enum AgentState: Equatable {
         case idle
@@ -442,7 +447,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 out.append(s)
             case .content(.resourceLink(let uri, let name)):
                 out.append("[\(name ?? uri)]")
-            case .content(.image(_, _)):
+            case .content(.image):
                 out.append("[image]")
             case .diff(let path, let old, let new):
                 var lines: [String] = ["--- \(path)"]

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -584,7 +584,7 @@ extension ACPSessionManager {
             }
         }
         do {
-            try await connection.initialize()
+            session.imageInputSupported = (try await connection.initialize())
             let pendingRecovery = (try? store.loadSession(id: sessionId)?.contextRecoveryPending) == true
             let result: ACPSessionNewResult
             var restoreWarning: ACPSession.ContextRestoreWarning?

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -480,19 +480,63 @@ extension ACPSessionRunner {
     }
 
     /// Build the canonical `[ACPContentBlock]` array from a composer-shaped
-    /// `(text, attachments)` pair: leading text block followed by one
-    /// `.resourceLink` per attachment. Shared with
+    /// `(text, attachments)` pair: a leading text block followed by one block
+    /// per attachment — a DEFERRED `.image` (data: nil, carrying the staged
+    /// file uri) for image attachments, a `.resourceLink` for everything else.
+    /// Image blocks stay deferred here so SQLite never holds base64; `hydrate`
+    /// resolves them at send time. Shared with
     /// `ACPSessionManager.enqueueWhileRecovering` so prompts persisted before
     /// the runner exists look identical on the wire to ones the runner enqueues.
     static func blocks(
         text: String,
         attachments: [ACPMessage.Attachment]
     ) -> [ACPContentBlock] {
-        var blocks: [ACPContentBlock] = [.text(text)]
+        // Omit the leading text block for an image-only prompt so we don't send
+        // an empty/whitespace `.text` ahead of the image(s). The composer leaves
+        // a trailing space after an image chip, so the image-only text is " ",
+        // not "" — trim before deciding.
+        var blocks: [ACPContentBlock] = text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? []
+            : [.text(text)]
         for a in attachments {
-            blocks.append(.resourceLink(uri: a.uri, name: a.name))
+            if let mime = a.mimeType, mime.hasPrefix("image/") {
+                // Deferred: the staged file is referenced by uri; the inline
+                // base64 (or resource-link fallback) is resolved at send time
+                // by `hydrate`, so SQLite never stores the base64 payload.
+                blocks.append(.image(data: nil, uri: a.uri, mimeType: mime))
+            } else {
+                blocks.append(.resourceLink(uri: a.uri, name: a.name))
+            }
         }
         return blocks
+    }
+
+    /// Maximum dimension for an inline base64 image, in pixels.
+    nonisolated static let inlineImageMaxDimension: CGFloat = 1568
+
+    /// Resolve deferred image blocks just before sending. When the agent
+    /// supports inline images, read the staged file, downscale, and base64-
+    /// encode it; otherwise degrade to a `file://` resource link the agent
+    /// reads from disk. Non-image blocks (and already-hydrated images that
+    /// carry `data`) pass through untouched.
+    ///
+    /// `nonisolated async` so the synchronous file reads + downscale/base64
+    /// encoding (up to 10 × 20 MB) run off the main actor; awaiting it from the
+    /// main-actor send path hops to the cooperative pool instead of freezing
+    /// the composer/transcript while a prompt is prepared.
+    nonisolated static func hydrate(_ blocks: [ACPContentBlock], imageInputSupported: Bool) async -> [ACPContentBlock] {
+        blocks.map { block in
+            guard case .image(let data, let uri, let mime) = block, data == nil, let uri else {
+                return block
+            }
+            let name = (URL(string: uri)?.lastPathComponent) ?? "image"
+            if imageInputSupported,
+               let fileURL = URL(string: uri),
+               let encoded = ACPImageEncoding.inlineBase64(fileURL: fileURL, maxDimension: inlineImageMaxDimension) {
+                return .image(data: encoded.data, uri: nil, mimeType: encoded.mimeType)
+            }
+            return .resourceLink(uri: uri, name: name)
+        }
     }
 
     /// Primary entry. Resolves the routing then dispatches to one of:
@@ -728,7 +772,11 @@ extension ACPSessionRunner {
             }
             do {
                 let remoteId = self.session.remoteSessionId ?? self.sessionId
-                try await self.connection.prompt(sessionId: remoteId, blocks: blocks)
+                // Read the capability flag on the main actor (cheap), then
+                // hydrate off-main so file reads + base64 encoding don't block UI.
+                let imageSupported = self.session.imageInputSupported
+                let wireBlocks = await Self.hydrate(blocks, imageInputSupported: imageSupported)
+                try await self.connection.prompt(sessionId: remoteId, blocks: wireBlocks)
                 await MainActor.run {
                     let isActivePrompt = self.activePromptID == promptID
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
@@ -846,13 +894,20 @@ extension ACPSessionRunner {
         }.joined()
     }
 
-    /// Resource-link attachments derived from the prompt blocks. Mirrors
-    /// the shape `recordUserPrompt` expects (which previously came from
-    /// the composer-level attachments array).
+    /// Attachments derived from the prompt blocks for the user-bubble UI:
+    /// resource links plus deferred image blocks (which still carry the staged
+    /// file uri). Mirrors the shape `recordUserPrompt` expects (which
+    /// previously came from the composer-level attachments array). Inline-
+    /// hydrated images (uri == nil) are intentionally skipped — they have no
+    /// file to point the thumbnail at and only appear post-`hydrate`.
     static func attachments(of blocks: [ACPContentBlock]) -> [ACPMessage.Attachment] {
         blocks.compactMap { b -> ACPMessage.Attachment? in
             if case .resourceLink(let uri, let name) = b {
                 return ACPMessage.Attachment(uri: uri, name: name)
+            }
+            if case .image(_, let uri, let mime) = b, let uri {
+                let name = URL(string: uri)?.lastPathComponent
+                return ACPMessage.Attachment(uri: uri, name: name, mimeType: mime ?? "image/png")
             }
             return nil
         }

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 
 typealias ACPComposerSubmitCompletion = @MainActor (_ succeeded: Bool) -> Void
 typealias ACPComposerSubmitHandler = (
@@ -27,6 +28,9 @@ struct ACPInputField: NSViewRepresentable {
     /// textview should be cleared) or `false` to keep the draft in
     /// place (e.g. session not ready, prompt already in flight).
     let onSubmit: ACPComposerSubmitHandler
+    /// Called when image staging fails so the chrome can show a transient
+    /// notice. Receives the specific error that caused the failure.
+    let onImageError: (ACPImageStaging.StagingError) -> Void
 
     func makeNSView(context: Context) -> NSScrollView {
         let textView = ACPNSTextView()
@@ -42,6 +46,8 @@ struct ACPInputField: NSViewRepresentable {
         textView.textColor = NSColor(named: "fg") ?? NSColor.labelColor
         textView.insertionPointColor = NSColor.controlAccentColor
         context.coordinator.textView = textView
+        context.coordinator.onImageError = onImageError
+        textView.registerForDraggedTypes([.fileURL, .png, .tiff])
         context.coordinator.restoreInitialDraft(into: textView)
         // Publish the submit closure so the SwiftUI send button can fire
         // the same code path as ⏎.
@@ -49,6 +55,10 @@ struct ACPInputField: NSViewRepresentable {
         actions.submitWithIntent = { [weak coord] intent in
             guard let coord, let tv = coord.textView else { return }
             coord.submit(tv, intent: intent)
+        }
+        actions.presentImagePicker = { [weak coord] in
+            guard let coord, let tv = coord.textView as? ACPNSTextView else { return }
+            tv.presentImagePicker()
         }
         let scroll = NSScrollView()
         scroll.hasVerticalScroller = true
@@ -130,6 +140,8 @@ struct ACPInputField: NSViewRepresentable {
         /// can render its SwiftUI content with our theme tokens.
         var theme: Theme?
         weak var textView: NSTextView?
+        /// Set by the composer chrome to surface staging failures (Task 14).
+        var onImageError: ((ACPImageStaging.StagingError) -> Void)?
         private var restoringDraft = false
         private var lastSyncedDraft: ACPComposerDraft
         private var nextSubmitID = 0
@@ -138,6 +150,10 @@ struct ACPInputField: NSViewRepresentable {
         private var pendingRestyleGeneration = 0
         private var pendingRestyleRange: NSRange?
         private static let restyleDebounceInterval: Double = 0.5
+
+        func reportImageError(_ error: ACPImageStaging.StagingError) {
+            onImageError?(error)
+        }
 
         func flushPendingRestyleNow() {
             guard let work = pendingRestyleWork else { return }
@@ -255,7 +271,10 @@ struct ACPInputField: NSViewRepresentable {
             flushPendingRestyleNow()
             let attributed = textView.attributedString()
             let (text, attachments) = Self.extract(attributed)
-            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            // Allow image-only prompts: an attached image carries no text, so
+            // submit must be gated on text OR attachments, not text alone.
+            guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || !attachments.isEmpty else { return }
             let draft = Self.draft(from: attributed)
             // Rejected submits keep the editable draft in place. Accepted
             // submits clear only the visible text view here; persisted
@@ -328,12 +347,12 @@ struct ACPInputField: NSViewRepresentable {
             let full = NSRange(location: 0, length: attributed.length)
             guard attributed.length > 0 else { return ACPComposerDraft(segments: []) }
 
-            // Fast path: no chip mentions in the storage. The whole
-            // string is plain text, so skip the enumerateAttribute walk
-            // entirely. This is the common case while typing.
+            // Fast path: no chip mentions or image chips in the storage.
+            // The whole string is plain text, so skip the enumerateAttributes
+            // walk entirely. This is the common case while typing.
             var hasChip = false
-            attributed.enumerateAttribute(.attachmentURI, in: full) { value, _, stop in
-                if value != nil {
+            attributed.enumerateAttributes(in: full) { keys, _, stop in
+                if keys[.attachmentURI] != nil || keys[.imageAttachmentURI] != nil {
                     hasChip = true
                     stop.pointee = true
                 }
@@ -344,20 +363,22 @@ struct ACPInputField: NSViewRepresentable {
             }
 
             var segments: [ACPComposerDraft.Segment] = []
-            attributed.enumerateAttribute(.attachmentURI, in: full) { value, range, _ in
-                if let uri = value as? String,
-                   let chip = attributed.attribute(.attachment, at: range.location, effectiveRange: nil)
-                   as? ACPMentionChipAttachment {
-                    segments.append(.mention(displayName: chip.displayName, uri: uri))
-                } else if let uri = value as? String {
-                    let segment = attributed.attributedSubstring(from: range).string
-                    let displayName = segment.trimmingCharacters(in: .init(charactersIn: "@ "))
-                    segments.append(.mention(displayName: displayName, uri: uri))
+            attributed.enumerateAttributes(in: full) { keys, range, _ in
+                if let uri = keys[.imageAttachmentURI] as? String {
+                    let mime = (keys[.imageAttachmentMime] as? String) ?? "image/png"
+                    segments.append(.image(uri: uri, mimeType: mime))
+                } else if let uri = keys[.attachmentURI] as? String {
+                    if let chip = attributed.attribute(.attachment, at: range.location, effectiveRange: nil)
+                       as? ACPMentionChipAttachment {
+                        segments.append(.mention(displayName: chip.displayName, uri: uri))
+                    } else {
+                        let segment = attributed.attributedSubstring(from: range).string
+                        let displayName = segment.trimmingCharacters(in: .init(charactersIn: "@ "))
+                        segments.append(.mention(displayName: displayName, uri: uri))
+                    }
                 } else {
                     let text = attributed.attributedSubstring(from: range).string
-                    if !text.isEmpty {
-                        segments.append(.text(text))
-                    }
+                    if !text.isEmpty { segments.append(.text(text)) }
                 }
             }
             return ACPComposerDraft(segments: segments)
@@ -381,34 +402,52 @@ struct ACPInputField: NSViewRepresentable {
                         .toolTip: URL(string: uri)?.path ?? uri,
                     ], range: NSRange(location: 0, length: chip.length))
                     result.append(chip)
+                case .image(let uri, let mimeType):
+                    // Drop the chip if the staged file is gone — a deleted
+                    // attachment shouldn't restore as a broken placeholder or
+                    // get sent as a dangling resource link.
+                    guard let fileURL = URL(string: uri),
+                          FileManager.default.fileExists(atPath: fileURL.path) else { break }
+                    let attachment = ACPImageChipAttachment(fileURL: fileURL, mimeType: mimeType)
+                    let chip = NSMutableAttributedString(attachment: attachment)
+                    chip.addAttributes([
+                        .imageAttachmentURI: uri,
+                        .imageAttachmentMime: mimeType,
+                        .toolTip: fileURL.lastPathComponent,
+                    ], range: NSRange(location: 0, length: chip.length))
+                    result.append(chip)
                 }
             }
             return result
         }
 
-        /// Walks the attributed string. Mention chips (attachments tagged
-        /// with `attachmentURI`) become resource_link attachments and emit
-        /// `@filename` in the text. Everything else is concatenated as-is —
-        /// the user's markdown markers (`**bold**`, `# heading`, etc.) are
-        /// preserved verbatim for the receiving agent.
+        /// Walks the attributed string. Image chips (tagged with
+        /// `.imageAttachmentURI`) become image attachments and contribute NO
+        /// text. Mention chips (tagged with `.attachmentURI`) become
+        /// resource_link attachments and emit `@filename` in the text.
+        /// Everything else is concatenated as-is — the user's markdown
+        /// markers (`**bold**`, `# heading`, etc.) are preserved verbatim for
+        /// the receiving agent.
         static func extract(_ attributed: NSAttributedString) -> (String, [ACPMessage.Attachment]) {
             var text = ""
             var atts: [ACPMessage.Attachment] = []
-            attributed.enumerateAttribute(
-                .attachmentURI,
-                in: NSRange(location: 0, length: attributed.length)
-            ) { value, range, _ in
-                if let uri = value as? String,
-                   let chip = attributed.attribute(.attachment, at: range.location, effectiveRange: nil)
-                            as? ACPMentionChipAttachment {
-                    text += "@" + chip.displayName + " "
-                    atts.append(.init(uri: uri, name: chip.displayName))
-                } else if let uri = value as? String {
-                    // Legacy text-based chip (background-color attribute);
-                    // keep the substring so old drafts still work.
-                    let segment = attributed.attributedSubstring(from: range).string
-                    text += segment + " "
-                    atts.append(.init(uri: uri, name: segment.trimmingCharacters(in: .init(charactersIn: "@ "))))
+            let full = NSRange(location: 0, length: attributed.length)
+            attributed.enumerateAttributes(in: full) { keys, range, _ in
+                if let uri = keys[.imageAttachmentURI] as? String {
+                    let mime = (keys[.imageAttachmentMime] as? String) ?? "image/png"
+                    let name = URL(string: uri)?.lastPathComponent
+                    atts.append(.init(uri: uri, name: name, mimeType: mime))
+                    // Image chips contribute NO text.
+                } else if let uri = keys[.attachmentURI] as? String {
+                    if let chip = attributed.attribute(.attachment, at: range.location, effectiveRange: nil)
+                                as? ACPMentionChipAttachment {
+                        text += "@" + chip.displayName + " "
+                        atts.append(.init(uri: uri, name: chip.displayName))
+                    } else {
+                        let segment = attributed.attributedSubstring(from: range).string
+                        text += segment + " "
+                        atts.append(.init(uri: uri, name: segment.trimmingCharacters(in: .init(charactersIn: "@ "))))
+                    }
                 } else {
                     text += attributed.attributedSubstring(from: range).string
                 }
@@ -420,6 +459,8 @@ struct ACPInputField: NSViewRepresentable {
 
 extension NSAttributedString.Key {
     static let attachmentURI = NSAttributedString.Key("alas.acp.attachmentURI")
+    static let imageAttachmentURI = NSAttributedString.Key("alas.acp.imageAttachmentURI")
+    static let imageAttachmentMime = NSAttributedString.Key("alas.acp.imageAttachmentMime")
 }
 
 final class ACPNSTextView: NSTextView {
@@ -459,6 +500,16 @@ final class ACPNSTextView: NSTextView {
     }
 
     override func keyDown(with event: NSEvent) {
+        // ⌃V parity with agent CLIs — paste an image when one is on the
+        // clipboard. Only intercept when there IS an image, so Cocoa's
+        // default ⌃V (page down / emacs binding) is otherwise preserved.
+        if event.modifierFlags.contains(.control),
+           event.charactersIgnoringModifiers?.lowercased() == "v",
+           pasteboardHasImage {
+            paste(nil)
+            return
+        }
+
         // Slash-picker keyboard handling — runs BEFORE super so the
         // arrow keys / Enter don't fall through to text-view motion or
         // submit. Esc closes the picker without canceling the prompt.
@@ -567,6 +618,178 @@ final class ACPNSTextView: NSTextView {
     /// without reaching across private state.
     var isSlashPanelOpen: Bool { slashPanel != nil }
     func dismissSlashPanel() { closeSlashPanel() }
+
+    var worktreeIdForStaging: String {
+        coordinator?.worktreeRoot.lastPathComponent ?? "default"
+    }
+
+    static let maxImagesPerMessage = 10
+
+    private func currentImageChipCount() -> Int {
+        guard let storage = textStorage else { return 0 }
+        var count = 0
+        storage.enumerateAttribute(.imageAttachmentURI, in: NSRange(location: 0, length: storage.length)) { v, _, _ in
+            if v != nil { count += 1 }
+        }
+        return count
+    }
+
+    @discardableResult
+    func insertImage(data: Data, worktreeId: String) -> Bool {
+        guard currentImageChipCount() < Self.maxImagesPerMessage else {
+            coordinator?.reportImageError(.tooManyImages)
+            return false
+        }
+        do {
+            let staged = try ACPImageStaging.stage(data: data, into: worktreeId)
+            let attachment = ACPImageChipAttachment(fileURL: staged.url, mimeType: staged.mimeType)
+            let chipString = NSMutableAttributedString(attachment: attachment)
+            chipString.addAttributes([
+                .imageAttachmentURI: staged.url.absoluteString,
+                .imageAttachmentMime: staged.mimeType,
+                .toolTip: staged.url.lastPathComponent,
+            ], range: NSRange(location: 0, length: chipString.length))
+            // Color the trailing space and reset typingAttributes so text the
+            // user types right after the chip is the normal label color
+            // immediately — otherwise it inherits color-less attributes and
+            // renders black until the debounced restyler repaints the line.
+            let baseAttrs: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: 13),
+                .foregroundColor: NSColor.labelColor,
+            ]
+            chipString.append(NSAttributedString(string: " ", attributes: baseAttrs))
+            let insertAt = selectedRange()
+            textStorage?.replaceCharacters(in: insertAt, with: chipString)
+            setSelectedRange(NSRange(location: insertAt.location + chipString.length, length: 0))
+            typingAttributes = baseAttrs
+            didChangeText()
+            return true
+        } catch let error as ACPImageStaging.StagingError {
+            coordinator?.reportImageError(error)
+            return false
+        } catch {
+            coordinator?.reportImageError(.writeFailed)
+            return false
+        }
+    }
+
+    func presentImagePicker() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.allowedContentTypes = [.png, .jpeg, .gif, .webP]
+        panel.begin { [weak self] response in
+            guard let self, response == .OK else { return }
+            for url in panel.urls {
+                switch Self.readImageFile(url) {
+                case .data(let data):
+                    _ = self.insertImage(data: data, worktreeId: self.worktreeIdForStaging)
+                case .tooLarge:
+                    self.coordinator?.reportImageError(.tooLarge)
+                case .unsupported:
+                    break
+                }
+            }
+        }
+    }
+
+    /// Cheap probe: does `pb` hold a supported image, WITHOUT reading whole
+    /// files? Inspects pasteboard types for raw image data and peeks only the
+    /// header + size of image file URLs, so hovering a huge file during a drag
+    /// (or a ⌃V availability check) doesn't allocate the whole file.
+    private func hasImage(in pb: NSPasteboard) -> Bool {
+        let types = pb.types ?? []
+        if types.contains(.png) || types.contains(.tiff) { return true }
+        if let urls = pb.readObjects(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) as? [URL] {
+            return urls.contains { Self.isSupportedImageFile($0) }
+        }
+        return false
+    }
+
+    /// True when `url` is a supported image within the size cap, decided by
+    /// reading only its first bytes — never the whole file.
+    private static func isSupportedImageFile(_ url: URL) -> Bool {
+        if let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+           size > ACPImageStaging.maxBytes { return false }
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        let header = (try? handle.read(upToCount: 16)) ?? Data()
+        return ACPImageStaging.sniffMIME(header) != nil
+    }
+
+    enum FileImageRead {
+        case data(Data)
+        case tooLarge
+        case unsupported
+    }
+
+    /// Read a file URL's image bytes, applying the size cap from its metadata
+    /// BEFORE reading the file into memory (so an oversized pick/drop reports
+    /// `.tooLarge` instead of allocating the whole file).
+    static func readImageFile(_ url: URL) -> FileImageRead {
+        if let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+           size > ACPImageStaging.maxBytes { return .tooLarge }
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return .unsupported }
+        let header = (try? handle.read(upToCount: 16)) ?? Data()
+        try? handle.close()
+        guard ACPImageStaging.sniffMIME(header) != nil,
+              let data = try? Data(contentsOf: url) else { return .unsupported }
+        return .data(data)
+    }
+
+    /// Stage and insert every supported image from `pb` — raw bitmap data
+    /// (one screenshot) or one-per image file URL (multiple Finder files). Each
+    /// `insertImage` enforces the per-message cap; oversized file URLs surface
+    /// the `.tooLarge` notice. Returns true if any image source was handled.
+    @discardableResult
+    private func insertImages(from pb: NSPasteboard) -> Bool {
+        for type in [NSPasteboard.PasteboardType.png, .tiff] {
+            if let data = pb.data(forType: type) {
+                if type == .tiff, let rep = NSBitmapImageRep(data: data),
+                   let png = rep.representation(using: .png, properties: [:]) {
+                    _ = insertImage(data: png, worktreeId: worktreeIdForStaging)
+                    return true
+                }
+                if ACPImageStaging.sniffMIME(data) != nil {
+                    _ = insertImage(data: data, worktreeId: worktreeIdForStaging)
+                    return true
+                }
+            }
+        }
+        guard let urls = pb.readObjects(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) as? [URL]
+        else { return false }
+        var handled = false
+        for url in urls {
+            switch Self.readImageFile(url) {
+            case .data(let data):
+                handled = true
+                _ = insertImage(data: data, worktreeId: worktreeIdForStaging)
+            case .tooLarge:
+                handled = true
+                coordinator?.reportImageError(.tooLarge)
+            case .unsupported:
+                break
+            }
+        }
+        return handled
+    }
+
+    /// True when the general pasteboard currently holds a supported image.
+    private var pasteboardHasImage: Bool { hasImage(in: NSPasteboard.general) }
+
+    override func paste(_ sender: Any?) {
+        if insertImages(from: NSPasteboard.general) { return }
+        super.paste(sender)
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        hasImage(in: sender.draggingPasteboard) ? .copy : super.draggingEntered(sender)
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        if insertImages(from: sender.draggingPasteboard) { return true }
+        return super.performDragOperation(sender)
+    }
 
     private func insertMention(_ url: URL) {
         let name = url.lastPathComponent

--- a/Alas/Sources/ACP/UI/ACPComposerActions.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActions.swift
@@ -7,6 +7,9 @@ import Foundation
 @MainActor
 final class ACPComposerActions: ObservableObject {
     var submitWithIntent: ((ACPSubmitIntent) -> Void)?
+    /// Published by the coordinator; opens an image picker and inserts the
+    /// chosen files as chips.
+    var presentImagePicker: (() -> Void)?
     /// Convenience used by call sites that just want default submit.
     func submit() { submitWithIntent?(.auto) }
 }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -18,6 +18,7 @@ struct ACPComposer: View {
     @State private var inputFocused = false
     @StateObject private var actions = ACPComposerActions()
     @State private var hasText: Bool = false
+    @State private var imageNotice: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -50,6 +51,13 @@ struct ACPComposer: View {
 
     private var pill: some View {
         VStack(spacing: 6) {
+            if let imageNotice {
+                Text(imageNotice)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(theme.color("del"))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .transition(.opacity)
+            }
             ACPInputField(
                 session: session,
                 worktreeRoot: worktreeRoot,
@@ -61,7 +69,13 @@ struct ACPComposer: View {
                     hasText = draft.hasContent
                 },
                 onDraftClear: { manager.clearComposerDraft(for: session) },
-                onSubmit: onSubmit
+                onSubmit: onSubmit,
+                onImageError: { error in
+                    imageNotice = error.userMessage
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                        if imageNotice == error.userMessage { imageNotice = nil }
+                    }
+                }
             )
             .frame(minHeight: 44, maxHeight: 140)
             .onAppear {
@@ -74,6 +88,7 @@ struct ACPComposer: View {
             HStack(spacing: 8) {
                 hint
                 Spacer()
+                attachButton
                 autoRunToggle
                 if let thinking = session.chipState.thinking {
                     thinkingChip(thinking)
@@ -227,6 +242,22 @@ struct ACPComposer: View {
         session.autoRunEnabled
             ? Color.blend(theme.color("caution"), .white, t: 0.55)
             : theme.color("fg-muted")
+    }
+
+    private var attachButton: some View {
+        Button {
+            actions.presentImagePicker?()
+        } label: {
+            Image(systemName: "photo")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(theme.color("fg-muted"))
+                .frame(width: 28, height: 24)
+                .background(RoundedRectangle(cornerRadius: 6).fill(theme.color("bg-3").opacity(0.7)))
+                .overlay(RoundedRectangle(cornerRadius: 6).strokeBorder(theme.color("line"), lineWidth: 0.75))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Attach image")
+        .help("Attach an image")
     }
 
     // MARK: - Chip builders driven by ACPChipState

--- a/Alas/Sources/ACP/UI/ACPImageChipAttachment.swift
+++ b/Alas/Sources/ACP/UI/ACPImageChipAttachment.swift
@@ -1,0 +1,60 @@
+import AppKit
+
+/// NSTextAttachment that renders a small image thumbnail inline in the
+/// composer's NSTextView. Holds the staged file URL + MIME so submit and
+/// draft serialization can recover it (tagged on its attribute range via
+/// `.imageAttachmentURI` / `.imageAttachmentMime`).
+final class ACPImageChipAttachment: NSTextAttachment {
+    let fileURL: URL
+    let mimeType: String
+
+    init(fileURL: URL, mimeType: String) {
+        self.fileURL = fileURL
+        self.mimeType = mimeType
+        super.init(data: nil, ofType: nil)
+        self.attachmentCell = ACPImageChipCell(thumbnail: NSImage(contentsOf: fileURL))
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+}
+
+private final class ACPImageChipCell: NSTextAttachmentCell {
+    private let thumbnail: NSImage?
+    private static let side: CGFloat = 20
+
+    init(thumbnail: NSImage?) {
+        self.thumbnail = thumbnail
+        super.init(textCell: "")
+    }
+    required init(coder: NSCoder) { fatalError() }
+
+    override var cellSize: NSSize { NSSize(width: Self.side, height: Self.side) }
+
+    override func cellBaselineOffset() -> NSPoint { NSPoint(x: 0, y: -5) }
+
+    override func draw(withFrame frame: NSRect, in controlView: NSView?) {
+        let rect = frame.insetBy(dx: 1, dy: 1)
+        let path = NSBezierPath(roundedRect: rect, xRadius: 5, yRadius: 5)
+        path.addClip()
+        if let thumbnail {
+            thumbnail.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1.0)
+        } else {
+            NSColor.darkGray.setFill()
+            rect.fill()
+        }
+        path.lineWidth = 0.75
+        NSColor.controlAccentColor.withAlphaComponent(0.55).setStroke()
+        path.stroke()
+    }
+
+    override func highlight(_ flag: Bool, withFrame frame: NSRect, in controlView: NSView?) {
+        draw(withFrame: frame, in: controlView)
+    }
+
+    override func cellFrame(for textContainer: NSTextContainer,
+                            proposedLineFragment lineFrag: NSRect,
+                            glyphPosition position: NSPoint,
+                            characterIndex charIndex: Int) -> NSRect {
+        NSRect(origin: .zero, size: cellSize)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPImageEncoding.swift
+++ b/Alas/Sources/ACP/UI/ACPImageEncoding.swift
@@ -1,0 +1,45 @@
+import AppKit
+import Foundation
+
+/// Produces the inline base64 payload Alas sends for an image when the agent
+/// advertises image capability. Large images are downscaled to a max
+/// dimension (keeping aspect ratio) and re-encoded as PNG to keep the
+/// JSON-RPC payload sane. Returns `nil` if the file can't be read/decoded.
+enum ACPImageEncoding {
+    static func inlineBase64(fileURL: URL, maxDimension: CGFloat) -> (data: String, mimeType: String)? {
+        guard let raw = try? Data(contentsOf: fileURL),
+              let rep = NSBitmapImageRep(data: raw) else { return nil }
+
+        let w = CGFloat(rep.pixelsWide), h = CGFloat(rep.pixelsHigh)
+        guard w > 0, h > 0 else { return nil }
+
+        // Never upscale: clamp the scale at 1. Within-cap images keep their
+        // original pixel size; only oversized ones shrink.
+        let scale = min(1, maxDimension / max(w, h))
+
+        // Within cap AND we can identify the format → send the original bytes
+        // untouched (preserves GIF animation, JPEG quality, etc.). A within-cap
+        // image whose MIME we can't sniff falls through and is re-encoded as
+        // PNG at its ORIGINAL size (scale == 1), never upscaled.
+        if scale >= 1, let mime = ACPImageStaging.sniffMIME(raw) {
+            return (raw.base64EncodedString(), mime)
+        }
+
+        let target = NSSize(width: floor(w * scale), height: floor(h * scale))
+        guard let scaled = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int(target.width), pixelsHigh: Int(target.height),
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+        ) else { return nil }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: scaled)
+        NSGraphicsContext.current?.imageInterpolation = .high
+        rep.draw(in: NSRect(origin: .zero, size: target))
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard let png = scaled.representation(using: .png, properties: [:]) else { return nil }
+        return (png.base64EncodedString(), "image/png")
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPImageStaging.swift
+++ b/Alas/Sources/ACP/UI/ACPImageStaging.swift
@@ -1,0 +1,78 @@
+import Foundation
+import CryptoKit
+
+/// Writes pasted/dropped/picked image bytes to a durable, content-addressed
+/// file under Application Support so drafts, the queue, and the transcript
+/// can all reference the same `file://` path. Sniffs the MIME from the bytes,
+/// rejects non-images and oversized payloads.
+enum ACPImageStaging {
+    struct Staged: Equatable {
+        let url: URL
+        let mimeType: String
+    }
+
+    enum StagingError: Error, Equatable {
+        case unsupportedFormat
+        case tooLarge
+        case tooManyImages
+        case writeFailed
+    }
+
+    /// Hard ceiling on a single original image (≈20 MB).
+    static let maxBytes = 20 * 1024 * 1024
+
+    /// Accepted image MIME types.
+    static let supportedMIMEs: Set<String> = ["image/png", "image/jpeg", "image/gif", "image/webp"]
+
+    static func stage(data: Data, into worktreeId: String) throws -> Staged {
+        guard data.count <= maxBytes else { throw StagingError.tooLarge }
+        guard let mime = sniffMIME(data), supportedMIMEs.contains(mime) else {
+            throw StagingError.unsupportedFormat
+        }
+        let ext = fileExtension(forMIME: mime)
+        let hash = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        let dir = Paths.acpAttachmentsDir(forWorktreeId: worktreeId)
+        do {
+            try Paths.ensureDirectoryExists(dir)
+            let url = dir.appendingPathComponent("\(hash).\(ext)")
+            if !FileManager.default.fileExists(atPath: url.path) {
+                try data.write(to: url, options: .atomic)
+            }
+            return Staged(url: url, mimeType: mime)
+        } catch {
+            throw StagingError.writeFailed
+        }
+    }
+
+    /// Sniff a MIME type from magic bytes. Covers the four supported formats.
+    static func sniffMIME(_ data: Data) -> String? {
+        let b = [UInt8](data.prefix(16))
+        if b.count >= 8, b[0] == 0x89, b[1] == 0x50, b[2] == 0x4E, b[3] == 0x47 { return "image/png" }
+        if b.count >= 3, b[0] == 0xFF, b[1] == 0xD8, b[2] == 0xFF { return "image/jpeg" }
+        if b.count >= 6, b[0] == 0x47, b[1] == 0x49, b[2] == 0x46 { return "image/gif" }
+        if b.count >= 12, b[0] == 0x52, b[1] == 0x49, b[2] == 0x46, b[3] == 0x46,
+           b[8] == 0x57, b[9] == 0x45, b[10] == 0x42, b[11] == 0x50 { return "image/webp" }
+        return nil
+    }
+
+    static func fileExtension(forMIME mime: String) -> String {
+        switch mime {
+        case "image/png": return "png"
+        case "image/jpeg": return "jpg"
+        case "image/gif": return "gif"
+        case "image/webp": return "webp"
+        default: return "img"
+        }
+    }
+}
+
+extension ACPImageStaging.StagingError {
+    var userMessage: String {
+        switch self {
+        case .unsupportedFormat: return "That image format isn't supported (use PNG, JPEG, GIF, or WebP)."
+        case .tooLarge: return "That image is too large (max 20 MB)."
+        case .tooManyImages: return "You can attach up to 10 images per message."
+        case .writeFailed: return "Couldn't save that image. Please try again."
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPImageThumbnail.swift
+++ b/Alas/Sources/ACP/UI/ACPImageThumbnail.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import AppKit
+
+/// A clickable thumbnail for a sent image attachment. Tapping opens the
+/// staged file in a floating preview panel over Alas.
+struct ACPImageThumbnail: View {
+    let fileURL: URL
+
+    var body: some View {
+        Button {
+            ACPImagePreview.shared.show(fileURL)
+        } label: {
+            thumbnail
+        }
+        .buttonStyle(.plain)
+        // Make the entire 96×96 frame hit-testable, not just opaque pixels.
+        .contentShape(Rectangle())
+        .help(fileURL.lastPathComponent)
+    }
+
+    @ViewBuilder private var thumbnail: some View {
+        if let image = NSImage(contentsOf: fileURL) {
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 96, height: 96)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(.white.opacity(0.15), lineWidth: 0.5))
+        } else {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(.gray.opacity(0.3))
+                .frame(width: 96, height: 96)
+                .overlay(Image(systemName: "photo"))
+        }
+    }
+}
+
+/// Floating image preview owned entirely by Alas. We deliberately avoid
+/// `QLPreviewPanel.shared()`: the shared Quick Look panel takes control via
+/// the responder chain, and since nothing in a SwiftUI app implements the
+/// `QLPreviewPanelController` protocol it resets our data source and shows
+/// "nothing selected". A self-owned `NSPanel` hosting an `NSImageView` is
+/// reliable and stays above the app.
+@MainActor
+final class ACPImagePreview {
+    static let shared = ACPImagePreview()
+    private var panel: NSPanel?
+
+    func show(_ url: URL) {
+        guard let image = NSImage(contentsOf: url) else { return }
+        panel?.close()
+
+        let screen = NSScreen.main?.visibleFrame.size ?? NSSize(width: 1280, height: 800)
+        let cap = NSSize(width: screen.width * 0.8, height: screen.height * 0.8)
+        let size = Self.fit(image.size, into: cap)
+
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isFloatingPanel = true
+        panel.titlebarAppearsTransparent = true
+        panel.title = url.lastPathComponent
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = false
+
+        let imageView = NSImageView(frame: NSRect(origin: .zero, size: size))
+        imageView.image = image
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.autoresizingMask = [.width, .height]
+        panel.contentView = imageView
+
+        panel.center()
+        panel.makeKeyAndOrderFront(nil)
+        self.panel = panel
+    }
+
+    /// Scale `size` down to fit within `cap`, preserving aspect ratio. Never
+    /// scales up — a small image previews at its native size.
+    private static func fit(_ size: NSSize, into cap: NSSize) -> NSSize {
+        guard size.width > 0, size.height > 0 else { return cap }
+        let scale = min(1, min(cap.width / size.width, cap.height / size.height))
+        return NSSize(width: size.width * scale, height: size.height * scale)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
+++ b/Alas/Sources/ACP/UI/ACPMarkdownLiveStyler.swift
@@ -55,10 +55,11 @@ enum ACPMarkdownLiveStyler {
         storage.beginEditing()
         defer { storage.endEditing() }
 
-        // Reset to defaults — but preserve our chip attribute so existing
-        // mentions don't get bulldozed by every keystroke.
-        storage.enumerateAttribute(.attachmentURI, in: target) { value, range, _ in
-            if value == nil {
+        // Reset to defaults — but preserve our chip attributes so existing
+        // mention AND image chips don't get bulldozed (their `.attachment`
+        // cell stripped) by every keystroke's restyle.
+        storage.enumerateAttributes(in: target) { attrs, range, _ in
+            if attrs[.attachmentURI] == nil, attrs[.imageAttachmentURI] == nil {
                 storage.setAttributes([
                     .font: baseFont,
                     .foregroundColor: NSColor.labelColor,
@@ -106,10 +107,10 @@ enum ACPMarkdownLiveStyler {
                               attrs: [NSAttributedString.Key: Any]) {
         regex.enumerateMatches(in: storage.string, range: range) { match, _, _ in
             guard let m = match else { return }
-            // Don't double-style chip mentions.
+            // Don't double-style chip mentions or image chips.
             var skip = false
-            storage.enumerateAttribute(.attachmentURI, in: m.range) { v, _, stop in
-                if v != nil {
+            storage.enumerateAttributes(in: m.range) { attrs, _, stop in
+                if attrs[.attachmentURI] != nil || attrs[.imageAttachmentURI] != nil {
                     skip = true
                     stop.pointee = true
                 }

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -548,9 +548,25 @@ private struct UserMessageRow: View {
             Spacer(minLength: 40)
             VStack(alignment: .trailing, spacing: 4) {
                 if !attachments.isEmpty {
-                    HStack(spacing: 4) {
-                        ForEach(attachments, id: \.uri) { a in
-                            FileChip(path: a.name ?? a.uri, lines: nil, iconSystemName: "at")
+                    let images = attachments.filter { ($0.mimeType?.hasPrefix("image/")) == true }
+                    let others = attachments.filter { ($0.mimeType?.hasPrefix("image/")) != true }
+                    if !images.isEmpty {
+                        HStack(spacing: 6) {
+                            // Key by index, not uri: content-addressed staging
+                            // means the same image attached twice shares a uri,
+                            // and duplicate ForEach ids collapse the row.
+                            ForEach(Array(images.enumerated()), id: \.offset) { _, a in
+                                if let url = URL(string: a.uri) {
+                                    ACPImageThumbnail(fileURL: url)
+                                }
+                            }
+                        }
+                    }
+                    if !others.isEmpty {
+                        HStack(spacing: 4) {
+                            ForEach(others, id: \.uri) { a in
+                                FileChip(path: a.name ?? a.uri, lines: nil, iconSystemName: "at")
+                            }
                         }
                     }
                 }

--- a/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
+++ b/Alas/Sources/ACP/UI/ACPQueuedBubble.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// A single queued-item bubble, rendered below the transcript. Right-
@@ -37,20 +38,36 @@ struct ACPQueuedBubble: View {
                         actionsRow
                     }
                 }
-                ACPMarkdownText(raw: Self.textPreview(of: item.blocks))
-                    .padding(.vertical, 9).padding(.horizontal, 13)
-                    .background(theme.color("accent").opacity(0.10))
-                    .clipShape(
-                        UnevenRoundedRectangle(
-                            cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
+                if !imageURLs.isEmpty {
+                    HStack(spacing: 4) {
+                        ForEach(Array(imageURLs.enumerated()), id: \.offset) { _, url in
+                            if let image = NSImage(contentsOf: url) {
+                                Image(nsImage: image)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fill)
+                                    .frame(width: 48, height: 48)
+                                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                            }
+                        }
+                    }
+                }
+                let preview = Self.textPreview(of: item.blocks)
+                if !preview.isEmpty {
+                    ACPMarkdownText(raw: preview)
+                        .padding(.vertical, 9).padding(.horizontal, 13)
+                        .background(theme.color("accent").opacity(0.10))
+                        .clipShape(
+                            UnevenRoundedRectangle(
+                                cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
+                            )
                         )
-                    )
-                    .overlay(
-                        UnevenRoundedRectangle(
-                            cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
+                        .overlay(
+                            UnevenRoundedRectangle(
+                                cornerRadii: .init(topLeading: 12, bottomLeading: 12, bottomTrailing: 4, topTrailing: 12)
+                            )
+                            .strokeBorder(borderColor, style: borderStyle)
                         )
-                        .strokeBorder(borderColor, style: borderStyle)
-                    )
+                }
             }
             .opacity(item.status == .sending ? 0.85 : 0.6)
             .frame(maxWidth: 540, alignment: .trailing)
@@ -95,6 +112,15 @@ struct ACPQueuedBubble: View {
             }
             .buttonStyle(.plain)
             .help("Remove from queue")
+        }
+    }
+
+    /// Staged file URLs for the queued prompt's image blocks, so an image-only
+    /// queued item still shows a thumbnail (its text preview is empty).
+    private var imageURLs: [URL] {
+        item.blocks.compactMap { block in
+            if case .image(_, let uri, _) = block, let uri { return URL(string: uri) }
+            return nil
         }
     }
 

--- a/Alas/Sources/Persistence/Paths.swift
+++ b/Alas/Sources/Persistence/Paths.swift
@@ -47,3 +47,11 @@ extension Paths {
         appSupportRoot.appendingPathComponent("acp-adapter-updates.json")
     }
 }
+
+extension Paths {
+    static var acpAttachmentsRoot: URL { appSupportRoot.appendingPathComponent("acp-attachments", isDirectory: true) }
+
+    static func acpAttachmentsDir(forWorktreeId id: String) -> URL {
+        acpAttachmentsRoot.appendingPathComponent(id, isDirectory: true)
+    }
+}

--- a/AlasTests/ACP/Protocol/ACPContentBlockImageTests.swift
+++ b/AlasTests/ACP/Protocol/ACPContentBlockImageTests.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPContentBlock image")
+struct ACPContentBlockImageTests {
+    @Test("encodes inline base64 image with data and mimeType")
+    func encodesInlineImage() throws {
+        let block = ACPContentBlock.image(data: "QUJD", uri: nil, mimeType: "image/png")
+        let data = try JSONEncoder().encode(block)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["type"] as? String == "image")
+        #expect(json["data"] as? String == "QUJD")
+        #expect(json["mimeType"] as? String == "image/png")
+        #expect(json["uri"] == nil)
+    }
+
+    @Test("round-trips an image block carrying only a uri")
+    func roundTripsUriOnly() throws {
+        let block = ACPContentBlock.image(data: nil, uri: "file:///tmp/a.png", mimeType: "image/png")
+        let data = try JSONEncoder().encode(block)
+        let decoded = try JSONDecoder().decode(ACPContentBlock.self, from: data)
+        #expect(decoded == block)
+    }
+
+    @Test("round-trips an image block carrying only base64 data")
+    func roundTripsDataOnly() throws {
+        let block = ACPContentBlock.image(data: "QUJD", uri: nil, mimeType: "image/png")
+        let data = try JSONEncoder().encode(block)
+        let decoded = try JSONDecoder().decode(ACPContentBlock.self, from: data)
+        #expect(decoded == block)
+    }
+}

--- a/AlasTests/ACP/Protocol/ACPPromptCapabilitiesTests.swift
+++ b/AlasTests/ACP/Protocol/ACPPromptCapabilitiesTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP prompt capabilities decoding")
+struct ACPPromptCapabilitiesTests {
+    @Test("image-only capabilities decode with audio defaulting to false")
+    func imageOnlyDecodes() throws {
+        // ACP defines each prompt capability as defaulting to false, so an
+        // agent advertising only `image` must still decode and report image
+        // support (rather than failing the whole initialize result).
+        let json = #"""
+        {"protocolVersion":1,"agentCapabilities":{"promptCapabilities":{"image":true}},"authMethods":[]}
+        """#.data(using: .utf8)!
+        let result = try JSONDecoder().decode(ACPInitializeResult.self, from: json)
+        #expect(result.agentCapabilities?.promptCapabilities?.image == true)
+        #expect(result.agentCapabilities?.promptCapabilities?.audio == false)
+    }
+}

--- a/AlasTests/ACP/Protocol/ACPToolCallContentTests.swift
+++ b/AlasTests/ACP/Protocol/ACPToolCallContentTests.swift
@@ -19,7 +19,7 @@ struct ACPToolCallContentTests {
         }
         #expect(uri == "file:///tmp/x.txt")
         #expect(name == "x.txt")
-        guard case .content(.image(let uri2, let mime)) = items[2] else {
+        guard case .content(.image(_, let uri2, let mime)) = items[2] else {
             Issue.record("expected .content(.image)")
             return
         }

--- a/AlasTests/ACP/Session/ACPAttachmentMimeTypeTests.swift
+++ b/AlasTests/ACP/Session/ACPAttachmentMimeTypeTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPMessage.Attachment mimeType")
+struct ACPAttachmentMimeTypeTests {
+    @Test("decodes legacy attachment JSON without mimeType as nil")
+    func decodesLegacy() throws {
+        let json = #"{"uri":"file:///a.swift","name":"a.swift"}"#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(ACPMessage.Attachment.self, from: json)
+        #expect(decoded.mimeType == nil)
+        #expect(decoded.uri == "file:///a.swift")
+    }
+
+    @Test("round-trips an image attachment with mimeType")
+    func roundTripsImage() throws {
+        let att = ACPMessage.Attachment(uri: "file:///tmp/x.png", name: "x.png", mimeType: "image/png")
+        let data = try JSONEncoder().encode(att)
+        let decoded = try JSONDecoder().decode(ACPMessage.Attachment.self, from: data)
+        #expect(decoded == att)
+        #expect(decoded.mimeType == "image/png")
+    }
+}

--- a/AlasTests/ACP/Session/ACPComposerDraftTests.swift
+++ b/AlasTests/ACP/Session/ACPComposerDraftTests.swift
@@ -25,4 +25,23 @@ struct ACPComposerDraftTests {
         #expect(!ACPComposerDraft(segments: [.text(" ")]).isEmpty)
         #expect(!ACPComposerDraft(segments: [.mention(displayName: "a.swift", uri: "file:///a.swift")]).isEmpty)
     }
+
+    @Test("codable round trip preserves an image segment")
+    func codableImageRoundTrip() throws {
+        let draft = ACPComposerDraft(segments: [
+            .text("Look at "),
+            .image(uri: "file:///tmp/shot.png", mimeType: "image/png"),
+            .text(" please.")
+        ])
+        let data = try JSONEncoder().encode(draft)
+        let decoded = try JSONDecoder().decode(ACPComposerDraft.self, from: data)
+        #expect(decoded == draft)
+    }
+
+    @Test("an image-only draft has content and is not empty")
+    func imageOnlyDraftHasContent() {
+        let draft = ACPComposerDraft(segments: [.image(uri: "file:///tmp/a.png", mimeType: "image/png")])
+        #expect(!draft.isEmpty)
+        #expect(draft.hasContent)
+    }
 }

--- a/AlasTests/ACP/Session/ACPImageBlocksTests.swift
+++ b/AlasTests/ACP/Session/ACPImageBlocksTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP image blocks")
+@MainActor
+struct ACPImageBlocksTests {
+    @Test("image attachment becomes a deferred image block; mention stays a link")
+    func buildsDeferredImageBlock() {
+        let blocks = ACPSessionRunner.blocks(
+            text: "see this",
+            attachments: [
+                .init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png"),
+                .init(uri: "file:///tmp/File.swift", name: "File.swift")
+            ])
+        #expect(blocks.contains(.image(data: nil, uri: "file:///tmp/shot.png", mimeType: "image/png")))
+        #expect(blocks.contains(.resourceLink(uri: "file:///tmp/File.swift", name: "File.swift")))
+    }
+
+    @Test("hydrate falls back to a resource link when images are unsupported")
+    func hydrateFallsBack() async {
+        let deferred: [ACPContentBlock] = [
+            .text("x"),
+            .image(data: nil, uri: "file:///tmp/shot.png", mimeType: "image/png")
+        ]
+        let wire = await ACPSessionRunner.hydrate(deferred, imageInputSupported: false)
+        #expect(wire.contains(.text("x")))
+        #expect(wire.contains(.resourceLink(uri: "file:///tmp/shot.png", name: "shot.png")))
+        #expect(!wire.contains { block in
+            if case .image = block { return true }
+            return false
+        })
+    }
+
+    @Test("attachments(of:) surfaces image blocks as image attachments")
+    func attachmentsIncludeImages() {
+        let atts = ACPSessionRunner.attachments(of: [
+            .image(data: nil, uri: "file:///tmp/shot.png", mimeType: "image/png")
+        ])
+        #expect(atts == [.init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png")])
+    }
+
+    @Test("image-only prompt omits the whitespace leading text block")
+    func imageOnlyOmitsTextBlock() {
+        // The composer leaves a trailing space after an image chip, so an
+        // image-only prompt's extracted text is " ", not "".
+        let blocks = ACPSessionRunner.blocks(
+            text: " ",
+            attachments: [.init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png")])
+        #expect(blocks == [.image(data: nil, uri: "file:///tmp/shot.png", mimeType: "image/png")])
+    }
+}

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -628,12 +628,12 @@ struct ACPComposerDraftBridgeTests {
         ]))
     }
 
-    @Test("image block becomes a mention chip carrying its uri")
-    func imageBlockBecomesMention() {
+    @Test("image block becomes an image segment carrying its uri and mime")
+    func imageBlockBecomesImageSegment() {
         #expect(ACPComposerDraft(blocks: [
-            .image(uri: "file:///tmp/shot.png", mimeType: "image/png"),
+            .image(data: nil, uri: "file:///tmp/shot.png", mimeType: "image/png"),
         ]) == ACPComposerDraft(segments: [
-            .mention(displayName: "shot.png", uri: "file:///tmp/shot.png"),
+            .image(uri: "file:///tmp/shot.png", mimeType: "image/png"),
         ]))
     }
 

--- a/AlasTests/ACP/UI/ACPComposerImageExtractTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerImageExtractTests.swift
@@ -1,0 +1,41 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP composer image extraction")
+@MainActor
+struct ACPComposerImageExtractTests {
+    /// Build an attributed string with one image chip between two text runs,
+    /// mirroring what `insertImage` produces.
+    private func makeStorage() -> NSAttributedString {
+        let s = NSMutableAttributedString(string: "before ")
+        let url = URL(string: "file:///tmp/shot.png")!
+        let attachment = ACPImageChipAttachment(fileURL: url, mimeType: "image/png")
+        let chip = NSMutableAttributedString(attachment: attachment)
+        chip.addAttributes([
+            .imageAttachmentURI: url.absoluteString,
+            .imageAttachmentMime: "image/png",
+        ], range: NSRange(location: 0, length: chip.length))
+        s.append(chip)
+        s.append(NSAttributedString(string: " after"))
+        return s
+    }
+
+    @Test("extract pulls an image attachment and omits chip from text")
+    func extractsImage() {
+        let (text, atts) = ACPInputField.Coordinator.extract(makeStorage())
+        #expect(text == "before  after")
+        #expect(atts == [.init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png")])
+    }
+
+    @Test("draft(from:) yields an image segment in place")
+    func draftHasImageSegment() {
+        let draft = ACPInputField.Coordinator.draft(from: makeStorage())
+        #expect(draft.segments == [
+            .text("before "),
+            .image(uri: "file:///tmp/shot.png", mimeType: "image/png"),
+            .text(" after")
+        ])
+    }
+}

--- a/AlasTests/ACP/UI/ACPImageEncodingTests.swift
+++ b/AlasTests/ACP/UI/ACPImageEncodingTests.swift
@@ -1,0 +1,52 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPImageEncoding")
+struct ACPImageEncodingTests {
+    /// Write a solid-color PNG of EXACTLY the given pixel size to a temp file.
+    /// Builds the bitmap rep directly (not via `NSImage.lockFocus`, which
+    /// rasterizes at the display's backing scale and would yield 2× pixels on
+    /// a Retina screen — making the dimension assertions flaky).
+    private func writePNG(width: Int, height: Int) throws -> URL {
+        let rep = try #require(NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width, pixelsHigh: height,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0))
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        NSColor.red.setFill()
+        NSRect(x: 0, y: 0, width: width, height: height).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        let png = try #require(rep.representation(using: .png, properties: [:]))
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("enc-\(width)x\(height).png")
+        try png.write(to: url)
+        return url
+    }
+
+    @Test("downscales an oversized image below the cap and returns base64")
+    func downscalesLarge() throws {
+        let url = try writePNG(width: 4000, height: 2000)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let result = try #require(ACPImageEncoding.inlineBase64(fileURL: url, maxDimension: 1568))
+        #expect(result.mimeType == "image/png")
+        let decoded = try #require(Data(base64Encoded: result.data))
+        let rep = try #require(NSBitmapImageRep(data: decoded))
+        #expect(rep.pixelsWide <= 1568)
+        #expect(rep.pixelsHigh <= 1568)
+    }
+
+    @Test("leaves a small image at its original dimensions")
+    func keepsSmall() throws {
+        let url = try writePNG(width: 100, height: 80)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let result = try #require(ACPImageEncoding.inlineBase64(fileURL: url, maxDimension: 1568))
+        let decoded = try #require(Data(base64Encoded: result.data))
+        let rep = try #require(NSBitmapImageRep(data: decoded))
+        #expect(rep.pixelsWide == 100)
+        #expect(rep.pixelsHigh == 80)
+    }
+}

--- a/AlasTests/ACP/UI/ACPImageStagingTests.swift
+++ b/AlasTests/ACP/UI/ACPImageStagingTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPImageStaging")
+struct ACPImageStagingTests {
+    // A minimal valid 1x1 PNG.
+    private var pngBytes: Data {
+        Data(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==")!
+    }
+
+    @Test("sniffs png mime and writes a content-addressed file")
+    func stagesPNG() throws {
+        let staged = try ACPImageStaging.stage(data: pngBytes, into: "wt-test")
+        #expect(staged.mimeType == "image/png")
+        #expect(staged.url.pathExtension == "png")
+        #expect(FileManager.default.fileExists(atPath: staged.url.path))
+        try? FileManager.default.removeItem(at: staged.url)
+    }
+
+    @Test("identical bytes dedupe to the same path")
+    func dedupes() throws {
+        let a = try ACPImageStaging.stage(data: pngBytes, into: "wt-test")
+        let b = try ACPImageStaging.stage(data: pngBytes, into: "wt-test")
+        #expect(a.url == b.url)
+        try? FileManager.default.removeItem(at: a.url)
+    }
+
+    @Test("rejects non-image bytes")
+    func rejectsNonImage() {
+        #expect(throws: ACPImageStaging.StagingError.self) {
+            _ = try ACPImageStaging.stage(data: Data("not an image".utf8), into: "wt-test")
+        }
+    }
+
+    @Test("rejects oversized images")
+    func rejectsOversize() {
+        var big = pngBytes
+        big.append(Data(count: ACPImageStaging.maxBytes + 1))
+        #expect(throws: ACPImageStaging.StagingError.self) {
+            _ = try ACPImageStaging.stage(data: big, into: "wt-test")
+        }
+    }
+}

--- a/AlasTests/ACP/UI/ACPMarkdownLiveStylerImageChipTests.swift
+++ b/AlasTests/ACP/UI/ACPMarkdownLiveStylerImageChipTests.swift
@@ -1,0 +1,33 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPMarkdownLiveStyler image chip preservation")
+@MainActor
+struct ACPMarkdownLiveStylerImageChipTests {
+    /// Regression: the live styler resets attributes on every edit. Image
+    /// chips are tagged with `.imageAttachmentURI` (not `.attachmentURI`),
+    /// so an earlier version bulldozed their `.attachment` cell on the
+    /// debounced restyle — the chip flashed in then vanished.
+    @Test("restyle preserves an image chip's attachment and uri attribute")
+    func preservesImageChip() {
+        let storage = NSTextStorage(string: "look ")
+        let url = URL(string: "file:///tmp/shot.png")!
+        let attachment = ACPImageChipAttachment(fileURL: url, mimeType: "image/png")
+        let chip = NSMutableAttributedString(attachment: attachment)
+        chip.addAttributes([
+            .imageAttachmentURI: url.absoluteString,
+            .imageAttachmentMime: "image/png",
+        ], range: NSRange(location: 0, length: chip.length))
+        storage.append(chip)
+        storage.append(NSAttributedString(string: " **bold** after"))
+
+        ACPMarkdownLiveStyler.restyle(storage, in: NSRange(location: 0, length: storage.length))
+
+        // The chip occupies the single attachment character right after "look ".
+        let chipIndex = 5
+        #expect(storage.attribute(.imageAttachmentURI, at: chipIndex, effectiveRange: nil) as? String == url.absoluteString)
+        #expect(storage.attribute(.attachment, at: chipIndex, effectiveRange: nil) is ACPImageChipAttachment)
+    }
+}


### PR DESCRIPTION
## What

Adds image support to the ACP pane composer.

- **Input:** paste (⌘V and ⌃V), drag-and-drop, and a toolbar attach button. Each image is staged to a content-addressed file under Application Support and shown as an inline thumbnail chip in the composer.
- **Wire:** on submit, images go to the agent as inline base64 (downscaled to 1568px) when it advertises `promptCapabilities.image`, or as a `file://` resource link otherwise. The choice happens at send time, so the queued/persisted form only ever references the staged file — base64 never lands in SQLite. An image-only prompt sends just the image block(s).
- **Transcript:** sent images render as thumbnails in the user bubble and open in a floating preview panel on click. They restore correctly when a session is reopened.
- **Limits/errors:** PNG/JPEG/GIF/WebP, ≤10 images per message, ≤20 MB each; failures surface as a transient notice above the composer.
- Captures the agent's image capability from `initialize` into a runtime-only `ACPSession.imageInputSupported`. `ACPPromptCapabilities` now decodes `image`/`audio` with a `false` default per the ACP spec, so an agent advertising only `{ "image": true }` keeps image support.

## Tests

New Swift Testing coverage for the pure logic: content-block `data` round-trip, attachment `mimeType` back-compat, draft image segment, staging (content-addressed + dedupe + size/format guards), downscale encoding, deferred-block + hydrate gating, image-only block shape, prompt-capability defaulting, composer extract/draft of image chips, and the live-styler preserving image chips. Full suite green; AppKit paste/drag/picker and the preview panel verified manually.

## Known follow-up (separate)

Reopening a session with a replaying agent double-renders the transcript: Alas hydrates its own persisted copy from SQLite, and the agent also replays the whole conversation on `session/load`, which is appended. Reconciling these two sources (and the related `user_message_chunk` echo de-duplication) is pre-existing session-lifecycle behavior, not introduced here, and is tracked for a focused follow-up.