### PR TITLE
fix(ACP): composer draft observation jank

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -1,6 +1,21 @@
 import Foundation
 import Combine
 
+/// Narrow observable holder for the rapidly-mutating composer draft.
+/// Keystrokes update this object instead of `ACPSession` so the transcript
+/// pane is not invalidated while the user types in long sessions.
+@MainActor
+final class ACPComposerState: ObservableObject {
+    private(set) var draft: ACPComposerDraft = .empty
+    private(set) var revision: Int = 0
+
+    func replaceDraft(_ draft: ACPComposerDraft) {
+        objectWillChange.send()
+        self.draft = draft
+        revision += 1
+    }
+}
+
 enum ACPSessionTitleSource: String, Codable {
     case placeholder
     case generated
@@ -17,6 +32,7 @@ final class ACPSession: ObservableObject, Identifiable {
     let createdAt: Date
     let restoredFromPersistence: Bool
     let transcript = ACPTranscript()
+    let composer = ACPComposerState()
     let terminalHost: ACPTerminalHost = ACPTerminalHost(sessionCwd: "/", sessionEnv: [:])
 
     @Published var title: String
@@ -28,8 +44,6 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var currentMode: String?
     @Published var promptSuggestions: [ACPPromptSuggestion] = []
     @Published var autoRunEnabled: Bool = false
-    @Published var composerDraft: ACPComposerDraft = .empty
-    @Published private(set) var composerDraftRevision: Int = 0
     @Published var setupState: SetupState = .checking
     @Published var lastError: String?
     @Published var contextRestoreWarning: ContextRestoreWarning?
@@ -99,9 +113,11 @@ final class ACPSession: ObservableObject, Identifiable {
         }
     }
 
+    var composerDraft: ACPComposerDraft { composer.draft }
+    var composerDraftRevision: Int { composer.revision }
+
     func replaceComposerDraft(_ draft: ACPComposerDraft) {
-        composerDraft = draft
-        composerDraftRevision += 1
+        composer.replaceDraft(draft)
     }
 
     enum HydrationState: Equatable {

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -12,6 +12,7 @@ typealias ACPComposerSubmitHandler = (
 
 struct ACPInputField: NSViewRepresentable {
     @ObservedObject var session: ACPSession
+    @ObservedObject var composer: ACPComposerState
     let worktreeRoot: URL
     let actions: ACPComposerActions
     @Binding var isFocused: Bool
@@ -74,7 +75,7 @@ struct ACPInputField: NSViewRepresentable {
         if let tv = nsView.documentView as? ACPNSTextView {
             tv.placeholderText = Self.placeholder(for: session.transcript.streamingState, sendOnEnter: sendOnEnter)
             tv.needsDisplay = true
-            context.coordinator.syncPersistedDraft(session.composerDraft, into: tv)
+            context.coordinator.syncPersistedDraft(composer.draft, into: tv)
         }
     }
 
@@ -101,7 +102,7 @@ struct ACPInputField: NSViewRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator(
             worktreeRoot: worktreeRoot,
-            initialDraft: session.composerDraft,
+            initialDraft: composer.draft,
             isFocused: $isFocused,
             sendOnEnter: sendOnEnter,
             onDraftChange: onDraftChange,

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// animated send button that mirrors `session.transcript.streamingState`.
 struct ACPComposer: View {
     @ObservedObject var session: ACPSession
+    @ObservedObject private var composer: ACPComposerState
     let manager: ACPSessionManager
     let worktreeRoot: URL
     let agentLookup: (String) -> AgentDefinition?
@@ -18,6 +19,23 @@ struct ACPComposer: View {
     @State private var inputFocused = false
     @StateObject private var actions = ACPComposerActions()
     @State private var hasText: Bool = false
+
+    init(
+        session: ACPSession,
+        manager: ACPSessionManager,
+        worktreeRoot: URL,
+        agentLookup: @escaping (String) -> AgentDefinition?,
+        sendOnEnter: Bool,
+        onSubmit: @escaping ACPComposerSubmitHandler
+    ) {
+        self._session = ObservedObject(wrappedValue: session)
+        self._composer = ObservedObject(wrappedValue: session.composer)
+        self.manager = manager
+        self.worktreeRoot = worktreeRoot
+        self.agentLookup = agentLookup
+        self.sendOnEnter = sendOnEnter
+        self.onSubmit = onSubmit
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -52,6 +70,7 @@ struct ACPComposer: View {
         VStack(spacing: 6) {
             ACPInputField(
                 session: session,
+                composer: composer,
                 worktreeRoot: worktreeRoot,
                 actions: actions,
                 isFocused: $inputFocused,
@@ -65,10 +84,10 @@ struct ACPComposer: View {
             )
             .frame(minHeight: 44, maxHeight: 140)
             .onAppear {
-                hasText = session.composerDraft.hasContent
+                hasText = composer.draft.hasContent
             }
-            .onChange(of: session.composerDraftRevision) { _, _ in
-                hasText = session.composerDraft.hasContent
+            .onChange(of: composer.revision) { _, _ in
+                hasText = composer.draft.hasContent
             }
 
             HStack(spacing: 8) {

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -100,6 +100,32 @@ struct ACPSessionManagerTests {
         #expect(try store.loadComposerDraft(sessionId: session.id) == nil)
     }
 
+    @Test("persisting composer drafts does not publish the whole session")
+    func persistingComposerDraftDoesNotPublishWholeSession() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-observation-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let session = mgr.createSession(agentId: "claude")
+        let sessionStorageLabels = Set(Mirror(reflecting: session).children.compactMap(\.label))
+        var sessionPublishCount = 0
+        var composerPublishCount = 0
+        let sessionCancellable = session.objectWillChange.sink { _ in
+            sessionPublishCount += 1
+        }
+        let composerCancellable = session.composer.objectWillChange.sink { _ in
+            composerPublishCount += 1
+        }
+
+        withExtendedLifetime((sessionCancellable, composerCancellable)) {
+            mgr.persistComposerDraft(ACPComposerDraft(segments: [.text("typing")]), for: session)
+        }
+
+        #expect(!sessionStorageLabels.contains("_composerDraft"))
+        #expect(!sessionStorageLabels.contains("_composerDraftRevision"))
+        #expect(sessionPublishCount == 0)
+        #expect(composerPublishCount == 1)
+    }
+
     @Test("clearComposerDraft removes draft from memory and store")
     func clearComposerDraft() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-draft-clear-explicit-\(UUID()).sqlite")


### PR DESCRIPTION
## Summary

- Move rapidly-changing ACP composer draft state into a narrow `ACPComposerState` observable.
- Keep existing `ACPSession.composerDraft` and revision accessors for persistence and submit flows while avoiding broad session invalidation on every keystroke.
- Wire the composer input field to observe composer state directly and add regression coverage for the observation boundary.

## Root cause

`ACPSession.composerDraft` was `@Published`, so every composer keystroke published the whole session. With a long ACP transcript open, that could invalidate the transcript pane and scroll/markdown bookkeeping while typing, causing app-wide jank and composer lag.

## Validation

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`