### PR TITLE
fix(ACP): suppress ACP load replay after hydration

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -583,8 +583,30 @@ extension ACPSessionManager {
                 stderrBuffer.append(data)
             }
         }
+        var startedRunner: ACPSessionRunner?
         do {
             session.promptCapabilities = (try await connection.initialize())
+            let shouldSuppressLoadReplay = !freshlyCreated
+                && session.hydrationState == .ready
+                && session.hasConversationTranscript
+                && !(session.remoteSessionId ?? "").isEmpty
+            let runner = ACPSessionRunner(session: session, connection: connection,
+                                          store: store, sessionId: sessionId,
+                                          worktreePath: worktreePath,
+                                          agentEnv: Self.mergeEnv(extra: spec.extraEnv),
+                                          suppressingLoadReplay: shouldSuppressLoadReplay,
+                                          onDirtyCheck: onDirtyCheck,
+                                          onLiveBufferRead: onLiveBufferRead)
+            var runnerStarted = false
+            func startRunnerIfNeeded() {
+                guard !runnerStarted else { return }
+                runner.start()
+                runnerStarted = true
+                startedRunner = runner
+            }
+            if shouldSuppressLoadReplay {
+                startRunnerIfNeeded()
+            }
             let pendingRecovery = (try? store.loadSession(id: sessionId)?.contextRecoveryPending) == true
             let result: ACPSessionNewResult
             var restoreWarning: ACPSession.ContextRestoreWarning?
@@ -594,7 +616,13 @@ extension ACPSessionManager {
             } else if let remoteId = session.remoteSessionId, !remoteId.isEmpty {
                 do {
                     result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
+                    runner.finishSuppressingLoadReplay(
+                        throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                    )
                 } catch {
+                    runner.finishSuppressingLoadReplay(
+                        throughYieldedUpdateCount: connection.client.yieldedUpdateCount
+                    )
                     result = try await connection.newSession(cwd: worktreePath)
                     if session.hasConversationTranscript {
                         shouldHoldQueueForRecovery = true
@@ -631,13 +659,7 @@ extension ACPSessionManager {
             session.availableConfigOptions = result.configOptions
             session.contextRestoreWarning = restoreWarning
             persistSessionRemoteId(session)
-            let runner = ACPSessionRunner(session: session, connection: connection,
-                                          store: store, sessionId: sessionId,
-                                          worktreePath: worktreePath,
-                                          agentEnv: Self.mergeEnv(extra: spec.extraEnv),
-                                          onDirtyCheck: onDirtyCheck,
-                                          onLiveBufferRead: onLiveBufferRead)
-            runner.start()
+            startRunnerIfNeeded()
             runners[sessionId] = runner
             session.agentState = .ready
             if !shouldHoldQueueForRecovery {
@@ -653,6 +675,7 @@ extension ACPSessionManager {
             let full = tail.isEmpty ? base : base + "\nstderr: " + tail
             session.lastError = full
             session.agentState = .failed(full)
+            startedRunner?.stop()
             await connection.shutdown()
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -53,6 +53,9 @@ final class ACPSessionRunner {
     private var cancelledPromptIDs: Set<Int> = []
     private var appliedUpdateCount = 0
     private var pendingCompletedOutputBoundaryUpdateCount: Int?
+    private var suppressingLoadReplay: Bool
+    private var loadReplaySuppressionTarget: Int?
+    private var observedUpdateCount = 0
     /// Set while `steer` is between `userCancel` and the redirect's
     /// `sendNow`. `flushQueueIfIdle` no-ops while this is true so an
     /// Undo tapped during the cancel round-trip can't drain the just-
@@ -63,6 +66,7 @@ final class ACPSessionRunner {
     init(session: ACPSession, connection: ACPConnection, store: ACPSessionStore,
          sessionId: String, worktreePath: String,
          agentEnv: [String: String] = ProcessInfo.processInfo.environment,
+         suppressingLoadReplay: Bool = false,
          onDirtyCheck: ((String) -> Bool)? = nil,
          onLiveBufferRead: ((String) -> String?)? = nil)
     {
@@ -72,6 +76,7 @@ final class ACPSessionRunner {
         self.sessionId = sessionId
         self.worktreePath = worktreePath
         self.agentEnv = agentEnv
+        self.suppressingLoadReplay = suppressingLoadReplay
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
         self.policy = ACPPermissionPolicy(
@@ -88,8 +93,16 @@ final class ACPSessionRunner {
             guard let self else { return }
             for await u in self.connection.client.incomingUpdates {
                 await MainActor.run {
-                    let dirty = self.session.apply(u.update)
+                    self.observedUpdateCount += 1
                     self.appliedUpdateCount += 1
+                    if self.suppressingLoadReplay {
+                        if let target = self.loadReplaySuppressionTarget,
+                           self.observedUpdateCount >= target {
+                            self.suppressingLoadReplay = false
+                        }
+                        return
+                    }
+                    let dirty = self.session.apply(u.update)
                     self.persistIndices(dirty)
                     if self.applyPendingCompletedOutputBoundaryIfReady() {
                         self.flushQueueIfIdle()
@@ -209,6 +222,14 @@ final class ACPSessionRunner {
             for await req in self.connection.client.terminalRequests {
                 self.handleTerminalRequest(req)
             }
+        }
+    }
+
+    func finishSuppressingLoadReplay(throughYieldedUpdateCount target: Int) {
+        guard suppressingLoadReplay else { return }
+        loadReplaySuppressionTarget = target
+        if observedUpdateCount >= target {
+            suppressingLoadReplay = false
         }
     }
 

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -25,6 +25,175 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(try store.loadSession(id: "local")?.remoteSessionId == "remote-restored")
     }
 
+    @Test("replayed load history is ignored when a session is already hydrated")
+    func replayedLoadHistoryIgnoredWhenHydrated() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        try appendMessage(
+            .user(
+                id: UUID(),
+                text: "look at this",
+                attachments: [
+                    .init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png")
+                ]
+            ),
+            to: store,
+            seq: 0
+        )
+        try appendMessage(
+            .agent(id: UUID(), StreamingText("the image looks good")),
+            to: store,
+            seq: 1
+        )
+        try appendMessage(
+            .toolCall(.init(
+                toolCallId: "tool-1",
+                title: "Read file",
+                kind: "read",
+                status: "completed",
+                content: "done"
+            )),
+            to: store,
+            seq: 2
+        )
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.scriptAsync(method: "session/load") { _ in
+            client.emit(.init(sessionId: "remote-old", update: .userMessageChunk(.text("look at this"))))
+            client.emit(.init(sessionId: "remote-old", update: .agentMessageChunk(.text("the image looks good"))))
+            client.emit(.init(sessionId: "remote-old", update: .toolCall(.init(
+                toolCallId: "tool-1",
+                title: "Read file",
+                kind: "read",
+                status: "completed",
+                content: [.content(.text("done"))],
+                locations: nil,
+                rawInput: nil,
+                rawOutput: nil
+            ))))
+            return try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-restored",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        client.script(method: "session/prompt") { _ in
+            client.emit(.init(sessionId: "remote-restored", update: .agentMessageChunk(.text("prompt response"))))
+            return Data("null".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        #expect(session.transcript.messages.count == 3)
+
+        await manager.attach(to: session.id, freshlyCreated: false)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(client.yieldedUpdateCount == 3)
+        #expect(client.sent.map(\.method) == ["initialize", "session/load"])
+        #expect(session.transcript.messages.count == 3)
+        #expect(try store.loadMessages(sessionId: "local").count == 3)
+        guard case .user(_, let text, let attachments) = session.transcript.messages[0] else {
+            Issue.record("Expected hydrated user message to remain first")
+            return
+        }
+        #expect(text == "look at this")
+        #expect(attachments == [
+            .init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png")
+        ])
+
+        client.emit(.init(sessionId: "remote-restored", update: .agentMessageChunk(.text("live follow-up"))))
+        try await waitUntil { session.transcript.messages.count == 4 }
+        guard case .agent(_, let liveText) = session.transcript.messages[3] else {
+            Issue.record("Expected post-load live update to be applied")
+            return
+        }
+        #expect(liveText.value == "live follow-up")
+
+        let runner = try #require(manager.runners[session.id])
+        var delivered: Bool?
+        runner.send(text: "next prompt", attachments: []) { succeeded in
+            delivered = succeeded
+        }
+        try await waitUntil {
+            delivered == true
+                && session.transcript.streamingState == .idle
+                && session.transcript.messages.count == 6
+        }
+    }
+
+    @Test("fresh session keeps updates emitted during session new")
+    func freshSessionKeepsUpdatesEmittedDuringNew() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.scriptAsync(method: "session/new") { _ in
+            client.emit(.init(sessionId: "remote-new", update: .agentMessageChunk(.text("welcome"))))
+            return try JSONEncoder().encode(ACPSessionNewResult(
+                sessionId: "remote-new",
+                availableModels: [],
+                availableModes: [],
+                currentModel: nil,
+                currentMode: nil,
+                promptSuggestions: []
+            ))
+        }
+        let manager = manager(store: store, client: client)
+        let session = manager.createSession(agentId: "claude")
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+        try await waitUntil { session.transcript.messages.count == 1 }
+
+        guard case .agent(_, let text) = session.transcript.messages[0] else {
+            Issue.record("Expected fresh session update to be applied")
+            return
+        }
+        #expect(text.value == "welcome")
+    }
+
+    @Test("non-replaying load still flushes queued prompt")
+    func nonReplayingLoadStillFlushesQueuedPrompt() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        try appendMessage(
+            .user(id: UUID(), text: "prior prompt", attachments: []),
+            to: store,
+            seq: 0
+        )
+        try store.upsertQueue(sessionId: "local", items: [
+            QueuedPrompt(blocks: [.text("queued prompt")])
+        ])
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-restored")
+        client.script(method: "session/prompt") { request in
+            let params = try #require(request.params as? ACPSessionPromptParams)
+            #expect(params.sessionId == "remote-restored")
+            #expect(params.prompt == [.text("queued prompt")])
+            return Data("null".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        try await waitUntil {
+            client.sent.map(\.method) == ["initialize", "session/load", "session/prompt"]
+                && session.queue.isEmpty
+        }
+        #expect(session.transcript.messages.count == 2)
+        guard case .user(_, let text, _) = session.transcript.messages[1] else {
+            Issue.record("Expected queued prompt to append after hydrated transcript")
+            return
+        }
+        #expect(text == "queued prompt")
+    }
+
     @Test("load failure falls back to session/new with transcript warning")
     func loadFailureFallsBackToNewWithWarning() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())


### PR DESCRIPTION
## Summary

- Suppress buffered `session/load` replay updates when reopening an already-hydrated ACP session.
- Keep Alas's persisted SQLite transcript authoritative so user bubbles and image attachments restore once.
- Add regression coverage for replaying load, fresh sessions, and non-replaying agents with queued prompts.

## Root Cause

Reopening an ACP session hydrated the transcript from Alas's SQLite store, then consumed the agent's full replay from `session/load` as normal live updates. Those replay updates were appended after the hydrated transcript, duplicating the conversation.

## Validation

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`