### PR TITLE
feat(ACP): Add ACP embedded resource support

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -7,9 +7,10 @@ final class ACPConnection: @unchecked Sendable {
 
     init(client: ACPClient) { self.client = client }
 
-    /// Returns whether the agent advertises inline-image prompt capability.
+    /// Returns the prompt capabilities advertised by the agent, defaulting
+    /// missing capability fields to false.
     @discardableResult
-    func initialize() async throws -> Bool {
+    func initialize() async throws -> ACPInitializeResult.ACPPromptCapabilities {
         let req = ACPRequest(method: "initialize",
                              params: ACPInitializeParams(
                                 protocolVersion: ACPProtocolVersion.current,
@@ -18,7 +19,7 @@ final class ACPConnection: @unchecked Sendable {
                                     terminal: true)))
         let resp = try await client.send(req)
         let result = try? JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)
-        return result?.agentCapabilities?.promptCapabilities?.image ?? false
+        return result?.agentCapabilities?.promptCapabilities ?? .init()
     }
 
     func newSession(cwd: String) async throws -> ACPSessionNewResult {

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -74,20 +74,23 @@ struct ACPInitializeResult: Codable, Equatable {
     struct ACPPromptCapabilities: Codable, Equatable {
         let image: Bool
         let audio: Bool
+        let embeddedContext: Bool
 
-        init(image: Bool = false, audio: Bool = false) {
+        init(image: Bool = false, audio: Bool = false, embeddedContext: Bool = false) {
             self.image = image
             self.audio = audio
+            self.embeddedContext = embeddedContext
         }
 
         // ACP defines each prompt capability as defaulting to false when
         // omitted, so an agent advertising only `{ "image": true }` must still
-        // decode (a non-optional `audio` would otherwise fail the whole
-        // initialize result and silently drop image support).
+        // decode (a non-optional `audio` or `embeddedContext` would otherwise
+        // fail the whole initialize result and silently drop image support).
         init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             image = try c.decodeIfPresent(Bool.self, forKey: .image) ?? false
             audio = try c.decodeIfPresent(Bool.self, forKey: .audio) ?? false
+            embeddedContext = try c.decodeIfPresent(Bool.self, forKey: .embeddedContext) ?? false
         }
     }
     struct ACPAuthMethod: Codable, Equatable {
@@ -349,8 +352,27 @@ enum ACPContentBlock: Codable, Equatable {
     case text(String)
     case resourceLink(uri: String, name: String?)
     case image(data: String?, uri: String?, mimeType: String?)
+    case resource(uri: String, mimeType: String?, text: String)
 
-    private enum Keys: String, CodingKey { case type, text, uri, name, mimeType, data }
+    private enum Keys: String, CodingKey { case type, text, uri, name, mimeType, data, resource }
+    private struct EmbeddedResource: Codable, Equatable {
+        let uri: String
+        let mimeType: String?
+        let text: String?
+        let blob: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case uri, mimeType, text, blob
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(uri, forKey: .uri)
+            try c.encodeIfPresent(mimeType, forKey: .mimeType)
+            try c.encodeIfPresent(text, forKey: .text)
+            try c.encodeIfPresent(blob, forKey: .blob)
+        }
+    }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: Keys.self)
@@ -366,6 +388,13 @@ enum ACPContentBlock: Codable, Equatable {
                 data: try? c.decode(String.self, forKey: .data),
                 uri: try? c.decode(String.self, forKey: .uri),
                 mimeType: try? c.decode(String.self, forKey: .mimeType))
+        case "resource":
+            let resource = try c.decode(EmbeddedResource.self, forKey: .resource)
+            if let text = resource.text {
+                self = .resource(uri: resource.uri, mimeType: resource.mimeType, text: text)
+            } else {
+                self = .resourceLink(uri: resource.uri, name: URL(string: resource.uri)?.lastPathComponent)
+            }
         default:
             self = .text("")
         }
@@ -385,6 +414,11 @@ enum ACPContentBlock: Codable, Equatable {
             try c.encodeIfPresent(data, forKey: .data)
             try c.encodeIfPresent(uri, forKey: .uri)
             try c.encodeIfPresent(mime, forKey: .mimeType)
+        case .resource(let uri, let mime, let text):
+            try c.encode("resource", forKey: .type)
+            try c.encode(
+                EmbeddedResource(uri: uri, mimeType: mime, text: text, blob: nil),
+                forKey: .resource)
         }
     }
 }

--- a/Alas/Sources/ACP/Session/ACPComposerDraft.swift
+++ b/Alas/Sources/ACP/Session/ACPComposerDraft.swift
@@ -123,6 +123,8 @@ extension ACPComposerDraft {
                 text += value
             case .resourceLink(let uri, let name):
                 links.append((name ?? Self.displayName(forURI: uri), uri))
+            case .resource(let uri, _, _):
+                links.append((Self.displayName(forURI: uri), uri))
             case .image(_, let uri, let mimeType):
                 if let uri {
                     segments.append(contentsOf: Self.rebuild(text: text, links: links))

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -48,11 +48,13 @@ final class ACPSession: ObservableObject, Identifiable {
     /// lifecycle), distinct from `StreamingState.idle` which means
     /// "runner is attached but not currently mid-prompt" (turn lifecycle).
     @Published var agentState: AgentState = .idle
-    /// Whether the connected agent accepts inline image content blocks
-    /// (`promptCapabilities.image`). Runtime-only: re-learned on each
-    /// `initialize`, never persisted. Drives the send-time hydration in
-    /// `ACPSessionRunner.hydrate`.
-    @Published var imageInputSupported: Bool = false
+    /// Prompt content capabilities learned from ACP `initialize`.
+    /// Runtime-only: re-learned on each attach, never persisted. Drives
+    /// send-time hydration in `ACPSessionRunner.hydrate`.
+    @Published var promptCapabilities: ACPInitializeResult.ACPPromptCapabilities = .init()
+
+    var imageInputSupported: Bool { promptCapabilities.image }
+    var embeddedContextSupported: Bool { promptCapabilities.embeddedContext }
 
     enum AgentState: Equatable {
         case idle
@@ -449,6 +451,8 @@ final class ACPSession: ObservableObject, Identifiable {
                 out.append("[\(name ?? uri)]")
             case .content(.image):
                 out.append("[image]")
+            case .content(.resource(let uri, _, _)):
+                out.append("[\(URL(string: uri)?.lastPathComponent ?? uri)]")
             case .diff(let path, let old, let new):
                 var lines: [String] = ["--- \(path)"]
                 if let old, !old.isEmpty {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -584,7 +584,7 @@ extension ACPSessionManager {
             }
         }
         do {
-            session.imageInputSupported = (try await connection.initialize())
+            session.promptCapabilities = (try await connection.initialize())
             let pendingRecovery = (try? store.loadSession(id: sessionId)?.contextRecoveryPending) == true
             let result: ACPSessionNewResult
             var restoreWarning: ACPSession.ContextRestoreWarning?

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -514,29 +514,91 @@ extension ACPSessionRunner {
     /// Maximum dimension for an inline base64 image, in pixels.
     nonisolated static let inlineImageMaxDimension: CGFloat = 1568
 
-    /// Resolve deferred image blocks just before sending. When the agent
-    /// supports inline images, read the staged file, downscale, and base64-
-    /// encode it; otherwise degrade to a `file://` resource link the agent
-    /// reads from disk. Non-image blocks (and already-hydrated images that
-    /// carry `data`) pass through untouched.
+    /// Resolve deferred attachment blocks just before sending. When the agent
+    /// supports inline images, read the staged image file, downscale, and
+    /// base64-encode it; otherwise degrade to a `file://` resource link the
+    /// agent reads from disk. When the agent supports embedded context,
+    /// readable text resource links inside the worktree become ACP `resource`
+    /// blocks. Persisted queue state stays lightweight either way.
     ///
     /// `nonisolated async` so the synchronous file reads + downscale/base64
     /// encoding (up to 10 × 20 MB) run off the main actor; awaiting it from the
     /// main-actor send path hops to the cooperative pool instead of freezing
     /// the composer/transcript while a prompt is prepared.
-    nonisolated static func hydrate(_ blocks: [ACPContentBlock], imageInputSupported: Bool) async -> [ACPContentBlock] {
+    nonisolated static func hydrate(
+        _ blocks: [ACPContentBlock],
+        promptCapabilities: ACPInitializeResult.ACPPromptCapabilities,
+        worktreePath: String
+    ) async -> [ACPContentBlock] {
         blocks.map { block in
-            guard case .image(let data, let uri, let mime) = block, data == nil, let uri else {
-                return block
+            if case .image(let data, let uri, _) = block, data == nil, let uri {
+                let name = (URL(string: uri)?.lastPathComponent) ?? "image"
+                if promptCapabilities.image,
+                   let fileURL = URL(string: uri),
+                   let encoded = ACPImageEncoding.inlineBase64(fileURL: fileURL, maxDimension: inlineImageMaxDimension) {
+                    return .image(data: encoded.data, uri: nil, mimeType: encoded.mimeType)
+                }
+                return .resourceLink(uri: uri, name: name)
             }
-            let name = (URL(string: uri)?.lastPathComponent) ?? "image"
-            if imageInputSupported,
-               let fileURL = URL(string: uri),
-               let encoded = ACPImageEncoding.inlineBase64(fileURL: fileURL, maxDimension: inlineImageMaxDimension) {
-                return .image(data: encoded.data, uri: nil, mimeType: encoded.mimeType)
+            if case .resourceLink(let uri, let name) = block,
+               promptCapabilities.embeddedContext,
+               let embedded = Self.embeddedTextResource(uri: uri, name: name, worktreePath: worktreePath) {
+                return embedded
             }
-            return .resourceLink(uri: uri, name: name)
+            return block
         }
+    }
+
+    nonisolated private static func embeddedTextResource(
+        uri: String,
+        name: String?,
+        worktreePath: String
+    ) -> ACPContentBlock? {
+        guard let fileURL = URL(string: uri), fileURL.isFileURL else {
+            return nil
+        }
+        let rootURL = URL(fileURLWithPath: worktreePath).resolvingSymlinksInPath()
+        let resolvedURL = fileURL.resolvingSymlinksInPath()
+        guard Self.isWithinWorktree(resolvedURL, rootURL: rootURL) else {
+            return nil
+        }
+        guard let values = try? resolvedURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+              values.isRegularFile == true else {
+            return nil
+        }
+        if let byteCount = values.fileSize, byteCount > 1_000_000 {
+            return nil
+        }
+        guard let text = try? String(contentsOf: resolvedURL, encoding: .utf8) else {
+            return nil
+        }
+        return .resource(uri: uri, mimeType: Self.textMimeType(for: resolvedURL, fallbackName: name), text: text)
+    }
+
+    nonisolated private static func isWithinWorktree(_ url: URL, rootURL: URL) -> Bool {
+        let rootPath = rootURL.path
+        let path = url.path
+        return path == rootPath || path.hasPrefix(rootPath + "/")
+    }
+
+    nonisolated private static func textMimeType(for url: URL, fallbackName: String?) -> String {
+        let ext = (url.pathExtension.isEmpty ? URL(fileURLWithPath: fallbackName ?? "").pathExtension : url.pathExtension)
+            .lowercased()
+        switch ext {
+        case "md", "markdown": return "text/markdown"
+        case "json": return "application/json"
+        case "html", "htm": return "text/html"
+        case "css": return "text/css"
+        case "js", "mjs", "cjs": return "text/javascript"
+        case "xml": return "application/xml"
+        case "yaml", "yml": return "application/yaml"
+        default: return "text/plain"
+        }
+    }
+
+    /// Backwards-compatible helper for existing image-only tests.
+    nonisolated static func hydrate(_ blocks: [ACPContentBlock], imageInputSupported: Bool) async -> [ACPContentBlock] {
+        await hydrate(blocks, promptCapabilities: .init(image: imageInputSupported), worktreePath: "/")
     }
 
     /// Primary entry. Resolves the routing then dispatches to one of:
@@ -772,10 +834,14 @@ extension ACPSessionRunner {
             }
             do {
                 let remoteId = self.session.remoteSessionId ?? self.sessionId
-                // Read the capability flag on the main actor (cheap), then
-                // hydrate off-main so file reads + base64 encoding don't block UI.
-                let imageSupported = self.session.imageInputSupported
-                let wireBlocks = await Self.hydrate(blocks, imageInputSupported: imageSupported)
+                // Read the capability flags on the main actor (cheap), then
+                // hydrate off-main so file reads + encoding don't block UI.
+                let promptCapabilities = self.session.promptCapabilities
+                let wireBlocks = await Self.hydrate(
+                    blocks,
+                    promptCapabilities: promptCapabilities,
+                    worktreePath: self.worktreePath
+                )
                 try await self.connection.prompt(sessionId: remoteId, blocks: wireBlocks)
                 await MainActor.run {
                     let isActivePrompt = self.activePromptID == promptID
@@ -904,6 +970,9 @@ extension ACPSessionRunner {
         blocks.compactMap { b -> ACPMessage.Attachment? in
             if case .resourceLink(let uri, let name) = b {
                 return ACPMessage.Attachment(uri: uri, name: name)
+            }
+            if case .resource(let uri, _, _) = b {
+                return ACPMessage.Attachment(uri: uri, name: URL(string: uri)?.lastPathComponent)
             }
             if case .image(_, let uri, let mime) = b, let uri {
                 let name = URL(string: uri)?.lastPathComponent

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -28,6 +28,31 @@ struct ACPConnectionTests {
         #expect(new.availableModes.first?.id == "agent")
     }
 
+    @Test("initialize returns prompt capabilities")
+    func initializeReturnsPromptCapabilities() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "initialize") { _ in
+            try JSONEncoder().encode(ACPInitializeResult(
+                protocolVersion: 1,
+                agentCapabilities: .init(
+                    promptCapabilities: .init(
+                        image: true,
+                        audio: false,
+                        embeddedContext: true
+                    )
+                ),
+                authMethods: []
+            ))
+        }
+
+        let conn = ACPConnection(client: mock)
+        let capabilities = try await conn.initialize()
+
+        #expect(capabilities.image == true)
+        #expect(capabilities.audio == false)
+        #expect(capabilities.embeddedContext == true)
+    }
+
     @Test("loadSession sends session/load with cwd and remote session id")
     func loadSessionRPC() async throws {
         let mock = ACPMockClient()

--- a/AlasTests/ACP/Protocol/ACPContentBlockImageTests.swift
+++ b/AlasTests/ACP/Protocol/ACPContentBlockImageTests.swift
@@ -30,4 +30,23 @@ struct ACPContentBlockImageTests {
         let decoded = try JSONDecoder().decode(ACPContentBlock.self, from: data)
         #expect(decoded == block)
     }
+
+    @Test("round-trips embedded text resource block")
+    func roundTripsResource() throws {
+        let block = ACPContentBlock.resource(
+            uri: "file:///tmp/File.swift",
+            mimeType: "text/plain",
+            text: "let value = 1\n"
+        )
+        let data = try JSONEncoder().encode(block)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["type"] as? String == "resource")
+        let resource = try #require(json["resource"] as? [String: Any])
+        #expect(resource["uri"] as? String == "file:///tmp/File.swift")
+        #expect(resource["mimeType"] as? String == "text/plain")
+        #expect(resource["text"] as? String == "let value = 1\n")
+
+        let decoded = try JSONDecoder().decode(ACPContentBlock.self, from: data)
+        #expect(decoded == block)
+    }
 }

--- a/AlasTests/ACP/Protocol/ACPPromptCapabilitiesTests.swift
+++ b/AlasTests/ACP/Protocol/ACPPromptCapabilitiesTests.swift
@@ -15,5 +15,17 @@ struct ACPPromptCapabilitiesTests {
         let result = try JSONDecoder().decode(ACPInitializeResult.self, from: json)
         #expect(result.agentCapabilities?.promptCapabilities?.image == true)
         #expect(result.agentCapabilities?.promptCapabilities?.audio == false)
+        #expect(result.agentCapabilities?.promptCapabilities?.embeddedContext == false)
+    }
+
+    @Test("embedded context capability decodes")
+    func embeddedContextDecodes() throws {
+        let json = #"""
+        {"protocolVersion":1,"agentCapabilities":{"promptCapabilities":{"embeddedContext":true}},"authMethods":[]}
+        """#.data(using: .utf8)!
+        let result = try JSONDecoder().decode(ACPInitializeResult.self, from: json)
+        #expect(result.agentCapabilities?.promptCapabilities?.image == false)
+        #expect(result.agentCapabilities?.promptCapabilities?.audio == false)
+        #expect(result.agentCapabilities?.promptCapabilities?.embeddedContext == true)
     }
 }

--- a/AlasTests/ACP/Session/ACPImageBlocksTests.swift
+++ b/AlasTests/ACP/Session/ACPImageBlocksTests.swift
@@ -23,7 +23,11 @@ struct ACPImageBlocksTests {
             .text("x"),
             .image(data: nil, uri: "file:///tmp/shot.png", mimeType: "image/png")
         ]
-        let wire = await ACPSessionRunner.hydrate(deferred, imageInputSupported: false)
+        let wire = await ACPSessionRunner.hydrate(
+            deferred,
+            promptCapabilities: .init(image: false),
+            worktreePath: "/tmp"
+        )
         #expect(wire.contains(.text("x")))
         #expect(wire.contains(.resourceLink(uri: "file:///tmp/shot.png", name: "shot.png")))
         #expect(!wire.contains { block in
@@ -48,5 +52,58 @@ struct ACPImageBlocksTests {
             text: " ",
             attachments: [.init(uri: "file:///tmp/shot.png", name: "shot.png", mimeType: "image/png")])
         #expect(blocks == [.image(data: nil, uri: "file:///tmp/shot.png", mimeType: "image/png")])
+    }
+
+    @Test("hydrate embeds readable worktree text resource when supported")
+    func hydrateEmbedsTextResource() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-acp-resource-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let file = root.appendingPathComponent("File.swift")
+        try "let value = 1\n".write(to: file, atomically: true, encoding: .utf8)
+
+        let wire = await ACPSessionRunner.hydrate(
+            [.resourceLink(uri: file.absoluteString, name: "File.swift")],
+            promptCapabilities: .init(embeddedContext: true),
+            worktreePath: root.path
+        )
+
+        #expect(wire == [
+            .resource(
+                uri: file.absoluteString,
+                mimeType: "text/plain",
+                text: "let value = 1\n"
+            )
+        ])
+    }
+
+    @Test("hydrate keeps resource link when embedded context is unsupported or outside worktree")
+    func hydrateResourceFallbacks() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-acp-resource-\(UUID().uuidString)", isDirectory: true)
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-acp-outside-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try "outside\n".write(to: outside, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+
+        let unsupported = await ACPSessionRunner.hydrate(
+            [.resourceLink(uri: outside.absoluteString, name: "outside.txt")],
+            promptCapabilities: .init(embeddedContext: false),
+            worktreePath: root.path
+        )
+        #expect(unsupported == [.resourceLink(uri: outside.absoluteString, name: "outside.txt")])
+
+        let outsideWorktree = await ACPSessionRunner.hydrate(
+            [.resourceLink(uri: outside.absoluteString, name: "outside.txt")],
+            promptCapabilities: .init(embeddedContext: true),
+            worktreePath: root.path
+        )
+        #expect(outsideWorktree == [.resourceLink(uri: outside.absoluteString, name: "outside.txt")])
     }
 }


### PR DESCRIPTION
## Summary

- decode and store ACP prompt capabilities, including `embeddedContext`
- add ACP `resource` content block encoding/decoding
- hydrate safe in-worktree UTF-8 file mentions into embedded resources when the agent supports embedded context, with fallback to `resource_link`

## Validation

- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPPromptCapabilitiesTests -only-testing:AlasTests/ACPConnectionTests -only-testing:AlasTests/ACPContentBlockImageTests -only-testing:AlasTests/ACPImageBlocksTests test`
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`