### PR TITLE
fix(right): load branches before showing selector

### DIFF
--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct BaseBranchSelector: View {
     @Binding var baseBranch: String
     let branches: [String]
+    let isLoadingBranches: Bool
+    let hasLoadedBranches: Bool
     let currentRef: String?
     let onSelect: (String) -> Void
     let onOpen: () -> Void
@@ -45,7 +47,16 @@ struct BaseBranchSelector: View {
             AlasField(text: $search, placeholder: "Search branches...")
                 .padding(8)
             Divider().background(theme.color("line"))
-            if branches.isEmpty {
+            if Self.shouldShowLoading(isLoading: isLoadingBranches, hasLoaded: hasLoadedBranches) {
+                HStack(spacing: 8) {
+                    Spinner(lineWidth: 1.5, duration: 0.7)
+                        .frame(width: 12, height: 12)
+                    Text("Loading branches...")
+                        .font(.system(size: 12))
+                        .foregroundColor(theme.color("fg-dim"))
+                }
+                .padding(12)
+            } else if branches.isEmpty {
                 Text("No branches")
                     .font(.system(size: 12))
                     .foregroundColor(theme.color("fg-dim"))
@@ -90,6 +101,10 @@ struct BaseBranchSelector: View {
 }
 
 extension BaseBranchSelector {
+    static func shouldShowLoading(isLoading: Bool, hasLoaded: Bool) -> Bool {
+        isLoading || !hasLoaded
+    }
+
     static func isSelected(row name: String, baseBranch: String, currentRef: String?) -> Bool {
         name == (currentRef ?? baseBranch)
     }

--- a/Alas/Sources/Right/ChangesTabView.swift
+++ b/Alas/Sources/Right/ChangesTabView.swift
@@ -138,6 +138,8 @@ struct ChangesTabView: View {
                     upstream: rps.upstreamRef,
                     recent: rps.recentBaseBranches
                 ),
+                isLoadingBranches: rps.isFetchingBranches,
+                hasLoadedBranches: rps.hasFetchedBranches,
                 onSelect: onSelectCommit,
                 onCopySHA: copyCommitSHA,
                 onEdit: { commit in

--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -30,6 +30,8 @@ struct CommitsSectionView: View {
     @Binding var expanded: Bool
     @Binding var baseBranch: String
     let branches: [String]
+    let isLoadingBranches: Bool
+    let hasLoadedBranches: Bool
     let onSelect: (CommitInfo) -> Void
     let onCopySHA: (CommitInfo) -> Void
     let onEdit: (CommitInfo) -> Void
@@ -64,6 +66,8 @@ struct CommitsSectionView: View {
                     BaseBranchSelector(
                         baseBranch: $baseBranch,
                         branches: branches,
+                        isLoadingBranches: isLoadingBranches,
+                        hasLoadedBranches: hasLoadedBranches,
                         currentRef: comparisonRef,
                         onSelect: onSelectBaseBranch,
                         onOpen: onOpenBaseBranchSelector

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -121,6 +121,8 @@ final class RightPaneState {
     /// Branches available in this worktree, populated on-demand by
     /// `fetchBranches()`. Used by the base-branch picker.
     private(set) var availableBranches: [String] = []
+    private(set) var isFetchingBranches: Bool = false
+    private(set) var hasFetchedBranches: Bool = false
 
     /// Upstream tracking ref of the current branch (e.g. `origin/main`),
     /// resolved during `refreshSyncStatus()`. Used by the base-branch
@@ -211,6 +213,13 @@ final class RightPaneState {
 
     /// Populate `availableBranches` from git. Best-effort; errors are logged.
     func fetchBranches() async {
+        guard !isFetchingBranches else { return }
+        isFetchingBranches = true
+        defer {
+            isFetchingBranches = false
+            hasFetchedBranches = true
+        }
+
         do {
             availableBranches = try await git.branches(at: worktree.path)
         } catch {

--- a/AlasTests/BaseBranchSelectorTests.swift
+++ b/AlasTests/BaseBranchSelectorTests.swift
@@ -121,6 +121,13 @@ struct BaseBranchSelectorTests {
         #expect(result.isEmpty)
     }
 
+    @Test func unloadedBranchesRenderAsLoading() {
+        #expect(BaseBranchSelector.shouldShowLoading(isLoading: false, hasLoaded: false))
+        #expect(BaseBranchSelector.shouldShowLoading(isLoading: true, hasLoaded: false))
+        #expect(BaseBranchSelector.shouldShowLoading(isLoading: true, hasLoaded: true))
+        #expect(!BaseBranchSelector.shouldShowLoading(isLoading: false, hasLoaded: true))
+    }
+
     @Test func smartListIncludesCurrentRefWhenAbsentFromShortlist() {
         let result = BaseBranchSelector.smartList(
             branches: ["main", "origin/main"],

--- a/AlasTests/RightPaneStateLoadOlderTests.swift
+++ b/AlasTests/RightPaneStateLoadOlderTests.swift
@@ -43,6 +43,21 @@ struct RightPaneStateLoadOlderTests {
         return repo
     }
 
+    private func makeRepoWithRemoteBranches() async throws -> (repo: URL, remote: URL) {
+        let repo = try await makeRepoOnMain(commits: 1)
+        let remote = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-remote-\(UUID().uuidString).git")
+        _ = try await Process.git(["init", "-q", "--bare", remote.path], cwd: repo)
+        _ = try await Process.git(["remote", "add", "origin", remote.path], cwd: repo)
+        _ = try await Process.git(["checkout", "-q", "-b", "worktree/task-branch"], cwd: repo)
+        try "task\n".write(to: repo.appendingPathComponent("task.txt"), atomically: true, encoding: .utf8)
+        _ = try await Process.git(["add", "."], cwd: repo)
+        _ = try await Process.git(["commit", "-q", "-m", "feat: task"], cwd: repo)
+        _ = try await Process.git(["push", "-q", "origin", "main", "worktree/task-branch"], cwd: repo)
+        _ = try await Process.git(["fetch", "-q", "origin"], cwd: repo)
+        return (repo, remote)
+    }
+
     @Test func firstPageUsesParentOfLastAheadCommit() async throws {
         let repo = try await makeBranchAhead(base: 25, ahead: 3)
         defer { try? FileManager.default.removeItem(at: repo) }
@@ -58,6 +73,39 @@ struct RightPaneStateLoadOlderTests {
         // First older entry is the parent of the oldest ahead commit
         // ("ahead1"), which is the latest base commit "c25".
         #expect(state.olderCommits[0].subject == "c25")
+    }
+
+    @Test func branchFetchMarksLoadingAndPublishesCompleteInitialList() async throws {
+        let fixture = try await makeRepoWithRemoteBranches()
+        defer {
+            try? FileManager.default.removeItem(at: fixture.repo)
+            try? FileManager.default.removeItem(at: fixture.remote)
+        }
+        let state = RightPaneState(
+            worktree: makeWorktree(at: fixture.repo, branch: "worktree/task-branch"),
+            baseBranch: "main"
+        )
+
+        #expect(state.availableBranches.isEmpty)
+        #expect(state.isFetchingBranches == false)
+        #expect(state.hasFetchedBranches == false)
+        #expect(BaseBranchSelector.shouldShowLoading(
+            isLoading: state.isFetchingBranches,
+            hasLoaded: state.hasFetchedBranches
+        ))
+
+        await state.fetchBranches()
+
+        #expect(state.isFetchingBranches == false)
+        #expect(state.hasFetchedBranches)
+        #expect(!BaseBranchSelector.shouldShowLoading(
+            isLoading: state.isFetchingBranches,
+            hasLoaded: state.hasFetchedBranches
+        ))
+        #expect(state.availableBranches.contains("main"))
+        #expect(state.availableBranches.contains("worktree/task-branch"))
+        #expect(state.availableBranches.contains("origin/main"))
+        #expect(state.availableBranches.contains("origin/worktree/task-branch"))
     }
 
     @Test func subsequentPageContinuesFromOlderCursor() async throws {


### PR DESCRIPTION
## Summary
- add explicit branch fetch state for the right-pane commits branch selector
- show an explicit loading row until the first complete branch ref fetch finishes
- add regression coverage for initial branch-list loading and remote branch discovery

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test