### PR TITLE
fix(acp): ignore unsafe agent discovery path entries

### DIFF
--- a/Alas/Sources/Agents/AgentDetector.swift
+++ b/Alas/Sources/Agents/AgentDetector.swift
@@ -14,7 +14,7 @@ enum AgentDetector {
         path: String,
         agents: [AgentDefinition]
     ) async -> Set<String> {
-        let dirs = path.split(separator: ":", omittingEmptySubsequences: true).map(String.init)
+        let dirs = executableSearchDirectories(path: path)
         var found: Set<String> = []
         for agent in agents {
             let effective: String = {
@@ -34,6 +34,19 @@ enum AgentDetector {
             }
         }
         return found
+    }
+
+    static func executableSearchDirectories(path: String) -> [String] {
+        path
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .compactMap { raw in
+                let dir = String(raw)
+                guard dir.hasPrefix("/") else { return nil }
+                var isDir: ObjCBool = false
+                guard FileManager.default.fileExists(atPath: dir, isDirectory: &isDir),
+                      isDir.boolValue else { return nil }
+                return dir
+            }
     }
 
     /// Scan the running process's `PATH`, augmented with well-known CLI

--- a/AlasTests/AgentDetectorTests.swift
+++ b/AlasTests/AgentDetectorTests.swift
@@ -39,6 +39,22 @@ struct AgentDetectorTests {
         #expect(installed.isEmpty)
     }
 
+    @Test func searchDirectoriesIgnoreRelativeCurrentAndEmptyPathEntries() throws {
+        let absolute = try tmpDir()
+        let homeRelativeName = "alas-det-home-path-\(UUID().uuidString)"
+        let homeRelative = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(homeRelativeName)
+        defer { try? FileManager.default.removeItem(at: absolute) }
+        defer { try? FileManager.default.removeItem(at: homeRelative) }
+        try FileManager.default.createDirectory(at: homeRelative, withIntermediateDirectories: true)
+
+        let dirs = AgentDetector.executableSearchDirectories(
+            path: ":\(absolute.path):relative-bin:.:~/\(homeRelativeName):/missing/path:"
+        )
+
+        #expect(dirs == [absolute.path])
+    }
+
     @Test func binaryOverrideHonoured() async throws {
         let dir = try tmpDir()
         defer { try? FileManager.default.removeItem(at: dir) }


### PR DESCRIPTION
## Summary

- adapt the ACP provider auto-discovery plan to the current Swift agent detector
- ignore empty, relative, current-directory, and missing PATH entries when scanning agent binaries
- add regression coverage for the safe discovery directory filter

## Validation

- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AgentDetectorTests test`\n- `rtk xcodegen`\n- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`