### PR TITLE
fix(acp): dedupe agent discovery path entries

### DIFF
--- a/Alas/Sources/Agents/AgentDetector.swift
+++ b/Alas/Sources/Agents/AgentDetector.swift
@@ -37,16 +37,17 @@ enum AgentDetector {
     }
 
     static func executableSearchDirectories(path: String) -> [String] {
-        path
-            .split(separator: ":", omittingEmptySubsequences: true)
-            .compactMap { raw in
-                let dir = String(raw)
-                guard dir.hasPrefix("/") else { return nil }
-                var isDir: ObjCBool = false
-                guard FileManager.default.fileExists(atPath: dir, isDirectory: &isDir),
-                      isDir.boolValue else { return nil }
-                return dir
-            }
+        var seen: Set<String> = []
+        var dirs: [String] = []
+        for raw in path.split(separator: ":", omittingEmptySubsequences: true) {
+            let dir = String(raw)
+            guard dir.hasPrefix("/"), seen.insert(dir).inserted else { continue }
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: dir, isDirectory: &isDir),
+                  isDir.boolValue else { continue }
+            dirs.append(dir)
+        }
+        return dirs
     }
 
     /// Scan the running process's `PATH`, augmented with well-known CLI

--- a/AlasTests/AgentDetectorTests.swift
+++ b/AlasTests/AgentDetectorTests.swift
@@ -55,6 +55,19 @@ struct AgentDetectorTests {
         #expect(dirs == [absolute.path])
     }
 
+    @Test func searchDirectoriesDeduplicateAbsolutePathEntries() throws {
+        let first = try tmpDir()
+        let second = try tmpDir()
+        defer { try? FileManager.default.removeItem(at: first) }
+        defer { try? FileManager.default.removeItem(at: second) }
+
+        let dirs = AgentDetector.executableSearchDirectories(
+            path: "\(first.path):\(second.path):\(first.path):\(second.path)"
+        )
+
+        #expect(dirs == [first.path, second.path])
+    }
+
     @Test func binaryOverrideHonoured() async throws {
         let dir = try tmpDir()
         defer { try? FileManager.default.removeItem(at: dir) }


### PR DESCRIPTION
## Summary

- continue the ACP provider auto-discovery plan in the current Swift detector
- dedupe absolute PATH directories before probing agent binaries
- add regression coverage that preserves first-seen PATH order

## Validation

- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AgentDetectorTests test`\n- `rtk xcodegen`\n- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`\n- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`