### PR TITLE
Fix merge conflict gutter alignment

### DIFF
--- a/Alas/Sources/Center/Merge/MergeActionGutter.swift
+++ b/Alas/Sources/Center/Merge/MergeActionGutter.swift
@@ -128,14 +128,14 @@ struct MergeActionGutter: NSViewRepresentable {
                 return (
                     leftStart: range.localRows.lowerBound,
                     leftEnd: range.localRows.upperBound,
-                    rightStart: range.resultRows.lowerBound,
-                    rightEnd: range.resultRows.upperBound,
+                    rightStart: range.resultLocalRows.lowerBound,
+                    rightEnd: range.resultLocalRows.upperBound,
                     sourceStart: range.localRows.lowerBound
                 )
             case .resultToRemote:
                 return (
-                    leftStart: range.resultRows.lowerBound,
-                    leftEnd: range.resultRows.upperBound,
+                    leftStart: range.resultRemoteRows.lowerBound,
+                    leftEnd: range.resultRemoteRows.upperBound,
                     rightStart: range.remoteRows.lowerBound,
                     rightEnd: range.remoteRows.upperBound,
                     sourceStart: range.remoteRows.lowerBound

--- a/Alas/Sources/Center/Merge/MergeRegionVisualLayout.swift
+++ b/Alas/Sources/Center/Merge/MergeRegionVisualLayout.swift
@@ -22,6 +22,8 @@ enum MergeRegionVisualLayout {
         let localRows: Range<Int>
         let baseRows: Range<Int>
         let resultRows: Range<Int>
+        let resultLocalRows: Range<Int>
+        let resultRemoteRows: Range<Int>
         let remoteRows: Range<Int>
     }
 
@@ -95,6 +97,8 @@ enum MergeRegionVisualLayout {
                     localRows: localStart ..< (localStart + localCount),
                     baseRows: (resultStart + localCount) ..< (resultStart + localCount + baseCount),
                     resultRows: resultStart ..< (resultStart + localCount + baseCount + remoteCount),
+                    resultLocalRows: resultStart ..< (resultStart + localCount),
+                    resultRemoteRows: (resultStart + localCount + baseCount) ..< (resultStart + localCount + baseCount + remoteCount),
                     remoteRows: (remoteStart + localCount + baseCount) ..< (remoteStart + localCount + baseCount + remoteCount)
                 ))
                 ordinal += 1

--- a/AlasTests/MergeRegionVisualLayoutTests.swift
+++ b/AlasTests/MergeRegionVisualLayoutTests.swift
@@ -61,6 +61,8 @@ struct MergeRegionVisualLayoutTests {
         #expect(layout.conflictRanges.count == 1)
         let r = layout.conflictRanges[0]
         #expect(r.resultRows == 1 ..< 4)
+        #expect(r.resultLocalRows == 1 ..< 3)
+        #expect(r.resultRemoteRows == 3 ..< 4)
         #expect(r.localRows == 1 ..< 3)
         #expect(r.remoteRows == 3 ..< 4)
     }
@@ -147,6 +149,8 @@ struct MergeRegionVisualLayoutTests {
         // conflictRange.baseRows covers the BASE portion in RESULT.
         let r = try #require(layout.conflictRanges.first)
         #expect(r.baseRows == 2 ..< 4)
+        #expect(r.resultLocalRows == 1 ..< 2)
+        #expect(r.resultRemoteRows == 4 ..< 5)
         #expect(r.localRows == 1 ..< 2)
         #expect(r.remoteRows == 4 ..< 5)
         #expect(r.resultRows == 1 ..< 5)


### PR DESCRIPTION
## Summary
- Split merge conflict RESULT ranges into LOCAL and REMOTE segments.
- Connect each action gutter to the matching RESULT segment instead of the full conflict block.
- Add regression coverage for normal and BASE-visible conflict layouts.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`