### PR TITLE
fix merge conflict scroll gutters

### DIFF
--- a/Alas/Sources/Center/Merge/MergeActionGutter.swift
+++ b/Alas/Sources/Center/Merge/MergeActionGutter.swift
@@ -2,12 +2,8 @@ import AppKit
 import SwiftUI
 
 /// Narrow vertical strip between LOCAL ↔ RESULT or RESULT ↔ REMOTE.
-/// Two responsibilities:
-/// 1. Draws a diagonal quadrilateral per conflict block, connecting
-///    the hunk's row range in the side pane to the corresponding row
-///    range inside RESULT.
-/// 2. Hosts the accept (`»`/`«`) and reject (`×`) glyphs aligned with
-///    each hunk's first visible row, positioned above the diagonal.
+/// Draws a small rounded rail per conflict block and hosts accept /
+/// reject controls aligned to the same row coordinates.
 ///
 /// Layout positions are driven by `MergeScrollCoordinator` and the
 /// per-pane row mappings published by `MergeRegionVisualLayout`. The
@@ -58,24 +54,26 @@ struct MergeActionGutter: NSViewRepresentable {
             super.draw(dirtyRect)
             guard let coordinator else { return }
             let rowHeight = coordinator.rowHeight
-            let scrollOffset = CGFloat(coordinator.logicalRow) * rowHeight
-            let fill: NSColor = side == .localToResult
+            let scrollOffset = coordinator.scrollY
+            let fill = side == .localToResult
                 ? NSColor.systemGreen.withAlphaComponent(0.22)
                 : NSColor.systemBlue.withAlphaComponent(0.22)
+            let stroke = side == .localToResult
+                ? NSColor.systemGreen.withAlphaComponent(0.58)
+                : NSColor.systemBlue.withAlphaComponent(0.58)
             for range in conflictRanges {
                 let pts = endpoints(for: range)
-                let leftTop = CGFloat(pts.leftStart) * rowHeight - scrollOffset
-                let leftBottom = CGFloat(pts.leftEnd) * rowHeight - scrollOffset
-                let rightTop = CGFloat(pts.rightStart) * rowHeight - scrollOffset
-                let rightBottom = CGFloat(pts.rightEnd) * rowHeight - scrollOffset
-                let path = NSBezierPath()
-                path.move(to: NSPoint(x: 0, y: leftTop))
-                path.line(to: NSPoint(x: bounds.width, y: rightTop))
-                path.line(to: NSPoint(x: bounds.width, y: rightBottom))
-                path.line(to: NSPoint(x: 0, y: leftBottom))
-                path.close()
+                let top = min(CGFloat(pts.leftStart), CGFloat(pts.rightStart)) * rowHeight + coordinator.contentTopInset - scrollOffset
+                let bottom = max(CGFloat(pts.leftEnd), CGFloat(pts.rightEnd)) * rowHeight + coordinator.contentTopInset - scrollOffset
+                let railHeight = max(rowHeight, bottom - top)
+                let railX = side == .localToResult ? bounds.width - 10 : 4
+                let rect = NSRect(x: railX, y: top, width: 6, height: railHeight)
+                let path = NSBezierPath(roundedRect: rect, xRadius: 3, yRadius: 3)
                 fill.setFill()
                 path.fill()
+                stroke.setStroke()
+                path.lineWidth = 1
+                path.stroke()
             }
         }
 
@@ -84,10 +82,10 @@ struct MergeActionGutter: NSViewRepresentable {
             subviews.forEach { $0.removeFromSuperview() }
             guard let coordinator else { return }
             let rowHeight = coordinator.rowHeight
-            let scrollOffset = CGFloat(coordinator.logicalRow) * rowHeight
+            let scrollOffset = coordinator.scrollY
             for range in conflictRanges {
                 let pts = endpoints(for: range)
-                let y = CGFloat(pts.sourceStart) * rowHeight - scrollOffset
+                let y = CGFloat(pts.sourceStart) * rowHeight + coordinator.contentTopInset - scrollOffset
                 let accept = makeButton(
                     glyph: side == .localToResult ? "chevron.right.2" : "chevron.left.2",
                     label: side == .localToResult
@@ -95,7 +93,7 @@ struct MergeActionGutter: NSViewRepresentable {
                         : "Accept REMOTE conflict \(range.conflictOrdinal + 1)",
                     accent: NSColor.systemBlue
                 ) { [weak self] in self?.onAccept?(range.conflictOrdinal) }
-                accept.frame = NSRect(x: 4, y: y, width: 16, height: rowHeight)
+                accept.frame = NSRect(x: 6, y: y, width: 16, height: rowHeight)
                 addSubview(accept)
                 let reject = makeButton(
                     glyph: "xmark",
@@ -104,20 +102,14 @@ struct MergeActionGutter: NSViewRepresentable {
                         : "Reject REMOTE conflict \(range.conflictOrdinal + 1)",
                     accent: NSColor.gray
                 ) { [weak self] in self?.onReject?(range.conflictOrdinal) }
-                reject.frame = NSRect(x: 4, y: y + rowHeight, width: 16, height: rowHeight)
+                reject.frame = NSRect(x: 6, y: y + rowHeight, width: 16, height: rowHeight)
                 addSubview(reject)
             }
         }
 
         /// Left-edge and right-edge row ranges (half-open) for the
-        /// diagonal quad. "Left" is the column nearer x=0 in the
-        /// gutter, "right" is nearer x=bounds.width. For
-        /// `.localToResult` that means LOCAL on the left and RESULT
-        /// on the right; for `.resultToRemote` it's RESULT on the
-        /// left and REMOTE on the right. Returning left/right
-        /// directly avoids the naming inversion that would happen if
-        /// we returned (source, result) because RESULT plays "source"
-        /// in one branch and "destination" in the other.
+        /// visual hunk rail. "Left" is the column nearer x=0 in the
+        /// gutter, "right" is nearer x=bounds.width.
         private func endpoints(for range: MergeRegionVisualLayout.VisualConflictRange) -> (
             leftStart: Int, leftEnd: Int,
             rightStart: Int, rightEnd: Int,

--- a/Alas/Sources/Center/Merge/MergeResultPane.swift
+++ b/Alas/Sources/Center/Merge/MergeResultPane.swift
@@ -111,6 +111,7 @@ struct MergeResultPane: NSViewRepresentable {
         }
         textView.backgroundColor = NSColor(theme.color("bg-1"))
         coordinator.rowHeight = lineHeight()
+        coordinator.contentTopInset = textView.textContainerInset.height
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -147,9 +148,8 @@ struct MergeResultPane: NSViewRepresentable {
                 coord.applyPaneY(y, source: .result)
             }
             MainActor.assumeIsolated {
-                coord.onSyncResult = { @MainActor [weak coord, weak scroll] row in
-                    guard let scroll, let coord else { return }
-                    let y = CGFloat(row) * coord.rowHeight
+                coord.onSyncResult = { @MainActor [weak scroll] y in
+                    guard let scroll else { return }
                     scroll.contentView.scroll(to: NSPoint(x: 0, y: y))
                     scroll.reflectScrolledClipView(scroll.contentView)
                 }

--- a/Alas/Sources/Center/Merge/MergeScrollCoordinator.swift
+++ b/Alas/Sources/Center/Merge/MergeScrollCoordinator.swift
@@ -2,12 +2,8 @@ import Foundation
 import Observation
 
 /// Single source of truth for synchronized scrolling across the three
-/// merge panes. Holds a logical row index that all three panes derive
-/// their actual scroll Y from. When one pane scrolls (user touched its
-/// trackpad), it pushes the new Y; the coordinator converts to a
-/// logical row and broadcasts the corresponding Y to the others. A
-/// reentry counter prevents the broadcast from being re-interpreted as
-/// a fresh scroll and causing a feedback loop.
+/// merge panes. Holds the exact pixel Y offset so trackpad scrolling
+/// remains smooth; row indexes are derived only for navigation.
 @MainActor
 @Observable
 final class MergeScrollCoordinator {
@@ -19,7 +15,9 @@ final class MergeScrollCoordinator {
     /// font at the same size, so a single number is enough. Set by the
     /// view once the font is known; defaults to 16pt.
     var rowHeight: CGFloat = 16
+    var contentTopInset: CGFloat = 6
 
+    private(set) var scrollY: CGFloat = 0
     private(set) var logicalRow: Int = 0
 
     /// Per-target scroll handlers. Each pane (LOCAL, RESULT, REMOTE)
@@ -27,20 +25,21 @@ final class MergeScrollCoordinator {
     /// each other — a single-slot closure would have meant whichever
     /// pane registered last wins. `applyPaneY` dispatches to the
     /// handler for every target OTHER than the source of the scroll.
-    var onSyncLocal: ((Int) -> Void)?
-    var onSyncResult: ((Int) -> Void)?
-    var onSyncRemote: ((Int) -> Void)?
+    var onSyncLocal: ((CGFloat) -> Void)?
+    var onSyncResult: ((CGFloat) -> Void)?
+    var onSyncRemote: ((CGFloat) -> Void)?
 
     /// Programmatic setter. Doesn't broadcast — the caller is
     /// presumed to be initialization or a non-scroll trigger.
     func setLogicalRow(_ row: Int) {
         logicalRow = max(0, row)
+        scrollY = CGFloat(logicalRow) * rowHeight
     }
 
     /// Returns the Y offset (points) corresponding to the current
     /// logical row, suitable for an `NSClipView.scroll(to:)` call.
     func paneY() -> CGFloat {
-        CGFloat(logicalRow) * rowHeight
+        scrollY
     }
 
     /// Called by a pane's scroll observer when the user scrolls it.
@@ -53,14 +52,16 @@ final class MergeScrollCoordinator {
         // N+1 when y is near (N + 0.5) * rowHeight). floor matches the
         // conventional "the row at top of viewport is the logical row"
         // invariant.
-        let row = max(0, Int((y / max(rowHeight, 1)).rounded(.down)))
-        guard row != logicalRow else { return }
+        let nextY = max(0, y)
+        guard abs(nextY - scrollY) > 0.5 else { return }
+        scrollY = nextY
+        let row = max(0, Int((nextY / max(rowHeight, 1)).rounded(.down)))
         logicalRow = row
         for target in [Source.local, .result, .remote] where target != source {
             switch target {
-            case .local:  onSyncLocal?(row)
-            case .result: onSyncResult?(row)
-            case .remote: onSyncRemote?(row)
+            case .local:  onSyncLocal?(nextY)
+            case .result: onSyncResult?(nextY)
+            case .remote: onSyncRemote?(nextY)
             }
         }
     }

--- a/Alas/Sources/Center/Merge/MergeSidePane.swift
+++ b/Alas/Sources/Center/Merge/MergeSidePane.swift
@@ -77,6 +77,7 @@ struct MergeSidePane: NSViewRepresentable {
         context.coordinator.side = side
         context.coordinator.lastRowHeight = lineHeight()
         coordinator.rowHeight = lineHeight()
+        coordinator.contentTopInset = textView.textContainerInset.height
     }
 
     func makeCoordinator() -> Coordinator {
@@ -114,9 +115,8 @@ struct MergeSidePane: NSViewRepresentable {
             }
             let mySource: MergeScrollCoordinator.Source = (side == .local) ? .local : .remote
             MainActor.assumeIsolated {
-                let handler: @MainActor (Int) -> Void = { [weak coord, weak scroll] row in
-                    guard let scroll, let coord else { return }
-                    let y = CGFloat(row) * coord.rowHeight
+                let handler: @MainActor (CGFloat) -> Void = { [weak scroll] y in
+                    guard let scroll else { return }
                     scroll.contentView.scroll(to: NSPoint(x: 0, y: y))
                     scroll.reflectScrolledClipView(scroll.contentView)
                 }

--- a/Alas/Sources/Center/Merge/MergeView3Way.swift
+++ b/Alas/Sources/Center/Merge/MergeView3Way.swift
@@ -141,9 +141,10 @@ struct MergeView3Way: View {
         guard ordinal < layout.conflictRanges.count else { return }
         let row = layout.conflictRanges[ordinal].resultRows.lowerBound
         coordinator.setLogicalRow(row)
-        coordinator.onSyncLocal?(row)
-        coordinator.onSyncResult?(row)
-        coordinator.onSyncRemote?(row)
+        let y = coordinator.paneY()
+        coordinator.onSyncLocal?(y)
+        coordinator.onSyncResult?(y)
+        coordinator.onSyncRemote?(y)
     }
 
     private func acceptLocal(at ordinal: Int) {
@@ -175,6 +176,7 @@ struct MergeView3Way: View {
                         .padding(.horizontal, 4)
                 }
             }
+            .padding(.top, coordinator.contentTopInset)
             .offset(y: -coordinator.paneY())
             Spacer(minLength: 0)
         }

--- a/AlasTests/MergeScrollCoordinatorTests.swift
+++ b/AlasTests/MergeScrollCoordinatorTests.swift
@@ -7,6 +7,7 @@ struct MergeScrollCoordinatorTests {
     @Test func defaultsToRowZero() {
         let coord = MergeScrollCoordinator()
         #expect(coord.logicalRow == 0)
+        #expect(coord.scrollY == 0)
     }
 
     @Test func paneYToLogicalRowRoundTrip() {
@@ -16,22 +17,48 @@ struct MergeScrollCoordinatorTests {
         #expect(coord.paneY() == 112)
         coord.applyPaneY(48, source: .local)
         #expect(coord.logicalRow == 3)
+        #expect(coord.scrollY == 48)
+    }
+
+    @Test func pixelScrollOffsetIsPreserved() {
+        let coord = MergeScrollCoordinator()
+        coord.rowHeight = 16
+        var resultObserved: [CGFloat] = []
+        coord.onSyncResult = { resultObserved.append($0) }
+
+        coord.applyPaneY(48.5, source: .local)
+
+        #expect(coord.logicalRow == 3)
+        #expect(coord.scrollY == 48.5)
+        #expect(resultObserved == [48.5])
     }
 
     @Test func reentryGuardPreventsLoops() {
         let coord = MergeScrollCoordinator()
         coord.rowHeight = 16
-        var localObserved: [Int] = []
-        var resultObserved: [Int] = []
-        var remoteObserved: [Int] = []
+        var localObserved: [CGFloat] = []
+        var resultObserved: [CGFloat] = []
+        var remoteObserved: [CGFloat] = []
         coord.onSyncLocal = { localObserved.append($0) }
         coord.onSyncResult = { resultObserved.append($0) }
         coord.onSyncRemote = { remoteObserved.append($0) }
         // Source = .result → should broadcast to .local and .remote
         coord.applyPaneY(32, source: .result)
         #expect(coord.logicalRow == 2)
-        #expect(localObserved == [2])
-        #expect(remoteObserved == [2])
+        #expect(localObserved == [32])
+        #expect(remoteObserved == [32])
         #expect(resultObserved.isEmpty) // never bounced back to source
+    }
+
+    @Test func repeatedSamePixelOffsetDoesNotRebroadcast() {
+        let coord = MergeScrollCoordinator()
+        coord.rowHeight = 16
+        var resultObserved: [CGFloat] = []
+        coord.onSyncResult = { resultObserved.append($0) }
+
+        coord.applyPaneY(48.5, source: .local)
+        coord.applyPaneY(48.5, source: .local)
+
+        #expect(resultObserved == [48.5])
     }
 }


### PR DESCRIPTION
## Summary

- Preserve exact pixel scroll offsets across the three merge panes instead of rounding sync to whole rows.
- Align merge action gutter rails and controls with the text view top inset.
- Add merge scroll coordinator coverage for fractional offsets and duplicate scroll suppression.

## Validation

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/MergeScrollCoordinatorTests`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`