### PR TITLE
fix(right): size branch selector dropdown

### DIFF
--- a/Alas/Sources/Right/BaseBranchSelector.swift
+++ b/Alas/Sources/Right/BaseBranchSelector.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct BaseBranchSelector: View {
+    private static let branchRowHeight: CGFloat = 28
+    private static let maxVisibleBranchRows = 5
+
     @Binding var baseBranch: String
     let branches: [String]
     let isLoadingBranches: Bool
@@ -69,7 +72,7 @@ struct BaseBranchSelector: View {
                         }
                     }
                 }
-                .frame(maxHeight: 320)
+                .frame(height: Self.branchListHeight(optionCount: filteredBranches.count))
             }
         }
         .frame(width: 280)
@@ -93,7 +96,7 @@ struct BaseBranchSelector: View {
                 Spacer(minLength: 0)
             }
             .padding(.horizontal, 10)
-            .padding(.vertical, 6)
+            .frame(height: Self.branchRowHeight)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -103,6 +106,14 @@ struct BaseBranchSelector: View {
 extension BaseBranchSelector {
     static func shouldShowLoading(isLoading: Bool, hasLoaded: Bool) -> Bool {
         isLoading || !hasLoaded
+    }
+
+    static func visibleBranchRowCount(optionCount: Int) -> Int {
+        min(max(optionCount, 1), maxVisibleBranchRows)
+    }
+
+    static func branchListHeight(optionCount: Int) -> CGFloat {
+        CGFloat(visibleBranchRowCount(optionCount: optionCount)) * branchRowHeight
     }
 
     static func isSelected(row name: String, baseBranch: String, currentRef: String?) -> Bool {

--- a/AlasTests/BaseBranchSelectorTests.swift
+++ b/AlasTests/BaseBranchSelectorTests.swift
@@ -128,6 +128,20 @@ struct BaseBranchSelectorTests {
         #expect(!BaseBranchSelector.shouldShowLoading(isLoading: false, hasLoaded: true))
     }
 
+    @Test func branchListShowsUpToFiveRows() {
+        #expect(BaseBranchSelector.visibleBranchRowCount(optionCount: 1) == 1)
+        #expect(BaseBranchSelector.visibleBranchRowCount(optionCount: 4) == 4)
+        #expect(BaseBranchSelector.visibleBranchRowCount(optionCount: 5) == 5)
+        #expect(BaseBranchSelector.visibleBranchRowCount(optionCount: 8) == 5)
+    }
+
+    @Test func branchListHeightMatchesVisibleRows() {
+        let oneRow = BaseBranchSelector.branchListHeight(optionCount: 1)
+        #expect(BaseBranchSelector.branchListHeight(optionCount: 4) == oneRow * 4)
+        #expect(BaseBranchSelector.branchListHeight(optionCount: 5) == oneRow * 5)
+        #expect(BaseBranchSelector.branchListHeight(optionCount: 12) == oneRow * 5)
+    }
+
     @Test func smartListIncludesCurrentRefWhenAbsentFromShortlist() {
         let result = BaseBranchSelector.smartList(
             branches: ["main", "origin/main"],


### PR DESCRIPTION
## Summary
- Size the Changes tab comparison branch selector to show up to five branch/ref options.
- Shrink the dropdown for shorter option lists while preserving scrolling for longer lists.
- Add regression coverage for the dropdown row-count and height calculations.

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination platform=macOS -quiet build
- Focused BaseBranchSelectorTests: 17 tests passed

Full xcodebuild test previously hit unrelated zmx timeouts in ACP/worktree launch tests.