### PR TITLE
fix(acp): reduce long session scaling work

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -93,6 +93,7 @@ final class ACPSession: ObservableObject, Identifiable {
     var remoteSessionId: String?
     @Published var queue: [QueuedPrompt] = []
     @Published var steerUndo: SteerUndoState?
+    private var toolCallIndices: [String: Int] = [:]
 
     struct SteerUndoState: Equatable {
         /// Unique per-snapshot id used by SwiftUI for view diffing — letting
@@ -166,6 +167,7 @@ final class ACPSession: ObservableObject, Identifiable {
 
     func recordUserPrompt(text: String, attachments: [ACPMessage.Attachment]) {
         transcript.messages.append(.user(id: UUID(), text: text, attachments: attachments))
+        didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
         if titleSource == .placeholder {
             let candidate = text
@@ -198,6 +200,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case .userMessageChunk(let block):
             // Agents rarely emit these; treat as informational.
             transcript.messages.append(.systemNotice(id: UUID(), text: text(of: block)))
+            didAppendTranscriptMessage()
             transcript.completedOutputBoundaryMessageIds.removeAll()
             return [transcript.messages.count - 1]
         case .agentThoughtChunk(let block):
@@ -218,6 +221,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 preview: Self.previewLine(full),
                 locations: payload.locations?.map(\.path) ?? [],
                 terminalIds: Self.extractTerminalIds(items))))
+            didAppendTranscriptMessage()
             transcript.completedOutputBoundaryMessageIds.removeAll()
             return [transcript.messages.count - 1]
         case .toolCallUpdate(let u):
@@ -251,6 +255,7 @@ final class ACPSession: ObservableObject, Identifiable {
                 return [i]
             } else {
                 transcript.messages.append(.plan(id: UUID(), items))
+                didAppendTranscriptMessage()
                 transcript.completedOutputBoundaryMessageIds.removeAll()
                 return [transcript.messages.count - 1]
             }
@@ -276,11 +281,18 @@ final class ACPSession: ObservableObject, Identifiable {
 
     func appendSystemNotice(_ text: String) {
         transcript.messages.append(.systemNotice(id: UUID(), text: text))
+        didAppendTranscriptMessage()
     }
 
     func appendFileEdit(_ edit: ACPMessage.FileEdit) {
         transcript.messages.append(.fileEdit(id: UUID(), edit))
+        didAppendTranscriptMessage()
         transcript.completedOutputBoundaryMessageIds.removeAll()
+    }
+
+    func replaceTranscriptMessages(_ messages: [ACPMessage]) {
+        transcript.messages = messages
+        rebuildToolCallIndices()
     }
 
     func markCompletedOutputBoundary() {
@@ -604,17 +616,50 @@ final class ACPSession: ObservableObject, Identifiable {
             }
         }
         transcript.messages.append(makeNew())
+        didAppendTranscriptMessage()
         return transcript.messages.count - 1
     }
     /// Returns the index of the matching tool call, or nil if no match.
     private func updateToolCall(id: String, _ mutate: (inout ACPMessage.ToolCall) -> Void) -> Int? {
+        if let i = toolCallIndices[id],
+           transcript.messages.indices.contains(i),
+           case .toolCall(var tc) = transcript.messages[i],
+           tc.toolCallId == id {
+            mutate(&tc)
+            transcript.messages[i] = .toolCall(tc)
+            return i
+        }
+
         for i in transcript.messages.indices {
             if case .toolCall(var tc) = transcript.messages[i], tc.toolCallId == id {
+                toolCallIndices[id] = i
                 mutate(&tc)
                 transcript.messages[i] = .toolCall(tc)
                 return i
             }
         }
         return nil
+    }
+
+    private func didAppendTranscriptMessage() {
+        let index = transcript.messages.count - 1
+        if case .toolCall(let tc) = transcript.messages[index] {
+            toolCallIndices[tc.toolCallId] = index
+        }
+        advanceRenderWindowIfFollowingTail()
+    }
+
+    private func rebuildToolCallIndices() {
+        toolCallIndices.removeAll(keepingCapacity: true)
+        for i in transcript.messages.indices {
+            if case .toolCall(let tc) = transcript.messages[i] {
+                toolCallIndices[tc.toolCallId] = i
+            }
+        }
+    }
+
+    private func advanceRenderWindowIfFollowingTail() {
+        guard followsTranscriptTail else { return }
+        transcript.setVisibleHead(max(0, transcript.messages.count - ACPTranscript.tailWindow))
     }
 }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -207,7 +207,7 @@ final class ACPSessionManager: ObservableObject {
     private func applyHydration(_ result: HydrationResult, to session: ACPSession) {
         // Convert wire variants into full ACPMessages (allocates StreamingText
         // for agent/thought) in one main-actor pass.
-        session.transcript.messages = result.wireMessages.map { $0.toMessage() }
+        session.replaceTranscriptMessages(result.wireMessages.map { $0.toMessage() })
         session.transcript.resetWindowToTail()
         session.restoreQueue(result.queue)
         // The composer is rendered (and focused) the moment the placeholder
@@ -510,14 +510,7 @@ final class ACPSessionManager: ObservableObject {
     /// was truncated to save memory. Returns nil if the row is gone or
     /// the payload can't be decoded.
     func reloadFullToolCallContent(sessionId: ACPSession.ID, toolCallId: String) -> String? {
-        guard let stored = try? store.loadMessages(sessionId: sessionId) else { return nil }
-        for row in stored where row.kind == "tool_call" {
-            if let tc = try? JSONDecoder().decode(ACPMessage.ToolCall.self, from: row.payload),
-               tc.toolCallId == toolCallId {
-                return tc.content
-            }
-        }
-        return nil
+        try? store.loadToolCallContent(sessionId: sessionId, toolCallId: toolCallId)
     }
 }
 

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -52,6 +52,7 @@ final class ACPSessionRunner {
     private var activePromptID: Int?
     private var cancelledPromptIDs: Set<Int> = []
     private var appliedUpdateCount = 0
+    private var persistedMessageCount: Int
     private var pendingCompletedOutputBoundaryUpdateCount: Int?
     private var suppressingLoadReplay: Bool
     private var loadReplaySuppressionTarget: Int?
@@ -79,13 +80,12 @@ final class ACPSessionRunner {
         self.suppressingLoadReplay = suppressingLoadReplay
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
+        self.persistedMessageCount = (try? store.messageCount(sessionId: sessionId)) ?? 0
         self.policy = ACPPermissionPolicy(
             session: session,
             log: ACPPermissionDecisionLog(store: store)
         )
-        if let stored = try? store.loadMessages(sessionId: sessionId) {
-            self.seq = Int64(stored.count)
-        }
+        self.seq = Int64(persistedMessageCount)
     }
 
     func start() {
@@ -1051,17 +1051,21 @@ extension ACPSessionRunner {
         guard !indices.isEmpty else { return }
         let messages = session.transcript.messages
         let now = Int64(Date().timeIntervalSince1970)
-        let existingCount = (try? store.loadMessages(sessionId: sessionId).count) ?? 0
         for i in indices.sorted() {
             guard i >= 0, i < messages.count else { continue }
             let m = messages[i]
             guard let payload = try? ACPMessageCodec.encode(m) else { continue }
             let id = "msg-\(sessionId)-\(i)"
-            if i < existingCount {
+            if i < persistedMessageCount {
                 try? store.updateMessagePayload(id: id, payload: payload)
             } else {
-                try? store.appendMessage(sessionId: sessionId, id: id, kind: m.kind,
-                                         seq: Int64(i), payload: payload, createdAt: now)
+                do {
+                    try store.appendMessage(sessionId: sessionId, id: id, kind: m.kind,
+                                            seq: Int64(i), payload: payload, createdAt: now)
+                    persistedMessageCount = max(persistedMessageCount, i + 1)
+                } catch {
+                    continue
+                }
             }
         }
     }
@@ -1094,16 +1098,20 @@ extension ACPSessionRunner {
         }
 
         let now = Int64(Date().timeIntervalSince1970)
-        let existingCount = (try? store.loadMessages(sessionId: sessionId).count) ?? 0
         for i in lowerBound..<messages.count {
             let m = messages[i]
             guard let payload = try? ACPMessageCodec.encode(m) else { continue }
             let id = "msg-\(sessionId)-\(i)"
-            if i < existingCount {
+            if i < persistedMessageCount {
                 try? store.updateMessagePayload(id: id, payload: payload)
             } else {
-                try? store.appendMessage(sessionId: sessionId, id: id, kind: m.kind,
-                                         seq: Int64(i), payload: payload, createdAt: now)
+                do {
+                    try store.appendMessage(sessionId: sessionId, id: id, kind: m.kind,
+                                            seq: Int64(i), payload: payload, createdAt: now)
+                    persistedMessageCount = max(persistedMessageCount, i + 1)
+                } catch {
+                    continue
+                }
             }
         }
     }

--- a/Alas/Sources/ACP/Session/ACPSessionStore.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionStore.swift
@@ -36,6 +36,7 @@ final class ACPSessionStore {
         } else if current < Self.targetSchemaVersion {
             try db.exec("UPDATE schema_version SET version = ?", bindings: [Int64(Self.targetSchemaVersion)])
         }
+        try db.exec("CREATE INDEX IF NOT EXISTS messages_session_kind_seq_idx ON messages(session_id, kind, seq)")
     }
 
     private func migrate_to_v1() throws {
@@ -247,6 +248,14 @@ extension ACPSessionStore {
         try db.exec("UPDATE messages SET payload = ? WHERE id = ?", bindings: [payload, id])
     }
 
+    func messageCount(sessionId: String) throws -> Int {
+        let rows = try db.query("""
+        SELECT COUNT(*) AS count
+        FROM messages WHERE session_id = ?
+        """, bindings: [sessionId])
+        return Int((rows.first?["count"] as? Int64) ?? 0)
+    }
+
     func loadMessages(sessionId: String) throws -> [ACPStoredMessage] {
         let rows = try db.query("""
         SELECT id, session_id, kind, seq, payload, created_at
@@ -261,6 +270,23 @@ extension ACPSessionStore {
                 payload: (r["payload"] as? Data) ?? Data(),
                 createdAt: (r["created_at"] as? Int64) ?? 0)
         }
+    }
+
+    func loadToolCallContent(sessionId: String, toolCallId: String) throws -> String? {
+        let rows = try db.query("""
+        SELECT payload FROM messages
+        WHERE session_id = ? AND kind = 'tool_call'
+        ORDER BY seq ASC
+        """, bindings: [sessionId])
+        let decoder = JSONDecoder()
+        for row in rows {
+            guard let payload = row["payload"] as? Data,
+                  let tc = try? decoder.decode(ACPMessage.ToolCall.self, from: payload),
+                  tc.toolCallId == toolCallId
+            else { continue }
+            return tc.content
+        }
+        return nil
     }
 
     private static func rowToSession(_ r: [String: Any?]) -> ACPSessionRow {

--- a/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionStoreCRUDTests.swift
@@ -166,6 +166,27 @@ struct ACPSessionStoreCRUDTests {
         #expect(loaded[0].payload == m1)
     }
 
+    @Test("message count uses a narrow aggregate query")
+    func messageCount() throws {
+        let store = try tmp()
+        try store.upsertSession(.init(id: "s", agentId: "claude", title: "t",
+            titleSource: .placeholder,
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        try store.upsertSession(.init(id: "other", agentId: "claude", title: "t",
+            titleSource: .placeholder,
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        try store.appendMessage(sessionId: "s", id: "m1", kind: "user", seq: 0, payload: Data("one".utf8), createdAt: 1)
+        try store.appendMessage(sessionId: "s", id: "m2", kind: "agent", seq: 1, payload: Data("two".utf8), createdAt: 2)
+        try store.appendMessage(sessionId: "other", id: "m3", kind: "agent", seq: 0, payload: Data("three".utf8), createdAt: 3)
+
+        #expect(try store.messageCount(sessionId: "s") == 2)
+        #expect(try store.messageCount(sessionId: "other") == 1)
+        #expect(try store.messageCount(sessionId: "missing") == 0)
+    }
+
     @Test("composer draft upsert load and delete round-trips")
     func composerDraftCRUD() throws {
         let url = tmpURL()

--- a/AlasTests/ACP/Session/ACPSessionTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionTests.swift
@@ -127,6 +127,29 @@ struct ACPSessionTests {
         #expect(!session.followsTranscriptTail)
     }
 
+    @Test("live transcript advances render window while following tail")
+    func liveTranscriptAdvancesRenderWindow() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+
+        for i in 0..<50 {
+            session.appendSystemNotice("notice \(i)")
+        }
+
+        #expect(session.transcript.visibleHead == 20)
+    }
+
+    @Test("live transcript does not advance render window when user is reading history")
+    func liveTranscriptKeepsWindowWhenNotFollowingTail() async {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "w", title: "t")
+        session.followsTranscriptTail = false
+
+        for i in 0..<50 {
+            session.appendSystemNotice("notice \(i)")
+        }
+
+        #expect(session.transcript.visibleHead == 0)
+    }
+
     @Test("empty transcript has no conversation transcript")
     func emptyTranscriptHasNoConversationTranscript() async {
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "w", title: "t")


### PR DESCRIPTION
## Summary

This reduces ACP long-session scaling work in the hot update path.

- Avoids reloading and materializing every persisted message just to decide whether an ACP update should append or update a row.
- Tracks persisted message count in the runner and adds a narrow SQLite count helper.
- Adds a tool-call id to message-index map so tool-call updates do not scan the whole transcript every time.
- Advances the live render window while the transcript is following the tail, so long sessions do not keep every historical row rendered until a reopen.
- Adds regression coverage for cheap message counting and live tail-window advancement.

## Validation

- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused ACP tests for session, store, runner, hydration, attach/restore, and tool-call truncation

Full `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` currently fails in unrelated `BaseBranchSelectorTests.branchListHeightMatchesVisibleRows` exact `CGFloat` equality assertions; the ACP-focused suites pass.