### PR TITLE
fix(sidebar): persist project expansion state

### DIFF
--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -8,7 +8,6 @@ struct RootView: View {
     @State private var removingProject: ProjectConfig?
     @State private var showNewWorktree = false
     @State private var newWorktreePresetProjectId: String?
-    @State private var collapsedProjects: Set<String> = []
     @Environment(\.openWindow) private var openWindow
 
     var body: some View {
@@ -36,7 +35,13 @@ struct RootView: View {
                         sidebar: {
                             SidebarView(
                                 state: state,
-                                collapsedProjects: $collapsedProjects,
+                                collapsedProjects: Binding(
+                                    get: { Set(state.config.collapsedProjectIds) },
+                                    set: { collapsedProjects in
+                                        state.config.collapsedProjectIds = collapsedProjects.sorted()
+                                        state.saveConfig()
+                                    }
+                                ),
                                 onSettings: { openSettingsWindow() },
                                 onAddProject: { showNewProject = true },
                                 onEditProject: { projectId in

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -34,6 +34,7 @@ struct AppConfig: Codable, Equatable {
     var recentProjectIds: [String] = []
     var recentWorktreeIdsByProject: [String: [String]] = [:]
     var recentWorktreeRefs: [RepoSelectorRecents.RecentWorktreeRef] = []
+    var collapsedProjectIds: [String] = []
     var sidebarChromeOverrides: [String: SidebarChromeOverride] = [:]
     var shortcutOverrides: [String: ShortcutBinding?] = [:]
 
@@ -364,6 +365,7 @@ struct AppConfig: Codable, Equatable {
         recentProjectIds: [],
         recentWorktreeIdsByProject: [:],
         recentWorktreeRefs: [],
+        collapsedProjectIds: [],
         sidebarChromeOverrides: SidebarChromeOverride.bundledDefaults,
         shortcutOverrides: [:]
     )
@@ -434,6 +436,7 @@ extension AppConfig {
              agents,
              files,
              recentProjectIds, recentWorktreeIdsByProject, recentWorktreeRefs,
+             collapsedProjectIds,
              sidebarChromeOverrides,
              shortcutOverrides
     }
@@ -605,6 +608,8 @@ extension AppConfig {
             (try? c.decode([String: [String]].self, forKey: .recentWorktreeIdsByProject)) ?? [:]
         recentWorktreeRefs =
             (try? c.decode([RepoSelectorRecents.RecentWorktreeRef].self, forKey: .recentWorktreeRefs)) ?? []
+        collapsedProjectIds =
+            (try? c.decode([String].self, forKey: .collapsedProjectIds)) ?? []
         sidebarChromeOverrides =
             (try? c.decode([String: SidebarChromeOverride].self, forKey: .sidebarChromeOverrides)) ?? [:]
         shortcutOverrides =

--- a/AlasTests/AppConfigTests.swift
+++ b/AlasTests/AppConfigTests.swift
@@ -23,6 +23,7 @@ struct AppConfigTests {
         #expect(cfg.rightPaneWidth == 320)
         #expect(cfg.rightPaneVisible == true)
         #expect(cfg.sidebarVisible == true)
+        #expect(cfg.collapsedProjectIds == [])
         #expect(cfg.terminal.shell == "/bin/zsh")
         #expect(cfg.harness.notifyOnFinish == true)
         #expect(cfg.harness.notifyOnAwaiting == true)
@@ -64,6 +65,17 @@ struct AppConfigTests {
         let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
         #expect(cfg.harness.notifyOnFinish == false)
         #expect(cfg.harness.notifyOnAwaiting == true)
+        #expect(cfg.collapsedProjectIds == [])
+    }
+
+    @Test func collapsedProjectIdsRoundTripIndependently() throws {
+        var cfg = AppConfig.defaults
+        cfg.collapsedProjectIds = ["project-b", "project-a"]
+
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.collapsedProjectIds == ["project-b", "project-a"])
     }
 
     @Test func decodeOldConfigPreservesPreviousSidebarMaterial() throws {


### PR DESCRIPTION
## Summary
- persist collapsed project IDs in AppConfig
- wire the left sidebar project expansion binding to saved config
- add config tests for defaults, old configs, and multi-project persistence

## Validation
- xcodegen
- git diff --check
- focused config tests attempted; full Xcode validation was blocked locally by disk pressure in DerivedData/SwiftPM caches