### PR TITLE
fix(settings): align row controls to right column

### DIFF
--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -80,27 +80,14 @@ struct AgentsPane: View {
                 }
 
                 SettingsGroup(title: "Harness") {
-                    HStack(alignment: .top, spacing: 16) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Terminal / Harness")
-                                .font(.system(size: 12.5, weight: .medium))
-                                .foregroundColor(theme.color("fg"))
-                            Text("Configure harness notifications and install hooks.")
-                                .font(.system(size: 11.5))
-                                .foregroundColor(theme.color("fg-dim"))
-                                .fixedSize(horizontal: false, vertical: true)
+                    SettingsRow(
+                        name: "Terminal / Harness",
+                        desc: "Configure harness notifications and install hooks."
+                    ) {
+                        AlasButton(title: "Open Terminal Settings", style: .subtle) {
+                            onNavigate(.terminal)
                         }
-                        .frame(width: 240, alignment: .leading)
-                        .padding(.top, 4)
-                        VStack(alignment: .leading, spacing: 6) {
-                            AlasButton(title: "Open Terminal Settings", style: .subtle) {
-                                onNavigate(.terminal)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    .padding(.vertical, 10)
-                    .overlay(Divider().opacity(0.5), alignment: .top)
                 }
             }
             .padding(.horizontal, 32).padding(.vertical, 24)

--- a/Alas/Sources/Settings/SettingsRow.swift
+++ b/Alas/Sources/Settings/SettingsRow.swift
@@ -1,5 +1,13 @@
 import SwiftUI
 
+enum SettingsRowLayout {
+    static let columnSpacing: CGFloat = 16
+
+    static func columnWidth(for rowWidth: CGFloat) -> CGFloat {
+        max(0, (rowWidth - columnSpacing) / 2)
+    }
+}
+
 struct SettingsRow<Control: View>: View {
     let name: String
     var desc: String? = nil
@@ -7,7 +15,7 @@ struct SettingsRow<Control: View>: View {
     @Environment(\.theme) var theme
 
     var body: some View {
-        HStack(alignment: .top, spacing: 16) {
+        HStack(alignment: .top, spacing: SettingsRowLayout.columnSpacing) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(name).font(.system(size: 12.5, weight: .medium))
                     .foregroundColor(theme.color("fg"))
@@ -17,13 +25,14 @@ struct SettingsRow<Control: View>: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .frame(width: 240, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.top, 4)
             VStack(alignment: .leading, spacing: 6) {
                 control()
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 10)
         .overlay(Divider().opacity(0.5), alignment: .top)
     }

--- a/AlasTests/SettingsSectionTests.swift
+++ b/AlasTests/SettingsSectionTests.swift
@@ -2,6 +2,16 @@ import Testing
 @testable import Alas
 
 struct SettingsSectionTests {
+    @Test func settingsRowColumnsSplitAvailableWidthEvenly() {
+        #expect(SettingsRowLayout.columnWidth(for: 616) == 300)
+        #expect(SettingsRowLayout.columnWidth(for: 680) == 332)
+    }
+
+    @Test func settingsRowColumnWidthDoesNotGoNegative() {
+        #expect(SettingsRowLayout.columnWidth(for: 0) == 0)
+        #expect(SettingsRowLayout.columnWidth(for: 8) == 0)
+    }
+
     @Test func sidebarSectionsDoNotIncludeStandaloneMarkdown() {
         let labels = SettingsSection.allCases.map(\.label)
 


### PR DESCRIPTION
## Summary
- split SettingsRow into equal label/control halves
- keep controls leading-aligned in the right half so dropdowns start at the expected edge
- reuse SettingsRow for the Agents pane row and cover column sizing with tests

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test