### PR TITLE
Handle ACP auth failures with terminal sign-in

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		40A21E55EB86B5F3D42AEFF2 /* InlineDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */; };
 		40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */; };
 		412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */; };
+		4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
@@ -364,6 +365,7 @@
 		6DDB5FC604A28D699350C3BD /* TabActivityIconTintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */; };
 		6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */; };
 		6E52521BCD52ED8DB496E74B /* CompletionDocumentationRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */; };
+		6E66AD13D1763D61F619F3D1 /* ACPAuthNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */; };
 		6E69D87B57B23223A48AB6F7 /* ProjectsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FFC9539E615699AC90A7412 /* ProjectsManager.swift */; };
 		6ED129AC9B6798F76F7D3A51 /* FileTypeIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */; };
 		6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */; };
@@ -1487,6 +1489,7 @@
 		CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallCard.swift; sourceTree = "<group>"; };
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
+		CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBanner.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstaller.swift; sourceTree = "<group>"; };
 		CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
@@ -1616,6 +1619,7 @@
 		F5C6A07D7C67D02C8638D8C1 /* LSPMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessages.swift; sourceTree = "<group>"; };
 		F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeBulkResolvePromptEditorWindow.swift; sourceTree = "<group>"; };
 		F6883364648BF4B9F5DA131F /* EditorOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOverlayPanel.swift; sourceTree = "<group>"; };
+		F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBannerTests.swift; sourceTree = "<group>"; };
 		F721FB733081A583D4053DDA /* FileTypeIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconView.swift; sourceTree = "<group>"; };
 		F787781F8DE2077B7B679C07 /* RepoSelectorRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRowView.swift; sourceTree = "<group>"; };
 		F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterPaneView.swift; sourceTree = "<group>"; };
@@ -2480,6 +2484,7 @@
 		8050E4DD79EA4EEE490BC1F1 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */,
 				D3EDEEB00185F9C717205540 /* ACPAutoRunToggle.swift */,
 				530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */,
 				C496549308D5C3DD20E988AD /* ACPComposer.swift */,
@@ -2867,6 +2872,7 @@
 				1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */,
 				A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */,
 				5EF6536F169B7C7B2C339B1C /* ACPAdapterVersionCheckerTests.swift */,
+				F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */,
 				B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */,
 				6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */,
 				C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */,
@@ -3375,6 +3381,7 @@
 				C245B74D0083CE00B6CD392C /* ACPAdapterVersionChecker.swift in Sources */,
 				4C31A14595F4AE906BFE67D2 /* ACPAgentProfiles.swift in Sources */,
 				FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */,
+				6E66AD13D1763D61F619F3D1 /* ACPAuthNudgeBanner.swift in Sources */,
 				56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */,
 				C00E549FA69AB3D3C55B85EB /* ACPChipState.swift in Sources */,
 				A70A62FDF7EA38F99D9E2B06 /* ACPClient.swift in Sources */,
@@ -3816,6 +3823,7 @@
 				CC531074F02A34E48A1E6133 /* ACPAgentProfilesTests.swift in Sources */,
 				B339F5B376407CFD88B0E7B8 /* ACPAttachmentMimeTypeTests.swift in Sources */,
 				D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */,
+				4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -726,6 +726,7 @@
 		D8741FB38F9FB2C180FE37E3 /* AppStateCreateWorktreeLaunchSurfaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8A5932B664C88F20BF00CA /* AppStateCreateWorktreeLaunchSurfaceTests.swift */; };
 		D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */; };
 		D8ACECF849D38029FB56C303 /* CenterTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0307CFD55404D01F14A5B602 /* CenterTypography.swift */; };
+		D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380D04E9EB0D0ED0C24702DA /* ACPAuthFailureTests.swift */; };
 		DA5ED6D708DD8C0B5563AB4F /* WindowDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */; };
 		DAA6F5DABE3214693628C730 /* ACPFilesystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D9E527A76820947F426A8 /* ACPFilesystem.swift */; };
 		DABD0B9B7817F4A080512501 /* FilesTabLoadingIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */; };
@@ -816,6 +817,7 @@
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
 		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
 		FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */; };
+		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
@@ -991,6 +993,7 @@
 		2CBAD18141C1A9B654F56982 /* FileTypeIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypeIconTests.swift; sourceTree = "<group>"; };
 		2CDC00065CA8839DA1AD0E0F /* TrafficLights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrafficLights.swift; sourceTree = "<group>"; };
 		2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanPillState.swift; sourceTree = "<group>"; };
+		2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailure.swift; sourceTree = "<group>"; };
 		2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnosticsTests.swift; sourceTree = "<group>"; };
 		2E669FEBE09BC250B477B335 /* ACPLaunchCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalog.swift; sourceTree = "<group>"; };
 		2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLifecycleTests.swift; sourceTree = "<group>"; };
@@ -1031,6 +1034,7 @@
 		379D90AD620EAF6E84A04902 /* ImageDiffSideBySideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffSideBySideView.swift; sourceTree = "<group>"; };
 		37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorEnvironment.swift; sourceTree = "<group>"; };
 		37F1D616B884AAAB57463CDD /* EditorLSPStatusResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusResolver.swift; sourceTree = "<group>"; };
+		380D04E9EB0D0ED0C24702DA /* ACPAuthFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailureTests.swift; sourceTree = "<group>"; };
 		38499AFE31188908546EE222 /* LSPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransport.swift; sourceTree = "<group>"; };
 		3855FBA3E4444960418639E9 /* FileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileIndexTests.swift; sourceTree = "<group>"; };
 		38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairKind.swift; sourceTree = "<group>"; };
@@ -2034,6 +2038,7 @@
 		28DACFA5F60339EEE14A135F /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				380D04E9EB0D0ED0C24702DA /* ACPAuthFailureTests.swift */,
 				9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */,
 				701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */,
 				4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */,
@@ -2299,6 +2304,7 @@
 		4DB62FEBC3C8536A56117C23 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */,
 				1EC659A56A08A30F7784428D /* ACPClient.swift */,
 				88C6356C759B509DD81EDEBB /* ACPConfigOption.swift */,
 				E4C4BEC7F392AF938F468B1F /* ACPConnection.swift */,
@@ -3368,6 +3374,7 @@
 				B140AFAD75EC181870BDC0D1 /* ACPAdapterUpdateStore.swift in Sources */,
 				C245B74D0083CE00B6CD392C /* ACPAdapterVersionChecker.swift in Sources */,
 				4C31A14595F4AE906BFE67D2 /* ACPAgentProfiles.swift in Sources */,
+				FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */,
 				56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */,
 				C00E549FA69AB3D3C55B85EB /* ACPChipState.swift in Sources */,
 				A70A62FDF7EA38F99D9E2B06 /* ACPClient.swift in Sources */,
@@ -3808,6 +3815,7 @@
 				481DEBE64E91C54A81185D09 /* ACPAdapterVersionCheckerTests.swift in Sources */,
 				CC531074F02A34E48A1E6133 /* ACPAgentProfilesTests.swift in Sources */,
 				B339F5B376407CFD88B0E7B8 /* ACPAttachmentMimeTypeTests.swift in Sources */,
+				D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,

--- a/Alas/Sources/ACP/Adapter/ACPAdapterInstaller.swift
+++ b/Alas/Sources/ACP/Adapter/ACPAdapterInstaller.swift
@@ -16,6 +16,13 @@ enum ACPInstallError: LocalizedError {
 }
 
 enum ACPProcessEnvironment {
+    // Strip env vars that mark this process as running inside another coding
+    // agent. Claude-aware tools refuse to start when these leak through.
+    static let agentSessionMarkerKeys: Set<String> = [
+        "CLAUDECODE", "CLAUDE_CODE", "CLAUDE_PROJECT_DIR",
+        "CLAUDE_CODE_ENTRYPOINT", "CLAUDE_SESSION_ID",
+    ]
+
     static func augmented(
         _ environment: [String: String] = ProcessInfo.processInfo.environment,
         additionalPathDirectories: [String] = AgentPath.wellKnownDirectories
@@ -24,6 +31,15 @@ enum ACPProcessEnvironment {
         env["PATH"] = AgentPath.augment(
             base: env["PATH"] ?? "",
             wellKnown: additionalPathDirectories)
+        return env
+    }
+
+    static func sanitizedForACP(extra: [String: String]) -> [String: String] {
+        var env = augmented()
+        for key in agentSessionMarkerKeys {
+            env.removeValue(forKey: key)
+        }
+        for (k, v) in extra { env[k] = v }
         return env
     }
 }

--- a/Alas/Sources/ACP/Protocol/ACPAuthFailure.swift
+++ b/Alas/Sources/ACP/Protocol/ACPAuthFailure.swift
@@ -12,7 +12,6 @@ enum ACPAuthFailure {
             "invalid authentication credentials",
             "not authenticated",
             "login required",
-            "unauthorized",
             "token expired",
             "expired token"
         ]

--- a/Alas/Sources/ACP/Protocol/ACPAuthFailure.swift
+++ b/Alas/Sources/ACP/Protocol/ACPAuthFailure.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+enum ACPAuthFailure {
+    static func message(from error: any Error) -> String? {
+        let message = normalizedMessage(from: error)
+        let lowercased = message.lowercased()
+        let markers = [
+            "auth_required",
+            "auth required",
+            "failed to authenticate",
+            "invalid authentication credentials",
+            "unauthorized",
+            "401"
+        ]
+        guard markers.contains(where: { lowercased.contains($0) }) else {
+            return nil
+        }
+        return message
+    }
+
+    private static func normalizedMessage(from error: any Error) -> String {
+        let message: String
+        switch error {
+        case let error as JSONRPCError:
+            message = error.message
+        case ACPClientError.jsonrpc(let error):
+            message = error.message
+        case let error as any LocalizedError:
+            message = error.errorDescription ?? error.localizedDescription
+        default:
+            message = error.localizedDescription
+        }
+
+        let prefix = "Internal error: "
+        if message.hasPrefix(prefix) {
+            return String(message.dropFirst(prefix.count))
+        }
+        return message
+    }
+}

--- a/Alas/Sources/ACP/Protocol/ACPAuthFailure.swift
+++ b/Alas/Sources/ACP/Protocol/ACPAuthFailure.swift
@@ -7,15 +7,34 @@ enum ACPAuthFailure {
         let markers = [
             "auth_required",
             "auth required",
+            "authentication required",
             "failed to authenticate",
             "invalid authentication credentials",
+            "not authenticated",
+            "login required",
             "unauthorized",
-            "401"
+            "token expired",
+            "expired token"
         ]
-        guard markers.contains(where: { lowercased.contains($0) }) else {
+        guard markers.contains(where: { lowercased.contains($0) })
+            || containsAuthStatus401(lowercased)
+        else {
             return nil
         }
         return message
+    }
+
+    private static func containsAuthStatus401(_ message: String) -> Bool {
+        guard message.contains("401") else { return false }
+        let statusMarkers = [
+            "http 401",
+            "status 401",
+            "401 unauthorized",
+            "401 unauthorised",
+            "401 auth",
+            "401 authentication"
+        ]
+        return statusMarkers.contains { message.contains($0) }
     }
 
     private static func normalizedMessage(from error: any Error) -> String {

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct ACPInitializeOutcome: Equatable {
+    let promptCapabilities: ACPInitializeResult.ACPPromptCapabilities
+    let authMethods: [ACPInitializeResult.ACPAuthMethod]
+}
+
 /// Higher-level wrapper that owns one `ACPClient` and exposes typed
 /// methods for the messages we send.
 final class ACPConnection: @unchecked Sendable {
@@ -10,7 +15,7 @@ final class ACPConnection: @unchecked Sendable {
     /// Returns the prompt capabilities advertised by the agent, defaulting
     /// missing capability fields to false.
     @discardableResult
-    func initialize() async throws -> ACPInitializeResult.ACPPromptCapabilities {
+    func initialize() async throws -> ACPInitializeOutcome {
         let req = ACPRequest(method: "initialize",
                              params: ACPInitializeParams(
                                 protocolVersion: ACPProtocolVersion.current,
@@ -18,8 +23,11 @@ final class ACPConnection: @unchecked Sendable {
                                     fs: .init(readTextFile: true, writeTextFile: true),
                                     terminal: true)))
         let resp = try await client.send(req)
-        let result = try? JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)
-        return result?.agentCapabilities?.promptCapabilities ?? .init()
+        let result = try JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)
+        return ACPInitializeOutcome(
+            promptCapabilities: result.agentCapabilities?.promptCapabilities ?? .init(),
+            authMethods: result.authMethods
+        )
     }
 
     func newSession(cwd: String) async throws -> ACPSessionNewResult {

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -37,6 +37,13 @@ final class ACPConnection: @unchecked Sendable {
         return try JSONDecoder().decode(ACPSessionNewResult.self, from: resp.body)
     }
 
+    func authenticate(methodId: String) async throws {
+        _ = try await client.send(ACPRequest(
+            method: "authenticate",
+            params: ACPAuthenticateParams(methodId: methodId)
+        ))
+    }
+
     func loadSession(cwd: String, sessionId: String) async throws -> ACPSessionNewResult {
         let req = ACPRequest(method: "session/load",
                              params: ACPSessionLoadParams(cwd: cwd, sessionId: sessionId, mcpServers: []))

--- a/Alas/Sources/ACP/Protocol/ACPConnection.swift
+++ b/Alas/Sources/ACP/Protocol/ACPConnection.swift
@@ -12,8 +12,8 @@ final class ACPConnection: @unchecked Sendable {
 
     init(client: ACPClient) { self.client = client }
 
-    /// Returns the prompt capabilities advertised by the agent, defaulting
-    /// missing capability fields to false.
+    /// Returns the initialize outcome advertised by the agent, defaulting
+    /// missing prompt capability fields to false and missing auth methods to empty.
     @discardableResult
     func initialize() async throws -> ACPInitializeOutcome {
         let req = ACPRequest(method: "initialize",

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -81,9 +81,9 @@ struct ACPClientCapabilities: Codable, Equatable {
         fs = try c.decode(ACPFsCapabilities.self, forKey: .fs)
         terminal = try c.decode(Bool.self, forKey: .terminal)
         auth = try c.decodeIfPresent(ACPAuthCapabilities.self, forKey: .auth)
-            ?? .init(terminal: true)
+            ?? .init(terminal: false)
         meta = try c.decodeIfPresent(ACPClientCapabilitiesMeta.self, forKey: .meta)
-            ?? .terminalAuth
+            ?? .init(terminalAuth: false)
     }
 
     struct ACPFsCapabilities: Codable, Equatable {
@@ -94,6 +94,15 @@ struct ACPClientCapabilities: Codable, Equatable {
 
 struct ACPAuthCapabilities: Codable, Equatable {
     let terminal: Bool
+
+    init(terminal: Bool) {
+        self.terminal = terminal
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        terminal = try c.decodeIfPresent(Bool.self, forKey: .terminal) ?? false
+    }
 }
 
 struct ACPClientCapabilitiesMeta: Codable, Equatable {
@@ -101,8 +110,17 @@ struct ACPClientCapabilitiesMeta: Codable, Equatable {
 
     let terminalAuth: Bool
 
+    init(terminalAuth: Bool) {
+        self.terminalAuth = terminalAuth
+    }
+
     enum CodingKeys: String, CodingKey {
         case terminalAuth = "terminal-auth"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        terminalAuth = try c.decodeIfPresent(Bool.self, forKey: .terminalAuth) ?? false
     }
 }
 
@@ -110,6 +128,27 @@ struct ACPInitializeResult: Codable, Equatable {
     let protocolVersion: Int
     let agentCapabilities: ACPAgentCapabilities?
     let authMethods: [ACPAuthMethod]
+
+    init(
+        protocolVersion: Int,
+        agentCapabilities: ACPAgentCapabilities?,
+        authMethods: [ACPAuthMethod]
+    ) {
+        self.protocolVersion = protocolVersion
+        self.agentCapabilities = agentCapabilities
+        self.authMethods = authMethods
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case protocolVersion, agentCapabilities, authMethods
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        protocolVersion = try c.decode(Int.self, forKey: .protocolVersion)
+        agentCapabilities = try c.decodeIfPresent(ACPAgentCapabilities.self, forKey: .agentCapabilities)
+        authMethods = try c.decodeIfPresent([ACPAuthMethod].self, forKey: .authMethods) ?? []
+    }
 
     struct ACPAgentCapabilities: Codable, Equatable {
         let promptCapabilities: ACPPromptCapabilities?

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -56,10 +56,53 @@ struct ACPClientCapabilities: Codable, Equatable {
     /// Agents must check `clientCapabilities.terminal` during initialize
     /// and only invoke `terminal/*` methods when it is true (ACP spec).
     let terminal: Bool
+    let auth: ACPAuthCapabilities
+    let meta: ACPClientCapabilitiesMeta
+
+    init(
+        fs: ACPFsCapabilities,
+        terminal: Bool,
+        auth: ACPAuthCapabilities = .init(terminal: true),
+        meta: ACPClientCapabilitiesMeta = .terminalAuth
+    ) {
+        self.fs = fs
+        self.terminal = terminal
+        self.auth = auth
+        self.meta = meta
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case fs, terminal, auth
+        case meta = "_meta"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        fs = try c.decode(ACPFsCapabilities.self, forKey: .fs)
+        terminal = try c.decode(Bool.self, forKey: .terminal)
+        auth = try c.decodeIfPresent(ACPAuthCapabilities.self, forKey: .auth)
+            ?? .init(terminal: true)
+        meta = try c.decodeIfPresent(ACPClientCapabilitiesMeta.self, forKey: .meta)
+            ?? .terminalAuth
+    }
 
     struct ACPFsCapabilities: Codable, Equatable {
         let readTextFile: Bool
         let writeTextFile: Bool
+    }
+}
+
+struct ACPAuthCapabilities: Codable, Equatable {
+    let terminal: Bool
+}
+
+struct ACPClientCapabilitiesMeta: Codable, Equatable {
+    static let terminalAuth = ACPClientCapabilitiesMeta(terminalAuth: true)
+
+    let terminalAuth: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case terminalAuth = "terminal-auth"
     }
 }
 
@@ -96,6 +139,112 @@ struct ACPInitializeResult: Codable, Equatable {
     struct ACPAuthMethod: Codable, Equatable {
         let id: String
         let name: String
+        let description: String?
+        let kind: Kind
+        let args: [String]?
+        let env: [String: String]?
+        let vars: [ACPAuthEnvVar]?
+        let meta: Meta?
+
+        var terminalAuth: TerminalAuthMeta? { meta?.terminalAuth }
+
+        init(
+            id: String,
+            name: String,
+            description: String? = nil,
+            kind: Kind = .agent,
+            args: [String]? = nil,
+            env: [String: String]? = nil,
+            vars: [ACPAuthEnvVar]? = nil,
+            meta: Meta? = nil
+        ) {
+            self.id = id
+            self.name = name
+            self.description = description
+            self.kind = kind
+            self.args = args
+            self.env = env
+            self.vars = vars
+            self.meta = meta
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id, name, description, args, env, vars
+            case kind = "type"
+            case meta = "_meta"
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            id = try c.decode(String.self, forKey: .id)
+            name = try c.decode(String.self, forKey: .name)
+            description = try c.decodeIfPresent(String.self, forKey: .description)
+            kind = try c.decodeIfPresent(Kind.self, forKey: .kind) ?? .agent
+            args = try c.decodeIfPresent([String].self, forKey: .args)
+            env = try c.decodeIfPresent([String: String].self, forKey: .env)
+            vars = try c.decodeIfPresent([ACPAuthEnvVar].self, forKey: .vars)
+            meta = try c.decodeIfPresent(Meta.self, forKey: .meta)
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(id, forKey: .id)
+            try c.encode(name, forKey: .name)
+            try c.encodeIfPresent(description, forKey: .description)
+            try c.encode(kind, forKey: .kind)
+            try c.encodeIfPresent(args, forKey: .args)
+            try c.encodeIfPresent(env, forKey: .env)
+            try c.encodeIfPresent(vars, forKey: .vars)
+            try c.encodeIfPresent(meta, forKey: .meta)
+        }
+
+        enum Kind: Codable, Equatable {
+            case agent
+            case terminal
+            case envVar
+            case unknown(String)
+
+            init(from decoder: Decoder) throws {
+                let c = try decoder.singleValueContainer()
+                switch try c.decode(String.self) {
+                case "agent": self = .agent
+                case "terminal": self = .terminal
+                case "env_var": self = .envVar
+                case let value: self = .unknown(value)
+                }
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var c = encoder.singleValueContainer()
+                switch self {
+                case .agent: try c.encode("agent")
+                case .terminal: try c.encode("terminal")
+                case .envVar: try c.encode("env_var")
+                case .unknown(let value): try c.encode(value)
+                }
+            }
+        }
+
+        struct Meta: Codable, Equatable {
+            let terminalAuth: TerminalAuthMeta?
+
+            enum CodingKeys: String, CodingKey {
+                case terminalAuth = "terminal-auth"
+            }
+        }
+
+        struct TerminalAuthMeta: Codable, Equatable {
+            let command: String?
+            let args: [String]?
+            let label: String?
+        }
+
+        struct ACPAuthEnvVar: Codable, Equatable {
+            let name: String
+            let label: String?
+            let optional: Bool?
+            let secret: Bool?
+        }
     }
 }
 

--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -124,6 +124,12 @@ struct ACPClientCapabilitiesMeta: Codable, Equatable {
     }
 }
 
+// MARK: - authenticate
+
+struct ACPAuthenticateParams: Codable, Equatable {
+    let methodId: String
+}
+
 struct ACPInitializeResult: Codable, Equatable {
     let protocolVersion: Int
     let agentCapabilities: ACPAgentCapabilities?

--- a/Alas/Sources/ACP/Protocol/ACPMockClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMockClient.swift
@@ -10,6 +10,7 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     private let terminalsCont: AsyncStream<ACPTerminalRequest>.Continuation
     private let updateCountLock = NSLock()
     private var _yieldedUpdateCount = 0
+    private(set) var shutdownCount = 0
 
     let incomingUpdates: AsyncStream<ACPSessionUpdateParams>
     var yieldedUpdateCount: Int {
@@ -87,6 +88,7 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     }
 
     func shutdown() async {
+        shutdownCount += 1
         updatesCont.finish()
         permsCont.finish()
         filesCont.finish()

--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -31,8 +31,8 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
             arguments: arguments,
             environment: environment,
             framing: .newline,
-            // ACPSessionManager.mergeEnv has already produced the full env
-            // with Claude-specific markers scrubbed. Tell the transport not
+            // ACPProcessEnvironment.sanitizedForACP has already produced the
+            // full env with Claude-specific markers scrubbed. Tell the transport not
             // to re-overlay against the parent process's env (which would
             // re-introduce CLAUDECODE).
             replaceEnv: true

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -70,6 +70,10 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Runtime-only: re-learned on each attach and used when an agent asks
     /// the client to authenticate before ACP can continue.
     @Published var authMethods: [ACPInitializeResult.ACPAuthMethod] = []
+    /// Runtime-only auth method selected by the user in the sign-in banner.
+    /// The next attach consumes it by calling ACP `authenticate` after
+    /// initialize and before session creation/loading.
+    var pendingAuthMethodId: String?
 
     var imageInputSupported: Bool { promptCapabilities.image }
     var embeddedContextSupported: Bool { promptCapabilities.embeddedContext }

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -66,6 +66,10 @@ final class ACPSession: ObservableObject, Identifiable {
     /// Runtime-only: re-learned on each attach, never persisted. Drives
     /// send-time hydration in `ACPSessionRunner.hydrate`.
     @Published var promptCapabilities: ACPInitializeResult.ACPPromptCapabilities = .init()
+    /// Auth methods learned from ACP `initialize`.
+    /// Runtime-only: re-learned on each attach and used when an agent asks
+    /// the client to authenticate before ACP can continue.
+    @Published var authMethods: [ACPInitializeResult.ACPAuthMethod] = []
 
     var imageInputSupported: Bool { promptCapabilities.image }
     var embeddedContextSupported: Bool { promptCapabilities.embeddedContext }
@@ -138,6 +142,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case checking
         case ready
         case needsSetup(reason: String)
+        case needsAuth(methods: [ACPInitializeResult.ACPAuthMethod], reason: String?)
     }
     struct PendingPermission: Identifiable, Equatable {
         let id: JSONRPCID

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -65,12 +65,12 @@ final class ACPSessionManager: ObservableObject {
                 client = try ACPStdioClient(
                     executable: URL(fileURLWithPath: spec.command),
                     arguments: spec.arguments,
-                    environment: Self.mergeEnv(extra: spec.extraEnv))
+                    environment: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv))
             } else {
                 client = try ACPStdioClient(
                     executable: URL(fileURLWithPath: "/usr/bin/env"),
                     arguments: [spec.command] + spec.arguments,
-                    environment: Self.mergeEnv(extra: spec.extraEnv))
+                    environment: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv))
             }
             try client.start()
             return ACPConnection(client: client)
@@ -588,7 +588,7 @@ extension ACPSessionManager {
             let runner = ACPSessionRunner(session: session, connection: connection,
                                           store: store, sessionId: sessionId,
                                           worktreePath: worktreePath,
-                                          agentEnv: Self.mergeEnv(extra: spec.extraEnv),
+                                          agentEnv: ACPProcessEnvironment.sanitizedForACP(extra: spec.extraEnv),
                                           suppressingLoadReplay: shouldSuppressLoadReplay,
                                           onDirtyCheck: onDirtyCheck,
                                           onLiveBufferRead: onLiveBufferRead,
@@ -876,24 +876,6 @@ extension ACPSessionManager {
         // now that state is `.idle` so a closed-while-attached session
         // doesn't keep its transcript + caches resident indefinitely.
         evictIfIdle(id: sessionId)
-    }
-
-    private static func mergeEnv(extra: [String: String]) -> [String: String] {
-        var env = ACPProcessEnvironment.augmented()
-        // Strip env vars that mark this process as running INSIDE a coding
-        // agent's session. Without this, `claude-code-acp` (and likely any
-        // other Anthropic-aware tool we spawn) refuses to start, reporting
-        // "Claude Code cannot be launched inside another Claude Code session"
-        // — which is exactly what happens when Alas is run from a terminal
-        // that's itself inside Claude Code.
-        for key in [
-            "CLAUDECODE", "CLAUDE_CODE", "CLAUDE_PROJECT_DIR",
-            "CLAUDE_CODE_ENTRYPOINT", "CLAUDE_SESSION_ID",
-        ] {
-            env.removeValue(forKey: key)
-        }
-        for (k, v) in extra { env[k] = v }
-        return env
     }
 }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -580,6 +580,7 @@ extension ACPSessionManager {
         do {
             let initialized = try await connection.initialize()
             session.promptCapabilities = initialized.promptCapabilities
+            session.authMethods = initialized.authMethods
             let shouldSuppressLoadReplay = !freshlyCreated
                 && session.hydrationState == .ready
                 && session.hasConversationTranscript
@@ -617,6 +618,9 @@ extension ACPSessionManager {
                     runner.finishSuppressingLoadReplay(
                         throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                     )
+                    if ACPAuthFailure.message(from: error) != nil {
+                        throw error
+                    }
                     result = try await connection.newSession(cwd: worktreePath)
                     if session.hasConversationTranscript {
                         shouldHoldQueueForRecovery = true
@@ -665,10 +669,17 @@ extension ACPSessionManager {
             try? await Task.sleep(nanoseconds: 200_000_000)
             stderrTask.cancel()
             let tail = stderrBuffer.tail()
-            let base = "ACP initialize/new failed: \(error.localizedDescription)"
+            let authReason = ACPAuthFailure.message(from: error)
+            let baseMessage = authReason ?? error.localizedDescription
+            let base = "ACP initialize/new failed: \(baseMessage)"
             let full = tail.isEmpty ? base : base + "\nstderr: " + tail
             session.lastError = full
-            session.agentState = .failed(full)
+            if let authReason {
+                session.setupState = .needsAuth(methods: session.authMethods, reason: authReason)
+                session.agentState = .failed(authReason)
+            } else {
+                session.agentState = .failed(full)
+            }
             startedRunner?.stop()
             await connection.shutdown()
         }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -578,7 +578,8 @@ extension ACPSessionManager {
         }
         var startedRunner: ACPSessionRunner?
         do {
-            session.promptCapabilities = (try await connection.initialize())
+            let initialized = try await connection.initialize()
+            session.promptCapabilities = initialized.promptCapabilities
             let shouldSuppressLoadReplay = !freshlyCreated
                 && session.hydrationState == .ready
                 && session.hasConversationTranscript

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -581,6 +581,18 @@ extension ACPSessionManager {
             let initialized = try await connection.initialize()
             session.promptCapabilities = initialized.promptCapabilities
             session.authMethods = initialized.authMethods
+            if let pendingAuthMethodId = session.pendingAuthMethodId {
+                do {
+                    try await connection.authenticate(methodId: pendingAuthMethodId)
+                    session.pendingAuthMethodId = nil
+                } catch {
+                    let reason = ACPAuthFailure.message(from: error) ?? error.localizedDescription
+                    session.setupState = .needsAuth(methods: initialized.authMethods, reason: reason)
+                    session.agentState = .failed(reason)
+                    await connection.shutdown()
+                    return
+                }
+            }
             let shouldSuppressLoadReplay = !freshlyCreated
                 && session.hydrationState == .ready
                 && session.hasConversationTranscript

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -832,6 +832,10 @@ extension ACPSessionManager {
     ) async {
         guard runners[sessionId] === runner else { return }
         runner.invalidateActivePrompt()
+        if let session = sessions[sessionId] {
+            session.transcript.streamingState = .idle
+            session.restoreQueue(session.queue)
+        }
         runner.stop()
         runners[sessionId] = nil
         await runner.connection.shutdown()

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -591,7 +591,13 @@ extension ACPSessionManager {
                                           agentEnv: Self.mergeEnv(extra: spec.extraEnv),
                                           suppressingLoadReplay: shouldSuppressLoadReplay,
                                           onDirtyCheck: onDirtyCheck,
-                                          onLiveBufferRead: onLiveBufferRead)
+                                          onLiveBufferRead: onLiveBufferRead,
+                                          onAuthRequired: { [weak self] runner, _ in
+                                              await self?.handleAuthRequiredRunner(
+                                                runner,
+                                                sessionId: sessionId
+                                              )
+                                          })
             var runnerStarted = false
             func startRunnerIfNeeded() {
                 guard !runnerStarted else { return }
@@ -774,6 +780,9 @@ extension ACPSessionManager {
         onCompleted: @escaping @MainActor (Bool) -> Void
     ) -> Bool {
         guard let session = sessions[sessionId] else { return false }
+        if case .needsAuth = session.setupState {
+            return false
+        }
 
         switch session.agentState {
         case .ready:
@@ -815,6 +824,17 @@ extension ACPSessionManager {
             Task { @MainActor in await reattach(to: sessionId) }
             return true
         }
+    }
+
+    private func handleAuthRequiredRunner(
+        _ runner: ACPSessionRunner,
+        sessionId: ACPSession.ID
+    ) async {
+        guard runners[sessionId] === runner else { return }
+        runner.invalidateActivePrompt()
+        runner.stop()
+        runners[sessionId] = nil
+        await runner.connection.shutdown()
     }
 
     func detach(sessionId: ACPSession.ID) async {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -675,21 +675,24 @@ extension ACPSessionRunner {
         try? store.upsertQueue(sessionId: sessionId, items: session.queue)
     }
 
-    /// Drain the queue head if (a) state is `.idle`, (b) the head is
-    /// `.pending`, and (c) the head has no `lastError`. Marks the head
-    /// `.sending`, persists, and dispatches `sendNow` with the head's
-    /// id so success can pop the right item and failure can flag the
-    /// right item without disturbing the rest of the queue.
+    /// Drain the queue head if the runner is still live, setup is not
+    /// blocked on auth, transcript state is `.idle`, the head is `.pending`,
+    /// and the head has no `lastError`. Marks the head `.sending`, persists,
+    /// and dispatches `sendNow` with the head's id so success can pop the
+    /// right item and failure can flag the right item without disturbing
+    /// the rest of the queue.
     ///
     /// Chained drain is implicit: sendNow's completion sets state to
     /// `.idle` and calls back here.
     func flushQueueIfIdle() {
         guard !steerInProgress,
+              session.agentState == .ready,
               session.transcript.streamingState == .idle,
               let head = session.queue.first,
               head.status == .pending,
               head.lastError == nil
         else { return }
+        if case .needsAuth = session.setupState { return }
         session.markQueueHeadSending()
         persistQueue()
         sendNow(blocks: head.blocks, queuedItemId: head.id)

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -888,15 +888,24 @@ extension ACPSessionRunner {
                     let isActivePrompt = self.activePromptID == promptID
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
+                        let authReason = wasCancelled ? nil : ACPAuthFailure.message(from: error)
+                        let errorMessage = authReason ?? error.localizedDescription
                         if queuedItemId != nil, !wasCancelled {
                             // Queued send failed naturally — leave the item
                             // at the head with lastError so the bubble shows
                             // Retry. Cancelled queued sends had the item
                             // discarded elsewhere (steer) and don't surface.
-                            self.session.setQueueHeadError(error.localizedDescription)
+                            self.session.setQueueHeadError(errorMessage)
                             self.persistQueue()
                         } else if queuedItemId == nil, !wasCancelled {
-                            self.session.lastError = "prompt failed: \(error.localizedDescription)"
+                            self.session.lastError = "prompt failed: \(errorMessage)"
+                        }
+                        if let authReason {
+                            self.session.setupState = .needsAuth(
+                                methods: self.session.authMethods,
+                                reason: authReason
+                            )
+                            self.session.agentState = .failed(authReason)
                         }
                         self.activePromptID = nil
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -36,6 +36,7 @@ final class ACPSessionRunner {
     /// CLAUDECODE/CLAUDE_SESSION_ID markers that would otherwise leak
     /// back in via a re-augment from `ProcessInfo`.
     private let agentEnv: [String: String]
+    private let onAuthRequired: ((ACPSessionRunner, String) async -> Void)?
     private var updatesTask: Task<Void, Never>?
     private var permissionsTask: Task<Void, Never>?
     private var filesTask: Task<Void, Never>?
@@ -69,7 +70,8 @@ final class ACPSessionRunner {
          agentEnv: [String: String] = ProcessInfo.processInfo.environment,
          suppressingLoadReplay: Bool = false,
          onDirtyCheck: ((String) -> Bool)? = nil,
-         onLiveBufferRead: ((String) -> String?)? = nil)
+         onLiveBufferRead: ((String) -> String?)? = nil,
+         onAuthRequired: ((ACPSessionRunner, String) async -> Void)? = nil)
     {
         self.session = session
         self.connection = connection
@@ -77,6 +79,7 @@ final class ACPSessionRunner {
         self.sessionId = sessionId
         self.worktreePath = worktreePath
         self.agentEnv = agentEnv
+        self.onAuthRequired = onAuthRequired
         self.suppressingLoadReplay = suppressingLoadReplay
         self.onDirtyCheck = onDirtyCheck
         self.onLiveBufferRead = onLiveBufferRead
@@ -906,6 +909,9 @@ extension ACPSessionRunner {
                                 reason: authReason
                             )
                             self.session.agentState = .failed(authReason)
+                            Task { @MainActor in
+                                await self.onAuthRequired?(self, authReason)
+                            }
                         }
                         self.activePromptID = nil
                         if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -896,12 +896,15 @@ extension ACPSessionRunner {
                     if isActivePrompt {
                         let authReason = wasCancelled ? nil : ACPAuthFailure.message(from: error)
                         let errorMessage = authReason ?? error.localizedDescription
-                        if queuedItemId != nil, !wasCancelled {
+                        if queuedItemId != nil, !wasCancelled, authReason == nil {
                             // Queued send failed naturally — leave the item
                             // at the head with lastError so the bubble shows
                             // Retry. Cancelled queued sends had the item
                             // discarded elsewhere (steer) and don't surface.
                             self.session.setQueueHeadError(errorMessage)
+                            self.persistQueue()
+                        } else if queuedItemId != nil, authReason != nil {
+                            self.session.restoreQueue(self.session.queue)
                             self.persistQueue()
                         } else if queuedItemId == nil, !wasCancelled {
                             self.session.lastError = "prompt failed: \(errorMessage)"

--- a/Alas/Sources/ACP/UI/ACPAuthNudgeBanner.swift
+++ b/Alas/Sources/ACP/UI/ACPAuthNudgeBanner.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct ACPAuthTerminalCommand: Equatable {
+    let command: String
+    let args: [String]
+    let env: [String: String]
+
+    static func resolve(
+        method: ACPInitializeResult.ACPAuthMethod,
+        fallbackCommand: String
+    ) -> ACPAuthTerminalCommand? {
+        guard method.kind == .terminal else { return nil }
+        let env = method.env ?? [:]
+        if let command = method.terminalAuth?.command?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !command.isEmpty {
+            return ACPAuthTerminalCommand(
+                command: command,
+                args: method.terminalAuth?.args ?? method.args ?? [],
+                env: env
+            )
+        }
+        let args = method.args ?? []
+        guard !fallbackCommand.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !args.isEmpty
+        else { return nil }
+        return ACPAuthTerminalCommand(command: fallbackCommand, args: args, env: env)
+    }
+}
+
+enum ACPAuthNudgeBannerCopy {
+    static func message(agentDisplayName: String, reason: String?) -> String {
+        let base = "\(agentDisplayName) needs sign-in before it can continue."
+        guard let reason = reason?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !reason.isEmpty
+        else { return base }
+        return "\(base) \(reason)"
+    }
+
+    static func unsupportedMessage(agentDisplayName: String) -> String {
+        "\(agentDisplayName) requires environment credentials or agent sign-in, and sign-in is not supported yet. Add credentials outside Alas, then reconnect."
+    }
+
+    static func buttonTitle(method: ACPInitializeResult.ACPAuthMethod) -> String {
+        if let label = method.terminalAuth?.label?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !label.isEmpty {
+            return label
+        }
+        let name = method.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? "Sign In" : name
+    }
+}
+
+struct ACPAuthNudgeBanner: View {
+    let agentDisplayName: String
+    let methods: [ACPInitializeResult.ACPAuthMethod]
+    let reason: String?
+    let onSignIn: (ACPInitializeResult.ACPAuthMethod) -> Void
+    let onReconnect: () -> Void
+
+    @Environment(\.theme) private var theme
+
+    private var terminalMethod: ACPInitializeResult.ACPAuthMethod? {
+        methods.first { $0.kind == .terminal }
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "person.badge.key")
+                .font(.system(size: 11))
+                .foregroundStyle(theme.color("fg-faint"))
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundStyle(theme.color("fg-muted"))
+                .textSelection(.enabled)
+            Spacer()
+            if let terminalMethod {
+                Button(ACPAuthNudgeBannerCopy.buttonTitle(method: terminalMethod)) {
+                    onSignIn(terminalMethod)
+                }
+            } else {
+                Button("Reconnect") {
+                    onReconnect()
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(theme.color("bg-1").opacity(0.6))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(theme.color("line")).frame(height: 0.5)
+        }
+    }
+
+    private var message: String {
+        if terminalMethod != nil {
+            return ACPAuthNudgeBannerCopy.message(
+                agentDisplayName: agentDisplayName,
+                reason: reason
+            )
+        }
+        return ACPAuthNudgeBannerCopy.unsupportedMessage(agentDisplayName: agentDisplayName)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPAuthNudgeBanner.swift
+++ b/Alas/Sources/ACP/UI/ACPAuthNudgeBanner.swift
@@ -7,7 +7,7 @@ struct ACPAuthTerminalCommand: Equatable {
 
     static func resolve(
         method: ACPInitializeResult.ACPAuthMethod,
-        fallbackCommand: String
+        launchSpec: ACPLaunchSpec
     ) -> ACPAuthTerminalCommand? {
         guard method.kind == .terminal else { return nil }
         let env = method.env ?? [:]
@@ -19,11 +19,13 @@ struct ACPAuthTerminalCommand: Equatable {
                 env: env
             )
         }
-        let args = method.args ?? []
-        guard !fallbackCommand.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-              !args.isEmpty
-        else { return nil }
-        return ACPAuthTerminalCommand(command: fallbackCommand, args: args, env: env)
+        let fallbackCommand = launchSpec.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !fallbackCommand.isEmpty else { return nil }
+        return ACPAuthTerminalCommand(
+            command: fallbackCommand,
+            args: launchSpec.arguments + (method.args ?? []),
+            env: launchSpec.extraEnv.merging(env) { _, methodValue in methodValue }
+        )
     }
 }
 

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -135,6 +135,7 @@ private struct ACPSessionView: View {
         if session.hydrationState == .loading { return true }
         guard manager.runners[sessionId] == nil else { return false }
         if case .needsSetup = session.setupState { return false }
+        if case .needsAuth = session.setupState { return false }
         if session.lastError != nil { return false }
         if session.agentState == .disconnected { return false }
         return session.transcript.messages.isEmpty
@@ -303,39 +304,51 @@ private struct ACPSessionView: View {
 
     @ViewBuilder
     private func adapterBanner() -> some View {
-        let dismissedSetup = state.config.harness.dismissedACPSetupNudges.contains(session.agentId)
-        let decision = ACPAdapterUpdateBannerDecider.decide(
-            setupState: session.setupState,
-            updateState: updateState,
-            dismissedLatest: dismissedLatest)
+        if case .needsAuth(let methods, let reason) = session.setupState {
+            ACPAuthNudgeBanner(
+                agentDisplayName: state.agent(id: session.agentId)?.displayName
+                    ?? AgentBuiltins.entry(id: session.agentId)?.displayName
+                    ?? session.agentId,
+                methods: methods,
+                reason: reason,
+                onSignIn: { method in launchAuth(method) },
+                onReconnect: { Task { await reattach() } }
+            )
+        } else {
+            let dismissedSetup = state.config.harness.dismissedACPSetupNudges.contains(session.agentId)
+            let decision = ACPAdapterUpdateBannerDecider.decide(
+                setupState: session.setupState,
+                updateState: updateState,
+                dismissedLatest: dismissedLatest)
 
-        switch decision {
-        case .showInstall where !dismissedSetup:
-            if let installer = ACPInstallerRegistry.installer(for: session.agentId) {
-                ACPSetupNudgeBanner(
-                    agentID: session.agentId,
-                    agentDisplayName: AgentBuiltins.entry(id: session.agentId)?.displayName ?? session.agentId,
-                    installer: installer,
-                    mode: .install,
-                    onDismiss: { dismissNudge() },
-                    onInstalled: { await reattach() }
-                )
-            } else if case .needsSetup(let reason) = session.setupState {
-                setupReasonBanner(reason: reason)
+            switch decision {
+            case .showInstall where !dismissedSetup:
+                if let installer = ACPInstallerRegistry.installer(for: session.agentId) {
+                    ACPSetupNudgeBanner(
+                        agentID: session.agentId,
+                        agentDisplayName: AgentBuiltins.entry(id: session.agentId)?.displayName ?? session.agentId,
+                        installer: installer,
+                        mode: .install,
+                        onDismiss: { dismissNudge() },
+                        onInstalled: { await reattach() }
+                    )
+                } else if case .needsSetup(let reason) = session.setupState {
+                    setupReasonBanner(reason: reason)
+                }
+            case .showUpdate(let current, let latest):
+                if let installer = ACPInstallerRegistry.installer(for: session.agentId) {
+                    ACPSetupNudgeBanner(
+                        agentID: session.agentId,
+                        agentDisplayName: AgentBuiltins.entry(id: session.agentId)?.displayName ?? session.agentId,
+                        installer: installer,
+                        mode: .update(current: current, latest: latest),
+                        onDismiss: { dismissUpdate(latest: latest) },
+                        onInstalled: { await reattachAfterUpdate() }
+                    )
+                }
+            default:
+                EmptyView()
             }
-        case .showUpdate(let current, let latest):
-            if let installer = ACPInstallerRegistry.installer(for: session.agentId) {
-                ACPSetupNudgeBanner(
-                    agentID: session.agentId,
-                    agentDisplayName: AgentBuiltins.entry(id: session.agentId)?.displayName ?? session.agentId,
-                    installer: installer,
-                    mode: .update(current: current, latest: latest),
-                    onDismiss: { dismissUpdate(latest: latest) },
-                    onInstalled: { await reattachAfterUpdate() }
-                )
-            }
-        default:
-            EmptyView()
         }
     }
 
@@ -389,6 +402,27 @@ private struct ACPSessionView: View {
             remoteSessionId: session.remoteSessionId
         )
         await manager.attach(to: sessionId, freshlyCreated: freshlyCreated)
+    }
+
+    private func launchAuth(_ method: ACPInitializeResult.ACPAuthMethod) {
+        guard let spec = ACPLaunchCatalog.spec(for: session.agentId),
+              let command = ACPAuthTerminalCommand.resolve(
+                method: method,
+                fallbackCommand: spec.command
+              )
+        else {
+            session.lastError = "Failed to launch auth terminal: unsupported sign-in method."
+            return
+        }
+        do {
+            _ = try state.openACPAuthTerminalTab(for: worktree, command: command) {
+                Task { @MainActor in
+                    await reattach()
+                }
+            }
+        } catch {
+            session.lastError = "Failed to launch auth terminal: \(error.localizedDescription)"
+        }
     }
 
     private func dismissNudge() {

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -312,7 +312,7 @@ private struct ACPSessionView: View {
                 methods: methods,
                 reason: reason,
                 onSignIn: { method in launchAuth(method) },
-                onReconnect: { Task { await reattach() } }
+                onReconnect: { Task { await reattachAndRefreshAdapterUpdateState() } }
             )
         } else {
             let dismissedSetup = state.config.harness.dismissedACPSetupNudges.contains(session.agentId)
@@ -417,7 +417,7 @@ private struct ACPSessionView: View {
         do {
             _ = try state.openACPAuthTerminalTab(for: worktree, command: command) {
                 Task { @MainActor in
-                    await reattach()
+                    await reattachAndRefreshAdapterUpdateState()
                 }
             }
         } catch {
@@ -447,6 +447,11 @@ private struct ACPSessionView: View {
             updateState = nil
             dismissedLatest = nil
         }
+        await reattach()
+        await refreshAdapterUpdateState()
+    }
+
+    private func reattachAndRefreshAdapterUpdateState() async {
         await reattach()
         await refreshAdapterUpdateState()
     }

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -408,7 +408,7 @@ private struct ACPSessionView: View {
         guard let spec = ACPLaunchCatalog.spec(for: session.agentId),
               let command = ACPAuthTerminalCommand.resolve(
                 method: method,
-                fallbackCommand: spec.command
+                launchSpec: spec
               )
         else {
             session.lastError = "Failed to launch auth terminal: unsupported sign-in method."

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -417,6 +417,7 @@ private struct ACPSessionView: View {
         do {
             _ = try state.openACPAuthTerminalTab(for: worktree, command: command) {
                 Task { @MainActor in
+                    session.pendingAuthMethodId = method.id
                     await reattachAndRefreshAdapterUpdateState()
                 }
             }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -34,7 +34,9 @@ final class AppState {
         Theme,
         URL?,
         String?,
-        Bool
+        Bool,
+        [String: String],
+        Set<String>
     ) throws -> OpenedTerminalSession
 
     @ObservationIgnored
@@ -670,12 +672,24 @@ final class AppState {
         let tab = try openTerminalTab(
             for: worktree,
             startupScriptSuffix: startupScriptSuffix,
-            includeUserStartupScript: false
+            includeUserStartupScript: false,
+            environmentOverrides: Self.acpAuthTerminalEnvironmentOverrides(extra: command.env),
+            environmentRemovals: ACPProcessEnvironment.agentSessionMarkerKeys
         )
         if case .terminal(let terminal) = tab {
             acpAuthTerminalExitHandlers[terminal.root.firstLeaf().sessionId] = onExit
         }
         return tab
+    }
+
+    nonisolated private static func acpAuthTerminalEnvironmentOverrides(
+        extra: [String: String]
+    ) -> [String: String] {
+        var overrides = extra
+        if let path = ACPProcessEnvironment.augmented()["PATH"] {
+            overrides["PATH"] = path
+        }
+        return overrides
     }
 
     private func agentBypassPermissionsEnabled(for project: ProjectConfig) -> Bool {
@@ -1167,7 +1181,9 @@ final class AppState {
     func openTerminalTab(
         for worktree: Worktree,
         startupScriptSuffix: String? = nil,
-        includeUserStartupScript: Bool = true
+        includeUserStartupScript: Bool = true,
+        environmentOverrides: [String: String] = [:],
+        environmentRemovals: Set<String> = []
     ) throws -> Tab {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             throw NSError(domain: "AppState", code: 2)
@@ -1186,7 +1202,9 @@ final class AppState {
                 themeStore.current,
                 nil,
                 startupScriptSuffix,
-                includeUserStartupScript
+                includeUserStartupScript,
+                environmentOverrides,
+                environmentRemovals
             )
         } else {
             let session = try terminal.openSession(
@@ -1194,6 +1212,8 @@ final class AppState {
                 cfg: config.terminal, theme: themeStore.current,
                 startupScriptSuffix: startupScriptSuffix,
                 includeUserStartupScript: includeUserStartupScript,
+                environmentOverrides: environmentOverrides,
+                environmentRemovals: environmentRemovals,
                 leafId: leafId
             )
             opened = OpenedTerminalSession(id: session.id, foregroundPid: { [weak session] in

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -621,6 +621,17 @@ final class AppState {
         }
     }
 
+    enum ACPAuthTerminalLaunchError: LocalizedError, Equatable {
+        case invalidEnvKey(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidEnvKey(let key):
+                return "Invalid auth environment variable name: \(key)"
+            }
+        }
+    }
+
     @discardableResult
     func openAgentTerminalTab(for worktree: Worktree, agentId: String) throws -> Tab {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
@@ -649,13 +660,14 @@ final class AppState {
         command: ACPAuthTerminalCommand,
         onExit: @escaping () -> Void
     ) throws -> Tab {
+        let startupScriptSuffix = try Self.shellCommand(
+            command: command.command,
+            args: command.args,
+            env: command.env
+        )
         let tab = try openTerminalTab(
             for: worktree,
-            startupScriptSuffix: Self.shellCommand(
-                command: command.command,
-                args: command.args,
-                env: command.env
-            )
+            startupScriptSuffix: startupScriptSuffix
         )
         if case .terminal(let terminal) = tab {
             acpAuthTerminalExitHandlers[terminal.root.firstLeaf().sessionId] = onExit
@@ -678,11 +690,21 @@ final class AppState {
         command: String,
         args: [String],
         env: [String: String]
-    ) -> String {
+    ) throws -> String {
+        for key in env.keys where !isValidShellAssignmentName(key) {
+            throw ACPAuthTerminalLaunchError.invalidEnvKey(key)
+        }
         let envPrefix = env
             .sorted { $0.key < $1.key }
             .map { "\($0.key)=\(shellQuote($0.value))" }
         return (envPrefix + [shellQuote(command)] + args.map(shellQuote)).joined(separator: " ")
+    }
+
+    nonisolated private static func isValidShellAssignmentName(_ key: String) -> Bool {
+        key.range(
+            of: #"^[A-Za-z_][A-Za-z0-9_]*$"#,
+            options: .regularExpression
+        ) != nil
     }
 
     nonisolated private static func shellQuote(_ s: String) -> String {
@@ -1239,10 +1261,9 @@ final class AppState {
     /// ahead), returns without side effects.
     func handleTerminalProcessExited(worktreeId: String, leafId: String, processAlive: Bool) {
         guard !processAlive else { return }
+        let authExitHandler = acpAuthTerminalExitHandlers.removeValue(forKey: leafId)
         closePaneForProcessExit(worktreeId: worktreeId, leafId: leafId)
-        if let handler = acpAuthTerminalExitHandlers.removeValue(forKey: leafId) {
-            handler()
-        }
+        authExitHandler?()
     }
 
     func closePaneForProcessExit(worktreeId: String, leafId: String) {
@@ -1258,14 +1279,19 @@ final class AppState {
         case .tabRemoved:
             closeTab(worktreeId: worktreeId, tabId: tabId)
         case .leafRemoved:
-            terminal.closeSession(
+            closeTerminalSession(
                 id: leafId,
                 worktreeId: worktreeId,
                 projectPath: projectPath(forWorktreeId: worktreeId)
             )
-            harness.detector.unregister(sessionId: leafId)
-            harness.forgetSession(leafId)
         }
+    }
+
+    private func closeTerminalSession(id: String, worktreeId: String, projectPath: String?) {
+        acpAuthTerminalExitHandlers.removeValue(forKey: id)
+        harness.detector.unregister(sessionId: id)
+        harness.forgetSession(id)
+        terminal.closeSession(id: id, worktreeId: worktreeId, projectPath: projectPath)
     }
 
     /// Close the focused pane. If it was the last leaf, also closes the tab
@@ -1280,13 +1306,11 @@ final class AppState {
             closeTab(worktreeId: worktreeId, tabId: activeId)
         } else {
             let closedLeafId = outcome.closedLeafId
-            terminal.closeSession(
+            closeTerminalSession(
                 id: closedLeafId,
                 worktreeId: worktreeId,
                 projectPath: projectPath(forWorktreeId: worktreeId)
             )
-            harness.detector.unregister(sessionId: closedLeafId)
-            harness.forgetSession(closedLeafId)
         }
     }
 
@@ -1710,9 +1734,7 @@ final class AppState {
         if let tab = allTabs.first(where: { $0.id == tabId }) {
             if case .terminal(let s) = tab {
                 for leaf in s.root.leaves() {
-                    harness.detector.unregister(sessionId: leaf.id)
-                    harness.forgetSession(leaf.id)
-                    terminal.closeSession(id: leaf.id, worktreeId: worktreeId, projectPath: projectPath)
+                    closeTerminalSession(id: leaf.id, worktreeId: worktreeId, projectPath: projectPath)
                 }
             }
             if case .editor = tab {
@@ -1731,9 +1753,7 @@ final class AppState {
             if let tab = allTabs.first(where: { $0.id == id }),
                case .terminal(let s) = tab {
                 for leaf in s.root.leaves() {
-                    harness.detector.unregister(sessionId: leaf.id)
-                    harness.forgetSession(leaf.id)
-                    terminal.closeSession(id: leaf.id, worktreeId: worktreeId, projectPath: projectPath)
+                    closeTerminalSession(id: leaf.id, worktreeId: worktreeId, projectPath: projectPath)
                 }
             }
         }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -663,7 +663,8 @@ final class AppState {
         let startupScriptSuffix = try Self.shellCommand(
             command: command.command,
             args: command.args,
-            env: command.env
+            env: command.env,
+            exitOnCompletion: true
         )
         let tab = try openTerminalTab(
             for: worktree,
@@ -689,7 +690,8 @@ final class AppState {
     nonisolated private static func shellCommand(
         command: String,
         args: [String],
-        env: [String: String]
+        env: [String: String],
+        exitOnCompletion: Bool = false
     ) throws -> String {
         for key in env.keys where !isValidShellAssignmentName(key) {
             throw ACPAuthTerminalLaunchError.invalidEnvKey(key)
@@ -697,7 +699,9 @@ final class AppState {
         let envPrefix = env
             .sorted { $0.key < $1.key }
             .map { "\($0.key)=\(shellQuote($0.value))" }
-        return (envPrefix + [shellQuote(command)] + args.map(shellQuote)).joined(separator: " ")
+        let commandLine = (envPrefix + [shellQuote(command)] + args.map(shellQuote)).joined(separator: " ")
+        guard exitOnCompletion else { return commandLine }
+        return "\(commandLine)\nstatus=$?\nexit \"$status\""
     }
 
     nonisolated private static func isValidShellAssignmentName(_ key: String) -> Bool {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -38,6 +38,8 @@ final class AppState {
 
     @ObservationIgnored
     private let terminalSessionOpener: TerminalSessionOpener?
+    @ObservationIgnored
+    private var acpAuthTerminalExitHandlers: [String: () -> Void] = [:]
     let rightPaneStore = RightPaneStore()
     let harness = HarnessService()
     let acpAdapterUpdateStore = ACPAdapterUpdateStore()
@@ -641,6 +643,26 @@ final class AppState {
         }
     }
 
+    @discardableResult
+    func openACPAuthTerminalTab(
+        for worktree: Worktree,
+        command: ACPAuthTerminalCommand,
+        onExit: @escaping () -> Void
+    ) throws -> Tab {
+        let tab = try openTerminalTab(
+            for: worktree,
+            startupScriptSuffix: Self.shellCommand(
+                command: command.command,
+                args: command.args,
+                env: command.env
+            )
+        )
+        if case .terminal(let terminal) = tab {
+            acpAuthTerminalExitHandlers[terminal.root.firstLeaf().sessionId] = onExit
+        }
+        return tab
+    }
+
     private func agentBypassPermissionsEnabled(for project: ProjectConfig) -> Bool {
         switch project.startupScripts.worktreeAgentMode {
         case .disabled:
@@ -650,6 +672,17 @@ final class AppState {
         case .overrideGlobal, .appendToGlobal:
             return project.startupScripts.worktreeAgentUseBypassPermissions
         }
+    }
+
+    nonisolated private static func shellCommand(
+        command: String,
+        args: [String],
+        env: [String: String]
+    ) -> String {
+        let envPrefix = env
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\(shellQuote($0.value))" }
+        return (envPrefix + [shellQuote(command)] + args.map(shellQuote)).joined(separator: " ")
     }
 
     nonisolated private static func shellQuote(_ s: String) -> String {
@@ -959,8 +992,11 @@ final class AppState {
             self?.harness.socketServer.unlinkSession(leafId: leafId)
         }
         terminal.onSessionProcessExited = { [weak self] leafId, worktreeId, processAlive in
-            guard !processAlive else { return }
-            self?.closePaneForProcessExit(worktreeId: worktreeId, leafId: leafId)
+            self?.handleTerminalProcessExited(
+                worktreeId: worktreeId,
+                leafId: leafId,
+                processAlive: processAlive
+            )
         }
         harness.socketServer.onCLIRequest = { [weak self] request in
             await MainActor.run {
@@ -1201,6 +1237,14 @@ final class AppState {
     /// dead session and lets the sibling collapse take over the freed space.
     /// Idempotent: if the leaf is no longer in any tab (manual close raced
     /// ahead), returns without side effects.
+    func handleTerminalProcessExited(worktreeId: String, leafId: String, processAlive: Bool) {
+        guard !processAlive else { return }
+        closePaneForProcessExit(worktreeId: worktreeId, leafId: leafId)
+        if let handler = acpAuthTerminalExitHandlers.removeValue(forKey: leafId) {
+            handler()
+        }
+    }
+
     func closePaneForProcessExit(worktreeId: String, leafId: String) {
         let owningTabId = tabs.tabs(forWorktree: worktreeId).first { tab in
             guard case .terminal(let state) = tab else { return false }

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -33,7 +33,8 @@ final class AppState {
         AppConfig.Terminal,
         Theme,
         URL?,
-        String?
+        String?,
+        Bool
     ) throws -> OpenedTerminalSession
 
     @ObservationIgnored
@@ -668,7 +669,8 @@ final class AppState {
         )
         let tab = try openTerminalTab(
             for: worktree,
-            startupScriptSuffix: startupScriptSuffix
+            startupScriptSuffix: startupScriptSuffix,
+            includeUserStartupScript: false
         )
         if case .terminal(let terminal) = tab {
             acpAuthTerminalExitHandlers[terminal.root.firstLeaf().sessionId] = onExit
@@ -1164,7 +1166,8 @@ final class AppState {
     @discardableResult
     func openTerminalTab(
         for worktree: Worktree,
-        startupScriptSuffix: String? = nil
+        startupScriptSuffix: String? = nil,
+        includeUserStartupScript: Bool = true
     ) throws -> Tab {
         guard let project = projects.first(where: { $0.id == worktree.projectId }) else {
             throw NSError(domain: "AppState", code: 2)
@@ -1182,13 +1185,15 @@ final class AppState {
                 config.terminal,
                 themeStore.current,
                 nil,
-                startupScriptSuffix
+                startupScriptSuffix,
+                includeUserStartupScript
             )
         } else {
             let session = try terminal.openSession(
                 worktree: worktree, project: project,
                 cfg: config.terminal, theme: themeStore.current,
                 startupScriptSuffix: startupScriptSuffix,
+                includeUserStartupScript: includeUserStartupScript,
                 leafId: leafId
             )
             opened = OpenedTerminalSession(id: session.id, foregroundPid: { [weak session] in

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -71,6 +71,8 @@ final class TerminalService {
         forcedCwd: URL? = nil,
         startupScriptSuffix: String? = nil,
         includeUserStartupScript: Bool = true,
+        environmentOverrides: [String: String] = [:],
+        environmentRemovals: Set<String> = [],
         leafId: String = UUID().uuidString,
         allowLegacyAttach: Bool = false
     ) throws -> TerminalSession {
@@ -89,6 +91,12 @@ final class TerminalService {
             socketPath: perSessionSocket, inheritParent: cfg.inheritParentEnv,
             zmxDir: zmxClient.env.zmxDir?.path
         )
+        for key in environmentRemovals {
+            env.removeValue(forKey: key)
+        }
+        for (key, value) in environmentOverrides {
+            env[key] = value
+        }
         if perSessionSocket != nil {
             let binDir = try TerminalCLIInjection.installExecutables()
             env["PATH"] = TerminalCLIInjection.pathValue(

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -60,6 +60,8 @@ final class TerminalService {
     /// used by worktree-create's auto-launch-agent path to put the agent
     /// CLI directly into the new terminal session (visible, with a TTY,
     /// not a hidden detached process).
+    /// Auth-only terminals can set `includeUserStartupScript` false so a
+    /// long-running session-open script does not block the login command.
     @discardableResult
     func openSession(
         worktree: Worktree,
@@ -68,6 +70,7 @@ final class TerminalService {
         theme: Theme,
         forcedCwd: URL? = nil,
         startupScriptSuffix: String? = nil,
+        includeUserStartupScript: Bool = true,
         leafId: String = UUID().uuidString,
         allowLegacyAttach: Bool = false
     ) throws -> TerminalSession {
@@ -93,10 +96,9 @@ final class TerminalService {
                 to: env["PATH"]
             )
         }
-        let baseScript = StartupScriptResolver.sessionOpenScript(
-            global: cfg,
-            project: project
-        )
+        let baseScript = includeUserStartupScript
+            ? StartupScriptResolver.sessionOpenScript(global: cfg, project: project)
+            : ""
         let effectiveScript = Self.composeStartupScript(
             userStartupScript: baseScript,
             startupScriptSuffix: startupScriptSuffix

--- a/AlasTests/ACP/Adapter/ACPAuthNudgeBannerTests.swift
+++ b/AlasTests/ACP/Adapter/ACPAuthNudgeBannerTests.swift
@@ -34,7 +34,14 @@ struct ACPAuthNudgeBannerTests {
             )
         )
 
-        let command = ACPAuthTerminalCommand.resolve(method: method, fallbackCommand: "claude-agent-acp")
+        let command = ACPAuthTerminalCommand.resolve(
+            method: method,
+            launchSpec: launchSpec(
+                command: "claude-agent-acp",
+                arguments: ["ignored-launch-arg"],
+                extraEnv: ["IGNORED": "1"]
+            )
+        )
 
         #expect(command == ACPAuthTerminalCommand(
             command: "/usr/bin/node",
@@ -43,20 +50,43 @@ struct ACPAuthNudgeBannerTests {
         ))
     }
 
-    @Test("command resolver falls back to adapter command and method args")
+    @Test("command resolver falls back to adapter launch vector and appends method args")
     func commandResolverFallsBackToAdapterCommand() {
         let method = authMethod(
             args: ["auth", "login"],
-            env: ["TOKEN": "1"],
+            env: ["TOKEN": "1", "SHARED": "method"],
             terminalAuth: nil
         )
 
-        let command = ACPAuthTerminalCommand.resolve(method: method, fallbackCommand: "agent")
+        let command = ACPAuthTerminalCommand.resolve(
+            method: method,
+            launchSpec: launchSpec(
+                command: "agent",
+                arguments: ["acp"],
+                extraEnv: ["PATH": "/bin", "SHARED": "spec"]
+            )
+        )
 
         #expect(command == ACPAuthTerminalCommand(
             command: "agent",
-            args: ["auth", "login"],
-            env: ["TOKEN": "1"]
+            args: ["acp", "auth", "login"],
+            env: ["PATH": "/bin", "SHARED": "method", "TOKEN": "1"]
+        ))
+    }
+
+    @Test("command resolver supports terminal auth without extra method args")
+    func commandResolverAllowsEmptyMethodArgs() {
+        let method = authMethod(terminalAuth: nil)
+
+        let command = ACPAuthTerminalCommand.resolve(
+            method: method,
+            launchSpec: launchSpec(command: "gemini", arguments: ["--experimental-acp"])
+        )
+
+        #expect(command == ACPAuthTerminalCommand(
+            command: "gemini",
+            args: ["--experimental-acp"],
+            env: [:]
         ))
     }
 
@@ -64,7 +94,7 @@ struct ACPAuthNudgeBannerTests {
     func commandResolverRequiresTerminalMethod() {
         let method = authMethod(kind: .envVar, args: ["auth", "login"])
 
-        #expect(ACPAuthTerminalCommand.resolve(method: method, fallbackCommand: "agent") == nil)
+        #expect(ACPAuthTerminalCommand.resolve(method: method, launchSpec: launchSpec(command: "agent")) == nil)
     }
 
     private func authMethod(
@@ -84,6 +114,22 @@ struct ACPAuthNudgeBannerTests {
             meta: terminalAuth.map {
                 ACPInitializeResult.ACPAuthMethod.Meta(terminalAuth: $0)
             }
+        )
+    }
+
+    private func launchSpec(
+        command: String,
+        arguments: [String] = [],
+        extraEnv: [String: String] = [:]
+    ) -> ACPLaunchSpec {
+        ACPLaunchSpec(
+            agentID: "test-agent",
+            command: command,
+            arguments: arguments,
+            extraEnv: extraEnv,
+            setupCheck: .binaryOnPath(name: command),
+            supportsModelSelection: false,
+            supportsModeSelection: false
         )
     }
 }

--- a/AlasTests/ACP/Adapter/ACPAuthNudgeBannerTests.swift
+++ b/AlasTests/ACP/Adapter/ACPAuthNudgeBannerTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPAuthNudgeBanner")
+struct ACPAuthNudgeBannerTests {
+    @Test("button label uses terminal-auth metadata label")
+    func labelUsesTerminalMetadata() {
+        let method = authMethod(
+            name: "Claude Subscription",
+            terminalAuth: .init(command: nil, args: nil, label: "Claude Login")
+        )
+
+        #expect(ACPAuthNudgeBannerCopy.buttonTitle(method: method) == "Claude Login")
+    }
+
+    @Test("unsupported env auth copy mentions environment credentials")
+    func unsupportedEnvAuthCopy() {
+        let message = ACPAuthNudgeBannerCopy.unsupportedMessage(agentDisplayName: "Cursor")
+
+        #expect(message.contains("environment credentials"))
+        #expect(message.contains("sign-in is not supported yet"))
+    }
+
+    @Test("command resolver prefers terminal-auth metadata command args and method env")
+    func commandResolverPrefersTerminalMetadata() {
+        let method = authMethod(
+            args: ["ignored"],
+            env: ["A": "B"],
+            terminalAuth: .init(
+                command: "/usr/bin/node",
+                args: ["/opt/claude-agent-acp", "--cli"],
+                label: "Claude Login"
+            )
+        )
+
+        let command = ACPAuthTerminalCommand.resolve(method: method, fallbackCommand: "claude-agent-acp")
+
+        #expect(command == ACPAuthTerminalCommand(
+            command: "/usr/bin/node",
+            args: ["/opt/claude-agent-acp", "--cli"],
+            env: ["A": "B"]
+        ))
+    }
+
+    @Test("command resolver falls back to adapter command and method args")
+    func commandResolverFallsBackToAdapterCommand() {
+        let method = authMethod(
+            args: ["auth", "login"],
+            env: ["TOKEN": "1"],
+            terminalAuth: nil
+        )
+
+        let command = ACPAuthTerminalCommand.resolve(method: method, fallbackCommand: "agent")
+
+        #expect(command == ACPAuthTerminalCommand(
+            command: "agent",
+            args: ["auth", "login"],
+            env: ["TOKEN": "1"]
+        ))
+    }
+
+    @Test("command resolver ignores non-terminal auth methods")
+    func commandResolverRequiresTerminalMethod() {
+        let method = authMethod(kind: .envVar, args: ["auth", "login"])
+
+        #expect(ACPAuthTerminalCommand.resolve(method: method, fallbackCommand: "agent") == nil)
+    }
+
+    private func authMethod(
+        id: String = "login",
+        name: String = "Sign in",
+        kind: ACPInitializeResult.ACPAuthMethod.Kind = .terminal,
+        args: [String]? = nil,
+        env: [String: String]? = nil,
+        terminalAuth: ACPInitializeResult.ACPAuthMethod.TerminalAuthMeta? = nil
+    ) -> ACPInitializeResult.ACPAuthMethod {
+        ACPInitializeResult.ACPAuthMethod(
+            id: id,
+            name: name,
+            kind: kind,
+            args: args,
+            env: env,
+            meta: terminalAuth.map {
+                ACPInitializeResult.ACPAuthMethod.Meta(terminalAuth: $0)
+            }
+        )
+    }
+}

--- a/AlasTests/ACP/Protocol/ACPAuthFailureTests.swift
+++ b/AlasTests/ACP/Protocol/ACPAuthFailureTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPAuthFailure")
+struct ACPAuthFailureTests {
+    @Test("classifies auth-related JSON-RPC and runtime errors")
+    func classifiesAuthRelatedErrors() {
+        let cases: [(any Error, String)] = [
+            (JSONRPCError(code: -32000, message: "auth_required", data: nil), "auth_required"),
+            (JSONRPCError(code: -32000, message: "Internal error: auth required", data: nil), "auth required"),
+            (ACPClientError.jsonrpc(JSONRPCError(
+                code: -32000,
+                message: "failed to authenticate with provider",
+                data: nil
+            )), "failed to authenticate with provider"),
+            (NSError(
+                domain: "ACP",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "invalid authentication credentials"]
+            ), "invalid authentication credentials"),
+            (NSError(
+                domain: "ACP",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Internal error: 401 Unauthorized"]
+            ), "401 Unauthorized")
+        ]
+
+        for (error, expected) in cases {
+            #expect(ACPAuthFailure.message(from: error) == expected)
+        }
+    }
+
+    @Test("ignores non-auth errors")
+    func ignoresNonAuthErrors() {
+        #expect(ACPAuthFailure.message(from: JSONRPCError(
+            code: -32601,
+            message: "Method not found",
+            data: nil
+        )) == nil)
+        #expect(ACPAuthFailure.message(from: ACPClientError.noScript(method: "session/new")) == nil)
+    }
+}

--- a/AlasTests/ACP/Protocol/ACPAuthFailureTests.swift
+++ b/AlasTests/ACP/Protocol/ACPAuthFailureTests.swift
@@ -14,6 +14,11 @@ struct ACPAuthFailureTests {
                 message: "failed to authenticate with provider",
                 data: nil
             )), "failed to authenticate with provider"),
+            (JSONRPCError(code: -32000, message: "authentication required", data: nil), "authentication required"),
+            (JSONRPCError(code: -32000, message: "not authenticated", data: nil), "not authenticated"),
+            (JSONRPCError(code: -32000, message: "login required", data: nil), "login required"),
+            (JSONRPCError(code: -32000, message: "access token expired", data: nil), "access token expired"),
+            (JSONRPCError(code: -32000, message: "HTTP 401 Unauthorized", data: nil), "HTTP 401 Unauthorized"),
             (NSError(
                 domain: "ACP",
                 code: 1,
@@ -39,5 +44,10 @@ struct ACPAuthFailureTests {
             data: nil
         )) == nil)
         #expect(ACPAuthFailure.message(from: ACPClientError.noScript(method: "session/new")) == nil)
+        #expect(ACPAuthFailure.message(from: JSONRPCError(
+            code: -32000,
+            message: "read file 401.md failed",
+            data: nil
+        )) == nil)
     }
 }

--- a/AlasTests/ACP/Protocol/ACPAuthFailureTests.swift
+++ b/AlasTests/ACP/Protocol/ACPAuthFailureTests.swift
@@ -49,5 +49,10 @@ struct ACPAuthFailureTests {
             message: "read file 401.md failed",
             data: nil
         )) == nil)
+        #expect(ACPAuthFailure.message(from: JSONRPCError(
+            code: -32000,
+            message: "tool call unauthorized by workspace policy",
+            data: nil
+        )) == nil)
     }
 }

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -32,25 +32,30 @@ struct ACPConnectionTests {
     func initializeReturnsPromptCapabilities() async throws {
         let mock = ACPMockClient()
         mock.script(method: "initialize") { _ in
-            try JSONEncoder().encode(ACPInitializeResult(
-                protocolVersion: 1,
-                agentCapabilities: .init(
-                    promptCapabilities: .init(
-                        image: true,
-                        audio: false,
-                        embeddedContext: true
-                    )
-                ),
-                authMethods: []
-            ))
+            """
+            {
+              "protocolVersion": 1,
+              "agentCapabilities": {
+                "promptCapabilities": {
+                  "image": true,
+                  "audio": false,
+                  "embeddedContext": true
+                }
+              },
+              "authMethods": [
+                { "id": "claude-ai-login", "name": "Claude Subscription", "type": "terminal" }
+              ]
+            }
+            """.data(using: .utf8)!
         }
 
         let conn = ACPConnection(client: mock)
-        let capabilities = try await conn.initialize()
+        let initialized = try await conn.initialize()
 
-        #expect(capabilities.image == true)
-        #expect(capabilities.audio == false)
-        #expect(capabilities.embeddedContext == true)
+        #expect(initialized.promptCapabilities.image == true)
+        #expect(initialized.promptCapabilities.audio == false)
+        #expect(initialized.promptCapabilities.embeddedContext == true)
+        #expect(initialized.authMethods.map(\.id) == ["claude-ai-login"])
     }
 
     @Test("loadSession sends session/load with cwd and remote session id")

--- a/AlasTests/ACP/Protocol/ACPConnectionTests.swift
+++ b/AlasTests/ACP/Protocol/ACPConnectionTests.swift
@@ -84,6 +84,20 @@ struct ACPConnectionTests {
         #expect(params.mcpServers.isEmpty)
     }
 
+    @Test("authenticate sends method id")
+    func authenticateRPC() async throws {
+        let mock = ACPMockClient()
+        mock.script(method: "authenticate") { _ in Data() }
+
+        let conn = ACPConnection(client: mock)
+        try await conn.authenticate(methodId: "claude-login")
+
+        let req = try #require(mock.sent.last)
+        #expect(req.method == "authenticate")
+        let params = try #require(req.params as? ACPAuthenticateParams)
+        #expect(params.methodId == "claude-login")
+    }
+
     @Test("setConfigOption sends session/set_config_option with sessionId, configId, value")
     func setConfigOptionRPC() async throws {
         let mock = ACPMockClient()

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -16,12 +16,109 @@ struct ACPInitializeTests {
         #expect(env.params?.clientCapabilities.terminal == true)
     }
 
+    @Test("initialize request advertises terminal auth capabilities")
+    func initializeRequestAdvertisesAuth() throws {
+        let params = ACPInitializeParams(
+            protocolVersion: 1,
+            clientCapabilities: .init(
+                fs: .init(readTextFile: true, writeTextFile: true),
+                terminal: true
+            )
+        )
+        let envelope = JSONRPCEnvelope<ACPInitializeParams>(
+            id: .number(1),
+            method: "initialize",
+            params: params
+        )
+
+        let data = try JSONEncoder().encode(envelope)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let encodedParams = try #require(json["params"] as? [String: Any])
+        let capabilities = try #require(encodedParams["clientCapabilities"] as? [String: Any])
+        let auth = try #require(capabilities["auth"] as? [String: Any])
+        let meta = try #require(capabilities["_meta"] as? [String: Any])
+
+        #expect(auth["terminal"] as? Bool == true)
+        #expect(meta["terminal-auth"] as? Bool == true)
+        #expect(capabilities["terminal"] as? Bool == true)
+        let fs = try #require(capabilities["fs"] as? [String: Any])
+        #expect(fs["readTextFile"] as? Bool == true)
+        #expect(fs["writeTextFile"] as? Bool == true)
+    }
+
     @Test("decodes an initialize response")
     func decodeResponse() throws {
         let data = try fixture("initialize-response")
         let env = try JSONDecoder().decode(JSONRPCEnvelope<ACPInitializeResult>.self, from: data)
         #expect(env.result?.protocolVersion == 1)
         #expect(env.result?.authMethods.isEmpty == true)
+    }
+
+    @Test("decodes terminal auth method metadata")
+    func decodesTerminalAuthMethod() throws {
+        let data = Data("""
+        {
+          "protocolVersion": 1,
+          "authMethods": [
+            {
+              "id": "claude-ai-login",
+              "name": "Claude Subscription",
+              "description": "Use Claude subscription",
+              "type": "terminal",
+              "args": ["--cli", "auth", "login"],
+              "env": { "A": "B" },
+              "vars": [
+                { "name": "ANTHROPIC_API_KEY", "label": "API key", "optional": false, "secret": true }
+              ],
+              "_meta": {
+                "terminal-auth": {
+                  "command": "/usr/bin/node",
+                  "args": ["/opt/claude-agent-acp", "--cli"],
+                  "label": "Claude Login"
+                }
+              }
+            }
+          ]
+        }
+        """.utf8)
+
+        let result = try JSONDecoder().decode(ACPInitializeResult.self, from: data)
+        let method = try #require(result.authMethods.first)
+        #expect(method.id == "claude-ai-login")
+        #expect(method.name == "Claude Subscription")
+        #expect(method.description == "Use Claude subscription")
+        #expect(method.kind == .terminal)
+        #expect(method.args == ["--cli", "auth", "login"])
+        #expect(method.env == ["A": "B"])
+        #expect(method.vars?.first?.name == "ANTHROPIC_API_KEY")
+        #expect(method.vars?.first?.label == "API key")
+        #expect(method.vars?.first?.optional == false)
+        #expect(method.vars?.first?.secret == true)
+        #expect(method.terminalAuth?.command == "/usr/bin/node")
+        #expect(method.terminalAuth?.args == ["/opt/claude-agent-acp", "--cli"])
+        #expect(method.terminalAuth?.label == "Claude Login")
+    }
+
+    @Test("decodes auth method type variants")
+    func decodesAuthMethodTypeVariants() throws {
+        let data = Data("""
+        {
+          "protocolVersion": 1,
+          "authMethods": [
+            { "id": "agent-login", "name": "Agent Login" },
+            { "id": "env-login", "name": "Environment", "type": "env_var" },
+            { "id": "future-login", "name": "Future", "type": "browser" }
+          ]
+        }
+        """.utf8)
+
+        let result = try JSONDecoder().decode(ACPInitializeResult.self, from: data)
+
+        #expect(result.authMethods.map(\.kind) == [
+            .agent,
+            .envVar,
+            .unknown("browser"),
+        ])
     }
 
     private func fixture(_ name: String) throws -> Data {

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -16,6 +16,29 @@ struct ACPInitializeTests {
         #expect(env.params?.clientCapabilities.terminal == true)
     }
 
+    @Test("decoding legacy initialize request does not imply terminal auth")
+    func decodeLegacyRequestWithoutAuthCapability() throws {
+        let data = Data("""
+        {
+          "jsonrpc": "2.0",
+          "id": 1,
+          "method": "initialize",
+          "params": {
+            "protocolVersion": 1,
+            "clientCapabilities": {
+              "fs": { "readTextFile": true, "writeTextFile": true },
+              "terminal": true
+            }
+          }
+        }
+        """.utf8)
+
+        let env = try JSONDecoder().decode(JSONRPCEnvelope<ACPInitializeParams>.self, from: data)
+
+        #expect(env.params?.clientCapabilities.auth.terminal == false)
+        #expect(env.params?.clientCapabilities.meta.terminalAuth == false)
+    }
+
     @Test("initialize request advertises terminal auth capabilities")
     func initializeRequestAdvertisesAuth() throws {
         let params = ACPInitializeParams(
@@ -52,6 +75,25 @@ struct ACPInitializeTests {
         let env = try JSONDecoder().decode(JSONRPCEnvelope<ACPInitializeResult>.self, from: data)
         #expect(env.result?.protocolVersion == 1)
         #expect(env.result?.authMethods.isEmpty == true)
+    }
+
+    @Test("decodes initialize response without authMethods")
+    func decodeResponseWithoutAuthMethods() throws {
+        let data = Data("""
+        {
+          "protocolVersion": 1,
+          "agentCapabilities": {
+            "promptCapabilities": {
+              "embeddedContext": true
+            }
+          }
+        }
+        """.utf8)
+
+        let result = try JSONDecoder().decode(ACPInitializeResult.self, from: data)
+
+        #expect(result.authMethods.isEmpty)
+        #expect(result.agentCapabilities?.promptCapabilities?.embeddedContext == true)
     }
 
     @Test("decodes terminal auth method metadata")

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -283,6 +283,29 @@ struct ACPSessionManagerAttachRestoreTests {
         }
     }
 
+    @Test("pending auth method authenticates before creating session")
+    func pendingAuthMethodAuthenticatesBeforeSessionCreate() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        let method = terminalAuthMethod()
+        scriptInitialize(client, authMethods: [method])
+        client.script(method: "authenticate") { req in
+            let params = try #require(req.params as? ACPAuthenticateParams)
+            #expect(params.methodId == method.id)
+            return Data()
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        let manager = manager(store: store, client: client)
+        let session = manager.createSession(agentId: "claude")
+        session.pendingAuthMethodId = method.id
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "authenticate", "session/new"])
+        #expect(session.pendingAuthMethodId == nil)
+        #expect(session.agentState == .ready)
+    }
+
     @Test("prompt auth failure removes runner and blocks queue retry on failed connection")
     func promptAuthFailureRemovesRunnerAndBlocksQueueRetryOnFailedConnection() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -310,7 +310,9 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(client.shutdownCount == 1)
         #expect(client.sent.map(\.method) == ["initialize", "session/new", "session/prompt"])
         #expect(session.queue.count == 1)
+        #expect(session.queue[0].status == .pending)
         #expect(session.queue[0].lastError == "login required")
+        #expect(session.transcript.streamingState == .idle)
 
         session.queue[0].lastError = nil
         manager.persistQueue(for: session)
@@ -352,6 +354,7 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.queue[0].status == .pending)
         #expect(session.queue[0].lastError == nil)
         #expect(session.queue[0].blocks == [.text("follow-up")])
+        #expect(session.transcript.streamingState == .idle)
     }
 
     @Test("submit while needsAuth rejects prompt and preserves draft")

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -225,6 +225,64 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(row.contextRecoveryPending)
     }
 
+    @Test("new auth failure enters needsAuth with initialized auth method")
+    func newAuthFailureEntersNeedsAuthWithInitializedAuthMethod() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        let method = terminalAuthMethod()
+        scriptInitialize(client, authMethods: [method])
+        client.script(method: "session/new") { _ in
+            throw JSONRPCError(code: -32000, message: "Internal error: 401 Unauthorized", data: nil)
+        }
+        let manager = manager(store: store, client: client)
+        let session = manager.createSession(agentId: "claude")
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/new"])
+        #expect(session.authMethods == [method])
+        #expect(session.setupState == .needsAuth(methods: [method], reason: "401 Unauthorized"))
+        #expect(session.lastError?.contains("401 Unauthorized") == true)
+        #expect(manager.runners[session.id] == nil)
+        if case .failed(let message) = session.agentState {
+            #expect(message == "401 Unauthorized")
+        } else {
+            Issue.record("Expected failed agent state")
+        }
+    }
+
+    @Test("load auth failure does not fall back to session new")
+    func loadAuthFailureDoesNotFallBackToSessionNew() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        let client = ACPMockClient()
+        let method = terminalAuthMethod()
+        scriptInitialize(client, authMethods: [method])
+        client.script(method: "session/load") { _ in
+            throw JSONRPCError(code: -32000, message: "auth_required: 401", data: nil)
+        }
+        client.script(method: "session/new") { _ in
+            Issue.record("session/new should not be called after auth-related session/load failure")
+            return Data("{}".utf8)
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/load"])
+        #expect(session.remoteSessionId == "remote-old")
+        #expect(session.authMethods == [method])
+        #expect(session.setupState == .needsAuth(methods: [method], reason: "auth_required: 401"))
+        #expect(session.lastError?.contains("auth_required: 401") == true)
+        if case .failed(let message) = session.agentState {
+            #expect(message == "auth_required: 401")
+        } else {
+            Issue.record("Expected failed agent state")
+        }
+    }
+
     @Test("pending queued prompt waits for transcript recovery after load fallback")
     func queuedPromptWaitsForTranscriptRecoveryAfterLoadFallback() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
@@ -686,14 +744,25 @@ struct ACPSessionManagerAttachRestoreTests {
         )
     }
 
-    private func scriptInitialize(_ client: ACPMockClient) {
+    private func scriptInitialize(
+        _ client: ACPMockClient,
+        authMethods: [ACPInitializeResult.ACPAuthMethod] = []
+    ) {
         client.script(method: "initialize") { _ in
             try JSONEncoder().encode(ACPInitializeResult(
                 protocolVersion: 1,
                 agentCapabilities: nil,
-                authMethods: []
+                authMethods: authMethods
             ))
         }
+    }
+
+    private func terminalAuthMethod() -> ACPInitializeResult.ACPAuthMethod {
+        ACPInitializeResult.ACPAuthMethod(
+            id: "claude-login",
+            name: "Claude Login",
+            kind: .terminal
+        )
     }
 
     private func scriptSessionResult(_ client: ACPMockClient, method: String, sessionId: String) {

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -283,6 +283,74 @@ struct ACPSessionManagerAttachRestoreTests {
         }
     }
 
+    @Test("prompt auth failure removes runner and blocks queue retry on failed connection")
+    func promptAuthFailureRemovesRunnerAndBlocksQueueRetryOnFailedConnection() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        let method = terminalAuthMethod()
+        scriptInitialize(client, authMethods: [method])
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        client.script(method: "session/prompt") { _ in
+            throw JSONRPCError(code: -32000, message: "login required", data: nil)
+        }
+        let manager = manager(store: store, client: client)
+        let session = manager.createSession(agentId: "claude")
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+        let runner = try #require(manager.runners[session.id])
+        session.enqueue(blocks: [.text("queued")])
+        runner.persistQueue()
+
+        runner.flushQueueIfIdle()
+        try await waitUntil {
+            manager.runners[session.id] == nil
+                && session.setupState == .needsAuth(methods: [method], reason: "login required")
+        }
+
+        #expect(client.shutdownCount == 1)
+        #expect(client.sent.map(\.method) == ["initialize", "session/new", "session/prompt"])
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].lastError == "login required")
+
+        session.queue[0].lastError = nil
+        manager.persistQueue(for: session)
+        manager.runners[session.id]?.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/new", "session/prompt"])
+    }
+
+    @Test("submit while needsAuth rejects prompt and preserves draft")
+    func submitWhileNeedsAuthRejectsPromptAndPreservesDraft() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let manager = manager(store: store, client: ACPMockClient())
+        let session = manager.createSession(agentId: "claude")
+        let method = terminalAuthMethod()
+        let draft = ACPComposerDraft(segments: [.text("do not clear me")])
+        session.authMethods = [method]
+        session.setupState = .needsAuth(methods: [method], reason: "login required")
+        session.agentState = .failed("login required")
+        session.replaceComposerDraft(draft)
+        var completed: Bool?
+
+        let accepted = manager.submit(
+            sessionId: session.id,
+            text: "do not clear me",
+            attachments: [],
+            intent: .auto,
+            draft: draft
+        ) { succeeded in
+            completed = succeeded
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(accepted == false)
+        #expect(completed == nil)
+        #expect(session.queue.isEmpty)
+        #expect(session.composerDraft == draft)
+        #expect(session.setupState == .needsAuth(methods: [method], reason: "login required"))
+    }
+
     @Test("pending queued prompt waits for transcript recovery after load fallback")
     func queuedPromptWaitsForTranscriptRecoveryAfterLoadFallback() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -311,7 +311,7 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(client.sent.map(\.method) == ["initialize", "session/new", "session/prompt"])
         #expect(session.queue.count == 1)
         #expect(session.queue[0].status == .pending)
-        #expect(session.queue[0].lastError == "login required")
+        #expect(session.queue[0].lastError == nil)
         #expect(session.transcript.streamingState == .idle)
 
         session.queue[0].lastError = nil

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -320,6 +320,40 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(client.sent.map(\.method) == ["initialize", "session/new", "session/prompt"])
     }
 
+    @Test("direct auth failure leaves queued follow-up pending")
+    func directAuthFailureLeavesQueuedFollowUpPending() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        let client = ACPMockClient()
+        let gate = AuthPromptFailureGate()
+        let method = terminalAuthMethod()
+        scriptInitialize(client, authMethods: [method])
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        client.scriptAsync(method: "session/prompt") { _ in
+            try await gate.handlePrompt()
+        }
+        let manager = manager(store: store, client: client)
+        let session = manager.createSession(agentId: "claude")
+
+        await manager.attach(to: session.id, freshlyCreated: true)
+        let runner = try #require(manager.runners[session.id])
+        runner.send(blocks: [.text("first")], intent: .auto)
+        try await waitUntilAsync { await gate.hasEntered }
+        runner.send(blocks: [.text("follow-up")], intent: .auto)
+
+        await gate.release()
+        try await waitUntil {
+            manager.runners[session.id] == nil
+                && session.setupState == .needsAuth(methods: [method], reason: "login required")
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(client.sent.map(\.method) == ["initialize", "session/new", "session/prompt"])
+        #expect(session.queue.count == 1)
+        #expect(session.queue[0].status == .pending)
+        #expect(session.queue[0].lastError == nil)
+        #expect(session.queue[0].blocks == [.text("follow-up")])
+    }
+
     @Test("submit while needsAuth rejects prompt and preserves draft")
     func submitWhileNeedsAuthRejectsPromptAndPreservesDraft() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
@@ -859,6 +893,35 @@ struct ACPSessionManagerAttachRestoreTests {
             await withCheckedContinuation { continuation in
                 self.continuation = continuation
             }
+        }
+
+        func release() {
+            released = true
+            continuation?.resume()
+            continuation = nil
+        }
+    }
+
+    private actor AuthPromptFailureGate {
+        private var entered = false
+        private var released = false
+        private var attempts = 0
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        var hasEntered: Bool { entered }
+
+        func handlePrompt() async throws -> Data {
+            attempts += 1
+            guard attempts == 1 else {
+                return Data("null".utf8)
+            }
+            if !released {
+                entered = true
+                await withCheckedContinuation { continuation in
+                    self.continuation = continuation
+                }
+            }
+            throw JSONRPCError(code: -32000, message: "login required", data: nil)
         }
 
         func release() {

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -14,6 +14,7 @@ struct ACPSessionRunnerQueueTests {
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
         let mock = ACPMockClient()
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
         let runner = ACPSessionRunner(
             session: session,
             connection: ACPConnection(client: mock),
@@ -463,6 +464,7 @@ struct ACPSessionRunnerQueueTests {
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: FileManager.default.temporaryDirectory.path, store: store)
         let session2 = mgr.placeholderSession(id: "rt")!
         await mgr.hydrateIfNeeded(id: "rt")
+        session2.agentState = .ready
         #expect(session2.queue.count == 2)
         // .sending was normalized to .pending on restore.
         #expect(session2.queue[0].status == .pending)

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -79,6 +79,7 @@ struct ACPSessionRunnerTests {
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
         let client = BoundaryRaceClient()
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        session.agentState = .ready
         let runner = ACPSessionRunner(
             session: session,
             connection: ACPConnection(client: client),
@@ -126,6 +127,7 @@ struct ACPSessionRunnerTests {
             createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
         let client = BoundaryRaceClient()
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "t")
+        session.agentState = .ready
         let runner = ACPSessionRunner(
             session: session,
             connection: ACPConnection(client: client),
@@ -348,6 +350,7 @@ struct ACPSessionRunnerTests {
 
         let mock = ACPMockClient()
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
         let runner = ACPSessionRunner(
             session: session,
             connection: ACPConnection(client: mock),
@@ -377,6 +380,7 @@ struct ACPSessionRunnerTests {
 
         let mock = ACPMockClient()
         let session = ACPSession(id: "s", agentId: "claude", worktreeId: "wt", title: "t")
+        session.agentState = .ready
         let runner = ACPSessionRunner(
             session: session,
             connection: ACPConnection(client: mock),

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -20,6 +20,39 @@ struct ACPSessionRunnerTests {
         #expect(runner.session.transcript.streamingState == .idle)
     }
 
+    @Test("auth prompt failure enters needsAuth while preserving direct prompt error")
+    func authPromptFailureEntersNeedsAuth() async throws {
+        let (runner, mock) = try makeRunner()
+        let method = ACPInitializeResult.ACPAuthMethod(
+            id: "claude-login",
+            name: "Claude Login",
+            kind: .terminal
+        )
+        runner.session.authMethods = [method]
+        mock.script(method: "session/prompt") { _ in
+            throw JSONRPCError(
+                code: -32000,
+                message: "Internal error: invalid authentication credentials",
+                data: nil
+            )
+        }
+
+        let succeeded = await withCheckedContinuation { continuation in
+            runner.send(text: "hello", attachments: []) { succeeded in
+                continuation.resume(returning: succeeded)
+            }
+        }
+
+        #expect(succeeded == false)
+        #expect(runner.session.setupState == .needsAuth(
+            methods: [method],
+            reason: "invalid authentication credentials"
+        ))
+        #expect(runner.session.agentState == .failed("invalid authentication credentials"))
+        #expect(runner.session.lastError?.contains("invalid authentication credentials") == true)
+        #expect(runner.session.transcript.streamingState == .idle)
+    }
+
     @Test("send reports successful completion when session prompt succeeds")
     func sendReportsSuccessfulCompletionWhenPromptSucceeds() async throws {
         let (runner, mock) = try makeRunner()

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -180,6 +180,73 @@ struct AgentTerminalLaunchTests {
         }
     }
 
+    @Test func acpAuthLaunchAppendsQuotedCommandAndEnvPrefix() throws {
+        var capturedSuffix: String?
+        let project = project(mode: .useGlobal, useBypass: false)
+        let worktree = Worktree(
+            id: "wt",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/project"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix in
+                capturedSuffix = startupScriptSuffix
+                return AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
+            }
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+
+        _ = try state.openACPAuthTerminalTab(
+            for: worktree,
+            command: ACPAuthTerminalCommand(
+                command: "/Applications/Auth CLI/bin/node",
+                args: ["/opt/claude agent/acp", "--cli"],
+                env: ["TOKEN": "abc'123", "A": "two words"]
+            ),
+            onExit: {}
+        )
+
+        #expect(capturedSuffix == "A='two words' TOKEN='abc'\\''123' '/Applications/Auth CLI/bin/node' '/opt/claude agent/acp' --cli")
+    }
+
+    @Test func acpAuthLaunchRunsExitCallbackWhenTerminalExits() throws {
+        var exitCount = 0
+        let project = project(mode: .useGlobal, useBypass: false)
+        let worktree = Worktree(
+            id: "wt",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/project"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, _ in
+                AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
+            }
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+
+        _ = try state.openACPAuthTerminalTab(
+            for: worktree,
+            command: ACPAuthTerminalCommand(command: "agent", args: ["login"], env: [:])
+        ) {
+            exitCount += 1
+        }
+
+        state.handleTerminalProcessExited(worktreeId: worktree.id, leafId: "auth-session", processAlive: false)
+        state.handleTerminalProcessExited(worktreeId: worktree.id, leafId: "auth-session", processAlive: false)
+
+        #expect(exitCount == 1)
+    }
+
     @Test func launchingCopilotInstallsHookBeforeOpeningTerminal() throws {
         let (dir, cleanup) = tmpDir()
         defer { cleanup() }

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -145,6 +145,8 @@ struct AgentTerminalLaunchTests {
     @Test func manualLaunchAppendsTerminalTabWithStartupSuffix() throws {
         var capturedSuffix: String?
         var capturedIncludeUserStartupScript: Bool?
+        var capturedEnvironmentOverrides: [String: String]?
+        var capturedEnvironmentRemovals: Set<String>?
         let project = project(mode: .useGlobal, useBypass: false)
         let worktree = Worktree(
             id: "wt",
@@ -157,9 +159,11 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix, includeUserStartupScript in
+            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix, includeUserStartupScript, environmentOverrides, environmentRemovals in
                 capturedSuffix = startupScriptSuffix
                 capturedIncludeUserStartupScript = includeUserStartupScript
+                capturedEnvironmentOverrides = environmentOverrides
+                capturedEnvironmentRemovals = environmentRemovals
                 return AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
             }
         )
@@ -175,6 +179,8 @@ struct AgentTerminalLaunchTests {
 
         #expect(capturedSuffix == "test-agent --skip")
         #expect(capturedIncludeUserStartupScript == true)
+        #expect(capturedEnvironmentOverrides == [:])
+        #expect(capturedEnvironmentRemovals == [])
         #expect(state.tabs.tabs(forWorktree: worktree.id) == [tab])
         if case .terminal(let terminal) = tab {
             #expect(terminal.root.firstLeaf().sessionId == "session-1")
@@ -186,6 +192,8 @@ struct AgentTerminalLaunchTests {
     @Test func acpAuthLaunchAppendsQuotedCommandAndEnvPrefix() throws {
         var capturedSuffix: String?
         var capturedIncludeUserStartupScript: Bool?
+        var capturedEnvironmentOverrides: [String: String]?
+        var capturedEnvironmentRemovals: Set<String>?
         let project = project(mode: .useGlobal, useBypass: false)
         let worktree = Worktree(
             id: "wt",
@@ -198,9 +206,11 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix, includeUserStartupScript in
+            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix, includeUserStartupScript, environmentOverrides, environmentRemovals in
                 capturedSuffix = startupScriptSuffix
                 capturedIncludeUserStartupScript = includeUserStartupScript
+                capturedEnvironmentOverrides = environmentOverrides
+                capturedEnvironmentRemovals = environmentRemovals
                 return AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
             }
         )
@@ -222,6 +232,10 @@ struct AgentTerminalLaunchTests {
             "exit \"$status\"",
         ].joined(separator: "\n"))
         #expect(capturedIncludeUserStartupScript == false)
+        #expect(capturedEnvironmentOverrides?["A"] == "two words")
+        #expect(capturedEnvironmentOverrides?["TOKEN"] == "abc'123")
+        #expect(capturedEnvironmentOverrides?["PATH"] != nil)
+        #expect(capturedEnvironmentRemovals == ACPProcessEnvironment.agentSessionMarkerKeys)
     }
 
     @Test func acpAuthLaunchRejectsInvalidEnvKeyBeforeOpeningTerminal() {
@@ -238,7 +252,7 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
                 openerCalled = true
                 return AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
             }
@@ -274,7 +288,7 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
                 AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
             }
         )
@@ -307,7 +321,7 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
                 AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
             }
         )
@@ -344,7 +358,7 @@ struct AgentTerminalLaunchTests {
         var hookExistedBeforeOpen = false
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
                 hookExistedBeforeOpen = FileManager.default.fileExists(atPath: hookURL.path)
                 return AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
             }
@@ -378,7 +392,7 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
                 AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
             }
         )
@@ -421,7 +435,7 @@ struct AgentTerminalLaunchTests {
             fileActionErrorHandler: { title, _ in
                 launchErrorTitle = title
             },
-            terminalSessionOpener: { _, _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _, _, _ in
                 openerCalled = true
                 return AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
             }

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -214,6 +214,42 @@ struct AgentTerminalLaunchTests {
         #expect(capturedSuffix == "A='two words' TOKEN='abc'\\''123' '/Applications/Auth CLI/bin/node' '/opt/claude agent/acp' --cli")
     }
 
+    @Test func acpAuthLaunchRejectsInvalidEnvKeyBeforeOpeningTerminal() {
+        var openerCalled = false
+        let project = project(mode: .useGlobal, useBypass: false)
+        let worktree = Worktree(
+            id: "wt",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/project"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, _ in
+                openerCalled = true
+                return AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
+            }
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+
+        #expect(throws: AppState.ACPAuthTerminalLaunchError.invalidEnvKey("BAD-NAME")) {
+            _ = try state.openACPAuthTerminalTab(
+                for: worktree,
+                command: ACPAuthTerminalCommand(
+                    command: "agent",
+                    args: ["login"],
+                    env: ["BAD-NAME": "x"]
+                ),
+                onExit: {}
+            )
+        }
+        #expect(!openerCalled)
+        #expect(state.tabs.tabs(forWorktree: worktree.id).isEmpty)
+    }
+
     @Test func acpAuthLaunchRunsExitCallbackWhenTerminalExits() throws {
         var exitCount = 0
         let project = project(mode: .useGlobal, useBypass: false)
@@ -245,6 +281,39 @@ struct AgentTerminalLaunchTests {
         state.handleTerminalProcessExited(worktreeId: worktree.id, leafId: "auth-session", processAlive: false)
 
         #expect(exitCount == 1)
+    }
+
+    @Test func acpAuthManualTerminalCloseRemovesExitCallbackWithoutInvoking() throws {
+        var exitCount = 0
+        let project = project(mode: .useGlobal, useBypass: false)
+        let worktree = Worktree(
+            id: "wt",
+            projectId: project.id,
+            name: "main",
+            branch: "main",
+            path: URL(fileURLWithPath: "/tmp/project"),
+            status: .clean,
+            lastActivity: Date()
+        )
+        let state = AppState(
+            store: MemoryStore(),
+            terminalSessionOpener: { _, _, _, _, _, _ in
+                AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
+            }
+        )
+        state.projectsManager = ProjectsManager(persistedProjects: [project])
+
+        _ = try state.openACPAuthTerminalTab(
+            for: worktree,
+            command: ACPAuthTerminalCommand(command: "agent", args: ["login"], env: [:])
+        ) {
+            exitCount += 1
+        }
+
+        state.closeFocusedPane(worktreeId: worktree.id)
+        state.handleTerminalProcessExited(worktreeId: worktree.id, leafId: "auth-session", processAlive: false)
+
+        #expect(exitCount == 0)
     }
 
     @Test func launchingCopilotInstallsHookBeforeOpeningTerminal() throws {

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -144,6 +144,7 @@ struct AgentTerminalLaunchTests {
 
     @Test func manualLaunchAppendsTerminalTabWithStartupSuffix() throws {
         var capturedSuffix: String?
+        var capturedIncludeUserStartupScript: Bool?
         let project = project(mode: .useGlobal, useBypass: false)
         let worktree = Worktree(
             id: "wt",
@@ -156,8 +157,9 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix in
+            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix, includeUserStartupScript in
                 capturedSuffix = startupScriptSuffix
+                capturedIncludeUserStartupScript = includeUserStartupScript
                 return AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
             }
         )
@@ -172,6 +174,7 @@ struct AgentTerminalLaunchTests {
         let tab = try state.openAgentTerminalTab(for: worktree, agentId: "test-agent")
 
         #expect(capturedSuffix == "test-agent --skip")
+        #expect(capturedIncludeUserStartupScript == true)
         #expect(state.tabs.tabs(forWorktree: worktree.id) == [tab])
         if case .terminal(let terminal) = tab {
             #expect(terminal.root.firstLeaf().sessionId == "session-1")
@@ -182,6 +185,7 @@ struct AgentTerminalLaunchTests {
 
     @Test func acpAuthLaunchAppendsQuotedCommandAndEnvPrefix() throws {
         var capturedSuffix: String?
+        var capturedIncludeUserStartupScript: Bool?
         let project = project(mode: .useGlobal, useBypass: false)
         let worktree = Worktree(
             id: "wt",
@@ -194,8 +198,9 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix in
+            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix, includeUserStartupScript in
                 capturedSuffix = startupScriptSuffix
+                capturedIncludeUserStartupScript = includeUserStartupScript
                 return AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
             }
         )
@@ -216,6 +221,7 @@ struct AgentTerminalLaunchTests {
             "status=$?",
             "exit \"$status\"",
         ].joined(separator: "\n"))
+        #expect(capturedIncludeUserStartupScript == false)
     }
 
     @Test func acpAuthLaunchRejectsInvalidEnvKeyBeforeOpeningTerminal() {
@@ -232,7 +238,7 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _ in
                 openerCalled = true
                 return AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
             }
@@ -268,7 +274,7 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _ in
                 AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
             }
         )
@@ -301,7 +307,7 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _ in
                 AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
             }
         )
@@ -338,7 +344,7 @@ struct AgentTerminalLaunchTests {
         var hookExistedBeforeOpen = false
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _ in
                 hookExistedBeforeOpen = FileManager.default.fileExists(atPath: hookURL.path)
                 return AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
             }
@@ -372,7 +378,7 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _ in
                 AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
             }
         )
@@ -415,7 +421,7 @@ struct AgentTerminalLaunchTests {
             fileActionErrorHandler: { title, _ in
                 launchErrorTitle = title
             },
-            terminalSessionOpener: { _, _, _, _, _, _ in
+            terminalSessionOpener: { _, _, _, _, _, _, _ in
                 openerCalled = true
                 return AppState.OpenedTerminalSession(id: "session-1", foregroundPid: { nil })
             }

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -211,7 +211,11 @@ struct AgentTerminalLaunchTests {
             onExit: {}
         )
 
-        #expect(capturedSuffix == "A='two words' TOKEN='abc'\\''123' '/Applications/Auth CLI/bin/node' '/opt/claude agent/acp' --cli")
+        #expect(capturedSuffix == [
+            "A='two words' TOKEN='abc'\\''123' '/Applications/Auth CLI/bin/node' '/opt/claude agent/acp' --cli",
+            "status=$?",
+            "exit \"$status\"",
+        ].joined(separator: "\n"))
     }
 
     @Test func acpAuthLaunchRejectsInvalidEnvKeyBeforeOpeningTerminal() {

--- a/docs/superpowers/plans/2026-06-01-acp-terminal-auth.md
+++ b/docs/superpowers/plans/2026-06-01-acp-terminal-auth.md
@@ -1,0 +1,684 @@
+# ACP Terminal Auth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add first-class ACP terminal authentication so Claude/Cursor-style ACP auth failures surface as a sign-in banner that launches the provider's advertised login command and retries attach.
+
+**Architecture:** Extend ACP protocol models to advertise/decode auth. Add runtime auth setup state to `ACPSession` and classify auth-required JSON-RPC errors in manager/runner paths. Reuse the existing ACP top banner and AppState terminal-tab launcher for the interactive login command, with an exit callback that reattaches the ACP session.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Testing, existing Alas ACP JSON-RPC stdio client, existing terminal tab/Ghostty surface.
+
+---
+
+## File Structure
+
+- Modify `Alas/Sources/ACP/Protocol/ACPMessages.swift`: add auth capability and auth method wire models.
+- Modify `Alas/Sources/ACP/Protocol/ACPConnection.swift`: return initialize auth methods and add `authenticate(methodId:)`.
+- Modify `Alas/Sources/ACP/Protocol/ACPClient.swift`: improve JSON-RPC auth error description if needed.
+- Create `Alas/Sources/ACP/Protocol/ACPAuthFailure.swift`: shared auth-error classifier.
+- Modify `Alas/Sources/ACP/Session/ACPSession.swift`: add runtime auth state.
+- Modify `Alas/Sources/ACP/Session/ACPSessionManager.swift`: store auth methods and convert attach auth failures into setup state.
+- Modify `Alas/Sources/ACP/Session/ACPSessionRunner.swift`: convert prompt auth failures into setup state.
+- Create `Alas/Sources/ACP/UI/ACPAuthNudgeBanner.swift`: sign-in banner and copy helpers.
+- Modify `Alas/Sources/ACP/UI/ACPTabView.swift`: render auth banner and trigger auth terminal launch.
+- Modify `Alas/Sources/App/AppState.swift`: add ACP auth terminal launcher and terminal-exit callback hook.
+- Add/modify tests under `AlasTests/ACP/Protocol`, `AlasTests/ACP/Session`, `AlasTests/ACP/Adapter`, and `AlasTests/AgentTerminalLaunchTests.swift`.
+
+---
+
+### Task 1: Protocol Auth Models And Initialize Capability
+
+**Files:**
+- Modify: `Alas/Sources/ACP/Protocol/ACPMessages.swift`
+- Modify: `Alas/Sources/ACP/Protocol/ACPConnection.swift`
+- Modify: `Alas/Sources/ACP/Protocol/ACPMockClient.swift` if test helpers need method inspection only
+- Test: `AlasTests/ACP/Protocol/ACPInitializeTests.swift`
+- Test: `AlasTests/ACP/Protocol/ACPConnectionTests.swift`
+
+- [ ] **Step 1: Write failing protocol tests**
+
+Add tests covering the desired wire shape:
+
+```swift
+@Test("initialize request advertises terminal auth capabilities")
+func initializeRequestAdvertisesAuth() throws {
+    let req = ACPRequest(method: "initialize",
+                         params: ACPInitializeParams.defaultClient())
+    let data = try JSONEncoder().encode(JSONRPCEnvelope(id: .number(1), method: req.method, params: req.params as? ACPInitializeParams))
+    let json = try #require(String(data: data, encoding: .utf8))
+    #expect(json.contains(#""auth":{"terminal":true}"#))
+    #expect(json.contains(#""_meta":{"terminal-auth":true}"#))
+}
+
+@Test("decodes terminal auth method metadata")
+func decodesTerminalAuthMethod() throws {
+    let data = Data("""
+    {"protocolVersion":1,"authMethods":[{"id":"claude-ai-login","name":"Claude Subscription","description":"Use Claude subscription","type":"terminal","args":["--cli","auth","login"],"env":{"A":"B"},"_meta":{"terminal-auth":{"command":"/usr/bin/node","args":["/opt/claude-agent-acp","--cli"],"label":"Claude Login"}}}]}
+    """.utf8)
+    let result = try JSONDecoder().decode(ACPInitializeResult.self, from: data)
+    let method = try #require(result.authMethods.first)
+    #expect(method.id == "claude-ai-login")
+    #expect(method.kind == .terminal)
+    #expect(method.args == ["--cli", "auth", "login"])
+    #expect(method.env == ["A": "B"])
+    #expect(method.terminalAuth?.command == "/usr/bin/node")
+    #expect(method.terminalAuth?.args == ["/opt/claude-agent-acp", "--cli"])
+    #expect(method.terminalAuth?.label == "Claude Login")
+}
+```
+
+Add an `ACPConnectionTests` assertion that `initialize()` returns both prompt capabilities and auth methods:
+
+```swift
+let initialized = try await conn.initialize()
+#expect(initialized.promptCapabilities.embeddedContext == true)
+#expect(initialized.authMethods.map(\\.id) == ["claude-ai-login"])
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPInitializeTests -only-testing:AlasTests/ACPConnectionTests test
+```
+
+Expected: failures because auth capability/model fields and richer initialize return value do not exist yet.
+
+- [ ] **Step 3: Implement protocol models**
+
+In `ACPMessages.swift`, add:
+
+```swift
+struct ACPClientCapabilities: Codable, Equatable {
+    let fs: ACPFsCapabilities
+    let terminal: Bool
+    let auth: ACPAuthCapabilities
+    let meta: ACPClientCapabilitiesMeta
+
+    init(fs: ACPFsCapabilities, terminal: Bool, auth: ACPAuthCapabilities = .init(terminal: true), meta: ACPClientCapabilitiesMeta = .terminalAuth) {
+        self.fs = fs
+        self.terminal = terminal
+        self.auth = auth
+        self.meta = meta
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case fs, terminal, auth
+        case meta = "_meta"
+    }
+
+    struct ACPFsCapabilities: Codable, Equatable {
+        let readTextFile: Bool
+        let writeTextFile: Bool
+    }
+}
+
+struct ACPAuthCapabilities: Codable, Equatable {
+    let terminal: Bool
+}
+
+struct ACPClientCapabilitiesMeta: Codable, Equatable {
+    static let terminalAuth = ACPClientCapabilitiesMeta(terminalAuth: true)
+    let terminalAuth: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case terminalAuth = "terminal-auth"
+    }
+}
+```
+
+Replace the nested `ACPInitializeResult.ACPAuthMethod` with a richer nested model:
+
+```swift
+struct ACPAuthMethod: Codable, Equatable {
+    let id: String
+    let name: String
+    let description: String?
+    let kind: Kind
+    let args: [String]?
+    let env: [String: String]?
+    let vars: [ACPAuthEnvVar]?
+    let meta: Meta?
+
+    var terminalAuth: TerminalAuthMeta? { meta?.terminalAuth }
+
+    enum Kind: Equatable {
+        case agent
+        case terminal
+        case envVar
+        case unknown(String)
+    }
+
+    struct Meta: Codable, Equatable {
+        let terminalAuth: TerminalAuthMeta?
+        enum CodingKeys: String, CodingKey { case terminalAuth = "terminal-auth" }
+    }
+
+    struct TerminalAuthMeta: Codable, Equatable {
+        let command: String?
+        let args: [String]?
+        let label: String?
+    }
+
+    struct ACPAuthEnvVar: Codable, Equatable {
+        let name: String
+        let label: String?
+        let optional: Bool?
+        let secret: Bool?
+    }
+}
+```
+
+Implement custom Codable for `Kind` so missing `type` decodes as `.agent`, `"env_var"` decodes as `.envVar`, and unknown strings round-trip as `.unknown(value)`. Implement custom Codable for `ACPAuthMethod` to map JSON field `type` to `kind` and `_meta` to `meta`.
+
+- [ ] **Step 4: Implement initialize return value**
+
+In `ACPConnection.swift`, add:
+
+```swift
+struct ACPInitializeOutcome: Equatable {
+    let promptCapabilities: ACPInitializeResult.ACPPromptCapabilities
+    let authMethods: [ACPInitializeResult.ACPAuthMethod]
+}
+```
+
+Change `initialize()` to return `ACPInitializeOutcome`:
+
+```swift
+let result = try JSONDecoder().decode(ACPInitializeResult.self, from: resp.body)
+return ACPInitializeOutcome(
+    promptCapabilities: result.agentCapabilities?.promptCapabilities ?? .init(),
+    authMethods: result.authMethods
+)
+```
+
+Keep the initialize request's `clientCapabilities` creation using `.init(fs:..., terminal: true)` so the new default auth capability is encoded automatically.
+
+- [ ] **Step 5: Update direct callers and tests**
+
+Update `ACPSessionManager.attach` to use:
+
+```swift
+let initialized = try await connection.initialize()
+session.promptCapabilities = initialized.promptCapabilities
+session.authMethods = initialized.authMethods
+```
+
+Update existing tests that treated `initialize()` as returning prompt capabilities.
+
+- [ ] **Step 6: Run protocol tests and commit**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPInitializeTests -only-testing:AlasTests/ACPConnectionTests test
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+rtk proxy git add Alas/Sources/ACP/Protocol/ACPMessages.swift Alas/Sources/ACP/Protocol/ACPConnection.swift Alas/Sources/ACP/Session/ACPSessionManager.swift AlasTests/ACP/Protocol/ACPInitializeTests.swift AlasTests/ACP/Protocol/ACPConnectionTests.swift
+rtk proxy git commit -m "feat(acp): negotiate auth methods"
+```
+
+---
+
+### Task 2: Runtime Auth State And Error Classification
+
+**Files:**
+- Create: `Alas/Sources/ACP/Protocol/ACPAuthFailure.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSession.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionManager.swift`
+- Modify: `Alas/Sources/ACP/Session/ACPSessionRunner.swift`
+- Test: `AlasTests/ACP/Protocol/ACPAuthFailureTests.swift`
+- Test: `AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift`
+- Test: `AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift` or a focused runner test file
+
+- [ ] **Step 1: Write failing classifier tests**
+
+Create tests:
+
+```swift
+@Suite("ACPAuthFailure")
+struct ACPAuthFailureTests {
+    @Test("classifies JSON-RPC authentication failures")
+    func classifiesAuthenticationMessages() {
+        let error = ACPClientError.jsonrpc(.init(code: -32603, message: "Internal error: Failed to authenticate. API Error: 401 Invalid authentication credentials", data: nil))
+        #expect(ACPAuthFailure.message(from: error) == "Failed to authenticate. API Error: 401 Invalid authentication credentials")
+    }
+
+    @Test("does not classify unrelated failures")
+    func ignoresUnrelatedErrors() {
+        let error = ACPClientError.jsonrpc(.init(code: -32603, message: "Internal error: file not found", data: nil))
+        #expect(ACPAuthFailure.message(from: error) == nil)
+    }
+}
+```
+
+- [ ] **Step 2: Write failing manager auth-state test**
+
+In `ACPSessionManagerAttachRestoreTests.swift`, add a test where initialize returns a terminal auth method and `session/new` throws the 401 error. Assert:
+
+```swift
+if case .needsAuth(let methods, let reason) = session.setupState {
+    #expect(methods.map(\\.id) == ["claude-ai-login"])
+    #expect(reason?.contains("401") == true)
+} else {
+    Issue.record("Expected needsAuth")
+}
+#expect(session.agentState == .failed(reasonText))
+```
+
+Use the existing `manager(store:client:)`, `scriptInitialize`, and `scriptSessionResult` helpers where possible; add a helper for auth methods if useful.
+
+- [ ] **Step 3: Write failing prompt auth-state test**
+
+Add a runner/manager test where the session is ready, `session.authMethods` has a terminal method, and `connection.prompt` throws the same auth error. Assert:
+
+```swift
+if case .needsAuth(let methods, let reason) = session.setupState {
+    #expect(methods.first?.id == "claude-ai-login")
+    #expect(reason?.contains("401") == true)
+} else {
+    Issue.record("Expected needsAuth after prompt auth failure")
+}
+#expect(session.lastError?.contains("prompt failed") == true)
+```
+
+- [ ] **Step 4: Run tests and verify they fail**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPAuthFailureTests -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests test
+```
+
+Expected: failures because the classifier and setup state do not exist.
+
+- [ ] **Step 5: Implement classifier**
+
+Create `ACPAuthFailure.swift`:
+
+```swift
+import Foundation
+
+enum ACPAuthFailure {
+    static func message(from error: Error) -> String? {
+        let message: String
+        if let clientError = error as? ACPClientError,
+           case .jsonrpc(let rpc) = clientError {
+            message = rpc.message
+        } else if let rpc = error as? JSONRPCError {
+            message = rpc.message
+        } else {
+            message = error.localizedDescription
+        }
+        let lower = message.lowercased()
+        guard lower.contains("auth_required")
+            || lower.contains("auth required")
+            || lower.contains("failed to authenticate")
+            || lower.contains("invalid authentication credentials")
+            || lower.contains("unauthorized")
+            || lower.contains("401")
+        else { return nil }
+        return cleaned(message)
+    }
+
+    private static func cleaned(_ message: String) -> String {
+        let prefix = "Internal error: "
+        if message.hasPrefix(prefix) {
+            return String(message.dropFirst(prefix.count))
+        }
+        return message
+    }
+}
+```
+
+- [ ] **Step 6: Implement session auth state**
+
+In `ACPSession.swift`, add:
+
+```swift
+@Published var authMethods: [ACPInitializeResult.ACPAuthMethod] = []
+```
+
+Extend `SetupState`:
+
+```swift
+case needsAuth(methods: [ACPInitializeResult.ACPAuthMethod], reason: String?)
+```
+
+- [ ] **Step 7: Implement manager classification**
+
+In `ACPSessionManager.attach`, after initialize:
+
+```swift
+let initialized = try await connection.initialize()
+session.promptCapabilities = initialized.promptCapabilities
+session.authMethods = initialized.authMethods
+```
+
+In the outer `catch`, before setting generic failure:
+
+```swift
+if let authReason = ACPAuthFailure.message(from: error) {
+    session.setupState = .needsAuth(methods: session.authMethods, reason: authReason)
+    let full = tail.isEmpty ? authReason : authReason + "\nstderr: " + tail
+    session.lastError = full
+    session.agentState = .failed(full)
+    startedRunner?.stop()
+    await connection.shutdown()
+    return
+}
+```
+
+In the `session/load` catch, if `ACPAuthFailure.message(from: error) != nil`, rethrow instead of falling back to `session/new`.
+
+- [ ] **Step 8: Implement runner prompt classification**
+
+In `ACPSessionRunner.sendNow` catch path, when `!wasCancelled` and `ACPAuthFailure.message(from: error)` returns a reason:
+
+```swift
+self.session.setupState = .needsAuth(methods: self.session.authMethods, reason: authReason)
+self.session.agentState = .failed(authReason)
+```
+
+Then preserve existing queue/direct prompt error behavior so queued prompts still show retry and direct prompts still set `lastError`.
+
+- [ ] **Step 9: Run focused tests and commit**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPAuthFailureTests -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests test
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+rtk proxy git add Alas/Sources/ACP/Protocol/ACPAuthFailure.swift Alas/Sources/ACP/Session/ACPSession.swift Alas/Sources/ACP/Session/ACPSessionManager.swift Alas/Sources/ACP/Session/ACPSessionRunner.swift AlasTests/ACP/Protocol/ACPAuthFailureTests.swift AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+rtk proxy git commit -m "feat(acp): surface auth-required state"
+```
+
+---
+
+### Task 3: Auth Banner And Terminal Login Launch
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPAuthNudgeBanner.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPTabView.swift`
+- Modify: `Alas/Sources/App/AppState.swift`
+- Test: `AlasTests/ACP/Adapter/ACPAuthNudgeBannerTests.swift`
+- Test: `AlasTests/AgentTerminalLaunchTests.swift`
+
+- [ ] **Step 1: Write failing banner copy tests**
+
+Create `ACPAuthNudgeBannerTests.swift`:
+
+```swift
+@Suite("ACPAuthNudgeBanner")
+struct ACPAuthNudgeBannerTests {
+    @Test("prefers terminal-auth metadata label")
+    func labelUsesTerminalMetadata() {
+        let method = ACPInitializeResult.ACPAuthMethod.terminalForTesting(
+            id: "claude-ai-login",
+            name: "Claude Subscription",
+            label: "Claude Login"
+        )
+        #expect(ACPAuthNudgeBannerCopy.buttonTitle(method: method) == "Claude Login")
+    }
+
+    @Test("unsupported env auth copy is explicit")
+    func unsupportedEnvAuthCopy() {
+        #expect(ACPAuthNudgeBannerCopy.unsupportedMessage(agentDisplayName: "Cursor").contains("environment credentials"))
+    }
+}
+```
+
+If a `terminalForTesting` helper is not desired in production, construct the auth method directly with its memberwise initializer.
+
+- [ ] **Step 2: Write failing AppState terminal launch test**
+
+In `AgentTerminalLaunchTests.swift`, add a test that injects `terminalSessionOpener`, calls the new `openACPAuthTerminalTab`, and asserts the startup script includes the quoted command and env assignment:
+
+```swift
+var capturedSuffix: String?
+let state = AppState(... terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix in
+    capturedSuffix = startupScriptSuffix
+    return .init(id: "auth-session", foregroundPid: { nil })
+})
+_ = try state.openACPAuthTerminalTab(
+    for: worktree,
+    command: .init(command: "/usr/bin/node", args: ["/opt/claude-agent-acp", "--cli"], env: ["A": "B"])
+) {}
+#expect(capturedSuffix?.contains("A=B") == true)
+#expect(capturedSuffix?.contains("/usr/bin/node /opt/claude-agent-acp --cli") == true)
+```
+
+- [ ] **Step 3: Run tests and verify they fail**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPAuthNudgeBannerTests -only-testing:AlasTests/AgentTerminalLaunchTests test
+```
+
+Expected: failures because banner and launch API do not exist.
+
+- [ ] **Step 4: Implement auth command resolution**
+
+In `ACPAuthNudgeBanner.swift`, add a small value type:
+
+```swift
+struct ACPAuthTerminalCommand: Equatable {
+    let command: String
+    let args: [String]
+    let env: [String: String]
+
+    static func resolve(method: ACPInitializeResult.ACPAuthMethod, fallbackCommand: String) -> ACPAuthTerminalCommand? {
+        guard method.kind == .terminal else { return nil }
+        if let command = method.terminalAuth?.command, !command.isEmpty {
+            return .init(command: command, args: method.terminalAuth?.args ?? method.args ?? [], env: method.env ?? [:])
+        }
+        let args = method.args ?? []
+        guard !args.isEmpty else { return nil }
+        return .init(command: fallbackCommand, args: args, env: method.env ?? [:])
+    }
+}
+```
+
+Add `ACPAuthNudgeBannerCopy` with:
+
+```swift
+static func message(agentDisplayName: String, reason: String?) -> String
+static func unsupportedMessage(agentDisplayName: String) -> String
+static func buttonTitle(method: ACPInitializeResult.ACPAuthMethod) -> String
+```
+
+- [ ] **Step 5: Implement SwiftUI banner**
+
+Create `ACPAuthNudgeBanner` matching the existing setup banner style. Inputs:
+
+```swift
+let agentDisplayName: String
+let methods: [ACPInitializeResult.ACPAuthMethod]
+let reason: String?
+let onSignIn: (ACPInitializeResult.ACPAuthMethod) -> Void
+let onReconnect: () -> Void
+```
+
+Behavior:
+
+- If a terminal method exists, show `Sign In`/advertised label button.
+- If no terminal method exists, show unsupported copy and a `Reconnect` button.
+- Use the same quiet pane-level banner styling as `ACPSetupNudgeBanner`.
+
+- [ ] **Step 6: Implement AppState auth terminal launcher**
+
+In `AppState.swift`, add:
+
+```swift
+@ObservationIgnored
+private var acpAuthTerminalExitHandlers: [String: () -> Void] = [:]
+```
+
+Add:
+
+```swift
+@discardableResult
+func openACPAuthTerminalTab(
+    for worktree: Worktree,
+    command: ACPAuthTerminalCommand,
+    onExit: @escaping () -> Void
+) throws -> Tab {
+    let suffix = Self.shellCommand(command.command, args: command.args, env: command.env)
+    let tab = try openTerminalTab(for: worktree, startupScriptSuffix: suffix)
+    if case .terminal(let terminal) = tab {
+        acpAuthTerminalExitHandlers[terminal.sessionId] = onExit
+    }
+    return tab
+}
+```
+
+Add `shellCommand(command:args:env:)` using the existing `shellQuote` helper:
+
+```swift
+let envPrefix = env.sorted(by: { $0.key < $1.key }).map { "\\($0.key)=\\(shellQuote($0.value))" }
+return (envPrefix + [shellQuote(command)] + args.map(shellQuote)).joined(separator: " ")
+```
+
+In the existing `terminal.onSessionProcessExited` handler, after close-pane handling:
+
+```swift
+if let handler = self?.acpAuthTerminalExitHandlers.removeValue(forKey: leafId) {
+    handler()
+}
+```
+
+- [ ] **Step 7: Wire banner into ACPTabView**
+
+In `adapterBanner()`, handle `.needsAuth` before adapter install/update decisions:
+
+```swift
+if case .needsAuth(let methods, let reason) = session.setupState {
+    ACPAuthNudgeBanner(
+        agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
+        methods: methods,
+        reason: reason,
+        onSignIn: { method in launchAuth(method) },
+        onReconnect: { Task { await reattach() } }
+    )
+    return
+}
+```
+
+Add `launchAuth(_:)`:
+
+```swift
+private func launchAuth(_ method: ACPInitializeResult.ACPAuthMethod) {
+    guard let spec = ACPLaunchCatalog.spec(for: session.agentId),
+          let command = ACPAuthTerminalCommand.resolve(method: method, fallbackCommand: spec.command)
+    else { return }
+    do {
+        _ = try state.openACPAuthTerminalTab(for: worktree, command: command) {
+            Task { @MainActor in await reattach() }
+        }
+    } catch {
+        session.lastError = "Failed to launch auth terminal: \\(error.localizedDescription)"
+    }
+}
+```
+
+Update `isConnecting` to return false for `.needsAuth`.
+
+- [ ] **Step 8: Run focused tests and commit**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPAuthNudgeBannerTests -only-testing:AlasTests/AgentTerminalLaunchTests test
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+rtk proxy git add Alas/Sources/ACP/UI/ACPAuthNudgeBanner.swift Alas/Sources/ACP/UI/ACPTabView.swift Alas/Sources/App/AppState.swift AlasTests/ACP/Adapter/ACPAuthNudgeBannerTests.swift AlasTests/AgentTerminalLaunchTests.swift
+rtk proxy git commit -m "feat(acp): launch terminal auth from pane"
+```
+
+---
+
+### Task 4: Project Regeneration And End-to-End Verification
+
+**Files:**
+- Modify: `Alas.xcodeproj/project.pbxproj` if `xcodegen` updates it for new files.
+- Review all files touched by prior tasks.
+
+- [ ] **Step 1: Regenerate project**
+
+Run:
+
+```bash
+rtk xcodegen
+```
+
+Expected: exits 0. New Swift files appear in the generated Xcode project if required.
+
+- [ ] **Step 2: Run ACP-focused tests**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPInitializeTests -only-testing:AlasTests/ACPConnectionTests -only-testing:AlasTests/ACPAuthFailureTests -only-testing:AlasTests/ACPSessionManagerAttachRestoreTests -only-testing:AlasTests/ACPAuthNudgeBannerTests -only-testing:AlasTests/AgentTerminalLaunchTests test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run required build**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run required full tests if feasible**
+
+Run:
+
+```bash
+rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: PASS. If the suite times out or fails on known unrelated host-specific tests, capture exact failing test names and run the ACP-focused subset plus the quiet build before reporting.
+
+- [ ] **Step 5: Manual adapter handshake sanity check**
+
+Run:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":true,"writeTextFile":true},"terminal":true,"auth":{"terminal":true},"_meta":{"terminal-auth":true}}}}' | rtk claude-agent-acp
+```
+
+Expected: response includes terminal `authMethods` when auth methods are available, matching the protocol test fixture shape.
+
+- [ ] **Step 6: Commit verification/project regeneration**
+
+If `xcodegen` changed the project file, commit it:
+
+```bash
+rtk proxy git add Alas.xcodeproj/project.pbxproj
+rtk proxy git commit -m "chore: regenerate project"
+```
+
+If no project file changed, do not create an empty commit.
+

--- a/docs/superpowers/specs/2026-06-01-acp-terminal-auth-design.md
+++ b/docs/superpowers/specs/2026-06-01-acp-terminal-auth-design.md
@@ -1,0 +1,172 @@
+# ACP Terminal Auth Design
+
+Date: 2026-06-01
+
+## Problem
+
+Alas can launch ACP adapters and talk to agents, but it does not participate in ACP authentication negotiation. On machines where an adapter requires authentication, the ACP pane can fail with raw JSON-RPC errors such as:
+
+```text
+ACP error -32603: Internal error: Failed to authenticate. API Error: 401 Invalid authentication credentials
+```
+
+The same provider can still work in a normal terminal because terminal CLI auth and ACP auth are separate surfaces. Cursor showing similar ACP-only auth failure indicates this should be fixed at the ACP client layer, not with Claude-specific credential handling.
+
+## Goals
+
+- Advertise ACP terminal-auth support during `initialize`.
+- Decode advertised ACP auth methods with enough structure to support terminal login.
+- Surface auth-required failures as a clear pane-level auth state instead of a generic internal error.
+- Let the user launch the provider's advertised terminal auth command from Alas.
+- Retry ACP attach after the auth command exits.
+- Keep the first implementation narrowly focused on terminal auth.
+
+## Non-Goals
+
+- Do not build a secrets UI for environment-variable auth in the first pass.
+- Do not invent provider-specific Claude or Cursor login commands when the adapter advertises one.
+- Do not persist auth methods or auth state beyond the runtime session.
+- Do not change terminal CLI auth behavior outside ACP panes.
+
+## Current Behavior
+
+`ACPConnection.initialize()` sends only filesystem and terminal capabilities, then returns only prompt capabilities to callers. The client does decode `authMethods`, but only as `id` and `name`; method type, terminal arguments, environment variables, and `_meta` are discarded. There is also no `authenticate` method wrapper.
+
+The existing `ACPSession.SetupState` has only:
+
+- `checking`
+- `ready`
+- `needsSetup(reason:)`
+
+That state is already used by `ACPTabView` to show adapter install/update banners and retry attach after setup changes. ACP auth should reuse that pane-level setup surface rather than adding a detached alert or global settings flow.
+
+## Design
+
+### Protocol Model
+
+Extend `ACPClientCapabilities` to include:
+
+- `auth.terminal = true`
+- `_meta["terminal-auth"] = true`
+
+The `_meta` field is included because the current Claude ACP adapter checks it when returning richer terminal-auth command metadata. The standard `auth.terminal` field is the primary capability.
+
+Extend auth method decoding to model at least:
+
+- `agent`: default type, agent handles auth itself.
+- `terminal`: client launches an interactive terminal auth command.
+- `env_var`: provider needs credentials as environment variables.
+
+Terminal auth methods should retain:
+
+- `id`
+- `name`
+- `description`
+- `args`
+- `env`
+- `_meta["terminal-auth"].command`
+- `_meta["terminal-auth"].args`
+- `_meta["terminal-auth"].label`
+
+The login command resolution should prefer `_meta["terminal-auth"].command` and args when present, because that gives Alas a complete command line. If only `args` are present, run the current ACP adapter command with those args. If neither produces a runnable command, surface an unsupported-auth message.
+
+### Connection API
+
+Change initialization to return a richer value, for example:
+
+```swift
+struct ACPInitializedSession {
+    let promptCapabilities: ACPInitializeResult.ACPPromptCapabilities
+    let authMethods: [ACPAuthMethod]
+}
+```
+
+`ACPSessionManager.attach` stores the prompt capabilities as it does today and keeps the auth methods on the session runtime state.
+
+Add an `authenticate(methodId:)` wrapper for the ACP `authenticate` request, but do not require it for terminal auth unless a provider's advertised method needs it. The first implementation can launch terminal auth and then retry attach. The wrapper exists so future agent-handled methods have a protocol entry point.
+
+### Session State
+
+Extend `ACPSession.SetupState` with an auth-specific case:
+
+```swift
+case needsAuth(methods: [ACPAuthMethod], reason: String?)
+```
+
+This is runtime-only, matching the existing setup state. The session can also retain `authMethods` as a published runtime field if that keeps the enum lightweight and SwiftUI updates simpler.
+
+When `initialize`, `session/new`, `session/load`, or `session/prompt` fails with an auth-required ACP error or a recognizable 401 authentication message, translate it to `needsAuth` if auth methods are known. Do not leave the user with only `lastError`.
+
+If no auth methods are known, show a clear authentication-required message and keep the raw error available in `lastError` for diagnostics.
+
+### UI Flow
+
+Add an auth banner in the same top-of-pane region as the adapter setup nudge.
+
+For terminal auth:
+
+- Show a concise message such as `Claude needs sign-in to continue.`
+- Use the advertised label when available for the button, otherwise `Sign In`.
+- Launch the advertised terminal auth command in an Alas terminal surface using the same augmented ACP process environment.
+- When the auth command exits, clear the prior auth error and retry `attach`.
+
+For env-var auth in the first pass:
+
+- Decode the method.
+- Show a clear unsupported message such as `This provider requires environment credentials. Configure them in the environment used to launch Alas, then reconnect.`
+- Do not build a credential-entry UI yet.
+
+For agent auth in the first pass:
+
+- Decode the method.
+- If the provider returns auth-required and only agent methods are available, show a clear unsupported message rather than retrying blindly.
+
+### Data Flow
+
+1. `ACPSessionManager.attach` resolves the `ACPLaunchSpec`.
+2. Setup check passes and the ACP adapter process starts.
+3. `initialize` sends auth terminal capabilities.
+4. The manager stores prompt capabilities and advertised auth methods.
+5. If session creation succeeds, session state becomes ready as today.
+6. If session creation fails because auth is required, session state becomes `needsAuth`.
+7. The banner renders the best supported auth method.
+8. The user clicks `Sign In`.
+9. Alas launches the advertised terminal command with the ACP process environment.
+10. When that process exits, Alas retries attach.
+
+### Error Handling
+
+- Auth-required JSON-RPC errors should not be shown as generic internal errors.
+- Preserve the detailed raw message in `lastError` for debugging.
+- If terminal auth exits nonzero, keep `needsAuth` visible and show the exit failure in the banner.
+- If retry attach fails with auth again, keep the auth banner visible.
+- If retry attach succeeds, clear the auth state and last auth error.
+
+### Testing Strategy
+
+Use Swift Testing and test-first implementation.
+
+Protocol tests:
+
+- initialize request encodes `clientCapabilities.auth.terminal = true`.
+- initialize request encodes `_meta["terminal-auth"] = true`.
+- terminal auth methods decode command, args, label, and env.
+- env-var auth methods decode without crashing.
+
+Connection/manager tests:
+
+- initialize returns prompt capabilities and auth methods.
+- auth-required session creation sets `setupState = .needsAuth`.
+- non-auth JSON-RPC errors still surface as failures.
+- retry after auth uses the normal attach path.
+
+UI/copy tests:
+
+- auth banner chooses the first supported terminal auth method.
+- unsupported env-var-only auth produces clear copy.
+- sign-in button label uses advertised terminal auth label when present.
+
+## Rollout
+
+Keep the first PR scoped to terminal auth negotiation and launch. Do not include env-var credential storage or provider-specific command guesses. After terminal auth is working for Claude and Cursor, revisit env-var auth only if a real provider requires it.
+


### PR DESCRIPTION
## Summary
- Advertise terminal auth capability during ACP initialize while preserving compatibility with providers that omit auth fields.
- Map ACP authentication failures into a recoverable pane state that preserves drafts and prevents queued prompt auto-drain.
- Add an ACP auth banner that launches provider-declared terminal sign-in commands and reconnects after the terminal exits.

## Validation
- `rtk xcodegen`
- Focused ACP auth/session/UI tests
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Full `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test` currently fails in unrelated `BaseBranchSelectorTests.branchListHeightMatchesVisibleRows`, with equal-looking height expectations outside this change.