### PR TITLE
fix(acp): tail-first transcript hydration

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -295,6 +295,26 @@ final class ACPSession: ObservableObject, Identifiable {
         rebuildToolCallIndices()
     }
 
+    /// Insert `older` at the head of the transcript and shift `visibleHead`
+    /// forward by `older.count` so the visible tail window stays anchored to
+    /// the same messages. Used by the post-hydration backfill that prepends
+    /// pre-tail messages after the UI has already painted the tail.
+    func prependTranscriptMessages(_ older: [ACPMessage]) {
+        guard !older.isEmpty else { return }
+        transcript.messages.insert(contentsOf: older, at: 0)
+        // Rebuild tool-call indices because every prior entry's index just
+        // shifted by `older.count`. Cheaper than offsetting in place: the
+        // cache is dictionary-typed, so a full rebuild is O(N) and avoids
+        // any chance of drift if a streaming update lands mid-shift.
+        rebuildToolCallIndices()
+        // Keep the visible window anchored to the tail the user is already
+        // looking at. Bypass `setVisibleHead` — it strips markdown caches
+        // for messages below the new head, which is exactly what we want
+        // to *avoid* here (older messages weren't visible before the shift
+        // and never had caches; the tail's caches must survive untouched).
+        transcript.visibleHead = transcript.visibleHead + older.count
+    }
+
     func markCompletedOutputBoundary() {
         transcript.completedOutputBoundaryMessageIds.removeAll()
         for message in transcript.messages.reversed() {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -35,6 +35,10 @@ final class ACPSessionManager: ObservableObject {
     private let setupEvaluator: ACPSetupEvaluator
     private let connectionFactory: ACPConnectionFactory
     private var inFlightHydrations: [ACPSession.ID: Task<Void, Never>] = [:]
+    /// Per-session task that prepends pre-tail messages after the initial
+    /// tail-only paint applied by `applyHydration`. Tracked so tests (and
+    /// teardown) can wait for it; production UI does not.
+    private var inFlightBackfills: [ACPSession.ID: Task<Void, Never>] = [:]
 
     /// Per-session UI refcount. When this drops to zero AND the session is
     /// not `attached`, the cached `ACPSession` is evicted from `sessions`.
@@ -112,6 +116,16 @@ final class ACPSessionManager: ObservableObject {
         session.remoteSessionId = row.remoteSessionId
         sessions[id] = session
         return session
+    }
+
+    /// Awaits any in-flight background backfill of older transcript messages
+    /// for `id`. After `hydrateIfNeeded` returns, only the tail window has
+    /// been applied to the transcript so the UI can paint immediately; the
+    /// rest is prepended on a separate task. Production callers rarely need
+    /// to wait for it (the UI is happy with the tail), but tests use this to
+    /// observe the fully-materialised transcript.
+    func awaitBackfill(id: ACPSession.ID) async {
+        if let task = inFlightBackfills[id] { await task.value }
     }
 
     /// Drives a session from `.loading` to `.ready` (or `.failed`). Safe to
@@ -205,10 +219,32 @@ final class ACPSessionManager: ObservableObject {
     }
 
     private func applyHydration(_ result: HydrationResult, to session: ACPSession) {
-        // Convert wire variants into full ACPMessages (allocates StreamingText
-        // for agent/thought) in one main-actor pass.
-        session.replaceTranscriptMessages(result.wireMessages.map { $0.toMessage() })
-        session.transcript.resetWindowToTail()
+        // Tail-first hydration: a long transcript would otherwise force an
+        // O(N) main-actor pass to wrap every wire message in `StreamingText`
+        // (a `@MainActor` class) before the first paint can land, freezing
+        // the UI on every tab switch into a session with hundreds of stored
+        // messages. We instead apply only the messages SwiftUI will draw on
+        // first paint — the tail window — and prepend the rest from a
+        // background task once the tab has painted.
+        //
+        // The visible window is intentionally placed at index 0 of the
+        // initial array (rather than the natural `count - tailWindow`
+        // offset) so the tail array IS the visible window. When backfill
+        // later prepends the older entries, `visibleHead` is shifted by
+        // the prepended count so the same tail messages stay on screen
+        // without a layout jump.
+        let wires = result.wireMessages
+        let total = wires.count
+        let tailWindow = ACPTranscript.tailWindow
+        let tailStart = max(0, total - tailWindow)
+
+        var tail: [ACPMessage] = []
+        tail.reserveCapacity(total - tailStart)
+        for i in tailStart..<total {
+            tail.append(wires[i].toMessage())
+        }
+        session.replaceTranscriptMessages(tail)
+        session.transcript.visibleHead = 0
         session.restoreQueue(result.queue)
         // The composer is rendered (and focused) the moment the placeholder
         // appears, so the user can start typing before hydration finishes.
@@ -237,6 +273,61 @@ final class ACPSessionManager: ObservableObject {
         // we captured before the user typed it.
         session.hydrationState = .ready
         self.recent = result.recent
+        scheduleBackfillIfNeeded(olderWires: Array(wires.prefix(tailStart)),
+                                 sessionId: session.id, session: session)
+    }
+
+    /// Materialise the pre-tail messages on a follow-up task. The task
+    /// converts wires to `ACPMessage`s in chunks, yielding between batches
+    /// so SwiftUI gets cycles to lay out the just-painted tail and respond
+    /// to user input. When the conversion is done it prepends them all in
+    /// one transcript mutation — incremental prepends would re-render the
+    /// list once per batch for no visible benefit (the older messages are
+    /// hidden behind `visibleHead`).
+    ///
+    /// Bail out if the cached session for `sessionId` no longer points at
+    /// the same instance: the user closed-then-reopened the tab and the
+    /// fresh placeholder will run its own hydration.
+    private func scheduleBackfillIfNeeded(
+        olderWires: [ACPMessageWire],
+        sessionId: ACPSession.ID,
+        session: ACPSession
+    ) {
+        // Replace any prior pending backfill for this id — a re-hydration
+        // (close + reopen) supersedes an older run.
+        inFlightBackfills[sessionId]?.cancel()
+        inFlightBackfills[sessionId] = nil
+
+        guard !olderWires.isEmpty else { return }
+
+        let task = Task { @MainActor [weak self, weak session] in
+            defer { self?.inFlightBackfills[sessionId] = nil }
+            // Yield once so the tail paint reaches the screen before we
+            // start allocating older messages on the main actor.
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+
+            var older: [ACPMessage] = []
+            older.reserveCapacity(olderWires.count)
+            let batchSize = 100
+            var index = 0
+            while index < olderWires.count {
+                let end = min(index + batchSize, olderWires.count)
+                for i in index..<end {
+                    older.append(olderWires[i].toMessage())
+                }
+                index = end
+                if index < olderWires.count {
+                    await Task.yield()
+                    if Task.isCancelled { return }
+                }
+            }
+            guard let self, let session,
+                  self.sessions[sessionId] === session
+            else { return }
+            session.prependTranscriptMessages(older)
+        }
+        inFlightBackfills[sessionId] = task
     }
 
     func closeSession(id: ACPSession.ID) {
@@ -244,6 +335,8 @@ final class ACPSessionManager: ObservableObject {
         // session reference — otherwise a tab-switch-while-typing
         // window can lose the last ~300ms of input.
         flushPendingDraftWrite(for: id)
+        inFlightBackfills[id]?.cancel()
+        inFlightBackfills[id] = nil
         sessions[id]?.transcript.resetMarkdownCaches()
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
@@ -251,6 +344,8 @@ final class ACPSessionManager: ObservableObject {
 
     func deleteSession(id: ACPSession.ID) {
         cancelPendingDraftWrite(for: id)
+        inFlightBackfills[id]?.cancel()
+        inFlightBackfills[id] = nil
         sessions[id]?.transcript.resetMarkdownCaches()
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
@@ -297,6 +392,8 @@ final class ACPSessionManager: ObservableObject {
         // session is evicted — the timer task fires on a nil `sessions[id]`
         // and silently returns.
         flushPendingDraftWrite(for: id)
+        inFlightBackfills[id]?.cancel()
+        inFlightBackfills[id] = nil
         session.transcript.resetMarkdownCaches()
         sessions[id] = nil
     }

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -624,6 +624,24 @@ extension ACPSessionManager {
         case .spawning, .ready: return
         case .idle, .disconnected, .failed: break
         }
+        // Claim the spawn slot BEFORE awaiting backfill so a concurrent
+        // attach (e.g. retry button while the first attempt is still in the
+        // backfill wait) early-returns on the `.spawning` guard above
+        // instead of racing into a duplicate runner.
+        session.agentState = .spawning
+        // The runner persists transcript mutations under `msg-<sid>-<index>`,
+        // where `index` is the in-memory transcript position. Tail-first
+        // hydration leaves `transcript.messages` shorter than the persisted
+        // row count until backfill prepends the older entries, so any apply()
+        // that landed before that finished would overwrite the wrong stored
+        // row (or skip an append it should have made). Wait here so the
+        // in-memory and persisted indices line up before any runner work —
+        // including replayed load updates — touches the store. No-op once
+        // backfill is done.
+        await awaitBackfill(id: sessionId)
+        // Re-verify the session still exists; a close during the await above
+        // would have cleared it.
+        guard sessions[sessionId] === session else { return }
         // Drop any stale runner left over from a prior process (e.g. the
         // runner's stream-end branch flipped agentState to .disconnected
         // but did not unregister itself). The .ready/.spawning early-return

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -300,8 +300,23 @@ final class ACPSessionManager: ObservableObject {
 
         guard !olderWires.isEmpty else { return }
 
+        // Capture a stable handle the task body can compare against the
+        // current entry in `inFlightBackfills` before clearing it. Without
+        // this guard, a backfill that is cancelled and then immediately
+        // superseded (close + reopen, or a re-hydrate) would still run its
+        // cleanup when the cancelled task finally returns from its yield,
+        // clearing the slot that now holds the NEWER task. `awaitBackfill`
+        // would then observe no task and let `attach`/export proceed
+        // against the tail-only transcript — exactly the index-corruption
+        // path the gating exists to prevent.
+        final class TaskHandle { var task: Task<Void, Never>? }
+        let handle = TaskHandle()
         let task = Task { @MainActor [weak self, weak session] in
-            defer { self?.inFlightBackfills[sessionId] = nil }
+            defer {
+                if let me = handle.task, self?.inFlightBackfills[sessionId] == me {
+                    self?.inFlightBackfills[sessionId] = nil
+                }
+            }
             // Yield once so the tail paint reaches the screen before we
             // start allocating older messages on the main actor.
             await Task.yield()
@@ -327,6 +342,7 @@ final class ACPSessionManager: ObservableObject {
             else { return }
             session.prependTranscriptMessages(older)
         }
+        handle.task = task
         inFlightBackfills[sessionId] = task
     }
 

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -261,9 +261,16 @@ final class ACPSessionManager: ObservableObject {
             session.remoteSessionId = result.row.remoteSessionId
         }
         if result.row.contextRecoveryPending {
+            // Compute `canSendTranscript` against the FULL wire list rather
+            // than `session.hasConversationTranscript`. Tail-first hydration
+            // leaves only the last 30 messages in the in-memory transcript
+            // when this runs, so a long session whose tail is all tool
+            // calls / file edits would look conversation-less here and
+            // permanently disable the "Send transcript" action — the
+            // warning is set once and never recomputed after backfill.
             session.contextRestoreWarning = .init(
                 message: "Agent context could not be restored.",
-                canSendTranscript: session.hasConversationTranscript
+                canSendTranscript: Self.wireMessagesHaveConversation(result.wireMessages)
             )
         }
         session.autoRunEnabled = result.row.autoRun
@@ -275,6 +282,23 @@ final class ACPSessionManager: ObservableObject {
         self.recent = result.recent
         scheduleBackfillIfNeeded(olderWires: Array(wires.prefix(tailStart)),
                                  sessionId: session.id, session: session)
+    }
+
+    /// Mirror of `ACPSession.hasConversationTranscript` that operates on the
+    /// wire (Sendable) representation, so callers can ask the question
+    /// before the in-memory transcript has been fully reassembled — i.e.
+    /// during the tail-only window of tail-first hydration.
+    private static func wireMessagesHaveConversation(_ wires: [ACPMessageWire]) -> Bool {
+        wires.contains { wire in
+            switch wire {
+            case let .user(text, _):
+                return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case let .agent(text):
+                return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            default:
+                return false
+            }
+        }
     }
 
     /// Materialise the pre-tail messages on a follow-up task. The task

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1656,6 +1656,12 @@ final class AppState {
         mgr.retainSession(id: tabState.sessionId)
         defer { mgr.releaseSession(id: tabState.sessionId) }
         await mgr.hydrateIfNeeded(id: tabState.sessionId)
+        // Hydration applies the tail synchronously and backfills older
+        // messages on a follow-up task. Exporters need the FULL transcript,
+        // so block until backfill is done before handing the session to
+        // `body` — otherwise a long conversation would serialize as just
+        // its last 30 entries.
+        await mgr.awaitBackfill(id: tabState.sessionId)
         guard let session = mgr.sessions[tabState.sessionId] else { return }
         body(session)
     }

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -611,6 +611,59 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: nil) == false)
     }
 
+    @Test("attach waits for tail-first hydration backfill before runner setup")
+    func attachWaitsForBackfill() async throws {
+        // Persist enough messages that hydration splits into a tail-first
+        // apply + background backfill — otherwise the bug being guarded
+        // against (runner constructed against a partial transcript) can't
+        // even materialise.
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        let total = ACPTranscript.tailWindow * 3
+        for i in 0..<total {
+            try appendMessage(
+                .user(id: UUID(), text: "m\(i)", attachments: []),
+                to: store, seq: Int64(i))
+        }
+
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        scriptSessionResult(client, method: "session/load", sessionId: "remote-restored")
+
+        // Capture the in-memory transcript length at the moment attach decides
+        // setup is ready. With the fix in place, attach awaits backfill first,
+        // so the captured count matches the full persisted length. Without
+        // the fix, only the tail window has been applied.
+        final class Captured { var count: Int = -1 }
+        let captured = Captured()
+        let mgrBox: UnsafeMutablePointer<ACPSessionManager?> = .allocate(capacity: 1)
+        mgrBox.initialize(to: nil)
+        defer { mgrBox.deinitialize(count: 1)
+        mgrBox.deallocate() }
+        let manager = ACPSessionManager(
+            worktreeId: "wt",
+            worktreePath: "/tmp/wt",
+            store: store,
+            setupEvaluator: { _ in
+                captured.count = mgrBox.pointee?.sessions["local"]?.transcript.messages.count ?? -2
+                return .ready
+            },
+            connectionFactory: { _ in ACPConnection(client: client) }
+        )
+        mgrBox.pointee = manager
+
+        _ = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        // Sanity check: hydrateIfNeeded returned with only the tail applied.
+        #expect(manager.sessions["local"]?.transcript.messages.count == ACPTranscript.tailWindow)
+
+        await manager.attach(to: "local", freshlyCreated: false)
+
+        #expect(captured.count == total,
+                "setup evaluator must observe the fully-materialised transcript")
+        #expect(manager.sessions["local"]?.transcript.messages.count == total)
+    }
+
     private func tmpStorePath() -> String {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("mgr-attach-restore-\(UUID()).sqlite").path

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -160,8 +160,97 @@ struct ACPSessionManagerHydrationTests {
         let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
         let s = try #require(mgr.placeholderSession(id: "s"))
         await mgr.hydrateIfNeeded(id: "s")
+        // Older messages backfill off the critical path; drain that task so
+        // the final transcript state is observable to the assertions below.
+        await mgr.awaitBackfill(id: "s")
         #expect(s.transcript.messages.count == 40)
         #expect(s.transcript.visibleHead == 10) // 40 - 30
+    }
+
+    @Test("hydrateIfNeeded applies tail-window first and backfills older messages")
+    func hydrateAppliesTailFirst() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        // Seed 100 messages: the last 30 are the tail window; the earlier 70
+        // must arrive via the background backfill task.
+        for i in 0..<100 {
+            let m: ACPMessage = .user(id: UUID(), text: "m\(i)", attachments: [])
+            let payload = try ACPMessageCodec.encode(m)
+            try store.appendMessage(sessionId: "s", id: "m\(i)", kind: "user",
+                                    seq: Int64(i), payload: payload, createdAt: 0)
+        }
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+
+        await mgr.hydrateIfNeeded(id: "s")
+
+        // First paint: only the tail window is in the transcript and the entire
+        // array is visible (head at 0). This is what unblocks the UI — older
+        // messages are still in flight on a separate task.
+        #expect(s.hydrationState == .ready)
+        #expect(s.transcript.messages.count == ACPTranscript.tailWindow)
+        #expect(s.transcript.visibleHead == 0)
+        if case .user(_, let text, _) = s.transcript.messages.first {
+            #expect(text == "m70")
+        } else {
+            #expect(Bool(false), "expected first visible message to be .user m70")
+        }
+        if case .user(_, let text, _) = s.transcript.messages.last {
+            #expect(text == "m99")
+        } else {
+            #expect(Bool(false), "expected last visible message to be .user m99")
+        }
+
+        // Drain the backfill task — now every persisted message is present,
+        // ordered correctly, and visibleHead is anchored to the same tail.
+        await mgr.awaitBackfill(id: "s")
+        #expect(s.transcript.messages.count == 100)
+        #expect(s.transcript.visibleHead == 100 - ACPTranscript.tailWindow)
+        if case .user(_, let text, _) = s.transcript.messages.first {
+            #expect(text == "m0")
+        } else {
+            #expect(Bool(false), "expected first message to be .user m0 after backfill")
+        }
+        if case .user(_, let text, _) = s.transcript.messages[s.transcript.visibleHead] {
+            #expect(text == "m70")
+        } else {
+            #expect(Bool(false), "expected message at visibleHead to be .user m70")
+        }
+        if case .user(_, let text, _) = s.transcript.messages.last {
+            #expect(text == "m99")
+        } else {
+            #expect(Bool(false), "expected last message to be .user m99 after backfill")
+        }
+    }
+
+    @Test("hydrateIfNeeded for short transcripts skips backfill")
+    func hydrateShortTranscriptHasNoBackfill() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+        // Seed fewer messages than the tail window — one-pass hydration suffices.
+        for i in 0..<5 {
+            let m: ACPMessage = .user(id: UUID(), text: "m\(i)", attachments: [])
+            let payload = try ACPMessageCodec.encode(m)
+            try store.appendMessage(sessionId: "s", id: "m\(i)", kind: "user",
+                                    seq: Int64(i), payload: payload, createdAt: 0)
+        }
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        await mgr.hydrateIfNeeded(id: "s")
+        await mgr.awaitBackfill(id: "s") // no-op for short transcripts
+
+        #expect(s.transcript.messages.count == 5)
+        #expect(s.transcript.visibleHead == 0)
     }
 
     @Test("concurrent hydrateIfNeeded calls coalesce")

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -228,6 +228,48 @@ struct ACPSessionManagerHydrationTests {
         }
     }
 
+    @Test("contextRestoreWarning sees the full transcript even when only tail is in memory")
+    func contextRestoreWarningComputedFromFullWires() async throws {
+        let path = tmpStorePath()
+        let store = try ACPSessionStore(path: path)
+        // Persist a row that's flagged as needing recovery — applyHydration
+        // will surface a contextRestoreWarning derived from the wire list.
+        try store.upsertSession(.init(
+            id: "s", agentId: "claude", title: "t",
+            titleSource: .placeholder,
+            remoteSessionId: "remote-old",
+            contextRecoveryPending: true,
+            currentModel: nil, currentMode: nil, autoRun: false,
+            createdAt: 0, updatedAt: 0, lastOpenedAt: 0, archived: false))
+
+        // Seed a long transcript whose CONVERSATION lives entirely outside
+        // the tail window: a single user prompt at seq 0, then enough
+        // non-conversation messages (file edits) to push the tail past it.
+        let userMsg: ACPMessage = .user(id: UUID(), text: "kick off", attachments: [])
+        try store.appendMessage(sessionId: "s", id: "m0", kind: userMsg.kind,
+                                seq: 0, payload: try ACPMessageCodec.encode(userMsg), createdAt: 0)
+        let fillerStart = 1
+        let total = ACPTranscript.tailWindow * 2 + fillerStart
+        for i in fillerStart..<total {
+            let edit: ACPMessage = .fileEdit(id: UUID(), .init(
+                path: "f\(i).swift", added: 0, removed: 0))
+            try store.appendMessage(sessionId: "s", id: "m\(i)", kind: edit.kind,
+                                    seq: Int64(i), payload: try ACPMessageCodec.encode(edit),
+                                    createdAt: 0)
+        }
+
+        let mgr = ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+        let s = try #require(mgr.placeholderSession(id: "s"))
+        await mgr.hydrateIfNeeded(id: "s")
+
+        // The in-memory tail is all file edits, so checking the live
+        // transcript here would return false. The warning must look at the
+        // full wire list and find the buried user prompt.
+        #expect(s.hasConversationTranscript == false)
+        let warning = try #require(s.contextRestoreWarning)
+        #expect(warning.canSendTranscript)
+    }
+
     @Test("hydrateIfNeeded for short transcripts skips backfill")
     func hydrateShortTranscriptHasNoBackfill() async throws {
         let path = tmpStorePath()


### PR DESCRIPTION
## Summary

Long ACP sessions froze the UI on every tab activation because `applyHydration` ran an O(N) main-actor pass to wrap every persisted message in `StreamingText` (a `@MainActor` class) before the first paint could land — even though SwiftUI only drew the tail window once the data finally arrived.

Now hydration is split in two:

1. **Tail-first paint.** The last `tailWindow` messages (30) are converted on the synchronous path and applied with `visibleHead = 0`, so the tab paints immediately and the user sees the conversation they expect.
2. **Background backfill.** Older wires are materialised on a follow-up `Task` that yields between 100-message batches and prepends the result in one transcript mutation. `visibleHead` is shifted by the prepended count so the visible tail stays anchored — no layout jump.

The new `awaitBackfill(id:)` API lets tests observe the fully-materialised transcript; production UI doesn't need it. Pending backfills are cancelled in `closeSession`, `deleteSession`, and `evictIfIdle` so a re-hydration (or eviction) can't race with a stale prepend.

## Test plan

- [x] `ACPSessionManagerHydrationTests` — 16/16, including new `hydrateAppliesTailFirst` (asserts tail-only after hydrate; full transcript after `awaitBackfill`) and `hydrateShortTranscriptHasNoBackfill` (one-pass path for short sessions).
- [x] Existing `hydrateResetsWindow` updated to await backfill before asserting the final `visibleHead == count - tailWindow`.
- [x] Full ACP test surface: 114/114 across `ACPSessionTests`, `ACPSessionManagerAttachRestoreTests`, `ACPSessionManagerTests`, `ACPSessionManagerRetentionTests`, `ACPSessionRecoveryTests`, `ACPSessionRecoveryIntegrationTests`, `ACPSessionHydratorTests`, `ACPTranscriptWindowTests`, `ACPTranscriptMarkdownCacheEvictionTests`, `ACPSessionRunnerTests`.
- [ ] Manual: open a long ACP session, switch tabs, confirm no perceptible freeze.

## Follow-ups (not in this PR)

- Persist parsed-markdown snapshot so first paint doesn't re-parse markdown for the tail-window agent messages. This is the next planned change on top of this branch.