### PR TITLE
Preserve user env for ACP auth terminals

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -821,6 +821,7 @@ final class AppState {
             for: worktree,
             startupScriptSuffix: startupScriptSuffix,
             includeUserStartupScript: false,
+            forceInheritParentEnv: true,
             environmentOverrides: Self.acpAuthTerminalEnvironmentOverrides(extra: command.env),
             environmentRemovals: ACPProcessEnvironment.agentSessionMarkerKeys
         )
@@ -1335,6 +1336,7 @@ final class AppState {
         for worktree: Worktree,
         startupScriptSuffix: String? = nil,
         includeUserStartupScript: Bool = true,
+        forceInheritParentEnv: Bool = false,
         environmentOverrides: [String: String] = [:],
         environmentRemovals: Set<String> = []
     ) throws -> Tab {
@@ -1346,12 +1348,16 @@ final class AppState {
         // sessionId (mirrored to id on encode), and ALAS_SESSION_ID. Generated
         // here so every downstream call site receives the same value.
         let leafId = UUID().uuidString
+        var terminalConfig = config.terminal
+        if forceInheritParentEnv {
+            terminalConfig.inheritParentEnv = true
+        }
         let opened: OpenedTerminalSession
         if let terminalSessionOpener {
             opened = try terminalSessionOpener(
                 worktree,
                 project,
-                config.terminal,
+                terminalConfig,
                 themeStore.current,
                 nil,
                 startupScriptSuffix,
@@ -1362,7 +1368,7 @@ final class AppState {
         } else {
             let session = try terminal.openSession(
                 worktree: worktree, project: project,
-                cfg: config.terminal, theme: themeStore.current,
+                cfg: terminalConfig, theme: themeStore.current,
                 startupScriptSuffix: startupScriptSuffix,
                 includeUserStartupScript: includeUserStartupScript,
                 environmentOverrides: environmentOverrides,

--- a/AlasTests/AgentTerminalLaunchTests.swift
+++ b/AlasTests/AgentTerminalLaunchTests.swift
@@ -194,6 +194,7 @@ struct AgentTerminalLaunchTests {
         var capturedIncludeUserStartupScript: Bool?
         var capturedEnvironmentOverrides: [String: String]?
         var capturedEnvironmentRemovals: Set<String>?
+        var capturedInheritParentEnv: Bool?
         let project = project(mode: .useGlobal, useBypass: false)
         let worktree = Worktree(
             id: "wt",
@@ -206,14 +207,16 @@ struct AgentTerminalLaunchTests {
         )
         let state = AppState(
             store: MemoryStore(),
-            terminalSessionOpener: { _, _, _, _, _, startupScriptSuffix, includeUserStartupScript, environmentOverrides, environmentRemovals in
+            terminalSessionOpener: { _, _, terminalConfig, _, _, startupScriptSuffix, includeUserStartupScript, environmentOverrides, environmentRemovals in
                 capturedSuffix = startupScriptSuffix
+                capturedInheritParentEnv = terminalConfig.inheritParentEnv
                 capturedIncludeUserStartupScript = includeUserStartupScript
                 capturedEnvironmentOverrides = environmentOverrides
                 capturedEnvironmentRemovals = environmentRemovals
                 return AppState.OpenedTerminalSession(id: "auth-session", foregroundPid: { nil })
             }
         )
+        state.config.terminal.inheritParentEnv = false
         state.projectsManager = ProjectsManager(persistedProjects: [project])
 
         _ = try state.openACPAuthTerminalTab(
@@ -232,6 +235,7 @@ struct AgentTerminalLaunchTests {
             "exit \"$status\"",
         ].joined(separator: "\n"))
         #expect(capturedIncludeUserStartupScript == false)
+        #expect(capturedInheritParentEnv == true)
         #expect(capturedEnvironmentOverrides?["A"] == "two words")
         #expect(capturedEnvironmentOverrides?["TOKEN"] == "abc'123")
         #expect(capturedEnvironmentOverrides?["PATH"] != nil)


### PR DESCRIPTION
## Summary
- force ACP auth terminal launches to inherit the parent environment even when the normal terminal setting disables inheritance
- keep the auth-only startup script and agent-marker sanitization behavior intact
- add regression coverage for auth launch inheritance

## Verification
- `rtk swiftformat Alas/Sources/App/AppState.swift AlasTests/AgentTerminalLaunchTests.swift --lint --reporter github-actions-log`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/AgentTerminalLaunchTests -quiet test`