### PR TITLE
fix(acp): stop chat pagination spinner loop

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */; };
 		2FAA421AF3C23D27A864FDCA /* AgentBuiltins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F451C90EC9036CA8A7A04C /* AgentBuiltins.swift */; };
 		2FE10FC44BD9CDBD0C969374 /* MergeBulkResolvePromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */; };
+		303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */; };
 		30A1BE2F8E2777CFF6460486 /* ACPConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 701F837327D905FAAA0E0AF3 /* ACPConnectionTests.swift */; };
 		312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */; };
 		32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364507D55CD5D73CD44819E7 /* InstallerHostTests.swift */; };
@@ -828,6 +829,7 @@
 		FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */; };
 		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
+		FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */; };
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
@@ -1313,6 +1315,7 @@
 		91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictToolbar.swift; sourceTree = "<group>"; };
 		91C1705E68E97111E85D83F3 /* RightPaneState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneState.swift; sourceTree = "<group>"; };
 		91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParser.swift; sourceTree = "<group>"; };
+		9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageListPaginationTests.swift; sourceTree = "<group>"; };
 		9278ED5964A66871F5299F0C /* ImageDiffDifferenceComputerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceComputerTests.swift; sourceTree = "<group>"; };
 		92F1C71C2574B1077964E5E1 /* ACPPermissionDecisionLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionDecisionLogTests.swift; sourceTree = "<group>"; };
 		932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiInstaller.swift; sourceTree = "<group>"; };
@@ -1618,6 +1621,7 @@
 		EECD5B53A23694EF60F63041 /* MergeConflictAgentProposalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictAgentProposalView.swift; sourceTree = "<group>"; };
 		EF5F20AB3B3F7BCEAA56B143 /* SQLiteDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatabase.swift; sourceTree = "<group>"; };
 		EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateSpacesTests.swift; sourceTree = "<group>"; };
+		F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTopPaginationIndicator.swift; sourceTree = "<group>"; };
 		F03C1E46A0853704E9B4449A /* JSONRPCFramerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCFramerTests.swift; sourceTree = "<group>"; };
 		F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tool-call-content-blocks.json"; sourceTree = "<group>"; };
 		F0A443685B2A3322208D51AE /* ACPSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreTests.swift; sourceTree = "<group>"; };
@@ -2313,6 +2317,7 @@
 				A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */,
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
 				7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */,
+				9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */,
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
 				96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */,
 				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
@@ -2545,6 +2550,7 @@
 				0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */,
 				E6DE88BE229FD6C1DF35F7EA /* ACPToolbar.swift */,
 				CC3CF39EE3E5E2AB9B0968B3 /* ACPToolCallCard.swift */,
+				F01FD27D107E0207950F00D3 /* ACPTopPaginationIndicator.swift */,
 				FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */,
 				531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */,
 			);
@@ -3479,6 +3485,7 @@
 				48040D7ABD4A23B3947E945F /* ACPThoughtView.swift in Sources */,
 				3C30C1EAE4786BB1BE42F994 /* ACPToolCallCard.swift in Sources */,
 				312DB6016C040DE52CD365E8 /* ACPToolbar.swift in Sources */,
+				303E16565ECF8BDDC7A28AF1 /* ACPTopPaginationIndicator.swift in Sources */,
 				8927B4E929B4180F5B8984F1 /* ACPTranscript.swift in Sources */,
 				C12FCCB35EBD486D20EC65D2 /* ACPTranscriptMarkdown.swift in Sources */,
 				B8BA936481455853CFC3393F /* ANSIStream.swift in Sources */,
@@ -3872,6 +3879,7 @@
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */,
+				FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */,
 				9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */,
 				D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */,
 				BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -323,6 +323,7 @@ final class ACPSessionManager: ObservableObject {
         inFlightBackfills[sessionId] = nil
 
         guard !olderWires.isEmpty else { return }
+        session.transcript.isBackfillingOlderMessages = true
 
         // Capture a stable handle the task body can compare against the
         // current entry in `inFlightBackfills` before clearing it. Without
@@ -338,6 +339,7 @@ final class ACPSessionManager: ObservableObject {
         let task = Task { @MainActor [weak self, weak session] in
             defer {
                 if let me = handle.task, self?.inFlightBackfills[sessionId] == me {
+                    session?.transcript.isBackfillingOlderMessages = false
                     self?.inFlightBackfills[sessionId] = nil
                 }
             }

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -20,6 +20,11 @@ final class ACPTranscript: ObservableObject {
     /// stableId + StreamingText identity equality keep the ForEach row
     /// tree stable across ticks.
     @Published var streamingTick: UInt32 = 0
+    /// True while post-hydration tail-first backfill is materialising older
+    /// persisted rows. This is separate from `visibleHead`: a non-zero head
+    /// means older rows are available behind the render window, not that an
+    /// async load is still running.
+    @Published var isBackfillingOlderMessages: Bool = false
 
     /// Render window: `ACPMessageList` draws `messages[visibleHead...]`.
     /// Reset to `max(0, messages.count - tailWindow)` after hydration so

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -92,19 +92,20 @@ struct ACPMessageList: View {
             GeometryReader { viewport in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
-                        if transcript.visibleHead > 0 {
-                            ProgressView()
-                                .controlSize(.small)
+                        switch Self.topPaginationIndicator(
+                            visibleHead: transcript.visibleHead,
+                            isBackfillingOlderMessages: transcript.isBackfillingOlderMessages
+                        ) {
+                        case .hidden:
+                            EmptyView()
+                        case .sentinel:
+                            topPaginationSentinel
+                        case .spinner:
+                            Spinner(lineWidth: 1.5)
+                                .frame(width: 14, height: 14)
                                 .frame(maxWidth: .infinity, alignment: .center)
                                 .padding(.bottom, 4)
-                                .background(
-                                    GeometryReader { headGeom in
-                                        Color.clear.preference(
-                                            key: ACPHeadFramePreferenceKey.self,
-                                            value: headGeom.frame(in: .named(scrollSpaceName))
-                                        )
-                                    }
-                                )
+                                .background(topPaginationSentinel)
                         }
                         ForEach(visibleMessages, id: \.stableId) { message in
                             row(for: message)
@@ -245,6 +246,25 @@ struct ACPMessageList: View {
     private func setFollowsTranscriptTail(_ follows: Bool) {
         guard session.followsTranscriptTail != follows else { return }
         session.followsTranscriptTail = follows
+    }
+
+    private var topPaginationSentinel: some View {
+        GeometryReader { headGeom in
+            Color.clear.preference(
+                key: ACPHeadFramePreferenceKey.self,
+                value: headGeom.frame(in: .named(scrollSpaceName))
+            )
+        }
+        .frame(height: 1)
+    }
+
+    static func topPaginationIndicator(
+        visibleHead: Int,
+        isBackfillingOlderMessages: Bool
+    ) -> ACPTopPaginationIndicator {
+        if isBackfillingOlderMessages { return .spinner }
+        if visibleHead > 0 { return .sentinel }
+        return .hidden
     }
 
     /// Reveal older messages while keeping the viewport anchored to the

--- a/Alas/Sources/ACP/UI/ACPTopPaginationIndicator.swift
+++ b/Alas/Sources/ACP/UI/ACPTopPaginationIndicator.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum ACPTopPaginationIndicator: Equatable {
+    case hidden
+    case sentinel
+    case spinner
+}

--- a/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
+++ b/AlasTests/ACP/UI/ACPMessageListPaginationTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPMessageList pagination")
+struct ACPMessageListPaginationTests {
+    @Test("top indicator is hidden when the full transcript is visible")
+    func hiddenWhenFullyVisible() {
+        #expect(ACPMessageList.topPaginationIndicator(
+            visibleHead: 0,
+            isBackfillingOlderMessages: false
+        ) == .hidden)
+    }
+
+    @Test("top indicator keeps an invisible sentinel after backfill completes")
+    func sentinelWhenOlderRowsAreAvailable() {
+        #expect(ACPMessageList.topPaginationIndicator(
+            visibleHead: 30,
+            isBackfillingOlderMessages: false
+        ) == .sentinel)
+    }
+
+    @Test("top indicator shows spinner only while older rows are backfilling")
+    func spinnerWhileBackfilling() {
+        #expect(ACPMessageList.topPaginationIndicator(
+            visibleHead: 0,
+            isBackfillingOlderMessages: true
+        ) == .spinner)
+        #expect(ACPMessageList.topPaginationIndicator(
+            visibleHead: 30,
+            isBackfillingOlderMessages: true
+        ) == .spinner)
+    }
+}


### PR DESCRIPTION
## Summary
- split ACP chat pagination sentinel state from active backfill loading state
- replace the top pagination ProgressView with the shared Spinner component
- add focused tests for pagination indicator behavior

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test