### PR TITLE
fix(acp): normalize composer paste styling

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -818,11 +818,9 @@ final class ACPNSTextView: NSTextView {
             length: min(replacementRange.length, max(0, textStorage.length - replacementRange.location))
         )
         let attrs = Self.baseTypingAttributes
-        let attributed = NSAttributedString(string: text, attributes: attrs)
-        textStorage.replaceCharacters(in: boundedRange, with: attributed)
-        setSelectedRange(NSRange(location: boundedRange.location + attributed.length, length: 0))
         typingAttributes = attrs
-        didChangeText()
+        insertText(text, replacementRange: boundedRange)
+        typingAttributes = attrs
         return true
     }
 

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -802,7 +802,28 @@ final class ACPNSTextView: NSTextView {
 
     override func paste(_ sender: Any?) {
         if insertImages(from: NSPasteboard.general) { return }
+        if let text = NSPasteboard.general.string(forType: .string) {
+            insertPlainText(text)
+            return
+        }
         super.paste(sender)
+    }
+
+    @discardableResult
+    func insertPlainText(_ text: String) -> Bool {
+        guard let textStorage else { return false }
+        let replacementRange = selectedRange()
+        let boundedRange = NSRange(
+            location: min(replacementRange.location, textStorage.length),
+            length: min(replacementRange.length, max(0, textStorage.length - replacementRange.location))
+        )
+        let attrs = Self.baseTypingAttributes
+        let attributed = NSAttributedString(string: text, attributes: attrs)
+        textStorage.replaceCharacters(in: boundedRange, with: attributed)
+        setSelectedRange(NSRange(location: boundedRange.location + attributed.length, length: 0))
+        typingAttributes = attrs
+        didChangeText()
+        return true
     }
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -406,7 +406,68 @@ struct ACPComposerDraftBridgeTests {
         #expect(typingColor == NSColor.labelColor)
     }
 
+    @Test("plain paste insertion normalizes inherited rich text styling")
+    func plainPasteInsertionNormalizesRichTextStyling() throws {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 40))
+        let source = NSMutableAttributedString(
+            string: "before after",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 13),
+                .foregroundColor: NSColor.labelColor,
+            ]
+        )
+        textView.textStorage?.setAttributedString(source)
+        textView.setSelectedRange(NSRange(location: 7, length: 0))
+        textView.typingAttributes = [
+            .font: NSFont.systemFont(ofSize: 48),
+            .foregroundColor: NSColor.black,
+        ]
+
+        let inserted = textView.insertPlainText("RICH")
+
+        #expect(inserted)
+        #expect(textView.string == "before RICHafter")
+        let insertedRange = NSRange(location: 7, length: 4)
+        try assertComposerBaseStyle(in: textView.attributedString(), range: insertedRange)
+        #expect((textView.typingAttributes[.foregroundColor] as? NSColor) == NSColor.labelColor)
+        let typingFont = try #require(textView.typingAttributes[.font] as? NSFont)
+        #expect(typingFont.pointSize == 13)
+    }
+
+    @Test("plain paste insertion replaces selected text with normalized styling")
+    func plainPasteInsertionReplacesSelectionWithNormalizedStyling() throws {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 40))
+        textView.textStorage?.setAttributedString(NSAttributedString(
+            string: "replace me",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 13),
+                .foregroundColor: NSColor.labelColor,
+            ]
+        ))
+        textView.setSelectedRange(NSRange(location: 0, length: 7))
+
+        let inserted = textView.insertPlainText("keep")
+
+        #expect(inserted)
+        #expect(textView.string == "keep me")
+        #expect(textView.selectedRange() == NSRange(location: 4, length: 0))
+        try assertComposerBaseStyle(in: textView.attributedString(), range: NSRange(location: 0, length: 4))
+    }
+
     // MARK: - Keyboard intent resolution (doCommandBy)
+
+    private func assertComposerBaseStyle(
+        in attributed: NSAttributedString,
+        range: NSRange,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) throws {
+        attributed.enumerateAttributes(in: range) { attrs, _, _ in
+            let font = attrs[.font] as? NSFont
+            let color = attrs[.foregroundColor] as? NSColor
+            #expect(font?.pointSize == 13, sourceLocation: sourceLocation)
+            #expect(color == NSColor.labelColor, sourceLocation: sourceLocation)
+        }
+    }
 
     private func makeCoordinator(
         sendOnEnter: Bool,

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -454,6 +454,49 @@ struct ACPComposerDraftBridgeTests {
         try assertComposerBaseStyle(in: textView.attributedString(), range: NSRange(location: 0, length: 4))
     }
 
+    @Test("plain paste insertion goes through NSTextView editing hooks")
+    func plainPasteInsertionUsesTextViewEditingHooks() {
+        let textView = ACPNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 40))
+        let window = NSWindow(contentRect: textView.frame, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = textView
+        window.makeFirstResponder(textView)
+        textView.allowsUndo = true
+        textView.string = "before after"
+        textView.setSelectedRange(NSRange(location: 7, length: 0))
+        let delegate = EditingHookDelegate()
+        textView.delegate = delegate
+
+        let inserted = textView.insertPlainText("RICH")
+
+        #expect(inserted)
+        #expect(delegate.changes == [
+            EditingHookDelegate.Change(
+                range: NSRange(location: 7, length: 0),
+                replacement: "RICH"
+            )
+        ])
+        textView.undoManager?.undo()
+        #expect(textView.string == "before after")
+    }
+
+    private final class EditingHookDelegate: NSObject, NSTextViewDelegate {
+        struct Change: Equatable {
+            let range: NSRange
+            let replacement: String?
+        }
+
+        var changes: [Change] = []
+
+        func textView(
+            _ textView: NSTextView,
+            shouldChangeTextIn affectedCharRange: NSRange,
+            replacementString: String?
+        ) -> Bool {
+            changes.append(Change(range: affectedCharRange, replacement: replacementString))
+            return true
+        }
+    }
+
     // MARK: - Keyboard intent resolution (doCommandBy)
 
     private func assertComposerBaseStyle(


### PR DESCRIPTION
## Summary
- normalize rich text paste in the ACP composer to plain composer styling
- preserve existing image paste handling
- add paste tests for caret insertion, selection replacement, stripped styling, and follow-up typing attributes

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test