### PR TITLE
fix(3way): Fix large conflict merge editor layout

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -382,6 +382,7 @@
 		71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7554DEF788B5448132F2B93F /* BulkConflictResolveReport.swift */; };
 		724CD1B1450DEC33DE6B0DE3 /* ComposerActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */; };
 		724F35133677956CC64E7466 /* ShortcutChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410A42B1C46E68965FD36793 /* ShortcutChip.swift */; };
+		72CF403FFD14D75FC0DD15E3 /* MergeView3WayLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3FA58107EA372581313A5F /* MergeView3WayLayoutTests.swift */; };
 		730DA64B474FF176336B9E0B /* SettingsNavView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */; };
 		7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B767602C3F8E5909A44B7C /* CodeEditorLineNumberRulerView.swift */; };
 		73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C860C82F92CF8B7CC58FF4D /* BlockedNudgeBanner.swift */; };
@@ -1504,6 +1505,7 @@
 		CC83C13F9F6391F9CE8BF2CA /* MarkdownViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownViewMode.swift; sourceTree = "<group>"; };
 		CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		CE2AD8D0539591C434F51418 /* ACPAuthNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthNudgeBanner.swift; sourceTree = "<group>"; };
+		CE3FA58107EA372581313A5F /* MergeView3WayLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeView3WayLayoutTests.swift; sourceTree = "<group>"; };
 		CE6CCD7F7273667B5D67F821 /* SearchScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchScope.swift; sourceTree = "<group>"; };
 		CEA8BA11A167DA43E22E7D2D /* SpacesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacesManagerTests.swift; sourceTree = "<group>"; };
 		CEC2AE8D8A358AC0F83252CD /* OpenCodeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstaller.swift; sourceTree = "<group>"; };
@@ -1938,6 +1940,7 @@
 				0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */,
 				256257983A4B1E1E674DF5B8 /* MergeRegionVisualLayoutTests.swift */,
 				883981BBADF9816718091CE1 /* MergeScrollCoordinatorTests.swift */,
+				CE3FA58107EA372581313A5F /* MergeView3WayLayoutTests.swift */,
 				72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */,
 				E288FF8FA00AC18E1CDD3CA2 /* NewWorktreeDialogTests.swift */,
 				C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */,
@@ -4100,6 +4103,7 @@
 				5F7E14A0D7E1D3F036806B73 /* MergeOperationStateTests.swift in Sources */,
 				40D9FD39D36ADE353B9971E8 /* MergeRegionVisualLayoutTests.swift in Sources */,
 				7CA34C93E31EA98047AF6D81 /* MergeScrollCoordinatorTests.swift in Sources */,
+				72CF403FFD14D75FC0DD15E3 /* MergeView3WayLayoutTests.swift in Sources */,
 				9ED684E261871342BA6DFAC9 /* MergeWordDiffTests.swift in Sources */,
 				1201C8A30A1A932311FA2156 /* NewWorktreeDialogTests.swift in Sources */,
 				3E0AA46F17D152BFDA52A79D /* NotificationServiceTests.swift in Sources */,

--- a/Alas/Sources/Center/Merge/MergeActionGutter.swift
+++ b/Alas/Sources/Center/Merge/MergeActionGutter.swift
@@ -35,6 +35,7 @@ struct MergeActionGutter: NSViewRepresentable {
         view.side = side
         view.conflictRanges = conflictRanges
         view.coordinator = coordinator
+        view.observe(coordinator)
         view.onAccept = onAccept
         view.onReject = onReject
         view.needsDisplay = true
@@ -47,8 +48,22 @@ struct MergeActionGutter: NSViewRepresentable {
         var coordinator: MergeScrollCoordinator?
         var onAccept: ((Int) -> Void)?
         var onReject: ((Int) -> Void)?
+        private weak var observedCoordinator: MergeScrollCoordinator?
+        private var scrollObserverID: UUID?
 
         override var isFlipped: Bool { true }
+
+        func observe(_ coordinator: MergeScrollCoordinator) {
+            guard observedCoordinator !== coordinator else { return }
+            if let scrollObserverID, let observedCoordinator {
+                observedCoordinator.removeScrollObserver(scrollObserverID)
+            }
+            observedCoordinator = coordinator
+            scrollObserverID = coordinator.addScrollObserver { [weak self] _ in
+                self?.needsDisplay = true
+                self?.needsLayout = true
+            }
+        }
 
         override func draw(_ dirtyRect: NSRect) {
             super.draw(dirtyRect)
@@ -155,6 +170,14 @@ struct MergeActionGutter: NSViewRepresentable {
             let closure: () -> Void
             init(closure: @escaping () -> Void) { self.closure = closure }
             @objc func fire() { closure() }
+        }
+
+        deinit {
+            if let scrollObserverID, let observedCoordinator {
+                MainActor.assumeIsolated {
+                    observedCoordinator.removeScrollObserver(scrollObserverID)
+                }
+            }
         }
     }
 }

--- a/Alas/Sources/Center/Merge/MergeScrollCoordinator.swift
+++ b/Alas/Sources/Center/Merge/MergeScrollCoordinator.swift
@@ -7,7 +7,7 @@ import Observation
 @MainActor
 @Observable
 final class MergeScrollCoordinator {
-    enum Source: Equatable {
+    enum Source: Equatable, Hashable {
         case local, result, remote
     }
 
@@ -29,11 +29,20 @@ final class MergeScrollCoordinator {
     var onSyncResult: ((CGFloat) -> Void)?
     var onSyncRemote: ((CGFloat) -> Void)?
 
+    @ObservationIgnored
+    private var scrollObservers: [UUID: (CGFloat) -> Void] = [:]
+
+    /// Sources currently being moved by a coordinator-driven sync.
+    /// NSClipView posts boundsDidChange for programmatic scrolls too;
+    /// those callbacks must not be treated as a fresh user scroll.
+    private var syncingSources: Set<Source> = []
+
     /// Programmatic setter. Doesn't broadcast — the caller is
     /// presumed to be initialization or a non-scroll trigger.
     func setLogicalRow(_ row: Int) {
         logicalRow = max(0, row)
         scrollY = CGFloat(logicalRow) * rowHeight
+        notifyScrollObservers()
     }
 
     /// Returns the Y offset (points) corresponding to the current
@@ -47,6 +56,7 @@ final class MergeScrollCoordinator {
     /// `onSync`. The source pane is excluded from the broadcast so it
     /// doesn't bounce its own value back.
     func applyPaneY(_ y: CGFloat, source: Source) {
+        guard !syncingSources.contains(source) else { return }
         // floor() rather than rounded(): rounded() causes mid-row hysteresis
         // during slow trackpad scrolls (the value flickers between row N and
         // N+1 when y is near (N + 0.5) * rowHeight). floor matches the
@@ -57,12 +67,36 @@ final class MergeScrollCoordinator {
         scrollY = nextY
         let row = max(0, Int((nextY / max(rowHeight, 1)).rounded(.down)))
         logicalRow = row
+        notifyScrollObservers()
         for target in [Source.local, .result, .remote] where target != source {
-            switch target {
-            case .local:  onSyncLocal?(nextY)
-            case .result: onSyncResult?(nextY)
-            case .remote: onSyncRemote?(nextY)
-            }
+            sync(nextY, to: target)
+        }
+    }
+
+    @discardableResult
+    func addScrollObserver(_ observer: @escaping (CGFloat) -> Void) -> UUID {
+        let id = UUID()
+        scrollObservers[id] = observer
+        return id
+    }
+
+    func removeScrollObserver(_ id: UUID) {
+        scrollObservers.removeValue(forKey: id)
+    }
+
+    private func notifyScrollObservers() {
+        for observer in scrollObservers.values {
+            observer(scrollY)
+        }
+    }
+
+    private func sync(_ y: CGFloat, to target: Source) {
+        syncingSources.insert(target)
+        defer { syncingSources.remove(target) }
+        switch target {
+        case .local:  onSyncLocal?(y)
+        case .result: onSyncResult?(y)
+        case .remote: onSyncRemote?(y)
         }
     }
 }

--- a/Alas/Sources/Center/Merge/MergeSidePane.swift
+++ b/Alas/Sources/Center/Merge/MergeSidePane.swift
@@ -45,6 +45,9 @@ struct MergeSidePane: NSViewRepresentable {
         )
         textView.autoresizingMask = [.width]
         scroll.documentView = textView
+        scroll.hasVerticalRuler = true
+        scroll.rulersVisible = true
+        scroll.verticalRulerView = MergeSourceLineNumberRulerView(scrollView: scroll, theme: theme)
         context.coordinator.textView = textView
         // Forward scroll changes to the coordinator.
         context.coordinator.observeScroll(scroll, side: side, into: coordinator)
@@ -71,6 +74,14 @@ struct MergeSidePane: NSViewRepresentable {
             let attr = buildAttributedString(theme: theme)
             textView.textStorage?.setAttributedString(attr)
             context.coordinator.lastKey = key
+        }
+        if let ruler = scroll.verticalRulerView as? MergeSourceLineNumberRulerView {
+            ruler.update(
+                rows: rows,
+                rowHeight: lineHeight(),
+                contentTopInset: textView.textContainerInset.height,
+                theme: theme
+            )
         }
         textView.backgroundColor = bg
         context.coordinator.coordinator = coordinator
@@ -169,5 +180,110 @@ struct MergeSidePane: NSViewRepresentable {
             result.append(line)
         }
         return result
+    }
+}
+
+private final class MergeSourceLineNumberRulerView: NSRulerView {
+    private var rows: [MergeRegionVisualLayout.VisualRow] = []
+    private var theme: Theme
+    private var rowHeight: CGFloat = 16
+    private var contentTopInset: CGFloat = 6
+    private var boundsObserver: NSObjectProtocol?
+
+    private let minimumThickness: CGFloat = 34
+    private let horizontalPadding: CGFloat = 8
+
+    init(scrollView: NSScrollView, theme: Theme) {
+        self.theme = theme
+        super.init(scrollView: scrollView, orientation: .verticalRuler)
+        ruleThickness = minimumThickness
+        reservedThicknessForMarkers = 0
+        reservedThicknessForAccessoryView = 0
+        observe(scrollView: scrollView)
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("not used")
+    }
+
+    override var isFlipped: Bool { true }
+
+    func update(
+        rows: [MergeRegionVisualLayout.VisualRow],
+        rowHeight: CGFloat,
+        contentTopInset: CGFloat,
+        theme: Theme
+    ) {
+        self.rows = rows
+        self.rowHeight = rowHeight
+        self.contentTopInset = contentTopInset
+        self.theme = theme
+        updateThickness()
+        needsDisplay = true
+    }
+
+    override func drawHashMarksAndLabels(in rect: NSRect) {
+        NSColor(theme.color("bg-2")).setFill()
+        bounds.fill()
+
+        guard
+            let scrollView,
+            rowHeight > 0,
+            !rows.isEmpty
+        else { return }
+
+        let visible = scrollView.contentView.bounds
+        let firstRow = max(0, Int(floor((visible.minY - contentTopInset) / rowHeight)))
+        let lastRow = min(rows.count - 1, Int(ceil((visible.maxY - contentTopInset) / rowHeight)))
+        guard firstRow <= lastRow else { return }
+
+        let attributes = labelAttributes()
+        let textHeight = ("8" as NSString).size(withAttributes: attributes).height
+        for index in firstRow...lastRow {
+            guard let number = rows[index].sourceLineNumber else { continue }
+            let y = contentTopInset + CGFloat(index) * rowHeight - visible.minY
+            let drawRect = NSRect(
+                x: 0,
+                y: y + max((rowHeight - textHeight) / 2, 0),
+                width: ruleThickness - horizontalPadding,
+                height: textHeight
+            )
+            NSString(string: String(number)).draw(in: drawRect, withAttributes: attributes)
+        }
+    }
+
+    private func observe(scrollView: NSScrollView) {
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        boundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self] _ in
+            self?.needsDisplay = true
+        }
+    }
+
+    private func updateThickness() {
+        let maxLine = rows.compactMap(\.sourceLineNumber).max() ?? 1
+        let digits = String(maxLine).count
+        let sample = String(repeating: "8", count: digits) as NSString
+        let width = ceil(sample.size(withAttributes: labelAttributes()).width)
+        ruleThickness = max(minimumThickness, width + horizontalPadding * 2)
+    }
+
+    private func labelAttributes() -> [NSAttributedString.Key: Any] {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .right
+        return [
+            .font: NSFont.monospacedSystemFont(ofSize: 10, weight: .regular),
+            .foregroundColor: NSColor(theme.color("fg-faint")),
+            .paragraphStyle: paragraph,
+        ]
+    }
+
+    deinit {
+        if let boundsObserver {
+            NotificationCenter.default.removeObserver(boundsObserver)
+        }
     }
 }

--- a/Alas/Sources/Center/Merge/MergeView3Way.swift
+++ b/Alas/Sources/Center/Merge/MergeView3Way.swift
@@ -3,8 +3,6 @@ import SwiftUI
 
 /// Top-level coordinator view for the 3-way merge editor. Replaces
 /// the old `body3Columns` HStack. Composes:
-/// - Outer line-number gutters (LOCAL's source numbers + REMOTE's
-///   source numbers) on the far left and far right.
 /// - Three text panes: LOCAL (`MergeSidePane`), RESULT
 ///   (`MergeResultPane`), REMOTE (`MergeSidePane`).
 /// - Two action gutters (`MergeActionGutter`) between the panes.
@@ -71,8 +69,7 @@ struct MergeView3Way: View {
     var body: some View {
         let layout = self.layout
         let hunkPairs = model.allConflictBlocks().map { (local: $0.local, remote: $0.remote) }
-        HStack(spacing: 0) {
-            lineNumberGutter(rows: layout.local, alignment: .trailing)
+        MergeThreeWayLayout {
             MergeSidePane(
                 side: .local,
                 rows: layout.local,
@@ -81,7 +78,6 @@ struct MergeView3Way: View {
                 codeFontSize: codeFontSize,
                 coordinator: coordinator
             )
-            .frame(maxWidth: .infinity)
             MergeActionGutter(
                 side: .localToResult,
                 conflictRanges: layout.conflictRanges,
@@ -104,7 +100,6 @@ struct MergeView3Way: View {
                     model.applyEditedFullText(newText, showBase: showBase)
                 }
             )
-            .frame(maxWidth: .infinity)
             MergeActionGutter(
                 side: .resultToRemote,
                 conflictRanges: layout.conflictRanges,
@@ -121,15 +116,16 @@ struct MergeView3Way: View {
                 codeFontSize: codeFontSize,
                 coordinator: coordinator
             )
-            .frame(maxWidth: .infinity)
-            lineNumberGutter(rows: layout.remote, alignment: .leading)
             MergeConflictMinimap(
                 conflictCount: model.conflictCount,
                 resolvedCount: max(model.initialConflictCount - model.conflictCount, 0),
                 currentConflictIndex: model.currentConflictIndex,
                 onJump: onJumpToConflict
             )
+            .frame(width: 13)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .clipped()
         .onChange(of: model.currentConflictIndex, initial: true) { _, _ in
             scrollToCurrentConflict()
         }
@@ -158,30 +154,49 @@ struct MergeView3Way: View {
         guard ordinal < blocks.count else { return }
         model.acceptRemote(for: blocks[ordinal])
     }
+}
 
-    private func lineNumberGutter(rows: [MergeRegionVisualLayout.VisualRow], alignment: HorizontalAlignment) -> some View {
-        // Wrapped in a top-aligned container that clips overflow and
-        // offset by -coordinator.paneY() so the numbers track the
-        // synchronized scroll position of the three text panes. The
-        // gutter rows are still all materialised; the clip + offset
-        // is the cheap way to align them without a NSScrollView for
-        // a read-only column.
-        VStack(alignment: alignment, spacing: 0) {
-            VStack(alignment: alignment, spacing: 0) {
-                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-                    Text(row.sourceLineNumber.map(String.init) ?? "")
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundColor(theme.color("fg-faint"))
-                        .frame(height: coordinator.rowHeight, alignment: alignment == .trailing ? .trailing : .leading)
-                        .padding(.horizontal, 4)
-                }
-            }
-            .padding(.top, coordinator.contentTopInset)
-            .offset(y: -coordinator.paneY())
-            Spacer(minLength: 0)
+private struct MergeThreeWayLayout: Layout {
+    private let actionGutterWidth: CGFloat = 28
+    private let minimapWidth: CGFloat = 13
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        CGSize(
+            width: proposal.width ?? 900,
+            height: proposal.height ?? 600
+        )
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        guard subviews.count == 6 else { return }
+        let fixedWidth = actionGutterWidth * 2 + minimapWidth
+        let paneWidth = max((bounds.width - fixedWidth) / 3, 0)
+        let widths = [
+            paneWidth,
+            actionGutterWidth,
+            paneWidth,
+            actionGutterWidth,
+            paneWidth,
+            minimapWidth,
+        ]
+
+        var x = bounds.minX
+        for (index, width) in widths.enumerated() {
+            subviews[index].place(
+                at: CGPoint(x: x, y: bounds.minY),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(width: width, height: bounds.height)
+            )
+            x += width
         }
-        .frame(width: 28)
-        .background(theme.color("bg-2"))
-        .clipped()
     }
 }

--- a/AlasTests/BaseBranchSelectorTests.swift
+++ b/AlasTests/BaseBranchSelectorTests.swift
@@ -1,6 +1,7 @@
 import Testing
 @testable import Alas
 
+@MainActor
 struct BaseBranchSelectorTests {
     @Test func isSelectedUsesCurrentRefWhenAvailable() {
         #expect(BaseBranchSelector.isSelected(row: "origin/feature", baseBranch: "main", currentRef: "origin/feature"))
@@ -137,9 +138,9 @@ struct BaseBranchSelectorTests {
 
     @Test func branchListHeightMatchesVisibleRows() {
         let oneRow = BaseBranchSelector.branchListHeight(optionCount: 1)
-        #expect(BaseBranchSelector.branchListHeight(optionCount: 4) == oneRow * 4)
-        #expect(BaseBranchSelector.branchListHeight(optionCount: 5) == oneRow * 5)
-        #expect(BaseBranchSelector.branchListHeight(optionCount: 12) == oneRow * 5)
+        #expect(abs(BaseBranchSelector.branchListHeight(optionCount: 4) - oneRow * 4) < 0.001)
+        #expect(abs(BaseBranchSelector.branchListHeight(optionCount: 5) - oneRow * 5) < 0.001)
+        #expect(abs(BaseBranchSelector.branchListHeight(optionCount: 12) - oneRow * 5) < 0.001)
     }
 
     @Test func smartListIncludesCurrentRefWhenAbsentFromShortlist() {

--- a/AlasTests/MergeScrollCoordinatorTests.swift
+++ b/AlasTests/MergeScrollCoordinatorTests.swift
@@ -61,4 +61,38 @@ struct MergeScrollCoordinatorTests {
 
         #expect(resultObserved == [48.5])
     }
+
+    @Test func syncedPaneNotificationsDoNotClobberUserScrollOffset() {
+        let coord = MergeScrollCoordinator()
+        coord.rowHeight = 16
+        var localObserved: [CGFloat] = []
+        coord.onSyncLocal = { y in
+            localObserved.append(y)
+            // AppKit can emit a boundsDidChange notification while handling
+            // a programmatic sync scroll. If the target clamps slightly, that
+            // notification must not become the new source of truth and snap
+            // the pane the user actually scrolled back upward.
+            coord.applyPaneY(y - 24, source: .local)
+        }
+
+        coord.applyPaneY(120, source: .result)
+
+        #expect(localObserved == [120])
+        #expect(coord.scrollY == 120)
+        #expect(coord.logicalRow == 7)
+    }
+
+    @Test func scrollObserversAreNotifiedForUserAndProgrammaticScrolls() {
+        let coord = MergeScrollCoordinator()
+        coord.rowHeight = 10
+        var observed: [CGFloat] = []
+
+        let id = coord.addScrollObserver { observed.append($0) }
+        coord.applyPaneY(25, source: .result)
+        coord.setLogicalRow(4)
+        coord.removeScrollObserver(id)
+        coord.applyPaneY(60, source: .result)
+
+        #expect(observed == [25, 40])
+    }
 }

--- a/AlasTests/MergeView3WayLayoutTests.swift
+++ b/AlasTests/MergeView3WayLayoutTests.swift
@@ -1,0 +1,80 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct MergeView3WayLayoutTests {
+    @Test func longConflictedFilesDoNotExpandMergeViewHeight() throws {
+        let model = MergeConflictTabModel(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-layout-test"),
+            relativePath: "long.swift",
+            gitService: GitService()
+        )
+        model.resultText = Self.longConflictText(lineCount: 1_200)
+        model.reparse()
+
+        let view = MergeView3Way(
+            model: model,
+            fileExtension: "swift",
+            codeFontFamily: "SF Mono",
+            codeFontSize: 13,
+            showBase: false,
+            onJumpToConflict: { _ in }
+        )
+        .environment(\.theme, try ThemeStore().current)
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 1_200, height: 600)
+        controller.view.layoutSubtreeIfNeeded()
+
+        let fittingSize = controller.sizeThatFits(
+            in: NSSize(width: 1_200, height: 600)
+        )
+
+        #expect(fittingSize.height <= 600)
+
+        controller.view.layoutSubtreeIfNeeded()
+        let scrollFrames = controller.view.descendantScrollViews().map { $0.convert($0.bounds, to: controller.view) }
+        let scrollViews = controller.view.descendantScrollViews()
+        let scrollWidths = scrollFrames.map(\.width)
+        #expect(scrollWidths.count == 3)
+        #expect(scrollWidths.allSatisfy { $0 > 250 })
+        #expect(scrollFrames.allSatisfy { $0.minX >= 0 })
+        #expect(scrollFrames.allSatisfy { $0.maxX <= 1_200 })
+        #expect(scrollViews.filter { $0.verticalRulerView != nil }.count == 2)
+        #expect(scrollViews.filter(\.rulersVisible).count == 2)
+        let documentFrames = scrollViews.compactMap { $0.documentView?.frame }
+        #expect(documentFrames.count == 3)
+        #expect(documentFrames.allSatisfy { $0.width > 250 })
+        #expect(documentFrames.allSatisfy { $0.height > 100 })
+    }
+
+    private static func longConflictText(lineCount: Int) -> String {
+        let prefix = (0..<lineCount).map { "let before\($0) = \($0)" }.joined(separator: "\n")
+        let suffix = (0..<lineCount).map { "let after\($0) = \($0)" }.joined(separator: "\n")
+        return """
+        \(prefix)
+        <<<<<<< HEAD
+        let value = "local"
+        =======
+        let value = "remote"
+        >>>>>>> branch
+        \(suffix)
+        """
+    }
+}
+
+private extension NSView {
+    func descendantScrollViews() -> [NSScrollView] {
+        var result: [NSScrollView] = []
+        if let scrollView = self as? NSScrollView {
+            result.append(scrollView)
+        }
+        for subview in subviews {
+            result.append(contentsOf: subview.descendantScrollViews())
+        }
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- remove the standalone merge editor line-number gutters that could consume the visible 3-way layout
- keep merge pane widths under explicit layout control so large conflicted files remain scrollable
- ignore programmatic scroll-sync notifications so panes do not snap back during synchronized scrolling

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build\n- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test