### PR TITLE
feat(worktrees): default ordering for repo worktrees

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 		B1A6F39D02409339072EC164 /* HarnessDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9F85B92952C963DCF136315 /* HarnessDetector.swift */; };
 		B1CC27484E05C5B3DEB54857 /* MergeConflictMinimap.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5788263AE679D146F9BF49C /* MergeConflictMinimap.swift */; };
 		B339F5B376407CFD88B0E7B8 /* ACPAttachmentMimeTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */; };
+		B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */; };
 		B35BD3304D3A9EC5BABBC56E /* CommitRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D46BDE72E52818061452ECB /* CommitRowTests.swift */; };
 		B3BA844FBD11333E74A05655 /* MarkdownImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */; };
 		B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D921D1C8A44F1937769CDB60 /* EditorBufferStore.swift */; };
@@ -1297,6 +1298,7 @@
 		8942D0F47DBCFFB3549EE775 /* ShortcutReservations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutReservations.swift; sourceTree = "<group>"; };
 		89B23F35BE6FD53B74DD84ED /* ZmxSessionName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSessionName.swift; sourceTree = "<group>"; };
 		89C4AE9D01CA02A9689AAE8B /* CompletionWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionWindowControllerTests.swift; sourceTree = "<group>"; };
+		8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCodableTests.swift; sourceTree = "<group>"; };
 		8BCE20FA56461E66A58A7AA2 /* MemorySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySnapshot.swift; sourceTree = "<group>"; };
 		8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStatePersistenceTests.swift; sourceTree = "<group>"; };
 		8C245764E69F92CBB8D31BF6 /* GatekeeperRemediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediator.swift; sourceTree = "<group>"; };
@@ -2012,6 +2014,7 @@
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
 				5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */,
 				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
+				8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */,
 				3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */,
 				C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */,
 				6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */,
@@ -4182,6 +4185,7 @@
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
 				9BA16B0D5FC26501D54B5192 /* WorkingTreeStageAllActionTests.swift in Sources */,
 				BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */,
+				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,
 				8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */,
 				E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */,
 				2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		25CD620AE7FFA7DE82937F7E /* Spinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */; };
 		2659BA65A6CABBE800A06AB3 /* tool-call-content-diff.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
+		2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */; };
 		279BAFE41DCB69286B64CFB9 /* AdapterUpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */; };
 		281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
@@ -1204,6 +1205,7 @@
 		6A190D4B29B35C457AA9829F /* SettingsBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBinding.swift; sourceTree = "<group>"; };
 		6AF335AB8B3061C889A348B3 /* CommitDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetails.swift; sourceTree = "<group>"; };
 		6B3F942D660C7ABA8542C77D /* ImageFileType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFileType.swift; sourceTree = "<group>"; };
+		6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeServiceCreatedAtTests.swift; sourceTree = "<group>"; };
 		6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchOpsMenu.swift; sourceTree = "<group>"; };
 		6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecNpmPackageTests.swift; sourceTree = "<group>"; };
 		6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModelTests.swift; sourceTree = "<group>"; };
@@ -2012,6 +2014,7 @@
 				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
 				3B7BE659F7E386D15047C374 /* WorktreeCreateFetchTests.swift */,
 				C6C27094E7804D975635EB11 /* WorktreeRowHeightTests.swift */,
+				6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */,
 				D36137279CD9028BB6FFED0B /* WorktreeServiceTests.swift */,
 				670C7B064EA079D045F0D0DE /* WorktreeWatcherFilterTests.swift */,
 				321E1DBC8C06504AD3EE7D6E /* WorktreeWatcherTests.swift */,
@@ -4181,6 +4184,7 @@
 				BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */,
 				8B0593FC9BC9E683E0685DD0 /* WorktreeCreateFetchTests.swift in Sources */,
 				E6C5CD34C39ECF114DC3D4B4 /* WorktreeRowHeightTests.swift in Sources */,
+				2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */,
 				CB549B27BB0E578776AA7ED0 /* WorktreeServiceTests.swift in Sources */,
 				E4EAC28F55CBE987E0AB1F85 /* WorktreeWatcherFilterTests.swift in Sources */,
 				98B61C62BB4FEDCDE271FAC1 /* WorktreeWatcherTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -830,6 +830,7 @@
 		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
 		FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */; };
 		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
+		FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
 		FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */; };
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
@@ -1462,6 +1463,7 @@
 		BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequest.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
 		BFE0C069E5446132D39C4DE5 /* QueuedPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueuedPrompt.swift; sourceTree = "<group>"; };
+		C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigWorktreeOrderingDecodeTests.swift; sourceTree = "<group>"; };
 		C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeAgentTests.swift; sourceTree = "<group>"; };
 		C19E98A53E2B793436D2F10D /* NotificationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationDelegate.swift; sourceTree = "<group>"; };
 		C204307EE573512D731B8307 /* ACPGeminiE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPGeminiE2ETests.swift; sourceTree = "<group>"; };
@@ -1829,6 +1831,7 @@
 				705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */,
 				EC9F12CC9A1AA0A56CF7BA3A /* AppConfigTerminalTests.swift */,
 				B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */,
+				C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */,
 				620C4A708CD1013DE2736A00 /* AppIconTests.swift */,
 				447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */,
 				08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */,
@@ -3966,6 +3969,7 @@
 				C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */,
 				ECEE8511CA84DF4A15F01DC1 /* AppConfigTerminalTests.swift in Sources */,
 				6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */,
+				FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */,
 				C179C5202C4BB8D73E7EB701 /* AppIconTests.swift in Sources */,
 				A39D44E69D8BEF98C8934DF7 /* AppStateCLIRoutingTests.swift in Sources */,
 				0EC2E8C6E5E00DD040CC4847 /* AppStateCleanupTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -322,6 +322,12 @@ final class AppState {
             themeStore.setMatchSystem(true)
         }
         self.themeStore = themeStore
+        // All stored properties are initialized; we can safely capture `self`.
+        // Wire the live default-ordering source so the manager reads the
+        // current `config.worktrees.defaultOrdering` on every sort.
+        self.projectsManager.setDefaultOrdering { [weak self] in
+            self?.config.worktrees.defaultOrdering ?? .lastUpdateDesc
+        }
         WindowAppearance.apply(darkMode: themeStore.current.darkMode)
         // Tabs can't be loaded here: worktrees haven't been refreshed yet (that
         // happens async in RootView.task), so worktreesByProject is empty and

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -37,6 +37,10 @@ final class ProjectsManager {
         self.defaultOrderingSource = defaultOrdering
     }
 
+    /// Replace the live source of the global default sort mode. Callers must
+    /// also invoke `reapplyOrderingForAllProjects()` after a config change to
+    /// propagate the new mode to already-sorted lists — `setDefaultOrdering`
+    /// alone does not trigger a re-sort.
     func setDefaultOrdering(_ source: @escaping () -> AppConfig.WorktreeSortMode) {
         self.defaultOrderingSource = source
     }
@@ -141,6 +145,19 @@ final class ProjectsManager {
     func visibleMainWorktree(projectId: String) -> Worktree? {
         guard let project = projects.first(where: { $0.id == projectId }) else { return nil }
         return visibleWorktrees(projectId: projectId).first { isMainWorktree($0, project: project) }
+    }
+
+    func resetWorktreeOrder(projectId: String) {
+        guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return }
+        guard !projects[idx].worktreeOrder.isEmpty else { return }
+        projects[idx].worktreeOrder = []
+        applyWorktreeOrdering(projectId: projectId)
+    }
+
+    func reapplyOrderingForAllProjects() {
+        for project in projects {
+            applyWorktreeOrdering(projectId: project.id)
+        }
     }
 
     func reorderWorktree(projectId: String, fromIndex: Int, toIndex: Int) {

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -151,8 +151,10 @@ final class ProjectsManager {
 
     func resetWorktreeOrder(projectId: String) {
         guard let idx = projects.firstIndex(where: { $0.id == projectId }) else { return }
-        guard !projects[idx].worktreeOrder.isEmpty else { return }
+        let wasManual = projects[idx].worktreeOrderIsManual || !projects[idx].worktreeOrder.isEmpty
+        guard wasManual else { return }
         projects[idx].worktreeOrder = []
+        projects[idx].worktreeOrderIsManual = false
         applyWorktreeOrdering(projectId: projectId)
     }
 
@@ -191,6 +193,7 @@ final class ProjectsManager {
         rows.insert(moving, at: clampedDestination)
 
         worktreesByProject[projectId] = rows
+        projects[projectIndex].worktreeOrderIsManual = true
         projects[projectIndex].worktreeOrder = normalizedWorktreeOrder(
             rows.map(\.id),
             rows: rows,
@@ -374,7 +377,7 @@ final class ProjectsManager {
 
     private func sortedWorktrees(_ rows: [Worktree], project: ProjectConfig) -> [Worktree] {
         let effectiveMode: AppConfig.WorktreeSortMode =
-            project.worktreeOrder.isEmpty ? defaultOrderingSource() : .manual
+            project.worktreeOrderIsManual ? .manual : defaultOrderingSource()
 
         // Partition main first; main is always pinned at position 0.
         var main: [Worktree] = []

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -37,10 +37,12 @@ final class ProjectsManager {
         self.defaultOrderingSource = defaultOrdering
     }
 
-    /// Replace the live source of the global default sort mode. Callers must
-    /// also invoke `reapplyOrderingForAllProjects()` after a config change to
-    /// propagate the new mode to already-sorted lists — `setDefaultOrdering`
-    /// alone does not trigger a re-sort.
+    /// Replace the live source of the global default sort mode. The closure is
+    /// evaluated lazily on every sort, so a single wire-up at app launch suffices
+    /// to keep ordering current as the user toggles the setting — but a *re-sort
+    /// of already-sorted lists* is therefore not implicit. Callers must invoke
+    /// `reapplyOrderingForAllProjects()` after a config change to propagate the
+    /// new mode to lists that were already sorted.
     func setDefaultOrdering(_ source: @escaping () -> AppConfig.WorktreeSortMode) {
         self.defaultOrderingSource = source
     }
@@ -154,6 +156,11 @@ final class ProjectsManager {
         applyWorktreeOrdering(projectId: projectId)
     }
 
+    /// Re-sort every project's worktree list using the current effective sort
+    /// mode. Invoke after mutating `config.worktrees.defaultOrdering` (or
+    /// `setDefaultOrdering`) — otherwise the change only affects subsequent
+    /// sort triggers (worktree add/remove, refresh), not the lists already
+    /// rendered.
     func reapplyOrderingForAllProjects() {
         for project in projects {
             applyWorktreeOrdering(projectId: project.id)

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -27,7 +27,7 @@ final class ProjectsManager {
     /// Source of the global default sort mode. `AppState` rebinds this after
     /// its stored properties are initialized so it can capture `self` weakly;
     /// tests inject a fixed value via the convenience `defaultOrdering:` init.
-    private(set) var defaultOrderingSource: () -> AppConfig.WorktreeSortMode = { .manual }
+    private var defaultOrderingSource: () -> AppConfig.WorktreeSortMode = { .manual }
 
     init(
         persistedProjects: [ProjectConfig],

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -160,11 +160,18 @@ final class ProjectsManager {
     /// mode. Invoke after mutating `config.worktrees.defaultOrdering` (or
     /// `setDefaultOrdering`) — otherwise the change only affects subsequent
     /// sort triggers (worktree add/remove, refresh), not the lists already
-    /// rendered.
-    func reapplyOrderingForAllProjects() {
+    /// rendered. Returns `true` if any project's persisted `worktreeOrder`
+    /// actually changed (e.g. orphan ids dropped during normalization), so
+    /// callers can decide whether to persist.
+    @discardableResult
+    func reapplyOrderingForAllProjects() -> Bool {
+        var changed = false
         for project in projects {
-            applyWorktreeOrdering(projectId: project.id)
+            if applyWorktreeOrdering(projectId: project.id) {
+                changed = true
+            }
         }
+        return changed
     }
 
     func reorderWorktree(projectId: String, fromIndex: Int, toIndex: Int) {

--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -24,8 +24,21 @@ final class ProjectsManager {
     private let git = GitService()
     private let worktreeSvc = WorktreeService()
 
-    init(persistedProjects: [ProjectConfig]) {
+    /// Source of the global default sort mode. `AppState` rebinds this after
+    /// its stored properties are initialized so it can capture `self` weakly;
+    /// tests inject a fixed value via the convenience `defaultOrdering:` init.
+    private(set) var defaultOrderingSource: () -> AppConfig.WorktreeSortMode = { .manual }
+
+    init(
+        persistedProjects: [ProjectConfig],
+        defaultOrdering: @escaping () -> AppConfig.WorktreeSortMode = { .manual }
+    ) {
         self.projects = persistedProjects
+        self.defaultOrderingSource = defaultOrdering
+    }
+
+    func setDefaultOrdering(_ source: @escaping () -> AppConfig.WorktreeSortMode) {
+        self.defaultOrderingSource = source
     }
 
     func addProject(path: URL, displayName: String, color: String) async throws -> ProjectConfig {
@@ -329,20 +342,49 @@ final class ProjectsManager {
     }
 
     private func sortedWorktrees(_ rows: [Worktree], project: ProjectConfig) -> [Worktree] {
-        let order = normalizedWorktreeOrder(project.worktreeOrder, rows: rows, project: project)
-        let rank = Dictionary(uniqueKeysWithValues: order.enumerated().map { ($0.element, $0.offset) })
-        return rows.sorted { lhs, rhs in
-            let lhsIsMain = isMainWorktree(lhs, project: project)
-            let rhsIsMain = isMainWorktree(rhs, project: project)
-            if lhsIsMain != rhsIsMain { return lhsIsMain }
+        let effectiveMode: AppConfig.WorktreeSortMode =
+            project.worktreeOrder.isEmpty ? defaultOrderingSource() : .manual
 
-            let lhsRank = rank[lhs.id]
-            let rhsRank = rank[rhs.id]
-            if let lhsRank, let rhsRank, lhsRank != rhsRank { return lhsRank < rhsRank }
-            if lhsRank != nil { return true }
-            if rhsRank != nil { return false }
-            return lhs.path.path < rhs.path.path
+        // Partition main first; main is always pinned at position 0.
+        var main: [Worktree] = []
+        var others: [Worktree] = []
+        for row in rows {
+            if isMainWorktree(row, project: project) { main.append(row) } else { others.append(row) }
         }
+
+        let sortedOthers: [Worktree]
+        switch effectiveMode {
+        case .manual:
+            let order = normalizedWorktreeOrder(project.worktreeOrder, rows: rows, project: project)
+            let rank = Dictionary(uniqueKeysWithValues: order.enumerated().map { ($0.element, $0.offset) })
+            sortedOthers = others.sorted { lhs, rhs in
+                let lhsRank = rank[lhs.id]
+                let rhsRank = rank[rhs.id]
+                if let lhsRank, let rhsRank, lhsRank != rhsRank { return lhsRank < rhsRank }
+                if lhsRank != nil { return true }
+                if rhsRank != nil { return false }
+                return lhs.id < rhs.id
+            }
+        case .creationDesc:
+            sortedOthers = others.sorted { lhs, rhs in
+                if lhs.createdAt != rhs.createdAt { return lhs.createdAt > rhs.createdAt }
+                return lhs.id < rhs.id
+            }
+        case .lastUpdateDesc:
+            sortedOthers = others.sorted { lhs, rhs in
+                if lhs.lastActivity != rhs.lastActivity { return lhs.lastActivity > rhs.lastActivity }
+                return lhs.id < rhs.id
+            }
+        case .branchAsc:
+            sortedOthers = others.sorted { lhs, rhs in
+                let lb = lhs.branch.localizedLowercase
+                let rb = rhs.branch.localizedLowercase
+                if lb != rb { return lb < rb }
+                return lhs.id < rhs.id
+            }
+        }
+
+        return main + sortedOthers
     }
 
     private func normalizedWorktreeOrder(
@@ -350,6 +392,10 @@ final class ProjectsManager {
         rows: [Worktree],
         project: ProjectConfig
     ) -> [String] {
+        // Empty input means "follow default" — keep it empty so callers can
+        // distinguish manual-mode (non-empty) from auto-mode (empty).
+        if order.isEmpty { return [] }
+
         let nonMainIds = Set(rows.filter { !isMainWorktree($0, project: project) }.map(\.id))
         var seen: Set<String> = []
         var normalized: [String] = []

--- a/Alas/Sources/Git/GitTypes.swift
+++ b/Alas/Sources/Git/GitTypes.swift
@@ -12,8 +12,52 @@ struct Worktree: Identifiable, Equatable, Codable {
     var path: URL
     var status: WorktreeStatus
     var lastActivity: Date
+    var createdAt: Date
     var addedLines: Int = 0
     var deletedLines: Int = 0
+
+    enum CodingKeys: String, CodingKey {
+        case id, projectId, name, branch, path, status,
+             lastActivity, createdAt, addedLines, deletedLines
+    }
+
+    init(
+        id: String,
+        projectId: String,
+        name: String,
+        branch: String,
+        path: URL,
+        status: WorktreeStatus,
+        lastActivity: Date,
+        createdAt: Date? = nil,
+        addedLines: Int = 0,
+        deletedLines: Int = 0
+    ) {
+        self.id = id
+        self.projectId = projectId
+        self.name = name
+        self.branch = branch
+        self.path = path
+        self.status = status
+        self.lastActivity = lastActivity
+        self.createdAt = createdAt ?? lastActivity
+        self.addedLines = addedLines
+        self.deletedLines = deletedLines
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        projectId = try c.decode(String.self, forKey: .projectId)
+        name = try c.decode(String.self, forKey: .name)
+        branch = try c.decode(String.self, forKey: .branch)
+        path = try c.decode(URL.self, forKey: .path)
+        status = try c.decode(WorktreeStatus.self, forKey: .status)
+        lastActivity = try c.decode(Date.self, forKey: .lastActivity)
+        createdAt = (try? c.decode(Date.self, forKey: .createdAt)) ?? lastActivity
+        addedLines = (try? c.decode(Int.self, forKey: .addedLines)) ?? 0
+        deletedLines = (try? c.decode(Int.self, forKey: .deletedLines)) ?? 0
+    }
 
     static func makeId(path: URL) -> String {
         path.standardizedFileURL.path

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -39,38 +39,73 @@ struct WorktreeService {
     }
 
     /// Returns a best-effort "last activity" timestamp for the worktree at
-    /// `path`. Prefers the HEAD ref mtime (changes on commit/checkout/rebase),
-    /// falling back to the worktree directory mtime. macOS directory mtime
-    /// only changes on entry add/remove/rename, which misses file-content
-    /// edits and is a poor activity signal — HEAD mtime is much better as
-    /// the default sort key.
+    /// `path`. Resolves the worktree's HEAD ref through the symbolic-ref
+    /// indirection so commits actually update the timestamp:
+    ///   <worktree>/.git → gitdir → HEAD → (symbolic) refs/heads/<branch>
+    /// Falls back through packed-refs, HEAD's own mtime, and the worktree
+    /// directory mtime if any layer can't be resolved.
     static func lastActivity(forWorktreeAt path: URL) -> Date? {
         let fm = FileManager.default
-        let dotGit = path.appendingPathComponent(".git").path
-        if let attrs = try? fm.attributesOfItem(atPath: dotGit) {
-            let type = attrs[.type] as? FileAttributeType
-            let headPath: String?
-            if type == .typeRegular {
-                // Linked worktree: .git is a file with `gitdir: <abs-path>`.
-                if let contents = try? String(contentsOfFile: dotGit, encoding: .utf8),
-                   let line = contents.split(separator: "\n").first(where: { $0.hasPrefix("gitdir: ") }) {
-                    let gitdir = String(line.dropFirst("gitdir: ".count))
-                    headPath = (gitdir as NSString).appendingPathComponent("HEAD")
-                } else {
-                    headPath = nil
-                }
-            } else {
-                // Main worktree: .git is a directory containing HEAD.
-                headPath = (dotGit as NSString).appendingPathComponent("HEAD")
-            }
-            if let headPath,
-               let headAttrs = try? fm.attributesOfItem(atPath: headPath),
-               let mtime = headAttrs[.modificationDate] as? Date {
-                return mtime
-            }
+
+        func mtime(of pathStr: String) -> Date? {
+            (try? fm.attributesOfItem(atPath: pathStr)[.modificationDate]) as? Date
         }
-        // Fallback: directory mtime.
-        return (try? fm.attributesOfItem(atPath: path.path)[.modificationDate]) as? Date
+        func dirMtime() -> Date? { mtime(of: path.path) }
+
+        // 1. Resolve the gitdir.
+        let dotGit = path.appendingPathComponent(".git").path
+        let gitdir: String
+        if let attrs = try? fm.attributesOfItem(atPath: dotGit),
+           (attrs[.type] as? FileAttributeType) == .typeRegular,
+           let contents = try? String(contentsOfFile: dotGit, encoding: .utf8),
+           let line = contents.split(separator: "\n", omittingEmptySubsequences: true)
+               .first(where: { $0.hasPrefix("gitdir: ") }) {
+            // Linked worktree: ".git" file points to the gitdir.
+            gitdir = String(line.dropFirst("gitdir: ".count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } else if let attrs = try? fm.attributesOfItem(atPath: dotGit),
+                  (attrs[.type] as? FileAttributeType) == .typeDirectory {
+            // Main worktree: ".git" is the gitdir.
+            gitdir = dotGit
+        } else {
+            return dirMtime()
+        }
+
+        // 2. Resolve the common dir (where shared refs live).
+        let commonDir: String = {
+            let commondirFile = (gitdir as NSString).appendingPathComponent("commondir")
+            if let raw = try? String(contentsOfFile: commondirFile, encoding: .utf8) {
+                let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.hasPrefix("/") { return trimmed }
+                // Relative to gitdir.
+                return URL(fileURLWithPath: gitdir)
+                    .appendingPathComponent(trimmed)
+                    .standardizedFileURL.path
+            }
+            return gitdir
+        }()
+
+        // 3. Read HEAD.
+        let headPath = (gitdir as NSString).appendingPathComponent("HEAD")
+        guard let headContents = try? String(contentsOfFile: headPath, encoding: .utf8) else {
+            return dirMtime()
+        }
+        let head = headContents.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if head.hasPrefix("ref: ") {
+            // Symbolic ref — follow to the loose branch ref file.
+            let refRel = String(head.dropFirst("ref: ".count))
+                .trimmingCharacters(in: .whitespaces)
+            let refPath = (commonDir as NSString).appendingPathComponent(refRel)
+            if let m = mtime(of: refPath) { return m }
+            // Packed: fall through to packed-refs.
+            let packed = (commonDir as NSString).appendingPathComponent("packed-refs")
+            if let m = mtime(of: packed) { return m }
+        }
+        // Detached HEAD or unresolved symref — HEAD's own mtime is meaningful
+        // (it's rewritten on each detached commit/checkout).
+        if let m = mtime(of: headPath) { return m }
+        return dirMtime()
     }
 
     static func parsePorcelain(_ out: String, projectId: String) -> [Worktree] {

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -46,6 +46,9 @@ struct WorktreeService {
         func flush() {
             if let path = currentPath {
                 let branch = currentBranch ?? "(detached)"
+                let attrs = try? FileManager.default.attributesOfItem(atPath: path.path)
+                let mtime = (attrs?[.modificationDate] as? Date) ?? Date()
+                let ctime = (attrs?[.creationDate] as? Date) ?? mtime
                 result.append(Worktree(
                     id: Worktree.makeId(path: path),
                     projectId: projectId,
@@ -53,7 +56,8 @@ struct WorktreeService {
                     branch: branch,
                     path: path,
                     status: .clean,
-                    lastActivity: (try? FileManager.default.attributesOfItem(atPath: path.path)[.modificationDate] as? Date) ?? Date()
+                    lastActivity: mtime,
+                    createdAt: ctime
                 ))
             }
             currentPath = nil
@@ -492,14 +496,16 @@ struct WorktreeService {
     }
 
     private func makeWorktree(destination: URL, branch: String, projectId: String) -> Worktree {
-        Worktree(
+        let now = Date()
+        return Worktree(
             id: Worktree.makeId(path: destination),
             projectId: projectId,
             name: branch,
             branch: branch,
             path: destination,
             status: .clean,
-            lastActivity: Date()
+            lastActivity: now,
+            createdAt: now
         )
     }
 }

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -60,9 +60,14 @@ struct WorktreeService {
            let contents = try? String(contentsOfFile: dotGit, encoding: .utf8),
            let line = contents.split(separator: "\n", omittingEmptySubsequences: true)
                .first(where: { $0.hasPrefix("gitdir: ") }) {
-            // Linked worktree: ".git" file points to the gitdir.
-            gitdir = String(line.dropFirst("gitdir: ".count))
+            // Linked worktree (or submodule): ".git" file points to the gitdir.
+            // Git writes relative paths for submodules (e.g. "gitdir: ../.git/modules/sub")
+            // so resolve against the worktree directory before further use.
+            let raw = String(line.dropFirst("gitdir: ".count))
                 .trimmingCharacters(in: .whitespacesAndNewlines)
+            gitdir = raw.hasPrefix("/")
+                ? raw
+                : path.appendingPathComponent(raw).standardizedFileURL.path
         } else if let attrs = try? fm.attributesOfItem(atPath: dotGit),
                   (attrs[.type] as? FileAttributeType) == .typeDirectory {
             // Main worktree: ".git" is the gitdir.

--- a/Alas/Sources/Git/WorktreeService.swift
+++ b/Alas/Sources/Git/WorktreeService.swift
@@ -38,6 +38,41 @@ struct WorktreeService {
         return Self.parsePorcelain(result.stdout, projectId: projectId)
     }
 
+    /// Returns a best-effort "last activity" timestamp for the worktree at
+    /// `path`. Prefers the HEAD ref mtime (changes on commit/checkout/rebase),
+    /// falling back to the worktree directory mtime. macOS directory mtime
+    /// only changes on entry add/remove/rename, which misses file-content
+    /// edits and is a poor activity signal — HEAD mtime is much better as
+    /// the default sort key.
+    static func lastActivity(forWorktreeAt path: URL) -> Date? {
+        let fm = FileManager.default
+        let dotGit = path.appendingPathComponent(".git").path
+        if let attrs = try? fm.attributesOfItem(atPath: dotGit) {
+            let type = attrs[.type] as? FileAttributeType
+            let headPath: String?
+            if type == .typeRegular {
+                // Linked worktree: .git is a file with `gitdir: <abs-path>`.
+                if let contents = try? String(contentsOfFile: dotGit, encoding: .utf8),
+                   let line = contents.split(separator: "\n").first(where: { $0.hasPrefix("gitdir: ") }) {
+                    let gitdir = String(line.dropFirst("gitdir: ".count))
+                    headPath = (gitdir as NSString).appendingPathComponent("HEAD")
+                } else {
+                    headPath = nil
+                }
+            } else {
+                // Main worktree: .git is a directory containing HEAD.
+                headPath = (dotGit as NSString).appendingPathComponent("HEAD")
+            }
+            if let headPath,
+               let headAttrs = try? fm.attributesOfItem(atPath: headPath),
+               let mtime = headAttrs[.modificationDate] as? Date {
+                return mtime
+            }
+        }
+        // Fallback: directory mtime.
+        return (try? fm.attributesOfItem(atPath: path.path)[.modificationDate]) as? Date
+    }
+
     static func parsePorcelain(_ out: String, projectId: String) -> [Worktree] {
         var result: [Worktree] = []
         var currentPath: URL?
@@ -46,9 +81,10 @@ struct WorktreeService {
         func flush() {
             if let path = currentPath {
                 let branch = currentBranch ?? "(detached)"
-                let attrs = try? FileManager.default.attributesOfItem(atPath: path.path)
-                let mtime = (attrs?[.modificationDate] as? Date) ?? Date()
-                let ctime = (attrs?[.creationDate] as? Date) ?? mtime
+                let dirAttrs = try? FileManager.default.attributesOfItem(atPath: path.path)
+                let dirMtime = (dirAttrs?[.modificationDate] as? Date) ?? Date()
+                let lastActivity = WorktreeService.lastActivity(forWorktreeAt: path) ?? dirMtime
+                let ctime = (dirAttrs?[.creationDate] as? Date) ?? dirMtime
                 result.append(Worktree(
                     id: Worktree.makeId(path: path),
                     projectId: projectId,
@@ -56,7 +92,7 @@ struct WorktreeService {
                     branch: branch,
                     path: path,
                     status: .clean,
-                    lastActivity: mtime,
+                    lastActivity: lastActivity,
                     createdAt: ctime
                 ))
             }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -1,12 +1,5 @@
 import Foundation
 
-enum WorktreeSortMode: String, Codable, CaseIterable, Equatable {
-    case manual
-    case creationDesc
-    case lastUpdateDesc
-    case branchAsc
-}
-
 struct SidebarChromeOverride: Codable, Equatable {
     var backgroundOpacity: Double  // 0...1
     var textContrast: Double       // 0...1
@@ -286,6 +279,13 @@ struct AppConfig: Codable, Equatable {
 
     enum LauncherMode: String, Codable, Equatable, CaseIterable {
         case terminal, acp
+    }
+
+    enum WorktreeSortMode: String, Codable, Equatable, CaseIterable {
+        case manual
+        case creationDesc
+        case lastUpdateDesc
+        case branchAsc
     }
 
     struct Files: Codable, Equatable {

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+enum WorktreeSortMode: String, Codable, CaseIterable, Equatable {
+    case manual
+    case creationDesc
+    case lastUpdateDesc
+    case branchAsc
+}
+
 struct SidebarChromeOverride: Codable, Equatable {
     var backgroundOpacity: Double  // 0...1
     var textContrast: Double       // 0...1
@@ -59,11 +66,13 @@ struct AppConfig: Codable, Equatable {
         var fetchIntervalMinutes: Int
         var pruneStale: Bool
         var fetchRemoteBeforeCreate: Bool
+        var defaultOrdering: WorktreeSortMode
 
         enum CodingKeys: String, CodingKey {
             case rootPath, pathTemplate, branchPrefix, baseBranch,
                  trackUpstream, deleteBranchOnRemove, autoFetch,
-                 fetchIntervalMinutes, pruneStale, fetchRemoteBeforeCreate
+                 fetchIntervalMinutes, pruneStale, fetchRemoteBeforeCreate,
+                 defaultOrdering
         }
 
         init(
@@ -76,7 +85,8 @@ struct AppConfig: Codable, Equatable {
             autoFetch: Bool,
             fetchIntervalMinutes: Int,
             pruneStale: Bool,
-            fetchRemoteBeforeCreate: Bool = false
+            fetchRemoteBeforeCreate: Bool = false,
+            defaultOrdering: WorktreeSortMode = .lastUpdateDesc
         ) {
             self.rootPath = rootPath
             self.pathTemplate = pathTemplate
@@ -88,6 +98,7 @@ struct AppConfig: Codable, Equatable {
             self.fetchIntervalMinutes = fetchIntervalMinutes
             self.pruneStale = pruneStale
             self.fetchRemoteBeforeCreate = fetchRemoteBeforeCreate
+            self.defaultOrdering = defaultOrdering
         }
 
         init(from decoder: Decoder) throws {
@@ -102,6 +113,7 @@ struct AppConfig: Codable, Equatable {
             fetchIntervalMinutes = try c.decode(Int.self, forKey: .fetchIntervalMinutes)
             pruneStale = try c.decode(Bool.self, forKey: .pruneStale)
             fetchRemoteBeforeCreate = (try? c.decode(Bool.self, forKey: .fetchRemoteBeforeCreate)) ?? false
+            defaultOrdering = (try? c.decode(WorktreeSortMode.self, forKey: .defaultOrdering)) ?? .lastUpdateDesc
         }
     }
 
@@ -318,7 +330,8 @@ struct AppConfig: Codable, Equatable {
             autoFetch: true,
             fetchIntervalMinutes: 5,
             pruneStale: false,
-            fetchRemoteBeforeCreate: false
+            fetchRemoteBeforeCreate: false,
+            defaultOrdering: .lastUpdateDesc
         ),
         terminal: Terminal(
             shell: "/bin/zsh",

--- a/Alas/Sources/Persistence/ProjectConfig.swift
+++ b/Alas/Sources/Persistence/ProjectConfig.swift
@@ -81,6 +81,11 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var addedAt: Date
     var hiddenWorktreePaths: [String] = []
     var worktreeOrder: [String] = []
+    /// Explicit signal that the user dragged worktrees into a custom order.
+    /// When `false`, the global default sort mode applies regardless of any
+    /// legacy `worktreeOrder` left on disk. Set to `true` by drag reorders;
+    /// cleared by "Reset Sort to Default".
+    var worktreeOrderIsManual: Bool = false
     var startupScripts: ProjectStartupScripts = .defaults
     /// Per-project "open after create" preference. `nil` = use global default (true).
     var worktreeOpenAfterCreate: Bool?
@@ -88,7 +93,8 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
     var worktreeDefaultLauncherMode: AppConfig.LauncherMode?
 
     enum CodingKeys: String, CodingKey {
-        case id, name, path, color, addedAt, hiddenWorktreePaths, worktreeOrder, startupScripts,
+        case id, name, path, color, addedAt, hiddenWorktreePaths, worktreeOrder,
+             worktreeOrderIsManual, startupScripts,
              worktreeOpenAfterCreate, worktreeDefaultLauncherMode
     }
 
@@ -100,6 +106,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         addedAt: Date,
         hiddenWorktreePaths: [String] = [],
         worktreeOrder: [String] = [],
+        worktreeOrderIsManual: Bool = false,
         startupScripts: ProjectStartupScripts = .defaults,
         worktreeOpenAfterCreate: Bool? = nil,
         worktreeDefaultLauncherMode: AppConfig.LauncherMode? = nil
@@ -111,6 +118,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         self.addedAt = addedAt
         self.hiddenWorktreePaths = hiddenWorktreePaths
         self.worktreeOrder = worktreeOrder
+        self.worktreeOrderIsManual = worktreeOrderIsManual
         self.startupScripts = startupScripts
         self.worktreeOpenAfterCreate = worktreeOpenAfterCreate
         self.worktreeDefaultLauncherMode = worktreeDefaultLauncherMode
@@ -127,6 +135,7 @@ struct ProjectConfig: Codable, Equatable, Identifiable {
         addedAt = try c.decode(Date.self, forKey: .addedAt)
         hiddenWorktreePaths = (try? c.decode([String].self, forKey: .hiddenWorktreePaths)) ?? []
         worktreeOrder = (try? c.decode([String].self, forKey: .worktreeOrder)) ?? []
+        worktreeOrderIsManual = (try? c.decode(Bool.self, forKey: .worktreeOrderIsManual)) ?? false
         startupScripts = (try? c.decode(ProjectStartupScripts.self, forKey: .startupScripts))
             ?? .defaults
         worktreeOpenAfterCreate = try? c.decode(Bool.self, forKey: .worktreeOpenAfterCreate)

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -25,16 +25,9 @@ struct WorktreesPane: View {
                 SettingsGroup(title: "Sorting") {
                     SettingsRow(
                         name: "Default ordering",
-                        desc: "How worktrees are listed in the sidebar. Main is always pinned first. Reordering a repo's worktrees manually overrides this for that repo."
+                        desc: "Sort order for the worktrees sidebar list. Manual reordering of a repo overrides this for that repo."
                     ) {
-                        Picker("", selection: Binding(
-                            get: { state.config.worktrees.defaultOrdering },
-                            set: { newValue in
-                                state.config.worktrees.defaultOrdering = newValue
-                                state.saveConfig()
-                                state.projectsManager.reapplyOrderingForAllProjects()
-                            }
-                        )) {
+                        Picker("", selection: defaultOrderingBinding) {
                             Text("Last update time").tag(AppConfig.WorktreeSortMode.lastUpdateDesc)
                             Text("Creation time").tag(AppConfig.WorktreeSortMode.creationDesc)
                             Text("Branch name").tag(AppConfig.WorktreeSortMode.branchAsc)
@@ -103,6 +96,17 @@ struct WorktreesPane: View {
             get: { state.config[keyPath: kp] },
             set: { state.config[keyPath: kp] = $0
             state.saveConfig() }
+        )
+    }
+
+    private var defaultOrderingBinding: Binding<AppConfig.WorktreeSortMode> {
+        Binding(
+            get: { state.config.worktrees.defaultOrdering },
+            set: { newValue in
+                state.config.worktrees.defaultOrdering = newValue
+                state.saveConfig()
+                state.projectsManager.reapplyOrderingForAllProjects()
+            }
         )
     }
 

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -22,6 +22,28 @@ struct WorktreesPane: View {
                         AlasField(text: bind(\.worktrees.pathTemplate), monospaced: true)
                     }
                 }
+                SettingsGroup(title: "Sorting") {
+                    SettingsRow(
+                        name: "Default ordering",
+                        desc: "How worktrees are listed in the sidebar. Main is always pinned first. Reordering a repo's worktrees manually overrides this for that repo."
+                    ) {
+                        Picker("", selection: Binding(
+                            get: { state.config.worktrees.defaultOrdering },
+                            set: { newValue in
+                                state.config.worktrees.defaultOrdering = newValue
+                                state.saveConfig()
+                                state.projectsManager.reapplyOrderingForAllProjects()
+                            }
+                        )) {
+                            Text("Last update time").tag(AppConfig.WorktreeSortMode.lastUpdateDesc)
+                            Text("Creation time").tag(AppConfig.WorktreeSortMode.creationDesc)
+                            Text("Branch name").tag(AppConfig.WorktreeSortMode.branchAsc)
+                            Text("Manual").tag(AppConfig.WorktreeSortMode.manual)
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 240)
+                    }
+                }
                 SettingsGroup(title: "Branch defaults") {
                     SettingsRow(name: "Branch prefix",
                                 desc: "Default prefix when creating a new worktree.") {

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -105,7 +105,9 @@ struct WorktreesPane: View {
             set: { newValue in
                 state.config.worktrees.defaultOrdering = newValue
                 state.saveConfig()
-                state.projectsManager.reapplyOrderingForAllProjects()
+                if state.projectsManager.reapplyOrderingForAllProjects() {
+                    state.saveProjects()
+                }
             }
         )
     }

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -67,7 +67,7 @@ struct RepoGroupView: View {
             .contextMenu {
                 Button("Edit Project…", action: onEditProject)
                 Button("Reset Sort to Default", action: onResetSort)
-                    .disabled(project.worktreeOrder.isEmpty)
+                    .disabled(!project.worktreeOrderIsManual)
                 Menu("Spaces") {
                     ForEach(spaces) { space in
                         let isMember = isProjectInSpace(space.id)

--- a/Alas/Sources/Sidebar/RepoGroupView.swift
+++ b/Alas/Sources/Sidebar/RepoGroupView.swift
@@ -19,6 +19,7 @@ struct RepoGroupView: View {
     let onNewWorktree: () -> Void
     let onEditProject: () -> Void
     let onRemoveProject: () -> Void
+    let onResetSort: () -> Void
     let spaces: [SpaceConfig]
     let activeSpaceId: String
     let isProjectInSpace: (_ spaceId: String) -> Bool
@@ -65,6 +66,8 @@ struct RepoGroupView: View {
             .onTapGesture { collapsed.toggle() }
             .contextMenu {
                 Button("Edit Project…", action: onEditProject)
+                Button("Reset Sort to Default", action: onResetSort)
+                    .disabled(project.worktreeOrder.isEmpty)
                 Menu("Spaces") {
                     ForEach(spaces) { space in
                         let isMember = isProjectInSpace(space.id)

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -61,7 +61,10 @@ struct SidebarView: View {
                                 onNewWorktree: { onNewWorktree(project.id) },
                                 onEditProject: { onEditProject(project.id) },
                                 onRemoveProject: { onRemoveProject(project.id) },
-                                onResetSort: { state.projectsManager.resetWorktreeOrder(projectId: project.id) },
+                                onResetSort: {
+                                    state.projectsManager.resetWorktreeOrder(projectId: project.id)
+                                    state.saveProjects()
+                                },
                                 spaces: state.spacesManager.spaces,
                                 activeSpaceId: state.spacesManager.activeSpaceId,
                                 isProjectInSpace: { spaceId in

--- a/Alas/Sources/Sidebar/SidebarView.swift
+++ b/Alas/Sources/Sidebar/SidebarView.swift
@@ -61,6 +61,7 @@ struct SidebarView: View {
                                 onNewWorktree: { onNewWorktree(project.id) },
                                 onEditProject: { onEditProject(project.id) },
                                 onRemoveProject: { onRemoveProject(project.id) },
+                                onResetSort: { state.projectsManager.resetWorktreeOrder(projectId: project.id) },
                                 spaces: state.spacesManager.spaces,
                                 activeSpaceId: state.spacesManager.activeSpaceId,
                                 isProjectInSpace: { spaceId in

--- a/Alas/Sources/Watch/GitEventFilter.swift
+++ b/Alas/Sources/Watch/GitEventFilter.swift
@@ -43,26 +43,37 @@ enum GitEventFilter {
             return .headChange(worktreeRoot.standardizedFileURL)
         }
 
-        if rel.hasPrefix("worktrees/") == false {
-            if rel == "worktrees" { return .topologyChange }
+        if rel.hasPrefix("worktrees/") {
+            let parts = rel.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+            if parts.count == 2 { return .topologyChange }
+            if parts.count == 3 && parts[2] == "HEAD" {
+                let name = parts[1]
+                let gitdirFile = gitDir
+                    .appendingPathComponent("worktrees")
+                    .appendingPathComponent(name)
+                    .appendingPathComponent("gitdir")
+                guard let contents = try? String(contentsOf: gitdirFile, encoding: .utf8) else {
+                    return .other
+                }
+                let gitlink = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+                let worktreeRoot = URL(fileURLWithPath: gitlink).deletingLastPathComponent()
+                return .headChange(worktreeRoot.standardizedFileURL)
+            }
             return .other
         }
 
-        let parts = rel.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
-        if parts.count == 2 { return .topologyChange }
-        if parts.count == 3 && parts[2] == "HEAD" {
-            let name = parts[1]
-            let gitdirFile = gitDir
-                .appendingPathComponent("worktrees")
-                .appendingPathComponent(name)
-                .appendingPathComponent("gitdir")
-            guard let contents = try? String(contentsOf: gitdirFile, encoding: .utf8) else {
-                return .other
-            }
-            let gitlink = contents.trimmingCharacters(in: .whitespacesAndNewlines)
-            let worktreeRoot = URL(fileURLWithPath: gitlink).deletingLastPathComponent()
-            return .headChange(worktreeRoot.standardizedFileURL)
+        if rel == "worktrees" { return .topologyChange }
+
+        // Branch ref updates: refs/heads/<...> and the consolidated packed-refs
+        // file both reflect commit/checkout/reset/pull activity. Route through
+        // the topology debouncer so refreshWorktrees re-reads lastActivity from
+        // the updated ref file mtimes and re-applies ordering. (For the linked
+        // worktree HEAD case we already short-circuit via `worktrees/<name>/HEAD`
+        // above; this branch covers the shared branch refs.)
+        if rel == "packed-refs" || rel.hasPrefix("refs/heads/") {
+            return .topologyChange
         }
+
         return .other
     }
 }

--- a/AlasTests/AppConfigWorktreeOrderingDecodeTests.swift
+++ b/AlasTests/AppConfigWorktreeOrderingDecodeTests.swift
@@ -1,0 +1,50 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite struct AppConfigWorktreeOrderingDecodeTests {
+    @Test func defaultsUseLastUpdateDesc() {
+        #expect(AppConfig.defaults.worktrees.defaultOrdering == .lastUpdateDesc)
+    }
+
+    @Test func decodingOlderConfigWithoutDefaultOrderingFallsBack() throws {
+        // Older AppConfig blobs persisted before this feature have no
+        // defaultOrdering key. Decoding must succeed and yield .lastUpdateDesc.
+        let json = """
+        {
+          "rootPath": "~/.alas/worktrees",
+          "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+          "branchPrefix": "feature/",
+          "baseBranch": "main",
+          "trackUpstream": true,
+          "deleteBranchOnRemove": true,
+          "autoFetch": true,
+          "fetchIntervalMinutes": 5,
+          "pruneStale": false,
+          "fetchRemoteBeforeCreate": false
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppConfig.Worktrees.self, from: json)
+        #expect(decoded.defaultOrdering == .lastUpdateDesc)
+    }
+
+    @Test func decodingUnknownDefaultOrderingFallsBack() throws {
+        let json = """
+        {
+          "rootPath": "~/.alas/worktrees",
+          "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+          "branchPrefix": "feature/",
+          "baseBranch": "main",
+          "trackUpstream": true,
+          "deleteBranchOnRemove": true,
+          "autoFetch": true,
+          "fetchIntervalMinutes": 5,
+          "pruneStale": false,
+          "fetchRemoteBeforeCreate": false,
+          "defaultOrdering": "no-such-mode"
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(AppConfig.Worktrees.self, from: json)
+        #expect(decoded.defaultOrdering == .lastUpdateDesc)
+    }
+}

--- a/AlasTests/GitEventFilterTests.swift
+++ b/AlasTests/GitEventFilterTests.swift
@@ -65,7 +65,6 @@ struct GitEventFilterTests {
     @Test func ignoresUnrelatedPathsUnderGitDir() {
         let cases = [
             "/repo/.git/objects/pack/pack-abc.pack",
-            "/repo/.git/refs/heads/main",
             "/repo/.git/config",
             "/repo/.git/worktrees/feat/locked",
         ]
@@ -73,6 +72,36 @@ struct GitEventFilterTests {
             let cat = GitEventFilter.classify(eventPath: path, gitDir: gitDir, worktreeRoot: worktreeRoot)
             #expect(cat == .other, "expected .other for \(path), got \(cat)")
         }
+    }
+
+    @Test func branchRefUpdateIsTopology() {
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/refs/heads/main",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .topologyChange)
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/refs/heads/feature/foo",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .topologyChange)
+    }
+
+    @Test func packedRefsUpdateIsTopology() {
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/packed-refs",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .topologyChange)
+    }
+
+    @Test func refsTagsAreNotTopology() {
+        // Tag refs aren't activity signals for the worktree sort.
+        #expect(GitEventFilter.classify(
+            eventPath: "/repo/.git/refs/tags/v1",
+            gitDir: gitDir,
+            worktreeRoot: worktreeRoot
+        ) == .other)
     }
 
     @Test func ignoresPathsOutsideGitDir() {

--- a/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
+++ b/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
@@ -508,7 +508,11 @@ struct ProjectsManagerWorktreeOrderingTests {
                    lastActivity: now.addingTimeInterval(-3600))
         let b = wt(path: "/repo/wts/b", branch: "b",
                    lastActivity: now.addingTimeInterval(-7200))
-        // Seed in persisted-order to preserve manual order during partial state.
+        // Seed in persisted-order ([b, main, a] mirrors the worktreeOrder [b, a]
+        // with main inserted in the middle). insertOptimisticWorktree re-runs
+        // applyWorktreeOrdering after each insert, and the manual-mode normalizer
+        // drops ids that aren't in `rows` yet — so seeding `a` before `b` would
+        // temporarily strip `b` from worktreeOrder and break the persisted order.
         seed(mgr, projectId: "p1", [b, main, a])
 
         let trees = mgr.worktrees(projectId: "p1")

--- a/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
+++ b/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
@@ -5,7 +5,10 @@ import Foundation
 @MainActor
 @Suite(.serialized)
 struct ProjectsManagerWorktreeOrderingTests {
-    private func makeManager(repoPath: String = "/repo") -> (ProjectsManager, ProjectConfig) {
+    private func makeManager(
+        repoPath: String = "/repo",
+        defaultOrdering: AppConfig.WorktreeSortMode = .manual
+    ) -> (ProjectsManager, ProjectConfig) {
         let project = ProjectConfig(
             id: "p1",
             name: "p1",
@@ -13,7 +16,7 @@ struct ProjectsManagerWorktreeOrderingTests {
             color: "blue",
             addedAt: Date()
         )
-        let mgr = ProjectsManager(persistedProjects: [project])
+        let mgr = ProjectsManager(persistedProjects: [project], defaultOrdering: { defaultOrdering })
         return (mgr, project)
     }
 
@@ -22,7 +25,13 @@ struct ProjectsManagerWorktreeOrderingTests {
         for wt in wts { mgr.setOperationState(id: wt.id, state: nil) }
     }
 
-    private func wt(path: String, branch: String, projectId: String = "p1") -> Worktree {
+    private func wt(
+        path: String,
+        branch: String,
+        projectId: String = "p1",
+        lastActivity: Date = Date(),
+        createdAt: Date? = nil
+    ) -> Worktree {
         let url = URL(fileURLWithPath: path)
         return Worktree(
             id: Worktree.makeId(path: url),
@@ -31,7 +40,8 @@ struct ProjectsManagerWorktreeOrderingTests {
             branch: branch,
             path: url,
             status: .clean,
-            lastActivity: Date()
+            lastActivity: lastActivity,
+            createdAt: createdAt ?? lastActivity
         )
     }
 
@@ -297,6 +307,84 @@ struct ProjectsManagerWorktreeOrderingTests {
         decoder.dateDecodingStrategy = .secondsSince1970
         let file = try decoder.decode(ProjectsFile.self, from: json)
         #expect(file.projects[0].worktreeOrder == [])
+    }
+
+    // MARK: - auto sort modes
+
+    @Test func lastUpdateDescSortsByActivityDescending() {
+        let (mgr, project) = makeManager(defaultOrdering: .lastUpdateDesc)
+        let now = Date()
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo/wts/old", branch: "old", lastActivity: now.addingTimeInterval(-3600)),
+            wt(path: "/repo", branch: "main", lastActivity: now),
+            wt(path: "/repo/wts/new", branch: "new", lastActivity: now.addingTimeInterval(-60)),
+            wt(path: "/repo/wts/mid", branch: "mid", lastActivity: now.addingTimeInterval(-600)),
+        ])
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "new", "mid", "old"])
+    }
+
+    @Test func creationDescSortsByCreatedAtDescending() {
+        let (mgr, project) = makeManager(defaultOrdering: .creationDesc)
+        let now = Date()
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo/wts/old", branch: "old", createdAt: now.addingTimeInterval(-3600)),
+            wt(path: "/repo", branch: "main", createdAt: now.addingTimeInterval(-7200)),
+            wt(path: "/repo/wts/new", branch: "new", createdAt: now.addingTimeInterval(-60)),
+        ])
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "new", "old"])
+    }
+
+    @Test func branchAscSortsAlphabetically() {
+        let (mgr, project) = makeManager(defaultOrdering: .branchAsc)
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo/wts/zeta", branch: "Zeta"),
+            wt(path: "/repo", branch: "main"),
+            wt(path: "/repo/wts/alpha", branch: "alpha"),
+            wt(path: "/repo/wts/beta", branch: "beta"),
+        ])
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "alpha", "beta", "Zeta"])
+    }
+
+    @Test func manualOrderTrumpsGlobalDefault() {
+        // Project has a non-empty worktreeOrder. Global default is lastUpdateDesc.
+        // Manual order must win, and worktreeOrder must remain populated.
+        let main = wt(path: "/repo", branch: "main")
+        let feat = wt(path: "/repo/wts/feat", branch: "feat", lastActivity: Date())
+        let fix = wt(path: "/repo/wts/fix", branch: "fix",
+                     lastActivity: Date().addingTimeInterval(-3600))
+        let project = ProjectConfig(
+            id: "p1", name: "p1", path: "/repo", color: "blue", addedAt: Date(),
+            worktreeOrder: [fix.id, feat.id]
+        )
+        let mgr = ProjectsManager(persistedProjects: [project],
+                                  defaultOrdering: { .lastUpdateDesc })
+        // Seed in persisted-order so per-insert normalization keeps the manual
+        // order intact (each insert filters to currently-known ids).
+        seed(mgr, projectId: project.id, [fix, main, feat])
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "fix", "feat"])
+        #expect(mgr.projects[0].worktreeOrder == [fix.id, feat.id])
+    }
+
+    @Test func sortIsStableByIdOnTimestampTie() {
+        let (mgr, project) = makeManager(defaultOrdering: .lastUpdateDesc)
+        let same = Date(timeIntervalSince1970: 1_000_000)
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo", branch: "main", lastActivity: same),
+            wt(path: "/repo/wts/b", branch: "b", lastActivity: same),
+            wt(path: "/repo/wts/a", branch: "a", lastActivity: same),
+        ])
+
+        let trees = mgr.worktrees(projectId: project.id)
+        // After main, tied lastActivity → id ascending tiebreaker → "/repo/wts/a" then "/repo/wts/b"
+        #expect(trees.map(\.branch) == ["main", "a", "b"])
     }
 
     @Test func roundTripPreservesWorktreeOrder() throws {

--- a/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
+++ b/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
@@ -69,7 +69,8 @@ struct ProjectsManagerWorktreeOrderingTests {
             path: "/repo",
             color: "blue",
             addedAt: Date(),
-            worktreeOrder: [feat.id, main.id, fix.id]
+            worktreeOrder: [feat.id, main.id, fix.id],
+            worktreeOrderIsManual: true
         )
         let mgr = ProjectsManager(persistedProjects: [project])
         seed(mgr, projectId: project.id, [feat, main, fix])
@@ -92,7 +93,8 @@ struct ProjectsManagerWorktreeOrderingTests {
             path: "/repo",
             color: "blue",
             addedAt: Date(),
-            worktreeOrder: [feat.id, fix.id]
+            worktreeOrder: [feat.id, fix.id],
+            worktreeOrderIsManual: true
         )
         let mgr = ProjectsManager(persistedProjects: [project])
         seed(mgr, projectId: project.id, [feat, main, fix])
@@ -114,7 +116,8 @@ struct ProjectsManagerWorktreeOrderingTests {
             path: "/repo",
             color: "blue",
             addedAt: Date(),
-            worktreeOrder: [feat.id, fix.id]
+            worktreeOrder: [feat.id, fix.id],
+            worktreeOrderIsManual: true
         )
         let mgr = ProjectsManager(persistedProjects: [project])
         seed(mgr, projectId: project.id, [feat, main, fix])
@@ -136,7 +139,8 @@ struct ProjectsManagerWorktreeOrderingTests {
             path: "/repo",
             color: "blue",
             addedAt: Date(),
-            worktreeOrder: [feat.id, fix.id]
+            worktreeOrder: [feat.id, fix.id],
+            worktreeOrderIsManual: true
         )
         let mgr = ProjectsManager(persistedProjects: [project])
         seed(mgr, projectId: project.id, [feat, main, fix])
@@ -199,7 +203,8 @@ struct ProjectsManagerWorktreeOrderingTests {
                 Worktree.makeId(path: destB),
                 Worktree.makeId(path: repo),
                 Worktree.makeId(path: destA),
-            ]
+            ],
+            worktreeOrderIsManual: true
         )
         let mgr = ProjectsManager(persistedProjects: [project])
 
@@ -239,7 +244,8 @@ struct ProjectsManagerWorktreeOrderingTests {
             path: "/repo",
             color: "blue",
             addedAt: Date(),
-            worktreeOrder: [feat.id, fix.id]
+            worktreeOrder: [feat.id, fix.id],
+            worktreeOrderIsManual: true
         )
         let mgr = ProjectsManager(persistedProjects: [project])
         seed(mgr, projectId: project.id, [feat, main, fix])
@@ -278,7 +284,8 @@ struct ProjectsManagerWorktreeOrderingTests {
             color: "blue",
             addedAt: Date(),
             hiddenWorktreePaths: ["/repo"],
-            worktreeOrder: [feat.id, fix.id]
+            worktreeOrder: [feat.id, fix.id],
+            worktreeOrderIsManual: true
         )
         let mgr = ProjectsManager(persistedProjects: [project])
         seed(mgr, projectId: project.id, [feat, main, fix])
@@ -307,6 +314,7 @@ struct ProjectsManagerWorktreeOrderingTests {
         decoder.dateDecodingStrategy = .secondsSince1970
         let file = try decoder.decode(ProjectsFile.self, from: json)
         #expect(file.projects[0].worktreeOrder == [])
+        #expect(file.projects[0].worktreeOrderIsManual == false)
     }
 
     // MARK: - auto sort modes
@@ -360,7 +368,8 @@ struct ProjectsManagerWorktreeOrderingTests {
                      lastActivity: Date().addingTimeInterval(-3600))
         let project = ProjectConfig(
             id: "p1", name: "p1", path: "/repo", color: "blue", addedAt: Date(),
-            worktreeOrder: [fix.id, feat.id]
+            worktreeOrder: [fix.id, feat.id],
+            worktreeOrderIsManual: true
         )
         let mgr = ProjectsManager(persistedProjects: [project],
                                   defaultOrdering: { .lastUpdateDesc })
@@ -397,7 +406,8 @@ struct ProjectsManagerWorktreeOrderingTests {
                      lastActivity: now.addingTimeInterval(-3600))
         let project = ProjectConfig(
             id: "p1", name: "p1", path: "/repo", color: "blue", addedAt: Date(),
-            worktreeOrder: [fix.id, feat.id]   // manually placed fix above feat
+            worktreeOrder: [fix.id, feat.id],   // manually placed fix above feat
+            worktreeOrderIsManual: true
         )
         let mgr = ProjectsManager(
             persistedProjects: [project],
@@ -410,8 +420,9 @@ struct ProjectsManagerWorktreeOrderingTests {
 
         mgr.resetWorktreeOrder(projectId: project.id)
 
-        // After reset: empty worktreeOrder + global mode = lastUpdate desc.
+        // After reset: empty worktreeOrder + cleared manual flag + global mode = lastUpdate desc.
         #expect(mgr.projects[0].worktreeOrder == [])
+        #expect(mgr.projects[0].worktreeOrderIsManual == false)
         #expect(mgr.worktrees(projectId: project.id).map(\.branch) == ["main", "feat", "fix"])
     }
 
@@ -464,7 +475,8 @@ struct ProjectsManagerWorktreeOrderingTests {
         let project = ProjectConfig(
             id: "abc", name: "alpha", path: "/tmp/alpha",
             color: "#5fb7c4", addedAt: Date(timeIntervalSince1970: 0),
-            worktreeOrder: ["/tmp/alpha/wt-feat", "/tmp/alpha/wt-fix"]
+            worktreeOrder: ["/tmp/alpha/wt-feat", "/tmp/alpha/wt-fix"],
+            worktreeOrderIsManual: true
         )
         let file = ProjectsFile(projects: [project])
         let encoder = JSONEncoder()
@@ -474,11 +486,14 @@ struct ProjectsManagerWorktreeOrderingTests {
         decoder.dateDecodingStrategy = .secondsSince1970
         let decoded = try decoder.decode(ProjectsFile.self, from: data)
         #expect(decoded.projects[0].worktreeOrder == ["/tmp/alpha/wt-feat", "/tmp/alpha/wt-fix"])
+        #expect(decoded.projects[0].worktreeOrderIsManual == true)
     }
 
-    @Test func migrationPreservesPreExistingManualOrder() throws {
-        // Simulate decoding a ProjectsFile that was saved before this feature shipped:
-        // worktreeOrder is non-empty.
+    @Test func migrationFallsBackToGlobalDefaultForLegacyOrders() throws {
+        // Legacy projects.json from before this feature has worktreeOrder
+        // populated (the old normalize-on-refresh path), but no
+        // worktreeOrderIsManual flag. After upgrade, this should NOT be
+        // treated as manual mode — the user never explicitly dragged.
         let json = """
         {
           "version": 1,
@@ -495,9 +510,10 @@ struct ProjectsManagerWorktreeOrderingTests {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .secondsSince1970
         let file = try decoder.decode(ProjectsFile.self, from: json)
+        #expect(file.projects[0].worktreeOrderIsManual == false)
 
-        // Global default is .lastUpdateDesc, but the project has a manual order →
-        // manual must win.
+        // Global default is .lastUpdateDesc. The legacy worktreeOrder must be
+        // ignored — most recent activity wins.
         let mgr = ProjectsManager(
             persistedProjects: file.projects,
             defaultOrdering: { .lastUpdateDesc }
@@ -508,16 +524,63 @@ struct ProjectsManagerWorktreeOrderingTests {
                    lastActivity: now.addingTimeInterval(-3600))
         let b = wt(path: "/repo/wts/b", branch: "b",
                    lastActivity: now.addingTimeInterval(-7200))
-        // Seed in persisted-order ([b, main, a] mirrors the worktreeOrder [b, a]
-        // with main inserted in the middle). insertOptimisticWorktree re-runs
-        // applyWorktreeOrdering after each insert, and the manual-mode normalizer
-        // drops ids that aren't in `rows` yet — so seeding `a` before `b` would
-        // temporarily strip `b` from worktreeOrder and break the persisted order.
-        seed(mgr, projectId: "p1", [b, main, a])
+        seed(mgr, projectId: "p1", [main, a, b])
 
         let trees = mgr.worktrees(projectId: "p1")
-        // Manual order is [b, a] → expect [main, b, a] despite a having more
-        // recent activity than b.
-        #expect(trees.map(\.branch) == ["main", "b", "a"])
+        // a is newer than b → lastUpdateDesc orders [main, a, b], ignoring
+        // the legacy [b, a] worktreeOrder array.
+        #expect(trees.map(\.branch) == ["main", "a", "b"])
+    }
+
+    @Test func dragSetsManualFlagAndOverridesGlobal() throws {
+        // Build a project with worktreeOrderIsManual = false (the new normal).
+        let project = ProjectConfig(
+            id: "p1", name: "p1", path: "/repo", color: "blue", addedAt: Date()
+        )
+        let mgr = ProjectsManager(
+            persistedProjects: [project],
+            defaultOrdering: { .lastUpdateDesc }
+        )
+        let now = Date()
+        let main = wt(path: "/repo", branch: "main", lastActivity: now)
+        let a = wt(path: "/repo/wts/a", branch: "a", lastActivity: now)
+        let b = wt(path: "/repo/wts/b", branch: "b",
+                   lastActivity: now.addingTimeInterval(-3600))
+        seed(mgr, projectId: "p1", [main, a, b])
+
+        // Sanity: auto mode (lastUpdateDesc) → [main, a, b].
+        #expect(mgr.worktrees(projectId: "p1").map(\.branch) == ["main", "a", "b"])
+
+        // Simulate a drag: move row index 2 (b) to position 1.
+        mgr.reorderWorktree(projectId: "p1", fromIndex: 2, toIndex: 1)
+        #expect(mgr.projects[0].worktreeOrderIsManual == true)
+        // After drag, manual order applies.
+        #expect(mgr.worktrees(projectId: "p1").map(\.branch) == ["main", "b", "a"])
+    }
+
+    @Test func resetClearsBothOrderAndManualFlag() throws {
+        let project = ProjectConfig(
+            id: "p1", name: "p1", path: "/repo", color: "blue", addedAt: Date(),
+            worktreeOrder: ["/repo/wts/b", "/repo/wts/a"],
+            worktreeOrderIsManual: true
+        )
+        let mgr = ProjectsManager(
+            persistedProjects: [project],
+            defaultOrdering: { .lastUpdateDesc }
+        )
+        let now = Date()
+        seed(mgr, projectId: "p1", [
+            wt(path: "/repo/wts/b", branch: "b", lastActivity: now.addingTimeInterval(-3600)),
+            wt(path: "/repo", branch: "main", lastActivity: now),
+            wt(path: "/repo/wts/a", branch: "a", lastActivity: now.addingTimeInterval(-60)),
+        ])
+        #expect(mgr.projects[0].worktreeOrderIsManual == true)
+        #expect(mgr.worktrees(projectId: "p1").map(\.branch) == ["main", "b", "a"])
+
+        mgr.resetWorktreeOrder(projectId: "p1")
+        #expect(mgr.projects[0].worktreeOrder == [])
+        #expect(mgr.projects[0].worktreeOrderIsManual == false)
+        // Now ordering = lastUpdateDesc: [main, a (newer), b (older)].
+        #expect(mgr.worktrees(projectId: "p1").map(\.branch) == ["main", "a", "b"])
     }
 }

--- a/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
+++ b/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
@@ -387,6 +387,79 @@ struct ProjectsManagerWorktreeOrderingTests {
         #expect(trees.map(\.branch) == ["main", "a", "b"])
     }
 
+    // MARK: - reset
+
+    @Test func resetWorktreeOrderClearsManualAndRevertsToGlobalSort() {
+        let main = wt(path: "/repo", branch: "main")
+        let now = Date()
+        let feat = wt(path: "/repo/wts/feat", branch: "feat", lastActivity: now)
+        let fix = wt(path: "/repo/wts/fix", branch: "fix",
+                     lastActivity: now.addingTimeInterval(-3600))
+        let project = ProjectConfig(
+            id: "p1", name: "p1", path: "/repo", color: "blue", addedAt: Date(),
+            worktreeOrder: [fix.id, feat.id]   // manually placed fix above feat
+        )
+        let mgr = ProjectsManager(
+            persistedProjects: [project],
+            defaultOrdering: { .lastUpdateDesc }
+        )
+        seed(mgr, projectId: project.id, [fix, main, feat])
+
+        // Sanity: manual order applies first.
+        #expect(mgr.worktrees(projectId: project.id).map(\.branch) == ["main", "fix", "feat"])
+
+        mgr.resetWorktreeOrder(projectId: project.id)
+
+        // After reset: empty worktreeOrder + global mode = lastUpdate desc.
+        #expect(mgr.projects[0].worktreeOrder == [])
+        #expect(mgr.worktrees(projectId: project.id).map(\.branch) == ["main", "feat", "fix"])
+    }
+
+    @Test func resetWorktreeOrderIsNoOpWhenAlreadyEmpty() {
+        let (mgr, project) = makeManager(defaultOrdering: .lastUpdateDesc)
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo", branch: "main"),
+            wt(path: "/repo/wts/feat", branch: "feat"),
+        ])
+        mgr.resetWorktreeOrder(projectId: project.id)
+        // No crash, no spurious mutation.
+        #expect(mgr.projects[0].worktreeOrder == [])
+    }
+
+    @Test func reapplyOrderingForAllProjectsPicksUpModeChange() {
+        // Use a mutable holder the closure captures, so we can change the mode
+        // between calls without rebuilding the manager.
+        final class ModeHolder { var mode: AppConfig.WorktreeSortMode = .branchAsc }
+        let holder = ModeHolder()
+
+        let project = ProjectConfig(
+            id: "p1", name: "p1", path: "/repo", color: "blue", addedAt: Date()
+        )
+        let mgr = ProjectsManager(
+            persistedProjects: [project],
+            defaultOrdering: { holder.mode }
+        )
+        let now = Date()
+        // Timestamps chosen so the two modes produce different orders:
+        //   branchAsc       → [main, alpha, zeta]
+        //   lastUpdateDesc  → [main, zeta, alpha] (zeta is newer)
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo", branch: "main", lastActivity: now),
+            wt(path: "/repo/wts/zeta", branch: "zeta",
+               lastActivity: now.addingTimeInterval(-60)),
+            wt(path: "/repo/wts/alpha", branch: "alpha",
+               lastActivity: now.addingTimeInterval(-3600)),
+        ])
+
+        // Initial mode: branchAsc.
+        #expect(mgr.worktrees(projectId: project.id).map(\.branch) == ["main", "alpha", "zeta"])
+
+        // Flip to lastUpdateDesc and reapply.
+        holder.mode = .lastUpdateDesc
+        mgr.reapplyOrderingForAllProjects()
+        #expect(mgr.worktrees(projectId: project.id).map(\.branch) == ["main", "zeta", "alpha"])
+    }
+
     @Test func roundTripPreservesWorktreeOrder() throws {
         let project = ProjectConfig(
             id: "abc", name: "alpha", path: "/tmp/alpha",

--- a/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
+++ b/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
@@ -475,4 +475,45 @@ struct ProjectsManagerWorktreeOrderingTests {
         let decoded = try decoder.decode(ProjectsFile.self, from: data)
         #expect(decoded.projects[0].worktreeOrder == ["/tmp/alpha/wt-feat", "/tmp/alpha/wt-fix"])
     }
+
+    @Test func migrationPreservesPreExistingManualOrder() throws {
+        // Simulate decoding a ProjectsFile that was saved before this feature shipped:
+        // worktreeOrder is non-empty.
+        let json = """
+        {
+          "version": 1,
+          "projects": [{
+            "id": "p1",
+            "name": "p1",
+            "path": "/repo",
+            "color": "#5fb7c4",
+            "addedAt": 0,
+            "worktreeOrder": ["/repo/wts/b", "/repo/wts/a"]
+          }]
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let file = try decoder.decode(ProjectsFile.self, from: json)
+
+        // Global default is .lastUpdateDesc, but the project has a manual order →
+        // manual must win.
+        let mgr = ProjectsManager(
+            persistedProjects: file.projects,
+            defaultOrdering: { .lastUpdateDesc }
+        )
+        let now = Date()
+        let main = wt(path: "/repo", branch: "main", lastActivity: now)
+        let a = wt(path: "/repo/wts/a", branch: "a",
+                   lastActivity: now.addingTimeInterval(-3600))
+        let b = wt(path: "/repo/wts/b", branch: "b",
+                   lastActivity: now.addingTimeInterval(-7200))
+        // Seed in persisted-order to preserve manual order during partial state.
+        seed(mgr, projectId: "p1", [b, main, a])
+
+        let trees = mgr.worktrees(projectId: "p1")
+        // Manual order is [b, a] → expect [main, b, a] despite a having more
+        // recent activity than b.
+        #expect(trees.map(\.branch) == ["main", "b", "a"])
+    }
 }

--- a/AlasTests/RepoGroupViewLayoutTests.swift
+++ b/AlasTests/RepoGroupViewLayoutTests.swift
@@ -45,6 +45,7 @@ struct RepoGroupViewLayoutTests {
             onNewWorktree: {},
             onEditProject: {},
             onRemoveProject: {},
+            onResetSort: {},
             spaces: [],
             activeSpaceId: "",
             isProjectInSpace: { _ in false },

--- a/AlasTests/WorktreeCodableTests.swift
+++ b/AlasTests/WorktreeCodableTests.swift
@@ -23,10 +23,9 @@ import Foundation
         let decoder = JSONDecoder()
         let decoded = try decoder.decode(Worktree.self, from: data)
 
+        // Worktree.Equatable covers every stored property, so `decoded == original`
+        // is sufficient. createdAt and the diff counters (addedLines/deletedLines)
+        // are the fields this test specifically guards (Task 2 follow-up).
         #expect(decoded == original)
-        #expect(decoded.createdAt == original.createdAt)
-        #expect(decoded.addedLines == 12)
-        #expect(decoded.deletedLines == 3)
-        #expect(decoded.status == .dirty)
     }
 }

--- a/AlasTests/WorktreeCodableTests.swift
+++ b/AlasTests/WorktreeCodableTests.swift
@@ -1,0 +1,32 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite struct WorktreeCodableTests {
+    @Test func roundTripPreservesAllFields() throws {
+        let original = Worktree(
+            id: "/tmp/foo",
+            projectId: "p1",
+            name: "feature/x",
+            branch: "feature/x",
+            path: URL(fileURLWithPath: "/tmp/foo"),
+            status: .dirty,
+            lastActivity: Date(timeIntervalSince1970: 1_700_000_000),
+            createdAt: Date(timeIntervalSince1970: 1_600_000_000),
+            addedLines: 12,
+            deletedLines: 3
+        )
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(Worktree.self, from: data)
+
+        #expect(decoded == original)
+        #expect(decoded.createdAt == original.createdAt)
+        #expect(decoded.addedLines == 12)
+        #expect(decoded.deletedLines == 3)
+        #expect(decoded.status == .dirty)
+    }
+}

--- a/AlasTests/WorktreeServiceCreatedAtTests.swift
+++ b/AlasTests/WorktreeServiceCreatedAtTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import Foundation
+@testable import Alas
+
+@Suite struct WorktreeServiceCreatedAtTests {
+    @Test func parsePorcelainPopulatesCreatedAtFromFilesystem() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-ctime-\(UUID().uuidString)")
+        try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tmp) }
+
+        // The directory was just created; .creationDate should be near now.
+        let porcelain = """
+        worktree \(tmp.path)
+        branch refs/heads/feat
+        """
+        let parsed = WorktreeService.parsePorcelain(porcelain, projectId: "p1")
+        #expect(parsed.count == 1)
+        let wt = parsed[0]
+        // createdAt must be set to something more recent than distantPast,
+        // and within the last 60 seconds.
+        #expect(wt.createdAt > Date(timeIntervalSinceNow: -60))
+        #expect(wt.createdAt <= Date().addingTimeInterval(1))
+    }
+
+    @Test func decodingOlderWorktreeWithoutCreatedAtFallsBackToLastActivity() throws {
+        let ts = Date(timeIntervalSince1970: 1_700_000_000)
+        let json = """
+        {
+          "id": "/tmp/x",
+          "projectId": "p1",
+          "name": "feat",
+          "branch": "feat",
+          "path": "file:///tmp/x",
+          "status": "clean",
+          "lastActivity": \(ts.timeIntervalSinceReferenceDate),
+          "addedLines": 0,
+          "deletedLines": 0
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let wt = try decoder.decode(Worktree.self, from: json)
+        #expect(wt.createdAt == wt.lastActivity)
+    }
+}

--- a/AlasTests/WorktreeServiceCreatedAtTests.swift
+++ b/AlasTests/WorktreeServiceCreatedAtTests.swift
@@ -111,6 +111,33 @@ import Foundation
         #expect(WorktreeService.lastActivity(forWorktreeAt: tmp) == target)
     }
 
+    @Test func lastActivityResolvesRelativeGitdirPath() throws {
+        // Submodule layout: ".git" file contains a *relative* gitdir path.
+        //   parent/sub/.git           ← "gitdir: ../.git/modules/sub"
+        //   parent/.git/modules/sub/  ← actual gitdir
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-act-relgit-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: tmp) }
+        let parent = tmp.appendingPathComponent("parent")
+        let sub = parent.appendingPathComponent("sub")
+        let modulesGit = parent.appendingPathComponent(".git/modules/sub")
+        let refsDir = modulesGit.appendingPathComponent("refs/heads")
+        try fm.createDirectory(at: refsDir, withIntermediateDirectories: true)
+        try fm.createDirectory(at: sub, withIntermediateDirectories: true)
+
+        fm.createFile(atPath: modulesGit.appendingPathComponent("HEAD").path,
+                      contents: Data("ref: refs/heads/main\n".utf8))
+        fm.createFile(atPath: sub.appendingPathComponent(".git").path,
+                      contents: Data("gitdir: ../.git/modules/sub\n".utf8))
+
+        let refPath = refsDir.appendingPathComponent("main").path
+        fm.createFile(atPath: refPath, contents: Data("0000000000000000000000000000000000000000\n".utf8))
+        let target = Date(timeIntervalSince1970: 1_740_000_000)
+        try fm.setAttributes([.modificationDate: target], ofItemAtPath: refPath)
+
+        #expect(WorktreeService.lastActivity(forWorktreeAt: sub) == target)
+    }
+
     @Test func decodingOlderWorktreeWithoutCreatedAtFallsBackToLastActivity() throws {
         let ts = Date(timeIntervalSince1970: 1_700_000_000)
         let json = """

--- a/AlasTests/WorktreeServiceCreatedAtTests.swift
+++ b/AlasTests/WorktreeServiceCreatedAtTests.swift
@@ -23,6 +23,51 @@ import Foundation
         #expect(wt.createdAt <= Date().addingTimeInterval(1))
     }
 
+    @Test func lastActivityUsesHeadMtimeForMainWorktree() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-head-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: tmp) }
+        try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+        // Simulate a main worktree: .git is a directory containing HEAD.
+        let gitDir = tmp.appendingPathComponent(".git")
+        try fm.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        let headPath = gitDir.appendingPathComponent("HEAD").path
+        fm.createFile(atPath: headPath, contents: Data("ref: refs/heads/main\n".utf8))
+
+        // Set a known mtime on HEAD that's distinct from the dir mtime.
+        let target = Date(timeIntervalSince1970: 1_700_000_000)
+        try fm.setAttributes([.modificationDate: target], ofItemAtPath: headPath)
+
+        let result = WorktreeService.lastActivity(forWorktreeAt: tmp)
+        #expect(result == target)
+    }
+
+    @Test func lastActivityResolvesGitdirFileForLinkedWorktree() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-head-linked-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: tmp) }
+
+        // Linked worktree layout:
+        //   tmp/main-repo/.git/worktrees/feat/HEAD   ← the real HEAD
+        //   tmp/wt-feat/.git                          ← file: "gitdir: <abs-path-to-above-dir>"
+        let mainRepo = tmp.appendingPathComponent("main-repo")
+        let wtDir = tmp.appendingPathComponent("wt-feat")
+        let gitdir = mainRepo.appendingPathComponent(".git/worktrees/feat")
+        try fm.createDirectory(at: gitdir, withIntermediateDirectories: true)
+        try fm.createDirectory(at: wtDir, withIntermediateDirectories: true)
+
+        let headPath = gitdir.appendingPathComponent("HEAD").path
+        fm.createFile(atPath: headPath, contents: Data("ref: refs/heads/feat\n".utf8))
+        let dotGitFile = wtDir.appendingPathComponent(".git").path
+        fm.createFile(atPath: dotGitFile, contents: Data("gitdir: \(gitdir.path)\n".utf8))
+
+        let target = Date(timeIntervalSince1970: 1_710_000_000)
+        try fm.setAttributes([.modificationDate: target], ofItemAtPath: headPath)
+
+        let result = WorktreeService.lastActivity(forWorktreeAt: wtDir)
+        #expect(result == target)
+    }
+
     @Test func decodingOlderWorktreeWithoutCreatedAtFallsBackToLastActivity() throws {
         let ts = Date(timeIntervalSince1970: 1_700_000_000)
         let json = """

--- a/AlasTests/WorktreeServiceCreatedAtTests.swift
+++ b/AlasTests/WorktreeServiceCreatedAtTests.swift
@@ -23,49 +23,92 @@ import Foundation
         #expect(wt.createdAt <= Date().addingTimeInterval(1))
     }
 
-    @Test func lastActivityUsesHeadMtimeForMainWorktree() throws {
+    @Test func lastActivityFollowsSymbolicHeadToBranchRefMain() throws {
         let fm = FileManager.default
-        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-head-\(UUID().uuidString)")
+        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-act-symref-main-\(UUID().uuidString)")
         defer { try? fm.removeItem(at: tmp) }
         try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
-        // Simulate a main worktree: .git is a directory containing HEAD.
         let gitDir = tmp.appendingPathComponent(".git")
-        try fm.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        let refsDir = gitDir.appendingPathComponent("refs/heads")
+        try fm.createDirectory(at: refsDir, withIntermediateDirectories: true)
+
         let headPath = gitDir.appendingPathComponent("HEAD").path
         fm.createFile(atPath: headPath, contents: Data("ref: refs/heads/main\n".utf8))
 
-        // Set a known mtime on HEAD that's distinct from the dir mtime.
-        let target = Date(timeIntervalSince1970: 1_700_000_000)
-        try fm.setAttributes([.modificationDate: target], ofItemAtPath: headPath)
+        let refPath = refsDir.appendingPathComponent("main").path
+        fm.createFile(atPath: refPath, contents: Data("0000000000000000000000000000000000000000\n".utf8))
 
-        let result = WorktreeService.lastActivity(forWorktreeAt: tmp)
-        #expect(result == target)
+        let target = Date(timeIntervalSince1970: 1_700_000_000)
+        try fm.setAttributes([.modificationDate: target], ofItemAtPath: refPath)
+        // Set HEAD to a different mtime to prove we're not using HEAD.
+        try fm.setAttributes([.modificationDate: Date(timeIntervalSince1970: 1)], ofItemAtPath: headPath)
+
+        #expect(WorktreeService.lastActivity(forWorktreeAt: tmp) == target)
     }
 
-    @Test func lastActivityResolvesGitdirFileForLinkedWorktree() throws {
+    @Test func lastActivityFollowsSymbolicHeadToBranchRefLinked() throws {
         let fm = FileManager.default
-        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-head-linked-\(UUID().uuidString)")
+        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-act-symref-linked-\(UUID().uuidString)")
         defer { try? fm.removeItem(at: tmp) }
-
-        // Linked worktree layout:
-        //   tmp/main-repo/.git/worktrees/feat/HEAD   ← the real HEAD
-        //   tmp/wt-feat/.git                          ← file: "gitdir: <abs-path-to-above-dir>"
         let mainRepo = tmp.appendingPathComponent("main-repo")
-        let wtDir = tmp.appendingPathComponent("wt-feat")
-        let gitdir = mainRepo.appendingPathComponent(".git/worktrees/feat")
-        try fm.createDirectory(at: gitdir, withIntermediateDirectories: true)
-        try fm.createDirectory(at: wtDir, withIntermediateDirectories: true)
+        let wt = tmp.appendingPathComponent("wt-feat")
+        let mainGit = mainRepo.appendingPathComponent(".git")
+        let wtGitdir = mainGit.appendingPathComponent("worktrees/feat")
+        let refsDir = mainGit.appendingPathComponent("refs/heads")
+        try fm.createDirectory(at: wtGitdir, withIntermediateDirectories: true)
+        try fm.createDirectory(at: refsDir, withIntermediateDirectories: true)
+        try fm.createDirectory(at: wt, withIntermediateDirectories: true)
 
-        let headPath = gitdir.appendingPathComponent("HEAD").path
-        fm.createFile(atPath: headPath, contents: Data("ref: refs/heads/feat\n".utf8))
-        let dotGitFile = wtDir.appendingPathComponent(".git").path
-        fm.createFile(atPath: dotGitFile, contents: Data("gitdir: \(gitdir.path)\n".utf8))
+        fm.createFile(atPath: wtGitdir.appendingPathComponent("HEAD").path,
+                      contents: Data("ref: refs/heads/feat\n".utf8))
+        // commondir points back to mainGit (relative).
+        fm.createFile(atPath: wtGitdir.appendingPathComponent("commondir").path,
+                      contents: Data("../..\n".utf8))
+        // .git file in the worktree points to gitdir.
+        fm.createFile(atPath: wt.appendingPathComponent(".git").path,
+                      contents: Data("gitdir: \(wtGitdir.path)\n".utf8))
 
+        let refPath = refsDir.appendingPathComponent("feat").path
+        fm.createFile(atPath: refPath, contents: Data("0000000000000000000000000000000000000000\n".utf8))
         let target = Date(timeIntervalSince1970: 1_710_000_000)
+        try fm.setAttributes([.modificationDate: target], ofItemAtPath: refPath)
+
+        #expect(WorktreeService.lastActivity(forWorktreeAt: wt) == target)
+    }
+
+    @Test func lastActivityUsesHeadMtimeForDetachedHead() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-act-detached-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: tmp) }
+        try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let gitDir = tmp.appendingPathComponent(".git")
+        try fm.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        let headPath = gitDir.appendingPathComponent("HEAD").path
+        // Detached: raw SHA, no "ref: " prefix.
+        fm.createFile(atPath: headPath, contents: Data("0000000000000000000000000000000000000000\n".utf8))
+        let target = Date(timeIntervalSince1970: 1_720_000_000)
         try fm.setAttributes([.modificationDate: target], ofItemAtPath: headPath)
 
-        let result = WorktreeService.lastActivity(forWorktreeAt: wtDir)
-        #expect(result == target)
+        #expect(WorktreeService.lastActivity(forWorktreeAt: tmp) == target)
+    }
+
+    @Test func lastActivityFallsBackToPackedRefsWhenLooseRefMissing() throws {
+        let fm = FileManager.default
+        let tmp = fm.temporaryDirectory.appendingPathComponent("alas-act-packed-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: tmp) }
+        try fm.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let gitDir = tmp.appendingPathComponent(".git")
+        try fm.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        fm.createFile(atPath: gitDir.appendingPathComponent("HEAD").path,
+                      contents: Data("ref: refs/heads/packed\n".utf8))
+        // No loose ref file at refs/heads/packed.
+        let packedPath = gitDir.appendingPathComponent("packed-refs").path
+        fm.createFile(atPath: packedPath,
+                      contents: Data("# pack-refs with: peeled fully-peeled sorted\n0000000000000000000000000000000000000000 refs/heads/packed\n".utf8))
+        let target = Date(timeIntervalSince1970: 1_730_000_000)
+        try fm.setAttributes([.modificationDate: target], ofItemAtPath: packedPath)
+
+        #expect(WorktreeService.lastActivity(forWorktreeAt: tmp) == target)
     }
 
     @Test func decodingOlderWorktreeWithoutCreatedAtFallsBackToLastActivity() throws {


### PR DESCRIPTION
## Summary

Adds a global "Default ordering" setting under **Settings → Worktrees** with four modes:

- **Last update time** (newest first, default)
- **Creation time** (newest first, from filesystem ctime)
- **Branch name** (alphabetical, case-insensitive)
- **Manual**

Main worktree is always pinned first. Dragging a worktree silently flips that repo to manual mode for that one repo; a sidebar context-menu item **Reset Sort to Default** reverts the project to the global default.

Migration is implicit: existing projects with a non-empty `worktreeOrder` stay on manual after upgrade. Projects that never got dragged pick up the new `lastUpdateDesc` default on first render.

## Test plan

- [ ] Open Settings → Worktrees → Sorting. Default selection is "Last update time" on a fresh install; tolerant decode of an older config falls back to `lastUpdateDesc`.
- [ ] Cycle the dropdown between modes; sidebar resorts immediately for projects with no manual reorder.
- [ ] Drag a worktree in the sidebar. That project locks to manual order; subsequent mode changes in Settings do not affect it.
- [ ] Right-click the repo header → **Reset Sort to Default**. The item is disabled when no manual order exists, enabled after a drag. Clicking it snaps the project back to the global mode and persists.
- [ ] Existing projects with a populated `worktreeOrder` retain their order after upgrading (no reshuffle).