### PR TITLE
feat(changes): toggle to track upstream branch in Commits section

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1945,7 +1945,11 @@ final class AppState {
         guard let worktree = worktree(withId: worktreeId) else { return }
         config.rightPaneVisible = true
         _ = saveConfig()
-        let rps = rightPaneStore.state(for: worktree, baseBranch: config.worktrees.baseBranch)
+        let rps = rightPaneStore.state(
+            for: worktree,
+            baseBranch: config.worktrees.baseBranch,
+            trackUpstreamForCommits: config.changes.trackUpstreamForCommits
+        )
         rps.reveal(path: path)
     }
 

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -161,7 +161,8 @@ struct CenterPaneView: View {
                         )
                         let rps = state.rightPaneStore.state(
                             for: worktree,
-                            baseBranch: state.config.worktrees.baseBranch
+                            baseBranch: state.config.worktrees.baseBranch,
+                            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
                         )
                         DiffTabView(
                             worktreePath: worktree.path,
@@ -195,7 +196,8 @@ struct CenterPaneView: View {
                     case .draftCommit(let draftState):
                         let _ = state.rightPaneStore.state(
                             for: worktree,
-                            baseBranch: state.config.worktrees.baseBranch
+                            baseBranch: state.config.worktrees.baseBranch,
+                            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
                         )
                         DraftCommitTabView(
                             worktreePath: worktree.path,

--- a/Alas/Sources/Center/Commit/CommitEditorTabView.swift
+++ b/Alas/Sources/Center/Commit/CommitEditorTabView.swift
@@ -345,6 +345,7 @@ struct CommitEditorTabView: View {
         let currentSha = tabState.currentSha
         let baseRef = tabState.baseRef
         let prompt = appState.config.changes.prompt
+        let ignoreUpstream = !appState.config.changes.trackUpstreamForCommits
 
         busy = true
         error = nil
@@ -356,7 +357,11 @@ struct CommitEditorTabView: View {
                 let branchRaw = try await gitStdout(["rev-parse", "--abbrev-ref", "HEAD"])
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 let branch: String? = branchRaw == "HEAD" ? nil : branchRaw
-                let nearbyCommits = try await git.commitsAhead(at: worktreePath, baseBranch: baseRef).commits
+                let nearbyCommits = try await git.commitsAhead(
+                    at: worktreePath,
+                    baseBranch: baseRef,
+                    ignoreUpstream: ignoreUpstream
+                ).commits
                 let payload = CommitContextBuilder.buildForCommitEdit(
                     branch: branch,
                     base: baseRef,

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -250,9 +250,16 @@ struct AppConfig: Codable, Equatable {
         /// appended verbatim by `MergeAgent`. `{filePath}` and
         /// `{language}` are substituted; anything else passes through.
         var mergeSingleResolvePrompt: String
+        /// When true, the Commits section uses the branch's upstream
+        /// tracking ref (`@{u}`) as the comparison base once one exists,
+        /// matching git's own "ahead/behind" semantics. When false
+        /// (default), it always compares against `worktrees.baseBranch`,
+        /// so the list stays stable across pushes.
+        var trackUpstreamForCommits: Bool
 
         enum CodingKeys: String, CodingKey {
-            case aiToolId, prompt, mergeBulkResolvePrompt, mergeSingleResolvePrompt
+            case aiToolId, prompt, mergeBulkResolvePrompt, mergeSingleResolvePrompt,
+                 trackUpstreamForCommits
         }
     }
 
@@ -349,7 +356,8 @@ struct AppConfig: Codable, Equatable {
             aiToolId: "none",
             prompt: AppConfig.defaultCommitPrompt,
             mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
-            mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt
+            mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
+            trackUpstreamForCommits: false
         ),
         agents: Agents(
             builtinState: [:],
@@ -547,18 +555,21 @@ extension AppConfig {
                 ?? AppConfig.defaultMergeBulkResolvePrompt
             let singleResolve = (try? changesContainer.decode(String.self, forKey: .mergeSingleResolvePrompt))
                 ?? AppConfig.defaultMergeSingleResolvePrompt
+            let trackUpstream = (try? changesContainer.decode(Bool.self, forKey: .trackUpstreamForCommits)) ?? false
             changes = Changes(
                 aiToolId: toolId,
                 prompt: prompt,
                 mergeBulkResolvePrompt: bulkResolve,
-                mergeSingleResolvePrompt: singleResolve
+                mergeSingleResolvePrompt: singleResolve,
+                trackUpstreamForCommits: trackUpstream
             )
         } else {
             changes = Changes(
                 aiToolId: "none",
                 prompt: AppConfig.defaultCommitPrompt,
                 mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
-                mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt
+                mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
+                trackUpstreamForCommits: false
             )
         }
         if let agentsContainer = try? c.nestedContainer(

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -87,6 +87,13 @@ final class RightPaneState {
     /// (new config value) from a normal render (same config value).
     var lastConfigBaseBranch: String = ""
 
+    /// Mirrors `AppConfig.changes.trackUpstreamForCommits`. Synced by
+    /// `RightPaneStore` on every `state(for:)` call. When false (the
+    /// default), `refresh()` passes `ignoreUpstream: true` to
+    /// `commitsAhead`, so the Commits section compares HEAD against the
+    /// base branch instead of `@{u}`.
+    var trackUpstreamForCommits: Bool = false
+
     var pendingDiscard: PendingDiscard? = nil
 
     /// True while the workspace-level agent invocation is running.

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -89,9 +89,9 @@ final class RightPaneState {
 
     /// Mirrors `AppConfig.changes.trackUpstreamForCommits`. Synced by
     /// `RightPaneStore` on every `state(for:)` call. When false (the
-    /// default), `refresh()` passes `ignoreUpstream: true` to
-    /// `commitsAhead`, so the Commits section compares HEAD against the
-    /// base branch instead of `@{u}`.
+    /// default) — or when `userOverrodeBaseBranch` is true — `refresh()`
+    /// passes `ignoreUpstream: true` to `commitsAhead`, so the Commits
+    /// section compares HEAD against the base branch instead of `@{u}`.
     var trackUpstreamForCommits: Bool = false
 
     var pendingDiscard: PendingDiscard? = nil

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -246,8 +246,13 @@ final class RightPaneState {
             self.olderCommits = []
             self.hasMoreOlder = true
             self.isLoadingOlder = false
+            let ignoreUpstream = userOverrodeBaseBranch || !trackUpstreamForCommits
             async let s = git.status(worktreePath: worktree.path)
-            async let c = git.commitsAhead(at: worktree.path, baseBranch: baseBranch, ignoreUpstream: userOverrodeBaseBranch)
+            async let c = git.commitsAhead(
+                at: worktree.path,
+                baseBranch: baseBranch,
+                ignoreUpstream: ignoreUpstream
+            )
             async let br = git.currentBranch(worktreePath: worktree.path)
             async let mergeRefresh: Void = mergeOp.refresh()
             let entries = try await s

--- a/Alas/Sources/Right/RightPaneStore.swift
+++ b/Alas/Sources/Right/RightPaneStore.swift
@@ -16,10 +16,11 @@ final class RightPaneStore {
     /// retain the app.
     weak var appState: AppState?
 
-    func state(for worktree: Worktree, baseBranch: String) -> RightPaneState {
+    func state(for worktree: Worktree, baseBranch: String, trackUpstreamForCommits: Bool) -> RightPaneState {
         let id = worktree.id
         let result: RightPaneState
         if let existing = states[id] {
+            let trackUpstreamChanged = existing.trackUpstreamForCommits != trackUpstreamForCommits
             // If the global config base branch changed (Settings → Worktrees),
             // honor the new value and clear the user override. If it didn't
             // change, leave the state's baseBranch alone so a user-picked
@@ -42,10 +43,15 @@ final class RightPaneStore {
                     }
                 }
             }
+            if trackUpstreamChanged {
+                existing.trackUpstreamForCommits = trackUpstreamForCommits
+                Task { @MainActor in await existing.refresh() }
+            }
             result = existing
         } else {
             let new = RightPaneState(worktree: worktree, baseBranch: baseBranch)
             new.lastConfigBaseBranch = baseBranch
+            new.trackUpstreamForCommits = trackUpstreamForCommits
             new.closeDiffTabs = { [weak self] paths in
                 guard let app = self?.appState else { return }
                 let pathSet = Set(paths)

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -10,7 +10,11 @@ struct RightPaneView: View {
     @Environment(\.theme) var theme
 
     var body: some View {
-        let rps = state.rightPaneStore.state(for: worktree, baseBranch: state.config.worktrees.baseBranch)
+        let rps = state.rightPaneStore.state(
+            for: worktree,
+            baseBranch: state.config.worktrees.baseBranch,
+            trackUpstreamForCommits: state.config.changes.trackUpstreamForCommits
+        )
         let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
         ZStack {
             SidebarMaterialBackground(

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -13,6 +13,15 @@ struct ChangesPane: View {
                     .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
                     .padding(.bottom, 12)
 
+                SettingsGroup(title: "Commits section") {
+                    SettingsRow(
+                        name: "Track upstream branch",
+                        desc: "When on, the Commits section compares against your branch's remote tracking ref once you push, so it only lists unpushed commits. When off, it always compares against the base branch — you'll see every commit on this branch since it diverged from main."
+                    ) {
+                        AlasToggle(on: state.bind(\.changes.trackUpstreamForCommits))
+                    }
+                }
+
                 SettingsGroup(title: "Commit message") {
                     SettingsRow(name: "Agent",
                                 desc: "Used by the sparkle button in the draft commit tab.") {

--- a/AlasTests/AppConfigChangesTests.swift
+++ b/AlasTests/AppConfigChangesTests.swift
@@ -53,4 +53,59 @@ struct AppConfigChangesTests {
         #expect(decoded.changes.aiToolId == "claude")
         #expect(decoded.changes.prompt == "custom prompt")
     }
+
+    @Test func defaultsHaveTrackUpstreamForCommitsOff() {
+        #expect(AppConfig.defaults.changes.trackUpstreamForCommits == false)
+    }
+
+    @Test func decodesLegacyChangesWithoutTrackUpstreamForCommits() throws {
+        // A config blob with a `changes` section that predates the new key.
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/.alas/worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true, "notifyOnAwaiting": true},
+          "changes": {
+            "aiToolId": "claude",
+            "prompt": "p",
+            "mergeBulkResolvePrompt": "b",
+            "mergeSingleResolvePrompt": "s"
+          }
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.changes.aiToolId == "claude")
+        #expect(cfg.changes.trackUpstreamForCommits == false)
+    }
+
+    @Test func roundTripsTrackUpstreamForCommits() throws {
+        var cfg = AppConfig.defaults
+        cfg.changes.trackUpstreamForCommits = true
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.changes.trackUpstreamForCommits == true)
+    }
 }

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -163,14 +163,14 @@ struct RightPaneStateBaseBranchTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let wt = makeWorktree(at: repo, branch: "feature")
         let store = RightPaneStore()
-        let state = store.state(for: wt, baseBranch: "main")
+        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
 
         state.selectBaseBranch("develop")
         try await Task.sleep(for: .milliseconds(200))
         #expect(state.baseBranch == "develop")
         #expect(state.userOverrodeBaseBranch)
 
-        _ = store.state(for: wt, baseBranch: "develop")
+        _ = store.state(for: wt, baseBranch: "develop", trackUpstreamForCommits: false)
         try await Task.sleep(for: .milliseconds(600))
 
         #expect(!state.userOverrodeBaseBranch)
@@ -182,7 +182,7 @@ struct RightPaneStateBaseBranchTests {
         defer { try? FileManager.default.removeItem(at: tmp) }
         let wt = makeWorktree(at: tmp, branch: "feature")
         let store = RightPaneStore()
-        let state = store.state(for: wt, baseBranch: "main")
+        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
 
         #expect(store.commitEditorComparisonRef(worktreeId: wt.id) == nil)
 

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -152,6 +152,7 @@ struct RightPaneStateBaseBranchTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let wt = makeWorktree(at: repo, branch: "feature")
         let state = RightPaneState(worktree: wt, baseBranch: "main")
+        state.trackUpstreamForCommits = true
 
         await state.refresh()
 
@@ -163,14 +164,14 @@ struct RightPaneStateBaseBranchTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let wt = makeWorktree(at: repo, branch: "feature")
         let store = RightPaneStore()
-        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: false)
+        let state = store.state(for: wt, baseBranch: "main", trackUpstreamForCommits: true)
 
         state.selectBaseBranch("develop")
         try await Task.sleep(for: .milliseconds(200))
         #expect(state.baseBranch == "develop")
         #expect(state.userOverrodeBaseBranch)
 
-        _ = store.state(for: wt, baseBranch: "develop", trackUpstreamForCommits: false)
+        _ = store.state(for: wt, baseBranch: "develop", trackUpstreamForCommits: true)
         try await Task.sleep(for: .milliseconds(600))
 
         #expect(!state.userOverrodeBaseBranch)

--- a/AlasTests/RightPaneStateBaseBranchTests.swift
+++ b/AlasTests/RightPaneStateBaseBranchTests.swift
@@ -178,6 +178,21 @@ struct RightPaneStateBaseBranchTests {
         #expect(state.comparisonRef == "origin/feature")
     }
 
+    @Test func storeRefreshesWhenTrackUpstreamForCommitsToggles() async throws {
+        let (repo, root) = try await createTestRepoWithUpstream()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let wt = makeWorktree(at: repo, branch: "feature")
+        let store = RightPaneStore()
+        let state = store.state(for: wt, baseBranch: "master", trackUpstreamForCommits: true)
+        try await waitUntil { state.comparisonRef == "origin/feature" }
+        #expect(state.comparisonRef == "origin/feature")
+
+        _ = store.state(for: wt, baseBranch: "master", trackUpstreamForCommits: false)
+        try await waitUntil { state.comparisonRef == "master" }
+        #expect(state.comparisonRef == "master")
+        #expect(state.trackUpstreamForCommits == false)
+    }
+
     @Test func commitEditorComparisonRefReturnsOnlyResolvedRef() async throws {
         let tmp = try await createTestRepoWithBranches()
         defer { try? FileManager.default.removeItem(at: tmp) }


### PR DESCRIPTION
## Summary

- Adds a Settings toggle at `Changes › Commits section › Track upstream branch` (default **off**). When off, the Commits section in the Changes tab always compares HEAD against `worktrees.baseBranch` (preferring local mainline, falling back to `origin/<base>` — matching the existing `GitService.commitsAhead` cascade semantics for `ignoreUpstream`). When on, the legacy upstream-aware cascade is used: once you push, the section only lists unpushed commits.
- The "behind upstream" chip is unchanged — it uses an independent probe (`resolveUpstreamRef`) and remains useful regardless of this toggle.
- Same toggle wires into the AI commit-message generator's "nearby commits" context fetch in `CommitEditorTabView`, so both surfaces stay consistent.
- Existing user configs decode the missing key as `false` and pick up the new boring default on first launch.

## Behavior matrix

| Branch state | Toggle ON (legacy) | Toggle OFF (new default) |
|---|---|---|
| Unpushed, ahead of `main` | lists commits vs `origin/main` | lists commits vs `main`/`origin/main` |
| Pushed, even with upstream | **empty list** | lists commits vs `main`/`origin/main` |
| Pushed, behind upstream | lists upstream-only commits as "yours" | lists commits vs base |
| On `main` itself | empty | empty |

## Known follow-up (not blocking)

The design spec specified "prefer `origin/<base>`, fall back to local" for the toggle-off cascade, but `GitService.commitsAhead(ignoreUpstream: true)` actually prefers local when both exist (locked in by the existing `explicitSimpleBasePrefersLocalBranchOverOrigin` test). In practice this is fine — local `main` usually matches `origin/main` closely and the "N behind" chip already surfaces divergence — but worth a follow-up if we want strict origin-first semantics for the toggle-off case without changing user-override behavior.

## Test plan

- [x] Unit tests for config decode default + round-trip (`AppConfigChangesTests`).
- [x] Unit test for `RightPaneStore` refresh-on-toggle path (`storeRefreshesWhenTrackUpstreamForCommitsToggles`).
- [x] Existing upstream-cascade tests opted into `trackUpstreamForCommits = true` to remain valid.
- [ ] Manual: pushed feature branch with toggle off → Commits section lists everything since base.
- [ ] Manual: same branch, toggle on → Commits section empties (or shows only unpushed commits).
- [ ] Manual: flip toggle while a worktree is open → list updates without restarting the worktree.
- [ ] Manual: "N behind <ref>" chips behave the same regardless of toggle.