### PR TITLE
fix(files): clear focused file highlight

### DIFF
--- a/Alas/Sources/Right/FilesTabView.swift
+++ b/Alas/Sources/Right/FilesTabView.swift
@@ -10,23 +10,60 @@ struct FilesTabView: View {
     let showIgnored: Bool
     let revealPath: String?
     let revealTick: Int
+    let onClearReveal: () -> Void
 
     @Environment(\.theme) private var theme
 
     var body: some View {
         ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(Self.filteredNodes(nodes, showIgnored: showIgnored)) { node in
-                        renderNode(node, depth: 0)
+            VStack(spacing: 0) {
+                revealBar
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(Self.filteredNodes(nodes, showIgnored: showIgnored)) { node in
+                            renderNode(node, depth: 0)
+                        }
                     }
+                    .padding(.vertical, 4)
                 }
-                .padding(.vertical, 4)
+                .onChange(of: revealTick) { _, _ in
+                    guard let path = revealPath else { return }
+                    proxy.scrollTo("file:\(path)", anchor: .top)
+                    proxy.scrollTo("dir:\(path)", anchor: .top)
+                }
             }
-            .onChange(of: revealTick) { _, _ in
-                guard let path = revealPath else { return }
-                proxy.scrollTo("file:\(path)", anchor: .top)
-                proxy.scrollTo("dir:\(path)", anchor: .top)
+        }
+    }
+
+    @ViewBuilder
+    private var revealBar: some View {
+        if let revealPath {
+            HStack(spacing: 6) {
+                Icon(name: "target", size: 12, color: theme.color("accent"))
+                    .frame(width: 14, height: 14)
+                Text(Self.revealDisplayName(for: revealPath))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(theme.color("fg"))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 8)
+                Button(action: onClearReveal) {
+                    Icon(name: "x", size: 10, color: theme.color("fg-dim"))
+                        .frame(width: 18, height: 18)
+                }
+                .buttonStyle(.plain)
+                .contentShape(Rectangle())
+                .accessibilityLabel("Clear focused file highlight")
+                .help("Clear focused file highlight")
+            }
+            .padding(.leading, 12)
+            .padding(.trailing, 8)
+            .padding(.vertical, 5)
+            .background(theme.color("bg-3").opacity(0.92))
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(theme.color("line").opacity(0.7))
+                    .frame(height: 1)
             }
         }
     }
@@ -199,6 +236,10 @@ struct FilesTabView: View {
             }
             return copy
         }
+    }
+
+    nonisolated static func revealDisplayName(for path: String) -> String {
+        path.split(separator: "/").last.map(String.init) ?? path
     }
 
     private func isOffGit(_ node: FileTreeNode) -> Bool {

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -500,6 +500,10 @@ final class RightPaneState {
         revealTick += 1
     }
 
+    func clearReveal() {
+        revealPath = nil
+    }
+
     /// Paths to discard for the given file path. Expands staged renames into
     /// both new and original paths so the deletion of the old side is also
     /// restored. Returns `[]` if the path is not in `changes` (stale request).

--- a/Alas/Sources/Right/RightPaneView.swift
+++ b/Alas/Sources/Right/RightPaneView.swift
@@ -65,7 +65,8 @@ struct RightPaneView: View {
                         onLoadChildren: { rps.loadFileTreeChildren(path: $0) },
                         showIgnored: state.config.files.showIgnored,
                         revealPath: rps.revealPath,
-                        revealTick: rps.revealTick
+                        revealTick: rps.revealTick,
+                        onClearReveal: { rps.clearReveal() }
                     )
                 }
             }

--- a/AlasTests/FilesTabFilterTests.swift
+++ b/AlasTests/FilesTabFilterTests.swift
@@ -109,4 +109,9 @@ struct FilesTabFilterTests {
         #expect(result.map(\.path) == ["Sources"])
         #expect(result.first?.children?.isEmpty == true)
     }
+
+    @Test func revealDisplayNameUsesLastPathComponent() {
+        #expect(FilesTabView.revealDisplayName(for: "Sources/Center/App.swift") == "App.swift")
+        #expect(FilesTabView.revealDisplayName(for: "README.md") == "README.md")
+    }
 }

--- a/AlasTests/RightPaneStateFileTreeTests.swift
+++ b/AlasTests/RightPaneStateFileTreeTests.swift
@@ -390,6 +390,20 @@ struct RightPaneStateRevealTests {
         #expect(state.revealTick == before + 1)
     }
 
+    @Test func clearRevealRemovesRevealPathWithoutChangingNavigationState() {
+        let state = makeTestState()
+        state.reveal(path: "Sources/Center/App.swift")
+        let tick = state.revealTick
+
+        state.clearReveal()
+
+        #expect(state.revealPath == nil)
+        #expect(state.revealTick == tick)
+        #expect(state.activeTab == .files)
+        #expect(state.openPaths.contains("Sources"))
+        #expect(state.openPaths.contains("Sources/Center"))
+    }
+
     @Test func revealForDirectoryDoesNotIncludeSelfInAncestors() {
         let state = makeTestState()
         state.reveal(path: "Sources/Center")


### PR DESCRIPTION
## Summary
- Add a dismiss affordance for the focused-file marker in the Files tab.
- Clear the reveal path without changing tab selection, expansion state, or future breadcrumb centering behavior.
- Add tests for reveal clearing and focused filename display.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`