### PR TITLE
fix(acp): center inline image chips

### DIFF
--- a/Alas/Sources/ACP/UI/ACPImageChipAttachment.swift
+++ b/Alas/Sources/ACP/UI/ACPImageChipAttachment.swift
@@ -21,6 +21,7 @@ final class ACPImageChipAttachment: NSTextAttachment {
 private final class ACPImageChipCell: NSTextAttachmentCell {
     private let thumbnail: NSImage?
     private static let side: CGFloat = 20
+    private static let fallbackFont = NSFont.systemFont(ofSize: 13)
 
     init(thumbnail: NSImage?) {
         self.thumbnail = thumbnail
@@ -30,7 +31,9 @@ private final class ACPImageChipCell: NSTextAttachmentCell {
 
     override var cellSize: NSSize { NSSize(width: Self.side, height: Self.side) }
 
-    override func cellBaselineOffset() -> NSPoint { NSPoint(x: 0, y: -5) }
+    override func cellBaselineOffset() -> NSPoint {
+        NSPoint(x: 0, y: Self.baselineOffset(for: Self.fallbackFont, attachmentHeight: cellSize.height))
+    }
 
     override func draw(withFrame frame: NSRect, in controlView: NSView?) {
         let rect = frame.insetBy(dx: 1, dy: 1)
@@ -55,6 +58,22 @@ private final class ACPImageChipCell: NSTextAttachmentCell {
                             proposedLineFragment lineFrag: NSRect,
                             glyphPosition position: NSPoint,
                             characterIndex charIndex: Int) -> NSRect {
-        NSRect(origin: .zero, size: cellSize)
+        let size = cellSize
+        let font = textContainer.layoutManager?.textStorage?.attribute(
+            .font,
+            at: charIndex,
+            effectiveRange: nil
+        ) as? NSFont ?? Self.fallbackFont
+        return NSRect(
+            x: 0,
+            y: Self.baselineOffset(for: font, attachmentHeight: size.height),
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    private static func baselineOffset(for font: NSFont, attachmentHeight: CGFloat) -> CGFloat {
+        let letterCenterFromBaseline = (font.ascender + font.descender) / 2
+        return letterCenterFromBaseline - attachmentHeight / 2
     }
 }

--- a/AlasTests/ACP/UI/ACPComposerImageExtractTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerImageExtractTests.swift
@@ -38,4 +38,35 @@ struct ACPComposerImageExtractTests {
             .text(" after")
         ])
     }
+
+    @Test("image chip frame centers on surrounding text")
+    func imageChipFrameCentersOnText() throws {
+        let font = NSFont.systemFont(ofSize: 13)
+        let url = URL(string: "file:///tmp/shot.png")!
+        let attachment = ACPImageChipAttachment(fileURL: url, mimeType: "image/png")
+        let storage = NSTextStorage(string: "x", attributes: [.font: font])
+        let chip = NSMutableAttributedString(attachment: attachment)
+        chip.addAttributes([.font: font], range: NSRange(location: 0, length: chip.length))
+        storage.append(chip)
+        storage.append(NSAttributedString(string: "y", attributes: [.font: font]))
+
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 200, height: 100))
+        storage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+
+        let chipIndex = 1
+        let baseline = NSPoint(x: 12, y: 30)
+        let frame = try #require(attachment.attachmentCell).cellFrame(
+            for: textContainer,
+            proposedLineFragment: NSRect(x: 0, y: 0, width: 200, height: 20),
+            glyphPosition: baseline,
+            characterIndex: chipIndex
+        )
+
+        let textCenter = (font.ascender + font.descender) / 2
+        #expect(abs(frame.midY - textCenter) < 0.001)
+        #expect(frame.minY < -5)
+        #expect(frame.minX == 0)
+    }
 }


### PR DESCRIPTION
## Summary
- center ACP composer inline image chips against surrounding text metrics
- keep NSTextAttachmentCell frames relative to the glyph position
- add regression coverage for the image chip frame alignment

## Tests
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- TMPDIR=.build/xcode-tmp xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -resultBundlePath .build/xcresults/AlasTests.xcresult test