### PR TITLE
fix(acp): preserve plan sidebar layout

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -475,6 +475,7 @@
 		8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */; };
 		8E2FB28D4C7681611BC67537 /* WorkspaceLSPManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE809DBC1E614321EE793D00 /* WorkspaceLSPManager.swift */; };
 		8E8ABE6BBA778EEA4170423C /* MergeScrollCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */; };
+		8EEB68F55286EF9DADAA710A /* ACPSessionManagerPlanSidebarLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCFA45F98F080043C4D664A /* ACPSessionManagerPlanSidebarLayoutTests.swift */; };
 		8F4B6B83968BE4C1E6D0D912 /* AlasCLIRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA730D3A9214ED3ECD15C0ED /* AlasCLIRequestTests.swift */; };
 		8F5B93A115E4554430ADC0FD /* ChangesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */; };
 		8F803876128CC3199DE5DB22 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */; };
@@ -1072,6 +1073,7 @@
 		3D105CB2C185958ED23164D1 /* IndentationMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationMode.swift; sourceTree = "<group>"; };
 		3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
 		3DCEFADD952DB870B8BAB890 /* CommitRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRow.swift; sourceTree = "<group>"; };
+		3DCFA45F98F080043C4D664A /* ACPSessionManagerPlanSidebarLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerPlanSidebarLayoutTests.swift; sourceTree = "<group>"; };
 		3E0616B1F0B84C45792C804E /* ACPSessionRecoveryIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRecoveryIntegrationTests.swift; sourceTree = "<group>"; };
 		3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangedRow.swift; sourceTree = "<group>"; };
 		3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupChecker.swift; sourceTree = "<group>"; };
@@ -2754,6 +2756,7 @@
 				8D8A320D194DF0E64BF13BC5 /* ACPSessionHydratorTests.swift */,
 				F8D36A8AF55F212B9F32A944 /* ACPSessionManagerAttachRestoreTests.swift */,
 				472917238C382A8125A84103 /* ACPSessionManagerHydrationTests.swift */,
+				3DCFA45F98F080043C4D664A /* ACPSessionManagerPlanSidebarLayoutTests.swift */,
 				6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */,
 				FB5B73ECBD730B5BB24E2240 /* ACPSessionManagerTests.swift */,
 				0B057D23BD5B72E06E790C5B /* ACPSessionQueueAPITests.swift */,
@@ -3911,6 +3914,7 @@
 				C51451EC8E103EB5FEF82EFE /* ACPSessionLifecycleTests.swift in Sources */,
 				9C78AF82EA26A9928865C5C6 /* ACPSessionManagerAttachRestoreTests.swift in Sources */,
 				D204CCA2E2FE480D2C502186 /* ACPSessionManagerHydrationTests.swift in Sources */,
+				8EEB68F55286EF9DADAA710A /* ACPSessionManagerPlanSidebarLayoutTests.swift in Sources */,
 				095E7D98616FB77A9F8BDFD9 /* ACPSessionManagerRetentionTests.swift in Sources */,
 				E30243803319861ACA6A4513 /* ACPSessionManagerTests.swift in Sources */,
 				832BDA6FD48E68F76E46D786 /* ACPSessionQueueAPITests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -45,6 +45,11 @@ final class ACPSessionManager: ObservableObject {
     /// Re-opening through `placeholderSession` + `hydrateIfNeeded` recreates
     /// it cleanly from SQLite.
     private var sessionRefCounts: [ACPSession.ID: Int] = [:]
+    /// Runtime-only layout memory for the plan sidebar. This intentionally
+    /// lives on the manager rather than `ACPSession` so a tab switch can
+    /// evict and later recreate the session object without losing whether
+    /// the plan was last rendered inline or in the toolbar pill.
+    private var planSidebarVisibility: [ACPSession.ID: Bool] = [:]
 
     init(worktreeId: String, worktreePath: String, store: ACPSessionStore,
          hydratorPath: String? = nil,
@@ -382,6 +387,7 @@ final class ACPSessionManager: ObservableObject {
         sessions[id]?.transcript.resetMarkdownCaches()
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
+        planSidebarVisibility.removeValue(forKey: id)
     }
 
     func deleteSession(id: ACPSession.ID) {
@@ -391,6 +397,7 @@ final class ACPSessionManager: ObservableObject {
         sessions[id]?.transcript.resetMarkdownCaches()
         sessions[id] = nil
         sessionRefCounts.removeValue(forKey: id)
+        planSidebarVisibility.removeValue(forKey: id)
         try? store.deleteSession(id: id)
         refreshRecent()
     }
@@ -416,6 +423,14 @@ final class ACPSessionManager: ObservableObject {
         } else {
             sessionRefCounts[id] = next
         }
+    }
+
+    func rememberedPlanSidebarVisibility(for id: ACPSession.ID) -> Bool? {
+        planSidebarVisibility[id]
+    }
+
+    func rememberPlanSidebarVisibility(_ visible: Bool, for id: ACPSession.ID) {
+        planSidebarVisibility[id] = visible
     }
 
     /// Drops the cached `ACPSession` when its refcount is zero AND no live

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -59,6 +59,7 @@ private struct ACPSessionView: View {
     @State private var dismissedLatest: String?
     @Environment(\.theme) private var theme
     @State private var showPlanSidebar: Bool = false
+    @State private var suppressRestoredPlanSidebarPlanChange: Bool = false
 
     /// Re-evaluated on every width / plan change. Pure call into the
     /// hysteresis reducer; the `.spring` wrap lives at the call site.
@@ -80,6 +81,21 @@ private struct ACPSessionView: View {
             withAnimation(.spring(response: 0.32, dampingFraction: 0.85)) {
                 showPlanSidebar = next
             }
+        }
+        manager.rememberPlanSidebarVisibility(next, for: sessionId)
+    }
+
+    /// Restore the last layout when SwiftUI reconstructs this tab. Without
+    /// this, a hidden toolbar plan can promote to the inline sidebar solely
+    /// because the pane is wide when the user returns to the tab.
+    private func restoreOrInitializePlanSidebar(paneWidth: CGFloat) {
+        if let remembered = manager.rememberedPlanSidebarVisibility(for: sessionId) {
+            showPlanSidebar = remembered
+            if session.hydrationState == .loading {
+                suppressRestoredPlanSidebarPlanChange = true
+            }
+        } else {
+            updatePlanSidebar(paneWidth: paneWidth)
         }
     }
 
@@ -289,11 +305,16 @@ private struct ACPSessionView: View {
                 }
             }
             .frame(width: proxy.size.width, height: proxy.size.height)
-            .onAppear { updatePlanSidebar(paneWidth: proxy.size.width) }
+            .onAppear { restoreOrInitializePlanSidebar(paneWidth: proxy.size.width) }
             .onChange(of: proxy.size.width) { _, newWidth in
                 updatePlanSidebar(paneWidth: newWidth)
             }
             .onChange(of: session.transcript.latestPlan) { _, _ in
+                if suppressRestoredPlanSidebarPlanChange {
+                    suppressRestoredPlanSidebarPlanChange = false
+                    manager.rememberPlanSidebarVisibility(showPlanSidebar, for: sessionId)
+                    return
+                }
                 updatePlanSidebar(paneWidth: proxy.size.width)
             }
             .onChange(of: session.planSidebarMinimized) { _, _ in

--- a/AlasTests/ACP/Session/ACPSessionManagerPlanSidebarLayoutTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerPlanSidebarLayoutTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACPSessionManager plan sidebar layout memory")
+struct ACPSessionManagerPlanSidebarLayoutTests {
+    private func makeManager() throws -> ACPSessionManager {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mgr-plan-layout-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        return ACPSessionManager(worktreeId: "wt", worktreePath: "/tmp/wt", store: store)
+    }
+
+    @Test("remembered visibility survives idle session eviction")
+    func rememberedVisibilitySurvivesIdleEviction() throws {
+        let manager = try makeManager()
+        let session = manager.createSession(agentId: "claude")
+
+        manager.rememberPlanSidebarVisibility(false, for: session.id)
+        manager.retainSession(id: session.id)
+        manager.releaseSession(id: session.id)
+
+        #expect(manager.sessions[session.id] == nil)
+        #expect(manager.rememberedPlanSidebarVisibility(for: session.id) == false)
+    }
+
+    @Test("remembered visibility is scoped by session id")
+    func rememberedVisibilityIsScopedBySessionId() throws {
+        let manager = try makeManager()
+        let first = manager.createSession(agentId: "claude")
+        let second = manager.createSession(agentId: "claude")
+
+        manager.rememberPlanSidebarVisibility(false, for: first.id)
+        manager.rememberPlanSidebarVisibility(true, for: second.id)
+
+        #expect(manager.rememberedPlanSidebarVisibility(for: first.id) == false)
+        #expect(manager.rememberedPlanSidebarVisibility(for: second.id) == true)
+    }
+
+    @Test("close clears remembered visibility")
+    func closeClearsRememberedVisibility() throws {
+        let manager = try makeManager()
+        let session = manager.createSession(agentId: "claude")
+
+        manager.rememberPlanSidebarVisibility(false, for: session.id)
+        manager.closeSession(id: session.id)
+
+        #expect(manager.rememberedPlanSidebarVisibility(for: session.id) == nil)
+    }
+
+    @Test("delete clears remembered visibility")
+    func deleteClearsRememberedVisibility() throws {
+        let manager = try makeManager()
+        let session = manager.createSession(agentId: "claude")
+
+        manager.rememberPlanSidebarVisibility(true, for: session.id)
+        manager.deleteSession(id: session.id)
+
+        #expect(manager.rememberedPlanSidebarVisibility(for: session.id) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- remember ACP plan sidebar layout per session at runtime
- restore the prior sidebar visibility when returning to an ACP tab
- clear remembered layout on explicit ACP session close/delete

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test