### PR TITLE
feat(worktrees): add reverse time ordering options

### DIFF
--- a/Alas/Sources/App/ProjectsManager.swift
+++ b/Alas/Sources/App/ProjectsManager.swift
@@ -404,9 +404,19 @@ final class ProjectsManager {
                 if lhs.createdAt != rhs.createdAt { return lhs.createdAt > rhs.createdAt }
                 return lhs.id < rhs.id
             }
+        case .creationAsc:
+            sortedOthers = others.sorted { lhs, rhs in
+                if lhs.createdAt != rhs.createdAt { return lhs.createdAt < rhs.createdAt }
+                return lhs.id < rhs.id
+            }
         case .lastUpdateDesc:
             sortedOthers = others.sorted { lhs, rhs in
                 if lhs.lastActivity != rhs.lastActivity { return lhs.lastActivity > rhs.lastActivity }
+                return lhs.id < rhs.id
+            }
+        case .lastUpdateAsc:
+            sortedOthers = others.sorted { lhs, rhs in
+                if lhs.lastActivity != rhs.lastActivity { return lhs.lastActivity < rhs.lastActivity }
                 return lhs.id < rhs.id
             }
         case .branchAsc:

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -291,7 +291,9 @@ struct AppConfig: Codable, Equatable {
     enum WorktreeSortMode: String, Codable, Equatable, CaseIterable {
         case manual
         case creationDesc
+        case creationAsc
         case lastUpdateDesc
+        case lastUpdateAsc
         case branchAsc
     }
 

--- a/Alas/Sources/Settings/WorktreesPane.swift
+++ b/Alas/Sources/Settings/WorktreesPane.swift
@@ -28,8 +28,10 @@ struct WorktreesPane: View {
                         desc: "Sort order for the worktrees sidebar list. Manual reordering of a repo overrides this for that repo."
                     ) {
                         Picker("", selection: defaultOrderingBinding) {
-                            Text("Last update time").tag(AppConfig.WorktreeSortMode.lastUpdateDesc)
-                            Text("Creation time").tag(AppConfig.WorktreeSortMode.creationDesc)
+                            Text("Last update time (most recent first)").tag(AppConfig.WorktreeSortMode.lastUpdateDesc)
+                            Text("Last update time (least recent first)").tag(AppConfig.WorktreeSortMode.lastUpdateAsc)
+                            Text("Creation time (newest first)").tag(AppConfig.WorktreeSortMode.creationDesc)
+                            Text("Creation time (oldest first)").tag(AppConfig.WorktreeSortMode.creationAsc)
                             Text("Branch name").tag(AppConfig.WorktreeSortMode.branchAsc)
                             Text("Manual").tag(AppConfig.WorktreeSortMode.manual)
                         }

--- a/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
+++ b/AlasTests/ProjectsManagerWorktreeOrderingTests.swift
@@ -333,6 +333,20 @@ struct ProjectsManagerWorktreeOrderingTests {
         #expect(trees.map(\.branch) == ["main", "new", "mid", "old"])
     }
 
+    @Test func lastUpdateAscSortsByActivityAscending() {
+        let (mgr, project) = makeManager(defaultOrdering: .lastUpdateAsc)
+        let now = Date()
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo/wts/old", branch: "old", lastActivity: now.addingTimeInterval(-3600)),
+            wt(path: "/repo", branch: "main", lastActivity: now),
+            wt(path: "/repo/wts/new", branch: "new", lastActivity: now.addingTimeInterval(-60)),
+            wt(path: "/repo/wts/mid", branch: "mid", lastActivity: now.addingTimeInterval(-600)),
+        ])
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "old", "mid", "new"])
+    }
+
     @Test func creationDescSortsByCreatedAtDescending() {
         let (mgr, project) = makeManager(defaultOrdering: .creationDesc)
         let now = Date()
@@ -344,6 +358,19 @@ struct ProjectsManagerWorktreeOrderingTests {
 
         let trees = mgr.worktrees(projectId: project.id)
         #expect(trees.map(\.branch) == ["main", "new", "old"])
+    }
+
+    @Test func creationAscSortsByCreatedAtAscending() {
+        let (mgr, project) = makeManager(defaultOrdering: .creationAsc)
+        let now = Date()
+        seed(mgr, projectId: project.id, [
+            wt(path: "/repo/wts/old", branch: "old", createdAt: now.addingTimeInterval(-3600)),
+            wt(path: "/repo", branch: "main", createdAt: now.addingTimeInterval(-7200)),
+            wt(path: "/repo/wts/new", branch: "new", createdAt: now.addingTimeInterval(-60)),
+        ])
+
+        let trees = mgr.worktrees(projectId: project.id)
+        #expect(trees.map(\.branch) == ["main", "old", "new"])
     }
 
     @Test func branchAscSortsAlphabetically() {


### PR DESCRIPTION
## Summary
- Add reverse creation-time and update-time worktree ordering modes.
- Expose the new modes in Settings > Worktrees with explicit oldest/newest and least/most recently updated labels.
- Cover both new modes with focused Swift Testing ordering tests.

## Validation
- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`