### PR TITLE
feat(updates): check for updates against GitHub releases

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -768,6 +768,7 @@
 		E175AE346DFAD0B62827C921 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE948F94DB2759E66CD4DEF /* ProjectPicker.swift */; };
 		E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */; };
 		E1E4C11CC5BFF761DF397507 /* ACPToolCallContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */; };
+		E1EEC0425D8F30D85CDB35EE /* UpdateAvailableSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */; };
 		E2279478EBE8BF9CDC412EDE /* MarkdownParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373D587E3153D902EB10208B /* MarkdownParserTests.swift */; };
 		E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */; };
 		E29D10B84F406C38E2F4C457 /* FileResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3375A79ACFD3567389DA855C /* FileResultRow.swift */; };
@@ -917,6 +918,7 @@
 		0C5373F76231F229D3F96AF3 /* session-update-config-option.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-config-option.json"; sourceTree = "<group>"; };
 		0C70536C65F2A78F4935DCAD /* ACPTranscriptLatestPlanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptLatestPlanTests.swift; sourceTree = "<group>"; };
 		0C8541BE5617C7E212CCD034 /* FilesTabLoadingIndicatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesTabLoadingIndicatorTests.swift; sourceTree = "<group>"; };
+		0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAvailableSheet.swift; sourceTree = "<group>"; };
 		0D4901C499EFE969EC36D116 /* MarkdownPreviewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewController.swift; sourceTree = "<group>"; };
 		0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationStateTests.swift; sourceTree = "<group>"; };
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
@@ -2696,6 +2698,7 @@
 				9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */,
 				35004DC60214F616FA84ED8B /* ReleaseInfo.swift */,
 				8E8EB674A5221235F1C7594E /* SemanticVersion.swift */,
+				0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */,
 				2763F93ADFDCDF6B31D16475 /* UpdateController.swift */,
 				FE09B83A747269494B206F23 /* UpdateThrottle.swift */,
 			);
@@ -3884,6 +3887,7 @@
 				6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */,
 				5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */,
 				443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */,
+				E1EEC0425D8F30D85CDB35EE /* UpdateAvailableSheet.swift in Sources */,
 				C4466064F783E6667C5FD25D /* UpdateController.swift in Sources */,
 				EE06DE97F2DCEFAD2B48B05C /* UpdateThrottle.swift in Sources */,
 				B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -662,6 +662,7 @@
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
 		C2EDB6A5E6149758C4A0051E /* ConflictMarkerParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */; };
 		C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */; };
+		C4466064F783E6667C5FD25D /* UpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2763F93ADFDCDF6B31D16475 /* UpdateController.swift */; };
 		C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */; };
 		C487C3AD43E7B5BBB45490DB /* CodexInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F0314E357190EF2A1F861B /* CodexInstaller.swift */; };
 		C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */; };
@@ -997,6 +998,7 @@
 		269CE27A6F4F2E663EDF9052 /* GitNameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidator.swift; sourceTree = "<group>"; };
 		26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSubmitIntentTests.swift; sourceTree = "<group>"; };
 		271F79A165CAA8617C1EAA4E /* GitTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypesTests.swift; sourceTree = "<group>"; };
+		2763F93ADFDCDF6B31D16475 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateController.swift; sourceTree = "<group>"; };
 		2777D1596E51D8DCA8E7ABA3 /* ACPSessionToolCallTruncationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionToolCallTruncationTests.swift; sourceTree = "<group>"; };
 		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
 		27A92711BC1D9A78D8A80561 /* GitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypes.swift; sourceTree = "<group>"; };
@@ -2694,6 +2696,7 @@
 				9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */,
 				35004DC60214F616FA84ED8B /* ReleaseInfo.swift */,
 				8E8EB674A5221235F1C7594E /* SemanticVersion.swift */,
+				2763F93ADFDCDF6B31D16475 /* UpdateController.swift */,
 				FE09B83A747269494B206F23 /* UpdateThrottle.swift */,
 			);
 			path = Updates;
@@ -3881,6 +3884,7 @@
 				6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */,
 				5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */,
 				443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */,
+				C4466064F783E6667C5FD25D /* UpdateController.swift in Sources */,
 				EE06DE97F2DCEFAD2B48B05C /* UpdateThrottle.swift in Sources */,
 				B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */,
 				4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		5EA1AA5C8D9DE003BACE8291 /* AlasGhostty.Surface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */; };
 		5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE58EF9CF8EC461667D9430 /* AppConfig.swift */; };
 		5F7E14A0D7E1D3F036806B73 /* MergeOperationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D8D902B9FF4F44E5C2C7F03 /* MergeOperationStateTests.swift */; };
+		5FA0FC131F06178797420608 /* ReleaseChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */; };
 		5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC16D06302D9AD3C9F0BE3C /* TreeSitterHighlighter.swift */; };
 		603D2F40A0368A139822CE80 /* ACPLaunchCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */; };
 		604E881461FC839C4233B0AF /* LSPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D394D40BC9060833DD640A /* LSPInstaller.swift */; };
@@ -531,6 +532,7 @@
 		9D439D5F19ACEB5A39B7CB68 /* CodexACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3985F2F58DB6E3BBF3520EFD /* CodexACPInstaller.swift */; };
 		9D4F9F5CE9FF51C33E32703C /* ACPMessageWire.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21F30DB5A812E396262A926 /* ACPMessageWire.swift */; };
 		9D6FE5A4589D73A7480CE2B2 /* IndentationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */; };
+		9D99FFFDFB3A256C4960D388 /* ReleaseCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */; };
 		9DF0D37CE59DF8AAD7172443 /* ACPSetupChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E9864A515B0ED49C68739B6 /* ACPSetupChecker.swift */; };
 		9E302329243407946D47DC91 /* BranchPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFD4C762D8323B78934ECE7 /* BranchPicker.swift */; };
 		9E349701BA73BBCCCBB135B3 /* DraftCommitTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3CA543A17D1C3DFA70A80C /* DraftCommitTabView.swift */; };
@@ -1374,6 +1376,7 @@
 		9F650CFAC8E61B1EC99CD04A /* TabActivityPulseTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulseTransitionTests.swift; sourceTree = "<group>"; };
 		9F80EA8C6EFF2C0A8F02C62D /* InstallRecipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipe.swift; sourceTree = "<group>"; };
 		9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRefNameInputFilter.swift; sourceTree = "<group>"; };
+		9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseChecker.swift; sourceTree = "<group>"; };
 		A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParserTests.swift; sourceTree = "<group>"; };
 		A1BC298112812E38C99E0B71 /* ACPAdapterUpdateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateStoreTests.swift; sourceTree = "<group>"; };
 		A203964F9055BEF3F6142684 /* CodexACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexACPInstallerTests.swift; sourceTree = "<group>"; };
@@ -1479,6 +1482,7 @@
 		C2AEA30B7C74A39A46448AF5 /* NotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationServiceTests.swift; sourceTree = "<group>"; };
 		C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagedTests.swift; sourceTree = "<group>"; };
 		C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPromptCapabilitiesTests.swift; sourceTree = "<group>"; };
+		C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseCheckerTests.swift; sourceTree = "<group>"; };
 		C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextTests.swift; sourceTree = "<group>"; };
 		C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecTests.swift; sourceTree = "<group>"; };
 		C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSystemNoticeView.swift; sourceTree = "<group>"; };
@@ -1978,6 +1982,7 @@
 				CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */,
+				C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */,
 				6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */,
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
 				220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */,
@@ -2675,6 +2680,7 @@
 		96D582F846CA5342C74C984D /* Updates */ = {
 			isa = PBXGroup;
 			children = (
+				9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */,
 				35004DC60214F616FA84ED8B /* ReleaseInfo.swift */,
 				8E8EB674A5221235F1C7594E /* SemanticVersion.swift */,
 			);
@@ -3783,6 +3789,7 @@
 				0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */,
 				3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
+				5FA0FC131F06178797420608 /* ReleaseChecker.swift in Sources */,
 				D6F28C27DB02285A62C969A4 /* ReleaseInfo.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
@@ -4162,6 +4169,7 @@
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
 				B6580745C7EDF5AA65DB0A86 /* QueuedPromptTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,
+				9D99FFFDFB3A256C4960D388 /* ReleaseCheckerTests.swift in Sources */,
 				852B01E3449841603FEEDC61 /* ReleaseInfoTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 		809972779548945B012F8B6C /* ACPConnectingPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */; };
 		8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */; };
 		81214C5FDACA47C2FFC15E9E /* HoverWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8149AEEF45B05C60E06888E5 /* HoverWindowController.swift */; };
+		814193F0CC55B784481AA40A /* InstallSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A27D815CB567E3FEF2D3E6B /* InstallSourceTests.swift */; };
 		8147BF86F2E77D81BE885B8F /* ChangedRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E10A1919A8DDC6A8DBB8B97 /* ChangedRow.swift */; };
 		82124EF86A6964D12F3892D2 /* MonospaceFontCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */; };
 		823AA3E801A11C535C9438BD /* ACPPermissionScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */; };
@@ -818,6 +819,7 @@
 		F18EB035A8972F21D23F3810 /* SearchFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39DFD138FE855D8CFC464847 /* SearchFooter.swift */; };
 		F1C4DD0D3A95ED5301EE2AC9 /* ACPTranscriptMarkdownCacheEvictionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3708552C2BF0E70F10C76B63 /* ACPTranscriptMarkdownCacheEvictionTests.swift */; };
 		F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10602801D3FA990E60CB072D /* ACPQueueHeader.swift */; };
+		F2F75C44CD5042F209299FB9 /* InstallSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */; };
 		F3C9321ABD5230C4FA4F7D4E /* GatekeeperRemediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */; };
 		F3E7DF34D9DDA268E40575AE /* CommitInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9427B922BAFA43AF6EB21080 /* CommitInfoTests.swift */; };
 		F3EB289C9DA8B25FC26DAB58 /* MasonSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42E564C149FA33CF0E9870 /* MasonSnapshot.swift */; };
@@ -1017,6 +1019,7 @@
 		2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAuthFailure.swift; sourceTree = "<group>"; };
 		2DD6714E62064D5438AAE139 /* MemoryDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryDiagnosticsTests.swift; sourceTree = "<group>"; };
 		2E669FEBE09BC250B477B335 /* ACPLaunchCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchCatalog.swift; sourceTree = "<group>"; };
+		2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSource.swift; sourceTree = "<group>"; };
 		2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionLifecycleTests.swift; sourceTree = "<group>"; };
 		2EF18448EDA0DCC8B171F11D /* CommitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDiffView.swift; sourceTree = "<group>"; };
 		2F1CBD7C9E0119EC1656C1E2 /* GeminiInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstallerTests.swift; sourceTree = "<group>"; };
@@ -1116,6 +1119,7 @@
 		490AFAD12616D61858A19A31 /* ACPSetupCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSetupCheckerTests.swift; sourceTree = "<group>"; };
 		4941BFBEEEAF9DE9E1752548 /* OperationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationCard.swift; sourceTree = "<group>"; };
 		4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateDiscardPathsTests.swift; sourceTree = "<group>"; };
+		4A27D815CB567E3FEF2D3E6B /* InstallSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSourceTests.swift; sourceTree = "<group>"; };
 		4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCLIInjectionTests.swift; sourceTree = "<group>"; };
 		4AED8A6EE8EF0CC317D7A4C7 /* AgentBuiltinsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentBuiltinsTests.swift; sourceTree = "<group>"; };
 		4B1FE6E8E631C115C1AF02F9 /* GatekeeperAssessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperAssessor.swift; sourceTree = "<group>"; };
@@ -1946,6 +1950,7 @@
 				A300F7033D91C4A0D283F75E /* ImageFileTypeTests.swift */,
 				BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */,
 				A2345B9578E57D570FDB058B /* InlineErrorStripTests.swift */,
+				4A27D815CB567E3FEF2D3E6B /* InstallSourceTests.swift */,
 				835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */,
 				EB52B59655B85764D85CFB7F /* LineEndingTests.swift */,
 				19C327BB65463E878DDCDA5E /* MarkdownFileTypeTests.swift */,
@@ -2680,6 +2685,7 @@
 		96D582F846CA5342C74C984D /* Updates */ = {
 			isa = PBXGroup;
 			children = (
+				2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */,
 				9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */,
 				35004DC60214F616FA84ED8B /* ReleaseInfo.swift */,
 				8E8EB674A5221235F1C7594E /* SemanticVersion.swift */,
@@ -3709,6 +3715,7 @@
 				B614CD7F894DD6908C903254 /* InstallNudgeBanner.swift in Sources */,
 				0237F9775763E3C43D2D849A /* InstallNudgeResolver.swift in Sources */,
 				E6CB573877637461E11CACAF /* InstallRecipe.swift in Sources */,
+				F2F75C44CD5042F209299FB9 /* InstallSource.swift in Sources */,
 				6A386E5CF4C958D9F90DF692 /* InstallSplitButton.swift in Sources */,
 				0407824F9DA8EEFC5B5EEA8A /* InstallerHost.swift in Sources */,
 				255E9EAE89D521E08EB90918 /* JSONHookSettingsFile.swift in Sources */,
@@ -4118,6 +4125,7 @@
 				2ED636DD3A179B95C061A9E6 /* InlineErrorStripTests.swift in Sources */,
 				7A816022DD913BC76F5EBA7F /* InstallNudgeResolverTests.swift in Sources */,
 				D675E5B1E5E95E7239F3A89F /* InstallRecipeTests.swift in Sources */,
+				814193F0CC55B784481AA40A /* InstallSourceTests.swift in Sources */,
 				32660CEE9955165AE3CCDFBE /* InstallerHostTests.swift in Sources */,
 				9C9EC609F3ED8EFF1151D611 /* JSONRPCFramerTests.swift in Sources */,
 				524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		45B14EFA547AACAB5539504B /* ThreePaneSizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC68B05B719B9235865027F /* ThreePaneSizing.swift */; };
 		45B3616A459480A78A5004E8 /* ImageDiffPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */; };
 		45EEE2F32712FDEE392A9707 /* ZmxEnv.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E0BB32D1A3B26473464A0F /* ZmxEnv.swift */; };
+		466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0240C5961343C3042D865570 /* GeneralPane.swift */; };
 		467BA12331DB76C41313BF70 /* WorktreesPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F68A9692F85197ED9E16262 /* WorktreesPane.swift */; };
 		46E3CCB2AC426BD5F8CB55DC /* ACPImageBlocksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */; };
 		474DF7FE50CB6146644B2450 /* ImageDiffEndToEndTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638E94907851A6D0B4AB8F52 /* ImageDiffEndToEndTests.swift */; };
@@ -881,6 +882,7 @@
 		02161104BA524379A359CB2D /* SidebarChromeTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarChromeTheme.swift; sourceTree = "<group>"; };
 		02347E4D2EA79A5CB8DF82DC /* session-update-current-model.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-current-model.json"; sourceTree = "<group>"; };
 		023D0843198D3386919147FF /* SQLiteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteError.swift; sourceTree = "<group>"; };
+		0240C5961343C3042D865570 /* GeneralPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralPane.swift; sourceTree = "<group>"; };
 		028348C468E45161F567110A /* LSPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallerTests.swift; sourceTree = "<group>"; };
 		02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.SurfaceView.swift; sourceTree = "<group>"; };
 		0307CFD55404D01F14A5B602 /* CenterTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterTypography.swift; sourceTree = "<group>"; };
@@ -2426,6 +2428,7 @@
 				BB6A90FAE1D410744D02A454 /* CommitPromptEditorWindow.swift */,
 				1A61DF43677282D4CA21769A /* CommitPromptStatus.swift */,
 				12F5FD1C6AEC80509D52C724 /* FontFamilyPicker.swift */,
+				0240C5961343C3042D865570 /* GeneralPane.swift */,
 				2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */,
 				F61EB45499D244E44EB170BC /* MergeBulkResolvePromptEditorWindow.swift */,
 				749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */,
@@ -3681,6 +3684,7 @@
 				D5DD6DCD22D4984B296145EB /* GatekeeperAssessor.swift in Sources */,
 				1792FECCA58D7603BD4DBDE8 /* GatekeeperRemediator.swift in Sources */,
 				55A6D67E063518A3A757EE18 /* GeminiInstaller.swift in Sources */,
+				466F3E1F73B23B2819A69DD4 /* GeneralPane.swift in Sources */,
 				41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */,
 				41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */,
 				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */; };
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
 		0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB91379591DA21D216A894 /* RelativeTime.swift */; };
+		0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */; };
 		0E2D69C181ECD5233770BC01 /* AgentRunnerParseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E267334F2224961856D20BD8 /* AgentRunnerParseTests.swift */; };
 		0E892EAAAC4EBA733BC441F2 /* MergeRegionVisualLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */; };
 		0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */; };
@@ -811,6 +812,7 @@
 		ECF9400D49926064C4AE4F29 /* AppConfigMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987FAB1E4DB4B81D5D0902B1 /* AppConfigMarkdownTests.swift */; };
 		EDC5F3C0F2964AC78C832F87 /* StatusParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FA9EADDFC798777B5FC6A6 /* StatusParser.swift */; };
 		EE02460865C6A4ED1046B13F /* AgentLifecycleEventMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18B5372BF572EBA3A84113E4 /* AgentLifecycleEventMapperTests.swift */; };
+		EE06DE97F2DCEFAD2B48B05C /* UpdateThrottle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE09B83A747269494B206F23 /* UpdateThrottle.swift */; };
 		EE4E9C47863C4306F0D88A2F /* PersistenceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAE4B623CC10B4544E8D17A /* PersistenceStoreTests.swift */; };
 		EEB6534271EB7EA475A703DE /* HunkPatchBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A06D96DE3FEBF63E7A157DD /* HunkPatchBuilder.swift */; };
 		EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C58E8C0B1BC5B7CB2BBCB /* Code.swift */; };
@@ -1241,6 +1243,7 @@
 		70255847CE81CE85E0117A85 /* ACPMarkdownBlockCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCache.swift; sourceTree = "<group>"; };
 		70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerBufferTests.swift; sourceTree = "<group>"; };
 		705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigSidebarChromeOverridesTests.swift; sourceTree = "<group>"; };
+		708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateThrottleTests.swift; sourceTree = "<group>"; };
 		7094534860369BA79FC5A877 /* session-update-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-plan.json"; sourceTree = "<group>"; };
 		7095EA2868EF619BA4202BDF /* MergeScrollCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeScrollCoordinator.swift; sourceTree = "<group>"; };
 		711F3E7BD099EDADEA0802FD /* NewWorktreeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorktreeDialog.swift; sourceTree = "<group>"; };
@@ -1686,6 +1689,7 @@
 		FD0EBA9DC694E3F11300FC6C /* GeminiInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiInstaller.swift; sourceTree = "<group>"; };
 		FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallRecipeTests.swift; sourceTree = "<group>"; };
 		FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncodingTests.swift; sourceTree = "<group>"; };
+		FE09B83A747269494B206F23 /* UpdateThrottle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateThrottle.swift; sourceTree = "<group>"; };
 		FE2CDF03A998BADF20163D5A /* GitServiceUpstreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceUpstreamTests.swift; sourceTree = "<group>"; };
 		FE5FDAB31C577FC38CE53032 /* ComposerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerAction.swift; sourceTree = "<group>"; };
 		FE66950F2226F1182DCDD39A /* RightPaneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneView.swift; sourceTree = "<group>"; };
@@ -2038,6 +2042,7 @@
 				AE0A6F237480EE72CB8DBE28 /* TitlelessWindowTests.swift */,
 				56D1AC9E1E00C3C5C234382C /* TouchTargetSmokeTests.swift */,
 				AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */,
+				708AB670AB611EFB9D216D7C /* UpdateThrottleTests.swift */,
 				5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */,
 				AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */,
 				8B94010802299E6AC5597E85 /* WorktreeCodableTests.swift */,
@@ -2689,6 +2694,7 @@
 				9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */,
 				35004DC60214F616FA84ED8B /* ReleaseInfo.swift */,
 				8E8EB674A5221235F1C7594E /* SemanticVersion.swift */,
+				FE09B83A747269494B206F23 /* UpdateThrottle.swift */,
 			);
 			path = Updates;
 			sourceTree = "<group>";
@@ -3875,6 +3881,7 @@
 				6EFCC2646A708D0938485654 /* TrafficLights.swift in Sources */,
 				5FF61283B11E2696A72727D1 /* TreeSitterHighlighter.swift in Sources */,
 				443F48C0A1AF36BFAB8B61E8 /* UnionCanvasGeometry.swift in Sources */,
+				EE06DE97F2DCEFAD2B48B05C /* UpdateThrottle.swift in Sources */,
 				B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */,
 				4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */,
 				CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */,
@@ -4231,6 +4238,7 @@
 				9C65A1E2757C2503C02CD081 /* TouchTargetSmokeTests.swift in Sources */,
 				67981D1D60512503BFD901C8 /* TreeSitterHighlighterTests.swift in Sources */,
 				9C4246D4FEE6C6A7D3C738A8 /* UnionCanvasGeometryTests.swift in Sources */,
+				0DA68649E5F3C0018C4309DA /* UpdateThrottleTests.swift in Sources */,
 				9BA16B0D5FC26501D54B5192 /* WorkingTreeStageAllActionTests.swift in Sources */,
 				BE70DBB10DB7106860886AD7 /* WorkspaceLSPManagerStatusTests.swift in Sources */,
 				B34227BF866AFDACB3194333 /* WorktreeCodableTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		84E96EB0EF4267784462B866 /* ACPComposerImageExtractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */; };
 		8510C6B68C2CF6664574C161 /* ACPSystemNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */; };
 		8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */; };
+		852B01E3449841603FEEDC61 /* ReleaseInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */; };
 		859AD39BA8D5A9FCC905648D /* ImageDiffViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120D10644A278775A9AE1990 /* ImageDiffViewTests.swift */; };
 		85C7E65296AB9500FF52060A /* session-update-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = 7094534860369BA79FC5A877 /* session-update-plan.json */; };
 		85EAA2D64D794E045BDF7532 /* MergeAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14BF0C745544F99CB3C6006 /* MergeAgentTests.swift */; };
@@ -730,6 +731,7 @@
 		D675E5B1E5E95E7239F3A89F /* InstallRecipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB4C80D9DD6DA28DE182955 /* InstallRecipeTests.swift */; };
 		D6A8D3925ACCB69DAC380B95 /* AgentPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58DD85A6E01972B39F2D8AD /* AgentPath.swift */; };
 		D6B39CE8878BB196FF2277B6 /* AgentDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */; };
+		D6F28C27DB02285A62C969A4 /* ReleaseInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35004DC60214F616FA84ED8B /* ReleaseInfo.swift */; };
 		D76AE9874386832FF4C89E6E /* initialize-request.json in Resources */ = {isa = PBXBuildFile; fileRef = 3253B229B757C725B7747249 /* initialize-request.json */; };
 		D7A0A35396E440B31711F9D9 /* RepoSelectorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D37F962CC1C97981533A3 /* RepoSelectorModel.swift */; };
 		D7D45D387EEF0436834DF7AD /* ThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EE713DD3CACF29F206553C /* ThemeStore.swift */; };
@@ -1035,6 +1037,7 @@
 		3428750EA8626EEBF3FE928B /* TitlelessWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlelessWindow.swift; sourceTree = "<group>"; };
 		345CFF4DBE5794DEBF43F996 /* LanguageServerRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageServerRegistryTests.swift; sourceTree = "<group>"; };
 		348D2E5F6030BB9F2BDEFA26 /* CompletionPopup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionPopup.swift; sourceTree = "<group>"; };
+		35004DC60214F616FA84ED8B /* ReleaseInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseInfo.swift; sourceTree = "<group>"; };
 		3519B5A28746C49C35D9DAF9 /* SearchInputRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchInputRow.swift; sourceTree = "<group>"; };
 		35543E9F4994774A3743BC12 /* EditorBufferStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferStoreTests.swift; sourceTree = "<group>"; };
 		35C3F234BEF9CE053CD4DB1E /* IndentationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelper.swift; sourceTree = "<group>"; };
@@ -1220,6 +1223,7 @@
 		6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBranchSelectorTests.swift; sourceTree = "<group>"; };
 		6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRetentionTests.swift; sourceTree = "<group>"; };
 		6D46BDE72E52818061452ECB /* CommitRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRowTests.swift; sourceTree = "<group>"; };
+		6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseInfoTests.swift; sourceTree = "<group>"; };
 		6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceStagingTests.swift; sourceTree = "<group>"; };
 		6DF51E6FAFBB47E2F31DA287 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6E8B52175A7F6144B4C52010 /* EditorTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabView.swift; sourceTree = "<group>"; };
@@ -1974,6 +1978,7 @@
 				CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */,
 				4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */,
 				3711FACCAD4DE3E29AB13DD2 /* ProjectsManagerWorktreeOrderingTests.swift */,
+				6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */,
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
 				220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */,
 				784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */,
@@ -2670,6 +2675,7 @@
 		96D582F846CA5342C74C984D /* Updates */ = {
 			isa = PBXGroup;
 			children = (
+				35004DC60214F616FA84ED8B /* ReleaseInfo.swift */,
 				8E8EB674A5221235F1C7594E /* SemanticVersion.swift */,
 			);
 			path = Updates;
@@ -3777,6 +3783,7 @@
 				0FE1A3CCEB283E8780F52076 /* QueuedPrompt.swift in Sources */,
 				3AC6DD00AD2D19FB3A0CCD03 /* RecommendedLanguageCatalog.swift in Sources */,
 				0D8046E333B0DA2B45EE78D4 /* RelativeTime.swift in Sources */,
+				D6F28C27DB02285A62C969A4 /* ReleaseInfo.swift in Sources */,
 				A7340B3C1C6B2BC7189F3695 /* RepoDot.swift in Sources */,
 				2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */,
 				A2B0E4C1D80EB12F7BECE7FC /* RepoSelectorDialog.swift in Sources */,
@@ -4155,6 +4162,7 @@
 				66D3CC7109527B2938684292 /* ProjectsManagerWorktreeOrderingTests.swift in Sources */,
 				B6580745C7EDF5AA65DB0A86 /* QueuedPromptTests.swift in Sources */,
 				E89811545A8AD0ED03655AA3 /* RecommendedLanguageCatalogTests.swift in Sources */,
+				852B01E3449841603FEEDC61 /* ReleaseInfoTests.swift in Sources */,
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		2A19A7B4B392979989E25EC0 /* ACPDiffGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71D8A91D3A2BD4A522DD9AD /* ACPDiffGenerator.swift */; };
 		2ABA47D0AEE8C286572B2490 /* ShortcutBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9E3F080F847EF069137844 /* ShortcutBinding.swift */; };
 		2AC164837BF88D1BD0F20E97 /* TreeSitterCPP in Frameworks */ = {isa = PBXBuildFile; productRef = 5F82D581FFC7034146EAE020 /* TreeSitterCPP */; };
+		2B4CBD06D1568EBC1BD327E0 /* SemanticVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */; };
 		2B823A7361BB54D8D93D7C99 /* ACPMentionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */; };
 		2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A190D4B29B35C457AA9829F /* SettingsBinding.swift */; };
 		2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */; };
@@ -737,6 +738,7 @@
 		D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E8DE57F9A8D5230BCB7A2C /* ACPSubmitIntentTests.swift */; };
 		D87EC73A848929FFB819888C /* SpacesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA8BA11A167DA43E22E7D2D /* SpacesManagerTests.swift */; };
 		D8ACECF849D38029FB56C303 /* CenterTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0307CFD55404D01F14A5B602 /* CenterTypography.swift */; };
+		D8E808EF960CA0C10E59D44C /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8EB674A5221235F1C7594E /* SemanticVersion.swift */; };
 		D95A7FAF0B955642ED9D7521 /* ACPAuthFailureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380D04E9EB0D0ED0C24702DA /* ACPAuthFailureTests.swift */; };
 		DA5ED6D708DD8C0B5563AB4F /* WindowDragHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32D6E47CC4523FDE263C764C /* WindowDragHandle.swift */; };
 		DAA6F5DABE3214693628C730 /* ACPFilesystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435D9E527A76820947F426A8 /* ACPFilesystem.swift */; };
@@ -1116,6 +1118,7 @@
 		4B3300F31455EE1BDF7BDE15 /* ZmxClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClientTests.swift; sourceTree = "<group>"; };
 		4B450918CC98255AD9170586 /* AppearancePane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePane.swift; sourceTree = "<group>"; };
 		4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTabBar.swift; sourceTree = "<group>"; };
+		4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersionTests.swift; sourceTree = "<group>"; };
 		4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiACPInstallerTests.swift; sourceTree = "<group>"; };
 		4CE0FF00CB2F81000FB09A72 /* LegacyHookSweep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweep.swift; sourceTree = "<group>"; };
 		4D131C3F1E4BE68A850097A4 /* ScopeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeRow.swift; sourceTree = "<group>"; };
@@ -1310,6 +1313,7 @@
 		8DD66F449B380BC74B373647 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		8DEB85132B767DB3B253620C /* cool-slate.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "cool-slate.json"; sourceTree = "<group>"; };
 		8E3A9C194105E52A72293855 /* ProjectGitWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcherTests.swift; sourceTree = "<group>"; };
+		8E8EB674A5221235F1C7594E /* SemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersion.swift; sourceTree = "<group>"; };
 		8EC619ECA68DC50B9C56CC33 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitNameValidatorTests.swift; sourceTree = "<group>"; };
 		8EF52FE71B7FB41328859734 /* MarkdownRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRenderer.swift; sourceTree = "<group>"; };
@@ -1982,6 +1986,7 @@
 				0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */,
 				B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */,
 				6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */,
+				4BF2EE8A6AAA7F9B45DACC0C /* SemanticVersionTests.swift */,
 				9346272D3AF9A7D78067C96F /* SettingsSaveNormalizationTests.swift */,
 				E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */,
 				09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */,
@@ -2216,6 +2221,7 @@
 				F556D34B5B6FE20EA80F892A /* Terminal */,
 				7592B5DE2FBCFC47DB6F481D /* Theme */,
 				35407CBFC8CDF3C3395FE123 /* UI */,
+				96D582F846CA5342C74C984D /* Updates */,
 				FABA41CEBDC147EBC8EF4F1C /* Watch */,
 			);
 			path = Sources;
@@ -2659,6 +2665,14 @@
 				B302DA540625EA299CDC9833 /* font */,
 			);
 			path = src;
+			sourceTree = "<group>";
+		};
+		96D582F846CA5342C74C984D /* Updates */ = {
+			isa = PBXGroup;
+			children = (
+				8E8EB674A5221235F1C7594E /* SemanticVersion.swift */,
+			);
+			path = Updates;
 			sourceTree = "<group>";
 		};
 		986CC94FDFD6411BCED67A48 /* Search */ = {
@@ -3791,6 +3805,7 @@
 				3285F4B6AB6DB5A59AE66CF5 /* SearchScope.swift in Sources */,
 				02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */,
 				D05BDEF0D8651A9C2BD8C857 /* Seg.swift in Sources */,
+				D8E808EF960CA0C10E59D44C /* SemanticVersion.swift in Sources */,
 				9C394F07FDB8E398A034B778 /* SessionRegistry.swift in Sources */,
 				2C4EDD06B2D26DCBB18DC2D1 /* SettingsBinding.swift in Sources */,
 				3A866AA94C2B50FA00805875 /* SettingsGroup.swift in Sources */,
@@ -4153,6 +4168,7 @@
 				4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */,
 				B05D6011E0FDB7AA1B016844 /* SQLiteDatabaseTests.swift in Sources */,
 				3D5FC516052D2F06781A3F6E /* SearchModelTests.swift in Sources */,
+				2B4CBD06D1568EBC1BD327E0 /* SemanticVersionTests.swift in Sources */,
 				2F110275F3EC46505EF4DA48 /* SettingsSaveNormalizationTests.swift in Sources */,
 				2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */,
 				B574D2D5DF3129E326DCFCCF /* ShellEnvResolverTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -141,7 +141,7 @@ struct AlasApp: App {
             }
             CommandGroup(after: .appInfo) {
                 Button("Check for Updates…") {
-                    NotificationCenter.default.post(name: .alasCheckForUpdates, object: nil)
+                    state.updates.checkManually()
                 }
             }
         }

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -132,11 +132,18 @@ struct AlasApp: App {
             }
             .disabled(!state.hasActiveEditorTab)
         }
-        CommandGroup(replacing: .appSettings) {
-            Button("Settings…") {
-                NotificationCenter.default.post(name: .alasOpenSettings, object: nil)
+        Group {
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings…") {
+                    NotificationCenter.default.post(name: .alasOpenSettings, object: nil)
+                }
+                .keyboardShortcut(",", modifiers: .command)
             }
-            .keyboardShortcut(",", modifiers: .command)
+            CommandGroup(after: .appInfo) {
+                Button("Check for Updates…") {
+                    NotificationCenter.default.post(name: .alasCheckForUpdates, object: nil)
+                }
+            }
         }
         CommandMenu("Spaces") {
             Button("Select Space 1") {

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -49,6 +49,9 @@ final class AppState {
     let acpAdapterUpdateStore = ACPAdapterUpdateStore()
     @ObservationIgnored
     private var lspManager: WorkspaceLSPManager?
+    @ObservationIgnored lazy var updates = UpdateController(
+        isEnabled: { [weak self] in self?.config.general.autoUpdate ?? true }
+    )
 
     var isSearchOpen: Bool = false
     var isRepoSelectorOpen: Bool = false

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -470,7 +470,7 @@ private struct RootBaseHandlers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .alasTerminateAllTerminals)) { _ in
                 state.terminateAllTerminalSessions()
             }
-        let s = r
+        return r
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                 state.stopAllProjectGitWatchers()
                 state.tabs.snapshotDirtyBuffersForQuit()
@@ -482,10 +482,6 @@ private struct RootBaseHandlers: ViewModifier {
                 // HarnessService, which is one of the candidates for the
                 // permission-prompt avalanche reported on quit.
                 state.harness.stop()
-            }
-        return s
-            .onReceive(NotificationCenter.default.publisher(for: .alasCheckForUpdates)) { _ in
-                state.updates.checkManually()
             }
     }
 }
@@ -560,7 +556,6 @@ extension Notification.Name {
     static let alasResizePaneUp     = Notification.Name("AlasResizePaneUp")
     static let alasResizePaneDown   = Notification.Name("AlasResizePaneDown")
     static let alasTerminateAllTerminals = Notification.Name("AlasTerminateAllTerminals")
-    static let alasCheckForUpdates   = Notification.Name("AlasCheckForUpdates")
     static let alasShowFindReplace  = Notification.Name("AlasShowFindReplace")
     static let codeEditorDidAttach  = Notification.Name("CodeEditorDidAttach")
     static let codeEditorDidDetach  = Notification.Name("CodeEditorDidDetach")

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -170,6 +170,20 @@ struct RootView: View {
                 Text("Alas will stop tracking this project and its worktrees. No files will be deleted from disk. If any editor tabs have unsaved changes, you'll be asked to save or discard them.")
             }
         )
+        .onAppear {
+            state.updates.checkOnLaunch()
+        }
+        .sheet(item: Binding(
+            get: { state.updates.presentedUpdate },
+            set: { state.updates.presentedUpdate = $0 }
+        )) { info in
+            UpdateAvailableSheet(
+                info: info,
+                source: state.updates.source,
+                onDismiss: { state.updates.presentedUpdate = nil }
+            )
+            .environment(\.theme, state.themeStore.current)
+        }
         .task {
             state.startHarness()
             if await state.projectsManager.refreshAll() {
@@ -456,7 +470,7 @@ private struct RootBaseHandlers: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .alasTerminateAllTerminals)) { _ in
                 state.terminateAllTerminalSessions()
             }
-        return r
+        let s = r
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                 state.stopAllProjectGitWatchers()
                 state.tabs.snapshotDirtyBuffersForQuit()
@@ -468,6 +482,10 @@ private struct RootBaseHandlers: ViewModifier {
                 // HarnessService, which is one of the candidates for the
                 // permission-prompt avalanche reported on quit.
                 state.harness.stop()
+            }
+        return s
+            .onReceive(NotificationCenter.default.publisher(for: .alasCheckForUpdates)) { _ in
+                state.updates.checkManually()
             }
     }
 }
@@ -542,6 +560,7 @@ extension Notification.Name {
     static let alasResizePaneUp     = Notification.Name("AlasResizePaneUp")
     static let alasResizePaneDown   = Notification.Name("AlasResizePaneDown")
     static let alasTerminateAllTerminals = Notification.Name("AlasTerminateAllTerminals")
+    static let alasCheckForUpdates   = Notification.Name("AlasCheckForUpdates")
     static let alasShowFindReplace  = Notification.Name("AlasShowFindReplace")
     static let codeEditorDidAttach  = Notification.Name("CodeEditorDidAttach")
     static let codeEditorDidDetach  = Notification.Name("CodeEditorDidDetach")

--- a/Alas/Sources/Settings/GeneralPane.swift
+++ b/Alas/Sources/Settings/GeneralPane.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct GeneralPane: View {
+    @Bindable var state: AppState
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("General").font(.system(size: 18, weight: .semibold))
+                Text("Application behavior and updates.")
+                    .font(.system(size: 12.5)).foregroundColor(theme.color("fg-dim"))
+                    .padding(.bottom, 12)
+
+                SettingsGroup(title: "Updates") {
+                    SettingsRow(
+                        name: "Automatically check for updates",
+                        desc: "Check GitHub for new releases on launch, at most once a day."
+                    ) {
+                        AlasToggle(on: state.bind(\.general.autoUpdate))
+                    }
+                }
+            }
+            .padding(.horizontal, 32).padding(.vertical, 24)
+        }
+    }
+}

--- a/Alas/Sources/Settings/SettingsNavView.swift
+++ b/Alas/Sources/Settings/SettingsNavView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 enum SettingsSection: String, CaseIterable, Identifiable {
-    case agents, appearance, changes, code, shortcuts, spaces, terminal, worktrees, debug
+    case agents, appearance, changes, code, general, shortcuts, spaces, terminal, worktrees, debug
     var id: String { rawValue }
     var label: String {
         switch self {
@@ -10,6 +10,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .appearance: return "Appearance"
         case .changes:    return "Changes"
         case .code:       return "Code"
+        case .general:    return "General"
         case .shortcuts:  return "Shortcuts"
         case .spaces:     return "Spaces"
         case .terminal:   return "Terminal"
@@ -23,6 +24,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .appearance: return "palette"
         case .changes:    return "diff"
         case .code:       return "code"
+        case .general:    return "gear"
         case .shortcuts:  return "keyboard"
         case .spaces:     return "rectangle.3.group"
         case .terminal:   return "terminal"
@@ -72,6 +74,8 @@ struct SettingsNavView: View {
         let visible = SettingsSection.allCases
             .filter { showsDebug || $0 != .debug }
             .sorted(by: {
+                if $0 == .general { return true }
+                if $1 == .general { return false }
                 if $0 == .debug { return false }
                 if $1 == .debug { return true }
                 return $0.label < $1.label

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -30,6 +30,7 @@ struct SettingsWindow: View {
                 SettingsNavView(selection: $section, showsDebug: showsDebug)
                 Group {
                     switch section {
+                    case .general:    GeneralPane(state: state)
                     case .debug:      AdvancedPane(state: state)
                     case .agents:     AgentsPane(state: state) { section = $0 }
                     case .appearance: AppearancePane(state: state)

--- a/Alas/Sources/Updates/InstallSource.swift
+++ b/Alas/Sources/Updates/InstallSource.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// How this copy of Alas was installed, used to tailor the update action.
+enum InstallSource: Equatable {
+    case homebrew
+    case direct
+
+    /// Detects a Homebrew install by probing for the cask's Caskroom directory.
+    /// PATH-independent (does not shell out to `brew`), so it works for GUI launches.
+    static func detect(
+        fileManager: FileManager = .default,
+        caskroomPaths: [String] = [
+            "/opt/homebrew/Caskroom/alas",
+            "/usr/local/Caskroom/alas",
+        ]
+    ) -> InstallSource {
+        for path in caskroomPaths {
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: path, isDirectory: &isDirectory), isDirectory.boolValue {
+                return .homebrew
+            }
+        }
+        return .direct
+    }
+}

--- a/Alas/Sources/Updates/InstallSource.swift
+++ b/Alas/Sources/Updates/InstallSource.swift
@@ -5,15 +5,28 @@ enum InstallSource: Equatable {
     case homebrew
     case direct
 
-    /// Detects a Homebrew install by probing for the cask's Caskroom directory.
-    /// PATH-independent (does not shell out to `brew`), so it works for GUI launches.
+    /// Detects a Homebrew install by checking that the *running* app is the copy
+    /// the cask installed: it runs from the cask's app location
+    /// (`/Applications/Alas.app`) AND the cask's Caskroom directory exists.
+    /// PATH-independent (no `brew` subprocess), so it works for GUI launches.
+    ///
+    /// Requiring the running bundle to match the install location avoids
+    /// mislabeling a separately-downloaded DMG copy as Homebrew just because a
+    /// cask exists elsewhere on the machine — which would otherwise suggest
+    /// `brew upgrade`, updating the cask copy rather than the running app.
     static func detect(
+        bundlePath: String = Bundle.main.bundlePath,
         fileManager: FileManager = .default,
+        appInstallPath: String = "/Applications/Alas.app",
         caskroomPaths: [String] = [
             "/opt/homebrew/Caskroom/alas",
             "/usr/local/Caskroom/alas",
         ]
     ) -> InstallSource {
+        let running = URL(fileURLWithPath: bundlePath).standardizedFileURL.path
+        let installed = URL(fileURLWithPath: appInstallPath).standardizedFileURL.path
+        guard running == installed else { return .direct }
+
         for path in caskroomPaths {
             var isDirectory: ObjCBool = false
             if fileManager.fileExists(atPath: path, isDirectory: &isDirectory), isDirectory.boolValue {

--- a/Alas/Sources/Updates/ReleaseChecker.swift
+++ b/Alas/Sources/Updates/ReleaseChecker.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Queries GitHub for the latest stable release and produces a verdict.
+/// Network access is injected via `fetch` so tests run offline.
+struct ReleaseChecker {
+    enum CheckResult: Equatable {
+        case upToDate
+        case updateAvailable(ReleaseInfo)
+        case failed(String)
+    }
+
+    typealias Fetch = (URL) async throws -> Data
+
+    let latestReleaseURL: URL
+    let arch: String
+    let fetch: Fetch
+
+    init(
+        latestReleaseURL: URL = URL(string: "https://api.github.com/repos/mrmans0n/alas/releases/latest")!,
+        arch: String = HostArch.assetSlug,
+        fetch: @escaping Fetch = ReleaseChecker.defaultFetch
+    ) {
+        self.latestReleaseURL = latestReleaseURL
+        self.arch = arch
+        self.fetch = fetch
+    }
+
+    func check(current: SemanticVersion) async -> CheckResult {
+        do {
+            let data = try await fetch(latestReleaseURL)
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            let release = try decoder.decode(GitHubRelease.self, from: data)
+            guard let info = ReleaseInfo.make(from: release, arch: arch) else {
+                return .failed("The latest release could not be read.")
+            }
+            return info.version > current ? .updateAvailable(info) : .upToDate
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    static func defaultFetch(_ url: URL) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("Alas", forHTTPHeaderField: "User-Agent")
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return data
+    }
+}

--- a/Alas/Sources/Updates/ReleaseChecker.swift
+++ b/Alas/Sources/Updates/ReleaseChecker.swift
@@ -44,7 +44,10 @@ struct ReleaseChecker {
         var request = URLRequest(url: url)
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
         request.setValue("Alas", forHTTPHeaderField: "User-Agent")
-        let (data, _) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            throw URLError(.badServerResponse)
+        }
         return data
     }
 }

--- a/Alas/Sources/Updates/ReleaseInfo.swift
+++ b/Alas/Sources/Updates/ReleaseInfo.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// The current host's GitHub release asset arch slug.
+enum HostArch {
+    static var assetSlug: String {
+        #if arch(arm64)
+        return "arm64"
+        #else
+        return "x86_64"
+        #endif
+    }
+}
+
+/// Decoded subset of GitHub's `releases/latest` payload.
+/// Decode with `keyDecodingStrategy = .convertFromSnakeCase`.
+struct GitHubRelease: Decodable {
+    let tagName: String
+    let body: String?
+    let htmlUrl: URL
+    let prerelease: Bool
+    let draft: Bool
+    let assets: [Asset]
+
+    struct Asset: Decodable {
+        let name: String
+        let browserDownloadUrl: URL
+    }
+}
+
+/// Normalized release info the UI consumes.
+struct ReleaseInfo: Equatable, Identifiable {
+    let version: SemanticVersion
+    let releaseNotes: String
+    let htmlURL: URL
+    let dmgURL: URL?
+
+    var id: String { version.description }
+
+    /// Maps a decoded release to `ReleaseInfo`, resolving the DMG asset for
+    /// `arch`. Returns nil when the tag isn't a parseable version.
+    static func make(from release: GitHubRelease, arch: String) -> ReleaseInfo? {
+        guard let version = SemanticVersion(parsing: release.tagName) else { return nil }
+        let dmgName = "Alas-\(version)-\(arch).dmg"
+        let dmg = release.assets.first { $0.name == dmgName }?.browserDownloadUrl
+        return ReleaseInfo(
+            version: version,
+            releaseNotes: release.body ?? "",
+            htmlURL: release.htmlUrl,
+            dmgURL: dmg
+        )
+    }
+}

--- a/Alas/Sources/Updates/SemanticVersion.swift
+++ b/Alas/Sources/Updates/SemanticVersion.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Minimal semantic version (major.minor.patch) with numeric ordering.
+/// Pre-release / build metadata suffixes are parsed but ignored for comparison.
+struct SemanticVersion: Comparable, Equatable, CustomStringConvertible {
+    let major: Int
+    let minor: Int
+    let patch: Int
+
+    init(major: Int, minor: Int, patch: Int) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    init?(parsing raw: String) {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !s.isEmpty else { return nil }
+        if s.hasPrefix("v") || s.hasPrefix("V") { s.removeFirst() }
+
+        // Drop any "-prerelease" / "+build" suffix; compare on the core triple.
+        let core = s.split(whereSeparator: { $0 == "-" || $0 == "+" }).first.map(String.init) ?? s
+        let parts = core.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard (1...3).contains(parts.count) else { return nil }
+
+        func component(_ index: Int) -> Int? {
+            guard index < parts.count else { return 0 }
+            guard let value = Int(parts[index]), value >= 0 else { return nil }
+            return value
+        }
+        guard let ma = component(0), let mi = component(1), let pa = component(2) else { return nil }
+        self.init(major: ma, minor: mi, patch: pa)
+    }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        (lhs.major, lhs.minor, lhs.patch) < (rhs.major, rhs.minor, rhs.patch)
+    }
+
+    var description: String { "\(major).\(minor).\(patch)" }
+}

--- a/Alas/Sources/Updates/UpdateAvailableSheet.swift
+++ b/Alas/Sources/Updates/UpdateAvailableSheet.swift
@@ -1,0 +1,69 @@
+import AppKit
+import SwiftUI
+
+/// Themed sheet shown when a newer release exists. Renders release notes plus an
+/// install-source-tailored action. Pure view over `ReleaseInfo` + `InstallSource`.
+struct UpdateAvailableSheet: View {
+    let info: ReleaseInfo
+    let source: InstallSource
+    let onDismiss: () -> Void
+    @Environment(\.theme) var theme
+
+    private let brewCommand = "brew upgrade --cask alas"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Update available")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(theme.color("fg"))
+                Text("Alas \(info.version.description) is available.")
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 22).padding(.top, 18).padding(.bottom, 6)
+
+            ScrollView {
+                Text(info.releaseNotes.isEmpty ? "No release notes provided." : info.releaseNotes)
+                    .font(.system(size: 12))
+                    .foregroundColor(theme.color("fg-muted"))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+            .frame(height: 220)
+            .padding(.horizontal, 22).padding(.vertical, 12)
+
+            actionRow
+        }
+        .frame(width: 480)
+        .background(theme.color("bg-1"))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    @ViewBuilder private var actionRow: some View {
+        HStack(spacing: 8) {
+            switch source {
+            case .homebrew:
+                Text(brewCommand)
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundColor(theme.color("fg"))
+                    .textSelection(.enabled)
+                AlasButton(title: "Copy", style: .subtle) { Clipboard.copy(brewCommand) }
+                Spacer()
+                AlasButton(title: "View Release", style: .subtle) { NSWorkspace.shared.open(info.htmlURL) }
+                AlasButton(title: "Later", style: .primary, action: onDismiss)
+            case .direct:
+                AlasButton(title: "View Release Notes", style: .subtle) { NSWorkspace.shared.open(info.htmlURL) }
+                Spacer()
+                AlasButton(title: "Later", style: .subtle, action: onDismiss)
+                AlasButton(title: "Download", style: .primary) {
+                    NSWorkspace.shared.open(info.dmgURL ?? info.htmlURL)
+                }
+            }
+        }
+        .padding(.horizontal, 18).padding(.vertical, 12)
+        .background(theme.color("bg-2"))
+        .overlay(Divider().opacity(0.5), alignment: .top)
+    }
+}

--- a/Alas/Sources/Updates/UpdateController.swift
+++ b/Alas/Sources/Updates/UpdateController.swift
@@ -1,0 +1,75 @@
+import AppKit
+import Foundation
+import Observation
+
+/// Orchestrates update checks and drives presentation. The only stateful piece
+/// of the Updates module. Pure logic lives in the injected collaborators.
+@MainActor
+@Observable
+final class UpdateController {
+    /// Non-nil when an update sheet should be presented.
+    var presentedUpdate: ReleaseInfo?
+
+    private let currentVersion: SemanticVersion
+    private let checker: ReleaseChecker
+    private let installSource: InstallSource
+    private let defaults: UserDefaults
+    private let isEnabled: () -> Bool
+
+    private let lastCheckedKey = "io.nlopez.alas.updates.lastCheckedAt"
+
+    init(
+        currentVersion: SemanticVersion = UpdateController.bundleVersion(),
+        checker: ReleaseChecker = ReleaseChecker(),
+        installSource: InstallSource = .detect(),
+        defaults: UserDefaults = .standard,
+        isEnabled: @escaping () -> Bool
+    ) {
+        self.currentVersion = currentVersion
+        self.checker = checker
+        self.installSource = installSource
+        self.defaults = defaults
+        self.isEnabled = isEnabled
+    }
+
+    static func bundleVersion() -> SemanticVersion {
+        let raw = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        return SemanticVersion(parsing: raw) ?? SemanticVersion(major: 0, minor: 0, patch: 0)
+    }
+
+    /// Where this copy was installed — used by the sheet to tailor the action.
+    var source: InstallSource { installSource }
+
+    /// Throttled, silent-on-no-update check intended for app launch.
+    func checkOnLaunch() {
+        let last = defaults.object(forKey: lastCheckedKey) as? Date
+        guard UpdateThrottle.shouldCheck(enabled: isEnabled(), lastCheckedAt: last, now: Date()) else { return }
+        Task { await runCheck(announceNoUpdate: false) }
+    }
+
+    /// User-initiated check from the menu. Always runs; gives feedback either way.
+    func checkManually() {
+        Task { await runCheck(announceNoUpdate: true) }
+    }
+
+    private func runCheck(announceNoUpdate: Bool) async {
+        let result = await checker.check(current: currentVersion)
+        defaults.set(Date(), forKey: lastCheckedKey)
+        switch result {
+        case .updateAvailable(let info):
+            presentedUpdate = info
+        case .upToDate:
+            if announceNoUpdate { presentInfo(title: "You're up to date", message: "Alas \(currentVersion) is the latest version.") }
+        case .failed(let message):
+            if announceNoUpdate { presentInfo(title: "Couldn't check for updates", message: message) }
+        }
+    }
+
+    private func presentInfo(title: String, message: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}

--- a/Alas/Sources/Updates/UpdateController.swift
+++ b/Alas/Sources/Updates/UpdateController.swift
@@ -54,11 +54,15 @@ final class UpdateController {
 
     private func runCheck(announceNoUpdate: Bool) async {
         let result = await checker.check(current: currentVersion)
-        defaults.set(Date(), forKey: lastCheckedKey)
         switch result {
         case .updateAvailable(let info):
+            // Stamp only on a successful fetch — a failed check must not consume
+            // the throttle budget, or a transient network error on launch would
+            // suppress auto-checks for a full interval.
+            defaults.set(Date(), forKey: lastCheckedKey)
             presentedUpdate = info
         case .upToDate:
+            defaults.set(Date(), forKey: lastCheckedKey)
             if announceNoUpdate { presentInfo(title: "You're up to date", message: "Alas \(currentVersion) is the latest version.") }
         case .failed(let message):
             if announceNoUpdate { presentInfo(title: "Couldn't check for updates", message: message) }

--- a/Alas/Sources/Updates/UpdateThrottle.swift
+++ b/Alas/Sources/Updates/UpdateThrottle.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Pure decision for whether an automatic update check should run.
+enum UpdateThrottle {
+    /// Minimum spacing between automatic checks (24h).
+    static let interval: TimeInterval = 24 * 60 * 60
+
+    static func shouldCheck(
+        enabled: Bool,
+        lastCheckedAt: Date?,
+        now: Date,
+        interval: TimeInterval = UpdateThrottle.interval
+    ) -> Bool {
+        guard enabled else { return false }
+        guard let last = lastCheckedAt else { return true }
+        return now.timeIntervalSince(last) >= interval
+    }
+}

--- a/AlasTests/InstallSourceTests.swift
+++ b/AlasTests/InstallSourceTests.swift
@@ -3,19 +3,25 @@ import Testing
 @testable import Alas
 
 struct InstallSourceTests {
-    @Test func detectsHomebrewWhenCaskroomDirExists() throws {
+    private let appPath = "/Applications/Alas.app"
+
+    @Test func detectsHomebrewWhenRunningFromInstallPathAndCaskroomExists() throws {
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("alas-caskroom-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: tmp) }
 
-        let source = InstallSource.detect(caskroomPaths: [tmp.path])
+        let source = InstallSource.detect(
+            bundlePath: appPath, appInstallPath: appPath, caskroomPaths: [tmp.path]
+        )
         #expect(source == .homebrew)
     }
 
     @Test func detectsDirectWhenNoCaskroomDir() {
         let missing = "/tmp/definitely-not-a-caskroom-\(UUID().uuidString)"
-        #expect(InstallSource.detect(caskroomPaths: [missing]) == .direct)
+        #expect(InstallSource.detect(
+            bundlePath: appPath, appInstallPath: appPath, caskroomPaths: [missing]
+        ) == .direct)
     }
 
     @Test func ignoresPlainFileAtCaskroomPath() throws {
@@ -24,6 +30,24 @@ struct InstallSourceTests {
         try Data().write(to: tmp)
         defer { try? FileManager.default.removeItem(at: tmp) }
 
-        #expect(InstallSource.detect(caskroomPaths: [tmp.path]) == .direct)
+        #expect(InstallSource.detect(
+            bundlePath: appPath, appInstallPath: appPath, caskroomPaths: [tmp.path]
+        ) == .direct)
+    }
+
+    @Test func detectsDirectWhenRunningOutsideInstallPathEvenIfCaskroomExists() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("alas-caskroom-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // A separately-downloaded DMG/dev copy running from elsewhere must NOT be
+        // classified as Homebrew even though a cask exists on the machine.
+        let source = InstallSource.detect(
+            bundlePath: "/Users/someone/Downloads/Alas.app",
+            appInstallPath: appPath,
+            caskroomPaths: [tmp.path]
+        )
+        #expect(source == .direct)
     }
 }

--- a/AlasTests/InstallSourceTests.swift
+++ b/AlasTests/InstallSourceTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct InstallSourceTests {
+    @Test func detectsHomebrewWhenCaskroomDirExists() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("alas-caskroom-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let source = InstallSource.detect(caskroomPaths: [tmp.path])
+        #expect(source == .homebrew)
+    }
+
+    @Test func detectsDirectWhenNoCaskroomDir() {
+        let missing = "/tmp/definitely-not-a-caskroom-\(UUID().uuidString)"
+        #expect(InstallSource.detect(caskroomPaths: [missing]) == .direct)
+    }
+
+    @Test func ignoresPlainFileAtCaskroomPath() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("alas-caskroom-file-\(UUID().uuidString)")
+        try Data().write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        #expect(InstallSource.detect(caskroomPaths: [tmp.path]) == .direct)
+    }
+}

--- a/AlasTests/ReleaseCheckerTests.swift
+++ b/AlasTests/ReleaseCheckerTests.swift
@@ -63,4 +63,16 @@ struct ReleaseCheckerTests {
             return
         }
     }
+
+    @Test func reportsFailedWhenTagUnparseable() async {
+        let data = Data("""
+        {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":false,"draft":false,"assets":[]}
+        """.utf8)
+        let result = await checker(returning: data)
+            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+        guard case .failed = result else {
+            Issue.record("expected failed, got \(result)")
+            return
+        }
+    }
 }

--- a/AlasTests/ReleaseCheckerTests.swift
+++ b/AlasTests/ReleaseCheckerTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ReleaseCheckerTests {
+    private func json(tag: String) -> Data {
+        Data("""
+        {
+          "tag_name": "\(tag)",
+          "body": "notes",
+          "html_url": "https://github.com/mrmans0n/alas/releases/tag/\(tag)",
+          "prerelease": false,
+          "draft": false,
+          "assets": [
+            {"name": "Alas-\(tag.replacingOccurrences(of: "v", with: ""))-arm64.dmg",
+             "browser_download_url": "https://example.com/\(tag)-arm64.dmg"}
+          ]
+        }
+        """.utf8)
+    }
+
+    private func checker(returning data: Data, arch: String = "arm64") -> ReleaseChecker {
+        ReleaseChecker(arch: arch, fetch: { _ in data })
+    }
+
+    @Test func reportsUpdateWhenRemoteNewer() async {
+        let result = await checker(returning: json(tag: "v0.6.0"))
+            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+        guard case let .updateAvailable(info) = result else {
+            Issue.record("expected updateAvailable, got \(result)")
+            return
+        }
+        #expect(info.version == SemanticVersion(major: 0, minor: 6, patch: 0))
+    }
+
+    @Test func reportsUpToDateWhenEqual() async {
+        let result = await checker(returning: json(tag: "v0.5.1"))
+            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+        #expect(result == .upToDate)
+    }
+
+    @Test func reportsUpToDateWhenRemoteOlder() async {
+        let result = await checker(returning: json(tag: "v0.4.0"))
+            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+        #expect(result == .upToDate)
+    }
+
+    @Test func reportsFailedOnMalformedJSON() async {
+        let result = await checker(returning: Data("not json".utf8))
+            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+        guard case .failed = result else {
+            Issue.record("expected failed, got \(result)")
+            return
+        }
+    }
+
+    @Test func reportsFailedWhenFetchThrows() async {
+        struct Boom: Error {}
+        let checker = ReleaseChecker(arch: "arm64", fetch: { _ in throw Boom() })
+        let result = await checker.check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+        guard case .failed = result else {
+            Issue.record("expected failed, got \(result)")
+            return
+        }
+    }
+}

--- a/AlasTests/ReleaseInfoTests.swift
+++ b/AlasTests/ReleaseInfoTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ReleaseInfoTests {
+    private func decode(_ json: String) throws -> GitHubRelease {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(GitHubRelease.self, from: Data(json.utf8))
+    }
+
+    private let sample = """
+    {
+      "tag_name": "v0.6.0",
+      "body": "## Fixes\\n- thing",
+      "html_url": "https://github.com/mrmans0n/alas/releases/tag/v0.6.0",
+      "prerelease": false,
+      "draft": false,
+      "assets": [
+        {"name": "Alas-0.6.0-arm64.dmg", "browser_download_url": "https://example.com/arm64.dmg"},
+        {"name": "Alas-0.6.0-x86_64.dmg", "browser_download_url": "https://example.com/x86_64.dmg"}
+      ]
+    }
+    """
+
+    @Test func decodesGitHubReleaseSnakeCase() throws {
+        let release = try decode(sample)
+        #expect(release.tagName == "v0.6.0")
+        #expect(release.assets.count == 2)
+        #expect(release.assets.first?.browserDownloadUrl.absoluteString == "https://example.com/arm64.dmg")
+    }
+
+    @Test func mapsToReleaseInfoWithMatchingArchDMG() throws {
+        let info = ReleaseInfo.make(from: try decode(sample), arch: "arm64")
+        #expect(info?.version == SemanticVersion(major: 0, minor: 6, patch: 0))
+        #expect(info?.releaseNotes == "## Fixes\n- thing")
+        #expect(info?.dmgURL?.absoluteString == "https://example.com/arm64.dmg")
+        #expect(info?.htmlURL.absoluteString == "https://github.com/mrmans0n/alas/releases/tag/v0.6.0")
+    }
+
+    @Test func mapsWithNilDMGWhenArchAssetMissing() throws {
+        let info = ReleaseInfo.make(from: try decode(sample), arch: "riscv")
+        #expect(info?.dmgURL == nil)
+    }
+
+    @Test func mapFailsWhenTagUnparseable() throws {
+        let bad = """
+        {"tag_name": "nightly", "body": null, "html_url": "https://x.test", "prerelease": false, "draft": false, "assets": []}
+        """
+        #expect(ReleaseInfo.make(from: try decode(bad), arch: "arm64") == nil)
+    }
+
+    @Test func handlesNullBody() throws {
+        let noBody = """
+        {"tag_name": "v0.6.0", "body": null, "html_url": "https://x.test", "prerelease": false, "draft": false, "assets": []}
+        """
+        let info = ReleaseInfo.make(from: try decode(noBody), arch: "arm64")
+        #expect(info?.releaseNotes == "")
+    }
+}

--- a/AlasTests/SemanticVersionTests.swift
+++ b/AlasTests/SemanticVersionTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import Alas
+
+struct SemanticVersionTests {
+    @Test func parsesPlainTriple() {
+        let v = SemanticVersion(parsing: "1.2.3")
+        #expect(v == SemanticVersion(major: 1, minor: 2, patch: 3))
+    }
+
+    @Test func stripsLeadingV() {
+        #expect(SemanticVersion(parsing: "v0.5.1") == SemanticVersion(major: 0, minor: 5, patch: 1))
+    }
+
+    @Test func padsMissingComponents() {
+        #expect(SemanticVersion(parsing: "1") == SemanticVersion(major: 1, minor: 0, patch: 0))
+        #expect(SemanticVersion(parsing: "1.2") == SemanticVersion(major: 1, minor: 2, patch: 0))
+    }
+
+    @Test func ignoresPrereleaseAndBuildSuffix() {
+        #expect(SemanticVersion(parsing: "1.2.3-rc1") == SemanticVersion(major: 1, minor: 2, patch: 3))
+        #expect(SemanticVersion(parsing: "1.2.3+build7") == SemanticVersion(major: 1, minor: 2, patch: 3))
+    }
+
+    @Test func orderingIsNumericNotLexical() {
+        #expect(SemanticVersion(parsing: "0.10.0")! > SemanticVersion(parsing: "0.9.0")!)
+        #expect(SemanticVersion(parsing: "1.0.0")! > SemanticVersion(parsing: "0.99.99")!)
+    }
+
+    @Test func equalVersionsAreNotLess() {
+        let a = SemanticVersion(parsing: "0.5.1")!
+        #expect(!(a < a))
+    }
+
+    @Test func rejectsMalformed() {
+        #expect(SemanticVersion(parsing: "") == nil)
+        #expect(SemanticVersion(parsing: "abc") == nil)
+        #expect(SemanticVersion(parsing: "1.x.0") == nil)
+        #expect(SemanticVersion(parsing: "1.2.3.4") == nil)
+    }
+
+    @Test func descriptionRoundTrips() {
+        #expect(SemanticVersion(major: 0, minor: 5, patch: 1).description == "0.5.1")
+    }
+}

--- a/AlasTests/SettingsSectionTests.swift
+++ b/AlasTests/SettingsSectionTests.swift
@@ -16,7 +16,7 @@ struct SettingsSectionTests {
         let labels = SettingsSection.allCases.map(\.label)
 
         #expect(!labels.contains("Markdown"))
-        #expect(!labels.contains("General"))
+        #expect(labels.contains("General"))
         #expect(labels.contains("Appearance"))
     }
 

--- a/AlasTests/UpdateThrottleTests.swift
+++ b/AlasTests/UpdateThrottleTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct UpdateThrottleTests {
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    @Test func skipsWhenDisabled() {
+        #expect(UpdateThrottle.shouldCheck(enabled: false, lastCheckedAt: nil, now: now) == false)
+    }
+
+    @Test func checksWhenEnabledAndNeverChecked() {
+        #expect(UpdateThrottle.shouldCheck(enabled: true, lastCheckedAt: nil, now: now) == true)
+    }
+
+    @Test func skipsWithinInterval() {
+        let recent = now.addingTimeInterval(-3600) // 1h ago
+        #expect(UpdateThrottle.shouldCheck(enabled: true, lastCheckedAt: recent, now: now) == false)
+    }
+
+    @Test func checksAfterInterval() {
+        let stale = now.addingTimeInterval(-25 * 3600) // 25h ago
+        #expect(UpdateThrottle.shouldCheck(enabled: true, lastCheckedAt: stale, now: now) == true)
+    }
+
+    @Test func checksExactlyAtInterval() {
+        let exactly = now.addingTimeInterval(-UpdateThrottle.interval)
+        #expect(UpdateThrottle.shouldCheck(enabled: true, lastCheckedAt: exactly, now: now) == true)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a check-only "check for updates" capability. Alas queries GitHub Releases (`/releases/latest`), compares the running version against the latest stable release, and — when a newer version exists — shows a sheet with release notes plus an install-source-tailored next step.

- **Manual** "Check for Updates…" menu item under the app menu (always runs).
- **Automatic** check on launch, throttled to once per 24h, gated by a new **General → Automatically check for updates** Settings toggle (reuses the dormant `AppConfig.General.autoUpdate` field).
- **Stable-only** by construction (`/releases/latest` excludes prereleases/drafts).
- **Tailored hand-off:** Homebrew installs (detected via the Caskroom directory) get a copyable `brew upgrade --cask alas` command; direct-DMG installs get a Download button. No in-app self-replacement — Homebrew installs stay in sync with `brew`.

### Architecture

A self-contained `Alas/Sources/Updates/` module: pure, unit-tested value types (`SemanticVersion`, `ReleaseInfo`, `ReleaseChecker`, `InstallSource`, `UpdateThrottle`) behind injectable seams (no network/filesystem in tests), with a single `@MainActor @Observable` `UpdateController` orchestrating and a themed `UpdateAvailableSheet`. New `General` settings pane; menu/launch/sheet wiring in the app layer.

## Test Plan

- [ ] New unit suites pass: `SemanticVersionTests`, `ReleaseInfoTests`, `ReleaseCheckerTests`, `InstallSourceTests`, `UpdateThrottleTests`.
- [ ] Settings → **General** appears first, shows the auto-update toggle (default on), and the value persists.
- [ ] App menu shows **Check for Updates…** under About; on the latest version it reports "You're up to date".
- [ ] On a build older than the latest release, the sheet renders release notes and the correct action for the install source.