### PR TITLE
feat(ACP): new chat empty state

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		763947308C99E2D3CB565889 /* AgentKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C792D59DBFFF6C28F2D426 /* AgentKind.swift */; };
 		771CD72B94194370E783F7DD /* StartupScriptResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3C76F2F0F6BCE4023A9D7F /* StartupScriptResolverTests.swift */; };
 		78D25A04EAE26A0F3021A057 /* Paths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364213292935A05F3B52F51F /* Paths.swift */; };
+		7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */; };
 		79575F0DA597D2C2DFCDC9E2 /* LSPMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */; };
 		7A0D3E122F34EF1A2A04984F /* EnvBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159FE807399835B0821E1CAB /* EnvBuilder.swift */; };
 		7A2C912B677A34391361B720 /* AdvancedSettingsVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B123596E047E4CE0FAFE3E /* AdvancedSettingsVisibility.swift */; };
@@ -831,6 +832,7 @@
 		F9C3EA369FF29AC5D7BCA3C6 /* AgentHookSocketServerCLITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB19F036D793E5DFBBD3C675 /* AgentHookSocketServerCLITests.swift */; };
 		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
 		FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */; };
+		FB51C37DBD897B3A690DCDC3 /* ACPNewChatEmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */; };
 		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
 		FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
@@ -1522,8 +1524,10 @@
 		CF15D3E39502C1BA6618943B /* MergeConflictTabModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabModel.swift; sourceTree = "<group>"; };
 		CF41C5BD384265499AEEE4CF /* CompletionDocumentationRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionDocumentationRendererTests.swift; sourceTree = "<group>"; };
 		CF5143046167375A802ED378 /* SurfaceViewKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewKeyboardTests.swift; sourceTree = "<group>"; };
+		CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStatePolicy.swift; sourceTree = "<group>"; };
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolverTests.swift; sourceTree = "<group>"; };
+		D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateTests.swift; sourceTree = "<group>"; };
 		D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayout.swift; sourceTree = "<group>"; };
 		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
 		D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftTests.swift; sourceTree = "<group>"; };
@@ -2332,6 +2336,7 @@
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
 				7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */,
 				9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */,
+				D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */,
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
 				96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */,
 				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
@@ -2543,6 +2548,7 @@
 				329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */,
 				E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */,
 				3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */,
+				CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */,
 				0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */,
 				CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */,
 				B7AAAEB5A9C69FC459AAD70B /* ACPPlanPill.swift */,
@@ -3459,6 +3465,7 @@
 				9D4F9F5CE9FF51C33E32703C /* ACPMessageWire.swift in Sources */,
 				B8412B44C090B4AA6A892D25 /* ACPMessages.swift in Sources */,
 				552EBB79C20E7D939C7015A1 /* ACPMockClient.swift in Sources */,
+				7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */,
 				E4C6E2BE1C7F20AD29C66DF0 /* ACPPermissionDecisionLog.swift in Sources */,
 				CC30504E2DC245FD23347E33 /* ACPPermissionPolicy.swift in Sources */,
 				0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */,
@@ -3899,6 +3906,7 @@
 				D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */,
 				BC4B8B193F020CBEA02B01A6 /* ACPMessageWireTests.swift in Sources */,
 				395276FB3018E0B9E68A7D81 /* ACPMockClientTests.swift in Sources */,
+				FB51C37DBD897B3A690DCDC3 /* ACPNewChatEmptyStateTests.swift in Sources */,
 				4937795BA36F920B9930C916 /* ACPPermissionDecisionLogTests.swift in Sources */,
 				57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */,
 				8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		2C96C81EBF3C4B0951FA2A57 /* MarkdownFileType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D486FD440D802AEC65D1555 /* MarkdownFileType.swift */; };
 		2C9C311A6DFC9DC5954F5CC2 /* RepoGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768D12909DD5233659AC4E03 /* RepoGroupView.swift */; };
 		2D313A7E99C93242DD35AA8E /* CursorInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */; };
+		2D3E3F75B6CBDF63A3FF2CD7 /* ACPStarterPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C6D6594CCA4EBC83BDF264 /* ACPStarterPrompt.swift */; };
 		2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */; };
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
 		2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */; };
@@ -1343,6 +1344,7 @@
 		9546B1E19C972D3BF80FA050 /* ShortcutAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAction.swift; sourceTree = "<group>"; };
 		95DA6BFFE45ED25669869C76 /* CommitMessageEditorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitMessageEditorViewTests.swift; sourceTree = "<group>"; };
 		96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPlanSidebarVisibilityTests.swift; sourceTree = "<group>"; };
+		96C6D6594CCA4EBC83BDF264 /* ACPStarterPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStarterPrompt.swift; sourceTree = "<group>"; };
 		96E7159EED1183F784104B4F /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
 		97134381F91B44B46CAFE082 /* ContentResultGroupViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroupViewTests.swift; sourceTree = "<group>"; };
 		976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentHookSocketServer.swift; sourceTree = "<group>"; };
@@ -2563,6 +2565,7 @@
 				7C38FA009B7044E9DC5480A7 /* ACPSessionsButton.swift */,
 				6791BB640C39115289BF6D07 /* ACPSetupNudgeBanner.swift */,
 				93C3F02ECEA5D545FA268DB8 /* ACPSlashPicker.swift */,
+				96C6D6594CCA4EBC83BDF264 /* ACPStarterPrompt.swift */,
 				C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */,
 				C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */,
 				B832ED19AC178DAD77C78D37 /* ACPTabView.swift */,
@@ -3494,6 +3497,7 @@
 				9DF0D37CE59DF8AAD7172443 /* ACPSetupChecker.swift in Sources */,
 				3F54F0437585F96F5774A3BD /* ACPSetupNudgeBanner.swift in Sources */,
 				C5644E1144140B99E8676064 /* ACPSlashPicker.swift in Sources */,
+				2D3E3F75B6CBDF63A3FF2CD7 /* ACPStarterPrompt.swift in Sources */,
 				A3EE2DE5C01EB87DE7BCC801 /* ACPStdioClient.swift in Sources */,
 				1B7A283F7F585BA8D67C1959 /* ACPSteerUndoToast.swift in Sources */,
 				3537561BEB5D7D8666C7DFFD /* ACPStreamingText.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		57138814D45D03AE10BE9D67 /* ACPPermissionFSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */; };
 		57A5A3F4F14E75F6C00A2DC0 /* ACPSessionRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */; };
 		57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */; };
+		58ED3DFB6576F9B3C473D16C /* ACPNewChatEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */; };
 		5936DF2636F0B74BEAB33A57 /* DraftAmendPrefillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */; };
 		59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */; };
 		599A6D9A3A1CCF1F618146C8 /* LegacyHookSweepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */; };
@@ -1239,6 +1240,7 @@
 		71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterSelectionStateResolverTests.swift; sourceTree = "<group>"; };
 		71BFAD7D324EEAE4DA5D402E /* TerminalTabStateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabStateCodableTests.swift; sourceTree = "<group>"; };
 		71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftAmendPrefill.swift; sourceTree = "<group>"; };
+		7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateView.swift; sourceTree = "<group>"; };
 		72970A1D2817539DB5243058 /* MergeWordDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeWordDiffTests.swift; sourceTree = "<group>"; };
 		73A34259DE8E978943E8BE16 /* OKLCH.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCH.swift; sourceTree = "<group>"; };
 		73B17505E5DB94014B6FCB18 /* EditorLSPStatusOverridePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatusOverridePicker.swift; sourceTree = "<group>"; };
@@ -2551,6 +2553,7 @@
 				E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */,
 				3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */,
 				CF80D59C3200AD3215D1E140 /* ACPNewChatEmptyStatePolicy.swift */,
+				7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */,
 				0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */,
 				CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */,
 				B7AAAEB5A9C69FC459AAD70B /* ACPPlanPill.swift */,
@@ -3469,6 +3472,7 @@
 				B8412B44C090B4AA6A892D25 /* ACPMessages.swift in Sources */,
 				552EBB79C20E7D939C7015A1 /* ACPMockClient.swift in Sources */,
 				7950F5765E0B95EB1CB5B818 /* ACPNewChatEmptyStatePolicy.swift in Sources */,
+				58ED3DFB6576F9B3C473D16C /* ACPNewChatEmptyStateView.swift in Sources */,
 				E4C6E2BE1C7F20AD29C66DF0 /* ACPPermissionDecisionLog.swift in Sources */,
 				CC30504E2DC245FD23347E33 /* ACPPermissionPolicy.swift in Sources */,
 				0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -17,6 +17,7 @@ struct ACPInputField: NSViewRepresentable {
     let worktreeRoot: URL
     let actions: ACPComposerActions
     @Binding var isFocused: Bool
+    let focusRequest: Int
     /// True when ⏎ should submit with `.auto` intent (the default mapping
     /// — queue while busy). False when the user inverted the setting so
     /// ⏎ steers; the placeholder reverses accordingly while busy.
@@ -82,6 +83,13 @@ struct ACPInputField: NSViewRepresentable {
         context.coordinator.promptSuggestions = session.promptSuggestions
         context.coordinator.theme = context.environment.theme
         context.coordinator.sendOnEnter = sendOnEnter
+        if context.coordinator.focusRequest != focusRequest {
+            context.coordinator.focusRequest = focusRequest
+            if let tv = nsView.documentView as? ACPNSTextView,
+               let window = tv.window {
+                window.makeFirstResponder(tv)
+            }
+        }
         if let tv = nsView.documentView as? ACPNSTextView {
             tv.placeholderText = Self.placeholder(for: session.transcript.streamingState, sendOnEnter: sendOnEnter)
             tv.needsDisplay = true
@@ -114,6 +122,7 @@ struct ACPInputField: NSViewRepresentable {
             worktreeRoot: worktreeRoot,
             initialDraft: composer.draft,
             isFocused: $isFocused,
+            focusRequest: focusRequest,
             sendOnEnter: sendOnEnter,
             onDraftChange: onDraftChange,
             onDraftClear: onDraftClear,
@@ -125,6 +134,7 @@ struct ACPInputField: NSViewRepresentable {
         let worktreeRoot: URL
         let initialDraft: ACPComposerDraft
         var isFocused: Binding<Bool>
+        var focusRequest: Int
         /// Keyboard-only inversion flag. The coordinator resolves the
         /// raw modifier-derived intent (`.auto` for ⏎, `.steer` for ⌥⏎)
         /// against this and emits a FINAL intent to `onSubmit`. The
@@ -168,6 +178,7 @@ struct ACPInputField: NSViewRepresentable {
             worktreeRoot: URL,
             initialDraft: ACPComposerDraft,
             isFocused: Binding<Bool> = .constant(false),
+            focusRequest: Int,
             sendOnEnter: Bool,
             onDraftChange: @escaping (ACPComposerDraft) -> Void,
             onDraftClear: @escaping () -> Void,
@@ -176,6 +187,7 @@ struct ACPInputField: NSViewRepresentable {
             self.worktreeRoot = worktreeRoot
             self.initialDraft = initialDraft
             self.isFocused = isFocused
+            self.focusRequest = focusRequest
             self.sendOnEnter = sendOnEnter
             self.lastSyncedDraft = initialDraft
             self.onDraftChange = onDraftChange

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -13,6 +13,7 @@ struct ACPComposer: View {
     /// `ACPInputField` so its placeholder reflects whichever action ⏎
     /// triggers under the current mapping.
     let sendOnEnter: Bool
+    let focusRequest: Int
     let onSubmit: ACPComposerSubmitHandler
 
     @Environment(\.theme) private var theme
@@ -27,6 +28,7 @@ struct ACPComposer: View {
         worktreeRoot: URL,
         agentLookup: @escaping (String) -> AgentDefinition?,
         sendOnEnter: Bool,
+        focusRequest: Int = 0,
         onSubmit: @escaping ACPComposerSubmitHandler
     ) {
         self._session = ObservedObject(wrappedValue: session)
@@ -35,6 +37,7 @@ struct ACPComposer: View {
         self.worktreeRoot = worktreeRoot
         self.agentLookup = agentLookup
         self.sendOnEnter = sendOnEnter
+        self.focusRequest = focusRequest
         self.onSubmit = onSubmit
     }
 
@@ -82,6 +85,7 @@ struct ACPComposer: View {
                 worktreeRoot: worktreeRoot,
                 actions: actions,
                 isFocused: $inputFocused,
+                focusRequest: focusRequest,
                 sendOnEnter: sendOnEnter,
                 onDraftChange: { draft in
                     manager.persistComposerDraft(draft, for: session)

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+enum ACPComposerPlacement: Equatable {
+    case bottom
+    case raisedEmpty
+}
+
 /// Floating glass pill composer. Wraps the AppKit-backed `ACPInputField`
 /// in the design's chrome: heavy blur, model + mode pickers on the right,
 /// animated send button that mirrors `session.transcript.streamingState`.
@@ -14,6 +19,7 @@ struct ACPComposer: View {
     /// triggers under the current mapping.
     let sendOnEnter: Bool
     let focusRequest: Int
+    let placement: ACPComposerPlacement
     let onSubmit: ACPComposerSubmitHandler
 
     @Environment(\.theme) private var theme
@@ -29,6 +35,7 @@ struct ACPComposer: View {
         agentLookup: @escaping (String) -> AgentDefinition?,
         sendOnEnter: Bool,
         focusRequest: Int = 0,
+        placement: ACPComposerPlacement = .bottom,
         onSubmit: @escaping ACPComposerSubmitHandler
     ) {
         self._session = ObservedObject(wrappedValue: session)
@@ -38,36 +45,63 @@ struct ACPComposer: View {
         self.agentLookup = agentLookup
         self.sendOnEnter = sendOnEnter
         self.focusRequest = focusRequest
+        self.placement = placement
         self.onSubmit = onSubmit
     }
 
     var body: some View {
+        Group {
+            switch placement {
+            case .bottom:
+                bottomBody
+            case .raisedEmpty:
+                raisedEmptyBody
+            }
+        }
+    }
+
+    private var bottomBody: some View {
         VStack(spacing: 0) {
             Spacer(minLength: 0)
-            HStack {
-                Spacer(minLength: 0)
-                pill.frame(maxWidth: 720)
-                Spacer(minLength: 0)
-            }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 18)
-            .padding(.top, 28)
+            composerRow
+                .padding(.bottom, 18)
+                .padding(.top, 28)
         }
-        .background(
-            // Very gentle bottom shim — just enough that the pill doesn't
-            // sit on a hard edge of transcript text. The transcript itself
-            // has 240pt of bottom padding so most content stays above the
-            // pill; this gradient only touches the last ~80pt.
-            LinearGradient(
-                stops: [
-                    .init(color: .clear, location: 0.0),
-                    .init(color: .clear, location: 0.55),
-                    .init(color: theme.color("bg-1").opacity(0.55), location: 1.0),
-                ],
-                startPoint: .top, endPoint: .bottom
-            )
-            .allowsHitTesting(false)
+        .background(bottomShim)
+    }
+
+    private var raisedEmptyBody: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+            composerRow
+                .padding(.top, 320)
+            Spacer(minLength: 110)
+        }
+    }
+
+    private var composerRow: some View {
+        HStack {
+            Spacer(minLength: 0)
+            pill.frame(maxWidth: 720)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private var bottomShim: some View {
+        // Very gentle bottom shim — just enough that the pill doesn't
+        // sit on a hard edge of transcript text. The transcript itself
+        // has 240pt of bottom padding so most content stays above the
+        // pill; this gradient only touches the last ~80pt.
+        LinearGradient(
+            stops: [
+                .init(color: .clear, location: 0.0),
+                .init(color: .clear, location: 0.55),
+                .init(color: theme.color("bg-1").opacity(0.55), location: 1.0),
+            ],
+            startPoint: .top, endPoint: .bottom
         )
+        .allowsHitTesting(false)
     }
 
     private var pill: some View {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -3,6 +3,17 @@ import SwiftUI
 enum ACPComposerPlacement: Equatable {
     case bottom
     case raisedEmpty
+
+    static func bottomInset(for placement: ACPComposerPlacement, containerHeight: CGFloat) -> CGFloat {
+        switch placement {
+        case .bottom:
+            return 18
+        case .raisedEmpty:
+            let target = containerHeight * 0.34
+            let roomAwareMaximum = max(96, containerHeight - 260)
+            return min(max(target, 96), min(320, roomAwareMaximum))
+        }
+    }
 }
 
 /// Floating glass pill composer. Wraps the AppKit-backed `ACPInputField`
@@ -50,32 +61,13 @@ struct ACPComposer: View {
     }
 
     var body: some View {
-        Group {
-            switch placement {
-            case .bottom:
-                bottomBody
-            case .raisedEmpty:
-                raisedEmptyBody
-            }
-        }
-    }
-
-    private var bottomBody: some View {
-        VStack(spacing: 0) {
-            Spacer(minLength: 0)
-            composerRow
-                .padding(.bottom, 18)
-                .padding(.top, 28)
-        }
-        .background(bottomShim)
-    }
-
-    private var raisedEmptyBody: some View {
-        VStack(spacing: 0) {
-            Spacer(minLength: 0)
-            composerRow
-                .padding(.top, 320)
-            Spacer(minLength: 110)
+        GeometryReader { proxy in
+            composerLayout(
+                bottomInset: ACPComposerPlacement.bottomInset(
+                    for: placement,
+                    containerHeight: proxy.size.height
+                )
+            )
         }
     }
 
@@ -86,6 +78,17 @@ struct ACPComposer: View {
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 24)
+    }
+
+    private func composerLayout(bottomInset: CGFloat) -> some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+            composerRow
+                .padding(.top, 28)
+                .padding(.bottom, bottomInset)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(bottomShim.opacity(placement == .bottom ? 1 : 0))
     }
 
     private var bottomShim: some View {

--- a/Alas/Sources/ACP/UI/ACPNewChatEmptyStatePolicy.swift
+++ b/Alas/Sources/ACP/UI/ACPNewChatEmptyStatePolicy.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+enum ACPNewChatEmptyStatePolicy {
+    static func isVisible(for session: ACPSession) -> Bool {
+        guard !session.restoredFromPersistence else { return false }
+        guard session.transcript.messages.isEmpty else { return false }
+        guard session.hydrationState == .ready else { return false }
+        guard session.lastError == nil else { return false }
+
+        if case .ready = session.setupState {
+            // continue
+        } else {
+            return false
+        }
+
+        if case .ready = session.agentState {
+            return true
+        }
+        return false
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
+++ b/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
@@ -50,27 +50,46 @@ struct ACPNewChatEmptyStateView: View {
     }
 
     private var starterChips: some View {
+        ViewThatFits(in: .horizontal) {
+            starterChipRow
+            starterChipColumn
+        }
+    }
+
+    private var starterChipRow: some View {
         HStack(spacing: 8) {
             ForEach(ACPStarterPrompt.allCases) { prompt in
-                Button {
-                    onStarterPrompt(prompt)
-                } label: {
-                    Text(prompt.label)
-                        .font(.system(size: 11.5, weight: .medium))
-                        .foregroundStyle(theme.color("fg-muted"))
-                        .lineLimit(1)
-                        .padding(.horizontal, 10)
-                        .frame(height: 28)
-                        .background(theme.color("bg-2").opacity(0.58))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 7)
-                                .strokeBorder(theme.color("line"), lineWidth: 0.6)
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 7))
-                }
-                .buttonStyle(.plain)
-                .help(prompt.promptText)
+                starterChip(prompt)
             }
         }
+    }
+
+    private var starterChipColumn: some View {
+        VStack(spacing: 8) {
+            ForEach(ACPStarterPrompt.allCases) { prompt in
+                starterChip(prompt)
+            }
+        }
+    }
+
+    private func starterChip(_ prompt: ACPStarterPrompt) -> some View {
+        Button {
+            onStarterPrompt(prompt)
+        } label: {
+            Text(prompt.label)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(theme.color("fg-muted"))
+                .lineLimit(1)
+                .padding(.horizontal, 10)
+                .frame(height: 28)
+                .background(theme.color("bg-2").opacity(0.58))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.6)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 7))
+        }
+        .buttonStyle(.plain)
+        .help(prompt.promptText)
     }
 }

--- a/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
+++ b/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct ACPNewChatEmptyStateView: View {
+    let agentDisplayName: String
+    let onStarterPrompt: (ACPStarterPrompt) -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 14) {
+            mark
+            VStack(spacing: 5) {
+                Text("What should we work on?")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(theme.color("fg"))
+                Text("Start with a task, a file, or a rough idea.")
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(theme.color("fg-dim"))
+            }
+            starterChips
+        }
+        .frame(maxWidth: 640)
+        .padding(.horizontal, 28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(.bottom, 210)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("New \(agentDisplayName) chat")
+    }
+
+    private var mark: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            theme.color("accent-soft"),
+                            theme.color("bg-2").opacity(0.45),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(theme.color("accent").opacity(0.28), lineWidth: 0.75)
+            Image(systemName: "sparkle")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(theme.color("accent"))
+        }
+        .frame(width: 40, height: 40)
+    }
+
+    private var starterChips: some View {
+        HStack(spacing: 8) {
+            ForEach(ACPStarterPrompt.allCases) { prompt in
+                Button {
+                    onStarterPrompt(prompt)
+                } label: {
+                    Text(prompt.label)
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(theme.color("fg-muted"))
+                        .lineLimit(1)
+                        .padding(.horizontal, 10)
+                        .frame(height: 28)
+                        .background(theme.color("bg-2").opacity(0.58))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 7)
+                                .strokeBorder(theme.color("line"), lineWidth: 0.6)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 7))
+                }
+                .buttonStyle(.plain)
+                .help(prompt.promptText)
+            }
+        }
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPStarterPrompt.swift
+++ b/Alas/Sources/ACP/UI/ACPStarterPrompt.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+enum ACPStarterPrompt: String, CaseIterable, Identifiable {
+    case reviewChanges
+    case findBug
+    case planFeature
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .reviewChanges:
+            return "Review current changes"
+        case .findBug:
+            return "Find a bug"
+        case .planFeature:
+            return "Plan a feature"
+        }
+    }
+
+    var promptText: String {
+        switch self {
+        case .reviewChanges:
+            return "Review the current changes in this worktree and suggest the next steps."
+        case .findBug:
+            return "Look for likely bugs or fragile spots in this worktree. Start by inspecting the current changes."
+        case .planFeature:
+            return "Help me plan this feature. Ask clarifying questions first if the goal is ambiguous."
+        }
+    }
+
+    func applying(to draft: ACPComposerDraft) -> ACPComposerDraft {
+        let prompt = ACPComposerDraft(segments: [.text(promptText)])
+        if draft.isEmpty { return prompt }
+
+        var segments = draft.segments
+        if case .text(let text) = segments[segments.count - 1] {
+            segments[segments.count - 1] = .text(text + "\n\n")
+        } else {
+            segments.append(.text("\n\n"))
+        }
+        return ACPComposerDraft(segments: segments + prompt.segments)
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -60,6 +60,7 @@ private struct ACPSessionView: View {
     @Environment(\.theme) private var theme
     @State private var showPlanSidebar: Bool = false
     @State private var suppressRestoredPlanSidebarPlanChange: Bool = false
+    @State private var composerFocusRequest: Int = 0
 
     /// Re-evaluated on every width / plan change. Pure call into the
     /// hysteresis reducer; the `.spring` wrap lives at the call site.
@@ -144,6 +145,12 @@ private struct ACPSessionView: View {
         }
     }
 
+    private func insertStarterPrompt(_ starter: ACPStarterPrompt) {
+        let next = starter.applying(to: session.composerDraft)
+        manager.persistComposerDraft(next, for: session)
+        composerFocusRequest += 1
+    }
+
     /// True when we're actively spawning + initialising the agent on a
     /// fresh open. Don't show the empty transcript or "agent not yet
     /// attached" warning during this — render a skeleton instead.
@@ -157,6 +164,18 @@ private struct ACPSessionView: View {
         return session.transcript.messages.isEmpty
     }
 
+    private var isNewEmptySession: Bool {
+        ACPNewChatEmptyStatePolicy.isVisible(for: session)
+    }
+
+    private var composerPlacement: ACPComposerPlacement {
+        isNewEmptySession ? .raisedEmpty : .bottom
+    }
+
+    private var emptyStateAnimation: Animation {
+        .spring(response: 0.32, dampingFraction: 0.86)
+    }
+
     private var transcriptAndComposer: some View {
         GeometryReader { proxy in
             HStack(spacing: 0) {
@@ -166,66 +185,77 @@ private struct ACPSessionView: View {
                             agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId
                         )
                     } else {
-                        ACPMessageList(
-                            session: session,
-                            transcript: session.transcript,
-                            onOpenDiff: { relativePath in
-                                state.openDiffTab(forFileInWorktree: worktree, relativePath: relativePath)
-                            },
-                            // Use the runner's policy (where the agent's continuation
-                            // lives) — otherwise the user's click can't resolve the
-                            // pending permission request.
-                            policy: manager.runners[sessionId]?.policy,
-                            scopeKey: scopeKey(for: session.transcript.pendingPermission),
-                            onQueueEdit: { item in
-                                // Pull the queued prompt back into the composer
-                                // for editing — appended after any text the user
-                                // has already typed so nothing is clobbered.
-                                // `takeForEditing` removes the item and returns
-                                // its draft ONLY if it's still `.pending`; a
-                                // `.sending` item (promoted by the flusher
-                                // between render and click) returns nil and is
-                                // left in flight, so it can't be duplicated.
-                                guard let restored = session.takeForEditing(id: item.id) else { return }
-                                manager.persistComposerDraft(
-                                    session.composerDraft.appending(restored), for: session)
-                                manager.persistQueue(for: session)
-                                // Discarding the head can unblock a successor
-                                // that was waiting behind a `lastError` head.
-                                manager.runners[sessionId]?.flushQueueIfIdle()
-                            },
-                            onQueueRemove: { id in
-                                session.removeFromQueue(id: id)
-                                manager.persistQueue(for: session)
-                                manager.runners[sessionId]?.flushQueueIfIdle()
-                            },
-                            onQueueRetry: { id in
-                                guard let idx = session.queue.firstIndex(where: { $0.id == id }) else { return }
-                                session.queue[idx].lastError = nil
-                                manager.persistQueue(for: session)
-                                manager.runners[sessionId]?.flushQueueIfIdle()
-                            },
-                            onQueueReorder: { src, dst in
-                                session.moveInQueue(from: src, to: dst)
-                                manager.persistQueue(for: session)
-                                // Reordering can move a clean prompt to the head
-                                // where it can finally drain.
-                                manager.runners[sessionId]?.flushQueueIfIdle()
-                            },
-                            onQueueClearAll: {
-                                session.clearPendingQueue()
-                                manager.persistQueue(for: session)
-                                // No-op if the queue is now empty, but if a
-                                // `.sending` head survives the clear and the
-                                // user re-enqueues, the next idle drain still
-                                // needs to fire from this path.
-                                manager.runners[sessionId]?.flushQueueIfIdle()
-                            },
-                            onLoadFullToolCallContent: { toolCallId in
-                                manager.reloadFullToolCallContent(
-                                    sessionId: sessionId, toolCallId: toolCallId)
-                            }
-                        )
+                        if isNewEmptySession {
+                            ACPNewChatEmptyStateView(
+                                agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
+                                onStarterPrompt: insertStarterPrompt
+                            )
+                            .transition(
+                                .opacity.combined(with: .move(edge: .top))
+                            )
+                        } else {
+                            ACPMessageList(
+                                session: session,
+                                transcript: session.transcript,
+                                onOpenDiff: { relativePath in
+                                    state.openDiffTab(forFileInWorktree: worktree, relativePath: relativePath)
+                                },
+                                // Use the runner's policy (where the agent's continuation
+                                // lives) — otherwise the user's click can't resolve the
+                                // pending permission request.
+                                policy: manager.runners[sessionId]?.policy,
+                                scopeKey: scopeKey(for: session.transcript.pendingPermission),
+                                onQueueEdit: { item in
+                                    // Pull the queued prompt back into the composer
+                                    // for editing — appended after any text the user
+                                    // has already typed so nothing is clobbered.
+                                    // `takeForEditing` removes the item and returns
+                                    // its draft ONLY if it's still `.pending`; a
+                                    // `.sending` item (promoted by the flusher
+                                    // between render and click) returns nil and is
+                                    // left in flight, so it can't be duplicated.
+                                    guard let restored = session.takeForEditing(id: item.id) else { return }
+                                    manager.persistComposerDraft(
+                                        session.composerDraft.appending(restored), for: session)
+                                    manager.persistQueue(for: session)
+                                    // Discarding the head can unblock a successor
+                                    // that was waiting behind a `lastError` head.
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onQueueRemove: { id in
+                                    session.removeFromQueue(id: id)
+                                    manager.persistQueue(for: session)
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onQueueRetry: { id in
+                                    guard let idx = session.queue.firstIndex(where: { $0.id == id }) else { return }
+                                    session.queue[idx].lastError = nil
+                                    manager.persistQueue(for: session)
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onQueueReorder: { src, dst in
+                                    session.moveInQueue(from: src, to: dst)
+                                    manager.persistQueue(for: session)
+                                    // Reordering can move a clean prompt to the head
+                                    // where it can finally drain.
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onQueueClearAll: {
+                                    session.clearPendingQueue()
+                                    manager.persistQueue(for: session)
+                                    // No-op if the queue is now empty, but if a
+                                    // `.sending` head survives the clear and the
+                                    // user re-enqueues, the next idle drain still
+                                    // needs to fire from this path.
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onLoadFullToolCallContent: { toolCallId in
+                                    manager.reloadFullToolCallContent(
+                                        sessionId: sessionId, toolCallId: toolCallId)
+                                }
+                            )
+                            .transition(.opacity)
+                        }
                     }
 
                     ACPComposer(
@@ -233,7 +263,9 @@ private struct ACPSessionView: View {
                         manager: manager,
                         worktreeRoot: worktree.path,
                         agentLookup: { state.agent(id: $0) },
-                        sendOnEnter: state.config.harness.acpSendOnEnter
+                        sendOnEnter: state.config.harness.acpSendOnEnter,
+                        focusRequest: composerFocusRequest,
+                        placement: composerPlacement
                     ) { text, attachments, intent, draft, onPromptFinished -> Bool in
                         // `intent` is already resolved by the composer for keyboard
                         // submits; the toolbar send button bypasses the keyboard
@@ -295,6 +327,7 @@ private struct ACPSessionView: View {
                         .transition(.opacity)
                     }
                 }
+                .animation(emptyStateAnimation, value: isNewEmptySession)
 
                 if showPlanSidebar {
                     ACPPlanSidebar(

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -17,6 +17,7 @@ struct ACPComposerDraftBridgeTests {
                 get: { focused },
                 set: { focused = $0 }
             ),
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: { _ in },
             onDraftClear: {},
@@ -46,6 +47,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
@@ -81,6 +83,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
@@ -110,6 +113,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: {
                 #expect($0 == draft)
@@ -142,6 +146,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: {},
@@ -168,6 +173,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: { _ in },
             onDraftClear: {},
@@ -204,6 +210,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
@@ -242,6 +249,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
@@ -275,6 +283,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: submittedDraft,
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
@@ -300,6 +309,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: submittedDraft,
+            focusRequest: 0,
             sendOnEnter: true,
             onDraftChange: { changedDrafts.append($0) },
             onDraftClear: { clearCount += 1 },
@@ -329,6 +339,7 @@ struct ACPComposerDraftBridgeTests {
         let coordinator = ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            focusRequest: 0,
             sendOnEnter: false,           // user inverted the setting
             onDraftChange: { _ in },
             onDraftClear: {},
@@ -519,6 +530,7 @@ struct ACPComposerDraftBridgeTests {
         ACPInputField.Coordinator(
             worktreeRoot: URL(fileURLWithPath: "/tmp"),
             initialDraft: .empty,
+            focusRequest: 0,
             sendOnEnter: sendOnEnter,
             onDraftChange: { _ in },
             onDraftClear: {},

--- a/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
+++ b/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
@@ -124,4 +124,33 @@ struct ACPNewChatEmptyStateTests {
 
         #expect(ACPNewChatEmptyStatePolicy.isVisible(for: session))
     }
+
+    @Test("starter prompt replaces an empty draft")
+    func starterPromptReplacesEmptyDraft() {
+        let draft = ACPStarterPrompt.reviewChanges.applying(to: .empty)
+
+        #expect(draft == ACPComposerDraft(segments: [
+            .text("Review the current changes in this worktree and suggest the next steps.")
+        ]))
+    }
+
+    @Test("starter prompt appends after non-empty text with a blank line")
+    func starterPromptAppendsAfterExistingText() {
+        let existing = ACPComposerDraft(segments: [.text("Existing note")])
+        let draft = ACPStarterPrompt.planFeature.applying(to: existing)
+
+        #expect(draft == ACPComposerDraft(segments: [
+            .text("Existing note\n\n"),
+            .text("Help me plan this feature. Ask clarifying questions first if the goal is ambiguous.")
+        ]))
+    }
+
+    @Test("starter prompts expose stable short labels")
+    func starterPromptLabelsAreStable() {
+        #expect(ACPStarterPrompt.allCases.map(\.label) == [
+            "Review current changes",
+            "Find a bug",
+            "Plan a feature",
+        ])
+    }
 }

--- a/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
+++ b/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP new chat empty state")
+struct ACPNewChatEmptyStateTests {
+    @Test("fresh ready empty sessions show the new empty state")
+    func freshReadyEmptySessionShowsEmptyState() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "New session")
+        session.setupState = .ready
+        session.agentState = .ready
+
+        #expect(ACPNewChatEmptyStatePolicy.isVisible(for: session))
+    }
+
+    @Test("restored sessions do not show the new empty state")
+    func restoredSessionDoesNotShowEmptyState() {
+        let session = ACPSession(
+            id: "s",
+            agentId: "codex",
+            worktreeId: "wt",
+            title: "Restored",
+            hydrationState: .ready,
+            restoredFromPersistence: true
+        )
+        session.setupState = .ready
+        session.agentState = .ready
+
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: session))
+    }
+
+    @Test("hydrating and failed sessions do not show the new empty state")
+    func unavailableSessionStatesDoNotShowEmptyState() {
+        let loading = ACPSession(
+            id: "loading",
+            agentId: "codex",
+            worktreeId: "wt",
+            title: "Loading",
+            hydrationState: .loading
+        )
+        loading.setupState = .ready
+        loading.agentState = .ready
+
+        let failed = ACPSession(
+            id: "failed",
+            agentId: "codex",
+            worktreeId: "wt",
+            title: "Failed",
+            hydrationState: .failed("boom")
+        )
+        failed.setupState = .ready
+        failed.agentState = .ready
+
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: loading))
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: failed))
+    }
+
+    @Test("setup problems, agent failures, and existing transcript suppress the new empty state")
+    func blockedOrNonEmptySessionsDoNotShowEmptyState() {
+        let setup = ACPSession(id: "setup", agentId: "codex", worktreeId: "wt", title: "Setup")
+        setup.setupState = .needsSetup(reason: "Install Codex")
+        setup.agentState = .ready
+
+        let errored = ACPSession(id: "errored", agentId: "codex", worktreeId: "wt", title: "Errored")
+        errored.setupState = .ready
+        errored.agentState = .failed("boom")
+
+        let messaged = ACPSession(id: "messaged", agentId: "codex", worktreeId: "wt", title: "Messaged")
+        messaged.setupState = .ready
+        messaged.agentState = .ready
+        messaged.transcript.messages.append(.systemNotice(id: UUID(), text: "notice"))
+
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: setup))
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: errored))
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: messaged))
+    }
+
+    @Test("session errors suppress the new empty state")
+    func sessionErrorsDoNotShowEmptyState() {
+        let session = ACPSession(id: "errored", agentId: "codex", worktreeId: "wt", title: "Errored")
+        session.setupState = .ready
+        session.agentState = .ready
+        session.lastError = "boom"
+
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: session))
+    }
+
+    @Test("setup checking and unavailable agent states suppress the new empty state")
+    func unavailableReadinessStatesDoNotShowEmptyState() {
+        let checkingSetup = ACPSession(id: "checking", agentId: "codex", worktreeId: "wt", title: "Checking")
+        checkingSetup.setupState = .checking
+        checkingSetup.agentState = .ready
+
+        let idleAgent = ACPSession(id: "idle", agentId: "codex", worktreeId: "wt", title: "Idle")
+        idleAgent.setupState = .ready
+        idleAgent.agentState = .idle
+
+        let spawningAgent = ACPSession(id: "spawning", agentId: "codex", worktreeId: "wt", title: "Spawning")
+        spawningAgent.setupState = .ready
+        spawningAgent.agentState = .spawning
+
+        let disconnectedAgent = ACPSession(
+            id: "disconnected",
+            agentId: "codex",
+            worktreeId: "wt",
+            title: "Disconnected"
+        )
+        disconnectedAgent.setupState = .ready
+        disconnectedAgent.agentState = .disconnected
+
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: checkingSetup))
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: idleAgent))
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: spawningAgent))
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: disconnectedAgent))
+    }
+
+    @Test("fresh attached sessions remain empty even after receiving a remote session id")
+    func remoteSessionIdDoesNotSuppressFreshEmptyState() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "New session")
+        session.setupState = .ready
+        session.agentState = .ready
+        session.remoteSessionId = "remote-id"
+
+        #expect(ACPNewChatEmptyStatePolicy.isVisible(for: session))
+    }
+}

--- a/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
+++ b/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
@@ -153,4 +153,17 @@ struct ACPNewChatEmptyStateTests {
             "Plan a feature",
         ])
     }
+
+    @Test("raised composer placement scales with available height")
+    func raisedComposerPlacementScalesWithAvailableHeight() {
+        let bottom = ACPComposerPlacement.bottomInset(for: .bottom, containerHeight: 800)
+        let shortRaised = ACPComposerPlacement.bottomInset(for: .raisedEmpty, containerHeight: 360)
+        let regularRaised = ACPComposerPlacement.bottomInset(for: .raisedEmpty, containerHeight: 720)
+        let tallRaised = ACPComposerPlacement.bottomInset(for: .raisedEmpty, containerHeight: 1_200)
+
+        #expect(bottom == 18)
+        #expect(shortRaised > bottom)
+        #expect(regularRaised > shortRaised)
+        #expect(tallRaised == 320)
+    }
 }

--- a/docs/superpowers/plans/2026-06-01-acp-new-chat-empty-state.md
+++ b/docs/superpowers/plans/2026-06-01-acp-new-chat-empty-state.md
@@ -1,0 +1,869 @@
+# ACP New Chat Empty State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the approved centered ACP new-chat empty state with clickable starter prompts and a smooth transition back to the existing bottom composer after the first prompt starts.
+
+**Architecture:** Keep the feature local to the ACP UI. Add small pure helpers for the new-session visibility rule and starter prompt draft insertion, then wire those helpers into `ACPTabView`, `ACPComposer`, and `ACPInputField` without changing ACP protocol lifecycle or persistence semantics.
+
+**Tech Stack:** Swift 5.9, SwiftUI, AppKit `NSViewRepresentable`, Swift Testing, XcodeGen.
+
+---
+
+## File Structure
+
+- Create `Alas/Sources/ACP/UI/ACPNewChatEmptyStatePolicy.swift`
+  - Owns the pure visibility decision for the new empty state.
+- Create `Alas/Sources/ACP/UI/ACPStarterPrompt.swift`
+  - Owns chip labels, inserted prompt text, and draft appending behavior.
+- Create `Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift`
+  - Renders only the welcome text and starter chips. It does not own the composer.
+- Modify `Alas/Sources/ACP/UI/ACPComposer.swift`
+  - Adds a focus request token to `ACPInputField` so starter chips can focus the AppKit text view after inserting text.
+- Modify `Alas/Sources/ACP/UI/ACPComposerShell.swift`
+  - Adds a composer placement mode so the same composer can render in the current bottom position or raised new-chat position.
+- Modify `Alas/Sources/ACP/UI/ACPTabView.swift`
+  - Computes the new empty state, renders the welcome overlay, inserts starter prompts through existing draft persistence, and animates the composer placement change.
+- Create `AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift`
+  - Covers pure policy and starter prompt draft behavior.
+- Regenerate `Alas.xcodeproj` with `xcodegen` after adding source and test files.
+
+## Task 1: Add Pure Empty-State Policy
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPNewChatEmptyStatePolicy.swift`
+- Test: `AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift`
+
+- [ ] **Step 1: Write the failing policy tests**
+
+Create `AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+@Suite("ACP new chat empty state")
+struct ACPNewChatEmptyStateTests {
+    @Test("fresh ready empty sessions show the new empty state")
+    func freshReadyEmptySessionShowsEmptyState() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "New session")
+        session.setupState = .ready
+        session.agentState = .ready
+
+        #expect(ACPNewChatEmptyStatePolicy.isVisible(for: session))
+    }
+
+    @Test("restored sessions do not show the new empty state")
+    func restoredSessionDoesNotShowEmptyState() {
+        let session = ACPSession(
+            id: "s",
+            agentId: "codex",
+            worktreeId: "wt",
+            title: "Restored",
+            hydrationState: .ready,
+            restoredFromPersistence: true
+        )
+        session.setupState = .ready
+        session.agentState = .ready
+
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: session))
+    }
+
+    @Test("hydrating and failed sessions do not show the new empty state")
+    func unavailableSessionStatesDoNotShowEmptyState() {
+        let loading = ACPSession(
+            id: "loading",
+            agentId: "codex",
+            worktreeId: "wt",
+            title: "Loading",
+            hydrationState: .loading
+        )
+        loading.setupState = .ready
+        loading.agentState = .ready
+
+        let failed = ACPSession(
+            id: "failed",
+            agentId: "codex",
+            worktreeId: "wt",
+            title: "Failed",
+            hydrationState: .failed("boom")
+        )
+        failed.setupState = .ready
+        failed.agentState = .ready
+
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: loading))
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: failed))
+    }
+
+    @Test("setup problems, agent failures, and existing transcript suppress the new empty state")
+    func blockedOrNonEmptySessionsDoNotShowEmptyState() {
+        let setup = ACPSession(id: "setup", agentId: "codex", worktreeId: "wt", title: "Setup")
+        setup.setupState = .needsSetup(reason: "Install Codex")
+        setup.agentState = .ready
+
+        let errored = ACPSession(id: "errored", agentId: "codex", worktreeId: "wt", title: "Errored")
+        errored.setupState = .ready
+        errored.agentState = .failed("boom")
+
+        let messaged = ACPSession(id: "messaged", agentId: "codex", worktreeId: "wt", title: "Messaged")
+        messaged.setupState = .ready
+        messaged.agentState = .ready
+        messaged.transcript.messages.append(.systemNotice(id: UUID(), text: "notice"))
+
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: setup))
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: errored))
+        #expect(!ACPNewChatEmptyStatePolicy.isVisible(for: messaged))
+    }
+
+    @Test("fresh attached sessions remain empty even after receiving a remote session id")
+    func remoteSessionIdDoesNotSuppressFreshEmptyState() {
+        let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "New session")
+        session.setupState = .ready
+        session.agentState = .ready
+        session.remoteSessionId = "remote-id"
+
+        #expect(ACPNewChatEmptyStatePolicy.isVisible(for: session))
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPNewChatEmptyStateTests
+```
+
+Expected: FAIL because `ACPNewChatEmptyStatePolicy` does not exist.
+
+- [ ] **Step 3: Add the minimal policy implementation**
+
+Create `Alas/Sources/ACP/UI/ACPNewChatEmptyStatePolicy.swift`:
+
+```swift
+import Foundation
+
+@MainActor
+enum ACPNewChatEmptyStatePolicy {
+    static func isVisible(for session: ACPSession) -> Bool {
+        guard !session.restoredFromPersistence else { return false }
+        guard session.transcript.messages.isEmpty else { return false }
+        guard session.hydrationState == .ready else { return false }
+        guard session.lastError == nil else { return false }
+
+        if case .ready = session.setupState {
+            // continue
+        } else {
+            return false
+        }
+
+        if case .ready = session.agentState {
+            return true
+        }
+        return false
+    }
+}
+```
+
+- [ ] **Step 4: Regenerate the Xcode project**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: succeeds and updates `Alas.xcodeproj` if the file list changed.
+
+- [ ] **Step 5: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPNewChatEmptyStateTests
+```
+
+Expected: PASS for all policy tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/ACP/UI/ACPNewChatEmptyStatePolicy.swift AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift Alas.xcodeproj
+git commit -m "test: cover ACP new chat empty state policy"
+```
+
+## Task 2: Add Starter Prompt Draft Behavior
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPStarterPrompt.swift`
+- Modify: `AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift`
+
+- [ ] **Step 1: Add failing starter prompt tests**
+
+Append these tests inside `ACPNewChatEmptyStateTests`:
+
+```swift
+    @Test("starter prompt replaces an empty draft")
+    func starterPromptReplacesEmptyDraft() {
+        let draft = ACPStarterPrompt.reviewChanges.applying(to: .empty)
+
+        #expect(draft == ACPComposerDraft(segments: [
+            .text("Review the current changes in this worktree and suggest the next steps.")
+        ]))
+    }
+
+    @Test("starter prompt appends after non-empty text with a blank line")
+    func starterPromptAppendsAfterExistingText() {
+        let existing = ACPComposerDraft(segments: [.text("Existing note")])
+        let draft = ACPStarterPrompt.planFeature.applying(to: existing)
+
+        #expect(draft == ACPComposerDraft(segments: [
+            .text("Existing note\n\n"),
+            .text("Help me plan this feature. Ask clarifying questions first if the goal is ambiguous.")
+        ]))
+    }
+
+    @Test("starter prompts expose stable short labels")
+    func starterPromptLabelsAreStable() {
+        #expect(ACPStarterPrompt.allCases.map(\.label) == [
+            "Review current changes",
+            "Find a bug",
+            "Plan a feature",
+        ])
+    }
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPNewChatEmptyStateTests
+```
+
+Expected: FAIL because `ACPStarterPrompt` does not exist.
+
+- [ ] **Step 3: Add the starter prompt helper**
+
+Create `Alas/Sources/ACP/UI/ACPStarterPrompt.swift`:
+
+```swift
+import Foundation
+
+enum ACPStarterPrompt: String, CaseIterable, Identifiable {
+    case reviewChanges
+    case findBug
+    case planFeature
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .reviewChanges:
+            return "Review current changes"
+        case .findBug:
+            return "Find a bug"
+        case .planFeature:
+            return "Plan a feature"
+        }
+    }
+
+    var promptText: String {
+        switch self {
+        case .reviewChanges:
+            return "Review the current changes in this worktree and suggest the next steps."
+        case .findBug:
+            return "Look for likely bugs or fragile spots in this worktree. Start by inspecting the current changes."
+        case .planFeature:
+            return "Help me plan this feature. Ask clarifying questions first if the goal is ambiguous."
+        }
+    }
+
+    func applying(to draft: ACPComposerDraft) -> ACPComposerDraft {
+        let prompt = ACPComposerDraft(segments: [.text(promptText)])
+        if draft.isEmpty { return prompt }
+        return ACPComposerDraft(segments: draft.segments + [.text("\n\n")] + prompt.segments)
+    }
+}
+```
+
+- [ ] **Step 4: Regenerate the Xcode project**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: succeeds.
+
+- [ ] **Step 5: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPNewChatEmptyStateTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/ACP/UI/ACPStarterPrompt.swift AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift Alas.xcodeproj
+git commit -m "feat: add ACP starter prompt drafts"
+```
+
+## Task 3: Add Focus Request Plumbing to the Composer
+
+**Files:**
+- Modify: `Alas/Sources/ACP/UI/ACPComposer.swift`
+- Modify: `Alas/Sources/ACP/UI/ACPComposerShell.swift`
+
+- [ ] **Step 1: Add a focus request parameter to `ACPInputField`**
+
+In `Alas/Sources/ACP/UI/ACPComposer.swift`, add the stored property near `@Binding var isFocused`:
+
+```swift
+    let focusRequest: Int
+```
+
+Update the `ACPInputField` initializer call in `ACPComposerShell.swift` to pass the new value:
+
+```swift
+                focusRequest: focusRequest,
+```
+
+Expected: the project does not compile yet because `ACPComposer` does not define `focusRequest`.
+
+- [ ] **Step 2: Add focus tracking in the AppKit coordinator**
+
+In `ACPInputField.updateNSView`, after `context.coordinator.sendOnEnter = sendOnEnter`, add:
+
+```swift
+        if context.coordinator.focusRequest != focusRequest {
+            context.coordinator.focusRequest = focusRequest
+            if let tv = nsView.documentView as? ACPNSTextView,
+               let window = tv.window {
+                window.makeFirstResponder(tv)
+            }
+        }
+```
+
+In `ACPInputField.makeCoordinator()`, pass the token:
+
+```swift
+            focusRequest: focusRequest,
+```
+
+In `Coordinator`, add the stored property near `var sendOnEnter`:
+
+```swift
+        var focusRequest: Int
+```
+
+Update the coordinator initializer signature and assignment:
+
+```swift
+            focusRequest: Int,
+```
+
+```swift
+            self.focusRequest = focusRequest
+```
+
+- [ ] **Step 3: Thread focus request through `ACPComposer`**
+
+In `Alas/Sources/ACP/UI/ACPComposerShell.swift`, add a stored property near `sendOnEnter`:
+
+```swift
+    let focusRequest: Int
+```
+
+Update `ACPComposer.init` to accept a defaulted parameter before `onSubmit`:
+
+```swift
+        focusRequest: Int = 0,
+```
+
+Assign it in the initializer:
+
+```swift
+        self.focusRequest = focusRequest
+```
+
+Pass it into `ACPInputField`:
+
+```swift
+                focusRequest: focusRequest,
+```
+
+- [ ] **Step 4: Build to verify focus plumbing compiles**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Alas/Sources/ACP/UI/ACPComposer.swift Alas/Sources/ACP/UI/ACPComposerShell.swift
+git commit -m "feat: let ACP composer refocus on request"
+```
+
+## Task 4: Add Composer Placement Mode
+
+**Files:**
+- Modify: `Alas/Sources/ACP/UI/ACPComposerShell.swift`
+
+- [ ] **Step 1: Add placement type**
+
+At the top of `Alas/Sources/ACP/UI/ACPComposerShell.swift`, after the imports, add:
+
+```swift
+enum ACPComposerPlacement: Equatable {
+    case bottom
+    case raisedEmpty
+}
+```
+
+Add a stored property to `ACPComposer`:
+
+```swift
+    let placement: ACPComposerPlacement
+```
+
+Update `ACPComposer.init` to accept a defaulted placement:
+
+```swift
+        placement: ACPComposerPlacement = .bottom,
+```
+
+Assign it:
+
+```swift
+        self.placement = placement
+```
+
+- [ ] **Step 2: Split the composer layout body**
+
+Replace the current `var body: some View` in `ACPComposer` with:
+
+```swift
+    var body: some View {
+        Group {
+            switch placement {
+            case .bottom:
+                bottomBody
+            case .raisedEmpty:
+                raisedEmptyBody
+            }
+        }
+    }
+
+    private var bottomBody: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+            composerRow
+                .padding(.bottom, 18)
+                .padding(.top, 28)
+        }
+        .background(bottomShim)
+    }
+
+    private var raisedEmptyBody: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+            composerRow
+                .padding(.top, 320)
+            Spacer(minLength: 110)
+        }
+    }
+
+    private var composerRow: some View {
+        HStack {
+            Spacer(minLength: 0)
+            pill.frame(maxWidth: 720)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private var bottomShim: some View {
+        LinearGradient(
+            stops: [
+                .init(color: .clear, location: 0.0),
+                .init(color: .clear, location: 0.55),
+                .init(color: theme.color("bg-1").opacity(0.55), location: 1.0),
+            ],
+            startPoint: .top, endPoint: .bottom
+        )
+        .allowsHitTesting(false)
+    }
+```
+
+The `raisedEmptyBody` keeps the composer above the bottom while remaining responsive to pane height. If this looks too low or high in manual verification, adjust only the `padding(.top, 320)` and `Spacer(minLength: 110)` constants.
+
+- [ ] **Step 3: Build to verify placement compiles**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds and existing `ACPComposer` call sites still compile because placement defaults to `.bottom`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Alas/Sources/ACP/UI/ACPComposerShell.swift
+git commit -m "feat: add raised ACP composer placement"
+```
+
+## Task 5: Add the Welcome and Starter Chip View
+
+**Files:**
+- Create: `Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift`
+
+- [ ] **Step 1: Create the new empty-state view**
+
+Create `Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift`:
+
+```swift
+import SwiftUI
+
+struct ACPNewChatEmptyStateView: View {
+    let agentDisplayName: String
+    let onStarterPrompt: (ACPStarterPrompt) -> Void
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 14) {
+            mark
+            VStack(spacing: 5) {
+                Text("What should we work on?")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(theme.color("fg"))
+                Text("Start with a task, a file, or a rough idea.")
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(theme.color("fg-dim"))
+            }
+            starterChips
+        }
+        .frame(maxWidth: 640)
+        .padding(.horizontal, 28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .padding(.bottom, 210)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("New \(agentDisplayName) chat")
+    }
+
+    private var mark: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            theme.color("accent-soft"),
+                            theme.color("bg-2").opacity(0.45),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(theme.color("accent").opacity(0.28), lineWidth: 0.75)
+            Image(systemName: "sparkle")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(theme.color("accent"))
+        }
+        .frame(width: 40, height: 40)
+    }
+
+    private var starterChips: some View {
+        HStack(spacing: 8) {
+            ForEach(ACPStarterPrompt.allCases) { prompt in
+                Button {
+                    onStarterPrompt(prompt)
+                } label: {
+                    Text(prompt.label)
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(theme.color("fg-muted"))
+                        .lineLimit(1)
+                        .padding(.horizontal, 10)
+                        .frame(height: 28)
+                        .background(theme.color("bg-2").opacity(0.58))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 7)
+                                .strokeBorder(theme.color("line"), lineWidth: 0.6)
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 7))
+                }
+                .buttonStyle(.plain)
+                .help(prompt.promptText)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the Xcode project**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: succeeds.
+
+- [ ] **Step 3: Build to verify the new view compiles**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift Alas.xcodeproj
+git commit -m "feat: add ACP new chat welcome view"
+```
+
+## Task 6: Wire the Empty State into `ACPTabView`
+
+**Files:**
+- Modify: `Alas/Sources/ACP/UI/ACPTabView.swift`
+
+- [ ] **Step 1: Add local animation and focus state**
+
+Inside `ACPSessionView`, near the existing `@State private var showPlanSidebar`, add:
+
+```swift
+    @State private var composerFocusRequest: Int = 0
+```
+
+Add these computed properties near `isConnecting`:
+
+```swift
+    private var isNewEmptySession: Bool {
+        ACPNewChatEmptyStatePolicy.isVisible(for: session)
+    }
+
+    private var composerPlacement: ACPComposerPlacement {
+        isNewEmptySession ? .raisedEmpty : .bottom
+    }
+
+    private var emptyStateAnimation: Animation {
+        .spring(response: 0.32, dampingFraction: 0.86)
+    }
+```
+
+- [ ] **Step 2: Add starter prompt insertion**
+
+Inside `ACPSessionView`, add this method near `handleEscape()`:
+
+```swift
+    private func insertStarterPrompt(_ starter: ACPStarterPrompt) {
+        let next = starter.applying(to: session.composerDraft)
+        manager.persistComposerDraft(next, for: session)
+        composerFocusRequest += 1
+    }
+```
+
+- [ ] **Step 3: Render the welcome overlay and pass composer mode**
+
+In `transcriptAndComposer`, replace the `if isConnecting { ... } else { ACPMessageList(...) }` branch with this structure:
+
+```swift
+                    if isConnecting {
+                        ACPConnectingPlaceholder(
+                            agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId
+                        )
+                    } else {
+                        if isNewEmptySession {
+                            ACPNewChatEmptyStateView(
+                                agentDisplayName: state.agent(id: session.agentId)?.displayName ?? session.agentId,
+                                onStarterPrompt: insertStarterPrompt
+                            )
+                            .transition(
+                                .opacity.combined(with: .move(edge: .top))
+                            )
+                        } else {
+                            ACPMessageList(
+                                session: session,
+                                transcript: session.transcript,
+                                onOpenDiff: { relativePath in
+                                    state.openDiffTab(forFileInWorktree: worktree, relativePath: relativePath)
+                                },
+                                policy: manager.runners[sessionId]?.policy,
+                                scopeKey: scopeKey(for: session.transcript.pendingPermission),
+                                onQueueEdit: { item in
+                                    guard let restored = session.takeForEditing(id: item.id) else { return }
+                                    manager.persistComposerDraft(
+                                        session.composerDraft.appending(restored), for: session)
+                                    manager.persistQueue(for: session)
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onQueueRemove: { id in
+                                    session.removeFromQueue(id: id)
+                                    manager.persistQueue(for: session)
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onQueueRetry: { id in
+                                    guard let idx = session.queue.firstIndex(where: { $0.id == id }) else { return }
+                                    session.queue[idx].lastError = nil
+                                    manager.persistQueue(for: session)
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onQueueReorder: { src, dst in
+                                    session.moveInQueue(from: src, to: dst)
+                                    manager.persistQueue(for: session)
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onQueueClearAll: {
+                                    session.clearPendingQueue()
+                                    manager.persistQueue(for: session)
+                                    manager.runners[sessionId]?.flushQueueIfIdle()
+                                },
+                                onLoadFullToolCallContent: { toolCallId in
+                                    manager.reloadFullToolCallContent(
+                                        sessionId: sessionId, toolCallId: toolCallId)
+                                }
+                            )
+                            .transition(.opacity)
+                        }
+                    }
+```
+
+In the `ACPComposer` call, add:
+
+```swift
+                        placement: composerPlacement,
+                        focusRequest: composerFocusRequest,
+```
+
+Add this modifier to the outer `ZStack(alignment: .bottom)`:
+
+```swift
+                    .animation(emptyStateAnimation, value: isNewEmptySession)
+```
+
+- [ ] **Step 4: Build to catch integration errors**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/ACPNewChatEmptyStateTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Alas/Sources/ACP/UI/ACPTabView.swift
+git commit -m "feat: show ACP new chat empty state"
+```
+
+## Task 7: Final Verification and Polish
+
+**Files:**
+- Modify only when verification reveals a concrete issue:
+  - `Alas/Sources/ACP/UI/ACPComposerShell.swift`
+  - `Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift`
+  - `Alas/Sources/ACP/UI/ACPTabView.swift`
+
+- [ ] **Step 1: Run required project generation**
+
+Run:
+
+```bash
+xcodegen
+```
+
+Expected: succeeds.
+
+- [ ] **Step 2: Run the required build**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: succeeds.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Manual verification**
+
+Run the app from Xcode or the built product and verify:
+
+```text
+1. Create a new ACP chat tab.
+2. Confirm the loading skeleton appears during attach.
+3. Confirm the new empty state appears after the session is ready and still has no transcript messages.
+4. Click "Review current changes" and confirm the full prompt appears in the composer and the text view is focused.
+5. Type a note, click "Plan a feature", and confirm the new prompt appends after a blank line.
+6. Submit the first prompt and confirm the welcome fades/slides out while the composer animates down.
+7. Reopen a previous ACP session and confirm the old loading/restore path appears instead of the new empty state.
+```
+
+- [ ] **Step 5: Apply any measured layout polish**
+
+If manual verification shows the raised composer is visibly too low or too high, adjust only these constants in `ACPComposerShell.swift`:
+
+```swift
+                .padding(.top, 320)
+            Spacer(minLength: 110)
+```
+
+Run the build again after any adjustment:
+
+```bash
+xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
+```
+
+Expected: succeeds.
+
+- [ ] **Step 6: Commit final polish if files changed**
+
+```bash
+git status --short
+git add Alas/Sources/ACP/UI/ACPComposerShell.swift Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift Alas/Sources/ACP/UI/ACPTabView.swift Alas.xcodeproj
+git commit -m "polish: tune ACP new chat empty state"
+```
+
+If `git status --short` shows no changes after verification, skip this commit.

--- a/docs/superpowers/specs/2026-06-01-acp-new-chat-empty-state-design.md
+++ b/docs/superpowers/specs/2026-06-01-acp-new-chat-empty-state-design.md
@@ -1,0 +1,126 @@
+# ACP New Chat Empty State Design
+
+Date: 2026-06-01
+Status: Approved for implementation planning
+
+## Goal
+
+Give a completely new ACP chat pane a distinct empty state that feels ready to use before the first prompt. The composer should sit closer to the center of the pane, show a compact welcome treatment, and offer starter prompts. Once the user starts the session, the composer should animate smoothly to its current bottom position and the normal transcript layout should take over.
+
+The existing loading skeleton remains the state for restoring, reattaching, or loading an existing session.
+
+## Context
+
+The current ACP surface is built around:
+
+- `Alas/Sources/ACP/UI/ACPTabView.swift`
+- `Alas/Sources/ACP/UI/ACPComposer.swift`
+- `Alas/Sources/ACP/UI/ACPComposerShell.swift`
+- `Alas/Sources/ACP/UI/ACPConnectingPlaceholder.swift`
+- `Alas/Sources/ACP/UI/ACPMessageList.swift`
+
+`ACPComposer` is already the correct visual primitive: a floating glass pill with agent status, shortcut hints, attach/action controls, model/config chips, and send behavior. The new empty state should reuse that composer rather than introduce a separate input surface.
+
+## UX
+
+When an ACP chat is brand new and has no transcript messages, the center pane shows:
+
+- A small symbolic mark above the text.
+- Title: `What should we work on?`
+- Subtitle: `Start with a task, a file, or a rough idea.`
+- Three compact starter chips:
+  - `Review current changes`
+  - `Find a bug`
+  - `Plan a feature`
+- The normal ACP composer, horizontally centered and raised toward the middle of the pane.
+
+The starter chips insert editable text into the composer and focus it. They do not submit automatically.
+
+The empty state should be quiet and utility-focused. It should not become a landing page, should not use large decorative cards, and should not compete visually with the composer. The composer remains the dominant affordance.
+
+## State Rules
+
+Show the new empty state only when all of these are true:
+
+- The session is fresh rather than restored from persistence.
+- The ACP session has no transcript messages.
+- The session is not hydrating from storage.
+- The session is not showing a setup, hydration, or connection failure.
+- The session is sufficiently attached or attachable that the composer can accept input normally.
+
+Keep `ACPConnectingPlaceholder` for loading states, especially:
+
+- restoring a previous persisted session,
+- hydrating session history,
+- reattaching to an existing remote session,
+- initial agent process startup before the app can safely present the normal composer state.
+
+If the adapter requires setup, the existing setup/update banners remain responsible for that state. If session history exists, the normal transcript surface renders.
+
+## Interaction
+
+Clicking a starter chip:
+
+1. Inserts a predefined prompt into the ACP composer draft.
+2. Replaces an empty draft.
+3. Appends after existing non-empty draft content, separated by a blank line.
+4. Focuses the text input.
+5. Persists the draft through the existing composer draft path.
+
+Suggested inserted prompts:
+
+- `Review the current changes in this worktree and suggest the next steps.`
+- `Look for likely bugs or fragile spots in this worktree. Start by inspecting the current changes.`
+- `Help me plan this feature. Ask clarifying questions first if the goal is ambiguous.`
+
+These prompts can be adjusted during implementation to match available local helper APIs, but the chip labels should remain short.
+
+## Animation
+
+The transition from empty state to normal chat should happen when the first prompt is accepted into the session. The welcome content fades and moves slightly upward while the composer animates from the raised empty position to the existing bottom composer position.
+
+Use the app's existing SwiftUI animation style:
+
+- spring response around 0.3 seconds,
+- damping high enough to feel controlled,
+- opacity transition for the welcome content,
+- layout animation for the composer position.
+
+Do not delay message rendering solely for the animation. If the first user message appears quickly, the animation and transcript update should feel like one continuous transition.
+
+## Implementation Shape
+
+Prefer a local UI-level change in `ACPTabView`:
+
+- Derive an `isNewEmptySession` boolean from existing session state.
+- Add an empty-state overlay/view next to the existing `ACPMessageList` and `ACPConnectingPlaceholder` branches.
+- Add a layout mode parameter to `ACPComposer`, or wrap it in a container that controls vertical placement without changing the composer internals.
+- Add a small empty-state view component near the ACP UI files if that keeps `ACPTabView` readable.
+- Reuse existing theme tokens: `bg-*`, `fg-*`, `line`, `accent`, and `accent-soft`.
+
+Avoid adding persisted state for this visual mode unless implementation finds that freshness cannot be derived reliably. Avoid lifecycle changes that defer ACP attach until first send.
+
+## Tests
+
+Add focused Swift Testing coverage where practical:
+
+- Fresh, non-restored empty session resolves to the new empty state.
+- Restored or hydrating sessions continue to resolve to the existing connecting/loading state.
+- Any existing transcript messages suppress the new empty state.
+- Starter prompt insertion updates the composer draft without submitting.
+- Non-empty draft behavior is deterministic and covered.
+
+Manual verification should cover:
+
+- creating a new ACP chat and seeing the centered empty state,
+- clicking each starter chip and editing the inserted prompt,
+- submitting the first prompt and seeing the composer animate down,
+- reopening or restoring a previous session and seeing the existing loading/restore behavior instead of the new empty state.
+
+## Out of Scope
+
+- New ACP provider capabilities.
+- Changes to adapter setup/update banners.
+- New persistence fields unless the derived state proves insufficient.
+- Replacing the existing composer chrome.
+- Redesigning normal transcript rendering.


### PR DESCRIPTION
## Summary
- Add a fresh ACP chat empty state with welcome copy and starter prompt chips.
- Raise the composer for new empty sessions with a height-aware animated transition back to the normal bottom placement.
- Keep restored/loading session behavior on the existing placeholder path and add focused policy/draft/layout coverage.

## Test Plan
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`