### PR TITLE
fix(acp): keep queue badge visible

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 		3326658AC801C394C43AC8A2 /* SearchKbd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36992F601C8EB6C3D45B584F /* SearchKbd.swift */; };
 		33376EB37508D556E2385D33 /* ACPSessionUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */; };
 		3388D5141427C0046BD8CCC7 /* LanguageRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328607AAAAA12EE2206ED5A4 /* LanguageRegistry.swift */; };
+		33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */; };
 		34F18AB368DC5D93196056CA /* ACPComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C496549308D5C3DD20E988AD /* ACPComposer.swift */; };
 		35024237A37355969D6FA76A /* MergeResultPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC787CE0F5625F8114C9F6F /* MergeResultPane.swift */; };
 		3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */; };
@@ -1001,6 +1002,7 @@
 		2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownLiveStyler.swift; sourceTree = "<group>"; };
 		2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActions.swift; sourceTree = "<group>"; };
 		2B142F2A747C7F2D96E8BAD1 /* SessionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRegistry.swift; sourceTree = "<group>"; };
+		2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActionButtonMetricsTests.swift; sourceTree = "<group>"; };
 		2B932ED9D5A485AE1545223C /* ACPPermissionFSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionFSTests.swift; sourceTree = "<group>"; };
 		2B9E3F080F847EF069137844 /* ShortcutBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBinding.swift; sourceTree = "<group>"; };
 		2BFCE07604D55558B13FC33B /* DiffOpenFileAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffOpenFileAvailabilityTests.swift; sourceTree = "<group>"; };
@@ -2323,6 +2325,7 @@
 			isa = PBXGroup;
 			children = (
 				81773A01826A91080F5A2E95 /* ACPCodeBlockHighlighterTests.swift */,
+				2B7ADCB7C4178FE036A31214 /* ACPComposerActionButtonMetricsTests.swift */,
 				B9454F0214E21F91473C96F6 /* ACPComposerDraftBridgeTests.swift */,
 				A637073E5D65DAA4E0CF6EA4 /* ACPComposerImageExtractTests.swift */,
 				85E54E9F53ECFE9C205788F1 /* ACPComposerPlaceholderTests.swift */,
@@ -3873,6 +3876,7 @@
 				4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
+				33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,
 				84E96EB0EF4267784462B866 /* ACPComposerImageExtractTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerActionButton.swift
@@ -37,9 +37,9 @@ struct ACPComposerActionButton: View {
             }
             .foregroundStyle(theme.color("bg-0"))
             .padding(.horizontal, 11)
-            .frame(height: 26)
+            .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
             .background(
-                RoundedRectangle(cornerRadius: 7).fill(theme.color("accent"))
+                RoundedRectangle(cornerRadius: ACPComposerActionButtonMetrics.cornerRadius).fill(theme.color("accent"))
             )
             .overlay(alignment: .topTrailing) { badgeOverlay }
         }
@@ -59,12 +59,13 @@ struct ACPComposerActionButton: View {
             }
             .foregroundStyle(theme.color("del"))
             .padding(.horizontal, 11)
-            .frame(height: 26)
+            .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
             .background(
-                RoundedRectangle(cornerRadius: 7).fill(theme.color("del").opacity(0.15))
+                RoundedRectangle(cornerRadius: ACPComposerActionButtonMetrics.cornerRadius)
+                    .fill(theme.color("del").opacity(0.15))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 7)
+                RoundedRectangle(cornerRadius: ACPComposerActionButtonMetrics.cornerRadius)
                     .strokeBorder(theme.color("del").opacity(0.45), lineWidth: 0.75)
             )
         }
@@ -85,8 +86,18 @@ struct ACPComposerActionButton: View {
                 }
                 .foregroundStyle(theme.color("fg"))
                 .padding(.horizontal, 11)
-                .frame(height: 26)
-                .background(theme.color("bg-3"))
+                .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
+                .background(
+                    UnevenRoundedRectangle(
+                        cornerRadii: .init(
+                            topLeading: ACPComposerActionButtonMetrics.cornerRadius,
+                            bottomLeading: ACPComposerActionButtonMetrics.cornerRadius,
+                            bottomTrailing: 0,
+                            topTrailing: 0
+                        )
+                    )
+                    .fill(theme.color("bg-3"))
+                )
                 .overlay(alignment: .topTrailing) { badgeOverlay }
             }
             .buttonStyle(.plain)
@@ -104,8 +115,18 @@ struct ACPComposerActionButton: View {
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(theme.color("fg"))
                     .padding(.horizontal, 7)
-                    .frame(height: 26)
-                    .background(theme.color("bg-3"))
+                    .frame(height: ACPComposerActionButtonMetrics.capsuleHeight)
+                    .background(
+                        UnevenRoundedRectangle(
+                            cornerRadii: .init(
+                                topLeading: 0,
+                                bottomLeading: 0,
+                                bottomTrailing: ACPComposerActionButtonMetrics.cornerRadius,
+                                topTrailing: ACPComposerActionButtonMetrics.cornerRadius
+                            )
+                        )
+                        .fill(theme.color("bg-3"))
+                    )
             }
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
@@ -113,10 +134,9 @@ struct ACPComposerActionButton: View {
             .help("More actions")
         }
         .overlay(
-            RoundedRectangle(cornerRadius: 7)
+            RoundedRectangle(cornerRadius: ACPComposerActionButtonMetrics.cornerRadius)
                 .strokeBorder(theme.color("line"), lineWidth: 1)
         )
-        .clipShape(RoundedRectangle(cornerRadius: 7))
     }
 
     @ViewBuilder
@@ -147,11 +167,26 @@ struct ACPComposerActionButton: View {
                 .monospacedDigit()
                 .foregroundStyle(theme.color("bg-0"))
                 .padding(.horizontal, 4)
-                .frame(minWidth: 16, minHeight: 14)
+                .frame(
+                    minWidth: ACPComposerActionButtonMetrics.badgeMinWidth,
+                    minHeight: ACPComposerActionButtonMetrics.badgeMinHeight
+                )
                 .background(Capsule().fill(theme.color("warn")))
                 .overlay(Capsule().strokeBorder(theme.color("bg-0"), lineWidth: 1))
-                .offset(x: 6, y: -6)
+                .offset(ACPComposerActionButtonMetrics.badgeOffset)
                 .allowsHitTesting(false)
         }
+    }
+}
+
+enum ACPComposerActionButtonMetrics {
+    static let capsuleHeight: CGFloat = 26
+    static let cornerRadius: CGFloat = 7
+    static let badgeMinWidth: CGFloat = 16
+    static let badgeMinHeight: CGFloat = 14
+    static let badgeOffset = CGSize(width: 6, height: -6)
+
+    static var badgeTopOutset: CGFloat {
+        max(0, -badgeOffset.height)
     }
 }

--- a/AlasTests/ACP/UI/ACPComposerActionButtonMetricsTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerActionButtonMetricsTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPComposerActionButton metrics")
+struct ACPComposerActionButtonMetricsTests {
+    @Test("queue badge top outset is inside the split button layout bounds")
+    func queueBadgeTopOutsetIsAccountedFor() {
+        #expect(ACPComposerActionButtonMetrics.badgeTopOutset == 6)
+        #expect(ACPComposerActionButtonMetrics.badgeTopOutset < ACPComposerActionButtonMetrics.badgeMinHeight)
+        #expect(ACPComposerActionButtonMetrics.capsuleHeight + ACPComposerActionButtonMetrics.badgeTopOutset
+                >= ACPComposerActionButtonMetrics.capsuleHeight)
+    }
+
+    @Test("badge remains compact relative to the composer action capsule")
+    func badgeStaysCompactRelativeToActionCapsule() {
+        #expect(ACPComposerActionButtonMetrics.badgeMinHeight < ACPComposerActionButtonMetrics.capsuleHeight)
+        #expect(ACPComposerActionButtonMetrics.badgeMinWidth <= ACPComposerActionButtonMetrics.capsuleHeight)
+    }
+}


### PR DESCRIPTION
## Summary
- keep the ACP composer queue badge visible by removing the clipping source from the split queue button
- preserve the split-button pill appearance with per-half rounded backgrounds and shared outline
- add focused metrics coverage for the badge layout contract

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- focused tests: ACPComposerActionButtonMetricsTests, ComposerActionTests