### PR TITLE
feat(acp): per-message gutter actions menu

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -691,6 +691,7 @@
 		CCA4B9F1FFBE1CAC99839A07 /* WindowConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B026A6251DEC1BD1961C0 /* WindowConfigurator.swift */; };
 		CCB0C90ABC15D987D0EEB230 /* AppConfigFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCC34174A7CEFA72099DDFD /* AppConfigFilesTests.swift */; };
 		CD227C48AA85A5E74A92DF3F /* GitRefNameInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */; };
+		CD70FE88F62533B4A2A281B4 /* ACPMessageGutter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FCCD153F9C2AF78A7B2E47 /* ACPMessageGutter.swift */; };
 		CD7FB3120E4B194063C76817 /* ClaudeCodeACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AFF324FEE695AE18065D5A /* ClaudeCodeACPInstaller.swift */; };
 		CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */; };
 		CDD25FF161CF6DC83D92EA77 /* DraftAmendPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */; };
@@ -996,6 +997,7 @@
 		295319DB8544C170DDD6328D /* PathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsTests.swift; sourceTree = "<group>"; };
 		2975A1465CA308E9766521F2 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		29D7631D754795D16E946440 /* ACPFileEditCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileEditCard.swift; sourceTree = "<group>"; };
+		29FCCD153F9C2AF78A7B2E47 /* ACPMessageGutter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMessageGutter.swift; sourceTree = "<group>"; };
 		2A69F4742D3C251A59F400B8 /* MergeConflictTabState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictTabState.swift; sourceTree = "<group>"; };
 		2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownLiveStyler.swift; sourceTree = "<group>"; };
 		2B0206F856D9639147D0A4BF /* ACPComposerActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerActions.swift; sourceTree = "<group>"; };
@@ -2540,6 +2542,7 @@
 				DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */,
 				329882D757C34246C9848C3A /* ACPMentionChipAttachment.swift */,
 				E49006251DFBE67CCD0C4008 /* ACPMentionPicker.swift */,
+				29FCCD153F9C2AF78A7B2E47 /* ACPMessageGutter.swift */,
 				3F79A184C86BE6C6BF72EB57 /* ACPMessageList.swift */,
 				0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */,
 				CF02DDF9183C6C8D28EC68C0 /* ACPPlanChecklist.swift */,
@@ -3452,6 +3455,7 @@
 				CC64E79B9CF4AF1B3CE31261 /* ACPMentionChipAttachment.swift in Sources */,
 				2B823A7361BB54D8D93D7C99 /* ACPMentionPicker.swift in Sources */,
 				94354D17B0FEF3F0046B452A /* ACPMessage.swift in Sources */,
+				CD70FE88F62533B4A2A281B4 /* ACPMessageGutter.swift in Sources */,
 				37DD3F3B818131973DAA2B9B /* ACPMessageList.swift in Sources */,
 				9D4F9F5CE9FF51C33E32703C /* ACPMessageWire.swift in Sources */,
 				B8412B44C090B4AA6A892D25 /* ACPMessages.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPMessageGutter.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageGutter.swift
@@ -38,8 +38,19 @@ struct ACPMessageGutter<Content: View>: View {
                     // Sit flush with the right edge of the reserved lane: the
                     // button's own visible padding is 4pt each side (8pt total),
                     // so net inset is laneWidth - 8. y: -2 nudges it into optical
-                    // alignment with the top of the message content.
+                    // alignment with the top of the message content. The offset
+                    // intentionally escapes the content view's bounds into the
+                    // lane reserved by the container; this relies on no ancestor
+                    // applying `clipped()` (SwiftUI does not clip overlays by
+                    // default), which also keeps the button hit-testable.
                     .offset(x: ACPMessageGutterLayout.laneWidth - 8, y: -2)
+                    // The button sits in the lane, outside `content`'s hover
+                    // region, so it must keep itself alive while hovered —
+                    // otherwise pointing at it past the hide delay would fade
+                    // and disable it mid-aim. Mirrors the old copy button.
+                    .onHover { inside in
+                        if inside { hover.enter() } else { hover.leave() }
+                    }
             }
             .onHover { inside in
                 if inside { hover.enter() } else { hover.leave() }

--- a/Alas/Sources/ACP/UI/ACPMessageGutter.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageGutter.swift
@@ -1,0 +1,83 @@
+import AppKit
+import SwiftUI
+
+/// Reserves a hover-revealed action affordance in the right gutter of a
+/// transcript message. The "…" opens a native menu — the per-message action
+/// surface. Today it carries a single action ("Copy message"); future
+/// actions (e.g. fork-from-here) slot in as additional buttons with no
+/// structural change.
+///
+/// Reusable across message kinds: currently wraps user and agent rows; other
+/// block types can opt in later by wrapping their content the same way.
+///
+/// Layout note: the symmetric reserved *lanes* are applied once by the
+/// transcript container (`ACPMessageList`) so every row stays aligned. This
+/// wrapper only reveals the button and positions it into the reserved right
+/// lane via an offset.
+struct ACPMessageGutter<Content: View>: View {
+    /// Produces the raw Markdown copied by "Copy message". A closure (not a
+    /// stored `String`) so streaming agent text is read at click time rather
+    /// than captured stale at view-build time. Matches
+    /// `ACPTranscriptMarkdown.messageBody` for this message.
+    let markdown: () -> String
+    @ViewBuilder var content: Content
+
+    @StateObject private var hover = ACPDelayedHoverVisibility()
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        content
+            .overlay(alignment: .topTrailing) {
+                dotsMenu
+                    // Keep the menu label mounted at all times and toggle
+                    // visibility via opacity/hit-testing rather than inserting
+                    // and removing the view. Removing the label while its menu
+                    // is open can dismiss the menu; this avoids that.
+                    .opacity(hover.isVisible ? 1 : 0)
+                    .allowsHitTesting(hover.isVisible)
+                    // Sit flush with the right edge of the reserved lane: the
+                    // button's own visible padding is 4pt each side (8pt total),
+                    // so net inset is laneWidth - 8. y: -2 nudges it into optical
+                    // alignment with the top of the message content.
+                    .offset(x: ACPMessageGutterLayout.laneWidth - 8, y: -2)
+            }
+            .onHover { inside in
+                if inside { hover.enter() } else { hover.leave() }
+            }
+    }
+
+    private var dotsMenu: some View {
+        Menu {
+            Button("Copy message") {
+                let text = markdown()
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(text, forType: .string)
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(theme.color("fg-muted"))
+                .padding(4)
+                .background(theme.color("bg-3").opacity(0.85))
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                )
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Message actions")
+    }
+}
+
+/// Layout metrics for the message gutter. Kept on a non-generic type so the
+/// transcript container (`ACPMessageList`) can read `laneWidth` without having
+/// to specify `ACPMessageGutter`'s generic `Content` parameter.
+enum ACPMessageGutterLayout {
+    /// Width of each reserved side lane. The left lane stays empty (reads as
+    /// padding); the right lane hosts the "…" on hover.
+    static let laneWidth: CGFloat = 32
+}

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -149,7 +149,7 @@ struct ACPMessageList: View {
                             .id("__composer_spacer__")
                     }
                     .frame(maxWidth: 720, alignment: .leading)
-                    .padding(.horizontal, 28)
+                    .padding(.horizontal, 28 + ACPMessageGutterLayout.laneWidth)
                     .padding(.top, 24)
                     .frame(maxWidth: .infinity, alignment: .center)
                 }
@@ -302,9 +302,13 @@ struct ACPMessageList: View {
     private func row(for m: ACPMessage) -> some View {
         switch m {
         case .user(_, let text, let attachments):
-            UserMessageRow(text: text, attachments: attachments)
+            ACPMessageGutter(markdown: { text }) {
+                UserMessageRow(text: text, attachments: attachments)
+            }
         case .agent(let id, let buf):
-            AgentMessageRow(messageId: id.uuidString, transcript: transcript, buffer: buf)
+            ACPMessageGutter(markdown: { buf.value }) {
+                AgentMessageRow(messageId: id.uuidString, transcript: transcript, buffer: buf)
+            }
         case .thought(_, let buf):
             ACPThoughtView(buffer: buf)
         case .toolCall(let tc):
@@ -491,35 +495,6 @@ enum ACPUserScrollEvent {
     }
 }
 
-// MARK: - Hover copy button
-
-/// Hover-revealed affordance that copies a message's raw Markdown to the
-/// pasteboard as plain text. The caller passes exactly the text
-/// `ACPTranscriptMarkdown.messageBody` would return for this row.
-private struct ACPHoverCopyButton: View {
-    let markdown: String
-    var onHoverChange: ((Bool) -> Void)? = nil
-    @Environment(\.theme) private var theme
-
-    var body: some View {
-        Button {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(markdown, forType: .string)
-        } label: {
-            Image(systemName: "doc.on.doc")
-                .font(.system(size: 10.5))
-                .foregroundStyle(theme.color("fg-muted"))
-                .padding(4)
-                .background(theme.color("bg-3").opacity(0.85))
-                .clipShape(RoundedRectangle(cornerRadius: 5))
-                .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(theme.color("line"), lineWidth: 0.5))
-        }
-        .buttonStyle(.plain)
-        .onHover { onHoverChange?($0) }
-        .help("Copy message as Markdown")
-    }
-}
-
 @MainActor
 final class ACPDelayedHoverVisibility: ObservableObject {
     @Published private(set) var isVisible = false
@@ -561,8 +536,6 @@ private struct UserMessageRow: View {
     let text: String
     let attachments: [ACPMessage.Attachment]
     @Environment(\.theme) private var theme
-    @State private var hovering = false
-
     var body: some View {
         HStack {
             Spacer(minLength: 40)
@@ -616,12 +589,6 @@ private struct UserMessageRow: View {
                     .shadow(color: .black.opacity(0.2), radius: 8, y: 2)
             }
             .frame(maxWidth: 540, alignment: .trailing)
-            .overlay(alignment: .topLeading) {
-                if hovering {
-                    ACPHoverCopyButton(markdown: text).offset(x: -6, y: -6)
-                }
-            }
-            .onHover { hovering = $0 }
         }
         .frame(maxWidth: .infinity)
     }
@@ -633,29 +600,9 @@ private struct AgentMessageRow: View {
     let messageId: String
     let transcript: ACPTranscript
     @ObservedObject var buffer: StreamingText
-    @StateObject private var hoverVisibility = ACPDelayedHoverVisibility()
     var body: some View {
         ACPMarkdownText(raw: buffer.value, cache: transcript.markdownCache(forMessage: messageId))
             .frame(maxWidth: .infinity, alignment: .leading)
-            .overlay(alignment: .topTrailing) {
-                if hoverVisibility.isVisible {
-                    ACPHoverCopyButton(markdown: buffer.value) { hovering in
-                        if hovering {
-                            hoverVisibility.enter()
-                        } else {
-                            hoverVisibility.leave()
-                        }
-                    }
-                    .offset(x: -2, y: -6)
-                }
-            }
-            .onHover { hovering in
-                if hovering {
-                    hoverVisibility.enter()
-                } else {
-                    hoverVisibility.leave()
-                }
-            }
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the inline per-message copy button in the ACP chat transcript with a hover-revealed **"…" menu** in a reserved right-hand gutter. The menu's first action is **Copy message**; it's structured as the entrypoint for future per-message actions (e.g. fork-from-here).

- New `ACPMessageGutter` — a reusable generic wrapper that overlays a native `Menu` (matching the `BranchOpsMenu` pattern) in the right gutter on hover. Copy payload is a closure (`() -> String`) so streamed agent text is read at click time, not captured stale.
- Symmetric reserved lanes added once at the transcript container (`28 + ACPMessageGutterLayout.laneWidth`), so every row stays aligned and the "…" lands at the same far-right x for both user and agent messages.
- Old `ACPHoverCopyButton` and its inline corner overlays removed; `ACPDelayedHoverVisibility` retained and reused.
- Button keeps itself alive while hovered (its own `onHover`), so pointing at it past the hide delay doesn't fade/disable it mid-aim.

Copy output is unchanged (user: raw text, agent: `buffer.value`), still covered by `ACPTranscriptMarkdownTests`.

## Test Plan

- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test` — full suite green (incl. `ACPTranscriptMarkdownTests` copy-payload guard)
- [ ] Symmetric lanes look balanced at wide and narrow pane widths
- [ ] "…" reveals on hover in the right gutter, top-aligned, same x for user + agent messages
- [ ] Click registers on **user** messages (button sits past the bubble's right spacer)
- [ ] Menu → Copy message pastes correct Markdown (incl. just-streamed agent text)
- [ ] Menu not dismissed prematurely; button stays clickable when hovered
- [ ] Tool/file cards and thoughts still render, left-aligned with agent prose