### PR TITLE
feat(right-pane): transitional UI during creating/deleting/createFailed

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -655,6 +655,7 @@
 		C245B74D0083CE00B6CD392C /* ACPAdapterVersionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15630570F849AC577CA0D379 /* ACPAdapterVersionChecker.swift */; };
 		C2CE2E3DE88344FDDE67D66A /* LSPTransportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */; };
 		C2EDB6A5E6149758C4A0051E /* ConflictMarkerParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */; };
+		C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */; };
 		C3840EDD0105467D0678B69C /* AppConfigSidebarChromeOverridesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705A47F78FEC16C2CA293BAC /* AppConfigSidebarChromeOverridesTests.swift */; };
 		C45F78462F404C64D02C413B /* LanguageServerRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D238B1262EB2BC6AFCF621 /* LanguageServerRegistry.swift */; };
 		C487C3AD43E7B5BBB45490DB /* CodexInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F0314E357190EF2A1F861B /* CodexInstaller.swift */; };
@@ -831,6 +832,7 @@
 		FAC5B044ADA2ECF467814CE4 /* ConflictsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561094BA96058468F12002A1 /* ConflictsSection.swift */; };
 		FB2AE30704F39C0BDA83F3CC /* ACPConfigOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9877AAC39AAB55596495B816 /* ACPConfigOptionTests.swift */; };
 		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
+		FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */; };
 		FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
 		FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */; };
@@ -1148,6 +1150,7 @@
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
 		542B9A0D90AC20BBCA6073F8 /* MergeOperationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeOperationState.swift; sourceTree = "<group>"; };
 		5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemorySnapshotTests.swift; sourceTree = "<group>"; };
+		54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneSelectionStateResolverTests.swift; sourceTree = "<group>"; };
 		547176E79C529DBFE2086B88 /* ACPSessionRunnerQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionRunnerQueueTests.swift; sourceTree = "<group>"; };
 		54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPToolCallContentTests.swift; sourceTree = "<group>"; };
 		55DE02E1672044B68F9DE0B1 /* EditorFindController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindController.swift; sourceTree = "<group>"; };
@@ -1409,6 +1412,7 @@
 		AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPRecoveryPill.swift; sourceTree = "<group>"; };
 		AF2F716F911BB20B3E78C40B /* AgentDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDefinition.swift; sourceTree = "<group>"; };
 		B0D0ED01C390D1F729993B13 /* MarkdownImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoaderTests.swift; sourceTree = "<group>"; };
+		B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneSelectionState.swift; sourceTree = "<group>"; };
 		B1615F1953C6FE9D1A30A1A2 /* ACPImageEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPImageEncoding.swift; sourceTree = "<group>"; };
 		B204EC8484F51CDC8B5D06E2 /* MarkdownRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownRendererTests.swift; sourceTree = "<group>"; };
 		B24ABE96ED3C62146A3CED62 /* EmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyState.swift; sourceTree = "<group>"; };
@@ -1973,6 +1977,7 @@
 				01675626CE431DD5867636BF /* RepoGroupViewLayoutTests.swift */,
 				220514C66CF29B6FD04EAB0B /* RepoSelectorModelTests.swift */,
 				784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */,
+				54635D583B6B308B75ABCE63 /* RightPaneSelectionStateResolverTests.swift */,
 				6713F5A8712C0962BED1EFEA /* RightPaneStateBaseBranchTests.swift */,
 				4973BDD06953B7A1EB9A7A66 /* RightPaneStateDiscardPathsTests.swift */,
 				3D10596B1B9B854DB81DAF6A /* RightPaneStateDiscardTests.swift */,
@@ -3156,6 +3161,7 @@
 				417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */,
 				B44D759586280250330A9A04 /* FontSizeCommands.swift */,
 				7FFC9539E615699AC90A7412 /* ProjectsManager.swift */,
+				B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */,
 				69024633944E9FFF6DA76FAE /* RootView.swift */,
 				51B868809675C4110044C92E /* SpacesManager.swift */,
 				941BC60920D6A87164610273 /* WorktreeLaunchSurface.swift */,
@@ -3771,6 +3777,7 @@
 				E3158A4D8FBD36D06D421D28 /* RepoSelectorRecents.swift in Sources */,
 				2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */,
 				1B387AAB575A42ED1AFB5D46 /* RepoSelectorRowView.swift in Sources */,
+				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
 				BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */,
@@ -4143,6 +4150,7 @@
 				133597E7D43CFE746EF4EF2B /* RepoGroupViewLayoutTests.swift in Sources */,
 				737EC7C9A35C9ED61ED67B83 /* RepoSelectorModelTests.swift in Sources */,
 				35705563BBEDDC1D0092C1F5 /* RepoSelectorRecentsTests.swift in Sources */,
+				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
 				21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */,
 				8104F4F1DFD11BC5758545E9 /* RightPaneStateDiscardTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -335,6 +335,7 @@
 		603D2F40A0368A139822CE80 /* ACPLaunchCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29505F108227C8F43822585 /* ACPLaunchCatalogTests.swift */; };
 		604E881461FC839C4233B0AF /* LSPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D394D40BC9060833DD640A /* LSPInstaller.swift */; };
 		610486A9FA350E77D1BF594B /* ACPTerminalTailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFD1CE53DE229626220B457 /* ACPTerminalTailView.swift */; };
+		6117C4AD7519BCD82EA0CF56 /* RightPaneTransitionalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */; };
 		6140E9DE848A53A37DFB8890 /* CodexInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F59C2CF9199EC099B1814AC /* CodexInstallerTests.swift */; };
 		61D33019E9AA23F5042C39B2 /* ACPSessionHydrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D30693F45966ED1456811E /* ACPSessionHydrator.swift */; };
 		6256EAEB315812ED4F4E9107 /* StageChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1874031C788ADB4398151FF1 /* StageChip.swift */; };
@@ -1358,6 +1359,7 @@
 		9A2292E8F8E3D91440BE88FC /* ACPSessionTerminalRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionTerminalRoutingTests.swift; sourceTree = "<group>"; };
 		9A40BDC5115B641AB26220D9 /* ZmxSunPathBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxSunPathBudget.swift; sourceTree = "<group>"; };
 		9B15F58AFF7BC19419935C05 /* PendingDiscard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingDiscard.swift; sourceTree = "<group>"; };
+		9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneTransitionalView.swift; sourceTree = "<group>"; };
 		9C45A26ADB0D1CCFBB5BEAE8 /* TerminalSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSession.swift; sourceTree = "<group>"; };
 		9CA420C011D4235E47A3FB1B /* RepoSelectorRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecents.swift; sourceTree = "<group>"; };
 		9D209865BE187943BF14B830 /* AgentRunnerInvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRunnerInvocationTests.swift; sourceTree = "<group>"; };
@@ -2272,6 +2274,7 @@
 				91C1705E68E97111E85D83F3 /* RightPaneState.swift */,
 				795056B6AD803D2B555FC866 /* RightPaneStore.swift */,
 				4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */,
+				9C165BAAF80F9B4A5949BD39 /* RightPaneTransitionalView.swift */,
 				FE66950F2226F1182DCDD39A /* RightPaneView.swift */,
 				934BCC470703CF2DF2303357 /* SectionHeader.swift */,
 				DDE8B45ECF898B83A616586D /* SubHeader.swift */,
@@ -3781,6 +3784,7 @@
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,
 				BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */,
+				6117C4AD7519BCD82EA0CF56 /* RightPaneTransitionalView.swift in Sources */,
 				E4E04048352D9CBC77D954C5 /* RightPaneView.swift in Sources */,
 				7B85B033B476943E77867BA3 /* RootView.swift in Sources */,
 				175D0A77579A022F3AB81E48 /* SQLiteDatabase.swift in Sources */,

--- a/Alas/Sources/App/RightPaneSelectionState.swift
+++ b/Alas/Sources/App/RightPaneSelectionState.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+enum RightPaneSelectionState: Equatable {
+    case empty
+    case active(Worktree)
+    case creating(Worktree)
+    case deleting(Worktree)
+    case createFailed(Worktree)
+}
+
+struct RightPaneSelectionStateResolver {
+    let selectedWorktreeId: String?
+    let projects: [ProjectConfig]
+    let projectsManager: ProjectsManager
+
+    @MainActor
+    func resolve() -> RightPaneSelectionState {
+        guard let id = selectedWorktreeId else { return .empty }
+        guard let wt = findWorktree(by: id) else { return .empty }
+        if let op = projectsManager.operationState(for: wt.id) {
+            switch op {
+            case .creating:
+                return .creating(wt)
+            case .deleting:
+                return .deleting(wt)
+            case .createFailed:
+                return .createFailed(wt)
+            case .deleteFailed:
+                return .active(wt)
+            }
+        }
+        return .active(wt)
+    }
+
+    @MainActor
+    private func findWorktree(by id: String) -> Worktree? {
+        for project in projects {
+            if let wt = projectsManager.visibleWorktrees(projectId: project.id).first(where: { $0.id == id }) {
+                return wt
+            }
+        }
+        return nil
+    }
+}

--- a/Alas/Sources/App/RightPaneSelectionState.swift
+++ b/Alas/Sources/App/RightPaneSelectionState.swift
@@ -26,6 +26,9 @@ struct RightPaneSelectionStateResolver {
             case .createFailed:
                 return .createFailed(wt)
             case .deleteFailed:
+                // The worktree still exists on disk; the right pane shows
+                // real content while the center pane carries the failure
+                // hero and recovery actions.
                 return .active(wt)
             }
         }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -64,7 +64,15 @@ struct RootView: View {
                             centerContent()
                         },
                         right: {
-                            if let wt = selectedWorktree() {
+                            let resolver = RightPaneSelectionStateResolver(
+                                selectedWorktreeId: state.selectedWorktreeId,
+                                projects: state.activeSpaceProjects,
+                                projectsManager: state.projectsManager
+                            )
+                            switch resolver.resolve() {
+                            case .empty:
+                                EmptyView()
+                            case .active(let wt):
                                 RightPaneView(
                                     state: state,
                                     worktree: wt,
@@ -81,8 +89,12 @@ struct RootView: View {
                                         openOrFocusCommitEditor(worktree: wt, commit: commit, baseRef: baseRef)
                                     }
                                 )
-                            } else {
-                                EmptyView()
+                            case .creating(let wt):
+                                RightPaneTransitionalView(state: state, worktree: wt, kind: .creating)
+                            case .deleting(let wt):
+                                RightPaneTransitionalView(state: state, worktree: wt, kind: .deleting)
+                            case .createFailed(let wt):
+                                RightPaneTransitionalView(state: state, worktree: wt, kind: .createFailed)
                             }
                         }
                     )
@@ -231,21 +243,12 @@ struct RootView: View {
     }
 
     private func selectedWorktree() -> Worktree? {
-        guard let id = state.selectedWorktreeId else { return nil }
-        for project in state.activeSpaceProjects {
-            if let wt = state.projectsManager.visibleWorktrees(projectId: project.id).first(where: { $0.id == id }) {
-                // Do not treat a creating/deleting/failed-create row as the active worktree.
-                if let op = state.projectsManager.operationState(for: wt.id) {
-                    switch op {
-                    case .creating, .deleting, .createFailed:
-                        return nil
-                    case .deleteFailed:
-                        break
-                    }
-                }
-                return wt
-            }
-        }
+        let resolver = RightPaneSelectionStateResolver(
+            selectedWorktreeId: state.selectedWorktreeId,
+            projects: state.activeSpaceProjects,
+            projectsManager: state.projectsManager
+        )
+        if case .active(let wt) = resolver.resolve() { return wt }
         return nil
     }
 

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -21,7 +21,6 @@ struct RightPaneTransitionalView: View {
     let kind: Kind
 
     @State private var activeTab: RightPaneTab = .changes
-    @Environment(\.theme) private var theme
 
     var body: some View {
         let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
@@ -62,7 +61,7 @@ struct RightPaneTransitionalView: View {
         case .createFailed:
             CompactStateLabel(
                 systemIcon: "exclamationmark.triangle",
-                text: "Create failed",
+                text: "Create failed — \(worktree.branch)",
                 tone: .warning
             )
         }

--- a/Alas/Sources/Right/RightPaneTransitionalView.swift
+++ b/Alas/Sources/Right/RightPaneTransitionalView.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+
+/// The right pane while the selected worktree is in a transitional
+/// operation state: `.creating`, `.deleting`, or `.createFailed`.
+///
+/// Does not touch `RightPaneStore`, so no per-worktree state is allocated
+/// for a worktree that is not yet (or no longer) backed by a real path
+/// on disk. The tab bar is rendered for layout consistency but is
+/// `.disabled(true)` — all controls (including the hide-pane button) are
+/// inert. Recovery actions for the failure states live on the sidebar row
+/// context menu and the center pane.
+struct RightPaneTransitionalView: View {
+    enum Kind {
+        case creating
+        case deleting
+        case createFailed
+    }
+
+    @Bindable var state: AppState
+    let worktree: Worktree
+    let kind: Kind
+
+    @State private var activeTab: RightPaneTab = .changes
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        let override = state.config.sidebarChromeOverride(forThemeId: state.themeStore.current.id)
+        ZStack {
+            SidebarMaterialBackground(
+                choice: state.config.sidebarMaterial,
+                backgroundOpacity: override.backgroundOpacity
+            )
+            VStack(spacing: 0) {
+                RightPaneTabBar(
+                    activeTab: $activeTab,
+                    changesCount: 0,
+                    totalAdd: 0,
+                    totalDel: 0,
+                    onHidePane: {},
+                    showIgnored: state.config.files.showIgnored,
+                    onToggleShowIgnored: {}
+                )
+                .disabled(true)
+
+                content
+            }
+            .sidebarChromeTheme(textContrast: override.textContrast)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch kind {
+        case .creating:
+            CreatingSkeletonView(activeTab: activeTab)
+        case .deleting:
+            CompactStateLabel(
+                systemIcon: "trash",
+                text: "Deleting worktree…",
+                tone: .neutral
+            )
+        case .createFailed:
+            CompactStateLabel(
+                systemIcon: "exclamationmark.triangle",
+                text: "Create failed",
+                tone: .warning
+            )
+        }
+    }
+}
+
+// MARK: - Creating skeleton
+
+private struct CreatingSkeletonView: View {
+    let activeTab: RightPaneTab
+
+    var body: some View {
+        switch activeTab {
+        case .changes:
+            VStack(alignment: .leading, spacing: 0) {
+                SkeletonSectionHeader(title: "Working tree")
+                VStack(alignment: .leading, spacing: 6) {
+                    SkeletonRow(widthFraction: 0.75)
+                    SkeletonRow(widthFraction: 0.55)
+                    SkeletonRow(widthFraction: 0.65)
+                    SkeletonRow(widthFraction: 0.4)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+
+                SkeletonSectionHeader(title: "Commits")
+                VStack(alignment: .leading, spacing: 6) {
+                    SkeletonRow(widthFraction: 0.8)
+                    SkeletonRow(widthFraction: 0.6)
+                    SkeletonRow(widthFraction: 0.7)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+        case .files:
+            VStack(alignment: .leading, spacing: 6) {
+                SkeletonRow(widthFraction: 0.6,  leadingInset: 0)
+                SkeletonRow(widthFraction: 0.5,  leadingInset: 16)
+                SkeletonRow(widthFraction: 0.55, leadingInset: 16)
+                SkeletonRow(widthFraction: 0.45, leadingInset: 32)
+                SkeletonRow(widthFraction: 0.5,  leadingInset: 16)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+    }
+}
+
+// MARK: - Compact label (deleting / createFailed)
+
+private struct CompactStateLabel: View {
+    enum Tone {
+        case neutral
+        case warning
+    }
+
+    let systemIcon: String
+    let text: String
+    let tone: Tone
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: systemIcon)
+                .font(.system(size: 22))
+                .foregroundColor(iconColor)
+            Text(text)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(theme.color("fg-muted"))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 16)
+    }
+
+    private var iconColor: Color {
+        switch tone {
+        case .neutral: return theme.color("fg-faint")
+        case .warning: return theme.color("warning")
+        }
+    }
+}
+
+// MARK: - Skeleton primitives
+
+private struct SkeletonSectionHeader: View {
+    let title: String
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 6) {
+            // Matches the chevron slot in SectionHeader so the column
+            // alignment is the same as the real header.
+            Color.clear.frame(width: 14, height: 14)
+            Text(title.uppercased())
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.5)
+                .foregroundColor(theme.color("fg-muted"))
+            Spacer(minLength: 8)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 7)
+        .background(theme.color("section-head-bg"))
+    }
+}
+
+private struct SkeletonRow: View {
+    let widthFraction: CGFloat
+    var leadingInset: CGFloat = 0
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if leadingInset > 0 {
+                Color.clear.frame(width: leadingInset)
+            }
+            GeometryReader { geo in
+                Capsule()
+                    .fill(theme.color("fg-faint").opacity(0.3))
+                    .frame(width: max(20, geo.size.width * widthFraction), height: 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(height: 8)
+        }
+    }
+}

--- a/AlasTests/RightPaneSelectionStateResolverTests.swift
+++ b/AlasTests/RightPaneSelectionStateResolverTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+@MainActor
+struct RightPaneSelectionStateResolverTests {
+    @Test func emptyWhenNoSelection() {
+        let mgr = ProjectsManager(persistedProjects: [])
+        let resolver = RightPaneSelectionStateResolver(
+            selectedWorktreeId: nil,
+            projects: [],
+            projectsManager: mgr
+        )
+        let result = resolver.resolve()
+        #expect(result == .empty)
+    }
+
+    @Test func emptyWhenSelectionIdMissing() {
+        let project = ProjectConfig(id: "p1", name: "A", path: "/tmp/a", color: "#fff", addedAt: Date())
+        let mgr = ProjectsManager(persistedProjects: [project])
+        let resolver = RightPaneSelectionStateResolver(
+            selectedWorktreeId: "missing",
+            projects: [project],
+            projectsManager: mgr
+        )
+        let result = resolver.resolve()
+        #expect(result == .empty)
+    }
+
+    @Test func activeWhenNoOperationState() {
+        let project = ProjectConfig(id: "p1", name: "A", path: "/tmp/a", color: "#fff", addedAt: Date())
+        let wt = Worktree(id: "wt1", projectId: "p1", name: "main", branch: "main", path: URL(fileURLWithPath: "/tmp/a"), status: .clean, lastActivity: Date())
+        let mgr = ProjectsManager(persistedProjects: [project])
+        mgr.insertOptimisticWorktree(wt)
+        let resolver = RightPaneSelectionStateResolver(
+            selectedWorktreeId: wt.id,
+            projects: [project],
+            projectsManager: mgr
+        )
+        let result = resolver.resolve()
+        if case .active(let returned) = result {
+            #expect(returned.id == wt.id)
+        } else {
+            Issue.record("Expected .active, got \(result)")
+        }
+    }
+
+    @Test func creatingWhenCreatingState() {
+        let project = ProjectConfig(id: "p1", name: "A", path: "/tmp/a", color: "#fff", addedAt: Date())
+        let wt = Worktree(id: "wt1", projectId: "p1", name: "main", branch: "main", path: URL(fileURLWithPath: "/tmp/a"), status: .clean, lastActivity: Date())
+        let mgr = ProjectsManager(persistedProjects: [project])
+        mgr.insertOptimisticWorktree(wt)
+        mgr.setOperationState(id: wt.id, state: .creating)
+        let resolver = RightPaneSelectionStateResolver(
+            selectedWorktreeId: wt.id,
+            projects: [project],
+            projectsManager: mgr
+        )
+        let result = resolver.resolve()
+        if case .creating(let returned) = result {
+            #expect(returned.id == wt.id)
+        } else {
+            Issue.record("Expected .creating, got \(result)")
+        }
+    }
+
+    @Test func deletingWhenDeletingState() {
+        let project = ProjectConfig(id: "p1", name: "A", path: "/tmp/a", color: "#fff", addedAt: Date())
+        let wt = Worktree(id: "wt1", projectId: "p1", name: "main", branch: "main", path: URL(fileURLWithPath: "/tmp/a"), status: .clean, lastActivity: Date())
+        let mgr = ProjectsManager(persistedProjects: [project])
+        mgr.insertOptimisticWorktree(wt)
+        mgr.setOperationState(id: wt.id, state: .deleting)
+        let resolver = RightPaneSelectionStateResolver(
+            selectedWorktreeId: wt.id,
+            projects: [project],
+            projectsManager: mgr
+        )
+        let result = resolver.resolve()
+        if case .deleting(let returned) = result {
+            #expect(returned.id == wt.id)
+        } else {
+            Issue.record("Expected .deleting, got \(result)")
+        }
+    }
+
+    @Test func createFailedWhenCreateFailedState() {
+        let project = ProjectConfig(id: "p1", name: "A", path: "/tmp/a", color: "#fff", addedAt: Date())
+        let wt = Worktree(id: "wt1", projectId: "p1", name: "main", branch: "main", path: URL(fileURLWithPath: "/tmp/a"), status: .clean, lastActivity: Date())
+        let mgr = ProjectsManager(persistedProjects: [project])
+        mgr.insertOptimisticWorktree(wt)
+        mgr.setOperationState(id: wt.id, state: .createFailed(message: "disk full", base: "main"))
+        let resolver = RightPaneSelectionStateResolver(
+            selectedWorktreeId: wt.id,
+            projects: [project],
+            projectsManager: mgr
+        )
+        let result = resolver.resolve()
+        if case .createFailed(let returned) = result {
+            #expect(returned.id == wt.id)
+        } else {
+            Issue.record("Expected .createFailed, got \(result)")
+        }
+    }
+
+    @Test func activeWhenDeleteFailedState() {
+        let project = ProjectConfig(id: "p1", name: "A", path: "/tmp/a", color: "#fff", addedAt: Date())
+        let wt = Worktree(id: "wt1", projectId: "p1", name: "main", branch: "main", path: URL(fileURLWithPath: "/tmp/a"), status: .clean, lastActivity: Date())
+        let mgr = ProjectsManager(persistedProjects: [project])
+        mgr.insertOptimisticWorktree(wt)
+        mgr.setOperationState(id: wt.id, state: .deleteFailed(message: "permission denied"))
+        let resolver = RightPaneSelectionStateResolver(
+            selectedWorktreeId: wt.id,
+            projects: [project],
+            projectsManager: mgr
+        )
+        let result = resolver.resolve()
+        if case .active(let returned) = result {
+            #expect(returned.id == wt.id)
+        } else {
+            Issue.record("Expected .active, got \(result)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The right sidebar used to collapse to an empty grey column whenever the selected worktree was in a transitional operation state (`.creating`, `.deleting`, `.createFailed`). This change gives the right pane its own treatment for those states: a structured skeleton for `.creating`, a compact centred label for `.deleting` and `.createFailed`. `.deleteFailed` is deliberately unchanged — the worktree still exists on disk and the right pane keeps showing real content.

## What changes

- New `RightPaneSelectionState` enum + `RightPaneSelectionStateResolver` (`Alas/Sources/App/RightPaneSelectionState.swift`), modelled directly on the existing `CenterSelectionStateResolver`. Single source of truth for what the right pane should render.
- New `RightPaneTransitionalView` (`Alas/Sources/Right/RightPaneTransitionalView.swift`) with file-private `CreatingSkeletonView`, `CompactStateLabel`, `SkeletonSectionHeader`, `SkeletonRow` helpers. The view never touches `RightPaneStore`, so no per-worktree state is allocated for a worktree that isn't yet (or no longer) backed by a real path on disk.
- `RootView` right slot: `if let` → `switch` over `RightPaneSelectionStateResolver.resolve()`. The `.active` case keeps the existing `RightPaneView` wiring verbatim.
- `RootView.selectedWorktree()` reimplemented in terms of the resolver, preserving old semantics for every caller (`RootCommandHandlers`, `AgentLauncherDialog`). The `.deleteFailed` carve-out is preserved.

## Why

- Skeleton/label is calm and consistent with the rest of the app; no shimmer, no animation.
- Tab bar is rendered for layout consistency but `.disabled(true)` — recovery lives on the sidebar row context menu and the center pane, which is the existing pattern.
- The "right pane empty during normal worktree lifecycle work" feeling goes away.

## Out of scope

- Sidebar row, center pane's existing `DeletingWorktreeView` / `DeleteFailedWorktreeView`, and `WorktreeOperationState` are all unchanged.
- No shimmer or other animated skeleton primitive.
- `.deleteFailed` is not given a transitional treatment by design.

## Testing

- 7 new `RightPaneSelectionStateResolverTests` cover all spec'd branches: `.empty` × 2, `.active` × 2, `.creating`, `.deleting`, `.createFailed`.
- Full suite green: 2825/2825.

## Manual verification required before merge

The plan's Task 3 steps 5-9 require a human in the UI:
- `.creating` — skeleton appears immediately, swaps to real content when ready, tab bar inert.
- `.deleting` — "Deleting worktree…" label appears, disappears on completion.
- `.createFailed` — warning triangle + "Create failed — \<branch\>" appears; Retry from the sidebar context menu transitions back to the skeleton.
- `.deleteFailed` regression — right pane keeps showing real content (worktree still on disk, dirty state visible).
- Pane toggle closed/open during each transitional state — no crashes.