### PR TITLE
fix(settings): dismiss space emoji picker on selection

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -856,6 +856,7 @@
 		FD797B47C5EE0F82796A3733 /* LSPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028348C468E45161F567110A /* LSPInstallerTests.swift */; };
 		FDB1BD021ED0D2C7247E42D5 /* RightPaneStateLoadOlderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C89163A30EA4D278E86959 /* RightPaneStateLoadOlderTests.swift */; };
 		FE1517EC14DCB1C29528C865 /* StatusParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */; };
+		FE5846F4401C702264817399 /* SpaceEmojiPickerSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */; };
 		FF23739CD41997C6DD44E18B /* ACPFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0C0029F439C282D474ED77 /* ACPFileWriter.swift */; };
 		FF4707BB143F25062DD3BC43 /* AgentAutoLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F875ED8D44E6C298588E60 /* AgentAutoLaunchTests.swift */; };
 		FF7DDFC667CE2E3964B51FA5 /* LSPInstallProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */; };
@@ -1013,6 +1014,7 @@
 		279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTabAvailabilityTests.swift; sourceTree = "<group>"; };
 		27A92711BC1D9A78D8A80561 /* GitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTypes.swift; sourceTree = "<group>"; };
 		27E7E4823B42BBA6EA7610DB /* CommitFilesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitFilesListView.swift; sourceTree = "<group>"; };
+		28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceEmojiPickerSelectionTests.swift; sourceTree = "<group>"; };
 		292B5DA9EC17ED07588C48FD /* OpenCodeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeInstallerTests.swift; sourceTree = "<group>"; };
 		29313DDC46A0CCA2FA42CDE9 /* Icon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
 		295319DB8544C170DDD6328D /* PathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathsTests.swift; sourceTree = "<group>"; };
@@ -2035,6 +2037,7 @@
 				25DBE942154BD154F2D10B9D /* SidebarHeaderViewTests.swift */,
 				F226AB1F51ED675BC5171018 /* SidebarMaterialChoiceTests.swift */,
 				98A00D845A8B82E27B7D2352 /* SidebarVisibilityTests.swift */,
+				28777B087266D8AE174BA233 /* SpaceEmojiPickerSelectionTests.swift */,
 				E7D9230E4E0DD70D689F40DD /* SpacePagerIndicatorTests.swift */,
 				CEA8BA11A167DA43E22E7D2D /* SpacesManagerTests.swift */,
 				43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */,
@@ -4247,6 +4250,7 @@
 				08DBBE562CC62A888617AC09 /* SidebarHeaderViewTests.swift in Sources */,
 				8FD71F989EFA5BF22B92B4CD /* SidebarMaterialChoiceTests.swift in Sources */,
 				BD8E82E61D1E23931FE69C1D /* SidebarVisibilityTests.swift in Sources */,
+				FE5846F4401C702264817399 /* SpaceEmojiPickerSelectionTests.swift in Sources */,
 				E4FA8142AB5FF2AA63BF6DA1 /* SpacePagerIndicatorTests.swift in Sources */,
 				D87EC73A848929FFB819888C /* SpacesManagerTests.swift in Sources */,
 				DC0989E32F4B7BF023F784D6 /* StartupScriptInstallerTests.swift in Sources */,

--- a/Alas/Sources/Settings/SpacesPane.swift
+++ b/Alas/Sources/Settings/SpacesPane.swift
@@ -223,13 +223,55 @@ private struct SpaceEmojiPickerControl: NSViewRepresentable {
         }
 
         private func commit(_ rawValue: String) {
-            let icon = SpaceIcon.sanitized(rawValue, fallback: "")
-            guard !icon.isEmpty else { return }
+            guard SpaceEmojiPickerSelection.commit(
+                rawValue,
+                onSelect: { [weak self] icon in
+                    self?.input.stringValue = ""
+                    self?.onSelect?(icon)
+                },
+                dismissPicker: { [weak self] in
+                    SpaceEmojiPickerWindowDismissal.dismiss(excluding: self?.window)
+                }
+            ) else { return }
             input.stringValue = ""
-            onSelect?(icon)
             window?.makeFirstResponder(button)
             window?.makeKeyAndOrderFront(nil)
         }
+    }
+}
+
+enum SpaceEmojiPickerSelection {
+    @discardableResult
+    static func commit(
+        _ rawValue: String,
+        onSelect: (String) -> Void,
+        dismissPicker: () -> Void
+    ) -> Bool {
+        let icon = SpaceIcon.sanitized(rawValue, fallback: "")
+        guard !icon.isEmpty else { return false }
+
+        onSelect(icon)
+        dismissPicker()
+        return true
+    }
+}
+
+enum SpaceEmojiPickerWindowDismissal {
+    @MainActor
+    static func dismiss(excluding ownerWindow: NSWindow?) {
+        for window in NSApp.windows where window !== ownerWindow && window.isVisible && isCharacterPalette(window) {
+            window.orderOut(nil)
+        }
+    }
+
+    private static func isCharacterPalette(_ window: NSWindow) -> Bool {
+        let className = String(describing: type(of: window)).lowercased()
+        let title = window.title.lowercased()
+
+        return className.contains("character")
+            || className.contains("emoji")
+            || title.contains("character")
+            || title.contains("emoji")
     }
 }
 

--- a/AlasTests/SpaceEmojiPickerSelectionTests.swift
+++ b/AlasTests/SpaceEmojiPickerSelectionTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import Alas
+
+@MainActor
+struct SpaceEmojiPickerSelectionTests {
+    @Test func validEmojiSelectionCommitsAndDismissesPicker() {
+        var selections: [String] = []
+        var dismissCount = 0
+
+        let didCommit = SpaceEmojiPickerSelection.commit(
+            "🚀",
+            onSelect: { selections.append($0) },
+            dismissPicker: { dismissCount += 1 }
+        )
+
+        #expect(didCommit)
+        #expect(selections == ["🚀"])
+        #expect(dismissCount == 1)
+    }
+
+    @Test func invalidEmojiSelectionDoesNotDismissPicker() {
+        var selections: [String] = []
+        var dismissCount = 0
+
+        let didCommit = SpaceEmojiPickerSelection.commit(
+            "work",
+            onSelect: { selections.append($0) },
+            dismissPicker: { dismissCount += 1 }
+        )
+
+        #expect(!didCommit)
+        #expect(selections.isEmpty)
+        #expect(dismissCount == 0)
+    }
+}


### PR DESCRIPTION
## Summary
- Dismiss the Settings > Spaces emoji picker after a valid emoji is selected.
- Keep invalid picker input from committing or dismissing.
- Add focused Swift Testing coverage for the picker commit behavior.

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test