### PR TITLE
feat(selector): match worktrees by project name

### DIFF
--- a/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
+++ b/Alas/Sources/Dialogs/RepoSelector/RepoSelectorModel.swift
@@ -227,24 +227,32 @@ final class RepoSelectorModel {
     ) -> [RepoSelectorRow] {
         struct Scored {
             let worktree: Worktree
-            let result: FuzzyMatch.Result
+            let indices: [Int]
+            let score: Double
         }
         let currentId = env.currentWorktreeId()
         var scored: [Scored] = []
         for project in projects {
             for w in env.visibleWorktrees(project.id) {
                 if let r = FuzzyMatch.score(query: query, target: w.branch) {
-                    scored.append(Scored(worktree: w, result: r))
+                    scored.append(Scored(worktree: w, indices: r.indices, score: r.score))
+                } else if let r = FuzzyMatch.score(query: query, target: "\(project.name) \(w.branch)") {
+                    let branchStart = project.name.count + 1
+                    let branchIndices = r.indices.compactMap { index -> Int? in
+                        guard index >= branchStart else { return nil }
+                        return index - branchStart
+                    }
+                    scored.append(Scored(worktree: w, indices: branchIndices, score: r.score - 1))
                 }
             }
         }
         return scored
             .sorted { a, b in
-                if a.result.score != b.result.score { return a.result.score > b.result.score }
+                if a.score != b.score { return a.score > b.score }
                 return a.worktree.branch.localizedCaseInsensitiveCompare(b.worktree.branch)
                     == .orderedAscending
             }
-            .map { .worktree($0.worktree, indices: $0.result.indices, isCurrent: $0.worktree.id == currentId) }
+            .map { .worktree($0.worktree, indices: $0.indices, isCurrent: $0.worktree.id == currentId) }
     }
 
     // MARK: - Activation

--- a/AlasTests/RepoSelectorModelTests.swift
+++ b/AlasTests/RepoSelectorModelTests.swift
@@ -399,6 +399,66 @@ struct RepoSelectorModelTests {
         #expect(indices == [0, 1])
     }
 
+    @Test func filterModeMatchesProjectNameAndBranchTogether() {
+        let model = RepoSelectorModel()
+        let alas = project("p-alas", name: "alas")
+        let acme = project("p-acme", name: "acme")
+        let alasWorktree = worktree("alas-blabla", projectId: "p-alas", branch: "blabla")
+        let acmeWorktree = worktree("acme-blabla", projectId: "p-acme", branch: "blabla")
+        let e = env(
+            projects: [alas, acme],
+            worktrees: [
+                "p-alas": [alasWorktree],
+                "p-acme": [acmeWorktree]
+            ]
+        )
+        model.query = "alas blabla"
+
+        let rows = model.rows(environment: e)
+        let worktrees: [Worktree] = rows.compactMap {
+            if case .worktree(let w, _, _) = $0 { return w } else { return nil }
+        }
+        #expect(worktrees == [alasWorktree])
+    }
+
+    @Test func filterModeMatchesProjectNameOnly() {
+        let model = RepoSelectorModel()
+        let alas = project("p-alas", name: "alas")
+        let acme = project("p-acme", name: "acme")
+        let main = worktree("alas-main", projectId: "p-alas", branch: "main")
+        let feature = worktree("alas-feature", projectId: "p-alas", branch: "feature")
+        let other = worktree("acme-main", projectId: "p-acme", branch: "main")
+        let e = env(
+            projects: [alas, acme],
+            worktrees: [
+                "p-alas": [main, feature],
+                "p-acme": [other]
+            ]
+        )
+        model.query = "alas"
+
+        let rows = model.rows(environment: e)
+        let worktreeIds: [String] = rows.compactMap {
+            if case .worktree(let w, _, _) = $0 { return w.id } else { return nil }
+        }
+        #expect(Set(worktreeIds) == ["alas-main", "alas-feature"])
+    }
+
+    @Test func filterModeMapsScopedMatchIndicesToBranch() {
+        let model = RepoSelectorModel()
+        let alas = project("p-alas", name: "alas")
+        let worktree = worktree("alas-blabla", projectId: "p-alas", branch: "blabla")
+        let e = env(projects: [alas], worktrees: ["p-alas": [worktree]])
+        model.query = "alas bla"
+
+        let rows = model.rows(environment: e)
+        guard case .worktree(_, let indices, _) = rows.first else {
+            Issue.record("expected first row to be a worktree")
+            return
+        }
+        #expect(indices == [0, 1, 2])
+    }
+
     @Test func filterModePropagatesCurrentFlag() {
         let model = RepoSelectorModel()
         let p1 = project("p1")


### PR DESCRIPTION
## Summary
- Match Cmd+K worktree filtering against project/repo name plus worktree branch when branch-only matching fails
- Preserve branch-only highlight behavior and map project-assisted matches back to branch-relative highlights
- Add focused coverage for project+branch, project-only, and scoped highlight mapping cases

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test