### PR TITLE
Add optional close tab confirmations

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */; };
 		279BAFE41DCB69286B64CFB9 /* AdapterUpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */; };
 		281C65FD7F2B509B963B74ED /* AlasHookCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A77AA40A1700F0AF21335876 /* AlasHookCommandTests.swift */; };
+		2843F603A4D71AEEA4C09317 /* CloseTabConfirmationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */; };
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		28F42E0137436A3B5F72CB85 /* ACPImageEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */; };
 		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
@@ -629,6 +630,7 @@
 		B7D79703ABCAFBC04A0091E5 /* VisualEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97EF761C70A3AF83C00879A /* VisualEffectView.swift */; };
 		B7F78A0034B7EC38072C1116 /* AlasGhosttySmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CE1F098A251F24BC352816 /* AlasGhosttySmokeTests.swift */; };
 		B834ADF0BB988121361AF334 /* tool-call-content-blocks.json in Resources */ = {isa = PBXBuildFile; fileRef = F0641A41FC56C8F251D0C2BC /* tool-call-content-blocks.json */; };
+		B83DBBA1D5090E5E757B01F5 /* CloseTabConfirmationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */; };
 		B8412B44C090B4AA6A892D25 /* ACPMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46B68FD01B15E3EEA09CB79 /* ACPMessages.swift */; };
 		B8492C38E81BB859B4B7BFA4 /* MemoryDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D223B9B905C2BBEFDE50E36 /* MemoryDiagnostics.swift */; };
 		B87B51AC9B374F318CCF1F08 /* AppStateKeepSessionsAliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46554893BA6205CD856B99B5 /* AppStateKeepSessionsAliveTests.swift */; };
@@ -1178,6 +1180,7 @@
 		530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPCodeBlockHighlighter.swift; sourceTree = "<group>"; };
 		5319C6707FCBA825E5CB1003 /* HookInstallNudgeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookInstallNudgeResolver.swift; sourceTree = "<group>"; };
 		531DB20F5FBC0D8240778FE6 /* InlineDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineDiffView.swift; sourceTree = "<group>"; };
+		5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTabConfirmationPolicyTests.swift; sourceTree = "<group>"; };
 		5377288BFD5A1B410E141C54 /* ThreePaneLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneLayout.swift; sourceTree = "<group>"; };
 		53C792D59DBFFF6C28F2D426 /* AgentKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentKind.swift; sourceTree = "<group>"; };
 		541A75BBAF1CFF3EF89383C7 /* RepoSelectorDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorDialog.swift; sourceTree = "<group>"; };
@@ -1534,6 +1537,7 @@
 		C6E896FEA37B4691BD16E2DD /* EditorBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorBufferTests.swift; sourceTree = "<group>"; };
 		C7206BC51596AE2A57D8B28B /* InlineErrorStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineErrorStrip.swift; sourceTree = "<group>"; };
 		C741E646CFDECE0AF9520265 /* ACPSteerUndoToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSteerUndoToast.swift; sourceTree = "<group>"; };
+		C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseTabConfirmationPolicy.swift; sourceTree = "<group>"; };
 		C7A24E28C231CEA4225C23F0 /* EditorTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTheme.swift; sourceTree = "<group>"; };
 		C7DD2CA21EC45168D6E43564 /* TabActivityPulseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityPulseTests.swift; sourceTree = "<group>"; };
 		C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spinner.swift; sourceTree = "<group>"; };
@@ -1900,6 +1904,7 @@
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
 				A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */,
 				6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */,
+				5337D60F19641CF933A1F855 /* CloseTabConfirmationPolicyTests.swift */,
 				E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */,
 				7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */,
 				436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */,
@@ -2481,6 +2486,7 @@
 				18CA47D5E0D1BF962CF45ABE /* AgentHookInstallNudgeBanner.swift */,
 				F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */,
 				0307CFD55404D01F14A5B602 /* CenterTypography.swift */,
+				C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */,
 				E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */,
 				BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */,
 				D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */,
@@ -3642,6 +3648,7 @@
 				CD7FB3120E4B194063C76817 /* ClaudeCodeACPInstaller.swift in Sources */,
 				87ECE63567C08B2847844EDE /* ClaudeInstaller.swift in Sources */,
 				D0F4A4F5BF5F1C3C625F11D9 /* Clipboard.swift in Sources */,
+				2843F603A4D71AEEA4C09317 /* CloseTabConfirmationPolicy.swift in Sources */,
 				EF2540A211FBE06D7B30FC61 /* Code.swift in Sources */,
 				41F6712EA71CC9AF6AB7ED94 /* CodeEditorCoordinator.swift in Sources */,
 				7324AD398C5F4168C067F4B0 /* CodeEditorLineNumberRulerView.swift in Sources */,
@@ -4090,6 +4097,7 @@
 				188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */,
 				E0AA2F46C6E53C547FEB6495 /* ClaudeCodeACPInstallerTests.swift in Sources */,
 				E1DA1C6BF9D5E157DAF6EE00 /* ClaudeInstallerTests.swift in Sources */,
+				B83DBBA1D5090E5E757B01F5 /* CloseTabConfirmationPolicyTests.swift in Sources */,
 				01CBEF6793755D3D9B000BC1 /* CodeLanguageDetailViewTests.swift in Sources */,
 				1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */,
 				3C5E243B78F3461F75AB02A8 /* CodeTextViewCompletionTests.swift in Sources */,

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -1500,7 +1500,7 @@ final class AppState {
               case .terminal = tab else { return }
         guard let outcome = tabs.removeFocusedLeaf(worktreeId: worktreeId, tabId: activeId) else { return }
         if case .tabRemoved = outcome {
-            closeTab(worktreeId: worktreeId, tabId: activeId)
+            requestCloseTab(worktreeId: worktreeId, tabId: activeId)
         } else {
             let closedLeafId = outcome.closedLeafId
             closeTerminalSession(
@@ -1620,7 +1620,7 @@ final class AppState {
             return
         }
         if let activeId = tabs.activeTabId(forWorktree: worktreeId) {
-            closeTab(worktreeId: worktreeId, tabId: activeId)
+            requestCloseTab(worktreeId: worktreeId, tabId: activeId)
         }
     }
 
@@ -1948,6 +1948,25 @@ final class AppState {
             }
         }
         tabs.close(worktreeId: worktreeId, tabId: tabId)
+    }
+
+    func requestCloseTab(worktreeId: String, tabId: TabID) {
+        guard let tab = tabs.tabs(forWorktree: worktreeId).first(where: { $0.id == tabId }) else { return }
+        if let prompt = CloseTabConfirmationPolicy.prompt(for: tab, config: config),
+           !confirmCloseTab(prompt) {
+            return
+        }
+        closeTab(worktreeId: worktreeId, tabId: tabId)
+    }
+
+    private func confirmCloseTab(_ prompt: CloseTabConfirmationPolicy.Prompt) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = prompt.title
+        alert.informativeText = prompt.message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: prompt.confirmButtonTitle)
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
     }
 
     private func cleanupTerminals(worktreeId: String, allTabs: [Tab], tabIds: [TabID]) {

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -32,7 +32,7 @@ struct CenterPaneView: View {
                     return buffer?.dirty ?? false
                 },
                 onActivate: { id in state.tabs.activate(worktreeId: worktree.id, tabId: id) },
-                onClose:    { id in state.closeTab(worktreeId: worktree.id, tabId: id) },
+                onClose:    { id in state.requestCloseTab(worktreeId: worktree.id, tabId: id) },
                 onCloseOthers: { id in state.closeOtherTabs(worktreeId: worktree.id, keeping: id) },
                 onCloseAll: { state.closeAllTabs(worktreeId: worktree.id) },
                 onCloseToLeft: { id in state.closeTabsToLeft(worktreeId: worktree.id, of: id) },

--- a/Alas/Sources/Center/CloseTabConfirmationPolicy.swift
+++ b/Alas/Sources/Center/CloseTabConfirmationPolicy.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+enum CloseTabConfirmationPolicy {
+    enum Prompt: Equatable {
+        case terminal
+        case chat
+
+        var title: String {
+            switch self {
+            case .terminal: return "Close terminal tab?"
+            case .chat:     return "Close chat tab?"
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .terminal:
+                return "This will stop the terminal session and any running process in it."
+            case .chat:
+                return "This will stop the chat session. The transcript remains available only if it has already been persisted."
+            }
+        }
+
+        var confirmButtonTitle: String {
+            switch self {
+            case .terminal: return "Close Terminal"
+            case .chat:     return "Close Chat"
+            }
+        }
+    }
+
+    static func prompt(for tab: Tab, config: AppConfig) -> Prompt? {
+        switch tab {
+        case .terminal:
+            return config.terminal.confirmCloseTabs ? .terminal : nil
+        case .acpSession:
+            return config.harness.confirmCloseChatTabs ? .chat : nil
+        default:
+            return nil
+        }
+    }
+}

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -123,6 +123,7 @@ struct AppConfig: Codable, Equatable {
         var scrollbackLines: Int
         var bell: String                 // off | visual | sound
         var syncTabTitleWithTerminalTitle: Bool
+        var confirmCloseTabs: Bool
         /// When true, every interactive pane is wrapped in `zmx attach <name>`
         /// so the shell (and any running agents) survives app quit/relaunch.
         /// When false, panes launch as plain shells and die with the app.
@@ -132,7 +133,7 @@ struct AppConfig: Codable, Equatable {
             case shell, workingDirectory, startupScript, worktreeCreateScript,
                  inheritParentEnv, fontFamily, fontSize, cursorStyle, cursorBlink,
                  scrollbackLines, bell, syncTabTitleWithTerminalTitle,
-                 keepSessionsAlive
+                 confirmCloseTabs, keepSessionsAlive
         }
 
         init(
@@ -148,6 +149,7 @@ struct AppConfig: Codable, Equatable {
             scrollbackLines: Int,
             bell: String,
             syncTabTitleWithTerminalTitle: Bool,
+            confirmCloseTabs: Bool = false,
             keepSessionsAlive: Bool = true
         ) {
             self.shell = shell
@@ -162,6 +164,7 @@ struct AppConfig: Codable, Equatable {
             self.scrollbackLines = scrollbackLines
             self.bell = bell
             self.syncTabTitleWithTerminalTitle = syncTabTitleWithTerminalTitle
+            self.confirmCloseTabs = confirmCloseTabs
             self.keepSessionsAlive = keepSessionsAlive
         }
 
@@ -179,6 +182,7 @@ struct AppConfig: Codable, Equatable {
             scrollbackLines = try c.decode(Int.self, forKey: .scrollbackLines)
             bell = try c.decode(String.self, forKey: .bell)
             syncTabTitleWithTerminalTitle = (try? c.decode(Bool.self, forKey: .syncTabTitleWithTerminalTitle)) ?? false
+            confirmCloseTabs = (try? c.decode(Bool.self, forKey: .confirmCloseTabs)) ?? false
             keepSessionsAlive = (try? c.decode(Bool.self, forKey: .keepSessionsAlive)) ?? true
         }
     }
@@ -188,6 +192,7 @@ struct AppConfig: Codable, Equatable {
         var notifyOnAwaiting: Bool
         var dismissedHookInstallNudges: [String]
         var dismissedACPSetupNudges: [String]
+        var confirmCloseChatTabs: Bool
         /// When true (default): ⏎ submits with .auto intent, ⌥⏎ steers.
         /// When false: the two are inverted — ⏎ steers, ⌥⏎ queues. The
         /// label in Settings is "Send on ⏎, queue on ⌥⏎ while busy".
@@ -196,18 +201,20 @@ struct AppConfig: Codable, Equatable {
         enum CodingKeys: String, CodingKey {
             case notifyOnFinish, notifyOnAwaiting,
                  dismissedHookInstallNudges, dismissedACPSetupNudges,
-                 acpSendOnEnter
+                 confirmCloseChatTabs, acpSendOnEnter
         }
 
         init(notifyOnFinish: Bool, notifyOnAwaiting: Bool,
              dismissedHookInstallNudges: [String] = [],
              dismissedACPSetupNudges: [String] = [],
+             confirmCloseChatTabs: Bool = false,
              acpSendOnEnter: Bool = true)
         {
             self.notifyOnFinish = notifyOnFinish
             self.notifyOnAwaiting = notifyOnAwaiting
             self.dismissedHookInstallNudges = dismissedHookInstallNudges
             self.dismissedACPSetupNudges = dismissedACPSetupNudges
+            self.confirmCloseChatTabs = confirmCloseChatTabs
             self.acpSendOnEnter = acpSendOnEnter
         }
 
@@ -217,6 +224,7 @@ struct AppConfig: Codable, Equatable {
             notifyOnAwaiting = (try? c.decode(Bool.self, forKey: .notifyOnAwaiting)) ?? true
             dismissedHookInstallNudges = (try? c.decode([String].self, forKey: .dismissedHookInstallNudges)) ?? []
             dismissedACPSetupNudges = (try? c.decode([String].self, forKey: .dismissedACPSetupNudges)) ?? []
+            confirmCloseChatTabs = (try? c.decode(Bool.self, forKey: .confirmCloseChatTabs)) ?? false
             acpSendOnEnter = (try? c.decode(Bool.self, forKey: .acpSendOnEnter)) ?? true
         }
     }
@@ -355,6 +363,7 @@ struct AppConfig: Codable, Equatable {
             scrollbackLines: 10000,
             bell: "visual",
             syncTabTitleWithTerminalTitle: false,
+            confirmCloseTabs: false,
             keepSessionsAlive: true
         ),
         harness: Harness(notifyOnFinish: true, notifyOnAwaiting: true),
@@ -496,6 +505,7 @@ extension AppConfig {
             let scrollbackLines = (try? termContainer.decode(Int.self, forKey: .scrollbackLines)) ?? 10000
             let bell = (try? termContainer.decode(String.self, forKey: .bell)) ?? "visual"
             let syncTabTitleWithTerminalTitle = (try? termContainer.decode(Bool.self, forKey: .syncTabTitleWithTerminalTitle)) ?? false
+            let confirmCloseTabs = (try? termContainer.decode(Bool.self, forKey: .confirmCloseTabs)) ?? false
             let keepSessionsAlive = (try? termContainer.decode(Bool.self, forKey: .keepSessionsAlive)) ?? true
             terminal = Terminal(
                 shell: shell,
@@ -510,6 +520,7 @@ extension AppConfig {
                 scrollbackLines: scrollbackLines,
                 bell: bell,
                 syncTabTitleWithTerminalTitle: syncTabTitleWithTerminalTitle,
+                confirmCloseTabs: confirmCloseTabs,
                 keepSessionsAlive: keepSessionsAlive
             )
         } else {
@@ -526,6 +537,7 @@ extension AppConfig {
                 scrollbackLines: 10000,
                 bell: "visual",
                 syncTabTitleWithTerminalTitle: false,
+                confirmCloseTabs: false,
                 keepSessionsAlive: true
             )
         }

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -77,6 +77,14 @@ struct AgentsPane: View {
                             state.saveConfig() }
                         ))
                     }
+                    SettingsRow(name: "Confirm before closing chat tabs",
+                                desc: "Ask before closing Chat tabs with Command-W or the tab close button.") {
+                        AlasToggle(on: Binding(
+                            get: { state.config.harness.confirmCloseChatTabs },
+                            set: { state.config.harness.confirmCloseChatTabs = $0
+                            state.saveConfig() }
+                        ))
+                    }
                 }
 
                 SettingsGroup(title: "Harness") {

--- a/Alas/Sources/Settings/TerminalPane.swift
+++ b/Alas/Sources/Settings/TerminalPane.swift
@@ -38,6 +38,10 @@ struct TerminalPane: View {
                                 desc: "Terminal panes (and any running agents inside them) survive quit and relaunch with their shell, scrollback, and state.") {
                         AlasToggle(on: state.bind(\.terminal.keepSessionsAlive))
                     }
+                    SettingsRow(name: "Confirm before closing terminal tabs",
+                                desc: "Ask before closing Terminal tabs with Command-W or the tab close button.") {
+                        AlasToggle(on: state.bind(\.terminal.confirmCloseTabs))
+                    }
                 }
 
                 SettingsGroup(title: "Startup scripts") {

--- a/AlasTests/CloseTabConfirmationPolicyTests.swift
+++ b/AlasTests/CloseTabConfirmationPolicyTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import Alas
+
+struct CloseTabConfirmationPolicyTests {
+    @Test func terminalTabsRequireConfirmationOnlyWhenTerminalSettingIsEnabled() {
+        var config = AppConfig.defaults
+        let tab = Tab.terminal(TerminalTabState(id: "terminal-tab", title: "Terminal", sessionId: "session"))
+
+        #expect(CloseTabConfirmationPolicy.prompt(for: tab, config: config) == nil)
+
+        config.terminal.confirmCloseTabs = true
+        #expect(CloseTabConfirmationPolicy.prompt(for: tab, config: config) == .terminal)
+    }
+
+    @Test func chatTabsRequireConfirmationOnlyWhenChatSettingIsEnabled() {
+        var config = AppConfig.defaults
+        let tab = Tab.acpSession(ACPSessionTabState(sessionId: "chat-session", title: "Chat"))
+
+        #expect(CloseTabConfirmationPolicy.prompt(for: tab, config: config) == nil)
+
+        config.harness.confirmCloseChatTabs = true
+        #expect(CloseTabConfirmationPolicy.prompt(for: tab, config: config) == .chat)
+    }
+
+    @Test func otherTabTypesNeverRequireCloseConfirmation() {
+        var config = AppConfig.defaults
+        config.terminal.confirmCloseTabs = true
+        config.harness.confirmCloseChatTabs = true
+
+        let editor = Tab.editor(EditorTabState(id: "editor", title: "README.md", relativePath: "README.md"))
+        let diff = Tab.diff(DiffTabState(id: "diff", title: "Diff", relativePath: "README.md"))
+
+        #expect(CloseTabConfirmationPolicy.prompt(for: editor, config: config) == nil)
+        #expect(CloseTabConfirmationPolicy.prompt(for: diff, config: config) == nil)
+    }
+
+    @Test func promptCopyMatchesTabKind() {
+        #expect(CloseTabConfirmationPolicy.Prompt.terminal.title == "Close terminal tab?")
+        #expect(CloseTabConfirmationPolicy.Prompt.terminal.confirmButtonTitle == "Close Terminal")
+        #expect(CloseTabConfirmationPolicy.Prompt.chat.title == "Close chat tab?")
+        #expect(CloseTabConfirmationPolicy.Prompt.chat.confirmButtonTitle == "Close Chat")
+    }
+}

--- a/AlasTests/SettingsSaveNormalizationTests.swift
+++ b/AlasTests/SettingsSaveNormalizationTests.swift
@@ -62,6 +62,29 @@ struct SettingsSaveNormalizationTests {
         #expect(AppConfig.defaults.code.formatOnSave == false)
     }
 
+    @Test func decodeMissingCloseConfirmationSettingsDefaultToFalse() throws {
+        let json = #"{"themeId":"cool-slate","accent":"teal","density":"comfortable","matchSystemTheme":false,"sidebarMaterial":"appKitSidebar","sidebarWidth":244,"rightPaneWidth":320,"rightPaneVisible":true,"sidebarVisible":true,"commitDetailSplitRatio":0.32,"general":{"launchAtLogin":false,"closeToTray":true,"confirmQuit":true,"autoUpdate":true,"updateChannel":"Stable","crashReports":false,"usageAnalytics":false},"worktrees":{"rootPath":"~/.alas/worktrees","pathTemplate":"{worktreeRoot}/{repo}/{branch}","branchPrefix":"feature/","baseBranch":"main","trackUpstream":true,"deleteBranchOnRemove":true,"autoFetch":true,"fetchIntervalMinutes":5,"pruneStale":false},"terminal":{"shell":"/bin/zsh","workingDirectory":"worktreeRoot","startupScript":"","worktreeCreateScript":"","inheritParentEnv":true,"fontFamily":"JetBrains Mono","fontSize":13,"cursorStyle":"beam","cursorBlink":true,"scrollbackLines":10000,"bell":"visual","syncTabTitleWithTerminalTitle":false},"harness":{"notifyOnFinish":true,"notifyOnAwaiting":true},"code":{"fontFamily":"SF Mono","fontSize":13,"formatOnSave":true,"languageServers":[],"dismissedInstallNudges":[],"userDefinedRecipes":{}},"markdown":{"defaultViewMode":"editor"},"changes":{"aiToolId":"none","prompt":"Hello"},"agents":{"builtinState":{},"custom":[],"worktreeAutoLaunch":{"agentId":null,"useBypassPermissions":false}},"files":{"showIgnored":true}}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.terminal.confirmCloseTabs == false)
+        #expect(decoded.harness.confirmCloseChatTabs == false)
+    }
+
+    @Test func decodeExplicitCloseConfirmationSettingsArePreserved() throws {
+        let json = #"{"themeId":"cool-slate","accent":"teal","density":"comfortable","matchSystemTheme":false,"sidebarMaterial":"appKitSidebar","sidebarWidth":244,"rightPaneWidth":320,"rightPaneVisible":true,"sidebarVisible":true,"commitDetailSplitRatio":0.32,"general":{"launchAtLogin":false,"closeToTray":true,"confirmQuit":true,"autoUpdate":true,"updateChannel":"Stable","crashReports":false,"usageAnalytics":false},"worktrees":{"rootPath":"~/.alas/worktrees","pathTemplate":"{worktreeRoot}/{repo}/{branch}","branchPrefix":"feature/","baseBranch":"main","trackUpstream":true,"deleteBranchOnRemove":true,"autoFetch":true,"fetchIntervalMinutes":5,"pruneStale":false},"terminal":{"shell":"/bin/zsh","workingDirectory":"worktreeRoot","startupScript":"","worktreeCreateScript":"","inheritParentEnv":true,"fontFamily":"JetBrains Mono","fontSize":13,"cursorStyle":"beam","cursorBlink":true,"scrollbackLines":10000,"bell":"visual","syncTabTitleWithTerminalTitle":false,"confirmCloseTabs":true},"harness":{"notifyOnFinish":true,"notifyOnAwaiting":true,"confirmCloseChatTabs":true},"code":{"fontFamily":"SF Mono","fontSize":13,"formatOnSave":true,"languageServers":[],"dismissedInstallNudges":[],"userDefinedRecipes":{}},"markdown":{"defaultViewMode":"editor"},"changes":{"aiToolId":"none","prompt":"Hello"},"agents":{"builtinState":{},"custom":[],"worktreeAutoLaunch":{"agentId":null,"useBypassPermissions":false}},"files":{"showIgnored":true}}"#
+        let data = Data(json.utf8)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+
+        #expect(decoded.terminal.confirmCloseTabs == true)
+        #expect(decoded.harness.confirmCloseChatTabs == true)
+    }
+
+    @Test func staticDefaultConfigHasCloseConfirmationDisabled() {
+        #expect(AppConfig.defaults.terminal.confirmCloseTabs == false)
+        #expect(AppConfig.defaults.harness.confirmCloseChatTabs == false)
+    }
+
     @Test func decodeMissingSyncTabTitleField() throws {
         let json = #"{"themeId":"cool-slate","accent":"teal","density":"comfortable","matchSystemTheme":false,"sidebarMaterial":"appKitSidebar","sidebarWidth":244,"rightPaneWidth":320,"rightPaneVisible":true,"sidebarVisible":true,"commitDetailSplitRatio":0.32,"general":{"launchAtLogin":false,"closeToTray":true,"confirmQuit":true,"autoUpdate":true,"updateChannel":"Stable","crashReports":false,"usageAnalytics":false},"worktrees":{"rootPath":"~/.alas/worktrees","pathTemplate":"{worktreeRoot}/{repo}/{branch}","branchPrefix":"feature/","baseBranch":"main","trackUpstream":true,"deleteBranchOnRemove":true,"autoFetch":true,"fetchIntervalMinutes":5,"pruneStale":false},"terminal":{"shell":"/bin/zsh","workingDirectory":"worktreeRoot","startupScript":"","worktreeCreateScript":"","inheritParentEnv":true,"fontFamily":"JetBrains Mono","fontSize":13,"cursorStyle":"beam","cursorBlink":true,"scrollbackLines":10000,"bell":"visual"},"harness":{"notifyOnFinish":true,"notifyOnAwaiting":true},"code":{"fontFamily":"SF Mono","fontSize":13,"formatOnSave":true,"languageServers":[],"dismissedInstallNudges":[],"userDefinedRecipes":{}},"markdown":{"defaultViewMode":"editor"},"changes":{"aiToolId":"none","prompt":"Hello"},"agents":{"builtinState":{},"custom":[],"worktreeAutoLaunch":{"agentId":null,"useBypassPermissions":false}},"files":{"showIgnored":true}}"#
         let data = Data(json.utf8)

--- a/docs/superpowers/specs/2026-06-02-optional-close-tab-confirmation-design.md
+++ b/docs/superpowers/specs/2026-06-02-optional-close-tab-confirmation-design.md
@@ -1,0 +1,87 @@
+# Optional Close Tab Confirmation
+
+## Goal
+
+Add optional, disabled-by-default confirmation prompts before closing Terminal and Chat tabs. The feature protects users from accidental `Command-W` or tab close button actions without changing the default fast-close behavior.
+
+## Settings Placement
+
+Terminal and Chat confirmations are separate settings because they belong to different user workflows.
+
+- `Settings -> Terminal -> Sessions`
+  - Label: `Confirm before closing terminal tabs`
+  - Description: `Ask before closing Terminal tabs with Command-W or the tab close button.`
+  - Default: off
+
+- `Settings -> Agents -> Chat`
+  - Label: `Confirm before closing chat tabs`
+  - Description: `Ask before closing Chat tabs with Command-W or the tab close button.`
+  - Default: off
+
+Use "Chat" in the UI instead of "ACP" to match the existing user-facing language in Settings.
+
+## Behavior
+
+The confirmation applies only to single-tab close requests for the matching tab type:
+
+- Terminal tab close uses the Terminal setting.
+- Chat tab close uses the Agents/Chat setting.
+- Editor, diff, commit, image, markdown, and merge-conflict tabs keep their current behavior.
+- `Command-W` and the tab close button use the same close-request path.
+
+For split terminal tabs, the existing `Command-W` behavior remains: if the active terminal tab has multiple panes, `Command-W` closes the focused pane first. The terminal-tab confirmation applies only when the action would close the whole terminal tab.
+
+Bulk tab actions keep their existing behavior for this feature:
+
+- Close Other Tabs
+- Close All Tabs
+- Close Tabs to the Left
+- Close Tabs to the Right
+- Worktree archive/delete cleanup
+- Process-exit cleanup
+- Terminate All Terminal Sessions
+
+Those flows either already have their own confirmation semantics or are cleanup operations rather than accidental single-tab close actions.
+
+## Prompt Copy
+
+Terminal tab prompt:
+
+- Title: `Close terminal tab?`
+- Message: `This will stop the terminal session and any running process in it.`
+- Primary button: `Close Terminal`
+- Cancel button: `Cancel`
+
+Chat tab prompt:
+
+- Title: `Close chat tab?`
+- Message: `This will stop the chat session. The transcript remains available only if it has already been persisted.`
+- Primary button: `Close Chat`
+- Cancel button: `Cancel`
+
+The prompts should be standard warning alerts or SwiftUI alerts consistent with nearby destructive confirmations.
+
+## Data Model
+
+Persist two booleans with backwards-compatible defaults:
+
+- `AppConfig.Terminal.confirmCloseTabs = false`
+- `AppConfig.Harness.confirmCloseChatTabs = false`
+
+Older config files decode both as `false`.
+
+## Testing
+
+Add focused tests around the pure routing/policy where practical:
+
+- Terminal confirmation is required only for terminal tabs when the terminal setting is enabled.
+- Chat confirmation is required only for chat tabs when the chat setting is enabled.
+- Non-terminal and non-chat tabs never use these settings.
+- Missing settings in older config JSON decode to `false`.
+
+Manual verification should cover:
+
+- Toggling each setting in Settings.
+- Closing Terminal and Chat tabs through `Command-W`.
+- Closing Terminal and Chat tabs through the tab close button.
+- Split terminal `Command-W` still closes a pane before prompting for tab close.


### PR DESCRIPTION
## Summary
- Add separate disabled-by-default close confirmation settings for Terminal and Chat tabs
- Route user-triggered tab closes through a shared confirmation policy
- Preserve split-pane and bulk cleanup close behavior

## Tests
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test -only-testing:AlasTests/SettingsSaveNormalizationTests -only-testing:AlasTests/CloseTabConfirmationPolicyTests`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`