### PR TITLE
fix(settings): window chrome shouldn't show the semaphore buttons twice

### DIFF
--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -59,7 +59,6 @@ struct AlasApp: App {
         Window("Settings", id: "settings") {
             SettingsWindow(state: state)
         }
-        .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)
         .defaultSize(width: 880, height: 580)
 

--- a/Alas/Sources/App/WindowChrome/WindowConfigurator.swift
+++ b/Alas/Sources/App/WindowChrome/WindowConfigurator.swift
@@ -6,8 +6,8 @@ struct WindowConfigurator: NSViewRepresentable {
     /// (`isMovable = false`); regions that should still drag the window must
     /// be marked with `.windowDragHandle()`. The main workspace window needs
     /// this so the center pane's top tab bar isn't hijacked by the system
-    /// titlebar drag tracker. Secondary windows (e.g. Settings) keep the
-    /// default movable behavior so the system titlebar still drags them.
+    /// titlebar drag tracker. Secondary titleless windows keep the default
+    /// movable behavior so the system titlebar still drags them.
     var disablesSystemDrag: Bool = false
 
     func makeNSView(context: Context) -> NSView {

--- a/Alas/Sources/App/WindowChrome/WindowConfigurator.swift
+++ b/Alas/Sources/App/WindowChrome/WindowConfigurator.swift
@@ -11,15 +11,40 @@ struct WindowConfigurator: NSViewRepresentable {
     var disablesSystemDrag: Bool = false
 
     func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        let disablesSystemDrag = self.disablesSystemDrag
-        DispatchQueue.main.async {
-            if let window = view.window {
-                TitlelessWindow.configure(window, disablesSystemDrag: disablesSystemDrag)
-            }
-        }
-        return view
+        WindowConfigurationView(disablesSystemDrag: disablesSystemDrag)
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let view = nsView as? WindowConfigurationView else { return }
+        view.disablesSystemDrag = disablesSystemDrag
+        view.configureWindowIfNeeded()
+    }
+}
+
+final class WindowConfigurationView: NSView {
+    var disablesSystemDrag: Bool {
+        didSet {
+            configureWindowIfNeeded()
+        }
+    }
+
+    init(disablesSystemDrag: Bool) {
+        self.disablesSystemDrag = disablesSystemDrag
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        configureWindowIfNeeded()
+    }
+
+    func configureWindowIfNeeded() {
+        guard let window else { return }
+        TitlelessWindow.configure(window, disablesSystemDrag: disablesSystemDrag)
+    }
 }

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -14,11 +14,6 @@ struct SettingsWindow: View {
                     colors: [theme.color("bg-3"), theme.color("bg-2")],
                     startPoint: .top, endPoint: .bottom
                 )
-                HStack {
-                    TrafficLights()
-                    Spacer()
-                }
-                .padding(.leading, 16)
                 Text("Settings")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(theme.color("fg-muted"))
@@ -61,9 +56,7 @@ struct SettingsWindow: View {
         .frame(width: 880)
         .frame(maxHeight: .infinity)
         .background(theme.color("bg-1"))
-        .background(WindowConfigurator())
         .environment(\.theme, theme)
-        .ignoresSafeArea()
         .onAppear {
             showsDebug = AdvancedSettingsVisibility.isEnabled()
             consumePendingSettingsSection()

--- a/AlasTests/TitlelessWindowTests.swift
+++ b/AlasTests/TitlelessWindowTests.swift
@@ -31,4 +31,23 @@ struct TitlelessWindowTests {
 
         #expect(window.styleMask.contains(.fullSizeContentView))
     }
+
+    @Test func configurationViewConfiguresWindowWhenAttached() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let configurationView = WindowConfigurationView(disablesSystemDrag: false)
+
+        #expect(window.standardWindowButton(.closeButton)?.isHidden == false)
+
+        window.contentView = configurationView
+
+        #expect(window.standardWindowButton(.closeButton)?.isHidden == true)
+        #expect(window.standardWindowButton(.miniaturizeButton)?.isHidden == true)
+        #expect(window.standardWindowButton(.zoomButton)?.isHidden == true)
+        #expect(window.styleMask.contains(.fullSizeContentView))
+    }
 }


### PR DESCRIPTION
## Summary
- Use standard macOS window chrome for the Settings dialog
- Remove Settings-specific custom traffic-light rendering and titleless configurator usage
- Add regression coverage for Settings chrome policy

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test