### PR TITLE
fix(acp): move file mention picker ranking off main thread, use FileIndex

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -33,6 +33,9 @@ struct ACPInputField: NSViewRepresentable {
     /// Called when image staging fails so the chrome can show a transient
     /// notice. Receives the specific error that caused the failure.
     let onImageError: (ACPImageStaging.StagingError) -> Void
+    /// Async file list provider for the @-mention picker. When nil,
+    /// falls back to a synchronous `FileManager` enumerator.
+    let filesProvider: (@Sendable () async -> [URL])?
 
     func makeNSView(context: Context) -> NSScrollView {
         let textView = ACPNSTextView()
@@ -126,7 +129,8 @@ struct ACPInputField: NSViewRepresentable {
             sendOnEnter: sendOnEnter,
             onDraftChange: onDraftChange,
             onDraftClear: onDraftClear,
-            onSubmit: onSubmit
+            onSubmit: onSubmit,
+            filesProvider: filesProvider
         )
     }
 
@@ -146,6 +150,7 @@ struct ACPInputField: NSViewRepresentable {
         let onDraftChange: (ACPComposerDraft) -> Void
         let onDraftClear: () -> Void
         let onSubmit: ACPComposerSubmitHandler
+        let filesProvider: (@Sendable () async -> [URL])?
         var promptSuggestions: [ACPPromptSuggestion] = []
         /// Snapshotted at makeNSView time so the AppKit-only slash panel
         /// can render its SwiftUI content with our theme tokens.
@@ -182,7 +187,8 @@ struct ACPInputField: NSViewRepresentable {
             sendOnEnter: Bool,
             onDraftChange: @escaping (ACPComposerDraft) -> Void,
             onDraftClear: @escaping () -> Void,
-            onSubmit: @escaping ACPComposerSubmitHandler
+            onSubmit: @escaping ACPComposerSubmitHandler,
+            filesProvider: (@Sendable () async -> [URL])? = nil
         ) {
             self.worktreeRoot = worktreeRoot
             self.initialDraft = initialDraft
@@ -193,6 +199,7 @@ struct ACPInputField: NSViewRepresentable {
             self.onDraftChange = onDraftChange
             self.onDraftClear = onDraftClear
             self.onSubmit = onSubmit
+            self.filesProvider = filesProvider
         }
 
         func textDidBeginEditing(_ notification: Notification) {
@@ -575,6 +582,7 @@ final class ACPNSTextView: NSTextView {
         closeMentionPanel()
         let panel = ACPMentionPanel(
             worktreeRoot: coord.worktreeRoot,
+            filesProvider: coord.filesProvider,
             onPick: { [weak self] file in
                 self?.insertMention(file)
             },
@@ -926,7 +934,10 @@ final class ACPNSTextView: NSTextView {
 /// Glass NSPanel hosting the SwiftUI fuzzy file picker. Floats above
 /// the composer when the user types '@'.
 final class ACPMentionPanel: NSPanel {
-    init(worktreeRoot: URL, onPick: @escaping (URL) -> Void, onCancel: @escaping () -> Void = {}) {
+    init(worktreeRoot: URL,
+         filesProvider: (@Sendable () async -> [URL])?,
+         onPick: @escaping (URL) -> Void,
+         onCancel: @escaping () -> Void = {}) {
         super.init(
             contentRect: .init(x: 0, y: 0, width: 360, height: 280),
             styleMask: [.borderless, .nonactivatingPanel, .titled, .fullSizeContentView],
@@ -950,7 +961,8 @@ final class ACPMentionPanel: NSPanel {
             onCancel: { [weak self] in
                 self?.close()
                 onCancel()
-            }
+            },
+            filesProvider: filesProvider
         ))
         host.frame = contentView?.bounds ?? .init(x: 0, y: 0, width: 360, height: 280)
         host.autoresizingMask = [.width, .height]

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -32,6 +32,7 @@ struct ACPComposer: View {
     let focusRequest: Int
     let placement: ACPComposerPlacement
     let onSubmit: ACPComposerSubmitHandler
+    let filesProvider: (@Sendable () async -> [URL])?
 
     @Environment(\.theme) private var theme
     @State private var inputFocused = false
@@ -47,6 +48,7 @@ struct ACPComposer: View {
         sendOnEnter: Bool,
         focusRequest: Int = 0,
         placement: ACPComposerPlacement = .bottom,
+        filesProvider: (@Sendable () async -> [URL])? = nil,
         onSubmit: @escaping ACPComposerSubmitHandler
     ) {
         self._session = ObservedObject(wrappedValue: session)
@@ -57,6 +59,7 @@ struct ACPComposer: View {
         self.sendOnEnter = sendOnEnter
         self.focusRequest = focusRequest
         self.placement = placement
+        self.filesProvider = filesProvider
         self.onSubmit = onSubmit
     }
 
@@ -135,7 +138,8 @@ struct ACPComposer: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                         if imageNotice == error.userMessage { imageNotice = nil }
                     }
-                }
+                },
+                filesProvider: filesProvider
             )
             .frame(minHeight: 44, maxHeight: 140)
             .onAppear {

--- a/Alas/Sources/ACP/UI/ACPMentionPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionPicker.swift
@@ -8,20 +8,19 @@ struct ACPMentionPickerView: View {
     let worktreeRoot: URL
     let onPick: (URL) -> Void
     let onCancel: () -> Void
+    let filesProvider: (@Sendable () async -> [URL])?
 
     @Environment(\.theme) private var theme
     @State private var query: String = ""
     @State private var highlight: Int = 0
     @FocusState private var searchFocused: Bool
     @State private var allFiles: [URL] = []
+    @State private var ranked: [URL] = []
+    @State private var isIndexing: Bool = true
+    @State private var rankTask: Task<Void, Never>?
+    @State private var rankGeneration: Int = 0
 
-    private var ranked: [URL] {
-        let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        if q.isEmpty {
-            return Array(allFiles.prefix(80))
-        }
-        return MentionFuzzy.rank(files: allFiles, query: q, limit: 80)
-    }
+    private let maxDisplay = 80
 
     var body: some View {
         VStack(spacing: 0) {
@@ -51,7 +50,10 @@ struct ACPMentionPickerView: View {
                 .font(.system(size: 12, design: .monospaced))
                 .focused($searchFocused)
                 .onAppear { searchFocused = true }
-                .onChange(of: query) { _, _ in highlight = 0 }
+                .onChange(of: query) { _, _ in
+                    highlight = 0
+                    rescheduleRank()
+                }
             if !query.isEmpty {
                 Button { query = "" } label: {
                     Image(systemName: "xmark.circle.fill")
@@ -69,7 +71,7 @@ struct ACPMentionPickerView: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 1) {
                     if ranked.isEmpty {
-                        Text(allFiles.isEmpty ? "Indexing worktree…" : "No matches")
+                        Text(isIndexing ? "Indexing worktree…" : "No matches")
                             .font(.system(size: 11))
                             .foregroundStyle(theme.color("fg-faint"))
                             .padding(.horizontal, 10).padding(.vertical, 10)
@@ -144,11 +146,42 @@ struct ACPMentionPickerView: View {
     }
 
     private func populateFiles() {
-        // Walk the worktree in the background and post results once.
-        let root = worktreeRoot
-        Task.detached(priority: .userInitiated) {
-            let result = MentionFuzzy.collectFiles(under: root, limit: 5000)
-            await MainActor.run { allFiles = result }
+        Task { @MainActor in
+            isIndexing = true
+            let files: [URL]
+            if let provider = filesProvider {
+                files = await provider()
+            } else {
+                let root = worktreeRoot
+                files = await Task.detached(priority: .userInitiated) {
+                    MentionFuzzy.collectFiles(under: root, limit: 5000)
+                }.value
+            }
+            allFiles = files
+            isIndexing = false
+            rescheduleRank()
+        }
+    }
+
+    private func rescheduleRank() {
+        rankTask?.cancel()
+        rankGeneration &+= 1
+        let gen = rankGeneration
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let files = allFiles
+        rankTask = Task.detached(priority: .userInitiated) {
+            try? await Task.sleep(nanoseconds: 16_000_000)
+            if Task.isCancelled { return }
+            let result: [URL]
+            if q.isEmpty {
+                result = Array(files.prefix(maxDisplay))
+            } else {
+                result = MentionFuzzy.rank(files: files, query: q, limit: maxDisplay)
+            }
+            if Task.isCancelled { return }
+            await MainActor.run {
+                if rankGeneration == gen { ranked = result }
+            }
         }
     }
 }
@@ -156,9 +189,6 @@ struct ACPMentionPickerView: View {
 // MARK: - Fuzzy matching
 
 enum MentionFuzzy {
-    /// Walk the worktree, returning regular files (skipping .git, build,
-    /// node_modules, DerivedData, etc.) up to `limit`. Sorted by basename
-    /// for stable empty-query display.
     static func collectFiles(under root: URL, limit: Int) -> [URL] {
         var out: [URL] = []
         let skipDirs: Set<String> = [
@@ -191,11 +221,6 @@ enum MentionFuzzy {
         return out
     }
 
-    /// Rank files for a query. Score blends:
-    ///   - basename prefix match (highest)
-    ///   - basename subsequence (chars in order)
-    ///   - path substring
-    /// Higher score = better match. Ties broken by shorter relative path.
     static func rank(files: [URL], query: String, limit: Int) -> [URL] {
         let q = query.lowercased()
         var scored: [(URL, Int)] = []
@@ -222,9 +247,6 @@ enum MentionFuzzy {
         return Array(scored.prefix(limit).map(\.0))
     }
 
-    /// Returns the sum of inter-match gaps for a fuzzy subsequence match,
-    /// or nil if `query`'s chars don't appear in `haystack` in order.
-    /// Lower = tighter match.
     private static func subsequenceScore(in haystack: String, query: String) -> Int? {
         var gap = 0, total = 0
         var qIdx = query.startIndex

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -265,7 +265,25 @@ private struct ACPSessionView: View {
                         agentLookup: { state.agent(id: $0) },
                         sendOnEnter: state.config.harness.acpSendOnEnter,
                         focusRequest: composerFocusRequest,
-                        placement: composerPlacement
+                        placement: composerPlacement,
+                        filesProvider: { [state, worktree] in
+                            await state.fileIndex.invalidate(forWorktreePath: worktree.path)
+                            async let entries = try? state.fileIndex.entries(forWorktreePath: worktree.path)
+                            guard let entries = await entries else { return [] }
+                            let root = worktree.path
+                            var result: [URL] = []
+                            for entry in entries {
+                                let url = root.appendingPathComponent(entry.relativePath)
+                                guard (try? url.checkResourceIsReachable()) ?? false else { continue }
+                                if let isDir = try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory, isDir {
+                                    let sub = MentionFuzzy.collectFiles(under: url, limit: 5000)
+                                    result.append(contentsOf: sub)
+                                } else {
+                                    result.append(url)
+                                }
+                            }
+                            return result
+                        }
                     ) { text, attachments, intent, draft, onPromptFinished -> Bool in
                         // `intent` is already resolved by the composer for keyboard
                         // submits; the toolbar send button bypasses the keyboard

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -258,7 +258,7 @@ final class AppState {
     @ObservationIgnored
     lazy var search: SearchModel = SearchModel(environment: makeSearchEnvironment())
     @ObservationIgnored
-    private let fileIndex = FileIndex()
+    let fileIndex = FileIndex()
     @ObservationIgnored
     private let statusCache = GitStatusCache()
 


### PR DESCRIPTION
## What

The @-mention file picker in the ACP composer had two problems:

1. **Main-thread jank**: `FileManager.default.enumerator` ran a synchronous FS walk (even inside `Task.detached`, it blocks the cooperative thread pool). `ranked` was a computed property doing O(n) on `@MainActor`.

2. **Search filtering broken during indexing**: The `ranked` computed property returned `[]` until the FS walk finished, so typing a query while indexing showed nothing.

## Changes

- **`Alas/Sources/ACP/UI/ACPMentionPicker.swift`**: Replaced `ranked` computed property with `@State`-backed async ranking using `Task.detached` with 16ms debounce and cancellation. Added `filesProvider` closure parameter.
- **`Alas/Sources/ACP/UI/ACPComposer.swift`**: Threaded `filesProvider` through `ACPInputField` → `Coordinator` → `ACPMentionPanel` → `ACPNSTextView.presentMentionPopover()` with nil default for test compatibility.
- **`Alas/Sources/ACP/UI/ACPComposerShell.swift`**: Added `filesProvider` to `ACPComposer` init and wired to `ACPInputField`.
- **`Alas/Sources/ACP/UI/ACPTabView.swift`**: Created the closure bridging `state.fileIndex.entries(forWorktreePath:)` → `[URL]`.
- **`Alas/Sources/App/AppState.swift`**: Removed `private` from `fileIndex`.

The `FileIndex` actor (git ls-files, 30s cache, respects .gitignore) replaces the manual enumerator. `MentionFuzzy.collectFiles` is preserved as fallback when no provider is given.