### PR TITLE
feat(acp): synthesize Thinking chip for cursor-agent from model variants

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		5D8DF496FC722EE24F69A60A /* AgentHookSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 976B145EAC17A395380DFB47 /* AgentHookSocketServer.swift */; };
 		5DF3F01E3DC672E4C6CBEDBC /* CommitEditorTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7268D601058775FE02B6B06 /* CommitEditorTabView.swift */; };
 		5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239125BB939233233D405EB8 /* ACPChipStateTests.swift */; };
+		44FCBC1DFE01462AAAA3443F /* CursorModelVariantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D266C85C78433E91EAA36F /* CursorModelVariantsTests.swift */; };
 		5E687CE659E83EF3B71CA86F /* PiInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932EA49288A0444FB8BB9CE3 /* PiInstaller.swift */; };
 		5EA1AA5C8D9DE003BACE8291 /* AlasGhostty.Surface.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E76CA315A7B08E09A80AA8 /* AlasGhostty.Surface.swift */; };
 		5EB258E8B4A4DCD50DFE5E82 /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE58EF9CF8EC461667D9430 /* AppConfig.swift */; };
@@ -659,6 +660,7 @@
 		BFB452EE7A29CF81F7A4BD8A /* RightPaneTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B4ADD529F9B64DAD2994E0B /* RightPaneTabBar.swift */; };
 		BFF99F8FDEA5D05EF4E1EEC3 /* DiagnosticsRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 412B2AF1B68E3B56DE21EB91 /* DiagnosticsRangeTests.swift */; };
 		C00E549FA69AB3D3C55B85EB /* ACPChipState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */; };
+		F0CF3B4D32A742B2B6156381 /* CursorModelVariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A9E43BD088A43A0B218C32B /* CursorModelVariants.swift */; };
 		C04150547C17399FA9D7947C /* ACPComposerShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906D92F7AD84F313508D9CFD /* ACPComposerShell.swift */; };
 		C0A78F790FB9B52621D5798A /* ImageDiffSideBySideViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC13E4C0AF55A2524341EB36 /* ImageDiffSideBySideViewTests.swift */; };
 		C10B2726FF5606A3786ED3B4 /* TerminalServiceZmxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B6937D50514C34A2C14BE1 /* TerminalServiceZmxTests.swift */; };
@@ -999,6 +1001,7 @@
 		23532A4B85092F720FD0E9F9 /* HookCommandShellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookCommandShellTests.swift; sourceTree = "<group>"; };
 		2379C3F8504AD2EE73130AC4 /* LSPInstallProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPInstallProgressSheet.swift; sourceTree = "<group>"; };
 		239125BB939233233D405EB8 /* ACPChipStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipStateTests.swift; sourceTree = "<group>"; };
+		80D266C85C78433E91EAA36F /* CursorModelVariantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorModelVariantsTests.swift; sourceTree = "<group>"; };
 		2392A88D394E21DAB8C6EF33 /* ConflictMarkerParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMarkerParser.swift; sourceTree = "<group>"; };
 		23FECFF5D8673A3A8E7A1431 /* DiffSelectableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextView.swift; sourceTree = "<group>"; };
 		2440A9DE95B4F783AA69A355 /* ShortcutBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutBindingTests.swift; sourceTree = "<group>"; };
@@ -1610,6 +1613,7 @@
 		DE2AC16E9220C05F670BE3EB /* ACPMarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownText.swift; sourceTree = "<group>"; };
 		DE7675D7F75E36E9C81193C8 /* LSPMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPMessagesTests.swift; sourceTree = "<group>"; };
 		DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPChipState.swift; sourceTree = "<group>"; };
+		3A9E43BD088A43A0B218C32B /* CursorModelVariants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorModelVariants.swift; sourceTree = "<group>"; };
 		DFBD2A49431277EB68106AAA /* ACPConnectingPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPConnectingPlaceholder.swift; sourceTree = "<group>"; };
 		DFE20A3822FC26672DFD552C /* MarkdownImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownImageLoader.swift; sourceTree = "<group>"; };
 		DFEE7C5318AA6D04095403B2 /* ShellEnvResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolver.swift; sourceTree = "<group>"; };
@@ -2422,6 +2426,7 @@
 			children = (
 				DF9310EAA75C6B6567F303B6 /* ACPChipState.swift */,
 				A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */,
+				3A9E43BD088A43A0B218C32B /* CursorModelVariants.swift */,
 				321866B3EB8CCE337B1D3A58 /* ACPMessage.swift */,
 				D21F30DB5A812E396262A926 /* ACPMessageWire.swift */,
 				BBBEFD27FD7013D458435779 /* ACPSession.swift */,
@@ -2822,6 +2827,7 @@
 				AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */,
 				239125BB939233233D405EB8 /* ACPChipStateTests.swift */,
 				D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */,
+				80D266C85C78433E91EAA36F /* CursorModelVariantsTests.swift */,
 				BCE0DA8D81AE8E0BFE54D279 /* ACPImageBlocksTests.swift */,
 				6048519B4C444FCB46A11E49 /* ACPMessageStableIdTests.swift */,
 				C8A0A083659269CDD16A6764 /* ACPMessageTests.swift */,
@@ -3504,6 +3510,7 @@
 				56B6EF95B863B557992AE9DA /* ACPAutoRunToggle.swift in Sources */,
 				C00E549FA69AB3D3C55B85EB /* ACPChipState.swift in Sources */,
 				A70A62FDF7EA38F99D9E2B06 /* ACPClient.swift in Sources */,
+				F0CF3B4D32A742B2B6156381 /* CursorModelVariants.swift in Sources */,
 				EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */,
 				34F18AB368DC5D93196056CA /* ACPComposer.swift in Sources */,
 				9CF6B43A0B19392A597A53EC /* ACPComposerActionButton.swift in Sources */,
@@ -3964,6 +3971,7 @@
 				4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */,
 				5E5600E6451068BCBF732ABD /* ACPChipStateTests.swift in Sources */,
 				238BBB5FC59949CE6ABAFBEF /* ACPCodeBlockHighlighterTests.swift in Sources */,
+				44FCBC1DFE01462AAAA3443F /* CursorModelVariantsTests.swift in Sources */,
 				33A0FC862C45CDFF47053A04 /* ACPComposerActionButtonMetricsTests.swift in Sources */,
 				1721FFC6A99B6E2683378552 /* ACPComposerDraftBridgeTests.swift in Sources */,
 				3518735F0614C32919E3FC27 /* ACPComposerDraftTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -78,7 +78,14 @@ extension ACPChipState {
             let derived = CursorModelVariants.derive(
                 availableModels: availableModels,
                 currentModel: currentModel)
-            if let m = derived.model { result.models = m }
+            // Don't clobber a `category: "model"` configOption-sourced models
+            // chip — that path means Cursor advertised a proper model selector
+            // and we should respect it. Only overlay onto the legacy `.model`
+            // source (or when there's no models chip at all).
+            if let m = derived.model,
+               result.models == nil || result.models?.source == .model {
+                result.models = m
+            }
             if let t = derived.thinking { result.thinking = t }
         }
         return result

--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -65,8 +65,23 @@ extension ACPChipState {
                                 modes: availableModes,
                                 currentMode: currentMode,
                                 configOptions: configOptions)
-        return ACPChipState(models: models, mode: mode,
-                            thinking: thinking, autoRun: routing.autoRun)
+        var result = ACPChipState(models: models, mode: mode,
+                                  thinking: thinking, autoRun: routing.autoRun)
+
+        // Cursor encodes thinking as `[effort=…]` / `[thinking=…]` suffixes
+        // on model variant ids. When the standard thinking heuristic finds
+        // nothing (i.e. no proper `thought_level` configOption was
+        // advertised), derive Model + Thinking chips from the variant list.
+        // Guards ensure the overlay never fires for other agents or for
+        // future-fixed Cursor builds that ship a real config option.
+        if agentId == "cursor-agent", result.thinking == nil {
+            let derived = CursorModelVariants.derive(
+                availableModels: availableModels,
+                currentModel: currentModel)
+            if let m = derived.model { result.models = m }
+            if let t = derived.thinking { result.thinking = t }
+        }
+        return result
     }
 
     private static func chipSpec(

--- a/Alas/Sources/ACP/Session/CursorModelVariants.swift
+++ b/Alas/Sources/ACP/Session/CursorModelVariants.swift
@@ -70,40 +70,30 @@ extension CursorModelVariants {
             return Derived(model: nil, thinking: nil)
         }
 
-        // Which attr key represents "thinking" within the current base group?
-        // Prefer `effort`; fall back to `thinking`.
+        // The "thinking" axis can be expressed two ways within the same base
+        // group: `effort=low|medium|high` for graded thinking, and
+        // `thinking=true|false` for on/off. A real-world Cursor variant set
+        // can mix them — e.g. `[thinking=false]` (off, no effort attr) plus
+        // `[thinking=true,effort=high]` (on, graded). We pick a per-variant
+        // label that takes effort when present and falls back to the thinking
+        // value, so both dimensions stay reachable in the chip.
         let currentGroup = parsed.filter { $0.variant.base == currentVariant.base }
-        let thinkingKey: String? = {
-            if currentGroup.contains(where: { $0.variant.attrs.contains(where: { $0.key == "effort" }) }) {
-                return "effort"
-            }
-            if currentGroup.contains(where: { $0.variant.attrs.contains(where: { $0.key == "thinking" }) }) {
-                return "thinking"
-            }
-            return nil
-        }()
-
-        let currentThinkingValue = thinkingKey.flatMap { key in
-            currentVariant.attrs.first(where: { $0.key == key })?.value
-        }
+        let currentThinkingLabel = thinkingLabel(of: currentVariant)
 
         // Model chip: one item per distinct base, ordered by first appearance.
-        // For each base, prefer the variant whose thinking value matches the
+        // For each base, prefer the variant whose thinking label matches the
         // current selection AND whose other attrs (context, fast, …) best
         // match the current variant — picking the first match would silently
         // change hidden dimensions like context when the user only meant to
-        // switch the model.
+        // switch the model. Fall back to any variant of that base when no
+        // candidate carries the current thinking label.
         var seenBases = Set<String>()
         var modelItems: [ChipSpec.Item] = []
         for (info, variant) in parsed where seenBases.insert(variant.base).inserted {
-            let candidates = parsed.filter { p in
-                p.variant.base == variant.base
-                    && (thinkingKey.map { key in
-                        p.variant.attrs.first(where: { $0.key == key })?.value == currentThinkingValue
-                    } ?? true)
-            }
-            let preferred = bestMatch(in: candidates, against: currentVariant,
-                                       ignoring: thinkingKey) ?? (info, variant)
+            let sameBase = parsed.filter { $0.variant.base == variant.base }
+            let matching = sameBase.filter { thinkingLabel(of: $0.variant) == currentThinkingLabel }
+            let pool = matching.isEmpty ? sameBase : matching
+            let preferred = bestMatch(in: pool, against: currentVariant) ?? (info, variant)
             modelItems.append(ChipSpec.Item(
                 id: preferred.info.id,
                 name: preferred.info.name,
@@ -113,31 +103,37 @@ extension CursorModelVariants {
             ? ChipSpec(source: .model, options: modelItems, currentId: currentModel)
             : nil
 
-        // Thinking chip: one item per distinct thinking value within the
-        // current base, ordered by first appearance. For each value, pick
+        // Thinking chip: one item per distinct thinking label within the
+        // current base, ordered by first appearance. For each label, pick
         // the variant id whose non-thinking attrs best match the current
-        // variant — same reason as above.
-        let thinking: ChipSpec? = {
-            guard let thinkingKey else { return nil }
-            var seenValues = Set<String>()
-            var thinkingItems: [ChipSpec.Item] = []
-            for (_, variant) in currentGroup {
-                guard let value = variant.attrs.first(where: { $0.key == thinkingKey })?.value,
-                      seenValues.insert(value).inserted
-                else { continue }
-                let candidates = currentGroup.filter { p in
-                    p.variant.attrs.first(where: { $0.key == thinkingKey })?.value == value
-                }
-                guard let pick = bestMatch(in: candidates, against: currentVariant,
-                                           ignoring: thinkingKey) else { continue }
-                thinkingItems.append(ChipSpec.Item(
-                    id: pick.info.id, name: value, description: pick.info.description))
-            }
-            guard !thinkingItems.isEmpty else { return nil }
-            return ChipSpec(source: .model, options: thinkingItems, currentId: currentModel)
-        }()
+        // variant. A variant with no thinking/effort attr at all has no
+        // label and is skipped.
+        var seenLabels = Set<String>()
+        var thinkingItems: [ChipSpec.Item] = []
+        for (_, variant) in currentGroup {
+            guard let label = thinkingLabel(of: variant),
+                  seenLabels.insert(label).inserted
+            else { continue }
+            let candidates = currentGroup.filter { thinkingLabel(of: $0.variant) == label }
+            guard let pick = bestMatch(in: candidates, against: currentVariant) else { continue }
+            thinkingItems.append(ChipSpec.Item(
+                id: pick.info.id, name: label, description: pick.info.description))
+        }
+        let thinking = !thinkingItems.isEmpty
+            ? ChipSpec(source: .model, options: thinkingItems, currentId: currentModel)
+            : nil
 
         return Derived(model: model, thinking: thinking)
+    }
+
+    /// The label representing this variant's thinking axis. Cursor uses two
+    /// conventions: `effort=…` for graded thinking and `thinking=…` for
+    /// on/off. Effort wins when both are present on the same variant.
+    /// Returns nil when neither attr is set.
+    private static func thinkingLabel(of variant: Variant) -> String? {
+        if let v = variant.attrs.first(where: { $0.key == "effort" })?.value { return v }
+        if let v = variant.attrs.first(where: { $0.key == "thinking" })?.value { return v }
+        return nil
     }
 
     /// Pick the candidate whose non-thinking attrs best match `reference`.
@@ -145,24 +141,23 @@ extension CursorModelVariants {
     /// nil only when `candidates` is empty.
     private static func bestMatch(
         in candidates: [(info: ACPModelInfo, variant: Variant)],
-        against reference: Variant,
-        ignoring thinkingKey: String?
+        against reference: Variant
     ) -> (info: ACPModelInfo, variant: Variant)? {
         candidates.max { a, b in
-            attrMatchScore(a.variant, against: reference, ignoring: thinkingKey)
-                < attrMatchScore(b.variant, against: reference, ignoring: thinkingKey)
+            attrMatchScore(a.variant, against: reference)
+                < attrMatchScore(b.variant, against: reference)
         }
     }
 
     /// Count attrs in `candidate` whose `(key, value)` also appears in
-    /// `reference`, skipping the thinking key itself.
+    /// `reference`, ignoring both thinking-axis keys.
     private static func attrMatchScore(
         _ candidate: Variant,
-        against reference: Variant,
-        ignoring thinkingKey: String?
+        against reference: Variant
     ) -> Int {
-        candidate.attrs.reduce(0) { acc, attr in
-            if let thinkingKey, attr.key == thinkingKey { return acc }
+        let thinkingKeys: Set<String> = ["effort", "thinking"]
+        return candidate.attrs.reduce(0) { acc, attr in
+            if thinkingKeys.contains(attr.key) { return acc }
             let refValue = reference.attrs.first(where: { $0.key == attr.key })?.value
             return acc + (refValue == attr.value ? 1 : 0)
         }

--- a/Alas/Sources/ACP/Session/CursorModelVariants.swift
+++ b/Alas/Sources/ACP/Session/CursorModelVariants.swift
@@ -42,3 +42,89 @@ enum CursorModelVariants {
         return "\(base)[\(inner)]"
     }
 }
+
+extension CursorModelVariants {
+    struct Derived: Equatable {
+        var model: ChipSpec?
+        var thinking: ChipSpec?
+    }
+
+    /// Build orthogonal Model + Thinking chips from Cursor's variant list.
+    /// Both chips dispatch via `session/set_model` (item ids are full variant
+    /// strings). Returns `(nil, nil)` when there's nothing variant-shaped to
+    /// derive — the caller falls back to whatever the standard normalization
+    /// produced.
+    static func derive(
+        availableModels: [ACPModelInfo],
+        currentModel: String?
+    ) -> Derived {
+        guard let currentModel,
+              availableModels.contains(where: { $0.id.contains("[") })
+        else { return Derived(model: nil, thinking: nil) }
+
+        let parsed: [(info: ACPModelInfo, variant: Variant)] = availableModels.map {
+            ($0, parse($0.id))
+        }
+        let currentVariant = parse(currentModel)
+        guard parsed.contains(where: { $0.variant.base == currentVariant.base }) else {
+            return Derived(model: nil, thinking: nil)
+        }
+
+        // Which attr key represents "thinking" within the current base group?
+        // Prefer `effort`; fall back to `thinking`.
+        let currentGroup = parsed.filter { $0.variant.base == currentVariant.base }
+        let thinkingKey: String? = {
+            if currentGroup.contains(where: { $0.variant.attrs.contains(where: { $0.key == "effort" }) }) {
+                return "effort"
+            }
+            if currentGroup.contains(where: { $0.variant.attrs.contains(where: { $0.key == "thinking" }) }) {
+                return "thinking"
+            }
+            return nil
+        }()
+
+        let currentThinkingValue = thinkingKey.flatMap { key in
+            currentVariant.attrs.first(where: { $0.key == key })?.value
+        }
+
+        // Model chip: one item per distinct base, ordered by first appearance.
+        var seenBases = Set<String>()
+        var modelItems: [ChipSpec.Item] = []
+        for (info, variant) in parsed where seenBases.insert(variant.base).inserted {
+            // Pick the variant for this base whose thinking value matches the
+            // user's current selection; else any variant from this base.
+            let preferred = parsed.first(where: { p in
+                p.variant.base == variant.base
+                    && (thinkingKey.map { key in
+                        p.variant.attrs.first(where: { $0.key == key })?.value == currentThinkingValue
+                    } ?? true)
+            }) ?? (info, variant)
+            modelItems.append(ChipSpec.Item(
+                id: preferred.info.id,
+                name: preferred.info.name,
+                description: preferred.info.description))
+        }
+        let model = modelItems.count > 0
+            ? ChipSpec(source: .model, options: modelItems, currentId: currentModel)
+            : nil
+
+        // Thinking chip: one item per distinct thinking value within the
+        // current base, ordered by first appearance.
+        let thinking: ChipSpec? = {
+            guard let thinkingKey else { return nil }
+            var seenValues = Set<String>()
+            var thinkingItems: [ChipSpec.Item] = []
+            for (info, variant) in currentGroup {
+                guard let value = variant.attrs.first(where: { $0.key == thinkingKey })?.value,
+                      seenValues.insert(value).inserted
+                else { continue }
+                thinkingItems.append(ChipSpec.Item(
+                    id: info.id, name: value, description: info.description))
+            }
+            guard !thinkingItems.isEmpty else { return nil }
+            return ChipSpec(source: .model, options: thinkingItems, currentId: currentModel)
+        }()
+
+        return Derived(model: model, thinking: thinking)
+    }
+}

--- a/Alas/Sources/ACP/Session/CursorModelVariants.swift
+++ b/Alas/Sources/ACP/Session/CursorModelVariants.swift
@@ -131,12 +131,15 @@ extension CursorModelVariants {
 
     /// The label representing this variant's thinking axis. Cursor uses two
     /// conventions: `effort=…` for graded thinking and `thinking=…` for
-    /// on/off. Effort wins when both are present on the same variant.
-    /// Returns nil when neither attr is set.
+    /// on/off. An explicit `thinking=false` always wins so an "off" variant
+    /// that ships with a default `effort=…` does not collapse into an
+    /// on-thinking option. Otherwise effort wins, then thinking. Returns
+    /// nil when neither attr is set.
     private static func thinkingLabel(of variant: Variant) -> String? {
-        if let v = variant.attrs.first(where: { $0.key == "effort" })?.value { return v }
-        if let v = variant.attrs.first(where: { $0.key == "thinking" })?.value { return v }
-        return nil
+        let thinking = variant.attrs.first(where: { $0.key == "thinking" })?.value
+        if thinking == "false" { return "false" }
+        if let effort = variant.attrs.first(where: { $0.key == "effort" })?.value { return effort }
+        return thinking
     }
 
     /// Pick the candidate whose non-thinking attrs best match `reference`.

--- a/Alas/Sources/ACP/Session/CursorModelVariants.swift
+++ b/Alas/Sources/ACP/Session/CursorModelVariants.swift
@@ -88,17 +88,22 @@ extension CursorModelVariants {
         }
 
         // Model chip: one item per distinct base, ordered by first appearance.
+        // For each base, prefer the variant whose thinking value matches the
+        // current selection AND whose other attrs (context, fast, …) best
+        // match the current variant — picking the first match would silently
+        // change hidden dimensions like context when the user only meant to
+        // switch the model.
         var seenBases = Set<String>()
         var modelItems: [ChipSpec.Item] = []
         for (info, variant) in parsed where seenBases.insert(variant.base).inserted {
-            // Pick the variant for this base whose thinking value matches the
-            // user's current selection; else any variant from this base.
-            let preferred = parsed.first(where: { p in
+            let candidates = parsed.filter { p in
                 p.variant.base == variant.base
                     && (thinkingKey.map { key in
                         p.variant.attrs.first(where: { $0.key == key })?.value == currentThinkingValue
                     } ?? true)
-            }) ?? (info, variant)
+            }
+            let preferred = bestMatch(in: candidates, against: currentVariant,
+                                       ignoring: thinkingKey) ?? (info, variant)
             modelItems.append(ChipSpec.Item(
                 id: preferred.info.id,
                 name: preferred.info.name,
@@ -109,22 +114,57 @@ extension CursorModelVariants {
             : nil
 
         // Thinking chip: one item per distinct thinking value within the
-        // current base, ordered by first appearance.
+        // current base, ordered by first appearance. For each value, pick
+        // the variant id whose non-thinking attrs best match the current
+        // variant — same reason as above.
         let thinking: ChipSpec? = {
             guard let thinkingKey else { return nil }
             var seenValues = Set<String>()
             var thinkingItems: [ChipSpec.Item] = []
-            for (info, variant) in currentGroup {
+            for (_, variant) in currentGroup {
                 guard let value = variant.attrs.first(where: { $0.key == thinkingKey })?.value,
                       seenValues.insert(value).inserted
                 else { continue }
+                let candidates = currentGroup.filter { p in
+                    p.variant.attrs.first(where: { $0.key == thinkingKey })?.value == value
+                }
+                guard let pick = bestMatch(in: candidates, against: currentVariant,
+                                           ignoring: thinkingKey) else { continue }
                 thinkingItems.append(ChipSpec.Item(
-                    id: info.id, name: value, description: info.description))
+                    id: pick.info.id, name: value, description: pick.info.description))
             }
             guard !thinkingItems.isEmpty else { return nil }
             return ChipSpec(source: .model, options: thinkingItems, currentId: currentModel)
         }()
 
         return Derived(model: model, thinking: thinking)
+    }
+
+    /// Pick the candidate whose non-thinking attrs best match `reference`.
+    /// Ties resolve to the first candidate in source order (stable). Returns
+    /// nil only when `candidates` is empty.
+    private static func bestMatch(
+        in candidates: [(info: ACPModelInfo, variant: Variant)],
+        against reference: Variant,
+        ignoring thinkingKey: String?
+    ) -> (info: ACPModelInfo, variant: Variant)? {
+        candidates.max { a, b in
+            attrMatchScore(a.variant, against: reference, ignoring: thinkingKey)
+                < attrMatchScore(b.variant, against: reference, ignoring: thinkingKey)
+        }
+    }
+
+    /// Count attrs in `candidate` whose `(key, value)` also appears in
+    /// `reference`, skipping the thinking key itself.
+    private static func attrMatchScore(
+        _ candidate: Variant,
+        against reference: Variant,
+        ignoring thinkingKey: String?
+    ) -> Int {
+        candidate.attrs.reduce(0) { acc, attr in
+            if let thinkingKey, attr.key == thinkingKey { return acc }
+            let refValue = reference.attrs.first(where: { $0.key == attr.key })?.value
+            return acc + (refValue == attr.value ? 1 : 0)
+        }
     }
 }

--- a/Alas/Sources/ACP/Session/CursorModelVariants.swift
+++ b/Alas/Sources/ACP/Session/CursorModelVariants.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Cursor ACP encodes thinking/effort/context as bracket-suffixed model
+/// variant ids — e.g. `claude-opus-4-6[thinking=true,context=200k,effort=high,fast=false]`.
+/// Cursor does NOT advertise a `thought_level` configOption; thinking is
+/// purely a function of which variant the client selects via
+/// `session/set_model`. This file parses that wire shape so we can derive
+/// orthogonal Model + Thinking chips client-side.
+///
+/// Pure functions: no I/O, no SwiftUI imports. The overlay that decides
+/// *whether* to use this lives in `ACPChipState.normalize`.
+enum CursorModelVariants {
+    struct Variant {
+        var base: String
+        /// Ordered key/value pairs. Order is preserved so `compose` round-trips.
+        var attrs: [(key: String, value: String)]
+    }
+
+    /// Parse a variant id. Ids without a `[…]` suffix return the whole
+    /// string as `base` with empty attrs. Malformed suffixes (no closing
+    /// `]`) are treated the same way — better to surface the raw id than
+    /// drop it.
+    static func parse(_ id: String) -> Variant {
+        guard let open = id.firstIndex(of: "["),
+              id.last == "]" else {
+            return Variant(base: id, attrs: [])
+        }
+        let base = String(id[..<open])
+        let inner = id[id.index(after: open)..<id.index(before: id.endIndex)]
+        let attrs: [(String, String)] = inner.split(separator: ",").compactMap { frag in
+            let parts = frag.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { return nil }
+            return (String(parts[0]), String(parts[1]))
+        }
+        return Variant(base: base, attrs: attrs)
+    }
+
+    /// Inverse of `parse`. With empty `attrs`, returns `base` unchanged.
+    static func compose(base: String, attrs: [(key: String, value: String)]) -> String {
+        guard !attrs.isEmpty else { return base }
+        let inner = attrs.map { "\($0.key)=\($0.value)" }.joined(separator: ",")
+        return "\(base)[\(inner)]"
+    }
+}

--- a/Alas/Sources/ACP/Session/CursorModelVariants.swift
+++ b/Alas/Sources/ACP/Session/CursorModelVariants.swift
@@ -65,10 +65,13 @@ extension CursorModelVariants {
         let parsed: [(info: ACPModelInfo, variant: Variant)] = availableModels.map {
             ($0, parse($0.id))
         }
-        let currentVariant = parse(currentModel)
-        guard parsed.contains(where: { $0.variant.base == currentVariant.base }) else {
+        // Require an exact match — a stale `currentModel` whose base happens
+        // to overlap with the advertised list would otherwise produce chips
+        // whose `currentId` is not one of their options.
+        guard parsed.contains(where: { $0.info.id == currentModel }) else {
             return Derived(model: nil, thinking: nil)
         }
+        let currentVariant = parse(currentModel)
 
         // The "thinking" axis can be expressed two ways within the same base
         // group: `effort=low|medium|high` for graded thinking, and

--- a/Alas/Sources/ACP/Session/CursorModelVariants.swift
+++ b/Alas/Sources/ACP/Session/CursorModelVariants.swift
@@ -104,7 +104,7 @@ extension CursorModelVariants {
                 name: preferred.info.name,
                 description: preferred.info.description))
         }
-        let model = modelItems.count > 0
+        let model = !modelItems.isEmpty
             ? ChipSpec(source: .model, options: modelItems, currentId: currentModel)
             : nil
 

--- a/Alas/Sources/Agents/ACPAgentProfiles.swift
+++ b/Alas/Sources/Agents/ACPAgentProfiles.swift
@@ -40,6 +40,16 @@ enum ACPAgentProfiles {
             return .init(modeSource: .mode,
                          thinkingSource: .configOption(id: "effort"),
                          autoRun: .supported)
+        case "cursor-agent":
+            // Cursor encodes thinking as `[effort=…]` / `[thinking=…]` suffixes
+            // on model variant ids rather than advertising a `thought_level`
+            // configOption. The heuristic still gets first shot here so that
+            // if Cursor ships a proper config option later, it wins
+            // automatically and the variant overlay in ACPChipState becomes
+            // a no-op.
+            return .init(modeSource: .mode,
+                         thinkingSource: .heuristic,
+                         autoRun: .supported)
         case "pi":
             return .init(modeSource: .none,
                          thinkingSource: .mode,

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -194,3 +194,72 @@ struct ACPChipStateTests {
         } else { Issue.record("configOption model chip should win") }
     }
 }
+
+extension ACPChipStateTests {
+    @Test("cursor-agent: variant suffixes synthesize Model + Thinking chips")
+    func cursorVariantsSynthesizeChips() {
+        let state = ACPChipState.normalize(
+            agentId: "cursor-agent",
+            availableModels: [
+                model("claude-opus-4-6[effort=low,context=200k]",    "Opus 4.6"),
+                model("claude-opus-4-6[effort=medium,context=200k]", "Opus 4.6"),
+                model("claude-opus-4-6[effort=high,context=200k]",   "Opus 4.6"),
+                model("gpt-5.3-codex[effort=medium]",                "GPT 5.3 Codex"),
+            ],
+            currentModel: "claude-opus-4-6[effort=medium,context=200k]",
+            availableModes: [mode("agent", "Agent")],
+            currentMode: "agent",
+            configOptions: [])
+        #expect(state.models?.options.map { $0.name }.sorted() == ["GPT 5.3 Codex", "Opus 4.6"])
+        #expect(state.thinking?.options.map { $0.name } == ["low", "medium", "high"])
+        #expect(state.thinking?.source == .model)
+        #expect(state.mode?.options.first?.name == "Agent")
+    }
+
+    @Test("cursor-agent: real thought_level configOption wins over variant overlay")
+    func cursorConfigOptionWinsOverVariants() {
+        let state = ACPChipState.normalize(
+            agentId: "cursor-agent",
+            availableModels: [
+                model("claude-opus-4-6[effort=high]", "Opus 4.6"),
+                model("claude-opus-4-6[effort=low]",  "Opus 4.6"),
+            ],
+            currentModel: "claude-opus-4-6[effort=high]",
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [configOption("effort",
+                                         current: "high",
+                                         options: [("low","Low"),("high","High")],
+                                         category: "thought_level")])
+        // The heuristic finds the configOption first; overlay is bypassed.
+        if case .configOption(let id)? = state.thinking?.source { #expect(id == "effort") }
+        else { Issue.record("expected configOption source") }
+        #expect(state.thinking?.options.map { $0.name } == ["Low", "High"])
+    }
+
+    @Test("cursor-agent: no brackets -> no synthesized chips")
+    func cursorNoBracketsNoOverlay() {
+        let state = ACPChipState.normalize(
+            agentId: "cursor-agent",
+            availableModels: [model("a", "A"), model("b", "B")],
+            currentModel: "a",
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [])
+        #expect(state.thinking == nil)
+        // Legacy availableModels path still produces a Model chip.
+        #expect(state.models?.options.map { $0.name } == ["A", "B"])
+    }
+
+    @Test("non-cursor agent with bracketed model id: overlay does NOT fire")
+    func nonCursorIgnoresVariants() {
+        let state = ACPChipState.normalize(
+            agentId: "future-agent",
+            availableModels: [model("m[effort=high]", "M"), model("m[effort=low]", "M")],
+            currentModel: "m[effort=high]",
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [])
+        #expect(state.thinking == nil)
+    }
+}

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -210,7 +210,8 @@ extension ACPChipStateTests {
             availableModes: [mode("agent", "Agent")],
             currentMode: "agent",
             configOptions: [])
-        #expect(state.models?.options.map { $0.name }.sorted() == ["GPT 5.3 Codex", "Opus 4.6"])
+        // Derived chips preserve first-appearance order from `availableModels`.
+        #expect(state.models?.options.map { $0.name } == ["Opus 4.6", "GPT 5.3 Codex"])
         #expect(state.thinking?.options.map { $0.name } == ["low", "medium", "high"])
         #expect(state.thinking?.source == .model)
         #expect(state.mode?.options.first?.name == "Agent")

--- a/AlasTests/ACP/Session/CursorModelVariantsTests.swift
+++ b/AlasTests/ACP/Session/CursorModelVariantsTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("CursorModelVariants.parse / compose")
+struct CursorModelVariantsTests {
+    @Test("plain id with no brackets parses to base and empty attrs")
+    func plainId() {
+        let v = CursorModelVariants.parse("gpt-5.3-codex")
+        #expect(v.base == "gpt-5.3-codex")
+        #expect(v.attrs.isEmpty)
+        #expect(CursorModelVariants.compose(base: v.base, attrs: v.attrs) == "gpt-5.3-codex")
+    }
+
+    @Test("bracketed id parses base and ordered attrs")
+    func bracketed() {
+        let id = "claude-opus-4-6[thinking=true,context=200k,effort=high,fast=false]"
+        let v = CursorModelVariants.parse(id)
+        #expect(v.base == "claude-opus-4-6")
+        #expect(v.attrs.map { $0.key } == ["thinking", "context", "effort", "fast"])
+        #expect(v.attrs.map { $0.value } == ["true", "200k", "high", "false"])
+        #expect(CursorModelVariants.compose(base: v.base, attrs: v.attrs) == id)
+    }
+
+    @Test("single-attr bracketed id round-trips")
+    func singleAttr() {
+        let id = "m[effort=medium]"
+        let v = CursorModelVariants.parse(id)
+        #expect(v.base == "m")
+        #expect(v.attrs.count == 1)
+        #expect(v.attrs[0].key == "effort")
+        #expect(v.attrs[0].value == "medium")
+        #expect(CursorModelVariants.compose(base: v.base, attrs: v.attrs) == id)
+    }
+
+    @Test("malformed bracketed id (missing close) treats whole string as base")
+    func malformedMissingClose() {
+        let v = CursorModelVariants.parse("m[effort=high")
+        #expect(v.base == "m[effort=high")
+        #expect(v.attrs.isEmpty)
+    }
+
+    @Test("attr fragments without '=' are skipped")
+    func skipsBareFragments() {
+        let v = CursorModelVariants.parse("m[effort=high,broken,context=4k]")
+        #expect(v.attrs.map { $0.key } == ["effort", "context"])
+    }
+}

--- a/AlasTests/ACP/Session/CursorModelVariantsTests.swift
+++ b/AlasTests/ACP/Session/CursorModelVariantsTests.swift
@@ -44,5 +44,6 @@ struct CursorModelVariantsTests {
     func skipsBareFragments() {
         let v = CursorModelVariants.parse("m[effort=high,broken,context=4k]")
         #expect(v.attrs.map { $0.key } == ["effort", "context"])
+        #expect(v.attrs.map { $0.value } == ["high", "4k"])
     }
 }

--- a/AlasTests/ACP/Session/CursorModelVariantsTests.swift
+++ b/AlasTests/ACP/Session/CursorModelVariantsTests.swift
@@ -155,6 +155,24 @@ struct CursorModelVariantsDeriveTests {
         #expect(b?.id == "b[effort=high,context=1m]")
     }
 
+    @Test("`thinking=false` wins over `effort` so off stays distinct")
+    func thinkingFalseWinsOverEffort() {
+        // Cursor sometimes ships the "off" variant with a default effort
+        // attr that mirrors the most common "on" effort level. Without an
+        // override the label-by-effort logic would collapse off + medium.
+        let models = [
+            model("m[thinking=false,effort=medium]", "M"),
+            model("m[thinking=true,effort=medium]",  "M"),
+            model("m[thinking=true,effort=high]",    "M"),
+        ]
+        let d = CursorModelVariants.derive(
+            availableModels: models,
+            currentModel: "m[thinking=false,effort=medium]")
+        #expect(d.thinking?.options.map { $0.name } == ["false", "medium", "high"])
+        #expect(d.thinking?.options.first { $0.name == "false" }?.id == "m[thinking=false,effort=medium]")
+        #expect(d.thinking?.options.first { $0.name == "medium" }?.id == "m[thinking=true,effort=medium]")
+    }
+
     @Test("currentModel shares a base but is not exactly advertised -> nil chips")
     func currentModelNotExactlyAdvertised() {
         // A stale `currentModel` whose base matches an advertised variant

--- a/AlasTests/ACP/Session/CursorModelVariantsTests.swift
+++ b/AlasTests/ACP/Session/CursorModelVariantsTests.swift
@@ -123,4 +123,35 @@ struct CursorModelVariantsDeriveTests {
         #expect(d.model?.options.map { $0.name }.sorted() == ["A", "B"])
         #expect(d.thinking == nil)
     }
+
+    @Test("Thinking chip preserves non-thinking attrs when picking a value")
+    func thinkingPreservesOtherAttrs() {
+        let models = [
+            model("m[effort=medium,context=1m]", "M"),
+            model("m[effort=high,context=200k]", "M"),
+            model("m[effort=high,context=1m]",   "M"),
+        ]
+        let d = CursorModelVariants.derive(
+            availableModels: models,
+            currentModel: "m[effort=medium,context=1m]")
+        // Picking `high` must preserve context=1m, not collapse to the first
+        // `high` variant (which has context=200k).
+        let high = d.thinking?.options.first { $0.name == "high" }
+        #expect(high?.id == "m[effort=high,context=1m]")
+    }
+
+    @Test("Model chip preserves non-thinking attrs when switching base")
+    func modelPreservesOtherAttrs() {
+        let models = [
+            model("a[effort=high,context=1m]",   "A"),
+            model("b[effort=high,context=200k]", "B"),
+            model("b[effort=high,context=1m]",   "B"),
+        ]
+        let d = CursorModelVariants.derive(
+            availableModels: models,
+            currentModel: "a[effort=high,context=1m]")
+        // Switching to base B must preserve context=1m, not the first B variant.
+        let b = d.model?.options.first { $0.name == "B" }
+        #expect(b?.id == "b[effort=high,context=1m]")
+    }
 }

--- a/AlasTests/ACP/Session/CursorModelVariantsTests.swift
+++ b/AlasTests/ACP/Session/CursorModelVariantsTests.swift
@@ -155,6 +155,22 @@ struct CursorModelVariantsDeriveTests {
         #expect(b?.id == "b[effort=high,context=1m]")
     }
 
+    @Test("currentModel shares a base but is not exactly advertised -> nil chips")
+    func currentModelNotExactlyAdvertised() {
+        // A stale `currentModel` whose base matches an advertised variant
+        // but whose exact id is not in the list would otherwise produce
+        // chips whose `currentId` isn't one of their options.
+        let models = [
+            model("m[effort=high,context=200k]", "M"),
+            model("m[effort=low,context=200k]",  "M"),
+        ]
+        let d = CursorModelVariants.derive(
+            availableModels: models,
+            currentModel: "m[effort=high,context=1m]")
+        #expect(d.model == nil)
+        #expect(d.thinking == nil)
+    }
+
     @Test("Thinking chip exposes both `thinking=false` and effort levels when mixed")
     func mixedThinkingAndEffort() {
         // Real Cursor shape: a "thinking off" variant has no effort attr,

--- a/AlasTests/ACP/Session/CursorModelVariantsTests.swift
+++ b/AlasTests/ACP/Session/CursorModelVariantsTests.swift
@@ -154,4 +154,24 @@ struct CursorModelVariantsDeriveTests {
         let b = d.model?.options.first { $0.name == "B" }
         #expect(b?.id == "b[effort=high,context=1m]")
     }
+
+    @Test("Thinking chip exposes both `thinking=false` and effort levels when mixed")
+    func mixedThinkingAndEffort() {
+        // Real Cursor shape: a "thinking off" variant has no effort attr,
+        // while "thinking on" variants carry effort=low/medium/high.
+        let models = [
+            model("m[thinking=false]",              "M"),
+            model("m[thinking=true,effort=high]",   "M"),
+            model("m[thinking=true,effort=medium]", "M"),
+            model("m[thinking=true,effort=low]",    "M"),
+        ]
+        let d = CursorModelVariants.derive(
+            availableModels: models,
+            currentModel: "m[thinking=false]")
+        // The off option must remain reachable; effort levels are alongside it.
+        #expect(d.thinking?.options.map { $0.name } == ["false", "high", "medium", "low"])
+        #expect(d.thinking?.options.first { $0.name == "false" }?.id == "m[thinking=false]")
+        #expect(d.thinking?.options.first { $0.name == "high" }?.id == "m[thinking=true,effort=high]")
+        #expect(d.thinking?.currentId == "m[thinking=false]")
+    }
 }

--- a/AlasTests/ACP/Session/CursorModelVariantsTests.swift
+++ b/AlasTests/ACP/Session/CursorModelVariantsTests.swift
@@ -47,3 +47,80 @@ struct CursorModelVariantsTests {
         #expect(v.attrs.map { $0.value } == ["high", "4k"])
     }
 }
+
+@Suite("CursorModelVariants.derive")
+struct CursorModelVariantsDeriveTests {
+    private func model(_ id: String, _ name: String) -> ACPModelInfo {
+        ACPModelInfo(id: id, name: name)
+    }
+
+    @Test("derives Model + Thinking from effort-bearing variants")
+    func effortVariants() {
+        let models = [
+            model("claude-opus-4-6[effort=low,context=200k]",    "Opus 4.6"),
+            model("claude-opus-4-6[effort=medium,context=200k]", "Opus 4.6"),
+            model("claude-opus-4-6[effort=high,context=200k]",   "Opus 4.6"),
+            model("gpt-5.3-codex[effort=medium]",                "GPT 5.3 Codex"),
+        ]
+        let d = CursorModelVariants.derive(
+            availableModels: models,
+            currentModel: "claude-opus-4-6[effort=medium,context=200k]")
+
+        #expect(d.model?.options.map { $0.name }.sorted() == ["GPT 5.3 Codex", "Opus 4.6"])
+        // Selecting GPT switches base while preserving the user's current effort=medium.
+        let gpt = d.model?.options.first { $0.name == "GPT 5.3 Codex" }
+        #expect(gpt?.id == "gpt-5.3-codex[effort=medium]")
+        #expect(d.model?.currentId == "claude-opus-4-6[effort=medium,context=200k]")
+
+        #expect(d.thinking?.options.map { $0.name } == ["low", "medium", "high"])
+        let medium = d.thinking?.options.first { $0.name == "medium" }
+        #expect(medium?.id == "claude-opus-4-6[effort=medium,context=200k]")
+        #expect(d.thinking?.currentId == "claude-opus-4-6[effort=medium,context=200k]")
+    }
+
+    @Test("falls back to `thinking` bool when no `effort` attrs present")
+    func thinkingBoolFallback() {
+        let models = [
+            model("claude-sonnet-4-6[thinking=true,context=200k]",  "Sonnet 4.6"),
+            model("claude-sonnet-4-6[thinking=false,context=200k]", "Sonnet 4.6"),
+        ]
+        let d = CursorModelVariants.derive(
+            availableModels: models,
+            currentModel: "claude-sonnet-4-6[thinking=true,context=200k]")
+        #expect(d.thinking?.options.map { $0.name } == ["true", "false"])
+        let on = d.thinking?.options.first { $0.name == "true" }
+        #expect(on?.id == "claude-sonnet-4-6[thinking=true,context=200k]")
+    }
+
+    @Test("no brackets anywhere -> both chips nil")
+    func noBrackets() {
+        let d = CursorModelVariants.derive(
+            availableModels: [model("a", "A"), model("b", "B")],
+            currentModel: "a")
+        #expect(d.model == nil)
+        #expect(d.thinking == nil)
+    }
+
+    @Test("currentModel not in availableModels -> nil chips")
+    func unknownCurrentModel() {
+        let models = [model("a[effort=high]", "A")]
+        let d = CursorModelVariants.derive(
+            availableModels: models,
+            currentModel: "z[effort=low]")
+        #expect(d.model == nil)
+        #expect(d.thinking == nil)
+    }
+
+    @Test("base group with no effort/thinking attr -> Thinking nil, Model still derived")
+    func modelOnlyWhenNoThinkingAttr() {
+        let models = [
+            model("a[context=4k]", "A"),
+            model("b[context=4k]", "B"),
+        ]
+        let d = CursorModelVariants.derive(
+            availableModels: models,
+            currentModel: "a[context=4k]")
+        #expect(d.model?.options.map { $0.name }.sorted() == ["A", "B"])
+        #expect(d.thinking == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Cursor's ACP server doesn't advertise a `thought_level` configOption like Claude/Codex/OpenCode/Pi — it encodes thinking as bracket-suffixed model variant ids, e.g. `claude-opus-4-6[effort=high,context=200k,thinking=true,fast=false]`. Without explicit handling Alas's heuristic finds nothing in `configOptions` and the Thinking chip stays hidden for cursor sessions.

This PR parses those variants client-side and synthesizes orthogonal Model + Thinking chips, both dispatching via the existing `session/set_model` path (item ids carry the full composed variant string).

- Prefer `effort` attr; fall back to `thinking` bool if no variant in the current base group has `effort`.
- Hide the Thinking chip when no model id contains a `[…]` suffix.
- Persist the full variant id as `currentModel` (no schema change).
- The overlay only fires for `agentId == "cursor-agent"` AND when the standard `thought_level`-heuristic returned nothing — so if Cursor later ships a real `thought_level` configOption, the heuristic wins and the workaround becomes a no-op automatically.
- Don't clobber a `category: "model"` configOption-sourced Model chip if one is present.

## Test plan

- [x] `CursorModelVariants` parser/compose round-trip + edge cases (no brackets, missing close, bare fragments)
- [x] `CursorModelVariants.derive` produces correct Model/Thinking chips for effort-bearing variants, falls back to `thinking` bool, hides Thinking when neither attr present, bails when current model isn't in the list
- [x] `ACPChipState.normalize` overlay fires only for cursor-agent + bracketed variants, defers to a real `thought_level` configOption when advertised, leaves other agents unaffected
- [x] Full AlasTests suite green (2893 tests in 365 suites)
- [ ] Manual verification: open a cursor-agent ACP session and confirm Model + Thinking chips render and `session/set_model` is dispatched with the composed variant id on selection