### PR TITLE
feat(updates): nightly release track

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -166,6 +166,20 @@ jobs:
             -destination 'platform=macOS,arch=arm64' \
             -quiet build
 
+      - name: Stamp nightly build identity into Info.plist
+        # Overwrite the stable-default Info.plist keys committed in the
+        # repo with the real track / SHA / build-date for this nightly.
+        # Must run BEFORE signing, since signing seals the bundle.
+        if: steps.skip-check.outputs.skip != 'true'
+        run: |
+          plist="build/Build/Products/Release/Alas.app/Contents/Info.plist"
+          sha="$(git rev-parse HEAD)"
+          iso_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          plutil -replace AlasReleaseTrack -string "nightly" "$plist"
+          plutil -replace AlasGitSHA -string "$sha" "$plist"
+          plutil -replace AlasBuildDate -string "$iso_date" "$plist"
+          plutil -lint "$plist"
+
       # Gate signing on main-built refs only — non-main workflow_dispatch
       # checks out (and runs scripts from) the dispatched ref, so handing
       # the Developer ID cert + notary credentials to that ref's scripts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -156,6 +156,23 @@ jobs:
           path: .build/xcode/SourcePackages
           key: ${{ steps.swiftpm-cache.outputs.cache-primary-key }}
 
+      - name: Stamp nightly build identity into source Info.plist
+        # Overwrite the stable-default Info.plist keys committed in the repo
+        # with the real track / SHA / build-date. Must run BEFORE the build
+        # so xcodebuild copies the stamped plist into the bundle and signing
+        # seals it. Stamping the built bundle's plist after signing would
+        # invalidate the signature on non-main dispatches (which build but
+        # skip the later Developer-ID signing step).
+        if: steps.skip-check.outputs.skip != 'true'
+        run: |
+          plist="Alas/Resources/Info.plist"
+          sha="$(git rev-parse HEAD)"
+          iso_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          plutil -replace AlasReleaseTrack -string "nightly" "$plist"
+          plutil -replace AlasGitSHA -string "$sha" "$plist"
+          plutil -replace AlasBuildDate -string "$iso_date" "$plist"
+          plutil -lint "$plist"
+
       - name: Build release app
         if: steps.skip-check.outputs.skip != 'true'
         run: |
@@ -165,20 +182,6 @@ jobs:
             -clonedSourcePackagesDirPath .build/xcode/SourcePackages \
             -destination 'platform=macOS,arch=arm64' \
             -quiet build
-
-      - name: Stamp nightly build identity into Info.plist
-        # Overwrite the stable-default Info.plist keys committed in the
-        # repo with the real track / SHA / build-date for this nightly.
-        # Must run BEFORE signing, since signing seals the bundle.
-        if: steps.skip-check.outputs.skip != 'true'
-        run: |
-          plist="build/Build/Products/Release/Alas.app/Contents/Info.plist"
-          sha="$(git rev-parse HEAD)"
-          iso_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          plutil -replace AlasReleaseTrack -string "nightly" "$plist"
-          plutil -replace AlasGitSHA -string "$sha" "$plist"
-          plutil -replace AlasBuildDate -string "$iso_date" "$plist"
-          plutil -lint "$plist"
 
       # Gate signing on main-built refs only — non-main workflow_dispatch
       # checks out (and runs scripts from) the dispatched ref, so handing

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */; };
 		0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
-		0C6B4043280C0787CC9F8DFC /* BuildIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBEF21062CAD30127BEB2AA /* BuildIdentityTests.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
 		0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */; };
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
@@ -92,6 +91,7 @@
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
 		1AE5FCAF7D44694876754813 /* HookInstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */; };
+		1B123A31842DDDB42C6820F1 /* BuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */; };
 		1B16FCB3621BB868C34334D7 /* ACPStreamingTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16F771D1DD9CAC618459D41 /* ACPStreamingTextTests.swift */; };
 		1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */; };
 		1B1A33B610D29116A1D08A74 /* PointingHandCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4A000B32C3BF0E253BB0B6 /* PointingHandCursor.swift */; };
@@ -289,6 +289,7 @@
 		4EC689B454508C1ED77C5FB4 /* RightPaneVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3EC1A61207050A2585288FB /* RightPaneVisibilityTests.swift */; };
 		4EC9752B397FD7FA89459AC1 /* MergeConflictColumnView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAB78A2ED0F4B736B089701 /* MergeConflictColumnView.swift */; };
 		4ECFD27396367A9A81D52A0D /* WorktreeRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C995611A6313FABE30508248 /* WorktreeRowView.swift */; };
+		5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */; };
 		502B274A6E7E801B76B8564A /* ACPScrollDirectionClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE5F609BDA1D7CE2DF4A491 /* ACPScrollDirectionClassifier.swift */; };
 		5031D53ED872A86B7C253696 /* MergeConflictToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B5694DB75F80C8D7B51E82 /* MergeConflictToolbar.swift */; };
 		50D7FF67981533B21FCB0890 /* PromptEditorBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B42244BDE33A69EDE16562 /* PromptEditorBody.swift */; };
@@ -616,7 +617,6 @@
 		B40B75555598C42713157C5C /* TreeSitterCSS in Frameworks */ = {isa = PBXBuildFile; productRef = 3F76DFBA5D1CB707989C86AB /* TreeSitterCSS */; };
 		B472D692A8D8D1C664EAC467 /* ACPSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */; };
 		B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA51D49B1AE4C4E10D450C6 /* ACPFileWriterTests.swift */; };
-		B50266FAD595DBF626CA199F /* BuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F152CCD7A9C7116A9E6A /* BuildIdentity.swift */; };
 		B54B0BFA87B2566DB59C3D59 /* ConflictMarkerParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */; };
 		B574D2D5DF3129E326DCFCCF /* ShellEnvResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */; };
 		B58BF89C3A788A31CBED2067 /* TreeSitterJavaScript in Frameworks */ = {isa = PBXBuildFile; productRef = B3568F495249430FBBE2FCCF /* TreeSitterJavaScript */; };
@@ -917,7 +917,6 @@
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
 		09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffMode.swift; sourceTree = "<group>"; };
-		0904F152CCD7A9C7116A9E6A /* BuildIdentity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BuildIdentity.swift; sourceTree = "<group>"; };
 		0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResolvedEmptyView.swift; sourceTree = "<group>"; };
 		09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolverTests.swift; sourceTree = "<group>"; };
 		0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPair.swift; sourceTree = "<group>"; };
@@ -1213,6 +1212,7 @@
 		5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.swift; sourceTree = "<group>"; };
 		5EF6536F169B7C7B2C339B1C /* ACPAdapterVersionCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterVersionCheckerTests.swift; sourceTree = "<group>"; };
 		5F128D8543DA5FC5C39C22E9 /* ACPPermissionDecisionLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionDecisionLog.swift; sourceTree = "<group>"; };
+		5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentity.swift; sourceTree = "<group>"; };
 		5F931B1EEA7F04855BAE5A43 /* WorkingTreeStageAllActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingTreeStageAllActionTests.swift; sourceTree = "<group>"; };
 		6016A3CF87F34222C533D350 /* ClaudeInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeInstallerTests.swift; sourceTree = "<group>"; };
 		6033DBD8BF13A76978A653A3 /* EditorFindControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFindControllerTests.swift; sourceTree = "<group>"; };
@@ -1254,7 +1254,6 @@
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
 		6CA51D49B1AE4C4E10D450C6 /* ACPFileWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileWriterTests.swift; sourceTree = "<group>"; };
 		6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBranchSelectorTests.swift; sourceTree = "<group>"; };
-		6CBEF21062CAD30127BEB2AA /* BuildIdentityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BuildIdentityTests.swift; sourceTree = "<group>"; };
 		6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRetentionTests.swift; sourceTree = "<group>"; };
 		6D46BDE72E52818061452ECB /* CommitRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRowTests.swift; sourceTree = "<group>"; };
 		6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseInfoTests.swift; sourceTree = "<group>"; };
@@ -1573,6 +1572,7 @@
 		D02E429B37288215EBC89571 /* CommitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitHeaderView.swift; sourceTree = "<group>"; };
 		D081C8802733D2532DBCD74D /* BlockedLanguageServerNudgeResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedLanguageServerNudgeResolverTests.swift; sourceTree = "<group>"; };
 		D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPNewChatEmptyStateTests.swift; sourceTree = "<group>"; };
+		D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIdentityTests.swift; sourceTree = "<group>"; };
 		D0FF6BFD0A460F0E723F796E /* MergeRegionVisualLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeRegionVisualLayout.swift; sourceTree = "<group>"; };
 		D12F540ABB23DDB829E1629D /* ProjectGitWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectGitWatcher.swift; sourceTree = "<group>"; };
 		D1B15CAE2163ED7C1A670F46 /* ACPComposerDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPComposerDraftTests.swift; sourceTree = "<group>"; };
@@ -1899,6 +1899,7 @@
 				EFDB90A7F9E58F4C1A258D23 /* AppStateSpacesTests.swift */,
 				279D43D7F43C40A004A2C4AC /* AppStateTabAvailabilityTests.swift */,
 				6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */,
+				D0EE31A4EB90FFE45DC46420 /* BuildIdentityTests.swift */,
 				71A2A074CEB9C9BA2AD34DD7 /* CenterSelectionStateResolverTests.swift */,
 				E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */,
 				E4E465A2468376AA840ADFBC /* ChangeSummaryVisibilityTests.swift */,
@@ -2095,7 +2096,6 @@
 				EAD92DAB367A7F31FF1223D1 /* Diagnostics */,
 				08BD96F4379A0D250DE4303C /* JSONRPC */,
 				5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */,
-				6CBEF21062CAD30127BEB2AA /* BuildIdentityTests.swift */,
 			);
 			path = AlasTests;
 			sourceTree = "<group>";
@@ -2733,6 +2733,7 @@
 		96D582F846CA5342C74C984D /* Updates */ = {
 			isa = PBXGroup;
 			children = (
+				5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */,
 				2E7E61C3BD4AD4AE3828A6F0 /* InstallSource.swift */,
 				9FF99EC1C513C5D76D690BC2 /* ReleaseChecker.swift */,
 				35004DC60214F616FA84ED8B /* ReleaseInfo.swift */,
@@ -2740,7 +2741,6 @@
 				0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */,
 				2763F93ADFDCDF6B31D16475 /* UpdateController.swift */,
 				FE09B83A747269494B206F23 /* UpdateThrottle.swift */,
-				0904F152CCD7A9C7116A9E6A /* BuildIdentity.swift */,
 			);
 			path = Updates;
 			sourceTree = "<group>";
@@ -3284,6 +3284,8 @@
 				5EEBBAEE60D2DB007AD92314 /* PBXTargetDependency */,
 			);
 			name = AlasTests;
+			packageProductDependencies = (
+			);
 			productName = AlasTests;
 			productReference = B65018D176CD2E52A3999CF0 /* AlasTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -3376,12 +3378,12 @@
 				7019D0C134F78A3B7F4CF4BB /* XCRemoteSwiftPackageReference "tree-sitter-swift" */,
 				A38DA0B05C2E29601ED4C8A9 /* XCRemoteSwiftPackageReference "tree-sitter-toml" */,
 				E32CC6F3745BD894D495E254 /* XCRemoteSwiftPackageReference "tree-sitter-typescript" */,
-				503F42153BDDB65CB9EC8A18 /* XCLocalSwiftPackageReference "TreeSitterCSS" */,
-				A2F1DF8F186FB086DEE6461B /* XCLocalSwiftPackageReference "TreeSitterHCL" */,
-				85BE587B3304F8D1B3C2A9E0 /* XCLocalSwiftPackageReference "TreeSitterJavaScript" */,
-				BF2BE955FBC2F9CE5DA291C5 /* XCLocalSwiftPackageReference "TreeSitterLua" */,
-				5844843C71BA73C8F5B45D8A /* XCLocalSwiftPackageReference "TreeSitterPython" */,
-				C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "TreeSitterYAML" */,
+				503F42153BDDB65CB9EC8A18 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterCSS" */,
+				A2F1DF8F186FB086DEE6461B /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterHCL" */,
+				85BE587B3304F8D1B3C2A9E0 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterJavaScript" */,
+				BF2BE955FBC2F9CE5DA291C5 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterLua" */,
+				5844843C71BA73C8F5B45D8A /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterPython" */,
+				C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterYAML" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C86FE0D59F990939C552C7E2 /* Products */;
@@ -3633,6 +3635,7 @@
 				73480309CF2CBA78879268DD /* BlockedNudgeBanner.swift in Sources */,
 				ACDDE4B18A94164BDFEED06B /* BranchOpsMenu.swift in Sources */,
 				9E302329243407946D47DC91 /* BranchPicker.swift in Sources */,
+				1B123A31842DDDB42C6820F1 /* BuildIdentity.swift in Sources */,
 				71D65CB923752CEDA6E86FCA /* BulkConflictResolveReport.swift in Sources */,
 				7C8E278F6BED0924531E3C91 /* BundledFontRegistrar.swift in Sources */,
 				139F45EE390C27342C5DD734 /* CenterPaneView.swift in Sources */,
@@ -3952,7 +3955,6 @@
 				45EEE2F32712FDEE392A9707 /* ZmxEnv.swift in Sources */,
 				2E952C4C62784847AF4B7870 /* ZmxSessionName.swift in Sources */,
 				99711AA1B0FB450D32770415 /* ZmxSunPathBudget.swift in Sources */,
-				B50266FAD595DBF626CA199F /* BuildIdentity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4089,6 +4091,7 @@
 				956B221EC4FF3A18C713A64F /* AppStateTabAvailabilityTests.swift in Sources */,
 				A5742BE7348C02324B8119D0 /* BaseBranchSelectorTests.swift in Sources */,
 				CF3567FA9501C1358D754D42 /* BlockedLanguageServerNudgeResolverTests.swift in Sources */,
+				5026424BC4EA8196D12E6F46 /* BuildIdentityTests.swift in Sources */,
 				F8143610563C28604A23B89A /* CenterSelectionStateResolverTests.swift in Sources */,
 				835AFE4A9EA0889E0AF316BD /* ChangeSummaryVisibilityTests.swift in Sources */,
 				59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */,
@@ -4313,7 +4316,6 @@
 				397FADBCCF3211504DAEDC35 /* ZmxEnvTests.swift in Sources */,
 				89A3BEAA64625C766E73F58E /* ZmxSessionNameTests.swift in Sources */,
 				F6C5274BCA0B3068C6C2D36A /* ZmxSunPathBudgetTests.swift in Sources */,
-				0C6B4043280C0787CC9F8DFC /* BuildIdentityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4473,10 +4475,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lc++",
-				);
+				OTHER_LDFLAGS = "$(inherited) -lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = io.nlopez.alas;
 				PRODUCT_NAME = Alas;
 				SDKROOT = macosx;
@@ -4518,10 +4517,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-lc++",
-				);
+				OTHER_LDFLAGS = "$(inherited) -lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = io.nlopez.alas;
 				PRODUCT_NAME = Alas;
 				SDKROOT = macosx;
@@ -4578,27 +4574,27 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		503F42153BDDB65CB9EC8A18 /* XCLocalSwiftPackageReference "TreeSitterCSS" */ = {
+		503F42153BDDB65CB9EC8A18 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterCSS" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterCSS;
 		};
-		5844843C71BA73C8F5B45D8A /* XCLocalSwiftPackageReference "TreeSitterPython" */ = {
+		5844843C71BA73C8F5B45D8A /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterPython" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterPython;
 		};
-		85BE587B3304F8D1B3C2A9E0 /* XCLocalSwiftPackageReference "TreeSitterJavaScript" */ = {
+		85BE587B3304F8D1B3C2A9E0 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterJavaScript" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterJavaScript;
 		};
-		A2F1DF8F186FB086DEE6461B /* XCLocalSwiftPackageReference "TreeSitterHCL" */ = {
+		A2F1DF8F186FB086DEE6461B /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterHCL" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterHCL;
 		};
-		BF2BE955FBC2F9CE5DA291C5 /* XCLocalSwiftPackageReference "TreeSitterLua" */ = {
+		BF2BE955FBC2F9CE5DA291C5 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterLua" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterLua;
 		};
-		C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "TreeSitterYAML" */ = {
+		C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterYAML" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterYAML;
 		};

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		0BA997A903C1DC2A41D64E22 /* AgentRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A919B8770029DBE7FCFF0EE2 /* AgentRunner.swift */; };
 		0BBFEE487AF71AD858B19EC5 /* ACPPermissionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BCD93747BF71CB256038314 /* ACPPermissionPrompt.swift */; };
 		0C54356D0ACEDD5275FFB6EB /* CodeLanguageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A727D24652E45B98C10917F8 /* CodeLanguageDetailView.swift */; };
+		0C6B4043280C0787CC9F8DFC /* BuildIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CBEF21062CAD30127BEB2AA /* BuildIdentityTests.swift */; };
 		0CF488290CC525EA7C11A43C /* DiffParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE26221DC8E8837FFEB87474 /* DiffParserTests.swift */; };
 		0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8BF1EC24E449A302A1E25C /* CopyFeedbackState.swift */; };
 		0D65F2B699E6B0CF0915D25D /* ImageDiffMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */; };
@@ -615,6 +616,7 @@
 		B40B75555598C42713157C5C /* TreeSitterCSS in Frameworks */ = {isa = PBXBuildFile; productRef = 3F76DFBA5D1CB707989C86AB /* TreeSitterCSS */; };
 		B472D692A8D8D1C664EAC467 /* ACPSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1281A3235F08DC8A95D015A9 /* ACPSessionTests.swift */; };
 		B4C4E13CFE986FC20DC12808 /* ACPFileWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA51D49B1AE4C4E10D450C6 /* ACPFileWriterTests.swift */; };
+		B50266FAD595DBF626CA199F /* BuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0904F152CCD7A9C7116A9E6A /* BuildIdentity.swift */; };
 		B54B0BFA87B2566DB59C3D59 /* ConflictMarkerParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A00CFC045C4BF9C13B4105BF /* ConflictMarkerParserTests.swift */; };
 		B574D2D5DF3129E326DCFCCF /* ShellEnvResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */; };
 		B58BF89C3A788A31CBED2067 /* TreeSitterJavaScript in Frameworks */ = {isa = PBXBuildFile; productRef = B3568F495249430FBBE2FCCF /* TreeSitterJavaScript */; };
@@ -915,6 +917,7 @@
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
 		09007B6E90DE89B7215A5D44 /* ImageDiffMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffMode.swift; sourceTree = "<group>"; };
+		0904F152CCD7A9C7116A9E6A /* BuildIdentity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BuildIdentity.swift; sourceTree = "<group>"; };
 		0914F0E19514D1DF89C74B41 /* MergeConflictResolvedEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MergeConflictResolvedEmptyView.swift; sourceTree = "<group>"; };
 		09246CDA0F77D86F05727407 /* ShellEnvResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellEnvResolverTests.swift; sourceTree = "<group>"; };
 		0934F7BB22E33263B63925B7 /* ImageDiffPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPair.swift; sourceTree = "<group>"; };
@@ -1251,6 +1254,7 @@
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
 		6CA51D49B1AE4C4E10D450C6 /* ACPFileWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileWriterTests.swift; sourceTree = "<group>"; };
 		6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBranchSelectorTests.swift; sourceTree = "<group>"; };
+		6CBEF21062CAD30127BEB2AA /* BuildIdentityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BuildIdentityTests.swift; sourceTree = "<group>"; };
 		6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRetentionTests.swift; sourceTree = "<group>"; };
 		6D46BDE72E52818061452ECB /* CommitRowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitRowTests.swift; sourceTree = "<group>"; };
 		6D788808DF3BE405143F91F7 /* ReleaseInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseInfoTests.swift; sourceTree = "<group>"; };
@@ -2091,6 +2095,7 @@
 				EAD92DAB367A7F31FF1223D1 /* Diagnostics */,
 				08BD96F4379A0D250DE4303C /* JSONRPC */,
 				5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */,
+				6CBEF21062CAD30127BEB2AA /* BuildIdentityTests.swift */,
 			);
 			path = AlasTests;
 			sourceTree = "<group>";
@@ -2735,6 +2740,7 @@
 				0CC074B85082A8BB30EEAFA5 /* UpdateAvailableSheet.swift */,
 				2763F93ADFDCDF6B31D16475 /* UpdateController.swift */,
 				FE09B83A747269494B206F23 /* UpdateThrottle.swift */,
+				0904F152CCD7A9C7116A9E6A /* BuildIdentity.swift */,
 			);
 			path = Updates;
 			sourceTree = "<group>";
@@ -3278,8 +3284,6 @@
 				5EEBBAEE60D2DB007AD92314 /* PBXTargetDependency */,
 			);
 			name = AlasTests;
-			packageProductDependencies = (
-			);
 			productName = AlasTests;
 			productReference = B65018D176CD2E52A3999CF0 /* AlasTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -3372,12 +3376,12 @@
 				7019D0C134F78A3B7F4CF4BB /* XCRemoteSwiftPackageReference "tree-sitter-swift" */,
 				A38DA0B05C2E29601ED4C8A9 /* XCRemoteSwiftPackageReference "tree-sitter-toml" */,
 				E32CC6F3745BD894D495E254 /* XCRemoteSwiftPackageReference "tree-sitter-typescript" */,
-				503F42153BDDB65CB9EC8A18 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterCSS" */,
-				A2F1DF8F186FB086DEE6461B /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterHCL" */,
-				85BE587B3304F8D1B3C2A9E0 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterJavaScript" */,
-				BF2BE955FBC2F9CE5DA291C5 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterLua" */,
-				5844843C71BA73C8F5B45D8A /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterPython" */,
-				C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterYAML" */,
+				503F42153BDDB65CB9EC8A18 /* XCLocalSwiftPackageReference "TreeSitterCSS" */,
+				A2F1DF8F186FB086DEE6461B /* XCLocalSwiftPackageReference "TreeSitterHCL" */,
+				85BE587B3304F8D1B3C2A9E0 /* XCLocalSwiftPackageReference "TreeSitterJavaScript" */,
+				BF2BE955FBC2F9CE5DA291C5 /* XCLocalSwiftPackageReference "TreeSitterLua" */,
+				5844843C71BA73C8F5B45D8A /* XCLocalSwiftPackageReference "TreeSitterPython" */,
+				C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "TreeSitterYAML" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C86FE0D59F990939C552C7E2 /* Products */;
@@ -3948,6 +3952,7 @@
 				45EEE2F32712FDEE392A9707 /* ZmxEnv.swift in Sources */,
 				2E952C4C62784847AF4B7870 /* ZmxSessionName.swift in Sources */,
 				99711AA1B0FB450D32770415 /* ZmxSunPathBudget.swift in Sources */,
+				B50266FAD595DBF626CA199F /* BuildIdentity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4308,6 +4313,7 @@
 				397FADBCCF3211504DAEDC35 /* ZmxEnvTests.swift in Sources */,
 				89A3BEAA64625C766E73F58E /* ZmxSessionNameTests.swift in Sources */,
 				F6C5274BCA0B3068C6C2D36A /* ZmxSunPathBudgetTests.swift in Sources */,
+				0C6B4043280C0787CC9F8DFC /* BuildIdentityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4467,7 +4473,10 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				OTHER_LDFLAGS = "$(inherited) -lc++";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.nlopez.alas;
 				PRODUCT_NAME = Alas;
 				SDKROOT = macosx;
@@ -4509,7 +4518,10 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				OTHER_LDFLAGS = "$(inherited) -lc++";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-lc++",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.nlopez.alas;
 				PRODUCT_NAME = Alas;
 				SDKROOT = macosx;
@@ -4566,27 +4578,27 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		503F42153BDDB65CB9EC8A18 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterCSS" */ = {
+		503F42153BDDB65CB9EC8A18 /* XCLocalSwiftPackageReference "TreeSitterCSS" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterCSS;
 		};
-		5844843C71BA73C8F5B45D8A /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterPython" */ = {
+		5844843C71BA73C8F5B45D8A /* XCLocalSwiftPackageReference "TreeSitterPython" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterPython;
 		};
-		85BE587B3304F8D1B3C2A9E0 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterJavaScript" */ = {
+		85BE587B3304F8D1B3C2A9E0 /* XCLocalSwiftPackageReference "TreeSitterJavaScript" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterJavaScript;
 		};
-		A2F1DF8F186FB086DEE6461B /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterHCL" */ = {
+		A2F1DF8F186FB086DEE6461B /* XCLocalSwiftPackageReference "TreeSitterHCL" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterHCL;
 		};
-		BF2BE955FBC2F9CE5DA291C5 /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterLua" */ = {
+		BF2BE955FBC2F9CE5DA291C5 /* XCLocalSwiftPackageReference "TreeSitterLua" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterLua;
 		};
-		C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "ThirdParty/TreeSitterYAML" */ = {
+		C9290CC4BA5D8FCABCC18EFD /* XCLocalSwiftPackageReference "TreeSitterYAML" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThirdParty/TreeSitterYAML;
 		};

--- a/Alas/Resources/Info.plist
+++ b/Alas/Resources/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AlasBuildDate</key>
+	<string></string>
+	<key>AlasGitSHA</key>
+	<string></string>
+	<key>AlasReleaseTrack</key>
+	<string>stable</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -191,7 +191,7 @@ struct RootView: View {
         )) { info in
             UpdateAvailableSheet(
                 info: info,
-                source: state.updates.source,
+                source: state.updates.track == .nightly ? .direct : state.updates.source,
                 onDismiss: { state.updates.presentedUpdate = nil }
             )
             .environment(\.theme, state.themeStore.current)

--- a/Alas/Sources/Updates/BuildIdentity.swift
+++ b/Alas/Sources/Updates/BuildIdentity.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Which GitHub release stream this build of Alas was published to.
+enum ReleaseTrack: String, Equatable {
+    case stable
+    case nightly
+}
+
+/// Build-time identity for the running app. Sourced from Info.plist keys:
+/// - `AlasReleaseTrack`: "stable" (default) or "nightly".
+/// - `AlasGitSHA`: 40-char hex commit SHA; empty string treated as nil.
+/// - `AlasBuildDate`: ISO-8601 UTC timestamp; empty/malformed treated as nil.
+/// - `CFBundleShortVersionString`: parsed via `SemanticVersion`.
+struct BuildIdentity: Equatable {
+    let track: ReleaseTrack
+    let version: SemanticVersion
+    let gitSHA: String?
+    let buildDate: Date?
+
+    init(
+        track: ReleaseTrack,
+        version: SemanticVersion,
+        gitSHA: String? = nil,
+        buildDate: Date? = nil
+    ) {
+        self.track = track
+        self.version = version
+        self.gitSHA = gitSHA
+        self.buildDate = buildDate
+    }
+
+    /// Reads identity from a raw Info.plist dictionary. Unknown / missing
+    /// values fall back to safe defaults rather than throwing — a misconfigured
+    /// build should still behave like a stable build, not crash on launch.
+    init(infoDictionary: [String: Any]?) {
+        let dict = infoDictionary ?? [:]
+
+        let rawTrack = dict["AlasReleaseTrack"] as? String ?? ""
+        self.track = ReleaseTrack(rawValue: rawTrack) ?? .stable
+
+        let rawVersion = dict["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        self.version = SemanticVersion(parsing: rawVersion) ?? SemanticVersion(major: 0, minor: 0, patch: 0)
+
+        let rawSHA = (dict["AlasGitSHA"] as? String) ?? ""
+        self.gitSHA = rawSHA.isEmpty ? nil : rawSHA
+
+        let rawDate = (dict["AlasBuildDate"] as? String) ?? ""
+        if rawDate.isEmpty {
+            self.buildDate = nil
+        } else {
+            let formatter = ISO8601DateFormatter()
+            self.buildDate = formatter.date(from: rawDate)
+        }
+    }
+
+    /// Convenience initializer that reads from `Bundle.main.infoDictionary`.
+    static func current() -> BuildIdentity {
+        BuildIdentity(infoDictionary: Bundle.main.infoDictionary)
+    }
+}

--- a/Alas/Sources/Updates/ReleaseChecker.swift
+++ b/Alas/Sources/Updates/ReleaseChecker.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Queries GitHub for the latest stable release and produces a verdict.
+/// Queries GitHub for the release on the build's track and produces a verdict.
 /// Network access is injected via `fetch` so tests run offline.
 struct ReleaseChecker {
     enum CheckResult: Equatable {
@@ -11,37 +11,79 @@ struct ReleaseChecker {
 
     typealias Fetch = (URL) async throws -> Data
 
-    let latestReleaseURL: URL
+    let stableReleaseURL: URL
+    let nightlyReleaseURL: URL
     let arch: String
     let fetch: Fetch
 
     init(
-        latestReleaseURL: URL = URL(string: "https://api.github.com/repos/mrmans0n/alas/releases/latest")!,
+        stableReleaseURL: URL = URL(string: "https://api.github.com/repos/mrmans0n/alas/releases/latest")!,
+        nightlyReleaseURL: URL = URL(string: "https://api.github.com/repos/mrmans0n/alas/releases/tags/nightly")!,
         arch: String = HostArch.assetSlug,
         fetch: @escaping Fetch = ReleaseChecker.defaultFetch
     ) {
-        self.latestReleaseURL = latestReleaseURL
+        self.stableReleaseURL = stableReleaseURL
+        self.nightlyReleaseURL = nightlyReleaseURL
         self.arch = arch
         self.fetch = fetch
     }
 
-    func check(current: SemanticVersion) async -> CheckResult {
+    func check(identity: BuildIdentity) async -> CheckResult {
+        switch identity.track {
+        case .stable:
+            return await checkStable(identity: identity)
+        case .nightly:
+            return await checkNightly(identity: identity)
+        }
+    }
+
+    private func checkStable(identity: BuildIdentity) async -> CheckResult {
         do {
-            let data = try await fetch(latestReleaseURL)
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            decoder.dateDecodingStrategy = .iso8601
-            let release = try decoder.decode(GitHubRelease.self, from: data)
+            let release = try await fetchRelease(at: stableReleaseURL)
             guard let info = ReleaseInfo.makeStable(from: release, arch: arch) else {
                 return .failed("The latest release could not be read.")
             }
-            guard case .stable(let stable) = info else {
+            guard case let .stable(stable) = info else {
                 return .failed("The latest release could not be read.")
             }
-            return stable.version > current ? .updateAvailable(info) : .upToDate
+            return stable.version > identity.version ? .updateAvailable(info) : .upToDate
         } catch {
             return .failed(error.localizedDescription)
         }
+    }
+
+    private func checkNightly(identity: BuildIdentity) async -> CheckResult {
+        do {
+            let release = try await fetchRelease(at: nightlyReleaseURL)
+            guard let info = ReleaseInfo.makeNightly(from: release) else {
+                return .failed("The latest nightly could not be read.")
+            }
+            guard case let .nightly(nightly) = info else {
+                return .failed("The latest nightly could not be read.")
+            }
+
+            // SHA + publishedAt pairing: a re-tag to the same SHA must not
+            // look like an update, and a force-pushed older SHA must not.
+            if let localSHA = identity.gitSHA {
+                let shaChanged = nightly.fullSHA != localSHA
+                let publishedNewer = identity.buildDate.map { nightly.publishedAt > $0 } ?? true
+                return (shaChanged && publishedNewer) ? .updateAvailable(info) : .upToDate
+            } else {
+                // No local SHA stamped — fall back to date-only compare.
+                let publishedNewer = identity.buildDate.map { nightly.publishedAt > $0 } ?? true
+                return publishedNewer ? .updateAvailable(info) : .upToDate
+            }
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    private func fetchRelease(at url: URL) async throws -> GitHubRelease {
+        let data = try await fetch(url)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(GitHubRelease.self, from: data)
     }
 
     static func defaultFetch(_ url: URL) async throws -> Data {

--- a/Alas/Sources/Updates/ReleaseChecker.swift
+++ b/Alas/Sources/Updates/ReleaseChecker.swift
@@ -13,17 +13,20 @@ struct ReleaseChecker {
 
     let stableReleaseURL: URL
     let nightlyReleaseURL: URL
+    let nightlyTagRefURL: URL
     let arch: String
     let fetch: Fetch
 
     init(
         stableReleaseURL: URL = URL(string: "https://api.github.com/repos/mrmans0n/alas/releases/latest")!,
         nightlyReleaseURL: URL = URL(string: "https://api.github.com/repos/mrmans0n/alas/releases/tags/nightly")!,
+        nightlyTagRefURL: URL = URL(string: "https://api.github.com/repos/mrmans0n/alas/git/ref/tags/nightly")!,
         arch: String = HostArch.assetSlug,
         fetch: @escaping Fetch = ReleaseChecker.defaultFetch
     ) {
         self.stableReleaseURL = stableReleaseURL
         self.nightlyReleaseURL = nightlyReleaseURL
+        self.nightlyTagRefURL = nightlyTagRefURL
         self.arch = arch
         self.fetch = fetch
     }
@@ -55,7 +58,12 @@ struct ReleaseChecker {
     private func checkNightly(identity: BuildIdentity) async -> CheckResult {
         do {
             let release = try await fetchRelease(at: nightlyReleaseURL)
-            guard let info = ReleaseInfo.makeNightly(from: release) else {
+            // The release's `target_commitish` is unreliable for the rolling
+            // nightly tag (GitHub leaves it at the original branch name when
+            // the tag already exists), so resolve the tag's true SHA via the
+            // git refs API.
+            let tagSHA = try await fetchTagSHA(at: nightlyTagRefURL)
+            guard let info = ReleaseInfo.makeNightly(from: release, tagSHA: tagSHA) else {
                 return .failed("The latest nightly could not be read.")
             }
             guard case let .nightly(nightly) = info else {
@@ -84,6 +92,14 @@ struct ReleaseChecker {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         decoder.dateDecodingStrategy = .iso8601
         return try decoder.decode(GitHubRelease.self, from: data)
+    }
+
+    private func fetchTagSHA(at url: URL) async throws -> String {
+        let data = try await fetch(url)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let ref = try decoder.decode(GitRef.self, from: data)
+        return ref.object.sha
     }
 
     static func defaultFetch(_ url: URL) async throws -> Data {

--- a/Alas/Sources/Updates/ReleaseChecker.swift
+++ b/Alas/Sources/Updates/ReleaseChecker.swift
@@ -70,17 +70,16 @@ struct ReleaseChecker {
                 return .failed("The latest nightly could not be read.")
             }
 
-            // SHA + publishedAt pairing: a re-tag to the same SHA must not
-            // look like an update, and a force-pushed older SHA must not.
-            if let localSHA = identity.gitSHA {
-                let shaChanged = nightly.fullSHA != localSHA
-                let publishedNewer = identity.buildDate.map { nightly.publishedAt > $0 } ?? true
-                return (shaChanged && publishedNewer) ? .updateAvailable(info) : .upToDate
-            } else {
-                // No local SHA stamped — fall back to date-only compare.
-                let publishedNewer = identity.buildDate.map { nightly.publishedAt > $0 } ?? true
-                return publishedNewer ? .updateAvailable(info) : .upToDate
-            }
+            // SHA-only comparison: the release's `published_at` is unreliable
+            // because `softprops/action-gh-release` updates the existing
+            // `nightly` release in place, leaving the original publish time.
+            // The tag SHA is the source of truth — if it differs from what
+            // this build was stamped with, a newer build exists.
+            //
+            // No local SHA (e.g. a hand-built nightly): we cannot compare,
+            // so report up-to-date rather than pester with spurious updates.
+            guard let localSHA = identity.gitSHA else { return .upToDate }
+            return nightly.fullSHA != localSHA ? .updateAvailable(info) : .upToDate
         } catch {
             return .failed(error.localizedDescription)
         }

--- a/Alas/Sources/Updates/ReleaseChecker.swift
+++ b/Alas/Sources/Updates/ReleaseChecker.swift
@@ -30,6 +30,7 @@ struct ReleaseChecker {
             let data = try await fetch(latestReleaseURL)
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
+            decoder.dateDecodingStrategy = .iso8601
             let release = try decoder.decode(GitHubRelease.self, from: data)
             guard let info = ReleaseInfo.make(from: release, arch: arch) else {
                 return .failed("The latest release could not be read.")

--- a/Alas/Sources/Updates/ReleaseChecker.swift
+++ b/Alas/Sources/Updates/ReleaseChecker.swift
@@ -32,10 +32,13 @@ struct ReleaseChecker {
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             decoder.dateDecodingStrategy = .iso8601
             let release = try decoder.decode(GitHubRelease.self, from: data)
-            guard let info = ReleaseInfo.make(from: release, arch: arch) else {
+            guard let info = ReleaseInfo.makeStable(from: release, arch: arch) else {
                 return .failed("The latest release could not be read.")
             }
-            return info.version > current ? .updateAvailable(info) : .upToDate
+            guard case .stable(let stable) = info else {
+                return .failed("The latest release could not be read.")
+            }
+            return stable.version > current ? .updateAvailable(info) : .upToDate
         } catch {
             return .failed(error.localizedDescription)
         }

--- a/Alas/Sources/Updates/ReleaseInfo.swift
+++ b/Alas/Sources/Updates/ReleaseInfo.swift
@@ -31,26 +31,85 @@ struct GitHubRelease: Decodable {
     }
 }
 
-/// Normalized release info the UI consumes.
-struct ReleaseInfo: Equatable, Identifiable {
-    let version: SemanticVersion
-    let releaseNotes: String
-    let htmlURL: URL
-    let dmgURL: URL?
+/// Normalized release info the UI consumes. Two variants:
+/// - `.stable` for SemVer-tagged releases from `/releases/latest`.
+/// - `.nightly` for the rolling pre-release from `/releases/tags/nightly`.
+enum ReleaseInfo: Equatable, Identifiable {
+    case stable(StableReleaseInfo)
+    case nightly(NightlyReleaseInfo)
 
-    var id: String { version.description }
+    var id: String {
+        switch self {
+        case .stable(let s): return "stable-\(s.version.description)"
+        case .nightly(let n): return "nightly-\(n.shortSHA)"
+        }
+    }
 
-    /// Maps a decoded release to `ReleaseInfo`, resolving the DMG asset for
-    /// `arch`. Returns nil when the tag isn't a parseable version.
-    static func make(from release: GitHubRelease, arch: String) -> ReleaseInfo? {
+    /// Shared fields the sheet always renders.
+    var releaseNotes: String {
+        switch self {
+        case .stable(let s): return s.releaseNotes
+        case .nightly(let n): return n.releaseNotes
+        }
+    }
+
+    var htmlURL: URL {
+        switch self {
+        case .stable(let s): return s.htmlURL
+        case .nightly(let n): return n.htmlURL
+        }
+    }
+
+    var dmgURL: URL? {
+        switch self {
+        case .stable(let s): return s.dmgURL
+        case .nightly(let n): return n.dmgURL
+        }
+    }
+
+    static func makeStable(from release: GitHubRelease, arch: String) -> ReleaseInfo? {
         guard let version = SemanticVersion(parsing: release.tagName) else { return nil }
         let dmgName = "Alas-\(version)-\(arch).dmg"
         let dmg = release.assets.first { $0.name == dmgName }?.browserDownloadUrl
-        return ReleaseInfo(
+        return .stable(StableReleaseInfo(
             version: version,
             releaseNotes: release.body ?? "",
             htmlURL: release.htmlUrl,
             dmgURL: dmg
-        )
+        ))
     }
+
+    /// Maps the rolling `nightly` release. `arch` is intentionally ignored —
+    /// nightlies publish a single `Alas-nightly.dmg` today. Returns nil if
+    /// `target_commitish` is empty (no SHA to compare against).
+    static func makeNightly(from release: GitHubRelease) -> ReleaseInfo? {
+        let sha = release.targetCommitish
+        guard !sha.isEmpty else { return nil }
+        let shortSHA = String(sha.prefix(7))
+        let dmg = release.assets.first { $0.name == "Alas-nightly.dmg" }?.browserDownloadUrl
+        return .nightly(NightlyReleaseInfo(
+            shortSHA: shortSHA,
+            fullSHA: sha,
+            publishedAt: release.publishedAt,
+            releaseNotes: release.body ?? "",
+            htmlURL: release.htmlUrl,
+            dmgURL: dmg
+        ))
+    }
+}
+
+struct StableReleaseInfo: Equatable {
+    let version: SemanticVersion
+    let releaseNotes: String
+    let htmlURL: URL
+    let dmgURL: URL?
+}
+
+struct NightlyReleaseInfo: Equatable {
+    let shortSHA: String
+    let fullSHA: String
+    let publishedAt: Date
+    let releaseNotes: String
+    let htmlURL: URL
+    let dmgURL: URL?
 }

--- a/Alas/Sources/Updates/ReleaseInfo.swift
+++ b/Alas/Sources/Updates/ReleaseInfo.swift
@@ -31,6 +31,19 @@ struct GitHubRelease: Decodable {
     }
 }
 
+/// Decoded subset of GitHub's `git/ref/tags/{tag}` payload. Used to resolve
+/// the true commit SHA a tag points to — `GitHubRelease.target_commitish` is
+/// unreliable for rolling tags (GitHub keeps it at the original branch name
+/// when the tag already exists).
+struct GitRef: Decodable {
+    let object: Object
+
+    struct Object: Decodable {
+        let sha: String
+        let type: String
+    }
+}
+
 /// Normalized release info the UI consumes. Two variants:
 /// - `.stable` for SemVer-tagged releases from `/releases/latest`.
 /// - `.nightly` for the rolling pre-release from `/releases/tags/nightly`.
@@ -80,16 +93,17 @@ enum ReleaseInfo: Equatable, Identifiable {
     }
 
     /// Maps the rolling `nightly` release. `arch` is intentionally ignored —
-    /// nightlies publish a single `Alas-nightly.dmg` today. Returns nil if
-    /// `target_commitish` is empty (no SHA to compare against).
-    static func makeNightly(from release: GitHubRelease) -> ReleaseInfo? {
-        let sha = release.targetCommitish
-        guard !sha.isEmpty else { return nil }
-        let shortSHA = String(sha.prefix(7))
+    /// nightlies publish a single `Alas-nightly.dmg` today. `tagSHA` must be
+    /// the commit SHA the `nightly` git tag actually points to (resolved via
+    /// the git refs API), not `release.targetCommitish`. Returns nil if the
+    /// SHA is empty.
+    static func makeNightly(from release: GitHubRelease, tagSHA: String) -> ReleaseInfo? {
+        guard !tagSHA.isEmpty else { return nil }
+        let shortSHA = String(tagSHA.prefix(7))
         let dmg = release.assets.first { $0.name == "Alas-nightly.dmg" }?.browserDownloadUrl
         return .nightly(NightlyReleaseInfo(
             shortSHA: shortSHA,
-            fullSHA: sha,
+            fullSHA: tagSHA,
             publishedAt: release.publishedAt,
             releaseNotes: release.body ?? "",
             htmlURL: release.htmlUrl,

--- a/Alas/Sources/Updates/ReleaseInfo.swift
+++ b/Alas/Sources/Updates/ReleaseInfo.swift
@@ -104,7 +104,6 @@ enum ReleaseInfo: Equatable, Identifiable {
         return .nightly(NightlyReleaseInfo(
             shortSHA: shortSHA,
             fullSHA: tagSHA,
-            publishedAt: release.publishedAt,
             releaseNotes: release.body ?? "",
             htmlURL: release.htmlUrl,
             dmgURL: dmg
@@ -122,7 +121,6 @@ struct StableReleaseInfo: Equatable {
 struct NightlyReleaseInfo: Equatable {
     let shortSHA: String
     let fullSHA: String
-    let publishedAt: Date
     let releaseNotes: String
     let htmlURL: URL
     let dmgURL: URL?

--- a/Alas/Sources/Updates/ReleaseInfo.swift
+++ b/Alas/Sources/Updates/ReleaseInfo.swift
@@ -11,14 +11,18 @@ enum HostArch {
     }
 }
 
-/// Decoded subset of GitHub's `releases/latest` payload.
-/// Decode with `keyDecodingStrategy = .convertFromSnakeCase`.
+/// Decoded subset of GitHub's release payload (`releases/latest` and
+/// `releases/tags/{tag}` share the same shape).
+/// Decode with `keyDecodingStrategy = .convertFromSnakeCase` and
+/// `dateDecodingStrategy = .iso8601`.
 struct GitHubRelease: Decodable {
     let tagName: String
     let body: String?
     let htmlUrl: URL
     let prerelease: Bool
     let draft: Bool
+    let targetCommitish: String
+    let publishedAt: Date
     let assets: [Asset]
 
     struct Asset: Decodable {

--- a/Alas/Sources/Updates/UpdateAvailableSheet.swift
+++ b/Alas/Sources/Updates/UpdateAvailableSheet.swift
@@ -11,13 +11,28 @@ struct UpdateAvailableSheet: View {
 
     private let brewCommand = "brew upgrade --cask alas"
 
+    private var subtitleText: String {
+        switch info {
+        case .stable(let s):
+            return "Alas \(s.version.description) is available."
+        case .nightly(let n):
+            return "Nightly \(n.shortSHA) · \(relativeTime(from: n.publishedAt))"
+        }
+    }
+
+    private func relativeTime(from date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Update available")
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundColor(theme.color("fg"))
-                Text("Alas \(info.version.description) is available.")
+                Text(subtitleText)
                     .font(.system(size: 12))
                     .foregroundColor(theme.color("fg-dim"))
             }

--- a/Alas/Sources/Updates/UpdateAvailableSheet.swift
+++ b/Alas/Sources/Updates/UpdateAvailableSheet.swift
@@ -16,14 +16,12 @@ struct UpdateAvailableSheet: View {
         case .stable(let s):
             return "Alas \(s.version.description) is available."
         case .nightly(let n):
-            return "Nightly \(n.shortSHA) · \(relativeTime(from: n.publishedAt))"
+            // Intentionally no timestamp: the release's `published_at` is
+            // unreliable for the rolling nightly (updated in place), so the
+            // tag's short SHA is the only trustworthy identifier the sheet
+            // can show.
+            return "Nightly \(n.shortSHA)"
         }
-    }
-
-    private func relativeTime(from date: Date) -> String {
-        let formatter = RelativeDateTimeFormatter()
-        formatter.unitsStyle = .full
-        return formatter.localizedString(for: date, relativeTo: Date())
     }
 
     private var titleText: String {

--- a/Alas/Sources/Updates/UpdateAvailableSheet.swift
+++ b/Alas/Sources/Updates/UpdateAvailableSheet.swift
@@ -26,10 +26,24 @@ struct UpdateAvailableSheet: View {
         return formatter.localizedString(for: date, relativeTo: Date())
     }
 
+    private var titleText: String {
+        switch info {
+        case .stable: return "Update available"
+        case .nightly: return "New nightly available"
+        }
+    }
+
+    private var viewReleaseLabel: String {
+        switch info {
+        case .stable: return "View Release Notes"
+        case .nightly: return "View on GitHub"
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Update available")
+                Text(titleText)
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundColor(theme.color("fg"))
                 Text(subtitleText)
@@ -69,7 +83,7 @@ struct UpdateAvailableSheet: View {
                 AlasButton(title: "View Release", style: .subtle) { NSWorkspace.shared.open(info.htmlURL) }
                 AlasButton(title: "Later", style: .primary, action: onDismiss)
             case .direct:
-                AlasButton(title: "View Release Notes", style: .subtle) { NSWorkspace.shared.open(info.htmlURL) }
+                AlasButton(title: viewReleaseLabel, style: .subtle) { NSWorkspace.shared.open(info.htmlURL) }
                 Spacer()
                 AlasButton(title: "Later", style: .subtle, action: onDismiss)
                 AlasButton(title: "Download", style: .primary) {

--- a/Alas/Sources/Updates/UpdateController.swift
+++ b/Alas/Sources/Updates/UpdateController.swift
@@ -10,7 +10,7 @@ final class UpdateController {
     /// Non-nil when an update sheet should be presented.
     var presentedUpdate: ReleaseInfo?
 
-    private let currentVersion: SemanticVersion
+    private let identity: BuildIdentity
     private let checker: ReleaseChecker
     private let installSource: InstallSource
     private let defaults: UserDefaults
@@ -19,26 +19,25 @@ final class UpdateController {
     private let lastCheckedKey = "io.nlopez.alas.updates.lastCheckedAt"
 
     init(
-        currentVersion: SemanticVersion = UpdateController.bundleVersion(),
+        identity: BuildIdentity = BuildIdentity.current(),
         checker: ReleaseChecker = ReleaseChecker(),
         installSource: InstallSource = .detect(),
         defaults: UserDefaults = .standard,
         isEnabled: @escaping () -> Bool
     ) {
-        self.currentVersion = currentVersion
+        self.identity = identity
         self.checker = checker
         self.installSource = installSource
         self.defaults = defaults
         self.isEnabled = isEnabled
     }
 
-    static func bundleVersion() -> SemanticVersion {
-        let raw = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-        return SemanticVersion(parsing: raw) ?? SemanticVersion(major: 0, minor: 0, patch: 0)
-    }
-
     /// Where this copy was installed — used by the sheet to tailor the action.
     var source: InstallSource { installSource }
+
+    /// Which release track this build belongs to. Surfaced for the sheet so
+    /// the nightly variant can force the direct action row.
+    var track: ReleaseTrack { identity.track }
 
     /// Throttled, silent-on-no-update check intended for app launch.
     func checkOnLaunch() {
@@ -53,7 +52,7 @@ final class UpdateController {
     }
 
     private func runCheck(announceNoUpdate: Bool) async {
-        let result = await checker.check(current: currentVersion)
+        let result = await checker.check(identity: identity)
         switch result {
         case .updateAvailable(let info):
             // Stamp only on a successful fetch — a failed check must not consume
@@ -63,9 +62,24 @@ final class UpdateController {
             presentedUpdate = info
         case .upToDate:
             defaults.set(Date(), forKey: lastCheckedKey)
-            if announceNoUpdate { presentInfo(title: "You're up to date", message: "Alas \(currentVersion) is the latest version.") }
+            if announceNoUpdate {
+                presentInfo(title: "You're up to date", message: upToDateMessage())
+            }
         case .failed(let message):
             if announceNoUpdate { presentInfo(title: "Couldn't check for updates", message: message) }
+        }
+    }
+
+    private func upToDateMessage() -> String {
+        switch identity.track {
+        case .stable:
+            return "Alas \(identity.version) is the latest version."
+        case .nightly:
+            if let sha = identity.gitSHA {
+                return "Nightly \(sha.prefix(7)) is current."
+            } else {
+                return "This nightly build is current."
+            }
         }
     }
 

--- a/AlasTests/BuildIdentityTests.swift
+++ b/AlasTests/BuildIdentityTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct BuildIdentityTests {
+    private func dict(
+        track: String? = nil,
+        sha: String? = nil,
+        buildDate: String? = nil,
+        version: String? = "0.5.1"
+    ) -> [String: Any] {
+        var d: [String: Any] = [:]
+        if let track { d["AlasReleaseTrack"] = track }
+        if let sha { d["AlasGitSHA"] = sha }
+        if let buildDate { d["AlasBuildDate"] = buildDate }
+        if let version { d["CFBundleShortVersionString"] = version }
+        return d
+    }
+
+    @Test func defaultsToStableWhenTrackMissing() {
+        let id = BuildIdentity(infoDictionary: dict())
+        #expect(id.track == .stable)
+    }
+
+    @Test func parsesStableExplicitly() {
+        let id = BuildIdentity(infoDictionary: dict(track: "stable"))
+        #expect(id.track == .stable)
+    }
+
+    @Test func parsesNightly() {
+        let id = BuildIdentity(infoDictionary: dict(track: "nightly"))
+        #expect(id.track == .nightly)
+    }
+
+    @Test func unknownTrackFallsBackToStable() {
+        let id = BuildIdentity(infoDictionary: dict(track: "weird"))
+        #expect(id.track == .stable)
+    }
+
+    @Test func emptyGitSHAIsNil() {
+        let id = BuildIdentity(infoDictionary: dict(track: "nightly", sha: ""))
+        #expect(id.gitSHA == nil)
+    }
+
+    @Test func populatedGitSHA() {
+        let id = BuildIdentity(infoDictionary: dict(track: "nightly", sha: "abc1234567890abcdef1234567890abcdef12345"))
+        #expect(id.gitSHA == "abc1234567890abcdef1234567890abcdef12345")
+    }
+
+    @Test func emptyBuildDateIsNil() {
+        let id = BuildIdentity(infoDictionary: dict(track: "nightly", buildDate: ""))
+        #expect(id.buildDate == nil)
+    }
+
+    @Test func parsesISO8601BuildDate() {
+        let id = BuildIdentity(infoDictionary: dict(track: "nightly", buildDate: "2026-06-02T10:21:00Z"))
+        #expect(id.buildDate != nil)
+        let formatter = ISO8601DateFormatter()
+        #expect(id.buildDate == formatter.date(from: "2026-06-02T10:21:00Z"))
+    }
+
+    @Test func malformedBuildDateIsNil() {
+        let id = BuildIdentity(infoDictionary: dict(track: "nightly", buildDate: "not-a-date"))
+        #expect(id.buildDate == nil)
+    }
+
+    @Test func versionDefaultsToZeroWhenMissing() {
+        let id = BuildIdentity(infoDictionary: dict(version: nil))
+        #expect(id.version == SemanticVersion(major: 0, minor: 0, patch: 0))
+    }
+
+    @Test func parsesVersionFromCFBundleShortVersionString() {
+        let id = BuildIdentity(infoDictionary: dict(version: "0.6.2"))
+        #expect(id.version == SemanticVersion(major: 0, minor: 6, patch: 2))
+    }
+}

--- a/AlasTests/ReleaseCheckerTests.swift
+++ b/AlasTests/ReleaseCheckerTests.swift
@@ -11,6 +11,8 @@ struct ReleaseCheckerTests {
           "html_url": "https://github.com/mrmans0n/alas/releases/tag/\(tag)",
           "prerelease": false,
           "draft": false,
+          "target_commitish": "abc1234567890abcdef1234567890abcdef12345",
+          "published_at": "2026-06-02T10:21:00Z",
           "assets": [
             {"name": "Alas-\(tag.replacingOccurrences(of: "v", with: ""))-arm64.dmg",
              "browser_download_url": "https://example.com/\(tag)-arm64.dmg"}
@@ -66,7 +68,7 @@ struct ReleaseCheckerTests {
 
     @Test func reportsFailedWhenTagUnparseable() async {
         let data = Data("""
-        {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":false,"draft":false,"assets":[]}
+        {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":false,"draft":false,"target_commitish":"abc1234","published_at":"2026-06-02T10:21:00Z","assets":[]}
         """.utf8)
         let result = await checker(returning: data)
             .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))

--- a/AlasTests/ReleaseCheckerTests.swift
+++ b/AlasTests/ReleaseCheckerTests.swift
@@ -98,7 +98,13 @@ struct ReleaseCheckerTests {
 
     // MARK: - Nightly track
 
-    private func nightlyJSON(sha: String, publishedAt: String) -> Data {
+    private static let stableTestURL = URL(string: "https://stable.test")!
+    private static let nightlyTestURL = URL(string: "https://nightly.test")!
+    private static let tagRefTestURL = URL(string: "https://tagref.test")!
+
+    private func nightlyReleaseJSON(publishedAt: String) -> Data {
+        // `target_commitish` is intentionally a branch name to mirror what
+        // GitHub returns for the rolling nightly release in production.
         Data("""
         {
           "tag_name": "nightly",
@@ -106,13 +112,34 @@ struct ReleaseCheckerTests {
           "html_url": "https://github.com/mrmans0n/alas/releases/tag/nightly",
           "prerelease": true,
           "draft": false,
-          "target_commitish": "\(sha)",
+          "target_commitish": "main",
           "published_at": "\(publishedAt)",
           "assets": [
             {"name": "Alas-nightly.dmg", "browser_download_url": "https://example.com/nightly.dmg"}
           ]
         }
         """.utf8)
+    }
+
+    private func nightlyTagRefJSON(sha: String) -> Data {
+        Data("""
+        {"ref":"refs/tags/nightly","node_id":"x","url":"https://example.test","object":{"sha":"\(sha)","type":"commit","url":"https://example.test/obj"}}
+        """.utf8)
+    }
+
+    private func nightlyChecker(tagSHA: String, publishedAt: String) -> ReleaseChecker {
+        ReleaseChecker(
+            stableReleaseURL: Self.stableTestURL,
+            nightlyReleaseURL: Self.nightlyTestURL,
+            nightlyTagRefURL: Self.tagRefTestURL,
+            arch: "arm64",
+            fetch: { url in
+                if url == Self.tagRefTestURL {
+                    return self.nightlyTagRefJSON(sha: tagSHA)
+                }
+                return self.nightlyReleaseJSON(publishedAt: publishedAt)
+            }
+        )
     }
 
     private func iso(_ s: String) -> Date {
@@ -129,12 +156,7 @@ struct ReleaseCheckerTests {
     }
 
     @Test func nightlyReportsUpdateWhenSHADiffersAndRemoteNewer() async {
-        let checker = ReleaseChecker(
-            stableReleaseURL: URL(string: "https://stable.test")!,
-            nightlyReleaseURL: URL(string: "https://nightly.test")!,
-            arch: "arm64",
-            fetch: { _ in self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-02T12:00:00Z") }
-        )
+        let checker = nightlyChecker(tagSHA: "fff9999", publishedAt: "2026-06-02T12:00:00Z")
         let result = await checker.check(identity: nightlyIdentity(
             sha: "aaa1111aaa1111aaa1111aaa1111aaa1111aaa11",
             buildDate: "2026-06-02T10:00:00Z"
@@ -148,12 +170,7 @@ struct ReleaseCheckerTests {
 
     @Test func nightlyReportsUpToDateWhenSHAMatches() async {
         let sameSHA = "abc1234567890abcdef1234567890abcdef12345"
-        let checker = ReleaseChecker(
-            stableReleaseURL: URL(string: "https://stable.test")!,
-            nightlyReleaseURL: URL(string: "https://nightly.test")!,
-            arch: "arm64",
-            fetch: { _ in self.nightlyJSON(sha: sameSHA, publishedAt: "2026-06-02T12:00:00Z") }
-        )
+        let checker = nightlyChecker(tagSHA: sameSHA, publishedAt: "2026-06-02T12:00:00Z")
         let result = await checker.check(identity: nightlyIdentity(
             sha: sameSHA,
             buildDate: "2026-06-02T10:00:00Z"
@@ -162,12 +179,7 @@ struct ReleaseCheckerTests {
     }
 
     @Test func nightlyReportsUpToDateWhenRemoteOlderEvenIfSHADiffers() async {
-        let checker = ReleaseChecker(
-            stableReleaseURL: URL(string: "https://stable.test")!,
-            nightlyReleaseURL: URL(string: "https://nightly.test")!,
-            arch: "arm64",
-            fetch: { _ in self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-01T08:00:00Z") }
-        )
+        let checker = nightlyChecker(tagSHA: "fff9999", publishedAt: "2026-06-01T08:00:00Z")
         let result = await checker.check(identity: nightlyIdentity(
             sha: "aaa1111aaa1111aaa1111aaa1111aaa1111aaa11",
             buildDate: "2026-06-02T10:00:00Z"
@@ -176,12 +188,7 @@ struct ReleaseCheckerTests {
     }
 
     @Test func nightlyFallsBackToDateCompareWhenLocalSHAMissing() async {
-        let checker = ReleaseChecker(
-            stableReleaseURL: URL(string: "https://stable.test")!,
-            nightlyReleaseURL: URL(string: "https://nightly.test")!,
-            arch: "arm64",
-            fetch: { _ in self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-02T12:00:00Z") }
-        )
+        let checker = nightlyChecker(tagSHA: "fff9999", publishedAt: "2026-06-02T12:00:00Z")
         let result = await checker.check(identity: nightlyIdentity(
             sha: nil,
             buildDate: "2026-06-02T10:00:00Z"
@@ -193,12 +200,7 @@ struct ReleaseCheckerTests {
     }
 
     @Test func nightlyFallbackReportsUpToDateWhenDatesAreEqual() async {
-        let checker = ReleaseChecker(
-            stableReleaseURL: URL(string: "https://stable.test")!,
-            nightlyReleaseURL: URL(string: "https://nightly.test")!,
-            arch: "arm64",
-            fetch: { _ in self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-02T10:00:00Z") }
-        )
+        let checker = nightlyChecker(tagSHA: "fff9999", publishedAt: "2026-06-02T10:00:00Z")
         let result = await checker.check(identity: nightlyIdentity(
             sha: nil,
             buildDate: "2026-06-02T10:00:00Z"
@@ -206,10 +208,27 @@ struct ReleaseCheckerTests {
         #expect(result == .upToDate)
     }
 
+    @Test func nightlyUsesTagRefSHANotTargetCommitish() async {
+        // Even though the release payload's `target_commitish` says "main",
+        // the checker must use the SHA returned by the tag-ref endpoint.
+        let checker = nightlyChecker(tagSHA: "deadbeef0000000000000000000000000000beef", publishedAt: "2026-06-02T12:00:00Z")
+        let result = await checker.check(identity: nightlyIdentity(
+            sha: "aaa1111aaa1111aaa1111aaa1111aaa1111aaa11",
+            buildDate: "2026-06-02T10:00:00Z"
+        ))
+        guard case let .updateAvailable(.nightly(info)) = result else {
+            Issue.record("expected .updateAvailable(.nightly), got \(result)")
+            return
+        }
+        #expect(info.shortSHA == "deadbee")
+        #expect(info.fullSHA == "deadbeef0000000000000000000000000000beef")
+    }
+
     @Test func stableViaIdentityStillReportsUpdate() async {
         let checker = ReleaseChecker(
-            stableReleaseURL: URL(string: "https://stable.test")!,
-            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            stableReleaseURL: Self.stableTestURL,
+            nightlyReleaseURL: Self.nightlyTestURL,
+            nightlyTagRefURL: Self.tagRefTestURL,
             arch: "arm64",
             fetch: { _ in self.json(tag: "v0.6.0") }
         )
@@ -223,18 +242,24 @@ struct ReleaseCheckerTests {
         #expect(stable.version == SemanticVersion(major: 0, minor: 6, patch: 0))
     }
 
-    @Test func checkerRoutesToCorrectURLPerTrack() async {
-        var observed: URL?
+    @Test func nightlyHitsBothReleaseAndTagRefURLs() async {
+        var observed: [URL] = []
         let checker = ReleaseChecker(
-            stableReleaseURL: URL(string: "https://stable.test")!,
-            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            stableReleaseURL: Self.stableTestURL,
+            nightlyReleaseURL: Self.nightlyTestURL,
+            nightlyTagRefURL: Self.tagRefTestURL,
             arch: "arm64",
             fetch: { url in
-                observed = url
-                return self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-02T12:00:00Z")
+                observed.append(url)
+                if url == Self.tagRefTestURL {
+                    return self.nightlyTagRefJSON(sha: "fff9999")
+                }
+                return self.nightlyReleaseJSON(publishedAt: "2026-06-02T12:00:00Z")
             }
         )
         _ = await checker.check(identity: nightlyIdentity(sha: "aaa", buildDate: "2026-06-02T10:00:00Z"))
-        #expect(observed?.absoluteString == "https://nightly.test")
+        #expect(observed.contains(Self.nightlyTestURL))
+        #expect(observed.contains(Self.tagRefTestURL))
+        #expect(!observed.contains(Self.stableTestURL))
     }
 }

--- a/AlasTests/ReleaseCheckerTests.swift
+++ b/AlasTests/ReleaseCheckerTests.swift
@@ -28,11 +28,12 @@ struct ReleaseCheckerTests {
     @Test func reportsUpdateWhenRemoteNewer() async {
         let result = await checker(returning: json(tag: "v0.6.0"))
             .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
-        guard case let .updateAvailable(info) = result else {
-            Issue.record("expected updateAvailable, got \(result)")
+        guard case let .updateAvailable(info) = result,
+              case let .stable(stable) = info else {
+            Issue.record("expected updateAvailable(.stable), got \(result)")
             return
         }
-        #expect(info.version == SemanticVersion(major: 0, minor: 6, patch: 0))
+        #expect(stable.version == SemanticVersion(major: 0, minor: 6, patch: 0))
     }
 
     @Test func reportsUpToDateWhenEqual() async {

--- a/AlasTests/ReleaseCheckerTests.swift
+++ b/AlasTests/ReleaseCheckerTests.swift
@@ -22,15 +22,27 @@ struct ReleaseCheckerTests {
     }
 
     private func checker(returning data: Data, arch: String = "arm64") -> ReleaseChecker {
-        ReleaseChecker(arch: arch, fetch: { _ in data })
+        ReleaseChecker(
+            stableReleaseURL: URL(string: "https://stable.test")!,
+            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            arch: arch,
+            fetch: { _ in data }
+        )
+    }
+
+    private func stableIdentity(version: SemanticVersion) -> BuildIdentity {
+        BuildIdentity(track: .stable, version: version)
     }
 
     @Test func reportsUpdateWhenRemoteNewer() async {
         let result = await checker(returning: json(tag: "v0.6.0"))
-            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
-        guard case let .updateAvailable(info) = result,
-              case let .stable(stable) = info else {
-            Issue.record("expected updateAvailable(.stable), got \(result)")
+            .check(identity: stableIdentity(version: SemanticVersion(major: 0, minor: 5, patch: 1)))
+        guard case let .updateAvailable(info) = result else {
+            Issue.record("expected updateAvailable, got \(result)")
+            return
+        }
+        guard case let .stable(stable) = info else {
+            Issue.record("expected .stable, got \(info)")
             return
         }
         #expect(stable.version == SemanticVersion(major: 0, minor: 6, patch: 0))
@@ -38,19 +50,19 @@ struct ReleaseCheckerTests {
 
     @Test func reportsUpToDateWhenEqual() async {
         let result = await checker(returning: json(tag: "v0.5.1"))
-            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+            .check(identity: stableIdentity(version: SemanticVersion(major: 0, minor: 5, patch: 1)))
         #expect(result == .upToDate)
     }
 
     @Test func reportsUpToDateWhenRemoteOlder() async {
         let result = await checker(returning: json(tag: "v0.4.0"))
-            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+            .check(identity: stableIdentity(version: SemanticVersion(major: 0, minor: 5, patch: 1)))
         #expect(result == .upToDate)
     }
 
     @Test func reportsFailedOnMalformedJSON() async {
         let result = await checker(returning: Data("not json".utf8))
-            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+            .check(identity: stableIdentity(version: SemanticVersion(major: 0, minor: 5, patch: 1)))
         guard case .failed = result else {
             Issue.record("expected failed, got \(result)")
             return
@@ -59,8 +71,13 @@ struct ReleaseCheckerTests {
 
     @Test func reportsFailedWhenFetchThrows() async {
         struct Boom: Error {}
-        let checker = ReleaseChecker(arch: "arm64", fetch: { _ in throw Boom() })
-        let result = await checker.check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+        let checker = ReleaseChecker(
+            stableReleaseURL: URL(string: "https://stable.test")!,
+            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            arch: "arm64",
+            fetch: { _ in throw Boom() }
+        )
+        let result = await checker.check(identity: stableIdentity(version: SemanticVersion(major: 0, minor: 5, patch: 1)))
         guard case .failed = result else {
             Issue.record("expected failed, got \(result)")
             return
@@ -72,10 +89,152 @@ struct ReleaseCheckerTests {
         {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":false,"draft":false,"target_commitish":"abc1234","published_at":"2026-06-02T10:21:00Z","assets":[]}
         """.utf8)
         let result = await checker(returning: data)
-            .check(current: SemanticVersion(major: 0, minor: 5, patch: 1))
+            .check(identity: stableIdentity(version: SemanticVersion(major: 0, minor: 5, patch: 1)))
         guard case .failed = result else {
             Issue.record("expected failed, got \(result)")
             return
         }
+    }
+
+    // MARK: - Nightly track
+
+    private func nightlyJSON(sha: String, publishedAt: String) -> Data {
+        Data("""
+        {
+          "tag_name": "nightly",
+          "body": "nightly notes",
+          "html_url": "https://github.com/mrmans0n/alas/releases/tag/nightly",
+          "prerelease": true,
+          "draft": false,
+          "target_commitish": "\(sha)",
+          "published_at": "\(publishedAt)",
+          "assets": [
+            {"name": "Alas-nightly.dmg", "browser_download_url": "https://example.com/nightly.dmg"}
+          ]
+        }
+        """.utf8)
+    }
+
+    private func iso(_ s: String) -> Date {
+        ISO8601DateFormatter().date(from: s)!
+    }
+
+    private func nightlyIdentity(sha: String?, buildDate: String?) -> BuildIdentity {
+        BuildIdentity(
+            track: .nightly,
+            version: SemanticVersion(major: 0, minor: 5, patch: 1),
+            gitSHA: sha,
+            buildDate: buildDate.map { iso($0) }
+        )
+    }
+
+    @Test func nightlyReportsUpdateWhenSHADiffersAndRemoteNewer() async {
+        let checker = ReleaseChecker(
+            stableReleaseURL: URL(string: "https://stable.test")!,
+            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            arch: "arm64",
+            fetch: { _ in self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-02T12:00:00Z") }
+        )
+        let result = await checker.check(identity: nightlyIdentity(
+            sha: "aaa1111aaa1111aaa1111aaa1111aaa1111aaa11",
+            buildDate: "2026-06-02T10:00:00Z"
+        ))
+        guard case let .updateAvailable(.nightly(info)) = result else {
+            Issue.record("expected .updateAvailable(.nightly), got \(result)")
+            return
+        }
+        #expect(info.shortSHA == "fff9999")
+    }
+
+    @Test func nightlyReportsUpToDateWhenSHAMatches() async {
+        let sameSHA = "abc1234567890abcdef1234567890abcdef12345"
+        let checker = ReleaseChecker(
+            stableReleaseURL: URL(string: "https://stable.test")!,
+            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            arch: "arm64",
+            fetch: { _ in self.nightlyJSON(sha: sameSHA, publishedAt: "2026-06-02T12:00:00Z") }
+        )
+        let result = await checker.check(identity: nightlyIdentity(
+            sha: sameSHA,
+            buildDate: "2026-06-02T10:00:00Z"
+        ))
+        #expect(result == .upToDate)
+    }
+
+    @Test func nightlyReportsUpToDateWhenRemoteOlderEvenIfSHADiffers() async {
+        let checker = ReleaseChecker(
+            stableReleaseURL: URL(string: "https://stable.test")!,
+            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            arch: "arm64",
+            fetch: { _ in self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-01T08:00:00Z") }
+        )
+        let result = await checker.check(identity: nightlyIdentity(
+            sha: "aaa1111aaa1111aaa1111aaa1111aaa1111aaa11",
+            buildDate: "2026-06-02T10:00:00Z"
+        ))
+        #expect(result == .upToDate)
+    }
+
+    @Test func nightlyFallsBackToDateCompareWhenLocalSHAMissing() async {
+        let checker = ReleaseChecker(
+            stableReleaseURL: URL(string: "https://stable.test")!,
+            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            arch: "arm64",
+            fetch: { _ in self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-02T12:00:00Z") }
+        )
+        let result = await checker.check(identity: nightlyIdentity(
+            sha: nil,
+            buildDate: "2026-06-02T10:00:00Z"
+        ))
+        guard case .updateAvailable = result else {
+            Issue.record("expected .updateAvailable, got \(result)")
+            return
+        }
+    }
+
+    @Test func nightlyFallbackReportsUpToDateWhenDatesAreEqual() async {
+        let checker = ReleaseChecker(
+            stableReleaseURL: URL(string: "https://stable.test")!,
+            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            arch: "arm64",
+            fetch: { _ in self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-02T10:00:00Z") }
+        )
+        let result = await checker.check(identity: nightlyIdentity(
+            sha: nil,
+            buildDate: "2026-06-02T10:00:00Z"
+        ))
+        #expect(result == .upToDate)
+    }
+
+    @Test func stableViaIdentityStillReportsUpdate() async {
+        let checker = ReleaseChecker(
+            stableReleaseURL: URL(string: "https://stable.test")!,
+            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            arch: "arm64",
+            fetch: { _ in self.json(tag: "v0.6.0") }
+        )
+        let result = await checker.check(identity: stableIdentity(
+            version: SemanticVersion(major: 0, minor: 5, patch: 1)
+        ))
+        guard case let .updateAvailable(.stable(stable)) = result else {
+            Issue.record("expected .updateAvailable(.stable), got \(result)")
+            return
+        }
+        #expect(stable.version == SemanticVersion(major: 0, minor: 6, patch: 0))
+    }
+
+    @Test func checkerRoutesToCorrectURLPerTrack() async {
+        var observed: URL?
+        let checker = ReleaseChecker(
+            stableReleaseURL: URL(string: "https://stable.test")!,
+            nightlyReleaseURL: URL(string: "https://nightly.test")!,
+            arch: "arm64",
+            fetch: { url in
+                observed = url
+                return self.nightlyJSON(sha: "fff9999", publishedAt: "2026-06-02T12:00:00Z")
+            }
+        )
+        _ = await checker.check(identity: nightlyIdentity(sha: "aaa", buildDate: "2026-06-02T10:00:00Z"))
+        #expect(observed?.absoluteString == "https://nightly.test")
     }
 }

--- a/AlasTests/ReleaseCheckerTests.swift
+++ b/AlasTests/ReleaseCheckerTests.swift
@@ -178,19 +178,13 @@ struct ReleaseCheckerTests {
         #expect(result == .upToDate)
     }
 
-    @Test func nightlyReportsUpToDateWhenRemoteOlderEvenIfSHADiffers() async {
-        let checker = nightlyChecker(tagSHA: "fff9999", publishedAt: "2026-06-01T08:00:00Z")
+    @Test func nightlyReportsUpdateEvenWhenReleasePublishedAtIsOld() async {
+        // The rolling nightly release's `published_at` reflects the original
+        // creation time, not the latest update, so it must not gate the SHA
+        // comparison. A different tag SHA always means a new build.
+        let checker = nightlyChecker(tagSHA: "fff9999", publishedAt: "2020-01-01T00:00:00Z")
         let result = await checker.check(identity: nightlyIdentity(
             sha: "aaa1111aaa1111aaa1111aaa1111aaa1111aaa11",
-            buildDate: "2026-06-02T10:00:00Z"
-        ))
-        #expect(result == .upToDate)
-    }
-
-    @Test func nightlyFallsBackToDateCompareWhenLocalSHAMissing() async {
-        let checker = nightlyChecker(tagSHA: "fff9999", publishedAt: "2026-06-02T12:00:00Z")
-        let result = await checker.check(identity: nightlyIdentity(
-            sha: nil,
             buildDate: "2026-06-02T10:00:00Z"
         ))
         guard case .updateAvailable = result else {
@@ -199,8 +193,10 @@ struct ReleaseCheckerTests {
         }
     }
 
-    @Test func nightlyFallbackReportsUpToDateWhenDatesAreEqual() async {
-        let checker = nightlyChecker(tagSHA: "fff9999", publishedAt: "2026-06-02T10:00:00Z")
+    @Test func nightlyReportsUpToDateWhenLocalSHAMissing() async {
+        // Hand-built nightlies (no stamped SHA) can't be compared. Don't
+        // pester with updates we can't verify.
+        let checker = nightlyChecker(tagSHA: "fff9999", publishedAt: "2026-06-02T12:00:00Z")
         let result = await checker.check(identity: nightlyIdentity(
             sha: nil,
             buildDate: "2026-06-02T10:00:00Z"

--- a/AlasTests/ReleaseInfoTests.swift
+++ b/AlasTests/ReleaseInfoTests.swift
@@ -108,8 +108,6 @@ struct ReleaseInfoTests {
         #expect(nightly.fullSHA == "abc1234567890abcdef1234567890abcdef12345")
         #expect(nightly.dmgURL?.absoluteString == "https://example.com/nightly.dmg")
         #expect(nightly.releaseNotes == "## Changes\n- nightly bits")
-        let formatter = ISO8601DateFormatter()
-        #expect(nightly.publishedAt == formatter.date(from: "2026-06-02T10:21:00Z"))
     }
 
     @Test func makeNightlyReturnsNilWhenTagSHAEmpty() throws {

--- a/AlasTests/ReleaseInfoTests.swift
+++ b/AlasTests/ReleaseInfoTests.swift
@@ -88,7 +88,7 @@ struct ReleaseInfoTests {
           "html_url": "https://github.com/mrmans0n/alas/releases/tag/nightly",
           "prerelease": true,
           "draft": false,
-          "target_commitish": "abc1234567890abcdef1234567890abcdef12345",
+          "target_commitish": "main",
           "published_at": "2026-06-02T10:21:00Z",
           "assets": [
             {"name": "Alas-nightly.dmg", "browser_download_url": "https://example.com/nightly.dmg"},
@@ -96,34 +96,49 @@ struct ReleaseInfoTests {
           ]
         }
         """
-        let info = ReleaseInfo.makeNightly(from: try decode(json))
+        let info = ReleaseInfo.makeNightly(
+            from: try decode(json),
+            tagSHA: "abc1234567890abcdef1234567890abcdef12345"
+        )
         guard case let .nightly(nightly) = info else {
             Issue.record("expected .nightly, got \(String(describing: info))")
             return
         }
         #expect(nightly.shortSHA == "abc1234")
+        #expect(nightly.fullSHA == "abc1234567890abcdef1234567890abcdef12345")
         #expect(nightly.dmgURL?.absoluteString == "https://example.com/nightly.dmg")
         #expect(nightly.releaseNotes == "## Changes\n- nightly bits")
         let formatter = ISO8601DateFormatter()
         #expect(nightly.publishedAt == formatter.date(from: "2026-06-02T10:21:00Z"))
     }
 
-    @Test func makeNightlyReturnsNilWhenTargetCommitishEmpty() throws {
+    @Test func makeNightlyReturnsNilWhenTagSHAEmpty() throws {
         let json = """
-        {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":true,"draft":false,"target_commitish":"","published_at":"2026-06-02T10:21:00Z","assets":[]}
+        {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":true,"draft":false,"target_commitish":"main","published_at":"2026-06-02T10:21:00Z","assets":[]}
         """
-        #expect(ReleaseInfo.makeNightly(from: try decode(json)) == nil)
+        #expect(ReleaseInfo.makeNightly(from: try decode(json), tagSHA: "") == nil)
     }
 
     @Test func makeNightlyHasNilDMGWhenAssetMissing() throws {
         let json = """
-        {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":true,"draft":false,"target_commitish":"abc1234","published_at":"2026-06-02T10:21:00Z","assets":[]}
+        {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":true,"draft":false,"target_commitish":"main","published_at":"2026-06-02T10:21:00Z","assets":[]}
         """
-        let info = ReleaseInfo.makeNightly(from: try decode(json))
+        let info = ReleaseInfo.makeNightly(from: try decode(json), tagSHA: "abc1234")
         guard case let .nightly(nightly) = info else {
             Issue.record("expected .nightly")
             return
         }
         #expect(nightly.dmgURL == nil)
+    }
+
+    @Test func decodesGitRef() throws {
+        let json = """
+        {"ref":"refs/tags/nightly","node_id":"abc","url":"https://example.test","object":{"sha":"abc1234567890abcdef1234567890abcdef12345","type":"commit","url":"https://example.test/obj"}}
+        """
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let ref = try decoder.decode(GitRef.self, from: Data(json.utf8))
+        #expect(ref.object.sha == "abc1234567890abcdef1234567890abcdef12345")
+        #expect(ref.object.type == "commit")
     }
 }

--- a/AlasTests/ReleaseInfoTests.swift
+++ b/AlasTests/ReleaseInfoTests.swift
@@ -6,6 +6,7 @@ struct ReleaseInfoTests {
     private func decode(_ json: String) throws -> GitHubRelease {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
         return try decoder.decode(GitHubRelease.self, from: Data(json.utf8))
     }
 
@@ -16,6 +17,8 @@ struct ReleaseInfoTests {
       "html_url": "https://github.com/mrmans0n/alas/releases/tag/v0.6.0",
       "prerelease": false,
       "draft": false,
+      "target_commitish": "abc1234567890abcdef1234567890abcdef12345",
+      "published_at": "2026-06-02T10:21:00Z",
       "assets": [
         {"name": "Alas-0.6.0-arm64.dmg", "browser_download_url": "https://example.com/arm64.dmg"},
         {"name": "Alas-0.6.0-x86_64.dmg", "browser_download_url": "https://example.com/x86_64.dmg"}
@@ -45,16 +48,23 @@ struct ReleaseInfoTests {
 
     @Test func mapFailsWhenTagUnparseable() throws {
         let bad = """
-        {"tag_name": "nightly", "body": null, "html_url": "https://x.test", "prerelease": false, "draft": false, "assets": []}
+        {"tag_name": "nightly", "body": null, "html_url": "https://x.test", "prerelease": false, "draft": false, "target_commitish": "abc1234", "published_at": "2026-06-02T10:21:00Z", "assets": []}
         """
         #expect(ReleaseInfo.make(from: try decode(bad), arch: "arm64") == nil)
     }
 
     @Test func handlesNullBody() throws {
         let noBody = """
-        {"tag_name": "v0.6.0", "body": null, "html_url": "https://x.test", "prerelease": false, "draft": false, "assets": []}
+        {"tag_name": "v0.6.0", "body": null, "html_url": "https://x.test", "prerelease": false, "draft": false, "target_commitish": "abc1234", "published_at": "2026-06-02T10:21:00Z", "assets": []}
         """
         let info = ReleaseInfo.make(from: try decode(noBody), arch: "arm64")
         #expect(info?.releaseNotes == "")
+    }
+
+    @Test func decodesTargetCommitishAndPublishedAt() throws {
+        let release = try decode(sample)
+        #expect(release.targetCommitish == "abc1234567890abcdef1234567890abcdef12345")
+        let formatter = ISO8601DateFormatter()
+        #expect(release.publishedAt == formatter.date(from: "2026-06-02T10:21:00Z"))
     }
 }

--- a/AlasTests/ReleaseInfoTests.swift
+++ b/AlasTests/ReleaseInfoTests.swift
@@ -33,32 +33,44 @@ struct ReleaseInfoTests {
         #expect(release.assets.first?.browserDownloadUrl.absoluteString == "https://example.com/arm64.dmg")
     }
 
-    @Test func mapsToReleaseInfoWithMatchingArchDMG() throws {
-        let info = ReleaseInfo.make(from: try decode(sample), arch: "arm64")
-        #expect(info?.version == SemanticVersion(major: 0, minor: 6, patch: 0))
-        #expect(info?.releaseNotes == "## Fixes\n- thing")
-        #expect(info?.dmgURL?.absoluteString == "https://example.com/arm64.dmg")
-        #expect(info?.htmlURL.absoluteString == "https://github.com/mrmans0n/alas/releases/tag/v0.6.0")
+    @Test func makesStableReleaseInfoWithMatchingArchDMG() throws {
+        let info = ReleaseInfo.makeStable(from: try decode(sample), arch: "arm64")
+        guard case let .stable(stable) = info else {
+            Issue.record("expected .stable, got \(String(describing: info))")
+            return
+        }
+        #expect(stable.version == SemanticVersion(major: 0, minor: 6, patch: 0))
+        #expect(stable.releaseNotes == "## Fixes\n- thing")
+        #expect(stable.dmgURL?.absoluteString == "https://example.com/arm64.dmg")
+        #expect(stable.htmlURL.absoluteString == "https://github.com/mrmans0n/alas/releases/tag/v0.6.0")
     }
 
-    @Test func mapsWithNilDMGWhenArchAssetMissing() throws {
-        let info = ReleaseInfo.make(from: try decode(sample), arch: "riscv")
-        #expect(info?.dmgURL == nil)
+    @Test func makesStableWithNilDMGWhenArchAssetMissing() throws {
+        let info = ReleaseInfo.makeStable(from: try decode(sample), arch: "riscv")
+        guard case let .stable(stable) = info else {
+            Issue.record("expected .stable")
+            return
+        }
+        #expect(stable.dmgURL == nil)
     }
 
-    @Test func mapFailsWhenTagUnparseable() throws {
+    @Test func makeStableReturnsNilWhenTagUnparseable() throws {
         let bad = """
         {"tag_name": "nightly", "body": null, "html_url": "https://x.test", "prerelease": false, "draft": false, "target_commitish": "abc1234", "published_at": "2026-06-02T10:21:00Z", "assets": []}
         """
-        #expect(ReleaseInfo.make(from: try decode(bad), arch: "arm64") == nil)
+        #expect(ReleaseInfo.makeStable(from: try decode(bad), arch: "arm64") == nil)
     }
 
-    @Test func handlesNullBody() throws {
+    @Test func stableHandlesNullBody() throws {
         let noBody = """
         {"tag_name": "v0.6.0", "body": null, "html_url": "https://x.test", "prerelease": false, "draft": false, "target_commitish": "abc1234", "published_at": "2026-06-02T10:21:00Z", "assets": []}
         """
-        let info = ReleaseInfo.make(from: try decode(noBody), arch: "arm64")
-        #expect(info?.releaseNotes == "")
+        let info = ReleaseInfo.makeStable(from: try decode(noBody), arch: "arm64")
+        guard case let .stable(stable) = info else {
+            Issue.record("expected .stable")
+            return
+        }
+        #expect(stable.releaseNotes == "")
     }
 
     @Test func decodesTargetCommitishAndPublishedAt() throws {
@@ -66,5 +78,52 @@ struct ReleaseInfoTests {
         #expect(release.targetCommitish == "abc1234567890abcdef1234567890abcdef12345")
         let formatter = ISO8601DateFormatter()
         #expect(release.publishedAt == formatter.date(from: "2026-06-02T10:21:00Z"))
+    }
+
+    @Test func makesNightlyReleaseInfoWithShortSHAAndAsset() throws {
+        let json = """
+        {
+          "tag_name": "nightly",
+          "body": "## Changes\\n- nightly bits",
+          "html_url": "https://github.com/mrmans0n/alas/releases/tag/nightly",
+          "prerelease": true,
+          "draft": false,
+          "target_commitish": "abc1234567890abcdef1234567890abcdef12345",
+          "published_at": "2026-06-02T10:21:00Z",
+          "assets": [
+            {"name": "Alas-nightly.dmg", "browser_download_url": "https://example.com/nightly.dmg"},
+            {"name": "Alas-nightly.app.zip", "browser_download_url": "https://example.com/nightly.zip"}
+          ]
+        }
+        """
+        let info = ReleaseInfo.makeNightly(from: try decode(json))
+        guard case let .nightly(nightly) = info else {
+            Issue.record("expected .nightly, got \(String(describing: info))")
+            return
+        }
+        #expect(nightly.shortSHA == "abc1234")
+        #expect(nightly.dmgURL?.absoluteString == "https://example.com/nightly.dmg")
+        #expect(nightly.releaseNotes == "## Changes\n- nightly bits")
+        let formatter = ISO8601DateFormatter()
+        #expect(nightly.publishedAt == formatter.date(from: "2026-06-02T10:21:00Z"))
+    }
+
+    @Test func makeNightlyReturnsNilWhenTargetCommitishEmpty() throws {
+        let json = """
+        {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":true,"draft":false,"target_commitish":"","published_at":"2026-06-02T10:21:00Z","assets":[]}
+        """
+        #expect(ReleaseInfo.makeNightly(from: try decode(json)) == nil)
+    }
+
+    @Test func makeNightlyHasNilDMGWhenAssetMissing() throws {
+        let json = """
+        {"tag_name":"nightly","body":null,"html_url":"https://x.test","prerelease":true,"draft":false,"target_commitish":"abc1234","published_at":"2026-06-02T10:21:00Z","assets":[]}
+        """
+        let info = ReleaseInfo.makeNightly(from: try decode(json))
+        guard case let .nightly(nightly) = info else {
+            Issue.record("expected .nightly")
+            return
+        }
+        #expect(nightly.dmgURL == nil)
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -124,6 +124,9 @@ targets:
     info:
       path: Alas/Resources/Info.plist
       properties:
+        AlasBuildDate: ""
+        AlasGitSHA: ""
+        AlasReleaseTrack: stable
         CFBundleDevelopmentRegion: en
         CFBundleShortVersionString: "0.5.1"
         CFBundleVersion: "1"


### PR DESCRIPTION
## Summary

- In-app "Check for Updates" now updates nightly builds off the rolling `nightly` GitHub release. Stable builds keep checking `releases/latest` exactly as before.
- A new `BuildIdentity` value type reads the running app's track / git SHA / build date from Info.plist keys (`AlasReleaseTrack`, `AlasGitSHA`, `AlasBuildDate`). Stable builds default to `track = stable`; the nightly workflow overwrites the three keys with `plutil` before signing so a nightly DMG carries its real identity.
- `ReleaseInfo` is now an enum of `.stable(StableReleaseInfo)` / `.nightly(NightlyReleaseInfo)`. The sheet branches title, subtitle, and the View-Release label by case. Nightly builds force the `.direct` action row regardless of `InstallSource` (the brew cask only tracks stable).
- Nightly freshness predicate: `remote.targetCommitish != local.gitSHA && remote.publishedAt > local.buildDate`, with date-only fallback when the local SHA is absent. A re-tag to the same SHA does not look like an update.

## Test plan
- [x] `xcodebuild test` — 50 tests across 6 suites pass (`BuildIdentityTests`, `ReleaseCheckerTests`, `ReleaseInfoTests`, `SemanticVersionTests`, `InstallSourceTests`, `UpdateThrottleTests`).
- [x] `xcodebuild build` clean.
- [ ] Hand-verify on a local **stable** build: launch the app, choose **Alas → Check for Updates…**, confirm the stable path still surfaces an update sheet (or "You're up to date") against `releases/latest`.
- [ ] Hand-verify nightly→nightly: only possible after this lands and the nightly workflow publishes a build carrying the new Info.plist keys. Smoke-test on the next nightly DMG.

## Notes
- Spec: `docs/superpowers/specs/2026-06-02-nightly-update-track-design.md` (gitignored locally per repo convention).
- Asset name for nightlies is `Alas-nightly.dmg` (arm64 only today). The arch argument is ignored on the nightly track; the pattern lives in one place if Intel nightlies arrive later.
- Out of scope: user-facing track switcher, cross-track notifications, in-app DMG download/apply, Intel nightly builds, updating the Homebrew cask.