### PR TITLE
fix(settings): restore custom titlebar without double semaphore

### DIFF
--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -59,6 +59,7 @@ struct AlasApp: App {
         Window("Settings", id: "settings") {
             SettingsWindow(state: state)
         }
+        .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)
         .defaultSize(width: 880, height: 580)
 

--- a/Alas/Sources/Settings/SettingsWindow.swift
+++ b/Alas/Sources/Settings/SettingsWindow.swift
@@ -14,6 +14,11 @@ struct SettingsWindow: View {
                     colors: [theme.color("bg-3"), theme.color("bg-2")],
                     startPoint: .top, endPoint: .bottom
                 )
+                HStack {
+                    TrafficLights()
+                    Spacer()
+                }
+                .padding(.leading, 16)
                 Text("Settings")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(theme.color("fg-muted"))
@@ -56,7 +61,9 @@ struct SettingsWindow: View {
         .frame(width: 880)
         .frame(maxHeight: .infinity)
         .background(theme.color("bg-1"))
+        .background(WindowConfigurator())
         .environment(\.theme, theme)
+        .ignoresSafeArea()
         .onAppear {
             showsDebug = AdvancedSettingsVisibility.isEnabled()
             consumePendingSettingsSection()


### PR DESCRIPTION
## What

Restores the custom Settings titlebar (custom `TrafficLights`, hidden native titlebar) that was replaced with the standard system chrome in #440. The standard titlebar looked disjointed from the rest of the app.

## Why the double semaphore happened

Settings uses `.windowStyle(.hiddenTitleBar)`, which makes the titlebar transparent but leaves the **native** traffic-light buttons visible. `WindowConfigurator` is responsible for hiding them. The old implementation did this via a fire-once `DispatchQueue.main.async { if let window = view.window }`, which silently no-ops when the view isn't yet attached to its window — a race that hit freshly-opened secondary windows like Settings. When it lost the race, the native buttons stayed up alongside the custom `TrafficLights()` view → intermittent **double semaphore**.

#440 worked around this by removing the custom chrome entirely. But #440's *first* commit had already fixed the actual race: `WindowConfigurator` now configures the window from `viewDidMoveToWindow()` (where AppKit guarantees `window != nil`), making the button-hiding deterministic.

## What changed

With the race gone, the custom chrome is safe to bring back:

- `AlasApp`: re-add `.windowStyle(.hiddenTitleBar)` to the Settings window.
- `SettingsWindow`: re-add the `TrafficLights` header, `.background(WindowConfigurator())`, and `.ignoresSafeArea()`.

## Testing

- `xcodebuild … build` succeeds.
- `AlasTests/TitlelessWindowTests` — all 3 pass, including `configurationViewConfiguresWindowWhenAttached`, which proves the native buttons are reliably hidden on window attach.