### PR TITLE
fix(tabs): use pleading face empty state icon

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -485,6 +485,7 @@
 		8B2A37F58F2C7D842204A596 /* ImageDiffOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87F114EBEEACCC95B9EF8D5 /* ImageDiffOverlayView.swift */; };
 		8B3D1B7B55629E989FCE53D1 /* ACPPermissionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F31D837F83B4F8B9FB348BD /* ACPPermissionPolicyTests.swift */; };
 		8BF52AFF90954B767B9D7E65 /* ACPSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBEFD27FD7013D458435779 /* ACPSession.swift */; };
+		8CEA8B0352538A42B8DC01A9 /* EmptyTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA09B830D18CCEE251D0E10A /* EmptyTabViewTests.swift */; };
 		8D22459A108B6BF47AEA71F7 /* session-update-available-models.json in Resources */ = {isa = PBXBuildFile; fileRef = 1B0785F1FFC8008C74009584 /* session-update-available-models.json */; };
 		8D86580619CA83FE832ACB25 /* AppConfigHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A216C9D856D2A6C43964E74 /* AppConfigHarnessTests.swift */; };
 		8DBA8F6E781ADBD5D59EDA13 /* CompletionDocumentationRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFB48AF581F74C564ACBCF5 /* CompletionDocumentationRenderer.swift */; };
@@ -1611,6 +1612,7 @@
 		D97EF761C70A3AF83C00879A /* VisualEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualEffectView.swift; sourceTree = "<group>"; };
 		D99E47A1F0E3C85A34EABBE6 /* EditorLSPStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorLSPStatus.swift; sourceTree = "<group>"; };
 		D9E6D61B213F3378243B4A26 /* AlasField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasField.swift; sourceTree = "<group>"; };
+		DA09B830D18CCEE251D0E10A /* EmptyTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTabViewTests.swift; sourceTree = "<group>"; };
 		DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRow.swift; sourceTree = "<group>"; };
 		DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitDetailsTests.swift; sourceTree = "<group>"; };
 		DBA6A9F78C8E8CDF6D170BDD /* StatusParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusParserTests.swift; sourceTree = "<group>"; };
@@ -1949,6 +1951,7 @@
 				209B2EDBA4EB4BF7A854FF96 /* EditorLSPStatusResolverTests.swift */,
 				208C9ABAF59F523D2DDC2F2A /* EditorOverlayPanelTests.swift */,
 				E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */,
+				DA09B830D18CCEE251D0E10A /* EmptyTabViewTests.swift */,
 				64CE9A3DB2C89A5B9C970ED3 /* EnvBuilderTests.swift */,
 				25493E3B18A1AB94EA6985C3 /* EventHolder.swift */,
 				3855FBA3E4444960418639E9 /* FileIndexTests.swift */,
@@ -4157,6 +4160,7 @@
 				A19D418808D8CCCE04242E07 /* EditorLSPStatusResolverTests.swift in Sources */,
 				0EB3B61ECD46CCF450E717BF /* EditorOverlayPanelTests.swift in Sources */,
 				1EBF9B83C26B9518AF70D2F3 /* EditorTabStateMarkdownCodableTests.swift in Sources */,
+				8CEA8B0352538A42B8DC01A9 /* EmptyTabViewTests.swift in Sources */,
 				C4D640619C91B2668340B04E /* EnvBuilderTests.swift in Sources */,
 				51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */,
 				8514D39E901232E7C7343C26 /* FakeJSONRPCTransport.swift in Sources */,

--- a/Alas/Sources/Center/EmptyTabView.swift
+++ b/Alas/Sources/Center/EmptyTabView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct EmptyTabView: View {
+    static let emptyIcon = "🥺"
+
     let onNewTerminal: () -> Void
     let onNewAgentTerminal: () -> Void
     let onNewAgentChat: () -> Void
@@ -16,9 +18,11 @@ struct EmptyTabView: View {
                                startPoint: .topLeading, endPoint: .bottomTrailing)
                     .frame(width: 80, height: 80)
                     .clipShape(RoundedRectangle(cornerRadius: 22))
-                Image(systemName: "airplane")
-                    .font(.system(size: 30))
-                    .foregroundColor(theme.color("accent"))
+                    .overlay(RoundedRectangle(cornerRadius: 22).strokeBorder(theme.color("line"), lineWidth: 0.5))
+                Text(Self.emptyIcon)
+                    .font(.system(size: 34))
+                    .shadow(color: theme.color("accent").opacity(0.2), radius: 8, y: 3)
+                    .accessibilityLabel("No tabs icon")
             }
             VStack(spacing: 5) {
                 Text("No tabs open")

--- a/AlasTests/EmptyTabViewTests.swift
+++ b/AlasTests/EmptyTabViewTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Alas
+
+@Suite("Empty tab view")
+@MainActor
+struct EmptyTabViewTests {
+    private func currentTheme() -> Theme {
+        try! ThemeStore().current
+    }
+
+    @Test("no-tabs empty state uses pleading face icon")
+    func usesPleadingFaceIcon() {
+        #expect(EmptyTabView.emptyIcon == "🥺")
+    }
+
+    @Test("no-tabs empty state renders")
+    func emptyStateRenders() {
+        let view = EmptyTabView(
+            onNewTerminal: {},
+            onNewAgentTerminal: {},
+            onNewAgentChat: {},
+            newTerminalShortcut: "⌘ T",
+            newAgentTerminalShortcut: nil,
+            newAgentChatShortcut: nil
+        )
+        .environment(\.theme, currentTheme())
+
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 520, height: 420)
+        controller.view.layoutSubtreeIfNeeded()
+
+        #expect(controller.view.fittingSize.width > 0)
+        #expect(controller.view.fittingSize.height > 0)
+    }
+}


### PR DESCRIPTION
## Summary
- replace the no-tabs empty-state airplane silhouette with the pleading face glyph
- keep the icon inside the existing themed empty-state tile styling
- add Swift Testing coverage for the glyph choice and basic view rendering

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test