### PR TITLE
fix(acp): use sparkles artwork in chat empty state

### DIFF
--- a/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
+++ b/Alas/Sources/ACP/UI/ACPNewChatEmptyStateView.swift
@@ -28,25 +28,13 @@ struct ACPNewChatEmptyStateView: View {
     }
 
     private var mark: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 10)
-                .fill(
-                    LinearGradient(
-                        colors: [
-                            theme.color("accent-soft"),
-                            theme.color("bg-2").opacity(0.45),
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-            RoundedRectangle(cornerRadius: 10)
-                .strokeBorder(theme.color("accent").opacity(0.28), lineWidth: 0.75)
-            Image(systemName: "sparkle")
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(theme.color("accent"))
-        }
-        .frame(width: 40, height: 40)
+        Image(systemName: ACPNewChatEmptyStateArtwork.systemImageName)
+            .font(.system(size: ACPNewChatEmptyStateArtwork.fontSize, weight: .semibold))
+            .foregroundStyle(theme.color("accent"))
+            .frame(
+                width: ACPNewChatEmptyStateArtwork.frameSize,
+                height: ACPNewChatEmptyStateArtwork.frameSize
+            )
     }
 
     private var starterChips: some View {
@@ -92,4 +80,10 @@ struct ACPNewChatEmptyStateView: View {
         .buttonStyle(.plain)
         .help(prompt.promptText)
     }
+}
+
+enum ACPNewChatEmptyStateArtwork {
+    static let systemImageName = "sparkles"
+    static let fontSize: CGFloat = 28
+    static let frameSize: CGFloat = 40
 }

--- a/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
+++ b/AlasTests/ACP/UI/ACPNewChatEmptyStateTests.swift
@@ -5,6 +5,13 @@ import Testing
 @MainActor
 @Suite("ACP new chat empty state")
 struct ACPNewChatEmptyStateTests {
+    @Test("empty state artwork uses the shared sparkles image")
+    func artworkUsesSharedSparklesImage() {
+        #expect(ACPNewChatEmptyStateArtwork.systemImageName == "sparkles")
+        #expect(ACPNewChatEmptyStateArtwork.frameSize == 40)
+        #expect(ACPNewChatEmptyStateArtwork.fontSize < ACPNewChatEmptyStateArtwork.frameSize)
+    }
+
     @Test("fresh ready empty sessions show the new empty state")
     func freshReadyEmptySessionShowsEmptyState() {
         let session = ACPSession(id: "s", agentId: "codex", worktreeId: "wt", title: "New session")


### PR DESCRIPTION
## Summary
- replace the ACP chat empty-state rounded-square single-star artwork with the existing sparkles treatment
- preserve the centered 40pt layout slot, accent tint, and surrounding spacing
- add focused regression coverage for the empty-state artwork contract

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test