### PR TITLE
fix(tabs): rename ACP chat menu section

### DIFF
--- a/Alas/Sources/Center/TabBarView.swift
+++ b/Alas/Sources/Center/TabBarView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 struct TabBarView: View {
+    static let terminalAgentMenuSectionTitle = "Terminal"
+    static let acpAgentMenuSectionTitle = "ACP Chat"
+
     let tabs: [Tab]
     let activeId: TabID?
     let harnessLookup: (TabID) -> (agent: AgentKind, state: ActivityState)?
@@ -256,7 +259,7 @@ private struct AgentSparkleMenu: View {
                 Text("No enabled agents")
             } else {
                 if !agents.isEmpty {
-                    Section("Terminal") {
+                    Section(TabBarView.terminalAgentMenuSectionTitle) {
                         ForEach(agents) { agent in
                             Button {
                                 onLaunchAgent(agent.id)
@@ -271,7 +274,7 @@ private struct AgentSparkleMenu: View {
                     }
                 }
                 if !acpAgents.isEmpty {
-                    Section("ACP session") {
+                    Section(TabBarView.acpAgentMenuSectionTitle) {
                         ForEach(acpAgents) { agent in
                             Button {
                                 onLaunchACPSession(agent.id)

--- a/AlasTests/TouchTargetSmokeTests.swift
+++ b/AlasTests/TouchTargetSmokeTests.swift
@@ -78,6 +78,52 @@ struct TouchTargetSmokeTests {
         #expect(controller.view != nil)
     }
 
+    @Test func agentMenuSectionTitlesUseCurrentLabels() {
+        #expect(TabBarView.terminalAgentMenuSectionTitle == "Terminal")
+        #expect(TabBarView.acpAgentMenuSectionTitle == "ACP Chat")
+    }
+
+    @Test func tabBarViewWithAgentMenuSectionsRendersWithoutCrashing() throws {
+        let tab = Tab.terminal(TerminalTabState(id: "term1", title: "bash", sessionId: "s1"))
+        let terminalAgent = try #require(AgentBuiltins.entry(id: "codex"))
+        let acpAgent = try #require(AgentBuiltins.entry(id: "claude"))
+        let view = TabBarView(
+            tabs: [tab],
+            activeId: tab.id,
+            harnessLookup: { _ in nil },
+            dirtyLookup: { _ in false },
+            onActivate: { _ in },
+            onClose: { _ in },
+            onCloseOthers: { _ in },
+            onCloseAll: { },
+            onCloseToLeft: { _ in },
+            onCloseToRight: { _ in },
+            onCopyPath: { _ in },
+            onCopyRelativePath: { _ in },
+            onRenameTerminal: { _ in },
+            onRenameACPSession: { _ in },
+            onCopyACPSession: { _ in },
+            onExportACPSession: { _ in },
+            onNewTerminal: { },
+            enabledAgents: [terminalAgent],
+            onLaunchAgent: { _ in },
+            onLaunchACPSession: { _ in },
+            acpAgents: [acpAgent],
+            onRevealRightSidebar: { },
+            rightSidebarHidden: false,
+            onRevealSidebar: { },
+            sidebarHidden: false,
+            onMove: { _, _ in },
+            titleLookup: { _ in nil },
+            transcriptLookup: { _ in nil }
+        )
+        .environment(\.theme, currentTheme())
+        let controller = NSHostingController(rootView: view)
+        controller.view.frame = NSRect(x: 0, y: 0, width: 800, height: 34)
+        controller.view.layoutSubtreeIfNeeded()
+        #expect(controller.view.fittingSize.height > 0)
+    }
+
     @Test func tabBarViewWithDirtyAndHarnessRendersWithoutCrashing() {
         let tab = Tab.terminal(TerminalTabState(id: "term1", title: "bash", sessionId: "s1"))
         let view = TabBarView(


### PR DESCRIPTION
## Summary
- rename the tabs row sparkles menu ACP section label to ACP Chat
- preserve the Terminal section label
- add regression and render smoke coverage for the menu labels

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test