### PR TITLE
Distinguish behind-base and behind-upstream commit chips

### DIFF
--- a/Alas/Sources/Right/CommitsSectionView.swift
+++ b/Alas/Sources/Right/CommitsSectionView.swift
@@ -1,20 +1,44 @@
 import SwiftUI
 
 /// Small pill shown in the Commits section header trailing slot when the
-/// worktree is behind a tracked ref (base trunk or its own upstream).
-/// Purely informative.
+/// worktree is behind a tracked ref. Purely informative. The `role` selects
+/// a distinct theme color so the "behind base" and "behind upstream" chips
+/// read as different things at a glance; the `label` names the target.
 struct BehindChip: View {
-    let text: String
+    /// Which "behind" signal this chip represents. Drives the color.
+    enum Role {
+        case base       // behind the trunk you compare against (e.g. main)
+        case upstream   // behind your branch's own remote tracking ref
+
+        /// Theme color token for this role.
+        var colorToken: String {
+            switch self {
+            case .base: return "accent"
+            case .upstream: return "caution"
+            }
+        }
+    }
+
+    let count: Int
+    let label: String
+    let role: Role
 
     @Environment(\.theme) private var theme
 
+    /// Pure text composition: `↓N label` (e.g. "↓3 main"). `↓` reads as
+    /// "commits to pull in."
+    static func displayText(count: Int, label: String) -> String {
+        "↓\(count) \(label)"
+    }
+
     var body: some View {
-        Text(text)
+        let tint = theme.color(role.colorToken)
+        return Text(Self.displayText(count: count, label: label))
             .font(.system(size: 9.5, weight: .semibold))
-            .foregroundColor(theme.color("accent"))
+            .foregroundColor(tint)
             .lineLimit(1)
             .padding(.horizontal, 6).padding(.vertical, 1)
-            .background(theme.color("accent").opacity(0.12))
+            .background(tint.opacity(0.12))
             .clipShape(Capsule())
     }
 }
@@ -56,11 +80,11 @@ struct CommitsSectionView: View {
             ) {
                 HStack(spacing: 6) {
                     if let s = behindBase {
-                        BehindChip(text: "\(s.count) behind")
+                        BehindChip(count: s.count, label: baseBranch, role: .base)
                             .help("\(s.count) behind \(s.ref)")
                     }
                     if let s = behindUpstream {
-                        BehindChip(text: "\(s.count) behind")
+                        BehindChip(count: s.count, label: "remote", role: .upstream)
                             .help("\(s.count) behind \(s.ref)")
                     }
                     BaseBranchSelector(

--- a/AlasTests/RightPaneStateSyncStatusTests.swift
+++ b/AlasTests/RightPaneStateSyncStatusTests.swift
@@ -328,4 +328,23 @@ struct RightPaneStateSyncStatusTests {
         try await Task.sleep(nanoseconds: 500_000_000)
         #expect(state.behindBase?.count == 0, "after rebase feature should be in sync with origin/main")
     }
+
+    // MARK: - BehindChip rendering
+
+    @Test func behindChipDisplayTextComposesArrowCountLabel() {
+        #expect(BehindChip.displayText(count: 3, label: "main") == "↓3 main")
+        #expect(BehindChip.displayText(count: 2, label: "remote") == "↓2 remote")
+    }
+
+    @Test func behindChipDisplayTextHandlesLongBaseName() {
+        #expect(BehindChip.displayText(count: 12, label: "release/v1") == "↓12 release/v1")
+    }
+
+    @Test func behindChipBaseRoleUsesAccentToken() {
+        #expect(BehindChip.Role.base.colorToken == "accent")
+    }
+
+    @Test func behindChipUpstreamRoleUsesCautionToken() {
+        #expect(BehindChip.Role.upstream.colorToken == "caution")
+    }
 }


### PR DESCRIPTION
## Summary
- The Commits section header (Changes tab) could show two identical `N behind` chips, distinguishable only by a hover tooltip. They now read `↓N <label>` with distinct colors so it's clear what each is behind at a glance.
- Base chip → `↓N <base-branch>` in the accent color (behind the trunk you compare against).
- Upstream chip → `↓N remote` in the caution color (your branch has commits on its remote tracking ref you don't have locally).
- `↓` denotes "commits to pull in"; each chip still only appears when its count is nonzero, and the full-ref tooltips are retained.

Rendering-only change to `BehindChip` and its two call sites in `CommitsSectionView.swift`; no changes to the git probes, visibility predicates, or `RightPaneState`/`GitService`.

## Test Plan
- [x] `RightPaneStateSyncStatusTests` (incl. 4 new `BehindChip` tests) pass: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/RightPaneStateSyncStatusTests test`
- [x] Full app builds: `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' build`
- [ ] Visual check in-app: behind base only → one accent `↓N <base>` chip; behind own remote only → one caution `↓N remote` chip; both → two visually distinct chips; tooltips show full refs.