### PR TITLE
Add auto-run default setting for new chat sessions

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -594,6 +594,7 @@
 		AC905947E88C7A2BE39D9B00 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA43AA9C8462D579E733B46C /* AppIntents.framework */; };
 		ACD22D2C262833B77006E8BE /* DeleteFailedWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */; };
 		ACDDE4B18A94164BDFEED06B /* BranchOpsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAD20759A17B6EFE3AC0C81 /* BranchOpsMenu.swift */; };
+		ACF240D867C3CCCD59E5A0E6 /* HarnessConfigAutoRunTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4F87B7B6F4A6E6ED882F1F /* HarnessConfigAutoRunTests.swift */; };
 		AD311BBE11A5A2751EA0907C /* HoverFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF8152B18C9D6290724122F /* HoverFeature.swift */; };
 		ADF6D3B634D9CCA17D7884EC /* PiACPInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6641006D2208E28C46AAB2 /* PiACPInstallerTests.swift */; };
 		AE179E24A9E308150D1FD1D5 /* CommitPromptStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E40B5F193E3CB5EB5BA945A /* CommitPromptStatusTests.swift */; };
@@ -1165,6 +1166,7 @@
 		4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioClient.swift; sourceTree = "<group>"; };
 		4D4A929D20297ED9DAB53982 /* TreeSitterYAML */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterYAML; path = ThirdParty/TreeSitterYAML; sourceTree = SOURCE_ROOT; };
 		4D4DEBF2A9CFDCFDAD288499 /* ACPContentBlockImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPContentBlockImageTests.swift; sourceTree = "<group>"; };
+		4D4F87B7B6F4A6E6ED882F1F /* HarnessConfigAutoRunTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HarnessConfigAutoRunTests.swift; sourceTree = "<group>"; };
 		4D5507CA73F4EE1717FD4D79 /* NumstatParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumstatParserTests.swift; sourceTree = "<group>"; };
 		4D63B166AF2C533BE6E59365 /* session-update-agent-chunk.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "session-update-agent-chunk.json"; sourceTree = "<group>"; };
 		4DA7089B238D285A1A2040CA /* PaneLeafEncodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneLeafEncodeTests.swift; sourceTree = "<group>"; };
@@ -2107,6 +2109,7 @@
 				2ED9D6E2F4F80DC4EC282918 /* Code */,
 				EAD92DAB367A7F31FF1223D1 /* Diagnostics */,
 				08BD96F4379A0D250DE4303C /* JSONRPC */,
+				D7416CBAB1B316023E546714 /* Persistence */,
 				5FA3F5C4A99F2C74080DA0EF /* SQLiteKit */,
 			);
 			path = AlasTests;
@@ -3078,6 +3081,14 @@
 				99DCC0EF4B5701083CB34167 /* ghostty */,
 			);
 			path = ThirdParty;
+			sourceTree = "<group>";
+		};
+		D7416CBAB1B316023E546714 /* Persistence */ = {
+			isa = PBXGroup;
+			children = (
+				4D4F87B7B6F4A6E6ED882F1F /* HarnessConfigAutoRunTests.swift */,
+			);
+			path = Persistence;
 			sourceTree = "<group>";
 		};
 		DA23E862C6C2D386B4C76E10 /* Shortcuts */ = {
@@ -4191,6 +4202,7 @@
 				1748C3645E9B769F371F69E6 /* GitServiceUpstreamTests.swift in Sources */,
 				A2298208242B45155BA07BCD /* GitStatusCacheTests.swift in Sources */,
 				9B6940D68B098D1F1305324B /* GitTypesTests.swift in Sources */,
+				ACF240D867C3CCCD59E5A0E6 /* HarnessConfigAutoRunTests.swift in Sources */,
 				D1F372532A0F9607051020F5 /* HarnessDetectorTests.swift in Sources */,
 				8FA934ED00389FC4D4A6A479 /* HarnessServiceTests.swift in Sources */,
 				3EA6388E72FDD02E5242002C /* HeadReaderTests.swift in Sources */,

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -87,18 +87,19 @@ final class ACPSessionManager: ObservableObject {
         self.recent = (try? store.recentSessions()) ?? []
     }
 
-    func createSession(agentId: String) -> ACPSession {
+    func createSession(agentId: String, autoRunDefault: Bool = false) -> ACPSession {
         let id = UUID().uuidString
         let now = Int64(Date().timeIntervalSince1970)
         let row = ACPSessionRow(
             id: id, agentId: agentId, title: "New session",
             titleSource: .placeholder,
-            currentModel: nil, currentMode: nil, autoRun: false,
+            currentModel: nil, currentMode: nil, autoRun: autoRunDefault,
             createdAt: now, updatedAt: now, lastOpenedAt: now, archived: false)
         try? store.upsertSession(row)
         let session = ACPSession(
             id: id, agentId: agentId, worktreeId: worktreeId,
             title: row.title, titleSource: .placeholder, hydrationState: .ready)
+        session.autoRunEnabled = autoRunDefault
         sessions[id] = session
         refreshRecent()
         return session

--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -2965,7 +2965,7 @@ final class AppState {
         guard let worktreeId = selectedWorktreeId,
               let worktree = worktree(withId: worktreeId) else { return }
         guard let mgr = acpManager(for: worktree) else { return }
-        let session = mgr.createSession(agentId: agentID)
+        let session = mgr.createSession(agentId: agentID, autoRunDefault: config.harness.acpAutoRunByDefault)
         let state = ACPSessionTabState(sessionId: session.id, title: session.title)
         tabs.append(acpSession: state, to: worktree.id)
     }

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -197,18 +197,23 @@ struct AppConfig: Codable, Equatable {
         /// When false: the two are inverted — ⏎ steers, ⌥⏎ queues. The
         /// label in Settings is "Send on ⏎, queue on ⌥⏎ while busy".
         var acpSendOnEnter: Bool
+        /// When true, newly created chat sessions start with auto-run enabled
+        /// (the agent runs tools without asking). Seeds the per-session value
+        /// only; the composer bolt still wins afterward. Default: false.
+        var acpAutoRunByDefault: Bool
 
         enum CodingKeys: String, CodingKey {
             case notifyOnFinish, notifyOnAwaiting,
                  dismissedHookInstallNudges, dismissedACPSetupNudges,
-                 confirmCloseChatTabs, acpSendOnEnter
+                 confirmCloseChatTabs, acpSendOnEnter, acpAutoRunByDefault
         }
 
-        init(notifyOnFinish: Bool, notifyOnAwaiting: Bool,
+        init(notifyOnFinish: Bool = true, notifyOnAwaiting: Bool = true,
              dismissedHookInstallNudges: [String] = [],
              dismissedACPSetupNudges: [String] = [],
              confirmCloseChatTabs: Bool = false,
-             acpSendOnEnter: Bool = true)
+             acpSendOnEnter: Bool = true,
+             acpAutoRunByDefault: Bool = false)
         {
             self.notifyOnFinish = notifyOnFinish
             self.notifyOnAwaiting = notifyOnAwaiting
@@ -216,6 +221,7 @@ struct AppConfig: Codable, Equatable {
             self.dismissedACPSetupNudges = dismissedACPSetupNudges
             self.confirmCloseChatTabs = confirmCloseChatTabs
             self.acpSendOnEnter = acpSendOnEnter
+            self.acpAutoRunByDefault = acpAutoRunByDefault
         }
 
         init(from decoder: Decoder) throws {
@@ -226,6 +232,7 @@ struct AppConfig: Codable, Equatable {
             dismissedACPSetupNudges = (try? c.decode([String].self, forKey: .dismissedACPSetupNudges)) ?? []
             confirmCloseChatTabs = (try? c.decode(Bool.self, forKey: .confirmCloseChatTabs)) ?? false
             acpSendOnEnter = (try? c.decode(Bool.self, forKey: .acpSendOnEnter)) ?? true
+            acpAutoRunByDefault = (try? c.decode(Bool.self, forKey: .acpAutoRunByDefault)) ?? false
         }
     }
 

--- a/Alas/Sources/Settings/AgentsPane.swift
+++ b/Alas/Sources/Settings/AgentsPane.swift
@@ -85,6 +85,14 @@ struct AgentsPane: View {
                             state.saveConfig() }
                         ))
                     }
+                    SettingsRow(name: "⚡ Auto-run",
+                                desc: "New chat sessions start with auto-run on — the agent runs tools without asking for permission. Toggle per-session with the bolt in the composer.") {
+                        AlasToggle(on: Binding(
+                            get: { state.config.harness.acpAutoRunByDefault },
+                            set: { state.config.harness.acpAutoRunByDefault = $0
+                            state.saveConfig() }
+                        ))
+                    }
                 }
 
                 SettingsGroup(title: "Harness") {

--- a/AlasTests/ACP/Session/ACPSessionManagerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerTests.swift
@@ -17,6 +17,28 @@ struct ACPSessionManagerTests {
         #expect(row?.agentId == "claude")
     }
 
+    @Test("createSession seeds autoRun from the default when true")
+    func createSessionSeedsAutoRunTrue() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-autorun-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let s = mgr.createSession(agentId: "claude", autoRunDefault: true)
+        #expect(s.autoRunEnabled == true)
+        let row = try store.loadSession(id: s.id)
+        #expect(row?.autoRun == true)
+    }
+
+    @Test("createSession defaults autoRun to false")
+    func createSessionDefaultsAutoRunFalse() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-autorun-off-\(UUID()).sqlite")
+        let store = try ACPSessionStore(path: url.path)
+        let mgr = ACPSessionManager(worktreeId: "/tmp/wt", worktreePath: "/tmp/wt", store: store)
+        let s = mgr.createSession(agentId: "claude")
+        #expect(s.autoRunEnabled == false)
+        let row = try store.loadSession(id: s.id)
+        #expect(row?.autoRun == false)
+    }
+
     @Test("placeholderSession marks store-backed sessions as restored from persistence")
     func placeholderSessionMarksRestoredFromPersistence() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("mgr-restored-\(UUID()).sqlite")

--- a/AlasTests/Persistence/HarnessConfigAutoRunTests.swift
+++ b/AlasTests/Persistence/HarnessConfigAutoRunTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("Harness.acpAutoRunByDefault")
+struct HarnessConfigAutoRunTests {
+    @Test("defaults to false")
+    func defaultsFalse() {
+        let h = AppConfig.Harness()
+        #expect(h.acpAutoRunByDefault == false)
+    }
+
+    @Test("missing key decodes to false")
+    func missingKeyDecodesFalse() throws {
+        let json = Data("{}".utf8)
+        let h = try JSONDecoder().decode(AppConfig.Harness.self, from: json)
+        #expect(h.acpAutoRunByDefault == false)
+    }
+
+    @Test("round-trips when set true")
+    func roundTripsTrue() throws {
+        var h = AppConfig.Harness()
+        h.acpAutoRunByDefault = true
+        let data = try JSONEncoder().encode(h)
+        let decoded = try JSONDecoder().decode(AppConfig.Harness.self, from: data)
+        #expect(decoded.acpAutoRunByDefault == true)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a global `acpAutoRunByDefault` harness preference (off by default) that seeds the initial auto-run state of newly created ACP chat sessions.
- Wire `ACPSessionManager.createSession` to accept an `autoRunDefault` and seed both the persisted session row and the in-memory `autoRunEnabled` flag; the sole `AppState` caller passes the new pref.
- Add a "⚡ Auto-run" toggle to Settings → Agents → Chat.

The setting only seeds *new* sessions — the per-session composer bolt still wins afterward, and existing sessions are untouched. With the setting off (the default), behavior is unchanged.

## Test Plan
- [x] `HarnessConfigAutoRunTests` — default false, missing-key decodes false, round-trips true (3 tests)
- [x] `ACPSessionManagerTests` — `createSession` seeds autoRun from the default (true) and defaults to false (2 new tests, 15 total pass)
- [x] `xcodebuild ... build` succeeds
- [ ] Manual: toggle off (default) → new session bolt unlit, permission prompts appear
- [ ] Manual: toggle on → new session bolt lit, tool calls auto-allow; per-session bolt off still wins and persists; existing sessions unaffected; value persists across restart