### PR TITLE
fix(ACP): mention picker search and chip alignment

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		25B94D8823F2A5A2BA4545B5 /* AppStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C11E3449E4A7B4E69E83C1C /* AppStatePersistenceTests.swift */; };
 		25CD620AE7FFA7DE82937F7E /* Spinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E01930F1D95B8D17BCBAC1 /* Spinner.swift */; };
 		2659BA65A6CABBE800A06AB3 /* tool-call-content-diff.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A187BD52742E8F4A6E52667 /* tool-call-content-diff.json */; };
+		26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */; };
 		2731B28802538E4FD7CBB0EA /* AgentDefinitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC7D583D292BB6D72670F0A /* AgentDefinitionTests.swift */; };
 		2735F19DF0AD717CA3CF3B23 /* WorktreeServiceCreatedAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA2F208DBC024A64D0ED065 /* WorktreeServiceCreatedAtTests.swift */; };
 		279BAFE41DCB69286B64CFB9 /* AdapterUpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F239EBD79AA346B7976B544 /* AdapterUpdateState.swift */; };
@@ -1664,6 +1665,7 @@
 		E91A6AFCC9B3AEFB43D8946F /* CodeLanguageDetailViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeLanguageDetailViewTests.swift; sourceTree = "<group>"; };
 		E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSectionTests.swift; sourceTree = "<group>"; };
 		E940D4265B42839BBC7681DC /* AppStateCreateWorktreeSymlinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCreateWorktreeSymlinkTests.swift; sourceTree = "<group>"; };
+		E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMentionPickerTests.swift; sourceTree = "<group>"; };
 		E98FAFF3AE36A17EE6AD029C /* EditorTabStateMarkdownCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorTabStateMarkdownCodableTests.swift; sourceTree = "<group>"; };
 		EAA78FF7BA562DC4423AC35D /* ACPSessionVisibleQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionVisibleQueueTests.swift; sourceTree = "<group>"; };
 		EB1E14CFAC880D31CE8FBE8F /* ChangesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesPane.swift; sourceTree = "<group>"; };
@@ -2404,6 +2406,7 @@
 				A53358B7D4D68BE2471187D4 /* ACPImageStagingTests.swift */,
 				84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */,
 				7F4B57FBB6E595E5DF1C6F93 /* ACPMarkdownLiveStylerImageChipTests.swift */,
+				E941397D0207F68135B3464D /* ACPMentionPickerTests.swift */,
 				9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */,
 				D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */,
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
@@ -4010,6 +4013,7 @@
 				7433DB9396574A02DBF9953D /* ACPLaunchSpecTests.swift in Sources */,
 				21A94ADFA16F85C7ACAB4DA1 /* ACPMarkdownBlockCacheTests.swift in Sources */,
 				6E0481CC3B5D8676A6E8BE69 /* ACPMarkdownLiveStylerImageChipTests.swift in Sources */,
+				26F83C65E75B5F44024FEF1F /* ACPMentionPickerTests.swift in Sources */,
 				FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */,
 				9737C1A3CD708D28C62FD6A5 /* ACPMessageStableIdTests.swift in Sources */,
 				D10A8F47A537C1C8969752B1 /* ACPMessageTests.swift in Sources */,

--- a/Alas/Sources/ACP/UI/ACPMentionChipAttachment.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionChipAttachment.swift
@@ -23,7 +23,6 @@ final class ACPMentionChipAttachment: NSTextAttachment {
 private final class ACPMentionChipCell: NSTextAttachmentCell {
     let displayName: String
     private let label: String
-    private let labelFont = NSFont.monospacedSystemFont(ofSize: 11.5, weight: .medium)
 
     init(displayName: String) {
         self.displayName = displayName
@@ -33,13 +32,18 @@ private final class ACPMentionChipCell: NSTextAttachmentCell {
     required init(coder: NSCoder) { fatalError() }
 
     override var cellSize: NSSize {
-        let attrs: [NSAttributedString.Key: Any] = [.font: labelFont]
-        let textSize = (label as NSString).size(withAttributes: attrs)
-        return NSSize(width: ceil(textSize.width) + 14, height: 18)
+        ACPMentionChipMetrics.cellSize(for: label)
     }
 
     override func cellBaselineOffset() -> NSPoint {
-        NSPoint(x: 0, y: -1)
+        let size = ACPMentionChipMetrics.cellSize(for: label)
+        return NSPoint(
+            x: 0,
+            y: ACPMentionChipMetrics.baselineOffset(
+                for: NSFont.systemFont(ofSize: 13),
+                attachmentHeight: size.height
+            )
+        )
     }
 
     override func draw(withFrame frame: NSRect, in controlView: NSView?) {
@@ -54,7 +58,7 @@ private final class ACPMentionChipCell: NSTextAttachmentCell {
 
         let textColor = accent.blended(withFraction: 0.55, of: .white) ?? .white
         let attrs: [NSAttributedString.Key: Any] = [
-            .font: labelFont,
+            .font: ACPMentionChipMetrics.labelFont,
             .foregroundColor: textColor,
         ]
         let textSize = (label as NSString).size(withAttributes: attrs)
@@ -73,6 +77,34 @@ private final class ACPMentionChipCell: NSTextAttachmentCell {
                             proposedLineFragment lineFrag: NSRect,
                             glyphPosition position: NSPoint,
                             characterIndex charIndex: Int) -> NSRect {
-        NSRect(origin: .zero, size: cellSize)
+        let size = ACPMentionChipMetrics.cellSize(for: label)
+        let font = textContainer.layoutManager?.textStorage?.attribute(
+            .font,
+            at: charIndex,
+            effectiveRange: nil
+        ) as? NSFont ?? NSFont.systemFont(ofSize: 13)
+        return NSRect(
+            x: 0,
+            y: ACPMentionChipMetrics.baselineOffset(for: font, attachmentHeight: size.height),
+            width: size.width,
+            height: size.height
+        )
+    }
+}
+
+private enum ACPMentionChipMetrics {
+    static var labelFont: NSFont {
+        NSFont.monospacedSystemFont(ofSize: 11.5, weight: .medium)
+    }
+
+    static func cellSize(for label: String) -> NSSize {
+        let attrs: [NSAttributedString.Key: Any] = [.font: labelFont]
+        let textSize = (label as NSString).size(withAttributes: attrs)
+        return NSSize(width: ceil(textSize.width) + 14, height: 18)
+    }
+
+    static func baselineOffset(for font: NSFont, attachmentHeight: CGFloat) -> CGFloat {
+        let letterCenterFromBaseline = (font.ascender + font.descender) / 2
+        return letterCenterFromBaseline - attachmentHeight / 2
     }
 }

--- a/Alas/Sources/ACP/UI/ACPMentionPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionPicker.swift
@@ -169,6 +169,7 @@ struct ACPMentionPickerView: View {
         let gen = rankGeneration
         let q = query.trimmingCharacters(in: .whitespacesAndNewlines)
         let files = allFiles
+        let root = worktreeRoot
         rankTask = Task.detached(priority: .userInitiated) {
             try? await Task.sleep(nanoseconds: 16_000_000)
             if Task.isCancelled { return }
@@ -176,7 +177,7 @@ struct ACPMentionPickerView: View {
             if q.isEmpty {
                 result = Array(files.prefix(maxDisplay))
             } else {
-                result = MentionFuzzy.rank(files: files, query: q, limit: maxDisplay)
+                result = MentionFuzzy.rank(files: files, query: q, limit: maxDisplay, relativeTo: root)
             }
             if Task.isCancelled { return }
             await MainActor.run {
@@ -221,47 +222,50 @@ enum MentionFuzzy {
         return out
     }
 
-    static func rank(files: [URL], query: String, limit: Int) -> [URL] {
-        let q = query.lowercased()
-        var scored: [(URL, Int)] = []
+    static func rank(files: [URL], query: String, limit: Int, relativeTo root: URL) -> [URL] {
+        let tokens = query
+            .split(whereSeparator: \.isWhitespace)
+            .map(String.init)
+        guard !tokens.isEmpty else { return Array(files.prefix(limit)) }
+
+        var scored: [(url: URL, score: Double, relativePath: String)] = []
         for f in files {
-            let name = f.lastPathComponent.lowercased()
-            let path = f.path.lowercased()
-            var score = 0
-            if name.hasPrefix(q) {
-                score = 1000 - name.count
-            } else if name.contains(q) {
-                score = 500 - name.count
-            } else if path.contains(q) {
-                score = 200
-            } else if let sub = subsequenceScore(in: name, query: q) {
-                score = 300 - (name.count - q.count) - sub
-            } else if let sub = subsequenceScore(in: path, query: q) {
-                score = 100 - sub
-            } else {
+            let relativePath = relativePath(for: f, root: root)
+            guard let score = score(file: f, relativePath: relativePath, tokens: tokens) else {
                 continue
             }
-            scored.append((f, score))
+            scored.append((f, score, relativePath))
         }
-        scored.sort { ($0.1, -$0.0.path.count) > ($1.1, -$1.0.path.count) }
-        return Array(scored.prefix(limit).map(\.0))
+        scored.sort {
+            if $0.score != $1.score { return $0.score > $1.score }
+            if $0.relativePath.count != $1.relativePath.count {
+                return $0.relativePath.count < $1.relativePath.count
+            }
+            return $0.relativePath.localizedStandardCompare($1.relativePath) == .orderedAscending
+        }
+        return Array(scored.prefix(limit).map(\.url))
     }
 
-    private static func subsequenceScore(in haystack: String, query: String) -> Int? {
-        var gap = 0, total = 0
-        var qIdx = query.startIndex
-        var lastMatch: String.Index?
-        for i in haystack.indices {
-            if qIdx == query.endIndex { break }
-            if haystack[i] == query[qIdx] {
-                if let last = lastMatch {
-                    gap = haystack.distance(from: last, to: i) - 1
-                    total += gap
-                }
-                lastMatch = i
-                qIdx = query.index(after: qIdx)
+    private static func score(file: URL, relativePath: String, tokens: [String]) -> Double? {
+        var total = 0.0
+        for token in tokens {
+            let nameScore = FuzzyMatch.score(query: token, target: file.lastPathComponent)?
+                .score
+                .advanced(by: 8)
+            let pathScore = FuzzyMatch.score(query: token, target: relativePath)?.score
+            guard let best = [nameScore, pathScore].compactMap(\.self).max() else {
+                return nil
             }
+            total += best
         }
-        return qIdx == query.endIndex ? total : nil
+        return total - Double(relativePath.count) * 0.001
+    }
+
+    private static func relativePath(for file: URL, root: URL) -> String {
+        let commonRoot = root.standardizedFileURL.path
+        let path = file.standardizedFileURL.path
+        let prefix = commonRoot.hasSuffix("/") ? commonRoot : commonRoot + "/"
+        guard path.hasPrefix(prefix) else { return path }
+        return String(path.dropFirst(prefix.count))
     }
 }

--- a/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerDraftBridgeTests.swift
@@ -417,6 +417,33 @@ struct ACPComposerDraftBridgeTests {
         #expect(typingColor == NSColor.labelColor)
     }
 
+    @Test("mention chip frame centers on surrounding text")
+    func mentionChipFrameCentersOnText() throws {
+        let font = NSFont.systemFont(ofSize: 13)
+        let attachment = ACPMentionChipAttachment(displayName: "build.yml", uri: "file:///tmp/build.yml")
+        let storage = NSTextStorage(string: "x", attributes: [.font: font])
+        let chip = NSMutableAttributedString(attachment: attachment)
+        chip.addAttributes([.font: font], range: NSRange(location: 0, length: chip.length))
+        storage.append(chip)
+        storage.append(NSAttributedString(string: "y", attributes: [.font: font]))
+
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 200, height: 100))
+        storage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(textContainer)
+
+        let frame = try #require(attachment.attachmentCell).cellFrame(
+            for: textContainer,
+            proposedLineFragment: NSRect(x: 0, y: 0, width: 200, height: 20),
+            glyphPosition: NSPoint(x: 12, y: 30),
+            characterIndex: 1
+        )
+
+        let textCenter = (font.ascender + font.descender) / 2
+        #expect(abs(frame.midY - textCenter) < 0.001)
+        #expect(frame.minY < -4)
+    }
+
     @Test("slash panel closes when filtering has no command matches")
     func slashPanelClosesWhenFilteringHasNoMatches() {
         let (textView, coordinator) = makeSlashTextView()

--- a/AlasTests/ACP/UI/ACPMentionPickerTests.swift
+++ b/AlasTests/ACP/UI/ACPMentionPickerTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACP mention picker")
+struct ACPMentionPickerTests {
+    @Test("ranks fuzzy basename and path matches with shared scorer")
+    func ranksFuzzyBasenameAndPathMatches() {
+        let root = URL(fileURLWithPath: "/tmp/project")
+        let files = [
+            root.appendingPathComponent("docs/build-notes.md"),
+            root.appendingPathComponent(".github/workflows/build.yml"),
+            root.appendingPathComponent(".github/workflows/nightly.yml"),
+            root.appendingPathComponent("Sources/ACP/UI/ACPComposer.swift"),
+        ]
+
+        let basenameMatches = MentionFuzzy.rank(files: files, query: "byml", limit: 10, relativeTo: root)
+        #expect(basenameMatches.first == root.appendingPathComponent(".github/workflows/build.yml"))
+
+        let pathMatches = MentionFuzzy.rank(files: files, query: "aui comp", limit: 10, relativeTo: root)
+        #expect(pathMatches.first == root.appendingPathComponent("Sources/ACP/UI/ACPComposer.swift"))
+    }
+
+    @Test("keeps directory tokens when candidates share a parent directory")
+    func keepsDirectoryTokensWhenCandidatesShareParent() {
+        let root = URL(fileURLWithPath: "/tmp/project")
+        let files = [
+            root.appendingPathComponent("Sources/App.swift"),
+            root.appendingPathComponent("Sources/Model.swift"),
+        ]
+
+        let matches = MentionFuzzy.rank(files: files, query: "Sources App", limit: 10, relativeTo: root)
+
+        #expect(matches.first == root.appendingPathComponent("Sources/App.swift"))
+    }
+}


### PR DESCRIPTION
## Summary
- Use the shared fuzzy matcher for ACP @ mention file ranking, including multi-token path queries.
- Align mention chips using surrounding font metrics so they sit on the composer baseline.
- Add regression coverage for fuzzy @ search and chip frame alignment.

## Validation
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- Focused ACP UI tests for `ACPMentionPickerTests` and `ACPComposerDraftBridgeTests`
- Manual launch and ACP composer check

Note: the full `xcodebuild ... test` run was attempted locally but interrupted after it stayed idle in build/pre-test state with no compiler or `xctest` child.