### PR TITLE
fix(ACP): dismiss composer pickers on tab switch

### DIFF
--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -103,6 +103,9 @@ struct ACPInputField: NSViewRepresentable {
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
         coordinator.isFocused.wrappedValue = false
         coordinator.flushPendingRestyleNow()
+        if let tv = nsView.documentView as? ACPNSTextView {
+            tv.dismissFloatingPanels()
+        }
     }
 
     /// When busy, the placeholder advertises whichever action ⏎ will
@@ -541,6 +544,17 @@ final class ACPNSTextView: NSTextView {
         super.didChangeText()
         // Trigger placeholder redraw when text becomes (non-)empty.
         needsDisplay = true
+    }
+
+    /// Dismiss any floating picker panel owned by this text view. The
+    /// panels are attached as child windows of the host window (not of
+    /// this view), so without an explicit close on teardown they outlive
+    /// the composer and stay visible across tab switches until app quit.
+    /// `dismantleNSView` calls this when the SwiftUI representable is
+    /// torn down (tab switch, window close).
+    func dismissFloatingPanels() {
+        dismissSlashPanel()
+        closeMentionPanel()
     }
 
     override func keyDown(with event: NSEvent) {


### PR DESCRIPTION
## Summary

- Close the slash and `@`-mention picker panels when the ACP composer is torn down (tab switch / window close), so they no longer outlive the composer and float across tabs until app quit.
- Cleanup runs from `dismantleNSView` (the SwiftUI-canonical teardown hook) rather than `viewWillMove(toWindow:)`. Closing a child `NSPanel` from inside SwiftUI's view-update commit re-entered the menu shortcut path and dismissed the just-opened replacement tab (e.g. ⌘T while the slash picker was open opened a terminal tab that was then immediately closed).

## Test plan

- [x] Open ACP tab, type \`/\`, switch to another tab — slash panel disappears.
- [x] Open ACP tab, type \`/\`, press ⌘T — new terminal tab stays.
- [ ] Same as above with \`@\` (mention picker).