### PR TITLE
fix(terminal): self-heal orphaned zmx sessions

### DIFF
--- a/Alas/Sources/App/AppState.swift
+++ b/Alas/Sources/App/AppState.swift
@@ -409,6 +409,28 @@ final class AppState {
         // waiting for `restoreTerminalTabIfNeeded` (driven by
         // TerminalTabView.task) to fire when the user opens the tab.
         refreshPersistedHookSymlinks()
+        sweepOrphanZmxSessions(worktreeIds: allWorktreeIds)
+    }
+
+    /// Compute (knownWorktreeIds, knownLeafIds) from in-memory state and
+    /// hand them to `TerminalService.sweepOrphans`. Run after `reloadTabs`
+    /// so persisted leaves are visible; without this, sessions leaked by
+    /// any prior bug (or quit race) would persist forever because nothing
+    /// would ever try to kill them on subsequent launches.
+    private func sweepOrphanZmxSessions(worktreeIds: [String]) {
+        var leafIds: Set<String> = []
+        for worktreeId in worktreeIds {
+            for tab in tabs.tabs(forWorktree: worktreeId) {
+                guard case .terminal(let state) = tab else { continue }
+                for leaf in state.root.leaves() {
+                    leafIds.insert(leaf.id)
+                }
+            }
+        }
+        terminal.sweepOrphans(
+            knownWorktreeIds: Set(worktreeIds),
+            knownLeafIds: leafIds
+        )
     }
 
     var projects: [ProjectConfig] { projectsManager.projects }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -485,6 +485,14 @@ private struct RootBaseHandlers: ViewModifier {
                 // HarnessService, which is one of the candidates for the
                 // permission-prompt avalanche reported on quit.
                 state.harness.stop()
+                // Block briefly so any in-flight `zmx kill` subprocesses
+                // (dispatched from close-tab/delete-worktree paths) finish
+                // talking to the daemon before our process exits — they'd
+                // otherwise die with us mid-flight, leaving daemon-side
+                // sessions orphaned. The boot-time sweep eventually cleans
+                // those up, but only if the user relaunches Alas; meanwhile
+                // they'd accumulate across the lifetime of the daemon.
+                state.terminal.waitForPendingKills(timeout: 3.0)
             }
     }
 }

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -269,16 +269,24 @@ final class TerminalService {
     /// `wtHash` won't be in our set and its sessions stay untouched.
     /// Legacy `alas-<leafId>` shapes are skipped — the existing close-path
     /// cleanup already handles those when the matching tab is closed.
+    ///
+    /// `ZMX_SESSION_PREFIX` is read from the current environment and applied
+    /// to ls-output stripping + kill-argument bare names, mirroring how the
+    /// rest of `ZmxClient` keeps the prefix transparent: zmx's CLI prepends
+    /// the env-set prefix on both create and kill, so we feed it the bare
+    /// `alas-…` name on either side.
     func sweepOrphans(knownWorktreeIds: Set<String>, knownLeafIds: Set<String>) {
         let wtHashes = Set(knownWorktreeIds.map(ZmxSessionName.hash16))
         let leafHashes = Set(knownLeafIds.map(ZmxSessionName.hash16))
+        let prefix = ProcessInfo.processInfo.environment["ZMX_SESSION_PREFIX"] ?? ""
         let client = zmxClient
         dispatchTrackedKill {
             let names = client.listSessions()
             let orphans = Self.orphanSessionNames(
                 allSessionNames: names,
                 knownWorktreeIdHashes: wtHashes,
-                knownLeafIdHashes: leafHashes
+                knownLeafIdHashes: leafHashes,
+                sessionPrefix: prefix
             )
             for name in orphans {
                 client.killSession(name: name)
@@ -288,17 +296,28 @@ final class TerminalService {
 
     /// Pure filter exposed for tests: pick the scoped `alas-*` sessions
     /// belonging to one of our worktrees that no known leaf claims.
+    /// Returns bare (unprefixed) names so callers can pass them straight to
+    /// `ZmxClient.killSession`, which lets the CLI re-prepend
+    /// `ZMX_SESSION_PREFIX` itself — matching the create/kill symmetry in
+    /// `ZmxClient.wrap` / `killSession`.
     nonisolated static func orphanSessionNames(
         allSessionNames: [String],
         knownWorktreeIdHashes: Set<String>,
-        knownLeafIdHashes: Set<String>
+        knownLeafIdHashes: Set<String>,
+        sessionPrefix: String = ""
     ) -> [String] {
-        allSessionNames.compactMap { name in
-            guard let parsed = ZmxSessionName.parseScoped(name),
+        allSessionNames.compactMap { rawName in
+            // With a prefix set, ignore names that don't carry it — those
+            // belong to a different tool or a stale unprefixed run, and
+            // re-killing them with the prefix re-applied could hit the wrong
+            // session.
+            guard rawName.hasPrefix(sessionPrefix) else { return nil }
+            let bareName = String(rawName.dropFirst(sessionPrefix.count))
+            guard let parsed = ZmxSessionName.parseScoped(bareName),
                   knownWorktreeIdHashes.contains(parsed.worktreeIdHash),
                   !knownLeafIdHashes.contains(parsed.leafIdHash)
             else { return nil }
-            return name
+            return bareName
         }
     }
 

--- a/Alas/Sources/Terminal/TerminalService.swift
+++ b/Alas/Sources/Terminal/TerminalService.swift
@@ -34,9 +34,27 @@ final class TerminalService {
     @ObservationIgnored var onSessionProcessExited: ((_ leafId: String, _ worktreeId: String, _ processAlive: Bool) -> Void)?
     @ObservationIgnored let zmxClient: ZmxClient
 
+    /// In-flight zmx kill tasks. Tracked so `waitForPendingKills` can drain
+    /// them at app quit instead of dropping them on the floor when the
+    /// process exits. Tasks insert themselves on dispatch and self-remove on
+    /// completion via a MainActor follow-up Task.
+    @ObservationIgnored private var pendingKillTasks: Set<Task<Void, Never>> = []
+
     /// Default initializer used by production code paths (AppState).
     init(zmxClient: ZmxClient = ZmxClient(env: ZmxEnv.resolve())) {
         self.zmxClient = zmxClient
+    }
+
+    /// Spawn a detached zmx-related task (kill, ls+kill, sweep) and track it
+    /// so `waitForPendingKills` can drain on quit. Replaces the bare
+    /// `Task.detached { … }` callers used pre-tracking.
+    private func dispatchTrackedKill(_ body: @escaping @Sendable () -> Void) {
+        let task = Task.detached(operation: body)
+        pendingKillTasks.insert(task)
+        Task { @MainActor [weak self] in
+            _ = await task.value
+            self?.pendingKillTasks.remove(task)
+        }
     }
 
     /// Build the global config file for this app + theme combination, then
@@ -175,14 +193,16 @@ final class TerminalService {
         }
         registry.unregister(id: id)
         // `zmxClient.killSession` blocks up to ~5s on a hung daemon. We're
-        // on @MainActor here, so dispatch it off-main as fire-and-forget
-        // (the call is documented best-effort; we don't read the result).
+        // on @MainActor here, so dispatch it off-main, tracked so
+        // `waitForPendingKills` can drain it before the app exits —
+        // otherwise a quick close+Cmd-Q race would leak the daemon-side
+        // session, and the next launch would carry forward the orphan.
         if let existingName = existing?.zmxSessionName {
             let client = zmxClient
-            Task.detached { client.killSession(name: existingName) }
+            dispatchTrackedKill { client.killSession(name: existingName) }
         } else if let worktreeId = explicitWorktreeId ?? existing?.worktreeId {
             let client = zmxClient
-            Task.detached {
+            dispatchTrackedKill {
                 let sessionNames = Self.sessionNamesForCleanup(
                     worktreeId: worktreeId,
                     projectPath: projectPath,
@@ -225,7 +245,7 @@ final class TerminalService {
             $0.zmxSessionName ?? ZmxSessionName.derive(worktreeId: $0.worktreeId, leafId: $0.id)
         }
         let client = zmxClient
-        Task.detached {
+        dispatchTrackedKill {
             var allNames = Set(liveNames)
             for session in additionalSessions {
                 allNames.formUnion(Self.sessionNamesForCleanup(
@@ -239,6 +259,72 @@ final class TerminalService {
                 client.killSession(name: name)
             }
         }
+    }
+
+    /// Self-heal at boot. Enumerates `zmx ls`, then kills every scoped
+    /// `alas-<wtHash>-<leafHash>` session whose `wtHash` matches one of
+    /// `knownWorktreeIds` but whose `leafHash` is absent from
+    /// `knownLeafIds`. Multi-instance safe: another Alas process under the
+    /// same `ZMX_DIR` has its own (different) worktree ids, so its
+    /// `wtHash` won't be in our set and its sessions stay untouched.
+    /// Legacy `alas-<leafId>` shapes are skipped — the existing close-path
+    /// cleanup already handles those when the matching tab is closed.
+    func sweepOrphans(knownWorktreeIds: Set<String>, knownLeafIds: Set<String>) {
+        let wtHashes = Set(knownWorktreeIds.map(ZmxSessionName.hash16))
+        let leafHashes = Set(knownLeafIds.map(ZmxSessionName.hash16))
+        let client = zmxClient
+        dispatchTrackedKill {
+            let names = client.listSessions()
+            let orphans = Self.orphanSessionNames(
+                allSessionNames: names,
+                knownWorktreeIdHashes: wtHashes,
+                knownLeafIdHashes: leafHashes
+            )
+            for name in orphans {
+                client.killSession(name: name)
+            }
+        }
+    }
+
+    /// Pure filter exposed for tests: pick the scoped `alas-*` sessions
+    /// belonging to one of our worktrees that no known leaf claims.
+    nonisolated static func orphanSessionNames(
+        allSessionNames: [String],
+        knownWorktreeIdHashes: Set<String>,
+        knownLeafIdHashes: Set<String>
+    ) -> [String] {
+        allSessionNames.compactMap { name in
+            guard let parsed = ZmxSessionName.parseScoped(name),
+                  knownWorktreeIdHashes.contains(parsed.worktreeIdHash),
+                  !knownLeafIdHashes.contains(parsed.leafIdHash)
+            else { return nil }
+            return name
+        }
+    }
+
+    /// Block the caller for up to `timeout` while in-flight zmx kills
+    /// complete. Called from `applicationWillTerminate` so a Cmd-Q
+    /// immediately after a tab close still flushes the kill subprocess
+    /// to the daemon before Alas exits (the subprocess would otherwise
+    /// die with us, leaving an orphan that next launch couldn't easily
+    /// trace back). Uses a semaphore from a background-thread awaiter
+    /// rather than blocking the @MainActor Task's executor, so the
+    /// follow-up `pendingKillTasks.remove` MainActor work can still
+    /// schedule.
+    func waitForPendingKills(timeout: TimeInterval) {
+        let tasks = pendingKillTasks
+        guard !tasks.isEmpty else { return }
+        let semaphore = DispatchSemaphore(value: 0)
+        Task.detached {
+            await withTaskGroup(of: Void.self) { group in
+                for task in tasks {
+                    group.addTask { await task.value }
+                }
+                for await _ in group {}
+            }
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + timeout)
     }
 
     /// Best-effort removal of the per-session rcfile artifacts written by

--- a/Alas/Sources/Terminal/Zmx/ZmxSessionName.swift
+++ b/Alas/Sources/Terminal/Zmx/ZmxSessionName.swift
@@ -5,6 +5,13 @@ import CryptoKit
 /// Used by both `ZmxClient.wrap` (at launch) and `TerminalService.closeSession`
 /// (at kill) so the two call sites can never drift.
 enum ZmxSessionName {
+    /// Decoded parts of a scoped session name (`alas-<wtHash>-<leafHash>`).
+    /// Returned by `parseScoped`; legacy `alas-<leafId>` names produce nil.
+    struct Parsed: Equatable {
+        let worktreeIdHash: String
+        let leafIdHash: String
+    }
+
     static func derive(worktreeId: String, leafId: String) -> String {
         "alas-\(hash16(worktreeId))-\(hash16(leafId))"
     }
@@ -13,7 +20,24 @@ enum ZmxSessionName {
         "alas-\(leafId)"
     }
 
-    private static func hash16(_ value: String) -> String {
+    /// Split a scoped session name into its (wt, leaf) hash halves. Returns
+    /// nil for legacy `alas-<UUID>` shapes (the leafId contains dashes, so
+    /// the segment count differs) and for any string that doesn't match the
+    /// 3-segment `alas-<16hex>-<16hex>` form.
+    static func parseScoped(_ name: String) -> Parsed? {
+        let parts = name.split(separator: "-")
+        guard parts.count == 3, parts[0] == "alas",
+              parts[1].count == 16, parts[2].count == 16,
+              parts[1].allSatisfy(\.isHexDigit), parts[2].allSatisfy(\.isHexDigit)
+        else { return nil }
+        return Parsed(worktreeIdHash: String(parts[1]), leafIdHash: String(parts[2]))
+    }
+
+    /// Same hash the `derive` call uses for each id-half. Exposed so callers
+    /// computing membership sets (e.g. the boot-time orphan sweep) can map
+    /// known worktree ids and leaf ids into hash space without re-implementing
+    /// the SHA256-prefix trick.
+    static func hash16(_ value: String) -> String {
         SHA256.hash(data: Data(value.utf8))
             .prefix(8)
             .map { String(format: "%02x", $0) }

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -399,6 +399,34 @@ struct TerminalServiceZmxTests {
     }
 
     @Test
+    func orphanFilterStripsZmxSessionPrefixBeforeMatching() {
+        let mineWt = "wt-1"
+        let mineWtHash = ZmxSessionName.hash16(mineWt)
+        let foreignHash = ZmxSessionName.hash16("wt-not-ours")
+        let unknownLeafHash = ZmxSessionName.hash16("leaf-stranded")
+
+        // With ZMX_SESSION_PREFIX=team-, zmx ls prefixes every session
+        // name. The filter must strip the prefix before parseScoped, and
+        // return bare names so callers can hand them to zmx kill (which
+        // re-prepends the prefix itself).
+        let names = [
+            "team-alas-\(mineWtHash)-\(unknownLeafHash)",     // ours, orphan — kill (bare form)
+            "team-alas-\(foreignHash)-\(unknownLeafHash)",    // another instance — skip
+            "alas-\(mineWtHash)-\(unknownLeafHash)",          // no prefix — not from this run, skip
+            "team-not-alas",                                    // prefixed but not scoped — skip
+        ]
+
+        let orphans = TerminalService.orphanSessionNames(
+            allSessionNames: names,
+            knownWorktreeIdHashes: [mineWtHash],
+            knownLeafIdHashes: [],
+            sessionPrefix: "team-"
+        )
+
+        #expect(orphans == ["alas-\(mineWtHash)-\(unknownLeafHash)"])
+    }
+
+    @Test
     func sweepOrphansIssuesKillsForFilteredNames() async {
         let mineWt = "wt-1"
         let mineLeaf = "leaf-keep"

--- a/AlasTests/TerminalServiceZmxTests.swift
+++ b/AlasTests/TerminalServiceZmxTests.swift
@@ -362,6 +362,142 @@ struct TerminalServiceZmxTests {
         ])
     }
 
+    // MARK: sweepOrphans — boot-time cleanup
+
+    @Test
+    func orphanFilterKillsOnlyOurWorktreeWithUnknownLeaf() {
+        let mineWtA = "wt-A"
+        let mineWtB = "wt-B"
+        let mineLeaf = "leaf-keep"
+        let unknownLeaf = "leaf-stranded"
+
+        let mineWtAHash = ZmxSessionName.hash16(mineWtA)
+        let mineWtBHash = ZmxSessionName.hash16(mineWtB)
+        let foreignHash = ZmxSessionName.hash16("wt-not-ours")
+        let mineLeafHash = ZmxSessionName.hash16(mineLeaf)
+        let unknownLeafHash = ZmxSessionName.hash16(unknownLeaf)
+
+        let names = [
+            "alas-\(mineWtAHash)-\(mineLeafHash)",       // ours, still referenced — keep
+            "alas-\(mineWtAHash)-\(unknownLeafHash)",    // ours, orphan — kill
+            "alas-\(mineWtBHash)-\(unknownLeafHash)",    // different wt of ours, orphan — kill
+            "alas-\(foreignHash)-\(unknownLeafHash)",    // another Alas instance — never touch
+            "alas-leaf-legacy-uuid-shape",                // legacy form — sweep ignores
+            "not-an-alas-session",                        // unrelated — ignore
+        ]
+
+        let orphans = TerminalService.orphanSessionNames(
+            allSessionNames: names,
+            knownWorktreeIdHashes: [mineWtAHash, mineWtBHash],
+            knownLeafIdHashes: [mineLeafHash]
+        )
+
+        #expect(Set(orphans) == Set([
+            "alas-\(mineWtAHash)-\(unknownLeafHash)",
+            "alas-\(mineWtBHash)-\(unknownLeafHash)",
+        ]))
+    }
+
+    @Test
+    func sweepOrphansIssuesKillsForFilteredNames() async {
+        let mineWt = "wt-1"
+        let mineLeaf = "leaf-keep"
+        let mineWtHash = ZmxSessionName.hash16(mineWt)
+        let foreignHash = ZmxSessionName.hash16("wt-not-ours")
+        let unknownLeafHash = ZmxSessionName.hash16("leaf-stranded")
+        let recorder = RecordingRunner()
+        recorder.resultsByFirstArg["ls"] = .init(
+            exitCode: 0,
+            stdout: """
+            alas-\(mineWtHash)-\(ZmxSessionName.hash16(mineLeaf))
+            alas-\(mineWtHash)-\(unknownLeafHash)
+            alas-\(foreignHash)-\(unknownLeafHash)
+            """,
+            stderr: ""
+        )
+        let service = TerminalService(
+            zmxClient: ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
+        )
+
+        service.sweepOrphans(
+            knownWorktreeIds: [mineWt],
+            knownLeafIds: [mineLeaf]
+        )
+        await waitForCalls(recorder, count: 2) { $0.calls.count }
+
+        // Expect `ls --short` then exactly one kill for the our-wt-but-unknown-leaf entry.
+        #expect(recorder.calls.map(\.args) == [
+            ["ls", "--short"],
+            ["kill", "alas-\(mineWtHash)-\(unknownLeafHash)"],
+        ])
+    }
+
+    // MARK: waitForPendingKills — quit drain
+
+    @Test
+    func waitForPendingKillsBlocksUntilDispatchedKillCompletes() {
+        let started = DispatchSemaphore(value: 0)
+        let unblock = DispatchSemaphore(value: 0)
+        let recorder = RecordingRunner()
+        // Replace runner so the kill subprocess parks until we let it
+        // through, simulating a slow daemon round-trip. The drain MUST
+        // observe completion before returning, otherwise a Cmd-Q would
+        // again abandon the in-flight task.
+        let stallRunner = SubprocessRunner { exe, args, _, _ in
+            recorder.calls.append(.init(executable: exe, args: args))
+            started.signal()
+            _ = unblock.wait(timeout: .now() + 5.0)
+            return .init(exitCode: 0, stdout: "", stderr: "")
+        }
+        let svc = TerminalService(
+            zmxClient: ZmxClient(env: makeZmxEnv(available: true), runner: stallRunner)
+        )
+
+        let surface = AlasGhostty.SurfaceView(testIO: FakeGhosttySurfaceIO())
+        let session = TerminalSession(
+            id: "leaf-drain",
+            worktreeId: "wt-1",
+            projectId: "proj-1",
+            surface: surface,
+            executable: "/bin/zsh",
+            args: [],
+            zmxSessionName: ZmxSessionName.derive(worktreeId: "wt-1", leafId: "leaf-drain")
+        )
+        svc.registry.register(session)
+        svc.closeSession(id: "leaf-drain", worktreeId: "wt-1")
+        // The detached task should have entered the runner by now.
+        _ = started.wait(timeout: .now() + 2.0)
+
+        // Drain runs on a background awaiter so the @MainActor task that
+        // removes the completed task from the tracking set can schedule
+        // even though the test thread is calling waitForPendingKills.
+        Thread.detachNewThread {
+            // Let the subprocess return shortly after the drain begins,
+            // proving the wait actually observed the task's completion
+            // (rather than just timing out).
+            Thread.sleep(forTimeInterval: 0.1)
+            unblock.signal()
+        }
+        let start = Date()
+        svc.waitForPendingKills(timeout: 2.0)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(elapsed < 1.5, "drain should return when the kill completes, not at timeout")
+        #expect(recorder.calls.map(\.args) == [["kill", "alas-\(ZmxSessionName.hash16("wt-1"))-\(ZmxSessionName.hash16("leaf-drain"))"]])
+    }
+
+    @Test
+    func waitForPendingKillsReturnsImmediatelyWhenNothingPending() {
+        let recorder = RecordingRunner()
+        let svc = TerminalService(
+            zmxClient: ZmxClient(env: makeZmxEnv(available: true), runner: recorder.runner())
+        )
+
+        let start = Date()
+        svc.waitForPendingKills(timeout: 5.0)
+        #expect(Date().timeIntervalSince(start) < 0.1)
+    }
+
     // MARK: resolveLaunchPlan — keepSessionsAlive gating
 
     @Test func resolveLaunchPlanWrapsWhenKeepAliveTrueAndZmxAvailable() {


### PR DESCRIPTION
## Summary

Tab-close and worktree-delete already dispatch `zmx kill` for each leaf, but the kill ran in a fire-and-forget `Task.detached` that the process could outlive on Cmd-Q. Anything lost that way persisted forever because nothing on a subsequent launch ever tried to clean it up — a user reported accumulating "a bajillion" leftover sessions after lots of tab closing.

Two complementary fixes:

- **Boot-time sweep**: after `reloadTabs`, enumerate `zmx ls` and kill any `alas-<wtHash>-<leafHash>` session whose `wtHash` matches one of our worktrees but whose `leafHash` isn't in any persisted leaf. Multi-instance safe — another Alas under the same `ZMX_DIR` has different `wtHash` values, so its sessions stay untouched. Legacy `alas-<leafId>` names are skipped (close-path cleanup still handles those).
- **Quit-time drain**: track every dispatched kill task; in `applicationWillTerminate`, block up to 3s on a background awaiter so in-flight `zmx kill` subprocesses finish talking to the daemon before the process exits.

## Test plan

- [x] `xcodebuild test` — all 2948 tests pass
- [x] New tests cover orphan filter (multi-instance safety + legacy ignored), sweep dispatch, drain blocks until kill completes, drain no-op when nothing pending
- [ ] Manual: open tabs, close one, Cmd-Q quickly, relaunch → `zmx ls` shows no orphan for the closed tab
- [ ] Manual: simulate a leak (e.g. `zmx run alas-<wtHash>-<random>` against a known worktree), relaunch Alas → orphan gone after boot