### PR TITLE
fix(ACP): request parameterized model picker

### DIFF
--- a/Alas/Sources/ACP/Protocol/ACPMessages.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMessages.swift
@@ -106,21 +106,27 @@ struct ACPAuthCapabilities: Codable, Equatable {
 }
 
 struct ACPClientCapabilitiesMeta: Codable, Equatable {
-    static let terminalAuth = ACPClientCapabilitiesMeta(terminalAuth: true)
+    static let terminalAuth = ACPClientCapabilitiesMeta(
+        terminalAuth: true,
+        parameterizedModelPicker: true)
 
     let terminalAuth: Bool
+    let parameterizedModelPicker: Bool
 
-    init(terminalAuth: Bool) {
+    init(terminalAuth: Bool, parameterizedModelPicker: Bool = false) {
         self.terminalAuth = terminalAuth
+        self.parameterizedModelPicker = parameterizedModelPicker
     }
 
     enum CodingKeys: String, CodingKey {
         case terminalAuth = "terminal-auth"
+        case parameterizedModelPicker
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         terminalAuth = try c.decodeIfPresent(Bool.self, forKey: .terminalAuth) ?? false
+        parameterizedModelPicker = try c.decodeIfPresent(Bool.self, forKey: .parameterizedModelPicker) ?? false
     }
 }
 

--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -6,7 +6,16 @@ struct ACPChipState: Equatable {
     var models: ChipSpec?
     var mode: ChipSpec?
     var thinking: ChipSpec?
+    var parameters: [ACPParameterChip]
     var autoRun: ACPAgentProfiles.AutoRunSupport
+}
+
+/// Additional select config options returned by parameterized model pickers.
+/// These are not canonical ACP chips, but still need to stay reachable.
+struct ACPParameterChip: Identifiable, Equatable {
+    let id: String
+    let label: String
+    let spec: ChipSpec
 }
 
 /// A single chip's data, plus a tag remembering where it came from so the
@@ -65,8 +74,16 @@ extension ACPChipState {
                                 modes: availableModes,
                                 currentMode: currentMode,
                                 configOptions: configOptions)
+        let consumedConfigIds = Set([
+            configOptionId(from: models),
+            configOptionId(from: mode),
+            configOptionId(from: thinking),
+        ].compactMap { $0 })
+        let parameters = parameterChips(from: configOptions,
+                                        excluding: consumedConfigIds)
         var result = ACPChipState(models: models, mode: mode,
-                                  thinking: thinking, autoRun: routing.autoRun)
+                                  thinking: thinking, parameters: parameters,
+                                  autoRun: routing.autoRun)
 
         // Cursor encodes thinking as `[effort=…]` / `[thinking=…]` suffixes
         // on model variant ids. When the standard thinking heuristic finds
@@ -141,11 +158,50 @@ extension ACPChipState {
         category: String,
         in options: [ACPConfigOption]
     ) -> ChipSpec? {
-        let accepted: Set<String> = [category, category.prefix(1).uppercased() + category.dropFirst()]
         guard let opt = options.first(where: {
             guard let c = $0.category else { return false }
-            return accepted.contains(c)
+            return categoryMatches(c, category)
         }) else { return nil }
         return selectOption(id: opt.id, in: options)
+    }
+
+    private static func parameterChips(
+        from options: [ACPConfigOption],
+        excluding consumedIds: Set<String>
+    ) -> [ACPParameterChip] {
+        options.compactMap { opt in
+            guard opt.type == "select", !opt.options.isEmpty,
+                  !consumedIds.contains(opt.id),
+                  !isCanonicalCategory(opt.category) else {
+                return nil
+            }
+
+            return ACPParameterChip(
+                id: opt.id,
+                label: opt.name.isEmpty ? opt.id.capitalized : opt.name,
+                spec: ChipSpec(
+                    source: .configOption(id: opt.id),
+                    options: opt.options.map {
+                        ChipSpec.Item(id: $0.id, name: $0.name, description: $0.description)
+                    },
+                    currentId: opt.currentValue))
+        }
+    }
+
+    private static func configOptionId(from spec: ChipSpec?) -> String? {
+        guard case .configOption(let id)? = spec?.source else { return nil }
+        return id
+    }
+
+    private static func isCanonicalCategory(_ category: String?) -> Bool {
+        guard let category else { return false }
+        return categoryMatches(category, "model")
+            || categoryMatches(category, "mode")
+            || categoryMatches(category, "thought_level")
+            || categoryMatches(category, "ThoughtLevel")
+    }
+
+    private static func categoryMatches(_ actual: String, _ expected: String) -> Bool {
+        actual == expected || actual == expected.prefix(1).uppercased() + expected.dropFirst()
     }
 }

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -157,6 +157,9 @@ struct ACPComposer: View {
                 if let thinking = session.chipState.thinking {
                     thinkingChip(thinking)
                 }
+                ForEach(session.chipState.parameters) { parameter in
+                    parameterChip(parameter)
+                }
                 if let mode = session.chipState.mode {
                     modeChip(mode)
                 }
@@ -347,6 +350,13 @@ struct ACPComposer: View {
                     ?? "Model",
              placeholder: "Model",
              accent: theme.color("syntax-keyword"))
+    }
+
+    private func parameterChip(_ parameter: ACPParameterChip) -> some View {
+        chip(spec: parameter.spec,
+             label: chipLabel(prefix: parameter.label, spec: parameter.spec),
+             placeholder: parameter.label,
+             accent: theme.color("fg-muted"))
     }
 
     private func chip(spec: ChipSpec,

--- a/AlasTests/ACP/Protocol/ACPInitializeTests.swift
+++ b/AlasTests/ACP/Protocol/ACPInitializeTests.swift
@@ -63,6 +63,7 @@ struct ACPInitializeTests {
 
         #expect(auth["terminal"] as? Bool == true)
         #expect(meta["terminal-auth"] as? Bool == true)
+        #expect(meta["parameterizedModelPicker"] as? Bool == true)
         #expect(capabilities["terminal"] as? Bool == true)
         let fs = try #require(capabilities["fs"] as? [String: Any])
         #expect(fs["readTextFile"] as? Bool == true)

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -238,6 +238,34 @@ extension ACPChipStateTests {
         #expect(state.thinking?.options.map { $0.name } == ["Low", "High"])
     }
 
+    @Test("cursor-agent: parameterized config options expose Thinking chip")
+    func cursorParameterizedConfigOptionsExposeThinking() {
+        let state = ACPChipState.normalize(
+            agentId: "cursor-agent",
+            availableModels: [model("gpt-5.5", "GPT-5.5")],
+            currentModel: "gpt-5.5",
+            availableModes: [mode("agent", "Agent")],
+            currentMode: "agent",
+            configOptions: [
+                configOption("model",
+                             current: "gpt-5.5",
+                             options: [("default", "Auto"), ("gpt-5.5", "GPT-5.5")],
+                             category: "model"),
+                configOption("reasoning",
+                             current: "medium",
+                             options: [("none", "None"), ("low", "Low"), ("medium", "Medium"),
+                                       ("high", "High"), ("extra-high", "Extra High")],
+                             category: "thought_level"),
+            ])
+
+        #expect(state.models?.currentId == "gpt-5.5")
+        if case .configOption(let id)? = state.thinking?.source {
+            #expect(id == "reasoning")
+        } else { Issue.record("expected configOption source") }
+        #expect(state.thinking?.currentId == "medium")
+        #expect(state.thinking?.options.map { $0.name } == ["None", "Low", "Medium", "High", "Extra High"])
+    }
+
     @Test("cursor-agent: no brackets -> no synthesized chips")
     func cursorNoBracketsNoOverlay() {
         let state = ACPChipState.normalize(

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -256,6 +256,12 @@ extension ACPChipStateTests {
                              options: [("none", "None"), ("low", "Low"), ("medium", "Medium"),
                                        ("high", "High"), ("extra-high", "Extra High")],
                              category: "thought_level"),
+                configOption("context",
+                             current: "272k",
+                             options: [("272k", "272k"), ("1m", "1m")]),
+                configOption("fast",
+                             current: "false",
+                             options: [("false", "Off"), ("true", "On")]),
             ])
 
         #expect(state.models?.currentId == "gpt-5.5")
@@ -264,6 +270,8 @@ extension ACPChipStateTests {
         } else { Issue.record("expected configOption source") }
         #expect(state.thinking?.currentId == "medium")
         #expect(state.thinking?.options.map { $0.name } == ["None", "Low", "Medium", "High", "Extra High"])
+        #expect(state.parameters.map { $0.label } == ["Context", "Fast"])
+        #expect(state.parameters.map { $0.spec.currentId } == ["272k", "false"])
     }
 
     @Test("cursor-agent: no brackets -> no synthesized chips")


### PR DESCRIPTION
## Summary
- Advertise `_meta.parameterizedModelPicker` during ACP initialize so Cursor returns parameterized model controls.
- Cover the initialize payload and Cursor's parameterized `reasoning` config option becoming the Thinking chip.

## Test plan
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPInitializeTests -only-testing:AlasTests/ACPChipStateTests test`
- Launched the Debug app locally and confirmed the Cursor ACP Thinking selector appears and works.