### PR TITLE
Don't show empty state during worktree creation

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		28BFB7C825FE3CFD8999A988 /* CodePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC9895F48619E97461875 /* CodePane.swift */; };
 		28F42E0137436A3B5F72CB85 /* ACPImageEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDE53456308778DF77B18AF4 /* ACPImageEncodingTests.swift */; };
 		2908D330D59E98775E26C688 /* MarkdownPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9287C21CF9E153D3D6D19 /* MarkdownPreviewView.swift */; };
+		292E443F13B06303EAF8E24B /* CreatingWorktreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3AC3A1F7C5649E75015293 /* CreatingWorktreeView.swift */; };
 		29418562DE5554B282C83D75 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9289893FA7DC9DB8565353 /* MarkdownParser.swift */; };
 		295EF629FAAA46FCD6802F4E /* ScrollEventCapturingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22E44126BAFC8F3B515BAC0 /* ScrollEventCapturingView.swift */; };
 		29806D50EECB300991471A7C /* AlasCLIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */; };
@@ -1515,6 +1516,7 @@
 		BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndentationHelperTests.swift; sourceTree = "<group>"; };
 		BEC7CCBF8463A95EAAE9EBCE /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		BEFDCAF3F099FE539D9737E9 /* InstallSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSplitButton.swift; sourceTree = "<group>"; };
+		BF3AC3A1F7C5649E75015293 /* CreatingWorktreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatingWorktreeView.swift; sourceTree = "<group>"; };
 		BF3F87CE04B7E98606BF76CA /* CursorInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstallerTests.swift; sourceTree = "<group>"; };
 		BF7E57BC5EC8A465F26B3642 /* AlasCLIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLIRequest.swift; sourceTree = "<group>"; };
 		BFD267BE3F08611B376F3CC7 /* EditorConflictBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorConflictBanner.swift; sourceTree = "<group>"; };
@@ -2500,6 +2502,7 @@
 				F8685E5E5AC7A77D6D27A847 /* CenterPaneView.swift */,
 				0307CFD55404D01F14A5B602 /* CenterTypography.swift */,
 				C78D0715973BD840FDE95AA2 /* CloseTabConfirmationPolicy.swift */,
+				BF3AC3A1F7C5649E75015293 /* CreatingWorktreeView.swift */,
 				E1944B7BC9FC74CD09D816B6 /* DeleteFailedWorktreeView.swift */,
 				BDD799D0EC22F74A3DCB7F09 /* DeletingWorktreeView.swift */,
 				D76C02E43360C0BCFEDF5428 /* DiffOpenFileAvailability.swift */,
@@ -3700,6 +3703,7 @@
 				A77E7290FD589BC3227ADE27 /* ContentSearcher.swift in Sources */,
 				3FE3D85D5E833DE3A91FD444 /* CopilotInstaller.swift in Sources */,
 				0D17211026C6790B96CC6578 /* CopyFeedbackState.swift in Sources */,
+				292E443F13B06303EAF8E24B /* CreatingWorktreeView.swift in Sources */,
 				2D313A7E99C93242DD35AA8E /* CursorInstaller.swift in Sources */,
 				725EDB42BF126786D99E359A /* CursorModelVariants.swift in Sources */,
 				49C8C4C8B34444953FBA1809 /* DebounceTimer.swift in Sources */,

--- a/Alas/Sources/App/CenterSelectionState.swift
+++ b/Alas/Sources/App/CenterSelectionState.swift
@@ -4,6 +4,7 @@ enum CenterSelectionState: Equatable {
     case worktree(Worktree)
     case deleting(Worktree)
     case deleteFailed(Worktree, message: String)
+    case creating(Worktree)
     case empty
 }
 
@@ -19,6 +20,9 @@ struct CenterSelectionStateResolver {
             switch op {
             case .deleting:
                 if let wt = findWorktree(by: id) { return .deleting(wt) }
+                return .empty
+            case .creating:
+                if let wt = findWorktree(by: id) { return .creating(wt) }
                 return .empty
             case .deleteFailed(let message):
                 if let wt = findWorktree(by: id) { return .deleteFailed(wt, message: message) }

--- a/Alas/Sources/App/RootView.swift
+++ b/Alas/Sources/App/RootView.swift
@@ -244,6 +244,8 @@ struct RootView: View {
                     pb.setString(message, forType: .string)
                 }
             )
+        case .creating(let wt):
+            CreatingWorktreeView(worktree: wt)
         case .empty:
             EmptyTabView(
                 onNewTerminal: {},

--- a/Alas/Sources/Center/CreatingWorktreeView.swift
+++ b/Alas/Sources/Center/CreatingWorktreeView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct CreatingWorktreeView: View {
+    private static let phrases: [String] = [
+        "Reticulating splines…",
+        "Herding git objects…",
+        "Polishing branches…",
+        "Spinning up the universe…",
+        "Mixing the terminal sauce…",
+        "Assembling worktree scaffolding…",
+        "Charging the flux capacitor…",
+        "Aligning cosmic rays…",
+        "Waking the daemons…",
+        "Brewing fresh commits…",
+        "Calibrating git-fluence…",
+        "Untangling branches…",
+        "Loading witty phrases…",
+        "Inflating the worktree…",
+        "Summoning the merge spirits…",
+    ]
+
+    let worktree: Worktree
+
+    @State private var phrase: String = Self.phrases.randomElement() ?? Self.phrases[0]
+    @Environment(\.theme) var theme
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Spinner()
+                .frame(width: 32, height: 32)
+            Text(phrase)
+                .font(.system(size: 12))
+                .foregroundColor(theme.color("fg-dim"))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.color("bg-1"))
+    }
+}

--- a/AlasTests/CenterSelectionStateResolverTests.swift
+++ b/AlasTests/CenterSelectionStateResolverTests.swift
@@ -73,7 +73,7 @@ struct CenterSelectionStateResolverTests {
         }
     }
 
-    @Test func returnsEmptyForCreatingState() {
+    @Test func returnsCreatingForCreatingState() {
         let project = ProjectConfig(id: "p1", name: "A", path: "/tmp/a", color: "#fff", addedAt: Date())
         let wt = Worktree(id: "wt1", projectId: "p1", name: "main", branch: "main", path: URL(fileURLWithPath: "/tmp/a"), status: .clean, lastActivity: Date())
         let mgr = ProjectsManager(persistedProjects: [project])
@@ -85,7 +85,11 @@ struct CenterSelectionStateResolverTests {
             projectsManager: mgr
         )
         let result = resolver.resolve()
-        #expect(result == .empty)
+        if case .creating(let returned) = result {
+            #expect(returned.id == wt.id)
+        } else {
+            Issue.record("Expected .creating, got \(result)")
+        }
     }
 
     @Test func returnsEmptyForCreateFailedState() {


### PR DESCRIPTION
## Summary
- Added `.creating` case to `CenterSelectionState` so the center pane knows when a worktree is being created
- New `CreatingWorktreeView` shows a spinner with random fun loading phrase instead of the sad empty state
- Mirrors the right pane's existing `RightPaneTransitionalView` pattern

## Before
During worktree creation, the center pane briefly flashes `EmptyTabView` (🥺 "No tabs open") for 1-2 seconds while `git worktree add` runs.

## After
A loading view with the app's spinner and a randomly selected playful phrase (e.g. "Reticulating splines…", "Herding git objects…", etc.)

## Test Plan
- All 2944 tests pass
- Manually verified: create a worktree with terminal/ACP launch surface — no more empty state flash