### PR TITLE
fix(search): rebind picker rows when query changes

### DIFF
--- a/Alas/Sources/ACP/UI/ACPMentionPicker.swift
+++ b/Alas/Sources/ACP/UI/ACPMentionPicker.swift
@@ -76,7 +76,7 @@ struct ACPMentionPickerView: View {
                             .foregroundStyle(theme.color("fg-faint"))
                             .padding(.horizontal, 10).padding(.vertical, 10)
                     } else {
-                        ForEach(Array(ranked.enumerated()), id: \.element) { idx, file in
+                        ForEach(Array(ranked.enumerated()), id: \.offset) { idx, file in
                             row(idx: idx, file: file).id(idx)
                         }
                     }

--- a/Alas/Sources/ACP/UI/ACPSelectChip.swift
+++ b/Alas/Sources/ACP/UI/ACPSelectChip.swift
@@ -180,7 +180,7 @@ private struct DropdownPanel: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 1) {
-                        ForEach(Array(filtered.enumerated()), id: \.element.id) { idx, item in
+                        ForEach(Array(filtered.enumerated()), id: \.offset) { idx, item in
                             row(idx: idx, item: item)
                                 .id(idx)
                         }

--- a/Alas/Sources/Agents/AgentLauncherDialog.swift
+++ b/Alas/Sources/Agents/AgentLauncherDialog.swift
@@ -152,7 +152,7 @@ struct AgentLauncherDialog: View {
                     if agents.isEmpty {
                         emptyState
                     } else {
-                        ForEach(Array(agents.enumerated()), id: \.element.id) { idx, agent in
+                        ForEach(Array(agents.enumerated()), id: \.offset) { idx, agent in
                             AgentLauncherRow(
                                 agent: agent,
                                 isSelected: idx == appState.agentLauncher.selectedIndex,

--- a/Alas/Sources/Search/Views/ContentResultGroup.swift
+++ b/Alas/Sources/Search/Views/ContentResultGroup.swift
@@ -13,7 +13,7 @@ struct ContentResultGroupView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
-            ForEach(Array(group.hits.enumerated()), id: \.element.id) { offset, hit in
+            ForEach(Array(group.hits.enumerated()), id: \.offset) { offset, hit in
                 let absIndex = baseIndex + offset
                 hitRow(hit: hit, absIndex: absIndex, isSelected: absIndex == selectedIndex)
                     // Match the scroll-target id used by file rows so the

--- a/Alas/Sources/Search/Views/FileSearchDialog.swift
+++ b/Alas/Sources/Search/Views/FileSearchDialog.swift
@@ -61,7 +61,7 @@ struct FileSearchDialog: View {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         switch model.kind {
                         case .files:
-                            ForEach(Array(model.results.fileResults.enumerated()), id: \.element.id) { idx, r in
+                            ForEach(Array(model.results.fileResults.enumerated()), id: \.offset) { idx, r in
                                 FileResultRow(
                                     result: r,
                                     isSelected: idx == model.selectedIndex,


### PR DESCRIPTION
## Problem

Filtered list dialogs (Cmd+P file search, and several composer pickers) showed **stale row contents** when the query changed. Rows stayed frozen on whatever rendered when the dialog opened — even though the count badge and empty-state updated correctly. Deleting/retyping the query didn't refresh the visible rows.

## Root cause

A SwiftUI **dual-identity conflict** in the result `ForEach`:

```swift
ForEach(Array(items.enumerated()), id: \.element.id) { idx, item in   // identity = content
    Row(...).id(idx)                                                   // identity = index
}
```

`ForEach` keyed rows by content id (changes every query → "replace all rows"), while the inner `.id(idx)` pinned each row's structural identity to its index (stable across queries). Inside a `LazyVStack` these two identity systems fight, so SwiftUI reuses the row view sitting at each index **without rebinding the new element**. The view-models were always correct — this was purely a view-layer bug.

Confirmed at runtime with a temporary debug overlay: `model.results` held the correct filtered set every time while the list rendered stale rows.

## Fix

Make the `ForEach` identity index-based (`id: \.offset`) so it agrees with the inner `.id(idx)` and the index-based `ScrollViewReader.scrollTo(selectedIndex)`. One line per site.

Five instances of the identical pattern, all on lists that change as you type:

- `FileSearchDialog` (Files)
- `ContentResultGroup` (search Content tab)
- `ACPMentionPicker` (composer @-file picker)
- `ACPSelectChip` (composer select dropdown)
- `AgentLauncherDialog`

Other enumerated `ForEach`s were audited: `RepoSelectorDialog`, `ACPSlashPicker`, `CompletionPopup`, `LSPInstallProgressSheet` were already consistent (`id: \.offset`), and content-id lists without a conflicting inner `.id` are fine.

## Testing

- `AlasTests/SearchModelTests` — 20/20 pass.
- Manually verified in an isolated build (distinct bundle id to avoid the daily-driver collision): typing and deleting characters now updates the visible rows live across all five dialogs.

Note: SwiftUI view identity isn't unit-testable with the current setup, so the regression check is manual.