### PR TITLE
feat(github): add AI-assisted draft PR generation

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		027A326E7DAB6C6E133E5FD3 /* ACPSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E1BF90CB3BE5BFDFA2EC7C /* ACPSessionStore.swift */; };
 		02B055E21896C1C14D2D980D /* SectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934BCC470703CF2DF2303357 /* SectionHeader.swift */; };
 		02D2512D2B9128E93C7DF6D5 /* NewProjectDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6599EB47850D1E13ACF0EB /* NewProjectDialog.swift */; };
+		02DF9E0F3A3C1BE39026AF28 /* DraftReviewRequestTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79624D3718BCE5CC605F0D6D /* DraftReviewRequestTabView.swift */; };
 		03F3504B261E9E6C79C80DD5 /* TreeSitterHCL in Frameworks */ = {isa = PBXBuildFile; productRef = E5B5088DE61D8706D3F358F9 /* TreeSitterHCL */; };
 		0407824F9DA8EEFC5B5EEA8A /* InstallerHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C506EF972D34E2F937D4FEEC /* InstallerHost.swift */; };
 		043D6A4860C1336134311DD3 /* tool-call-content-terminal.json in Resources */ = {isa = PBXBuildFile; fileRef = D60051A6C7BEE35773F3FBB9 /* tool-call-content-terminal.json */; };
@@ -1354,6 +1355,7 @@
 		784A5C206CA363AB14B709E6 /* RepoSelectorRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoSelectorRecentsTests.swift; sourceTree = "<group>"; };
 		7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorInstaller.swift; sourceTree = "<group>"; };
 		795056B6AD803D2B555FC866 /* RightPaneStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStore.swift; sourceTree = "<group>"; };
+		79624D3718BCE5CC605F0D6D /* DraftReviewRequestTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraftReviewRequestTabView.swift; sourceTree = "<group>"; };
 		7963D4DD10B67EB683510FF6 /* SpaceConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpaceConfig.swift; sourceTree = "<group>"; };
 		79DDEA496740F5B0B5EE808B /* Process+Git.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Process+Git.swift"; sourceTree = "<group>"; };
 		79F544A8DC56D0D4166E0A4F /* CommitContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitContextBuilderTests.swift; sourceTree = "<group>"; };
@@ -2508,6 +2510,14 @@
 			path = UI;
 			sourceTree = "<group>";
 		};
+		4AF44827354C470592274005 /* ReviewRequest */ = {
+			isa = PBXGroup;
+			children = (
+				79624D3718BCE5CC605F0D6D /* DraftReviewRequestTabView.swift */,
+			);
+			path = ReviewRequest;
+			sourceTree = "<group>";
+		};
 		4DB62FEBC3C8536A56117C23 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
@@ -2626,6 +2636,7 @@
 				EA78AC4E93C2130046C92571 /* Commit */,
 				DF2861B461606810647C1676 /* ImageDiff */,
 				073E19743F9145840DD47C8B /* Merge */,
+				4AF44827354C470592274005 /* ReviewRequest */,
 			);
 			path = Center;
 			sourceTree = "<group>";
@@ -3855,6 +3866,7 @@
 				AC47E67A657F67FF9374C654 /* DiffTabView.swift in Sources */,
 				CDD25FF161CF6DC83D92EA77 /* DraftAmendPrefill.swift in Sources */,
 				9E349701BA73BBCCCBB135B3 /* DraftCommitTabView.swift in Sources */,
+				02DF9E0F3A3C1BE39026AF28 /* DraftReviewRequestTabView.swift in Sources */,
 				1F5AA7624BE0459338EE0EEC /* DragHandle.swift in Sources */,
 				A050BAECF89694B0D613C5D2 /* EditorBuffer.swift in Sources */,
 				B40925F2FDA34DC0444D8632 /* EditorBufferStore.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		412F8D73E3E5CD7F57CD799A /* CompletionWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F3A80227DD4A52C4752722 /* CompletionWindowController.swift */; };
 		4151B68B1CF0A947AEC4C00A /* ACPAuthNudgeBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B06E93430D1C7B02F6BB2 /* ACPAuthNudgeBannerTests.swift */; };
 		4153DAD75F27395D2D385BED /* LanguageServerAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8CC42BD54479E057902D392 /* LanguageServerAvailabilityTests.swift */; };
+		418D526733AA6B50A66CCCAF /* TabsManagerReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */; };
 		41C3F07661CA9B2B4E2C7BB1 /* GhosttyConfigBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCA505FF2E6CFA8278C95C6E /* GhosttyConfigBuilder.swift */; };
 		41C7E41360B2A443AE2A18B8 /* GhosttyHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 215C9AE9FBCB1FD9F6D030FE /* GhosttyHost.swift */; };
 		41E0F62323F788B8A3D3D731 /* ACPTerminalHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E504D11F9B69ACCE7B8E5CA4 /* ACPTerminalHost.swift */; };
@@ -1382,6 +1383,7 @@
 		82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeHostRemoteDetector.swift; sourceTree = "<group>"; };
 		82F696636690652C48CE87D9 /* AlasGhostty.Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasGhostty.Config.swift; sourceTree = "<group>"; };
 		835D847AD52A2CEB36DD5022 /* LegacyHookSweepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyHookSweepTests.swift; sourceTree = "<group>"; };
+		83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsManagerReviewRequestDraftTests.swift; sourceTree = "<group>"; };
 		84E56989C04A4A478D68084C /* ACPMarkdownBlockCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMarkdownBlockCacheTests.swift; sourceTree = "<group>"; };
 		8526C9DB63760BDD2CE998BD /* fs-write.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "fs-write.json"; sourceTree = "<group>"; };
 		8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpec.swift; sourceTree = "<group>"; };
@@ -2137,6 +2139,7 @@
 				9F650CFAC8E61B1EC99CD04A /* TabActivityPulseTransitionTests.swift */,
 				14907D679267359B3FB8A848 /* TabMergeConflictCodingTests.swift */,
 				70377E10CD6D08B225BDFABE /* TabsManagerBufferTests.swift */,
+				83A8622BA130E8FA339EDCEB /* TabsManagerReviewRequestDraftTests.swift */,
 				D6A9977C979705A40595FD5E /* TabsManagerTests.swift */,
 				4A777C0D1DB412458D46A628 /* TerminalCLIInjectionTests.swift */,
 				606DD97D8F66AC2B5883F984 /* TerminalIntegrationActionsTests.swift */,
@@ -4460,6 +4463,7 @@
 				90F619F67402DB675E2614CC /* TabActivityPulseTransitionTests.swift in Sources */,
 				2EA0D9B6F711518ECBF14CF7 /* TabMergeConflictCodingTests.swift in Sources */,
 				0563F6A02BFFE6B5013D2190 /* TabsManagerBufferTests.swift in Sources */,
+				418D526733AA6B50A66CCCAF /* TabsManagerReviewRequestDraftTests.swift in Sources */,
 				E822ADCC0B35087C38FB01A3 /* TabsManagerTests.swift in Sources */,
 				BEFFE99F341935C249CA4943 /* TerminalCLIInjectionTests.swift in Sources */,
 				CAE149AF78F3A62AC985EA2D /* TerminalIntegrationActionsTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		4C31A14595F4AE906BFE67D2 /* ACPAgentProfiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3692D5EB4BCA66AB702D43 /* ACPAgentProfiles.swift */; };
 		4CFC511BB3BEFB139BDF66F6 /* MemoryReportWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C3E23DCE2A602A87915ECE /* MemoryReportWindow.swift */; };
 		4D1584E4013D1A667723E4A6 /* MergeAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D74C28EB7B8C3CBC53994D /* MergeAgent.swift */; };
+		4D9A57C74B314FA3570B0406 /* GitServiceReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */; };
 		4E08D715B766E9D04B4BA0B0 /* WindowAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB020862232495EC1C5ECBEA /* WindowAppearance.swift */; };
 		4E352BDC87A204DE2912F54F /* ACPHarnessBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EABFDF5380D8D48B15312C /* ACPHarnessBridge.swift */; };
 		4E7279E8E76C7778BC686DF1 /* ProjectPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00809DCA566AAAADD7448659 /* ProjectPickerTests.swift */; };
@@ -713,6 +714,7 @@
 		C5644E1144140B99E8676064 /* ACPSlashPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C3F02ECEA5D545FA268DB8 /* ACPSlashPicker.swift */; };
 		C618DE3EE2A7CA06876D6C68 /* Process+Git.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DDEA496740F5B0B5EE808B /* Process+Git.swift */; };
 		C653712419D5B5A78AA53E84 /* AgentsPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5E3661944CDA65ABCCB826 /* AgentsPaneTests.swift */; };
+		C70D6BEC5321C16B70301CBF /* GitService+ReviewRequestDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */; };
 		C7A839C87B7C9F70F5BD6631 /* CompletionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B0831638833C386E5CC9E8 /* CompletionEngine.swift */; };
 		C7AACF777FF0DAD9ACA426F3 /* AgentLifecycleEventMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B4D726525024EBE47A0C7E /* AgentLifecycleEventMapper.swift */; };
 		C7EC6D85810513194F831F13 /* ACPConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C4BEC7F392AF938F468B1F /* ACPConnection.swift */; };
@@ -979,6 +981,7 @@
 		0DDCB33A74DC088022E5BD5F /* SymbolsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolsFeature.swift; sourceTree = "<group>"; };
 		0E6600436B01C75D85C01FFA /* Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clipboard.swift; sourceTree = "<group>"; };
 		0E9F9769B8C6EC2F87092F1B /* OKLCHTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OKLCHTests.swift; sourceTree = "<group>"; };
+		0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitService+ReviewRequestDraft.swift"; sourceTree = "<group>"; };
 		0F2A5B37528AD21CAD5ED051 /* ACPSessionAgentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionAgentStateTests.swift; sourceTree = "<group>"; };
 		0F68A9692F85197ED9E16262 /* WorktreesPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreesPane.swift; sourceTree = "<group>"; };
 		0FB91182CAC794B0BEDD222D /* ACPThoughtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPThoughtView.swift; sourceTree = "<group>"; };
@@ -1801,6 +1804,7 @@
 		FEC68B05B719B9235865027F /* ThreePaneSizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreePaneSizing.swift; sourceTree = "<group>"; };
 		FF741B889D6DC8B1F4EB350F /* ProcessGitDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitDataTests.swift; sourceTree = "<group>"; };
 		FFAFB40F5FACBC726C7E4172 /* ACPAdapterInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterInstaller.swift; sourceTree = "<group>"; };
+		FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceReviewRequestDraftTests.swift; sourceTree = "<group>"; };
 		FFE911B77AC087704180BDB5 /* ImageDiffModeApplicabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffModeApplicabilityTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -2035,6 +2039,7 @@
 				F936C036893FC70AD506FDD4 /* GitServiceDiscardTests.swift */,
 				38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */,
 				B9749FB435319F01F9E70D08 /* GitServiceMergeTests.swift */,
+				FFB1CCDE2E4D85A46E6CFB1A /* GitServiceReviewRequestDraftTests.swift */,
 				C2CA853E91C240B7B5551859 /* GitServiceStagedTests.swift */,
 				6DF0AEE54BDB4FC4FD5E02F4 /* GitServiceStagingTests.swift */,
 				039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */,
@@ -2248,6 +2253,7 @@
 				7F4A17C42833BE6190A45AF3 /* GitService+CommitEditing.swift */,
 				90817EC3BAA727EF6D9FBD97 /* GitService+Discard.swift */,
 				764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */,
+				0EE97D2D6875CD6A1DBF4DE9 /* GitService+ReviewRequestDraft.swift */,
 				D2F90D03073708AA01531533 /* GitService+Staging.swift */,
 				27A92711BC1D9A78D8A80561 /* GitTypes.swift */,
 				CB2EB554CB6AF797545DB95D /* HeadReader.swift */,
@@ -3889,6 +3895,7 @@
 				DF8CAD5714483408B8BD72F7 /* GitService+Discard.swift in Sources */,
 				E703B4895A0337310A17FED6 /* GitService+ImageDiff.swift in Sources */,
 				5846A180EB68D905E9775401 /* GitService+ReviewLoop.swift in Sources */,
+				C70D6BEC5321C16B70301CBF /* GitService+ReviewRequestDraft.swift in Sources */,
 				0A480D9D7CE5BB837D7BCA13 /* GitService+Staging.swift in Sources */,
 				12035048B950CE0197604F89 /* GitService.swift in Sources */,
 				676C9F2E4246D5E383F83F72 /* GitStatusCache.swift in Sources */,
@@ -4332,6 +4339,7 @@
 				2C520D1FB289610CEB70BDB6 /* GitServiceDiscardTests.swift in Sources */,
 				1B197F39E826079635F843EB /* GitServiceHeadMessageTests.swift in Sources */,
 				7BD8965290B1F007B0E99BCF /* GitServiceMergeTests.swift in Sources */,
+				4D9A57C74B314FA3570B0406 /* GitServiceReviewRequestDraftTests.swift in Sources */,
 				478863759224A2278123B7B9 /* GitServiceStagedTests.swift in Sources */,
 				CB27451157E1BF95BE47248A /* GitServiceStagingTests.swift in Sources */,
 				E8CCFE313DFCCA35BE8F93D7 /* GitServiceTests.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		2D313A7E99C93242DD35AA8E /* CursorInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7948BA9EC461BA2E3617FBF0 /* CursorInstaller.swift */; };
 		2D3E3F75B6CBDF63A3FF2CD7 /* ACPStarterPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C6D6594CCA4EBC83BDF264 /* ACPStarterPrompt.swift */; };
 		2D6004EEFF10BA1E2B1357B9 /* SettingsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92F018C967A8D1421D83A06 /* SettingsSectionTests.swift */; };
+		2D80BC255AB24FA274617553 /* ReviewRequestPromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */; };
 		2DB9FB7D9A00E93375624914 /* AlasGhostty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E21106B4804D62C1D3C7F62 /* AlasGhostty.swift */; };
 		2DE20AB5DAEF233BE008E5AA /* RepoSelectorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5A64AEDC7F12F08DA8D2A5 /* RepoSelectorRow.swift */; };
 		2E1D743806714BE4CD88A240 /* ContentSearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E83B4DDF185280E01CA80A /* ContentSearcherTests.swift */; };
@@ -945,6 +946,7 @@
 		05EE713DD3CACF29F206553C /* ThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeStore.swift; sourceTree = "<group>"; };
 		06375E561569DA36EC289C6F /* JSONRPCNewlineFramer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONRPCNewlineFramer.swift; sourceTree = "<group>"; };
 		074A17527610230DCFBEA13C /* ACPMockClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPMockClient.swift; sourceTree = "<group>"; };
+		07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestPromptEditorWindow.swift; sourceTree = "<group>"; };
 		07BC4D03723CEB1B6C2F9D15 /* TabActivityIconTintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabActivityIconTintTests.swift; sourceTree = "<group>"; };
 		08ACB3B79B74153668DA29D8 /* LSPTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LSPTransportTests.swift; sourceTree = "<group>"; };
 		08F7B16F39935718801DAA95 /* AppStateCLIRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCLIRoutingTests.swift; sourceTree = "<group>"; };
@@ -2552,6 +2554,7 @@
 				749E3289E4C70DA7E4DD80E6 /* MergeSingleResolvePromptEditorWindow.swift */,
 				0B2F41880B917155F7ADE622 /* MonospaceFontCatalog.swift */,
 				01B42244BDE33A69EDE16562 /* PromptEditorBody.swift */,
+				07A17183B064CAB5EB5D5C11 /* ReviewRequestPromptEditorWindow.swift */,
 				6A190D4B29B35C457AA9829F /* SettingsBinding.swift */,
 				F3678A2904CBBFAC939C9275 /* SettingsGroup.swift */,
 				515B67124EA11DDCC29B6E36 /* SettingsNavView.swift */,
@@ -4003,6 +4006,7 @@
 				877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */,
 				F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */,
 				7BBF0BCBD3121E1C20EF93CA /* ReviewReadinessModel.swift in Sources */,
+				2D80BC255AB24FA274617553 /* ReviewRequestPromptEditorWindow.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
 				6D5DF06E64DA191F1EE4B057 /* RightPaneStore.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		51370BBBB2BDE992F6BA8B04 /* EventHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25493E3B18A1AB94EA6985C3 /* EventHolder.swift */; };
 		513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDED937A8E8340D6E685A6E /* GitNameValidatorTests.swift */; };
 		514C75877C1C3B1D19BB5BD5 /* StartupScriptInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56EFAFF71ABDBCDECAAA305 /* StartupScriptInstaller.swift */; };
+		518D1D069F821B232469C414 /* ReviewRequestContextBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3979B98C0A060BB118239A5E /* ReviewRequestContextBuilderTests.swift */; };
 		518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */; };
 		51E0500756DC8DD5238F4D19 /* AppStateOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FCCEC91C40EBC896CF9089 /* AppStateOverlayTests.swift */; };
 		523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE8B45ECF898B83A616586D /* SubHeader.swift */; };
@@ -382,6 +383,7 @@
 		6AE129E340CA74CC26B34B66 /* ACPMarkdownLiveStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE565966DD010FDFD7DFF50 /* ACPMarkdownLiveStyler.swift */; };
 		6AFE04B669CA654D7733F97E /* AlasCLICommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1271747193D1594AEA596278 /* AlasCLICommandRouter.swift */; };
 		6B2B0731DBCD5D1BE353FFCB /* AlasGhostty.SurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCDD45C23BAE141549D03F /* AlasGhostty.SurfaceView.swift */; };
+		6B9E188A6C0A39C38D8723BF /* ReviewRequestDraftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */; };
 		6BF6FE50DAC473322005A036 /* ProjectsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5B91F414F99741818BCB17 /* ProjectsManagerTests.swift */; };
 		6C800C9827E75F9F07C67DB9 /* AppConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B78A7E7888D552AFC80BA3AA /* AppConfigTests.swift */; };
 		6C9E804AB246E7BFF8906C17 /* MarkdownTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09A66AE390C7748A8847C8E /* MarkdownTabView.swift */; };
@@ -735,6 +737,7 @@
 		CD227C48AA85A5E74A92DF3F /* GitRefNameInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF41571C93C1C34A77951E2 /* GitRefNameInputFilter.swift */; };
 		CD70FE88F62533B4A2A281B4 /* ACPMessageGutter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FCCD153F9C2AF78A7B2E47 /* ACPMessageGutter.swift */; };
 		CD7FB3120E4B194063C76817 /* ClaudeCodeACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AFF324FEE695AE18065D5A /* ClaudeCodeACPInstaller.swift */; };
+		CDA1193EF673BA40A6548B2B /* ReviewRequestDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB5BDBCB990CC0452BF9164 /* ReviewRequestDraft.swift */; };
 		CDBC720BF4B0A7BE2404208F /* IndentationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBFA80B52FFFE5496164177 /* IndentationHelperTests.swift */; };
 		CDD25FF161CF6DC83D92EA77 /* DraftAmendPrefill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F9CE2A0C76E75E95A641AE /* DraftAmendPrefill.swift */; };
 		CDE156FA8E19E85437E79908 /* CompletionFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C80F21C310F35EBA6FBDF58 /* CompletionFeatureTests.swift */; };
@@ -828,6 +831,7 @@
 		E4FA8142AB5FF2AA63BF6DA1 /* SpacePagerIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D9230E4E0DD70D689F40DD /* SpacePagerIndicatorTests.swift */; };
 		E51AC728D0735EEC53825C68 /* SidebarChromeTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02161104BA524379A359CB2D /* SidebarChromeTheme.swift */; };
 		E540B305B2426590C219622C /* CommitDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5A2BDAA7ABD74C42BC51F8 /* CommitDetailsTests.swift */; };
+		E541E14A713FB78AF4595FEB /* ReviewRequestContextBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */; };
 		E551A81EBC839478D6999A97 /* ACPComposerDraft.swift in Sources */ = {isa = PBXBuildFile; fileRef = A47981117B0CDB5F71DECD64 /* ACPComposerDraft.swift */; };
 		E681EB5B83BAC199B1ED5E24 /* WorktreeWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AD81E0DFE33CE4DACF0ADF /* WorktreeWatcher.swift */; };
 		E6A429E3423A9A40A9B36C97 /* RepoSelectorEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C7F4710313BA1671A3AED0 /* RepoSelectorEnvironment.swift */; };
@@ -936,6 +940,7 @@
 		033CEEE92FCAFF8A177428E4 /* ACPStreamingText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStreamingText.swift; sourceTree = "<group>"; };
 		0359D6646D12B66B70B5BB43 /* AiSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSplitButton.swift; sourceTree = "<group>"; };
 		039741E1CCAEF9770D5DEE08 /* GitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceTests.swift; sourceTree = "<group>"; };
+		039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestContextBuilder.swift; sourceTree = "<group>"; };
 		03D901BF4399752A3FC658F8 /* ACPSessionStoreQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionStoreQueueTests.swift; sourceTree = "<group>"; };
 		04B44F1DD775D2543439D508 /* ACPTranscriptMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPTranscriptMarkdown.swift; sourceTree = "<group>"; };
 		0535D92433898E76670B9FF0 /* ACPUserScrollEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPUserScrollEventTests.swift; sourceTree = "<group>"; };
@@ -1128,6 +1133,7 @@
 		38EAFDB135BDCF0DFF0121B1 /* ImageDiffPairKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffPairKind.swift; sourceTree = "<group>"; };
 		38F5019E0550FA05436EFC74 /* GitServiceHeadMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitServiceHeadMessageTests.swift; sourceTree = "<group>"; };
 		3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewLoopStateTests.swift; sourceTree = "<group>"; };
+		3979B98C0A060BB118239A5E /* ReviewRequestContextBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestContextBuilderTests.swift; sourceTree = "<group>"; };
 		3985F2F58DB6E3BBF3520EFD /* CodexACPInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexACPInstaller.swift; sourceTree = "<group>"; };
 		39DFD138FE855D8CFC464847 /* SearchFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFooter.swift; sourceTree = "<group>"; };
 		3A0FF718D68E15F539577F56 /* SearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResult.swift; sourceTree = "<group>"; };
@@ -1244,6 +1250,7 @@
 		57DEA304B6038D986A372150 /* BundledFontRegistrar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledFontRegistrar.swift; sourceTree = "<group>"; };
 		58B78EE378B0A076C904E2E4 /* TreeSitterLua */ = {isa = PBXFileReference; lastKnownFileType = folder; name = TreeSitterLua; path = ThirdParty/TreeSitterLua; sourceTree = SOURCE_ROOT; };
 		59DBB72EE97F0E906442919B /* CommitTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitTabView.swift; sourceTree = "<group>"; };
+		5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDraftTests.swift; sourceTree = "<group>"; };
 		5A43A7D90E591CFD18088C70 /* AgentLauncherModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentLauncherModel.swift; sourceTree = "<group>"; };
 		5A85E1D1600F487D359F363F /* RightPaneStateFileTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightPaneStateFileTreeTests.swift; sourceTree = "<group>"; };
 		5B3FF64CC698074BFDE2A36A /* ProjectConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectConfigTests.swift; sourceTree = "<group>"; };
@@ -1604,6 +1611,7 @@
 		C9FE7571B9A83F6BFFA6BFC6 /* GatekeeperRemediatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatekeeperRemediatorTests.swift; sourceTree = "<group>"; };
 		CA43AA9C8462D579E733B46C /* AppIntents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppIntents.framework; path = System/Library/Frameworks/AppIntents.framework; sourceTree = SDKROOT; };
 		CA554728676F9D3B5E2C05FA /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		CAB5BDBCB990CC0452BF9164 /* ReviewRequestDraft.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestDraft.swift; sourceTree = "<group>"; };
 		CAE286A9D5A0032AE582B5C6 /* ContentResultGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentResultGroup.swift; sourceTree = "<group>"; };
 		CB020862232495EC1C5ECBEA /* WindowAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearance.swift; sourceTree = "<group>"; };
 		CB0315FB9B537C0A240CFA32 /* ProjectsManagerProjectOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsManagerProjectOrderingTests.swift; sourceTree = "<group>"; };
@@ -2418,6 +2426,8 @@
 				17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */,
 				0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */,
 				467E833E3CE05D82DB88C5C5 /* ReviewReadinessModel.swift */,
+				039C5E652B7A9457EB13BD70 /* ReviewRequestContextBuilder.swift */,
+				CAB5BDBCB990CC0452BF9164 /* ReviewRequestDraft.swift */,
 			);
 			path = CodeHost;
 			sourceTree = "<group>";
@@ -3170,6 +3180,8 @@
 				4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */,
 				3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */,
 				D52FB6333DDC1A21B0959C1B /* ReviewReadinessModelTests.swift */,
+				3979B98C0A060BB118239A5E /* ReviewRequestContextBuilderTests.swift */,
+				5A1A152D4297DBB5B8DFF950 /* ReviewRequestDraftTests.swift */,
 			);
 			path = Integrations;
 			sourceTree = "<group>";
@@ -4006,6 +4018,8 @@
 				877BEC66CEBB5C495536FA20 /* ReviewLoopHandoffBuilder.swift in Sources */,
 				F5626F154B2CF446FF3F917B /* ReviewLoopState.swift in Sources */,
 				7BBF0BCBD3121E1C20EF93CA /* ReviewReadinessModel.swift in Sources */,
+				E541E14A713FB78AF4595FEB /* ReviewRequestContextBuilder.swift in Sources */,
+				CDA1193EF673BA40A6548B2B /* ReviewRequestDraft.swift in Sources */,
 				2D80BC255AB24FA274617553 /* ReviewRequestPromptEditorWindow.swift in Sources */,
 				FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */,
 				3C57603EA801D8994B0B5525 /* RightPaneState.swift in Sources */,
@@ -4406,6 +4420,8 @@
 				096304FB0EA9B5EC04D76C49 /* ReviewLoopHandoffBuilderTests.swift in Sources */,
 				9654335704CB69BA7216DD63 /* ReviewLoopStateTests.swift in Sources */,
 				D8957FC6D928555E7C360B6E /* ReviewReadinessModelTests.swift in Sources */,
+				518D1D069F821B232469C414 /* ReviewRequestContextBuilderTests.swift in Sources */,
+				6B9E188A6C0A39C38D8723BF /* ReviewRequestDraftTests.swift in Sources */,
 				C35CB6B466364169DF2616C3 /* RightPaneSelectionStateResolverTests.swift in Sources */,
 				38EB2BAA50A7B7B37DDE2A4C /* RightPaneStateBaseBranchTests.swift in Sources */,
 				21332BF444F30835C0C70AD6 /* RightPaneStateDiscardPathsTests.swift in Sources */,

--- a/Alas/Sources/App/AlasApp.swift
+++ b/Alas/Sources/App/AlasApp.swift
@@ -70,6 +70,13 @@ struct AlasApp: App {
         .windowResizability(.contentSize)
         .defaultSize(width: 720, height: 560)
 
+        Window("Review Request Prompt", id: "review-request-prompt-editor") {
+            ReviewRequestPromptEditorWindow(state: state)
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowResizability(.contentSize)
+        .defaultSize(width: 720, height: 560)
+
         Window("Merge: Resolve All Prompt", id: "merge-bulk-prompt-editor") {
             MergeBulkResolvePromptEditorWindow(state: state)
         }

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -215,8 +215,13 @@ struct CenterPaneView: View {
                         )
                         .id(draftState.id)
                     case .draftReviewRequest(let draftState):
-                        Text(draftState.displayTitle)
-                            .id(draftState.id)
+                        DraftReviewRequestTabView(
+                            worktreePath: worktree.path,
+                            worktreeId: worktree.id,
+                            tabState: draftState,
+                            appState: state
+                        )
+                        .id(draftState.id)
                     case .imagePreview(let s):
                         ImagePreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,

--- a/Alas/Sources/Center/CenterPaneView.swift
+++ b/Alas/Sources/Center/CenterPaneView.swift
@@ -214,6 +214,9 @@ struct CenterPaneView: View {
                             appState: state
                         )
                         .id(draftState.id)
+                    case .draftReviewRequest(let draftState):
+                        Text(draftState.displayTitle)
+                            .id(draftState.id)
                     case .imagePreview(let s):
                         ImagePreviewTabView(worktreePath: worktree.path,
                                              relativePath: s.relativePath,

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -1,0 +1,523 @@
+import AppKit
+import SwiftUI
+
+struct DraftReviewRequestTabView: View {
+    let worktreePath: URL
+    let worktreeId: String
+    let tabState: DraftReviewRequestTabState
+    @Bindable var appState: AppState
+
+    @State private var title: String = ""
+    @State private var bodyText: String = ""
+    @State private var createAsDraft: Bool = false
+    @State private var selectedPath: String?
+    @State private var context: ReviewRequestDraftContext?
+    @State private var busy = false
+    @State private var error: String?
+    @State private var warning: String?
+    @State private var loadingContext = false
+    @State private var loadedContextKey: String?
+    @State private var generation: Task<Void, Never>? = nil
+
+    @Environment(\.theme) private var theme
+    @FocusState private var focused: Field?
+
+    private let git = GitService()
+    private static let minPaneWidth: CGFloat = 140
+
+    private enum Field: Hashable { case title, body }
+
+    private var snapshot: ReviewLoopSnapshot? {
+        appState.rightPaneStore.activeState(worktreeId: worktreeId)?.reviewLoop.snapshot
+    }
+
+    private var validationMessage: String? {
+        ReviewRequestDraft.validationMessage(
+            for: ReviewRequestDraft.ValidationInput(
+                title: title,
+                body: bodyText,
+                snapshot: snapshot
+            )
+        )
+    }
+
+    private var canCreate: Bool {
+        validationMessage == nil && !busy && tabState.createdURL == nil
+    }
+
+    private var contextKey: String {
+        let head = snapshot?.local.headSHA ?? tabState.headSHA
+        let base = snapshot?.local.baseBranch ?? tabState.baseBranch
+        return "\(head):\(base)"
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            contextBrowser
+        }
+        .onAppear { hydrateFromTabState() }
+        .onChange(of: title) { _, new in persist(title: new) }
+        .onChange(of: bodyText) { _, new in persist(body: new) }
+        .onChange(of: createAsDraft) { _, new in persist(createAsDraft: new) }
+        .onChange(of: selectedPath) { _, new in persist(selectedPath: new) }
+        .task(id: contextKey) { await loadContext() }
+        .onDisappear {
+            generation?.cancel()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            headerRow
+            titleField
+            bodyEditor
+            if let warning {
+                Text(warning)
+                    .font(.system(size: 10.5))
+                    .foregroundColor(theme.color("warn"))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            if let validationMessage, tabState.createdURL == nil {
+                Text(validationMessage)
+                    .font(.system(size: 10.5))
+                    .foregroundColor(theme.color("fg-dim"))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            if let error {
+                InlineErrorStrip(message: error, onDismiss: { self.error = nil })
+            }
+        }
+        .padding(12)
+        .background(
+            LinearGradient(
+                colors: [theme.color("composer-bg-top"), theme.color("composer-bg-bot")],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+        .overlay(alignment: .top) {
+            LinearGradient(
+                colors: [
+                    Color.clear,
+                    theme.color("accent-glow"),
+                    Color.clear,
+                ],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(height: 1)
+        }
+        .overlay(Divider().opacity(0.5), alignment: .bottom)
+    }
+
+    private var headerRow: some View {
+        HStack(spacing: 8) {
+            Icon(name: "branch", size: 12, color: theme.color("accent"))
+            Text("\(tabState.provider.displayName) \(tabState.provider.reviewRequestLabel)")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(theme.color("fg"))
+            Text(tabState.repositorySlug.isEmpty ? "Unknown repository" : tabState.repositorySlug)
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-dim"))
+            Text("\(tabState.branchName) -> \(tabState.baseBranch)")
+                .font(.system(size: 11))
+                .foregroundColor(theme.color("fg-faint"))
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+            Toggle(isOn: $createAsDraft) {
+                Text("Draft")
+                    .font(.system(size: 11))
+                    .foregroundColor(theme.color("fg-dim"))
+            }
+            .toggleStyle(.checkbox)
+            .disabled(busy || tabState.createdURL != nil)
+            AiSplitButton(
+                availableAgents: appState.agentRegistry.enabled(),
+                selectedToolId: appState.bind(\.changes.aiToolId),
+                busy: busy,
+                onGenerate: handleGenerate
+            )
+            createButton
+            if let createdURL = tabState.createdURL {
+                AlasButton(title: "Open \(tabState.provider.reviewRequestLabel)", icon: "arrow.up.right.square") {
+                    NSWorkspace.shared.open(createdURL)
+                }
+            }
+        }
+    }
+
+    private var createButton: some View {
+        Button(action: createReviewRequest) {
+            HStack(spacing: 8) {
+                if busy {
+                    Spinner(lineWidth: 1.5, duration: 0.7)
+                        .frame(width: 12, height: 12)
+                }
+                Text("Create \(tabState.provider.reviewRequestLabel)")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .padding(.horizontal, 14)
+            .frame(height: 28)
+            .foregroundColor(.white)
+            .background(canCreate ? theme.color("accent") : theme.color("accent").opacity(0.4))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .disabled(!canCreate)
+    }
+
+    private var titleField: some View {
+        TextField("Title", text: $title)
+            .textFieldStyle(.plain)
+            .font(.system(size: 12.5, weight: .medium))
+            .foregroundColor(theme.color("fg"))
+            .padding(.horizontal, 10)
+            .frame(height: 30)
+            .background(theme.color("field-bg"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(
+                        focused == .title ? theme.color("accent") : theme.color("line"),
+                        lineWidth: focused == .title ? 1 : 0.5
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(
+                        focused == .title ? theme.color("accent-glow-soft") : .clear,
+                        lineWidth: 2
+                    )
+                    .padding(-2)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .focused($focused, equals: .title)
+            .disabled(busy || tabState.createdURL != nil)
+    }
+
+    private var bodyEditor: some View {
+        TextEditor(text: $bodyText)
+            .font(.system(size: 12, design: .monospaced))
+            .frame(minHeight: 90, maxHeight: 180)
+            .scrollContentBackground(.hidden)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+            .background(theme.color("field-bg"))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(
+                        focused == .body ? theme.color("accent") : theme.color("line"),
+                        lineWidth: focused == .body ? 1 : 0.5
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(
+                        focused == .body ? theme.color("accent-glow-soft") : .clear,
+                        lineWidth: 2
+                    )
+                    .padding(-2)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .focused($focused, equals: .body)
+            .disabled(busy || tabState.createdURL != nil)
+    }
+
+    private var contextBrowser: some View {
+        GeometryReader { proxy in
+            let total = proxy.size.width
+            let ratio = max(0.15, min(0.7, appState.config.commitDetailSplitRatio))
+            let leftWidth = max(Self.minPaneWidth, total * ratio)
+            HStack(spacing: 0) {
+                leftContextPane
+                    .frame(width: leftWidth)
+                DragHandle(axis: .horizontal, onDrag: { delta in
+                    guard total > 0 else { return }
+                    let newWidth = max(Self.minPaneWidth, min(total - Self.minPaneWidth, leftWidth + delta))
+                    appState.config.commitDetailSplitRatio = newWidth / total
+                    appState.saveConfig()
+                })
+                rightContextPane
+            }
+        }
+    }
+
+    private var leftContextPane: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            contextSectionTitle("Commits")
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array((context?.commitSubjects ?? []).enumerated()), id: \.offset) { _, subject in
+                        Text(subject)
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.color("fg"))
+                            .lineLimit(2)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                    }
+                }
+            }
+            .frame(minHeight: 74)
+            Divider()
+            contextSectionTitle("Files")
+            fileList
+        }
+        .background(theme.color("bg-1"))
+    }
+
+    private var fileList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(context?.changedFiles ?? []) { file in
+                    Button {
+                        selectedPath = file.path
+                    } label: {
+                        HStack(spacing: 8) {
+                            Text(file.status)
+                                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                                .foregroundColor(statusColor(file.status))
+                                .frame(width: 18, alignment: .leading)
+                            Text(file.path)
+                                .font(.system(size: 11))
+                                .foregroundColor(theme.color("fg"))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Text("+\(file.add) -\(file.del)")
+                                .font(.system(size: 10, design: .monospaced))
+                                .foregroundColor(theme.color("fg-faint"))
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(selectedPath == file.path ? theme.color("accent").opacity(0.2) : Color.clear)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var rightContextPane: some View {
+        Group {
+            if loadingContext {
+                Spinner()
+                    .frame(width: 20, height: 20)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let context {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let selectedPath,
+                       let file = context.changedFiles.first(where: { $0.path == selectedPath }) {
+                        HStack(spacing: 8) {
+                            Text(file.path)
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundColor(theme.color("fg"))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Text("\(file.status)  +\(file.add) -\(file.del)")
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundColor(theme.color("fg-dim"))
+                        }
+                    } else {
+                        Text("Branch diff")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(theme.color("fg"))
+                    }
+                    ScrollView([.horizontal, .vertical]) {
+                        Text(context.diff.isEmpty ? "No committed diff." : context.diff)
+                            .font(.system(
+                                size: CGFloat(appState.config.code.fontSize),
+                                design: .monospaced
+                            ))
+                            .foregroundColor(theme.color("fg"))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(12)
+                    }
+                    .background(theme.color("field-bg"))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(theme.color("line"), lineWidth: 0.5)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .padding(12)
+            } else {
+                VStack(spacing: 8) {
+                    Text("No committed branch context.")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(theme.color("fg-dim"))
+                    AlasButton(title: "Reload", icon: "arrow.clockwise") {
+                        Task { await loadContext() }
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .background(theme.color("bg-0"))
+    }
+
+    private func contextSectionTitle(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundColor(theme.color("fg-faint"))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(theme.color("bg-2"))
+    }
+
+    private func hydrateFromTabState() {
+        title = tabState.title
+        bodyText = tabState.body
+        createAsDraft = tabState.createAsDraft
+        selectedPath = tabState.selectedPath
+    }
+
+    private func persist(
+        title: String? = nil,
+        body: String? = nil,
+        createAsDraft: Bool? = nil,
+        selectedPath: String?? = nil,
+        createdURL: URL?? = nil
+    ) {
+        appState.tabs.updateDraftReviewRequest(worktreeId: worktreeId, tabId: tabState.id) { state in
+            if let title { state.title = title }
+            if let body { state.body = body }
+            if let createAsDraft { state.createAsDraft = createAsDraft }
+            if let selectedPath { state.selectedPath = selectedPath }
+            if let createdURL { state.createdURL = createdURL }
+        }
+    }
+
+    private func loadContext() async {
+        let key = contextKey
+        let baseRef = snapshot?.local.baseBranch ?? tabState.baseBranch
+        loadingContext = true
+        context = nil
+        loadedContextKey = nil
+        warning = nil
+        error = nil
+        defer {
+            if key == contextKey {
+                loadingContext = false
+            }
+        }
+        do {
+            let loaded = try await git.reviewRequestDraftContext(
+                worktreePath: worktreePath,
+                baseRef: baseRef
+            )
+            guard !Task.isCancelled, key == contextKey else { return }
+            context = loaded
+            loadedContextKey = key
+            warning = loaded.hasUncommittedChanges
+                ? "Uncommitted changes are present but excluded from this \(tabState.provider.reviewRequestLabel)."
+                : nil
+            if let selectedPath, loaded.changedFiles.contains(where: { $0.path == selectedPath }) {
+                return
+            }
+            selectedPath = loaded.changedFiles.first?.path
+        } catch {
+            guard !Task.isCancelled, key == contextKey else { return }
+            self.error = (error as NSError).localizedDescription
+        }
+    }
+
+    private func handleGenerate() {
+        if busy {
+            generation?.cancel()
+            return
+        }
+        guard let agent = appState.agent(id: appState.config.changes.aiToolId) else {
+            error = "Select an AI tool to generate a \(tabState.provider.reviewRequestLabel) description."
+            return
+        }
+        guard !loadingContext, loadedContextKey == contextKey, let context else {
+            error = "Branch context is still loading."
+            return
+        }
+
+        busy = true
+        error = nil
+        let provider = tabState.provider.displayName
+        let repository = tabState.repositorySlug
+        let branch = snapshot?.local.branchName ?? tabState.branchName
+        let base = snapshot?.local.baseBranch ?? tabState.baseBranch
+        let prompt = appState.config.changes.reviewRequestPrompt
+        let payload = ReviewRequestContextBuilder.build(
+            provider: provider,
+            repository: repository,
+            branch: branch,
+            base: base,
+            hasUncommittedChanges: context.hasUncommittedChanges,
+            commitSubjects: context.commitSubjects,
+            diff: context.diff
+        )
+
+        generation = Task { @MainActor in
+            defer {
+                busy = false
+                generation = nil
+            }
+            do {
+                let raw = try await AgentRunner.runPromptRaw(
+                    agent: agent,
+                    input: payload,
+                    prompt: prompt,
+                    workingDirectory: worktreePath.path
+                )
+                guard !Task.isCancelled else { return }
+                let message = try ReviewRequestDraft.parseGeneratedMessage(raw)
+                title = message.title
+                bodyText = message.body
+            } catch is CancellationError {
+                // user-cancelled
+            } catch {
+                self.error = (error as NSError).localizedDescription
+            }
+        }
+    }
+
+    private func createReviewRequest() {
+        guard !busy, let snapshot, validationMessage == nil else { return }
+        busy = true
+        error = nil
+        let titleSnapshot = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let bodySnapshot = bodyText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let draftSnapshot = createAsDraft
+        Task { @MainActor in
+            defer { busy = false }
+            do {
+                let url = try await appState.rightPaneStore
+                    .activeState(worktreeId: worktreeId)?
+                    .reviewLoop
+                    .createReviewRequest(
+                        snapshot: snapshot,
+                        title: titleSnapshot,
+                        body: bodySnapshot,
+                        isDraft: draftSnapshot
+                    )
+                guard let url else {
+                    error = "Review state is still loading."
+                    return
+                }
+                persist(createdURL: url)
+                await appState.rightPaneStore.refresh(worktreeId: worktreeId)
+            } catch {
+                self.error = (error as NSError).localizedDescription
+            }
+        }
+    }
+
+    private func statusColor(_ status: String) -> Color {
+        switch status {
+        case "A": return theme.color("add")
+        case "D": return theme.color("del")
+        case "R", "C": return theme.color("accent")
+        default: return theme.color("fg-dim")
+        }
+    }
+}

--- a/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
+++ b/Alas/Sources/Center/ReviewRequest/DraftReviewRequestTabView.swift
@@ -31,8 +31,20 @@ struct DraftReviewRequestTabView: View {
         appState.rightPaneStore.activeState(worktreeId: worktreeId)?.reviewLoop.snapshot
     }
 
+    private var matchingSnapshot: ReviewLoopSnapshot? {
+        guard let snapshot, tabState.matchesTarget(snapshot) else { return nil }
+        return snapshot
+    }
+
+    private var targetMismatchMessage: String? {
+        guard let snapshot else { return nil }
+        guard !tabState.matchesTarget(snapshot) else { return nil }
+        return "This draft targets \(tabState.branchName) at \(tabState.headSHA.prefix(7)). Switch back to that branch state before creating it."
+    }
+
     private var validationMessage: String? {
-        ReviewRequestDraft.validationMessage(
+        if let targetMismatchMessage { return targetMismatchMessage }
+        return ReviewRequestDraft.validationMessage(
             for: ReviewRequestDraft.ValidationInput(
                 title: title,
                 body: bodyText,
@@ -46,8 +58,8 @@ struct DraftReviewRequestTabView: View {
     }
 
     private var contextKey: String {
-        let head = snapshot?.local.headSHA ?? tabState.headSHA
-        let base = snapshot?.local.baseBranch ?? tabState.baseBranch
+        let head = matchingSnapshot?.local.headSHA ?? tabState.headSHA
+        let base = matchingSnapshot?.local.baseBranch ?? tabState.baseBranch
         return "\(head):\(base)"
     }
 
@@ -86,6 +98,18 @@ struct DraftReviewRequestTabView: View {
             }
             if let error {
                 InlineErrorStrip(message: error, onDismiss: { self.error = nil })
+            }
+            if let createdURL = tabState.createdURL {
+                HStack(spacing: 6) {
+                    Icon(name: "link", size: 11, color: theme.color("accent"))
+                    Text(createdURL.absoluteString)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(theme.color("fg-dim"))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .padding(12)
@@ -307,6 +331,7 @@ struct DraftReviewRequestTabView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let context {
                 VStack(alignment: .leading, spacing: 8) {
+                    let preview = selectedDiffPreview(in: context)
                     if let selectedPath,
                        let file = context.changedFiles.first(where: { $0.path == selectedPath }) {
                         HStack(spacing: 8) {
@@ -326,7 +351,7 @@ struct DraftReviewRequestTabView: View {
                             .foregroundColor(theme.color("fg"))
                     }
                     ScrollView([.horizontal, .vertical]) {
-                        Text(context.diff.isEmpty ? "No committed diff." : context.diff)
+                        Text(preview.diff.isEmpty ? "No committed diff." : preview.diff)
                             .font(.system(
                                 size: CGFloat(appState.config.code.fontSize),
                                 design: .monospaced
@@ -394,7 +419,6 @@ struct DraftReviewRequestTabView: View {
 
     private func loadContext() async {
         let key = contextKey
-        let baseRef = snapshot?.local.baseBranch ?? tabState.baseBranch
         loadingContext = true
         context = nil
         loadedContextKey = nil
@@ -405,10 +429,14 @@ struct DraftReviewRequestTabView: View {
                 loadingContext = false
             }
         }
+        guard matchingSnapshot != nil else {
+            warning = targetMismatchMessage
+            return
+        }
         do {
             let loaded = try await git.reviewRequestDraftContext(
                 worktreePath: worktreePath,
-                baseRef: baseRef
+                baseRef: tabState.baseBranch
             )
             guard !Task.isCancelled, key == contextKey else { return }
             context = loaded
@@ -435,6 +463,10 @@ struct DraftReviewRequestTabView: View {
             error = "Select an AI tool to generate a \(tabState.provider.reviewRequestLabel) description."
             return
         }
+        guard matchingSnapshot != nil else {
+            error = targetMismatchMessage
+            return
+        }
         guard !loadingContext, loadedContextKey == contextKey, let context else {
             error = "Branch context is still loading."
             return
@@ -444,14 +476,12 @@ struct DraftReviewRequestTabView: View {
         error = nil
         let provider = tabState.provider.displayName
         let repository = tabState.repositorySlug
-        let branch = snapshot?.local.branchName ?? tabState.branchName
-        let base = snapshot?.local.baseBranch ?? tabState.baseBranch
         let prompt = appState.config.changes.reviewRequestPrompt
         let payload = ReviewRequestContextBuilder.build(
             provider: provider,
             repository: repository,
-            branch: branch,
-            base: base,
+            branch: tabState.branchName,
+            base: tabState.baseBranch,
             hasUncommittedChanges: context.hasUncommittedChanges,
             commitSubjects: context.commitSubjects,
             diff: context.diff
@@ -482,7 +512,7 @@ struct DraftReviewRequestTabView: View {
     }
 
     private func createReviewRequest() {
-        guard !busy, let snapshot, validationMessage == nil else { return }
+        guard !busy, let snapshot = matchingSnapshot, validationMessage == nil else { return }
         busy = true
         error = nil
         let titleSnapshot = title.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -496,6 +526,9 @@ struct DraftReviewRequestTabView: View {
                     .reviewLoop
                     .createReviewRequest(
                         snapshot: snapshot,
+                        branch: tabState.branchName,
+                        headOwner: tabState.headOwner,
+                        baseBranch: tabState.baseBranch,
                         title: titleSnapshot,
                         body: bodySnapshot,
                         isDraft: draftSnapshot
@@ -510,6 +543,15 @@ struct DraftReviewRequestTabView: View {
                 self.error = (error as NSError).localizedDescription
             }
         }
+    }
+
+    private func selectedDiffPreview(in context: ReviewRequestDraftContext) -> (path: String?, diff: String) {
+        guard let selectedPath,
+              let diff = context.fileDiffsByPath[selectedPath]
+        else {
+            return (nil, context.diff)
+        }
+        return (selectedPath, diff)
     }
 
     private func statusColor(_ status: String) -> Color {

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -170,6 +170,9 @@ struct DraftReviewRequestTabState: Codable, Equatable, Identifiable {
     }
 
     mutating func refreshSnapshotMetadata(from snapshot: ReviewLoopSnapshot) {
+        if headSHA != snapshot.local.headSHA {
+            createdURL = nil
+        }
         headOwner = snapshot.local.headRemoteOwner
         headSHA = snapshot.local.headSHA
     }

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -9,6 +9,7 @@ enum Tab: Codable, Equatable, Identifiable {
     case commit(CommitTabState)
     case commitEditor(CommitEditorTabState)
     case draftCommit(DraftCommitTabState)
+    case draftReviewRequest(DraftReviewRequestTabState)
     case imagePreview(ImagePreviewTabState)
     case mergeConflict(MergeConflictTabState)
     case acpSession(ACPSessionTabState)
@@ -21,6 +22,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .commit(let s):       return s.id
         case .commitEditor(let s): return s.id
         case .draftCommit(let s):  return s.id
+        case .draftReviewRequest(let s): return s.id
         case .imagePreview(let s): return s.id
         case .mergeConflict(let s): return s.id
         case .acpSession(let s):   return s.id
@@ -35,6 +37,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .commit(let s):       return s.title
         case .commitEditor(let s): return s.title
         case .draftCommit:         return "Draft commit"
+        case .draftReviewRequest(let s): return s.displayTitle
         case .imagePreview(let s): return s.title
         case .mergeConflict(let s): return s.title
         case .acpSession(let s):   return s.title
@@ -49,6 +52,7 @@ enum Tab: Codable, Equatable, Identifiable {
         case .commit:       return "commit"
         case .commitEditor: return "commit"
         case .draftCommit:  return "commit"
+        case .draftReviewRequest: return "pull-request"
         case .imagePreview: return "image"
         case .mergeConflict: return "diff"
         case .acpSession:   return "sparkle"
@@ -118,6 +122,56 @@ struct DraftCommitTabState: Codable, Equatable, Identifiable {
         self.bodyText = bodyText
         self.amend = amend
         self.selectedPath = selectedPath
+    }
+}
+
+struct DraftReviewRequestTabState: Codable, Equatable, Identifiable {
+    let id: TabID
+    let worktreeId: String
+    let provider: CodeHostKind
+    let repositorySlug: String
+    let branchName: String
+    let baseBranch: String
+    var headOwner: String?
+    var headSHA: String
+    var title: String
+    var body: String
+    var createAsDraft: Bool
+    var selectedPath: String?
+    var createdURL: URL?
+
+    var displayTitle: String {
+        if createdURL != nil { return "\(provider.reviewRequestLabel) created" }
+        return "Draft \(provider.reviewRequestLabel)"
+    }
+
+    init(worktreeId: String, snapshot: ReviewLoopSnapshot) {
+        let provider = snapshot.remote?.kind ?? .github
+        self.worktreeId = worktreeId
+        self.provider = provider
+        self.repositorySlug = snapshot.remote?.repositorySlug ?? ""
+        self.branchName = snapshot.local.branchName
+        self.baseBranch = snapshot.local.baseBranch
+        self.id = [
+            "draft-review-request",
+            worktreeId,
+            provider.rawValue,
+            self.repositorySlug,
+            snapshot.local.branchName,
+            snapshot.local.baseBranch,
+        ].joined(separator: ":")
+        self.headOwner = snapshot.local.headRemoteOwner
+        self.headSHA = snapshot.local.headSHA
+        self.title = ""
+        self.body = ""
+        self.createAsDraft = false
+        self.selectedPath = nil
+        self.createdURL = nil
+    }
+
+    mutating func refreshSnapshotMetadata(from snapshot: ReviewLoopSnapshot) {
+        headOwner = snapshot.local.headRemoteOwner
+        headSHA = snapshot.local.headSHA
     }
 }
 

--- a/Alas/Sources/Center/Tab.swift
+++ b/Alas/Sources/Center/Tab.swift
@@ -173,6 +173,14 @@ struct DraftReviewRequestTabState: Codable, Equatable, Identifiable {
         headOwner = snapshot.local.headRemoteOwner
         headSHA = snapshot.local.headSHA
     }
+
+    func matchesTarget(_ snapshot: ReviewLoopSnapshot) -> Bool {
+        snapshot.remote?.kind == provider
+            && snapshot.remote?.repositorySlug == repositorySlug
+            && snapshot.local.branchName == branchName
+            && snapshot.local.baseBranch == baseBranch
+            && snapshot.local.headSHA == headSHA
+    }
 }
 
 struct TerminalTabState: Codable, Equatable, Identifiable {

--- a/Alas/Sources/Center/TabsManager.swift
+++ b/Alas/Sources/Center/TabsManager.swift
@@ -643,6 +643,43 @@ final class TabsManager {
         return tab
     }
 
+    @discardableResult
+    func openOrFocusDraftReviewRequest(worktreeId: String, snapshot: ReviewLoopSnapshot) -> Tab {
+        let baseState = DraftReviewRequestTabState(worktreeId: worktreeId, snapshot: snapshot)
+        if var file = byWorktree[worktreeId],
+           let idx = file.tabs.firstIndex(where: { $0.id == baseState.id }),
+           case .draftReviewRequest(var existing) = file.tabs[idx] {
+            existing.refreshSnapshotMetadata(from: snapshot)
+            let tab = Tab.draftReviewRequest(existing)
+            file.tabs[idx] = tab
+            file.activeTabId = tab.id
+            byWorktree[worktreeId] = file
+            persist(worktreeId)
+            return tab
+        }
+        let tab = Tab.draftReviewRequest(baseState)
+        append(tab, to: worktreeId)
+        return tab
+    }
+
+    @discardableResult
+    func updateDraftReviewRequest(
+        worktreeId: String,
+        tabId: TabID,
+        mutate: (inout DraftReviewRequestTabState) -> Void
+    ) -> Tab? {
+        guard var file = byWorktree[worktreeId],
+              let idx = file.tabs.firstIndex(where: { $0.id == tabId }),
+              case .draftReviewRequest(var state) = file.tabs[idx]
+        else { return nil }
+        mutate(&state)
+        let tab = Tab.draftReviewRequest(state)
+        file.tabs[idx] = tab
+        byWorktree[worktreeId] = file
+        persist(worktreeId)
+        return tab
+    }
+
     /// Clear any stashed draft commit state for the given worktree.
     /// Used when the user explicitly discards the draft (via tab context
     /// menu) or after a successful commit consumes the draft.

--- a/Alas/Sources/Git/GitService+ReviewRequestDraft.swift
+++ b/Alas/Sources/Git/GitService+ReviewRequestDraft.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+struct ReviewRequestDraftContext: Equatable {
+    let commitSubjects: [String]
+    let changedFiles: [CommitChangedFile]
+    let diff: String
+    let hasUncommittedChanges: Bool
+}
+
+extension GitService {
+    func reviewRequestDraftContext(worktreePath: URL, baseRef: String) async throws -> ReviewRequestDraftContext {
+        async let subjectsResult = Process.git(
+            ["log", "\(baseRef)..HEAD", "--pretty=format:%s"],
+            cwd: worktreePath
+        )
+        async let diffResult = Process.git(
+            ["diff", "--no-color", "-M", "\(baseRef)..HEAD"],
+            cwd: worktreePath
+        )
+        async let filesResult = Process.git(
+            ["diff", "--no-color", "-M", "--numstat", "\(baseRef)..HEAD"],
+            cwd: worktreePath
+        )
+        async let namesResult = Process.git(
+            ["diff", "--no-color", "-M", "--name-status", "\(baseRef)..HEAD"],
+            cwd: worktreePath
+        )
+        async let statusResult = Process.git(
+            ["status", "--porcelain"],
+            cwd: worktreePath
+        )
+
+        let subjects = try await subjectsResult
+        let diff = try await diffResult
+        let files = try await filesResult
+        let names = try await namesResult
+        let status = try await statusResult
+
+        try Self.assertReviewRequestSuccess(subjects)
+        try Self.assertReviewRequestSuccess(diff)
+        try Self.assertReviewRequestSuccess(files)
+        try Self.assertReviewRequestSuccess(names)
+        try Self.assertReviewRequestSuccess(status)
+
+        let commitSubjects = subjects.stdout
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map(String.init)
+
+        let changedFiles = Self.reviewRequestChangedFiles(numstat: files.stdout, nameStatus: names.stdout)
+
+        return ReviewRequestDraftContext(
+            commitSubjects: commitSubjects,
+            changedFiles: changedFiles,
+            diff: diff.stdout,
+            hasUncommittedChanges: !status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        )
+    }
+
+    private static func assertReviewRequestSuccess(_ result: ProcessResult) throws {
+        guard result.exitCode == 0 else {
+            throw ProcessError.nonZeroExit(result.exitCode, result.stderr)
+        }
+    }
+
+    private static func reviewRequestChangedFiles(numstat: String, nameStatus: String) -> [CommitChangedFile] {
+        let stats = NumstatParser.parse(numstat)
+
+        return nameStatus
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { line in
+                let parts = line.split(separator: "\t", omittingEmptySubsequences: false)
+                guard parts.count >= 2 else { return nil }
+                let status = String(parts[0].prefix(1))
+                let path = String(parts.last ?? "")
+                let originalPath = parts.count >= 3 ? String(parts[1]) : nil
+                let stat = stats[path] ?? (0, 0)
+                return CommitChangedFile(
+                    path: path,
+                    originalPath: originalPath,
+                    status: status,
+                    add: stat.add,
+                    del: stat.del
+                )
+            }
+    }
+}

--- a/Alas/Sources/Git/GitService+ReviewRequestDraft.swift
+++ b/Alas/Sources/Git/GitService+ReviewRequestDraft.swift
@@ -4,6 +4,7 @@ struct ReviewRequestDraftContext: Equatable {
     let commitSubjects: [String]
     let changedFiles: [CommitChangedFile]
     let diff: String
+    let fileDiffsByPath: [String: String]
     let hasUncommittedChanges: Bool
 }
 
@@ -47,11 +48,27 @@ extension GitService {
             .map(String.init)
 
         let changedFiles = Self.reviewRequestChangedFiles(numstat: files.stdout, nameStatus: names.stdout)
+        var fileDiffsByPath: [String: String] = [:]
+        for file in changedFiles {
+            let fileDiff = try await Process.git(
+                [
+                    "diff",
+                    "--no-color",
+                    "-M",
+                    "\(baseRef)..HEAD",
+                    "--",
+                ] + file.diffPathspecs,
+                cwd: worktreePath
+            )
+            try Self.assertReviewRequestSuccess(fileDiff)
+            fileDiffsByPath[file.path] = fileDiff.stdout
+        }
 
         return ReviewRequestDraftContext(
             commitSubjects: commitSubjects,
             changedFiles: changedFiles,
             diff: diff.stdout,
+            fileDiffsByPath: fileDiffsByPath,
             hasUncommittedChanges: !status.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         )
     }
@@ -82,5 +99,14 @@ extension GitService {
                     del: stat.del
                 )
             }
+    }
+}
+
+private extension CommitChangedFile {
+    var diffPathspecs: [String] {
+        if let originalPath, originalPath != path {
+            return [originalPath, path]
+        }
+        return [path]
     }
 }

--- a/Alas/Sources/Git/GitService+ReviewRequestDraft.swift
+++ b/Alas/Sources/Git/GitService+ReviewRequestDraft.swift
@@ -10,20 +10,21 @@ struct ReviewRequestDraftContext: Equatable {
 
 extension GitService {
     func reviewRequestDraftContext(worktreePath: URL, baseRef: String) async throws -> ReviewRequestDraftContext {
+        let diffRange = "\(baseRef)...HEAD"
         async let subjectsResult = Process.git(
             ["log", "\(baseRef)..HEAD", "--pretty=format:%s"],
             cwd: worktreePath
         )
         async let diffResult = Process.git(
-            ["diff", "--no-color", "-M", "\(baseRef)..HEAD"],
+            ["diff", "--no-color", "-M", diffRange],
             cwd: worktreePath
         )
         async let filesResult = Process.git(
-            ["diff", "--no-color", "-M", "--numstat", "\(baseRef)..HEAD"],
+            ["diff", "--no-color", "-M", "--numstat", diffRange],
             cwd: worktreePath
         )
         async let namesResult = Process.git(
-            ["diff", "--no-color", "-M", "--name-status", "\(baseRef)..HEAD"],
+            ["diff", "--no-color", "-M", "--name-status", diffRange],
             cwd: worktreePath
         )
         async let statusResult = Process.git(
@@ -55,7 +56,7 @@ extension GitService {
                     "diff",
                     "--no-color",
                     "-M",
-                    "\(baseRef)..HEAD",
+                    diffRange,
                     "--",
                 ] + file.diffPathspecs,
                 cwd: worktreePath

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -58,6 +58,7 @@ protocol CodeHostProvider: Sendable {
         baseBranch: String,
         title: String,
         body: String,
+        isDraft: Bool,
         cwd: URL
     ) async throws -> URL
     func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck]

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -100,22 +100,24 @@ struct GitHubCLIProvider: CodeHostProvider {
         baseBranch: String,
         title: String,
         body: String,
+        isDraft: Bool,
         cwd: URL
     ) async throws -> URL {
         let head = Self.qualifiedHead(branch: branch, headOwner: headOwner, baseOwner: remote.owner)
         let base = Self.normalizedBaseBranch(baseBranch, remoteName: remote.remoteName)
-        let result = try await runner.run(
-            "gh",
-            args: [
-                "pr", "create",
-                "--base", base,
-                "--head", head,
-                "--title", title,
-                "--body", body,
-                "-R", remote.repositorySlug,
-            ],
-            cwd: cwd
-        )
+        var args = [
+            "pr", "create",
+            "--base", base,
+            "--head", head,
+            "--title", title,
+            "--body", body,
+            "-R", remote.repositorySlug,
+        ]
+        if isDraft {
+            args.append("--draft")
+        }
+
+        let result = try await runner.run("gh", args: args, cwd: cwd)
         guard result.exitCode == 0 else {
             throw CodeHostProviderError.commandFailed(command: "gh pr create", stderr: result.stderr)
         }

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -277,34 +277,27 @@ final class ReviewLoopState {
         }
     }
 
-    func createReviewRequest() async -> Bool {
-        guard let snapshot else { return false }
-        return await createReviewRequest(snapshot: snapshot)
-    }
-
-    func createReviewRequest(snapshot: ReviewLoopSnapshot) async -> Bool {
-        guard
-              let remote = snapshot.remote,
+    func createReviewRequest(
+        snapshot: ReviewLoopSnapshot,
+        title: String,
+        body: String,
+        isDraft: Bool
+    ) async throws -> URL {
+        guard let remote = snapshot.remote,
               let provider = providerRegistry.provider(for: remote.kind)
-        else { return false }
-
-        lastError = nil
-        do {
-            _ = try await provider.createReviewRequest(
-                remote: remote,
-                branch: snapshot.local.branchName,
-                headOwner: snapshot.local.headRemoteOwner,
-                baseBranch: snapshot.local.baseBranch,
-                title: snapshot.local.branchName,
-                body: "Created from Alas.",
-                isDraft: false,
-                cwd: worktreePath
-            )
-            return true
-        } catch {
-            lastError = Self.describe(error)
-            return false
+        else {
+            throw CodeHostProviderError.unsupportedProvider(snapshot.remote?.kind ?? .github)
         }
+        return try await provider.createReviewRequest(
+            remote: remote,
+            branch: snapshot.local.branchName,
+            headOwner: snapshot.local.headRemoteOwner,
+            baseBranch: snapshot.local.baseBranch,
+            title: title,
+            body: body,
+            isDraft: isDraft,
+            cwd: worktreePath
+        )
     }
 
     func rerunFailedChecks() async -> Bool {

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -283,6 +283,26 @@ final class ReviewLoopState {
         body: String,
         isDraft: Bool
     ) async throws -> URL {
+        try await createReviewRequest(
+            snapshot: snapshot,
+            branch: snapshot.local.branchName,
+            headOwner: snapshot.local.headRemoteOwner,
+            baseBranch: snapshot.local.baseBranch,
+            title: title,
+            body: body,
+            isDraft: isDraft
+        )
+    }
+
+    func createReviewRequest(
+        snapshot: ReviewLoopSnapshot,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        title: String,
+        body: String,
+        isDraft: Bool
+    ) async throws -> URL {
         guard let remote = snapshot.remote,
               let provider = providerRegistry.provider(for: remote.kind)
         else {
@@ -290,9 +310,9 @@ final class ReviewLoopState {
         }
         return try await provider.createReviewRequest(
             remote: remote,
-            branch: snapshot.local.branchName,
-            headOwner: snapshot.local.headRemoteOwner,
-            baseBranch: snapshot.local.baseBranch,
+            branch: branch,
+            headOwner: headOwner,
+            baseBranch: baseBranch,
             title: title,
             body: body,
             isDraft: isDraft,

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -297,6 +297,7 @@ final class ReviewLoopState {
                 baseBranch: snapshot.local.baseBranch,
                 title: snapshot.local.branchName,
                 body: "Created from Alas.",
+                isDraft: false,
                 cwd: worktreePath
             )
             return true

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -410,6 +410,10 @@ final class ReviewLoopState {
 
 #if DEBUG
 extension ReviewLoopState {
+    func setSnapshotForTests(_ snapshot: ReviewLoopSnapshot) {
+        self.snapshot = snapshot
+    }
+
     func updateLocalBranchForTests(_ branchName: String) {
         if let current = snapshot?.local {
             snapshot = ReviewLoopSnapshot(

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestContextBuilder.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestContextBuilder.swift
@@ -1,0 +1,26 @@
+enum ReviewRequestContextBuilder {
+    static func build(
+        provider: String,
+        repository: String,
+        branch: String,
+        base: String,
+        hasUncommittedChanges: Bool,
+        commitSubjects: [String],
+        diff: String
+    ) -> String {
+        var lines: [String] = []
+        lines.append("# Provider: \(provider)")
+        lines.append("# Repository: \(repository)")
+        lines.append("# Branch: \(branch)")
+        lines.append("# Base: \(base)")
+        lines.append("# Uncommitted changes: \(hasUncommittedChanges ? "present but excluded" : "none")")
+        if !commitSubjects.isEmpty {
+            lines.append("# Commit subjects:")
+            for subject in commitSubjects {
+                lines.append("#   \(subject)")
+            }
+        }
+        lines.append("---")
+        return lines.joined(separator: "\n") + "\n" + diff
+    }
+}

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDraft.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDraft.swift
@@ -38,6 +38,14 @@ enum ReviewRequestDraft {
         guard snapshot.reviewRequest == nil else { return "A PR already exists for this branch." }
         guard !isLocalBranchSelectedBase(snapshot) else { return "Switch to a feature branch before creating a PR." }
         guard snapshot.local.aheadCommitCount > 0 else { return "This branch has no committed changes to publish." }
+        switch snapshot.local.pushState {
+        case .diverged:
+            return "Remote has commits not in this branch. Pull, rebase, or force push before creating a PR."
+        case .stale:
+            return "Remote has commits not in this branch. Pull or rebase before creating a PR."
+        case .inSync, .missingUpstream, .unpushed:
+            break
+        }
         guard !snapshot.local.needsPush else { return "Push this branch before creating a PR." }
         return nil
     }

--- a/Alas/Sources/Integrations/CodeHost/ReviewRequestDraft.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewRequestDraft.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum ReviewRequestDraft {
+    struct GeneratedMessage: Equatable {
+        let title: String
+        let body: String
+    }
+
+    struct ValidationInput {
+        let title: String
+        let body: String
+        let snapshot: ReviewLoopSnapshot?
+    }
+
+    static func parseGeneratedMessage(_ raw: String) throws -> GeneratedMessage {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let firstLineEnd = normalized.firstIndex(of: "\n") else {
+            return GeneratedMessage(title: normalized, body: "")
+        }
+        let title = String(normalized[..<firstLineEnd]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let bodyStart = normalized.index(after: firstLineEnd)
+        let body = String(normalized[bodyStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return GeneratedMessage(title: title, body: body)
+    }
+
+    static func validationMessage(for input: ValidationInput) -> String? {
+        if input.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Title is required."
+        }
+        if input.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Description is required."
+        }
+        guard let snapshot = input.snapshot else { return "Review state is still loading." }
+        guard snapshot.remote != nil else { return "No supported review host." }
+        guard snapshot.providerAvailable else { return "Review host CLI is not available." }
+        guard snapshot.providerAuthenticated else { return "Review host authentication is required." }
+        guard snapshot.providerCapabilities.canCreateReviewRequest else { return "This review host cannot create review requests yet." }
+        guard snapshot.reviewRequest == nil else { return "A PR already exists for this branch." }
+        guard !isLocalBranchSelectedBase(snapshot) else { return "Switch to a feature branch before creating a PR." }
+        guard snapshot.local.aheadCommitCount > 0 else { return "This branch has no committed changes to publish." }
+        guard !snapshot.local.needsPush else { return "Push this branch before creating a PR." }
+        return nil
+    }
+
+    private static func isLocalBranchSelectedBase(_ snapshot: ReviewLoopSnapshot) -> Bool {
+        snapshot.local.branchName == normalizedBranchName(
+            snapshot.local.baseBranch,
+            remoteName: snapshot.remote?.remoteName
+        )
+    }
+
+    private static func normalizedBranchName(_ branchName: String, remoteName: String?) -> String {
+        guard let remoteName else { return branchName }
+        let prefix = "\(remoteName)/"
+        guard branchName.hasPrefix(prefix) else { return branchName }
+        return String(branchName.dropFirst(prefix.count))
+    }
+}

--- a/Alas/Sources/Persistence/AppConfig.swift
+++ b/Alas/Sources/Persistence/AppConfig.swift
@@ -262,6 +262,7 @@ struct AppConfig: Codable, Equatable {
     struct Changes: Codable, Equatable {
         var aiToolId: String   // "claude" | "codex" | "cursor-agent" | "pi" | "none"
         var prompt: String
+        var reviewRequestPrompt: String
         /// Workspace-level "fix every merge conflict in this repo"
         /// prompt fed to the agent CWD'd at the worktree. The agent
         /// uses its own filesystem tools to enumerate + reconcile.
@@ -279,8 +280,8 @@ struct AppConfig: Codable, Equatable {
         var trackUpstreamForCommits: Bool
 
         enum CodingKeys: String, CodingKey {
-            case aiToolId, prompt, mergeBulkResolvePrompt, mergeSingleResolvePrompt,
-                 trackUpstreamForCommits
+            case aiToolId, prompt, reviewRequestPrompt, mergeBulkResolvePrompt,
+                 mergeSingleResolvePrompt, trackUpstreamForCommits
         }
     }
 
@@ -387,6 +388,7 @@ struct AppConfig: Codable, Equatable {
         changes: Changes(
             aiToolId: "none",
             prompt: AppConfig.defaultCommitPrompt,
+            reviewRequestPrompt: AppConfig.defaultReviewRequestPrompt,
             mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
             mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
             trackUpstreamForCommits: false
@@ -429,6 +431,23 @@ extension AppConfig {
     When amending, the previous commit's message is provided — prefer
     refining it over starting from scratch unless the diff has materially
     changed.
+    """
+
+    static let defaultReviewRequestPrompt = """
+    You are writing a pull request title and description for the committed branch changes shown below.
+
+    Output format — strict:
+      Line 1: concise PR title, no trailing period.
+      Line 2: blank.
+      Line 3+: Markdown body with exactly these sections:
+               ## Summary
+               - 1-3 bullets describing the user-visible or reviewer-relevant changes.
+
+               ## Testing
+               - Bullets describing verification performed.
+               - Use "Not run (not provided)." only when no testing signal is present.
+
+    Use the branch diff and commit subjects as source material. Do not mention uncommitted working tree changes as implemented work. Do not include preamble, code fences, or extra headings.
     """
 
     static let defaultMergeBulkResolvePrompt = """
@@ -588,6 +607,8 @@ extension AppConfig {
         if let changesContainer = try? c.nestedContainer(keyedBy: AppConfig.Changes.CodingKeys.self, forKey: .changes) {
             let toolId = (try? changesContainer.decode(String.self, forKey: .aiToolId)) ?? "none"
             let prompt = (try? changesContainer.decode(String.self, forKey: .prompt)) ?? AppConfig.defaultCommitPrompt
+            let reviewRequestPrompt = (try? changesContainer.decode(String.self, forKey: .reviewRequestPrompt))
+                ?? AppConfig.defaultReviewRequestPrompt
             let bulkResolve = (try? changesContainer.decode(String.self, forKey: .mergeBulkResolvePrompt))
                 ?? AppConfig.defaultMergeBulkResolvePrompt
             let singleResolve = (try? changesContainer.decode(String.self, forKey: .mergeSingleResolvePrompt))
@@ -596,6 +617,7 @@ extension AppConfig {
             changes = Changes(
                 aiToolId: toolId,
                 prompt: prompt,
+                reviewRequestPrompt: reviewRequestPrompt,
                 mergeBulkResolvePrompt: bulkResolve,
                 mergeSingleResolvePrompt: singleResolve,
                 trackUpstreamForCommits: trackUpstream
@@ -604,6 +626,7 @@ extension AppConfig {
             changes = Changes(
                 aiToolId: "none",
                 prompt: AppConfig.defaultCommitPrompt,
+                reviewRequestPrompt: AppConfig.defaultReviewRequestPrompt,
                 mergeBulkResolvePrompt: AppConfig.defaultMergeBulkResolvePrompt,
                 mergeSingleResolvePrompt: AppConfig.defaultMergeSingleResolvePrompt,
                 trackUpstreamForCommits: false

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -268,19 +268,7 @@ final class RightPaneState {
             }
         case .createReviewRequest:
             guard let snapshot = reviewLoop.snapshot else { return }
-            Task { @MainActor in
-                do {
-                    _ = try await reviewLoop.createReviewRequest(
-                        snapshot: snapshot,
-                        title: snapshot.local.branchName,
-                        body: "Created from Alas.",
-                        isDraft: false
-                    )
-                    await refresh()
-                } catch {
-                    sidebarError = error.localizedDescription
-                }
-            }
+            appState.tabs.openOrFocusDraftReviewRequest(worktreeId: worktree.id, snapshot: snapshot)
         case .rerunFailedChecks:
             guard let snapshot = reviewLoop.snapshot else { return }
             Task { @MainActor in

--- a/Alas/Sources/Right/RightPaneState.swift
+++ b/Alas/Sources/Right/RightPaneState.swift
@@ -269,8 +269,16 @@ final class RightPaneState {
         case .createReviewRequest:
             guard let snapshot = reviewLoop.snapshot else { return }
             Task { @MainActor in
-                if await reviewLoop.createReviewRequest(snapshot: snapshot) {
+                do {
+                    _ = try await reviewLoop.createReviewRequest(
+                        snapshot: snapshot,
+                        title: snapshot.local.branchName,
+                        body: "Created from Alas.",
+                        isDraft: false
+                    )
                     await refresh()
+                } catch {
+                    sidebarError = error.localizedDescription
                 }
             }
         case .rerunFailedChecks:

--- a/Alas/Sources/Settings/ChangesPane.swift
+++ b/Alas/Sources/Settings/ChangesPane.swift
@@ -37,6 +37,19 @@ struct ChangesPane: View {
                     }
                 }
 
+                SettingsGroup(title: "Review requests") {
+                    SettingsRow(
+                        name: "Prompt",
+                        desc: "Used by the sparkle button in the draft PR tab. The committed branch diff is appended on stdin."
+                    ) {
+                        promptEditorRow(
+                            windowId: "review-request-prompt-editor",
+                            currentValue: state.config.changes.reviewRequestPrompt,
+                            defaultValue: AppConfig.defaultReviewRequestPrompt
+                        )
+                    }
+                }
+
                 SettingsGroup(title: "Merge conflicts") {
                     SettingsRow(name: "Bulk resolve prompt",
                                 desc: "Sent to the agent CWD'd at the worktree when the user clicks 'Resolve all with agent'. The agent uses its own tools to enumerate, reconcile, and stage every conflicted file.") {
@@ -72,8 +85,8 @@ struct ChangesPane: View {
             AlasButton(title: "Edit", style: .normal) {
                 openWindow(id: windowId)
             }
-            if currentValue != defaultValue {
-                PromptStatusChip(label: "Custom")
+            if let label = CommitPromptStatus.chipLabel(for: currentValue, defaultPrompt: defaultValue) {
+                PromptStatusChip(label: label)
             }
         }
     }

--- a/Alas/Sources/Settings/CommitPromptStatus.swift
+++ b/Alas/Sources/Settings/CommitPromptStatus.swift
@@ -1,5 +1,9 @@
 enum CommitPromptStatus {
     static func chipLabel(for prompt: String) -> String? {
-        prompt == AppConfig.defaultCommitPrompt ? nil : "Custom"
+        chipLabel(for: prompt, defaultPrompt: AppConfig.defaultCommitPrompt)
+    }
+
+    static func chipLabel(for prompt: String, defaultPrompt: String) -> String? {
+        prompt == defaultPrompt ? nil : "Custom"
     }
 }

--- a/Alas/Sources/Settings/ReviewRequestPromptEditorWindow.swift
+++ b/Alas/Sources/Settings/ReviewRequestPromptEditorWindow.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct ReviewRequestPromptEditorWindow: View {
+    @Bindable var state: AppState
+    @State private var draftPrompt = ""
+
+    var body: some View {
+        PromptEditorBody(
+            windowTitle: "Review Request Prompt",
+            title: "Review request prompt",
+            description: "Instructions sent to the selected AI tool. The committed branch diff is appended on stdin.",
+            draftPrompt: $draftPrompt,
+            onReset: { draftPrompt = AppConfig.defaultReviewRequestPrompt },
+            onCancel: { closeWindow() },
+            onSave: {
+                state.config.changes.reviewRequestPrompt = draftPrompt
+                state.saveConfig()
+                closeWindow()
+            },
+            theme: state.themeStore.current
+        )
+        .onAppear { draftPrompt = state.config.changes.reviewRequestPrompt }
+    }
+
+    private func closeWindow() {
+        NSApp.keyWindow?.close()
+    }
+}

--- a/AlasTests/AppConfigChangesTests.swift
+++ b/AlasTests/AppConfigChangesTests.swift
@@ -8,6 +8,14 @@ struct AppConfigChangesTests {
         #expect(!AppConfig.defaults.changes.prompt.isEmpty)
     }
 
+    @Test func defaultsHaveNonEmptyReviewRequestPrompt() {
+        #expect(!AppConfig.defaults.changes.reviewRequestPrompt.isEmpty)
+        #expect(AppConfig.defaults.changes.reviewRequestPrompt.contains("Line 1: concise PR title"))
+        #expect(AppConfig.defaults.changes.reviewRequestPrompt.contains("## Summary"))
+        #expect(AppConfig.defaults.changes.reviewRequestPrompt.contains("## Testing"))
+        #expect(AppConfig.defaults.changes.reviewRequestPrompt.contains("Do not mention uncommitted working tree changes"))
+    }
+
     @Test func decodesLegacyConfigWithoutChangesKey() throws {
         let json = """
         {
@@ -52,6 +60,56 @@ struct AppConfigChangesTests {
         let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
         #expect(decoded.changes.aiToolId == "claude")
         #expect(decoded.changes.prompt == "custom prompt")
+    }
+
+    @Test func decodesLegacyChangesWithoutReviewRequestPrompt() throws {
+        let json = """
+        {
+          "themeId": "cool-slate",
+          "accent": "teal",
+          "matchSystemTheme": false,
+          "sidebarWidth": 244,
+          "rightPaneWidth": 320,
+          "rightPaneVisible": true,
+          "general": {
+            "launchAtLogin": false, "closeToTray": true, "confirmQuit": true,
+            "autoUpdate": true, "updateChannel": "Stable",
+            "crashReports": false, "usageAnalytics": false
+          },
+          "worktrees": {
+            "rootPath": "~/.alas/worktrees",
+            "pathTemplate": "{worktreeRoot}/{repo}/{branch}",
+            "branchPrefix": "feature/", "baseBranch": "main",
+            "trackUpstream": true, "deleteBranchOnRemove": true,
+            "autoFetch": true, "fetchIntervalMinutes": 5, "pruneStale": false
+          },
+          "terminal": {
+            "shell": "/bin/zsh", "workingDirectory": "worktreeRoot",
+            "startupScript": "", "worktreeCreateScript": "",
+            "inheritParentEnv": true, "fontFamily": "JetBrains Mono",
+            "fontSize": 13, "cursorStyle": "beam", "cursorBlink": true,
+            "scrollbackLines": 10000, "bell": "visual"
+          },
+          "harness": {"notifyOnFinish": true, "notifyOnAwaiting": true},
+          "changes": {
+            "aiToolId": "none",
+            "prompt": "commit prompt",
+            "mergeBulkResolvePrompt": "bulk",
+            "mergeSingleResolvePrompt": "single",
+            "trackUpstreamForCommits": true
+          }
+        }
+        """
+        let cfg = try JSONDecoder().decode(AppConfig.self, from: Data(json.utf8))
+        #expect(cfg.changes.reviewRequestPrompt == AppConfig.defaultReviewRequestPrompt)
+    }
+
+    @Test func roundTripsReviewRequestPrompt() throws {
+        var cfg = AppConfig.defaults
+        cfg.changes.reviewRequestPrompt = "custom review request prompt"
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(AppConfig.self, from: data)
+        #expect(decoded.changes.reviewRequestPrompt == "custom review request prompt")
     }
 
     @Test func defaultsHaveTrackUpstreamForCommitsOff() {

--- a/AlasTests/CommitPromptStatusTests.swift
+++ b/AlasTests/CommitPromptStatusTests.swift
@@ -9,4 +9,15 @@ struct CommitPromptStatusTests {
     @Test func modifiedPromptUsesCustomStatusChip() {
         #expect(CommitPromptStatus.chipLabel(for: AppConfig.defaultCommitPrompt + "\nExtra instruction.") == "Custom")
     }
+
+    @Test func reviewRequestPromptStatusDetectsCustomPrompt() {
+        #expect(CommitPromptStatus.chipLabel(
+            for: AppConfig.defaultReviewRequestPrompt,
+            defaultPrompt: AppConfig.defaultReviewRequestPrompt
+        ) == nil)
+        #expect(CommitPromptStatus.chipLabel(
+            for: AppConfig.defaultReviewRequestPrompt + "\nExtra instruction.",
+            defaultPrompt: AppConfig.defaultReviewRequestPrompt
+        ) == "Custom")
+    }
 }

--- a/AlasTests/GitServiceReviewRequestDraftTests.swift
+++ b/AlasTests/GitServiceReviewRequestDraftTests.swift
@@ -28,8 +28,40 @@ struct GitServiceReviewRequestDraftTests {
         #expect(context.commitSubjects == ["feat: add committed file"])
         #expect(context.changedFiles.map(\.path) == ["Sources/A.swift"])
         #expect(context.diff.contains("Sources/A.swift"))
+        #expect(context.fileDiffsByPath["Sources/A.swift"]?.contains("Sources/A.swift") == true)
         #expect(!context.diff.contains("Uncommitted.swift"))
+        #expect(!context.fileDiffsByPath["Sources/A.swift", default: ""].contains("Uncommitted.swift"))
         #expect(context.hasUncommittedChanges)
+    }
+
+    @Test func loadsDiffForEachChangedFile() async throws {
+        let repo = try makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try await git(["init", "-b", "main"], cwd: repo)
+        try await git(["config", "user.email", "test@example.com"], cwd: repo)
+        try await git(["config", "user.name", "Test User"], cwd: repo)
+        try write("Sources/A.swift", "let a = 1\n", in: repo)
+        try write("Sources/B.swift", "let b = 1\n", in: repo)
+        try await git(["add", "."], cwd: repo)
+        try await git(["commit", "-m", "chore: initial"], cwd: repo)
+        try await git(["checkout", "-b", "feature/file-diffs"], cwd: repo)
+        try write("Sources/A.swift", "let a = 2\n", in: repo)
+        try write("Sources/B.swift", "let b = 2\n", in: repo)
+        try await git(["add", "."], cwd: repo)
+        try await git(["commit", "-m", "feat: update files"], cwd: repo)
+
+        let context = try await GitService().reviewRequestDraftContext(
+            worktreePath: repo,
+            baseRef: "main"
+        )
+
+        let aDiff = try #require(context.fileDiffsByPath["Sources/A.swift"])
+        let bDiff = try #require(context.fileDiffsByPath["Sources/B.swift"])
+        #expect(aDiff.contains("Sources/A.swift"))
+        #expect(!aDiff.contains("Sources/B.swift"))
+        #expect(bDiff.contains("Sources/B.swift"))
+        #expect(!bDiff.contains("Sources/A.swift"))
     }
 
     @Test func loadsRenameDestinationOriginalPathAndCounts() async throws {
@@ -85,6 +117,7 @@ struct GitServiceReviewRequestDraftTests {
         #expect(file.status.hasPrefix("R"))
         #expect(file.add > 0)
         #expect(file.del > 0)
+        #expect(context.fileDiffsByPath["Sources/New.swift"]?.contains("rename from Sources/Old.swift") == true)
     }
 
     private func makeRepo() throws -> URL {

--- a/AlasTests/GitServiceReviewRequestDraftTests.swift
+++ b/AlasTests/GitServiceReviewRequestDraftTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite(.serialized)
+struct GitServiceReviewRequestDraftTests {
+    @Test func loadsCommittedBranchContextAndExcludesWorkingTreeDiff() async throws {
+        let repo = try makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try await git(["init", "-b", "main"], cwd: repo)
+        try await git(["config", "user.email", "test@example.com"], cwd: repo)
+        try await git(["config", "user.name", "Test User"], cwd: repo)
+        try write("README.md", "Initial\n", in: repo)
+        try await git(["add", "README.md"], cwd: repo)
+        try await git(["commit", "-m", "chore: initial"], cwd: repo)
+        try await git(["checkout", "-b", "feature/pr-drafts"], cwd: repo)
+        try write("Sources/A.swift", "let committed = 1\n", in: repo)
+        try await git(["add", "Sources/A.swift"], cwd: repo)
+        try await git(["commit", "-m", "feat: add committed file"], cwd: repo)
+        try write("Sources/Uncommitted.swift", "let uncommitted = 1\n", in: repo)
+
+        let context = try await GitService().reviewRequestDraftContext(
+            worktreePath: repo,
+            baseRef: "main"
+        )
+
+        #expect(context.commitSubjects == ["feat: add committed file"])
+        #expect(context.changedFiles.map(\.path) == ["Sources/A.swift"])
+        #expect(context.diff.contains("Sources/A.swift"))
+        #expect(!context.diff.contains("Uncommitted.swift"))
+        #expect(context.hasUncommittedChanges)
+    }
+
+    @Test func loadsRenameDestinationOriginalPathAndCounts() async throws {
+        let repo = try makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try await git(["init", "-b", "main"], cwd: repo)
+        try await git(["config", "user.email", "test@example.com"], cwd: repo)
+        try await git(["config", "user.name", "Test User"], cwd: repo)
+        try write("Sources/Old.swift", """
+        let line1 = 1
+        let line2 = 2
+        let line3 = 3
+        let line4 = 4
+        let line5 = 5
+        let line6 = 6
+        let line7 = 7
+        let line8 = 8
+        let line9 = 9
+        let line10 = 10
+
+        """, in: repo)
+        try await git(["add", "Sources/Old.swift"], cwd: repo)
+        try await git(["commit", "-m", "chore: add old file"], cwd: repo)
+        try await git(["checkout", "-b", "feature/rename"], cwd: repo)
+        try await git(["mv", "Sources/Old.swift", "Sources/New.swift"], cwd: repo)
+        try write("Sources/New.swift", """
+        let line1 = 1
+        let line2 = 2
+        let line3 = 3
+        let line4 = 4
+        let line5 = 50
+        let line6 = 6
+        let line7 = 7
+        let line8 = 8
+        let line9 = 9
+        let line10 = 10
+        let line11 = 11
+
+        """, in: repo)
+        try await git(["add", "Sources/New.swift"], cwd: repo)
+        try await git(["commit", "-m", "refactor: rename file"], cwd: repo)
+
+        let context = try await GitService().reviewRequestDraftContext(
+            worktreePath: repo,
+            baseRef: "main"
+        )
+
+        let file = try #require(context.changedFiles.first)
+        #expect(context.changedFiles.count == 1)
+        #expect(file.path == "Sources/New.swift")
+        #expect(file.originalPath == "Sources/Old.swift")
+        #expect(file.status.hasPrefix("R"))
+        #expect(file.add > 0)
+        #expect(file.del > 0)
+    }
+
+    private func makeRepo() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("alas-pr-draft-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func write(_ path: String, _ contents: String, in repo: URL) throws {
+        let url = repo.appendingPathComponent(path)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    @discardableResult
+    private func git(_ args: [String], cwd: URL) async throws -> ProcessResult {
+        let result = try await Process.git(args, cwd: cwd)
+        #expect(result.exitCode == 0, Comment(rawValue: result.stderr))
+        return result
+    }
+}

--- a/AlasTests/GitServiceReviewRequestDraftTests.swift
+++ b/AlasTests/GitServiceReviewRequestDraftTests.swift
@@ -64,6 +64,38 @@ struct GitServiceReviewRequestDraftTests {
         #expect(!bDiff.contains("Sources/A.swift"))
     }
 
+    @Test func loadsBranchDiffFromMergeBaseWhenBaseBranchHasAdvanced() async throws {
+        let repo = try makeRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+
+        try await git(["init", "-b", "main"], cwd: repo)
+        try await git(["config", "user.email", "test@example.com"], cwd: repo)
+        try await git(["config", "user.name", "Test User"], cwd: repo)
+        try write("README.md", "Initial\n", in: repo)
+        try await git(["add", "README.md"], cwd: repo)
+        try await git(["commit", "-m", "chore: initial"], cwd: repo)
+        try await git(["checkout", "-b", "feature/stale-base"], cwd: repo)
+        try write("Sources/Feature.swift", "let feature = 1\n", in: repo)
+        try await git(["add", "Sources/Feature.swift"], cwd: repo)
+        try await git(["commit", "-m", "feat: add feature file"], cwd: repo)
+        try await git(["checkout", "main"], cwd: repo)
+        try write("Sources/MainOnly.swift", "let mainOnly = 1\n", in: repo)
+        try await git(["add", "Sources/MainOnly.swift"], cwd: repo)
+        try await git(["commit", "-m", "feat: advance main"], cwd: repo)
+        try await git(["checkout", "feature/stale-base"], cwd: repo)
+
+        let context = try await GitService().reviewRequestDraftContext(
+            worktreePath: repo,
+            baseRef: "main"
+        )
+
+        #expect(context.commitSubjects == ["feat: add feature file"])
+        #expect(context.changedFiles.map(\.path) == ["Sources/Feature.swift"])
+        #expect(context.diff.contains("Sources/Feature.swift"))
+        #expect(!context.diff.contains("Sources/MainOnly.swift"))
+        #expect(context.fileDiffsByPath["Sources/Feature.swift"]?.contains("Sources/Feature.swift") == true)
+    }
+
     @Test func loadsRenameDestinationOriginalPathAndCounts() async throws {
         let repo = try makeRepo()
         defer { try? FileManager.default.removeItem(at: repo) }

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -76,6 +76,7 @@ struct CodeHostProviderTests {
             baseBranch: String,
             title: String,
             body: String,
+            isDraft: Bool,
             cwd: URL
         ) async throws -> URL {
             remote.webURL

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -387,6 +387,7 @@ struct GitHubCLIProviderTests {
             baseBranch: "main",
             title: "feature/github-provider",
             body: "Created from Alas.",
+            isDraft: false,
             cwd: Self.cwd
         )
 
@@ -406,6 +407,46 @@ struct GitHubCLIProviderTests {
         ])
     }
 
+    @Test func createReviewRequestOmitsDraftFlagForNormalPR() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "https://github.com/mrmans0n/alas/pull/44\n", stderr: ""),
+        ])
+
+        _ = try await GitHubCLIProvider(runner: runner).createReviewRequest(
+            remote: Self.remote,
+            branch: "feature/review-draft",
+            headOwner: nil,
+            baseBranch: "origin/main",
+            title: "Add draft tab",
+            body: "## Summary\n- Adds a draft tab",
+            isDraft: false,
+            cwd: Self.cwd
+        )
+
+        #expect(await runner.commands.first?.args.contains("--draft") == false)
+    }
+
+    @Test func createReviewRequestAddsDraftFlagForDraftPR() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "https://github.com/mrmans0n/alas/pull/45\n", stderr: ""),
+        ])
+
+        _ = try await GitHubCLIProvider(runner: runner).createReviewRequest(
+            remote: Self.remote,
+            branch: "feature/review-draft",
+            headOwner: "nacho",
+            baseBranch: "origin/main",
+            title: "Add draft tab",
+            body: "## Summary\n- Adds a draft tab",
+            isDraft: true,
+            cwd: Self.cwd
+        )
+
+        let args = try #require(await runner.commands.first?.args)
+        #expect(args.contains("--draft"))
+        #expect(args.contains("nacho:feature/review-draft"))
+    }
+
     @Test func createReviewRequestNormalizesRemoteQualifiedBaseBranch() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: "https://github.com/mrmans0n/alas/pull/43\n", stderr: ""),
@@ -418,6 +459,7 @@ struct GitHubCLIProviderTests {
             baseBranch: "origin/main",
             title: "feature/github-provider",
             body: "Created from Alas.",
+            isDraft: false,
             cwd: Self.cwd
         )
 

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -847,6 +847,7 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
         let baseBranch: String
         let title: String
         let body: String
+        let isDraft: Bool
     }
 
     struct RerunFailedChecksRequest: Equatable {
@@ -923,6 +924,7 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
         baseBranch: String,
         title: String,
         body: String,
+        isDraft: Bool,
         cwd: URL
     ) async throws -> URL {
         if let createError { throw createError }
@@ -931,7 +933,8 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
             headOwner: headOwner,
             baseBranch: baseBranch,
             title: title,
-            body: body
+            body: body,
+            isDraft: isDraft
         ))
         return remote.webURL
     }

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -388,6 +388,36 @@ struct ReviewLoopStateTests {
         #expect(provider.createdReviewRequests.first?.branch == "feature/captured")
     }
 
+    @Test func createReviewRequestUsesExplicitDraftTarget() async throws {
+        let provider = FakeCodeHostProvider(kind: .github)
+        let state = ReviewLoopState(
+            worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
+            baseBranch: "main",
+            providerRegistry: CodeHostProviderRegistry(providers: [.github: provider])
+        )
+
+        await state.refresh(
+            local: Self.makeLocal(branchName: "feature/current", baseBranch: "main", needsPush: false),
+            remotes: [Self.makeGitHubRemote()]
+        )
+        let snapshot = try #require(state.snapshot)
+
+        _ = try await state.createReviewRequest(
+            snapshot: snapshot,
+            branch: "feature/captured",
+            headOwner: "nacho",
+            baseBranch: "release",
+            title: "Review loop title",
+            body: "Review loop body",
+            isDraft: true
+        )
+
+        #expect(provider.createdReviewRequests.first?.branch == "feature/captured")
+        #expect(provider.createdReviewRequests.first?.headOwner == "nacho")
+        #expect(provider.createdReviewRequests.first?.baseBranch == "release")
+        #expect(provider.createdReviewRequests.first?.isDraft == true)
+    }
+
     @Test func createReviewRequestRecordsProviderError() async throws {
         let provider = FakeCodeHostProvider(
             kind: .github,

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -256,13 +256,21 @@ struct ReviewLoopStateTests {
         )
 
         await state.refresh(local: Self.makeLocal(needsPush: false), remotes: [Self.makeGitHubRemote()])
-        let didRun = await state.createReviewRequest()
+        let snapshot = try #require(state.snapshot)
+        let url = try await state.createReviewRequest(
+            snapshot: snapshot,
+            title: "Review loop title",
+            body: "Review loop body",
+            isDraft: true
+        )
 
-        #expect(didRun)
+        #expect(url == Self.makeRemote().webURL)
         #expect(provider.createdReviewRequests.count == 1)
         #expect(provider.createdReviewRequests.first?.branch == "feature/review-loop")
         #expect(provider.createdReviewRequests.first?.baseBranch == "main")
-        #expect(provider.createdReviewRequests.first?.title == "feature/review-loop")
+        #expect(provider.createdReviewRequests.first?.title == "Review loop title")
+        #expect(provider.createdReviewRequests.first?.body == "Review loop body")
+        #expect(provider.createdReviewRequests.first?.isDraft == true)
     }
 
     @Test func createReviewRequestPassesForkHeadOwner() async throws {
@@ -288,9 +296,14 @@ struct ReviewLoopStateTests {
             Self.makeGitHubRemote(),
             GitRemote(name: "fork", url: "git@github.com:nacho/alas.git"),
         ])
-        let didRun = await state.createReviewRequest()
+        let snapshot = try #require(state.snapshot)
+        _ = try await state.createReviewRequest(
+            snapshot: snapshot,
+            title: "Review loop title",
+            body: "Review loop body",
+            isDraft: false
+        )
 
-        #expect(didRun)
         #expect(provider.createdReviewRequests.first?.headOwner == "nacho")
     }
 
@@ -317,9 +330,14 @@ struct ReviewLoopStateTests {
             GitRemote(name: "origin", url: "git@github.com:mrmans0n/alas.git"),
             GitRemote(name: "origin", url: "git@github.com:nacho/alas.git", direction: .push),
         ])
-        let didRun = await state.createReviewRequest()
+        let snapshot = try #require(state.snapshot)
+        _ = try await state.createReviewRequest(
+            snapshot: snapshot,
+            title: "Review loop title",
+            body: "Review loop body",
+            isDraft: false
+        )
 
-        #expect(didRun)
         #expect(state.snapshot?.remote?.owner == "mrmans0n")
         #expect(provider.createdReviewRequests.first?.headOwner == "nacho")
     }
@@ -360,9 +378,13 @@ struct ReviewLoopStateTests {
             remotes: [Self.makeGitHubRemote()]
         )
 
-        let didRun = await state.createReviewRequest(snapshot: capturedSnapshot)
+        _ = try await state.createReviewRequest(
+            snapshot: capturedSnapshot,
+            title: "Review loop title",
+            body: "Review loop body",
+            isDraft: false
+        )
 
-        #expect(didRun)
         #expect(provider.createdReviewRequests.first?.branch == "feature/captured")
     }
 
@@ -381,10 +403,19 @@ struct ReviewLoopStateTests {
         )
 
         await state.refresh(local: Self.makeLocal(needsPush: false), remotes: [Self.makeGitHubRemote()])
-        let didRun = await state.createReviewRequest()
+        let snapshot = try #require(state.snapshot)
 
-        #expect(!didRun)
-        #expect(state.lastError == "gh pr create failed: GraphQL: Head sha can't be blank")
+        await #expect(throws: CodeHostProviderError.commandFailed(
+            command: "gh pr create",
+            stderr: "GraphQL: Head sha can't be blank"
+        )) {
+            _ = try await state.createReviewRequest(
+                snapshot: snapshot,
+                title: "Review loop title",
+                body: "Review loop body",
+                isDraft: false
+            )
+        }
     }
 
     @Test func rerunFailedChecksUsesProviderWithoutSessionApproval() async throws {

--- a/AlasTests/Integrations/ReviewRequestContextBuilderTests.swift
+++ b/AlasTests/Integrations/ReviewRequestContextBuilderTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import Alas
+
+struct ReviewRequestContextBuilderTests {
+    @Test func buildsProviderBranchCommitAndDiffContext() {
+        let payload = ReviewRequestContextBuilder.build(
+            provider: "GitHub",
+            repository: "mrmans0n/alas",
+            branch: "feature/pr-drafts",
+            base: "origin/main",
+            hasUncommittedChanges: true,
+            commitSubjects: ["feat: add draft tab", "test: cover draft parser"],
+            diff: "diff --git a/A.swift b/A.swift\n+let value = 1\n"
+        )
+
+        #expect(payload == """
+        # Provider: GitHub
+        # Repository: mrmans0n/alas
+        # Branch: feature/pr-drafts
+        # Base: origin/main
+        # Uncommitted changes: present but excluded
+        # Commit subjects:
+        #   feat: add draft tab
+        #   test: cover draft parser
+        ---
+        diff --git a/A.swift b/A.swift
+        +let value = 1
+
+        """)
+    }
+
+    @Test func omitsCommitSubjectsHeaderWhenEmpty() {
+        let payload = ReviewRequestContextBuilder.build(
+            provider: "GitHub",
+            repository: "mrmans0n/alas",
+            branch: "feature/pr-drafts",
+            base: "origin/main",
+            hasUncommittedChanges: false,
+            commitSubjects: [],
+            diff: "diff --git a/A.swift b/A.swift\n+let value = 1\n"
+        )
+
+        #expect(payload == """
+        # Provider: GitHub
+        # Repository: mrmans0n/alas
+        # Branch: feature/pr-drafts
+        # Base: origin/main
+        # Uncommitted changes: none
+        ---
+        diff --git a/A.swift b/A.swift
+        +let value = 1
+
+        """)
+    }
+}

--- a/AlasTests/Integrations/ReviewRequestDraftTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDraftTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct ReviewRequestDraftTests {
+    @Test func parsesGeneratedTitleAndBody() throws {
+        let parsed = try ReviewRequestDraft.parseGeneratedMessage("""
+        Add review request drafts
+
+        ## Summary
+        - Adds a draft PR tab.
+
+        ## Testing
+        - xcodebuild test
+        """)
+
+        #expect(parsed.title == "Add review request drafts")
+        #expect(parsed.body.contains("## Summary"))
+        #expect(parsed.body.contains("## Testing"))
+    }
+
+    @Test func validationRequiresTitleBodyAndReadySnapshot() {
+        let ready = ReviewRequestDraft.ValidationInput(
+            title: "Add review request drafts",
+            body: "## Summary\n- Adds a tab\n\n## Testing\n- Not run",
+            snapshot: Self.snapshot(needsPush: false, aheadCommitCount: 2)
+        )
+        #expect(ReviewRequestDraft.validationMessage(for: ready) == nil)
+
+        let missingTitle = ReviewRequestDraft.ValidationInput(title: "", body: ready.body, snapshot: ready.snapshot)
+        #expect(ReviewRequestDraft.validationMessage(for: missingTitle) == "Title is required.")
+
+        let needsPush = ReviewRequestDraft.ValidationInput(
+            title: ready.title,
+            body: ready.body,
+            snapshot: Self.snapshot(needsPush: true, aheadCommitCount: 2)
+        )
+        #expect(ReviewRequestDraft.validationMessage(for: needsPush) == "Push this branch before creating a PR.")
+    }
+
+    @Test func validationBlocksExistingReviewRequest() {
+        let snapshot = Self.snapshot(
+            needsPush: false,
+            aheadCommitCount: 2,
+            reviewRequest: Self.reviewRequest()
+        )
+        let input = ReviewRequestDraft.ValidationInput(
+            title: "Add review request drafts",
+            body: "## Summary\n- Adds a tab",
+            snapshot: snapshot
+        )
+
+        #expect(ReviewRequestDraft.validationMessage(for: input) == "A PR already exists for this branch.")
+    }
+
+    @Test func validationBlocksLocalBranchMatchingSelectedBase() {
+        let snapshot = Self.snapshot(
+            branchName: "main",
+            baseBranch: "origin/main",
+            needsPush: false,
+            aheadCommitCount: 2
+        )
+        let input = ReviewRequestDraft.ValidationInput(
+            title: "Add review request drafts",
+            body: "## Summary\n- Adds a tab",
+            snapshot: snapshot
+        )
+
+        #expect(ReviewRequestDraft.validationMessage(for: input) == "Switch to a feature branch before creating a PR.")
+    }
+
+    private static func snapshot(needsPush: Bool, aheadCommitCount: Int) -> ReviewLoopSnapshot {
+        snapshot(
+            branchName: "feature/pr-drafts",
+            baseBranch: "origin/main",
+            needsPush: needsPush,
+            aheadCommitCount: aheadCommitCount
+        )
+    }
+
+    private static func snapshot(
+        branchName: String = "feature/pr-drafts",
+        baseBranch: String = "origin/main",
+        needsPush: Bool,
+        aheadCommitCount: Int,
+        reviewRequest: ReviewRequest? = nil
+    ) -> ReviewLoopSnapshot {
+        ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(
+                branchName: branchName,
+                headSHA: "abc123",
+                baseBranch: baseBranch,
+                hasWorkingTreeChanges: false,
+                hasStagedChanges: false,
+                aheadCommitCount: aheadCommitCount,
+                hasUpstream: true,
+                upstreamRemoteName: "origin",
+                upstreamBranchName: "feature/pr-drafts",
+                needsPush: needsPush
+            ),
+            remote: CodeHostRemote(
+                kind: .github,
+                host: "github.com",
+                owner: "mrmans0n",
+                repository: "alas",
+                remoteName: "origin",
+                webURL: URL(string: "https://github.com/mrmans0n/alas")!
+            ),
+            reviewRequest: reviewRequest,
+            providerAvailable: true,
+            providerAuthenticated: true,
+            providerCapabilities: .githubCLI,
+            errorMessage: nil
+        )
+    }
+
+    private static func reviewRequest() -> ReviewRequest {
+        ReviewRequest(
+            remote: CodeHostRemote(
+                kind: .github,
+                host: "github.com",
+                owner: "mrmans0n",
+                repository: "alas",
+                remoteName: "origin",
+                webURL: URL(string: "https://github.com/mrmans0n/alas")!
+            ),
+            number: 42,
+            title: "Add review request drafts",
+            url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!,
+            state: .open,
+            isDraft: true,
+            headRefName: "feature/pr-drafts",
+            baseRefName: "main",
+            reviewDecision: .reviewRequired,
+            mergeState: .unknown,
+            checks: [],
+            threads: []
+        )
+    }
+}

--- a/AlasTests/Integrations/ReviewRequestDraftTests.swift
+++ b/AlasTests/Integrations/ReviewRequestDraftTests.swift
@@ -36,6 +36,20 @@ struct ReviewRequestDraftTests {
             snapshot: Self.snapshot(needsPush: true, aheadCommitCount: 2)
         )
         #expect(ReviewRequestDraft.validationMessage(for: needsPush) == "Push this branch before creating a PR.")
+
+        let stale = ReviewRequestDraft.ValidationInput(
+            title: ready.title,
+            body: ready.body,
+            snapshot: Self.snapshot(needsPush: false, aheadCommitCount: 2, upstreamAheadCommitCount: 1)
+        )
+        #expect(ReviewRequestDraft.validationMessage(for: stale) == "Remote has commits not in this branch. Pull or rebase before creating a PR.")
+
+        let diverged = ReviewRequestDraft.ValidationInput(
+            title: ready.title,
+            body: ready.body,
+            snapshot: Self.snapshot(needsPush: true, aheadCommitCount: 2, upstreamAheadCommitCount: 1)
+        )
+        #expect(ReviewRequestDraft.validationMessage(for: diverged) == "Remote has commits not in this branch. Pull, rebase, or force push before creating a PR.")
     }
 
     @Test func validationBlocksExistingReviewRequest() {
@@ -69,12 +83,17 @@ struct ReviewRequestDraftTests {
         #expect(ReviewRequestDraft.validationMessage(for: input) == "Switch to a feature branch before creating a PR.")
     }
 
-    private static func snapshot(needsPush: Bool, aheadCommitCount: Int) -> ReviewLoopSnapshot {
+    private static func snapshot(
+        needsPush: Bool,
+        aheadCommitCount: Int,
+        upstreamAheadCommitCount: Int = 0
+    ) -> ReviewLoopSnapshot {
         snapshot(
             branchName: "feature/pr-drafts",
             baseBranch: "origin/main",
             needsPush: needsPush,
-            aheadCommitCount: aheadCommitCount
+            aheadCommitCount: aheadCommitCount,
+            upstreamAheadCommitCount: upstreamAheadCommitCount
         )
     }
 
@@ -83,6 +102,7 @@ struct ReviewRequestDraftTests {
         baseBranch: String = "origin/main",
         needsPush: Bool,
         aheadCommitCount: Int,
+        upstreamAheadCommitCount: Int = 0,
         reviewRequest: ReviewRequest? = nil
     ) -> ReviewLoopSnapshot {
         ReviewLoopSnapshot(
@@ -96,6 +116,7 @@ struct ReviewRequestDraftTests {
                 hasUpstream: true,
                 upstreamRemoteName: "origin",
                 upstreamBranchName: "feature/pr-drafts",
+                upstreamAheadCommitCount: upstreamAheadCommitCount,
                 needsPush: needsPush
             ),
             remote: CodeHostRemote(

--- a/AlasTests/RightPaneStateReviewLoopPushTests.swift
+++ b/AlasTests/RightPaneStateReviewLoopPushTests.swift
@@ -2,7 +2,38 @@ import Foundation
 import Testing
 @testable import Alas
 
+@MainActor
 struct RightPaneStateReviewLoopPushTests {
+    private struct MemoryStore: PersistenceStoreProtocol {
+        func write<T: Encodable>(_: T, to _: URL) throws {}
+        func readIfExists<T: Decodable>(_: T.Type, from _: URL) throws -> T? { nil }
+    }
+
+    @Test func createReviewRequestActionOpensDraftTab() {
+        let worktreeId = "wt-review-request-draft-action"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let appState = AppState(store: MemoryStore())
+        let worktree = Worktree(
+            id: worktreeId,
+            projectId: "p1",
+            name: "feature/pr-drafts",
+            branch: "feature/pr-drafts",
+            path: URL(fileURLWithPath: "/tmp/repo"),
+            status: .clean,
+            lastActivity: Date(timeIntervalSince1970: 0)
+        )
+        let state = RightPaneState(worktree: worktree, baseBranch: "main")
+        state.reviewLoop.setSnapshotForTests(Self.makeSnapshot())
+
+        state.handleReviewReadinessAction(.createReviewRequest, appState: appState)
+
+        let tabs = appState.tabs.tabs(forWorktree: worktreeId)
+        #expect(tabs.contains {
+            if case .draftReviewRequest = $0 { return true }
+            return false
+        })
+    }
+
     @Test func normalPushArgumentsDoNotForce() {
         let snapshot = Self.makeSnapshot()
 

--- a/AlasTests/TabsManagerReviewRequestDraftTests.swift
+++ b/AlasTests/TabsManagerReviewRequestDraftTests.swift
@@ -134,6 +134,17 @@ struct TabsManagerReviewRequestDraftTests {
         #expect(decoded.createdURL == URL(string: "https://github.com/mrmans0n/alas/pull/42")!)
     }
 
+    @Test func draftReviewRequestTargetRequiresSameBranchBaseProviderRepoAndHead() {
+        let state = DraftReviewRequestTabState(worktreeId: "wt-1", snapshot: Self.snapshot())
+
+        #expect(state.matchesTarget(Self.snapshot()))
+        #expect(!state.matchesTarget(Self.snapshot(branchName: "feature/other")))
+        #expect(!state.matchesTarget(Self.snapshot(baseBranch: "origin/release")))
+        #expect(!state.matchesTarget(Self.snapshot(provider: .gitlab)))
+        #expect(!state.matchesTarget(Self.snapshot(owner: "other")))
+        #expect(!state.matchesTarget(Self.snapshot(headSHA: "def456")))
+    }
+
     private static func snapshot(
         provider: CodeHostKind = .github,
         owner: String = "mrmans0n",

--- a/AlasTests/TabsManagerReviewRequestDraftTests.swift
+++ b/AlasTests/TabsManagerReviewRequestDraftTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@MainActor
+struct TabsManagerReviewRequestDraftTests {
+    @Test func opensOrFocusesDraftReviewRequestTab() {
+        let worktreeId = "review-request-draft-open"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let snapshot = Self.snapshot()
+
+        let first = manager.openOrFocusDraftReviewRequest(worktreeId: worktreeId, snapshot: snapshot)
+        let second = manager.openOrFocusDraftReviewRequest(worktreeId: worktreeId, snapshot: snapshot)
+
+        #expect(first.id == second.id)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 1)
+        #expect(manager.activeTabId(forWorktree: worktreeId) == first.id)
+    }
+
+    @Test func focusesSameDraftTargetPreservingEdits() {
+        let worktreeId = "review-request-draft-same-target"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let snapshot = Self.snapshot()
+        let first = manager.openOrFocusDraftReviewRequest(worktreeId: worktreeId, snapshot: snapshot)
+
+        _ = manager.updateDraftReviewRequest(worktreeId: worktreeId, tabId: first.id) { state in
+            state.title = "Add PR draft tab"
+            state.body = "## Summary\n- Adds a tab"
+            state.createAsDraft = true
+        }
+
+        let second = manager.openOrFocusDraftReviewRequest(worktreeId: worktreeId, snapshot: snapshot)
+
+        #expect(second.id == first.id)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 1)
+        guard case .draftReviewRequest(let state) = second else {
+            Issue.record("Expected draft review request tab")
+            return
+        }
+        #expect(state.title == "Add PR draft tab")
+        #expect(state.body == "## Summary\n- Adds a tab")
+        #expect(state.createAsDraft)
+    }
+
+    @Test func differentBaseBranchOpensSeparateDraftTab() {
+        let worktreeId = "review-request-draft-different-base"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+
+        let first = manager.openOrFocusDraftReviewRequest(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(baseBranch: "origin/main")
+        )
+        let second = manager.openOrFocusDraftReviewRequest(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(baseBranch: "origin/release")
+        )
+
+        #expect(first.id != second.id)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 2)
+        #expect(manager.activeTabId(forWorktree: worktreeId) == second.id)
+    }
+
+    @Test func sameDraftTargetRefreshesHeadSHAPreservingEdits() {
+        let worktreeId = "review-request-draft-refresh-head-sha"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let first = manager.openOrFocusDraftReviewRequest(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(headSHA: "abc123", headRemoteOwner: "mrmans0n")
+        )
+
+        _ = manager.updateDraftReviewRequest(worktreeId: worktreeId, tabId: first.id) { state in
+            state.title = "Add PR draft tab"
+            state.body = "## Summary\n- Adds a tab"
+        }
+
+        let second = manager.openOrFocusDraftReviewRequest(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(headSHA: "def456", headRemoteOwner: "nacho")
+        )
+
+        #expect(second.id == first.id)
+        #expect(manager.tabs(forWorktree: worktreeId).count == 1)
+        guard case .draftReviewRequest(let state) = second else {
+            Issue.record("Expected draft review request tab")
+            return
+        }
+        #expect(state.headSHA == "def456")
+        #expect(state.headOwner == "nacho")
+        #expect(state.title == "Add PR draft tab")
+        #expect(state.body == "## Summary\n- Adds a tab")
+    }
+
+    @Test func updatesDraftReviewRequestFields() {
+        let worktreeId = "review-request-draft-update"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let tab = manager.openOrFocusDraftReviewRequest(worktreeId: worktreeId, snapshot: Self.snapshot())
+
+        _ = manager.updateDraftReviewRequest(worktreeId: worktreeId, tabId: tab.id) { state in
+            state.title = "Add PR draft tab"
+            state.body = "## Summary\n- Adds a tab"
+            state.createAsDraft = true
+        }
+
+        guard case .draftReviewRequest(let state) = manager.tabs(forWorktree: worktreeId).first else {
+            Issue.record("Expected draft review request tab")
+            return
+        }
+        #expect(state.title == "Add PR draft tab")
+        #expect(state.body.contains("## Summary"))
+        #expect(state.createAsDraft)
+    }
+
+    @Test func draftReviewRequestTabStateCodableRoundTripsDraftFields() throws {
+        var state = DraftReviewRequestTabState(worktreeId: "wt-1", snapshot: Self.snapshot())
+        state.title = "Add PR draft tab"
+        state.body = "## Summary\n- Adds a tab"
+        state.createAsDraft = true
+        state.selectedPath = "Alas/Sources/Center/Tab.swift"
+        state.createdURL = URL(string: "https://github.com/mrmans0n/alas/pull/42")!
+
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(DraftReviewRequestTabState.self, from: data)
+
+        #expect(decoded == state)
+        #expect(decoded.title == "Add PR draft tab")
+        #expect(decoded.body.contains("Adds a tab"))
+        #expect(decoded.createAsDraft)
+        #expect(decoded.selectedPath == "Alas/Sources/Center/Tab.swift")
+        #expect(decoded.createdURL == URL(string: "https://github.com/mrmans0n/alas/pull/42")!)
+    }
+
+    private static func snapshot(
+        provider: CodeHostKind = .github,
+        owner: String = "mrmans0n",
+        repository: String = "alas",
+        branchName: String = "feature/pr-drafts",
+        headSHA: String = "abc123",
+        baseBranch: String = "origin/main",
+        headRemoteOwner: String? = nil
+    ) -> ReviewLoopSnapshot {
+        ReviewLoopSnapshot(
+            local: ReviewLoopLocalState(
+                branchName: branchName,
+                headSHA: headSHA,
+                baseBranch: baseBranch,
+                hasWorkingTreeChanges: false,
+                hasStagedChanges: false,
+                aheadCommitCount: 2,
+                hasUpstream: true,
+                upstreamRemoteName: "origin",
+                upstreamBranchName: "feature/pr-drafts",
+                headRemoteOwner: headRemoteOwner,
+                needsPush: false
+            ),
+            remote: CodeHostRemote(
+                kind: provider,
+                host: provider == .github ? "github.com" : "gitlab.com",
+                owner: owner,
+                repository: repository,
+                remoteName: "origin",
+                webURL: URL(string: "https://github.com/mrmans0n/alas")!
+            ),
+            reviewRequest: nil,
+            providerAvailable: true,
+            providerAuthenticated: true,
+            providerCapabilities: .githubCLI,
+            errorMessage: nil
+        )
+    }
+}

--- a/AlasTests/TabsManagerReviewRequestDraftTests.swift
+++ b/AlasTests/TabsManagerReviewRequestDraftTests.swift
@@ -94,6 +94,32 @@ struct TabsManagerReviewRequestDraftTests {
         #expect(state.body == "## Summary\n- Adds a tab")
     }
 
+    @Test func sameDraftTargetClearsCreatedURLWhenHeadChanges() {
+        let worktreeId = "review-request-draft-clear-created-url"
+        defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }
+        let manager = TabsManager()
+        let first = manager.openOrFocusDraftReviewRequest(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(headSHA: "abc123")
+        )
+
+        _ = manager.updateDraftReviewRequest(worktreeId: worktreeId, tabId: first.id) { state in
+            state.createdURL = URL(string: "https://github.com/mrmans0n/alas/pull/42")!
+        }
+
+        let second = manager.openOrFocusDraftReviewRequest(
+            worktreeId: worktreeId,
+            snapshot: Self.snapshot(headSHA: "def456")
+        )
+
+        guard case .draftReviewRequest(let state) = second else {
+            Issue.record("Expected draft review request tab")
+            return
+        }
+        #expect(state.headSHA == "def456")
+        #expect(state.createdURL == nil)
+    }
+
     @Test func updatesDraftReviewRequestFields() {
         let worktreeId = "review-request-draft-update"
         defer { try? FileManager.default.removeItem(at: Paths.tabsFile(forWorktreeId: worktreeId)) }

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -229,3 +229,12 @@ Inside an Alas-spawned terminal:
 5. On a branch with an open PR, confirm the drawer shows `GitHub #<number>` and compact check/review/merge status.
 6. For a failing check, confirm "Open in agent" creates an ACP tab with a focused handoff prompt.
 7. Confirm merge, comment posting, review-thread resolution, force-push, and editing-agent runs are not executed without explicit user action.
+
+### Draft PR generation
+
+1. Open a worktree branch with committed changes ahead of the selected base branch and no existing PR.
+2. Expand the review readiness drawer and click Create PR.
+3. Confirm a Draft PR tab opens with normal PR mode selected and Draft unchecked.
+4. Click the sparkle button with an enabled AI tool.
+5. Confirm title/body are filled with Summary and Testing sections.
+6. Toggle Draft, then create the PR from a disposable branch or cancel before submission during local-only testing.

--- a/docs/superpowers/specs/2026-06-03-review-request-draft-tab-design.md
+++ b/docs/superpowers/specs/2026-06-03-review-request-draft-tab-design.md
@@ -1,0 +1,177 @@
+# Review Request Draft Tab Design
+
+## Context
+
+Alas already surfaces GitHub pull request readiness in the Changes tab through
+the review readiness drawer. When a branch has pushed commits but no review
+request, the drawer can create a PR through the code host provider. Today that
+path submits directly with a branch-name title and fixed body.
+
+Commit creation has a better workflow: a draft commit tab lets the user inspect
+the relevant diff, generate text with the selected AI agent, edit the result,
+and only then publish the commit. Review request creation should follow the same
+shape so users can generate and review a proper PR title and description before
+opening the request.
+
+## Goals
+
+- Replace the direct Create PR action with a center-pane draft tab.
+- Generate PR title and description with AI assistance.
+- Keep the first implementation provider-neutral in shape, with GitHub support
+  through `gh` first.
+- Generate from committed branch content only: base branch to `HEAD`.
+- Let users customize the review request generation prompt in Settings.
+- Support normal PR creation by default, with an opt-in Draft checkbox.
+- Preserve user edits and keep failures local to the draft tab.
+
+## Non-Goals
+
+- GitLab `glab` support in the first implementation.
+- Generating PR content from uncommitted working tree or index changes.
+- Automatically submitting a generated PR without user review.
+- Editing existing review request titles or descriptions.
+- Reworking the entire review readiness drawer.
+
+## Architecture
+
+Add a provider-neutral center tab type, tentatively named
+`DraftReviewRequestTabState`. It stores the worktree id, a stable tab id,
+review kind metadata from the current snapshot, editable title, editable body,
+selected context item, and `createAsDraft`, defaulting to `false`.
+
+The existing readiness drawer action remains the entry point. When the model
+offers `createReviewRequest`, `RightPaneState.handleReviewReadinessAction`
+should open or focus the draft review request tab instead of calling
+`ReviewLoopState.createReviewRequest(snapshot:)` directly. The tab initializes
+from the current `ReviewLoopSnapshot`: provider kind, remote, branch, head
+owner, base branch, ahead commit count, push state, and current head SHA.
+
+Submission remains in the code host provider layer. Extend
+`CodeHostProvider.createReviewRequest(...)` with an `isDraft: Bool` argument.
+`GitHubCLIProvider` should pass `--draft` to `gh pr create` only when that flag
+is true. GitLab remains unavailable until a GitLab provider implements creation
+capability.
+
+Remove the old user-facing fixed-title/fixed-body creation path. Keep only a
+lower-level submit operation that requires caller-supplied title, body, and
+draft mode. User-facing creation should flow through the tab.
+
+## User Flow
+
+When the readiness drawer shows that the branch has committed work but no PR,
+the create action opens the draft tab. The tab title starts as "Draft PR" for
+GitHub and can use provider labels for future hosts.
+
+The tab header shows the provider and target repository, a title field, a
+Markdown body editor, a sparkle button for AI generation, a Draft checkbox, and
+a primary "Create PR" action. The Draft checkbox is off by default, so the
+default behavior creates a normal open PR.
+
+Below the editor, the tab shows committed branch context. The left side lists
+changed files from base to `HEAD`, with a compact commit-subject summary above
+the file list. The right side previews the selected file diff. The split should
+reuse existing commit and diff views where practical, but the editor remains the
+primary task surface.
+
+After successful creation, the draft should not disappear without feedback.
+Convert the tab into a simple created state, update the title to the provider
+identity when available, show the provider URL, and offer an Open action. The
+readiness drawer refresh should then pick up the new request.
+
+## AI Generation
+
+The draft tab uses the same selected AI tool as commit generation
+(`changes.aiToolId`), but with a dedicated prompt:
+`changes.reviewRequestPrompt`.
+
+The generated context should include:
+
+- provider and repository identity
+- branch name
+- base branch
+- commit subjects between base and `HEAD`
+- branch diff from base to `HEAD`
+- status facts such as uncommitted changes existing, without including those
+  uncommitted diffs
+
+The generator must exclude working tree and staged changes from the diff. If
+such changes exist, the tab should show a warning that they are not represented
+in generated PR content.
+
+The default prompt should require strict output:
+
+```text
+Line 1: PR title
+Line 2: blank
+Line 3+: Markdown body with:
+## Summary
+- ...
+
+## Testing
+- ...
+```
+
+The UI parses line 1 as the title and the remaining text as the Markdown body,
+matching the existing commit-message generation behavior.
+
+## Settings
+
+Add a "Review requests" section to the Changes settings pane. It should expose
+the review request prompt editor and show a Custom chip when the value differs
+from `AppConfig.defaultReviewRequestPrompt`.
+
+Config migration should preserve legacy files by defaulting missing
+`changes.reviewRequestPrompt` to `AppConfig.defaultReviewRequestPrompt`.
+
+The existing AI tool picker remains shared. The selected agent controls commit
+message generation, merge help, review handoffs, and review request draft
+generation.
+
+## Validation And Error Handling
+
+The draft tab should disable creation when:
+
+- title is empty
+- body is empty
+- no branch is checked out
+- no code host remote exists
+- provider is unavailable or unauthenticated
+- provider cannot create review requests
+- branch has no ahead commits
+- branch needs push before PR creation
+
+If the branch needs push, the readiness drawer remains responsible for guiding
+the push action. The draft tab can show the stale/push-needed state, but it
+should not submit until the snapshot is refreshed after push.
+
+AI failures should appear as inline tab errors. Manual edits must remain intact.
+Clicking sparkle may replace the title/body with newly generated output, but no
+background task should overwrite edited text without the user explicitly asking
+for generation.
+
+Provider creation failures should keep the draft open with the user's current
+title, body, and Draft checkbox state intact.
+
+## Testing Plan
+
+- `AppConfig` tests for default `reviewRequestPrompt`, legacy decode, and
+  round-trip persistence.
+- Prompt status/settings tests for the review request prompt custom chip.
+- Provider tests proving `GitHubCLIProvider` adds `--draft` only when requested.
+- Prompt context builder tests proving committed branch context is included and
+  uncommitted diffs are excluded.
+- Tab manager tests for open/focus/update behavior of the draft review request
+  tab.
+- Readiness action tests proving Create PR opens the draft tab instead of
+  directly submitting.
+- Draft-tab model tests for title/body validation, push-needed gating, and
+  creation failure preservation.
+
+## Open Decisions Resolved
+
+- Entry behavior: Create PR opens a draft tab.
+- Diff scope: committed branch changes only.
+- Provider scope: provider-neutral design, GitHub implementation first.
+- Prompt: dedicated customizable review request prompt.
+- Body shape: Summary and Testing sections by default.
+- PR mode: normal PR by default, Draft checkbox available.


### PR DESCRIPTION
## Summary
- Add a draft PR tab that opens from review readiness and persists title, body, draft mode, selected file, and created URL.
- Generate PR title/description from committed branch context with a configurable settings prompt.
- Add GitHub draft PR creation support plus guards for stale branch/base/head state and selected-file diff previews.

## Test Plan
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`