### PR TITLE
feat(gitlab): add review request provider

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -858,6 +858,7 @@
 		E9507AB389CE47A6A48C049B /* ACPProcessLiveness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA695BB3D2901435BFF6C0E /* ACPProcessLiveness.swift */; };
 		E99E4DB46496707E7A3F044A /* PiACPInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6F36C31DB1C13D86416B4B /* PiACPInstaller.swift */; };
 		EA0EE2D3301F5D79E0C1A280 /* LanguageServerAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B319CFA57A23CE36F2AAE /* LanguageServerAvailability.swift */; };
+		EA2BAFA70ED22F6085EB1971 /* GitLabCLIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */; };
 		EA6EFDDEAE3FF9D878824EDC /* ACPProcessLivenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9797C4D8F5DCCC9563D79007 /* ACPProcessLivenessTests.swift */; };
 		EA9B2D81920F620209AB2C34 /* MasonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FBCF0F61C80FD8020B1ADD /* MasonSnapshotTests.swift */; };
 		EACD40C757361FC2C78F912A /* ACPCodeBlockHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530767799372FE03C3695656 /* ACPCodeBlockHighlighter.swift */; };
@@ -1318,6 +1319,7 @@
 		6BDB3231FFACC0398F973876 /* ACPLaunchSpecNpmPackageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecNpmPackageTests.swift; sourceTree = "<group>"; };
 		6C4309EDC99FC1F98C479115 /* SearchModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModelTests.swift; sourceTree = "<group>"; };
 		6C4E238E48247A6CDD5565D2 /* WorktreeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeService.swift; sourceTree = "<group>"; };
+		6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProvider.swift; sourceTree = "<group>"; };
 		6CA51D49B1AE4C4E10D450C6 /* ACPFileWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFileWriterTests.swift; sourceTree = "<group>"; };
 		6CB9643BE01E416D3D2F4454 /* BaseBranchSelectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBranchSelectorTests.swift; sourceTree = "<group>"; };
 		6D1AAAE396590865426C592A /* ACPSessionManagerRetentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSessionManagerRetentionTests.swift; sourceTree = "<group>"; };
@@ -2447,6 +2449,7 @@
 				031B1108F04B06EAC224AB5B /* CodeHostProvider.swift */,
 				82E98F9835497D830C12AA8F /* CodeHostRemoteDetector.swift */,
 				B5D2DA50E978EB0571D6A74C /* GitHubCLIProvider.swift */,
+				6C4E2F83F9EAB77B96EBA152 /* GitLabCLIProvider.swift */,
 				2D4CC3ED497796474F107EBE /* ReviewLoopDrawer.swift */,
 				17F7DB6F391F1AAA9FED1A86 /* ReviewLoopHandoffBuilder.swift */,
 				0299820D15A2A4C7838B2CE9 /* ReviewLoopState.swift */,
@@ -3924,6 +3927,7 @@
 				7D75AEB67376431930CB37E3 /* GitEventFilter.swift in Sources */,
 				C1D83EEBE3AF4ABC04B3F7EB /* GitHubCLIProvider.swift in Sources */,
 				B66EE6A2445C0DDA607788C2 /* GitIgnoreService.swift in Sources */,
+				EA2BAFA70ED22F6085EB1971 /* GitLabCLIProvider.swift in Sources */,
 				175951CE78A1446A9131BA1F /* GitNameValidator.swift in Sources */,
 				CD227C48AA85A5E74A92DF3F /* GitRefNameInputFilter.swift in Sources */,
 				6FA1659F464BE9C03C90F787 /* GitService+CommitEditing.swift in Sources */,

--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		188D02B853162BF4533020E2 /* ChevronStabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42955D4178E97347B8C942A /* ChevronStabilityTests.swift */; };
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
+		195102F7D680452476D70329 /* GitLabCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */; };
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
 		1AE5FCAF7D44694876754813 /* HookInstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */; };
 		1B123A31842DDDB42C6820F1 /* BuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */; };
@@ -1603,6 +1604,7 @@
 		C2D7EA3F2B69C0A8D2F8F8A5 /* ACPPromptCapabilitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPromptCapabilitiesTests.swift; sourceTree = "<group>"; };
 		C2E0C7ED63A67D16A79DF4BA /* ReleaseCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseCheckerTests.swift; sourceTree = "<group>"; };
 		C34ED0F4DB5FB6620993ECFC /* DiffSelectableTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextTests.swift; sourceTree = "<group>"; };
+		C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitLabCLIProviderTests.swift; sourceTree = "<group>"; };
 		C3B53E3E92FA696866F44FDD /* ACPLaunchSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPLaunchSpecTests.swift; sourceTree = "<group>"; };
 		C3BC736DAAD590624B840923 /* ACPSystemNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPSystemNoticeView.swift; sourceTree = "<group>"; };
 		C47AF847BD698EAB373D128B /* ZmxClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxClient.swift; sourceTree = "<group>"; };
@@ -3220,6 +3222,7 @@
 				2449596651B3FE84E8E3832B /* CodeHostProviderTests.swift */,
 				DE74A483930F70A0C79CC3E8 /* CodeHostRemoteDetectorTests.swift */,
 				8C28D64372B5B4C734A92533 /* GitHubCLIProviderTests.swift */,
+				C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */,
 				B0F47561DB37D2ED72B6BE25 /* ReviewLoopDrawerTests.swift */,
 				4EC688020FD7B6A2A4393B72 /* ReviewLoopHandoffBuilderTests.swift */,
 				3939B27EA8D7A562048E5932 /* ReviewLoopStateTests.swift */,
@@ -4376,6 +4379,7 @@
 				D4934B70887DE314FD73B0D1 /* GitEventFilterTests.swift in Sources */,
 				6AA812880B9E28C4AE9A6BFC /* GitHubCLIProviderTests.swift in Sources */,
 				D27A1F6D7592D6A4BDD9FC4F /* GitIgnoreServiceTests.swift in Sources */,
+				195102F7D680452476D70329 /* GitLabCLIProviderTests.swift in Sources */,
 				513BF637E5FF0BF3883FB1CC /* GitNameValidatorTests.swift in Sources */,
 				881EB8E37CE9D947A2C74564 /* GitRefNameInputFilterTests.swift in Sources */,
 				EB6136E15E4F1A4CBA230D12 /* GitServiceBehindStatusTests.swift in Sources */,

--- a/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostModels.swift
@@ -61,6 +61,12 @@ struct CodeHostProviderCapabilities: Equatable, Sendable {
         canRerunFailedChecks: true,
         canOpenReviewRequest: true
     )
+
+    static let gitlabCLI = CodeHostProviderCapabilities(
+        canCreateReviewRequest: true,
+        canRerunFailedChecks: true,
+        canOpenReviewRequest: true
+    )
 }
 
 enum ReviewRequestState: String, Codable, Equatable, Sendable {

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -77,7 +77,10 @@ struct CodeHostProviderRegistry: Sendable {
     }
 
     static func live() -> CodeHostProviderRegistry {
-        CodeHostProviderRegistry(providers: [.github: GitHubCLIProvider()])
+        CodeHostProviderRegistry(providers: [
+            .github: GitHubCLIProvider(),
+            .gitlab: GitLabCLIProvider(),
+        ])
     }
 
     func provider(for kind: CodeHostKind) -> (any CodeHostProvider)? {

--- a/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/CodeHostProvider.swift
@@ -62,7 +62,13 @@ protocol CodeHostProvider: Sendable {
         cwd: URL
     ) async throws -> URL
     func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck]
-    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, cwd: URL) async throws
+    func rerunFailedChecks(
+        remote: CodeHostRemote,
+        branch: String,
+        headSHA: String,
+        request: ReviewRequest?,
+        cwd: URL
+    ) async throws
 }
 
 extension CodeHostProvider {

--- a/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitHubCLIProvider.swift
@@ -212,7 +212,14 @@ struct GitHubCLIProvider: CodeHostProvider {
         return try Self.parseReviewThreadsPage(result.stdout)
     }
 
-    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, cwd: URL) async throws {
+    func rerunFailedChecks(
+        remote: CodeHostRemote,
+        branch: String,
+        headSHA: String,
+        request: ReviewRequest?,
+        cwd: URL
+    ) async throws {
+        _ = request
         let listResult = try await runner.run(
             "gh",
             args: [

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+struct GitLabCLIProvider: CodeHostProvider {
+    let kind: CodeHostKind = .gitlab
+    let capabilities: CodeHostProviderCapabilities = .readOnly
+
+    private let runner: any CodeHostCommandRunning
+
+    init(runner: any CodeHostCommandRunning = ProcessCodeHostCommandRunner()) {
+        self.runner = runner
+    }
+
+    func isAvailable() async -> Bool {
+        do {
+            let result = try await runner.run("glab", args: ["--version"], cwd: nil)
+            return result.exitCode == 0
+        } catch {
+            return false
+        }
+    }
+
+    func isAuthenticated(remote: CodeHostRemote, cwd: URL) async -> Bool {
+        do {
+            let result = try await runner.run(
+                "glab",
+                args: ["auth", "status", "--hostname", remote.host],
+                cwd: cwd
+            )
+            return result.exitCode == 0
+        } catch {
+            return false
+        }
+    }
+
+    func currentReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        cwd: URL
+    ) async throws -> ReviewRequest? {
+        _ = (remote, branch, headOwner, baseBranch, cwd)
+        return nil
+    }
+
+    func createReviewRequest(
+        remote: CodeHostRemote,
+        branch: String,
+        headOwner: String?,
+        baseBranch: String,
+        title: String,
+        body: String,
+        isDraft: Bool,
+        cwd: URL
+    ) async throws -> URL {
+        _ = (branch, headOwner, baseBranch, title, body, isDraft, cwd)
+        return remote.webURL
+    }
+
+    func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] {
+        _ = (remote, request, cwd)
+        return []
+    }
+
+    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, cwd: URL) async throws {
+        _ = (remote, branch, headSHA, cwd)
+    }
+}

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -212,10 +212,6 @@ struct GitLabCLIProvider: CodeHostProvider {
         }
 
         let items = try Self.decodeMRList(json)
-        guard items.count > 1 else {
-            return [:]
-        }
-
         var pathsByID: [Int: String] = [:]
         let idsToResolve = Set(items.compactMap { item -> Int? in
             guard item.sourceProjectNamespace(sourceProjectPathsByID: [:]) == nil else {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -56,7 +56,18 @@ struct GitLabCLIProvider: CodeHostProvider {
             throw CodeHostProviderError.commandFailed(command: "glab mr list", stderr: result.stderr)
         }
 
-        guard let request = try Self.parseMRList(result.stdout, remote: remote, headOwner: headOwner) else {
+        let sourceProjectPathsByID = try await sourceProjectPathsByID(
+            fromMRListJSON: result.stdout,
+            headOwner: headOwner,
+            remote: remote,
+            cwd: cwd
+        )
+        guard let request = try Self.parseMRList(
+            result.stdout,
+            remote: remote,
+            headOwner: headOwner,
+            sourceProjectPathsByID: sourceProjectPathsByID
+        ) else {
             return nil
         }
 
@@ -190,6 +201,44 @@ struct GitLabCLIProvider: CodeHostProvider {
         return try Self.parseMRView(result.stdout, remote: remote)
     }
 
+    private func sourceProjectPathsByID(
+        fromMRListJSON json: String,
+        headOwner: String?,
+        remote: CodeHostRemote,
+        cwd: URL
+    ) async throws -> [Int: String] {
+        guard let headOwner = Self.normalizedOptionalString(headOwner), !headOwner.isEmpty else {
+            return [:]
+        }
+
+        let items = try Self.decodeMRList(json)
+        guard items.count > 1 else {
+            return [:]
+        }
+
+        var pathsByID: [Int: String] = [:]
+        let idsToResolve = Set(items.compactMap { item -> Int? in
+            guard item.sourceProjectNamespace(sourceProjectPathsByID: [:]) == nil else {
+                return nil
+            }
+            return item.sourceProjectID
+        })
+
+        for id in idsToResolve.sorted() {
+            let result = try await runner.run(
+                "glab",
+                args: ["api", "projects/\(id)", "--hostname", remote.host, "--output", "json"],
+                cwd: cwd
+            )
+            guard result.exitCode == 0 else {
+                throw CodeHostProviderError.commandFailed(command: "glab api projects/\(id)", stderr: result.stderr)
+            }
+            pathsByID[id] = try Self.parseProjectPath(result.stdout)
+        }
+
+        return pathsByID
+    }
+
     private func unresolvedDiscussions(
         remote: CodeHostRemote,
         request: ReviewRequest,
@@ -238,23 +287,24 @@ struct GitLabCLIProvider: CodeHostProvider {
         throw CodeHostProviderError.malformedOutput("glab mr create returned an invalid URL")
     }
 
-    static func parseMRList(_ json: String, remote: CodeHostRemote, headOwner: String?) throws -> ReviewRequest? {
-        let data = Data(json.utf8)
-        let items: [MRListItem]
-        do {
-            items = try JSONDecoder().decode([MRListItem].self, from: data)
-        } catch {
-            throw CodeHostProviderError.malformedOutput("Unable to parse glab mr list output")
-        }
+    static func parseMRList(
+        _ json: String,
+        remote: CodeHostRemote,
+        headOwner: String?,
+        sourceProjectPathsByID: [Int: String] = [:]
+    ) throws -> ReviewRequest? {
+        let items = try decodeMRList(json)
 
         guard let item = items.first else {
             return nil
         }
 
         if let headOwner = headOwner?.trimmingCharacters(in: .whitespacesAndNewlines), !headOwner.isEmpty {
-            let itemsWithSourceProject = items.filter { $0.sourceProjectNamespace != nil }
+            let itemsWithSourceProject = items.filter { $0.sourceProjectNamespace(sourceProjectPathsByID: sourceProjectPathsByID) != nil }
             if !itemsWithSourceProject.isEmpty {
-                guard let item = itemsWithSourceProject.first(where: { $0.matchesSourceProjectOwner(headOwner) }) else {
+                guard let item = itemsWithSourceProject.first(where: {
+                    $0.matchesSourceProjectOwner(headOwner, sourceProjectPathsByID: sourceProjectPathsByID)
+                }) else {
                     return nil
                 }
                 return try reviewRequest(from: item, remote: remote, context: "glab mr list")
@@ -266,6 +316,29 @@ struct GitLabCLIProvider: CodeHostProvider {
         }
 
         return try reviewRequest(from: item, remote: remote, context: "glab mr list")
+    }
+
+    static func parseProjectPath(_ json: String) throws -> String {
+        let data = Data(json.utf8)
+        let project: GitLabProject
+        do {
+            project = try JSONDecoder().decode(GitLabProject.self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab api project output")
+        }
+        guard let path = normalizedOptionalString(project.pathWithNamespace) else {
+            throw CodeHostProviderError.malformedOutput("glab api project output is missing path_with_namespace")
+        }
+        return path
+    }
+
+    private static func decodeMRList(_ json: String) throws -> [MRListItem] {
+        let data = Data(json.utf8)
+        do {
+            return try JSONDecoder().decode([MRListItem].self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab mr list output")
+        }
     }
 
     static func parseMRView(_ json: String, remote: CodeHostRemote) throws -> ReviewRequest {
@@ -563,6 +636,7 @@ private struct MRListItem: Decodable {
     let approvalsRequired: Int?
     let approvalsLeft: Int?
     let sourceProject: SourceProject?
+    let sourceProjectID: Int?
     let sourceProjectPath: String?
     let sourceProjectPathWithNamespace: String?
 
@@ -570,12 +644,15 @@ private struct MRListItem: Decodable {
         (draft ?? false) || (workInProgress ?? false)
     }
 
-    var sourceProjectNamespace: String? {
-        sourceProject?.pathWithNamespace ?? sourceProjectPathWithNamespace ?? sourceProjectPath
+    func sourceProjectNamespace(sourceProjectPathsByID: [Int: String]) -> String? {
+        sourceProject?.pathWithNamespace
+            ?? sourceProjectPathWithNamespace
+            ?? sourceProjectPath
+            ?? sourceProjectID.flatMap { sourceProjectPathsByID[$0] }
     }
 
-    func matchesSourceProjectOwner(_ headOwner: String) -> Bool {
-        guard let sourceProjectNamespace else {
+    func matchesSourceProjectOwner(_ headOwner: String, sourceProjectPathsByID: [Int: String]) -> Bool {
+        guard let sourceProjectNamespace = sourceProjectNamespace(sourceProjectPathsByID: sourceProjectPathsByID) else {
             return false
         }
         return sourceProjectNamespace == headOwner || sourceProjectNamespace.hasPrefix("\(headOwner)/")
@@ -596,12 +673,21 @@ private struct MRListItem: Decodable {
         case approvalsRequired = "approvals_required"
         case approvalsLeft = "approvals_left"
         case sourceProject = "source_project"
+        case sourceProjectID = "source_project_id"
         case sourceProjectPath = "source_project_path"
         case sourceProjectPathWithNamespace = "source_project_path_with_namespace"
     }
 }
 
 private struct SourceProject: Decodable {
+    let pathWithNamespace: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case pathWithNamespace = "path_with_namespace"
+    }
+}
+
+private struct GitLabProject: Decodable {
     let pathWithNamespace: String?
 
     private enum CodingKeys: String, CodingKey {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -394,7 +394,7 @@ struct GitLabCLIProvider: CodeHostProvider {
                     id: checkID(for: job, pipeline: pipeline),
                     name: job.name,
                     workflow: workflow,
-                    bucket: mapCheckBucket(job.status),
+                    bucket: mapCheckBucket(job.status, allowFailure: job.allowFailure),
                     detailURL: detailURL,
                     completedAt: try parseOptionalGitLabDate(job.finishedAt)
                 )
@@ -431,7 +431,7 @@ struct GitLabCLIProvider: CodeHostProvider {
     private static func failedJobIDs(fromPipelineJSON json: String) throws -> [Int] {
         let pipeline = try decodePipeline(json)
         return pipeline.jobs?.compactMap { job in
-            job.status.lowercased() == "failed" ? job.id : nil
+            job.status.lowercased() == "failed" && job.allowFailure != true ? job.id : nil
         } ?? []
     }
 
@@ -500,19 +500,26 @@ struct GitLabCLIProvider: CodeHostProvider {
     }
 
     private static func mapCheckBucket(_ status: String) -> ReviewCheckBucket {
+        mapCheckBucket(status, allowFailure: false)
+    }
+
+    private static func mapCheckBucket(_ status: String, allowFailure: Bool?) -> ReviewCheckBucket {
+        if status.lowercased() == "failed", allowFailure == true {
+            return .skipping
+        }
         switch status.lowercased() {
         case "success":
-            .pass
+            return .pass
         case "failed":
-            .fail
+            return .fail
         case "running", "pending", "created", "preparing", "waiting_for_resource", "manual", "scheduled":
-            .pending
+            return .pending
         case "canceled", "cancelled":
-            .cancel
+            return .cancel
         case "skipped":
-            .skipping
+            return .skipping
         default:
-            .unknown
+            return .unknown
         }
     }
 
@@ -719,6 +726,7 @@ private struct GitLabJob: Decodable {
     let id: Int?
     let name: String
     let status: String
+    let allowFailure: Bool?
     let webURL: String?
     let finishedAt: String?
 
@@ -726,6 +734,7 @@ private struct GitLabJob: Decodable {
         case id
         case name
         case status
+        case allowFailure = "allow_failure"
         case webURL = "web_url"
         case finishedAt = "finished_at"
     }

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -209,7 +209,7 @@ struct GitLabCLIProvider: CodeHostProvider {
             throw CodeHostProviderError.commandFailed(command: "glab mr note list", stderr: result.stderr)
         }
 
-        return []
+        return try Self.parseDiscussions(result.stdout, requestURL: request.url)
     }
 
     static func normalizedBaseBranch(_ baseBranch: String, remoteName: String) -> String {
@@ -278,6 +278,33 @@ struct GitLabCLIProvider: CodeHostProvider {
         }
 
         return try reviewRequest(from: item, remote: remote, context: "glab mr view")
+    }
+
+    static func parseDiscussions(_ json: String, requestURL: URL) throws -> [ReviewThreadSummary] {
+        let data = Data(json.utf8)
+        let discussions: [GitLabDiscussion]
+        do {
+            discussions = try JSONDecoder().decode([GitLabDiscussion].self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab mr note list output")
+        }
+
+        return try discussions.compactMap { discussion in
+            guard let note = discussion.notes.first(where: { note in
+                !note.isSystem && !note.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }) else {
+                return nil
+            }
+
+            return ReviewThreadSummary(
+                id: discussion.id,
+                author: note.author?.username,
+                body: note.body,
+                url: try discussionURL(note: note, requestURL: requestURL),
+                isResolved: discussion.isResolved,
+                isActionable: !discussion.isResolved
+            )
+        }
     }
 
     static func parsePipeline(_ json: String) throws -> [ReviewCheck] {
@@ -460,6 +487,18 @@ struct GitLabCLIProvider: CodeHostProvider {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    private static func discussionURL(note: GitLabDiscussionNote, requestURL: URL) throws -> URL? {
+        if let url = try parseOptionalHTTPURL(note.webURL, context: "glab mr note list returned an invalid URL") {
+            return url
+        }
+        guard let id = note.id else {
+            return nil
+        }
+        var components = URLComponents(url: requestURL, resolvingAgainstBaseURL: false)
+        components?.fragment = "note_\(id)"
+        return components?.url
+    }
+
     private static func checkID(for pipeline: GitLabPipeline) -> String {
         encodedID([
             "gitlab-pipeline-check",
@@ -604,6 +643,51 @@ private struct GitLabJob: Decodable {
         case webURL = "web_url"
         case finishedAt = "finished_at"
     }
+}
+
+private struct GitLabDiscussion: Decodable {
+    let id: String
+    let resolved: Bool?
+    let notes: [GitLabDiscussionNote]
+
+    var isResolved: Bool {
+        if let resolved {
+            return resolved
+        }
+        let resolvableNotes = notes.filter { $0.resolvable ?? false }
+        guard !resolvableNotes.isEmpty else {
+            return false
+        }
+        return resolvableNotes.allSatisfy { $0.resolved ?? false }
+    }
+}
+
+private struct GitLabDiscussionNote: Decodable {
+    let id: Int?
+    let body: String
+    let author: GitLabDiscussionAuthor?
+    let system: Bool?
+    let resolvable: Bool?
+    let resolved: Bool?
+    let webURL: String?
+
+    var isSystem: Bool {
+        system ?? false
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case body
+        case author
+        case system
+        case resolvable
+        case resolved
+        case webURL = "web_url"
+    }
+}
+
+private struct GitLabDiscussionAuthor: Decodable {
+    let username: String?
 }
 
 private extension CharacterSet {

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct GitLabCLIProvider: CodeHostProvider {
     let kind: CodeHostKind = .gitlab
-    let capabilities: CodeHostProviderCapabilities = .readOnly
+    let capabilities: CodeHostProviderCapabilities = .gitlabCLI
 
     private let runner: any CodeHostCommandRunning
 

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -39,8 +39,30 @@ struct GitLabCLIProvider: CodeHostProvider {
         baseBranch: String,
         cwd: URL
     ) async throws -> ReviewRequest? {
-        _ = (remote, branch, headOwner, baseBranch, cwd)
-        return nil
+        let base = Self.normalizedBaseBranch(baseBranch, remoteName: remote.remoteName)
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "mr", "list",
+                "--source-branch", branch,
+                "--target-branch", base,
+                "--output", "json",
+                "--per-page", "20",
+                "-R", remote.repositorySlug,
+            ],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab mr list", stderr: result.stderr)
+        }
+
+        guard let request = try Self.parseMRList(result.stdout, remote: remote, headOwner: headOwner) else {
+            return nil
+        }
+
+        let detailedRequest = (try? await reviewRequestDetails(remote: remote, request: request, cwd: cwd)) ?? request
+        let threads = (try? await unresolvedDiscussions(remote: remote, request: detailedRequest, cwd: cwd)) ?? []
+        return Self.withEnrichment(threads: threads, checks: [], on: detailedRequest)
     }
 
     func createReviewRequest(
@@ -91,6 +113,45 @@ struct GitLabCLIProvider: CodeHostProvider {
         _ = (remote, branch, headSHA, cwd)
     }
 
+    private func reviewRequestDetails(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        cwd: URL
+    ) async throws -> ReviewRequest {
+        let result = try await runner.run(
+            "glab",
+            args: ["mr", "view", "\(request.number)", "--output", "json", "-R", remote.repositorySlug],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab mr view", stderr: result.stderr)
+        }
+
+        return try Self.parseMRView(result.stdout, remote: remote)
+    }
+
+    private func unresolvedDiscussions(
+        remote: CodeHostRemote,
+        request: ReviewRequest,
+        cwd: URL
+    ) async throws -> [ReviewThreadSummary] {
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "mr", "note", "list", "\(request.number)",
+                "--state", "unresolved",
+                "--output", "json",
+                "-R", remote.repositorySlug,
+            ],
+            cwd: cwd
+        )
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab mr note list", stderr: result.stderr)
+        }
+
+        return []
+    }
+
     static func normalizedBaseBranch(_ baseBranch: String, remoteName: String) -> String {
         let prefix = "\(remoteName)/"
         guard baseBranch.hasPrefix(prefix) else { return baseBranch }
@@ -115,6 +176,194 @@ struct GitLabCLIProvider: CodeHostProvider {
             }
         }
         throw CodeHostProviderError.malformedOutput("glab mr create returned an invalid URL")
+    }
+
+    static func parseMRList(_ json: String, remote: CodeHostRemote, headOwner: String?) throws -> ReviewRequest? {
+        let data = Data(json.utf8)
+        let items: [MRListItem]
+        do {
+            items = try JSONDecoder().decode([MRListItem].self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab mr list output")
+        }
+
+        guard let item = items.first else {
+            return nil
+        }
+
+        if let headOwner = headOwner?.trimmingCharacters(in: .whitespacesAndNewlines), !headOwner.isEmpty {
+            let itemsWithSourceProject = items.filter { $0.sourceProjectNamespace != nil }
+            if !itemsWithSourceProject.isEmpty {
+                guard let item = itemsWithSourceProject.first(where: { $0.matchesSourceProjectOwner(headOwner) }) else {
+                    return nil
+                }
+                return try reviewRequest(from: item, remote: remote, context: "glab mr list")
+            }
+
+            guard items.count == 1 else {
+                return nil
+            }
+        }
+
+        return try reviewRequest(from: item, remote: remote, context: "glab mr list")
+    }
+
+    static func parseMRView(_ json: String, remote: CodeHostRemote) throws -> ReviewRequest {
+        let data = Data(json.utf8)
+        let item: MRListItem
+        do {
+            item = try JSONDecoder().decode(MRListItem.self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab mr view output")
+        }
+
+        return try reviewRequest(from: item, remote: remote, context: "glab mr view")
+    }
+
+    private static func reviewRequest(
+        from item: MRListItem,
+        remote: CodeHostRemote,
+        context: String
+    ) throws -> ReviewRequest {
+        guard let number = item.iid else {
+            throw CodeHostProviderError.malformedOutput("\(context) output is missing a merge request iid")
+        }
+        guard let url = URL(string: item.webURL), url.isHTTPOrHTTPS else {
+            throw CodeHostProviderError.malformedOutput("\(context) returned an invalid URL")
+        }
+
+        return ReviewRequest(
+            remote: remote,
+            number: number,
+            title: item.title,
+            url: url,
+            state: mapState(item.state),
+            isDraft: item.isDraft,
+            headRefName: item.sourceBranch,
+            baseRefName: item.targetBranch,
+            reviewDecision: mapReviewDecision(approvalsRequired: item.approvalsRequired, approvalsLeft: item.approvalsLeft),
+            mergeState: mapMergeState(detailed: item.detailedMergeStatus, fallback: item.mergeStatus),
+            checks: [],
+            threads: []
+        )
+    }
+
+    private static func mapState(_ value: String) -> ReviewRequestState {
+        switch value.lowercased() {
+        case "opened", "open": .open
+        case "merged": .merged
+        case "closed": .closed
+        default: .open
+        }
+    }
+
+    private static func mapReviewDecision(approvalsRequired: Int?, approvalsLeft: Int?) -> ReviewDecision {
+        guard let approvalsRequired, approvalsRequired > 0 else {
+            return .unknown
+        }
+        guard let approvalsLeft else {
+            return .unknown
+        }
+        return approvalsLeft == 0 ? .approved : .reviewRequired
+    }
+
+    private static func mapMergeState(detailed: String?, fallback: String?) -> ReviewMergeState {
+        switch (detailed ?? fallback)?.lowercased() {
+        case "mergeable", "can_be_merged":
+            .clean
+        case "conflict", "conflicts", "cannot_be_merged", "need_rebase":
+            .dirty
+        case "cannot_be_merged_recheck", "checking", "unchecked", "preparing", "ci_still_running", "commits_status",
+             "approvals_syncing", "not_ready":
+            .unstable
+        case "requested_changes", "blocked_status", "ci_must_pass", "discussions_not_resolved", "not_approved",
+             "draft_status", "external_status_checks", "security_policy_pipeline_check":
+            .blocked
+        default:
+            .unknown
+        }
+    }
+
+    private static func withEnrichment(
+        threads: [ReviewThreadSummary],
+        checks: [ReviewCheck],
+        on request: ReviewRequest
+    ) -> ReviewRequest {
+        ReviewRequest(
+            remote: request.remote,
+            number: request.number,
+            title: request.title,
+            url: request.url,
+            state: request.state,
+            isDraft: request.isDraft,
+            headRefName: request.headRefName,
+            baseRefName: request.baseRefName,
+            reviewDecision: request.reviewDecision,
+            mergeState: request.mergeState,
+            checks: checks,
+            threads: threads
+        )
+    }
+}
+
+private struct MRListItem: Decodable {
+    let id: Int?
+    let iid: Int?
+    let title: String
+    let webURL: String
+    let state: String
+    let draft: Bool?
+    let workInProgress: Bool?
+    let sourceBranch: String
+    let targetBranch: String
+    let mergeStatus: String?
+    let detailedMergeStatus: String?
+    let approvalsRequired: Int?
+    let approvalsLeft: Int?
+    let sourceProject: SourceProject?
+    let sourceProjectPath: String?
+    let sourceProjectPathWithNamespace: String?
+
+    var isDraft: Bool {
+        (draft ?? false) || (workInProgress ?? false)
+    }
+
+    var sourceProjectNamespace: String? {
+        sourceProject?.pathWithNamespace ?? sourceProjectPathWithNamespace ?? sourceProjectPath
+    }
+
+    func matchesSourceProjectOwner(_ headOwner: String) -> Bool {
+        guard let sourceProjectNamespace else {
+            return false
+        }
+        return sourceProjectNamespace == headOwner || sourceProjectNamespace.hasPrefix("\(headOwner)/")
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case iid
+        case title
+        case webURL = "web_url"
+        case state
+        case draft
+        case workInProgress = "work_in_progress"
+        case sourceBranch = "source_branch"
+        case targetBranch = "target_branch"
+        case mergeStatus = "merge_status"
+        case detailedMergeStatus = "detailed_merge_status"
+        case approvalsRequired = "approvals_required"
+        case approvalsLeft = "approvals_left"
+        case sourceProject = "source_project"
+        case sourceProjectPath = "source_project_path"
+        case sourceProjectPathWithNamespace = "source_project_path_with_namespace"
+    }
+}
+
+private struct SourceProject: Decodable {
+    let pathWithNamespace: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case pathWithNamespace = "path_with_namespace"
     }
 }
 

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -53,8 +53,33 @@ struct GitLabCLIProvider: CodeHostProvider {
         isDraft: Bool,
         cwd: URL
     ) async throws -> URL {
-        _ = (branch, headOwner, baseBranch, title, body, isDraft, cwd)
-        return remote.webURL
+        let base = Self.normalizedBaseBranch(baseBranch, remoteName: remote.remoteName)
+        var args = [
+            "mr", "create",
+            "--source-branch", branch,
+            "--target-branch", base,
+            "--title", title,
+            "--description", body,
+            "--yes",
+            "-R", remote.repositorySlug,
+        ]
+        if let headProject = Self.qualifiedHeadProject(
+            headOwner: headOwner,
+            baseOwner: remote.owner,
+            repository: remote.repository
+        ) {
+            args.append(contentsOf: ["--head", headProject])
+        }
+        if isDraft {
+            args.append("--draft")
+        }
+
+        let result = try await runner.run("glab", args: args, cwd: cwd)
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab mr create", stderr: result.stderr)
+        }
+
+        return try Self.parseCreateOutput(result.stdout)
     }
 
     func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] {
@@ -64,5 +89,41 @@ struct GitLabCLIProvider: CodeHostProvider {
 
     func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, cwd: URL) async throws {
         _ = (remote, branch, headSHA, cwd)
+    }
+
+    static func normalizedBaseBranch(_ baseBranch: String, remoteName: String) -> String {
+        let prefix = "\(remoteName)/"
+        guard baseBranch.hasPrefix(prefix) else { return baseBranch }
+        return String(baseBranch.dropFirst(prefix.count))
+    }
+
+    static func qualifiedHeadProject(headOwner: String?, baseOwner: String, repository: String) -> String? {
+        guard let headOwner = headOwner?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !headOwner.isEmpty,
+              headOwner != baseOwner
+        else {
+            return nil
+        }
+        return "\(headOwner)/\(repository)"
+    }
+
+    static func parseCreateOutput(_ stdout: String) throws -> URL {
+        for token in stdout.split(whereSeparator: \.isWhitespace) {
+            let candidate = String(token).trimmingCharacters(in: .gitLabCreateOutputURLDelimiters)
+            if let url = URL(string: candidate), url.isHTTPOrHTTPS {
+                return url
+            }
+        }
+        throw CodeHostProviderError.malformedOutput("glab mr create returned an invalid URL")
+    }
+}
+
+private extension CharacterSet {
+    static let gitLabCreateOutputURLDelimiters = CharacterSet(charactersIn: ".,;:)]}>\"'")
+}
+
+private extension URL {
+    var isHTTPOrHTTPS: Bool {
+        (scheme == "http" || scheme == "https") && !(host ?? "").isEmpty
     }
 }

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -62,7 +62,8 @@ struct GitLabCLIProvider: CodeHostProvider {
 
         let detailedRequest = (try? await reviewRequestDetails(remote: remote, request: request, cwd: cwd)) ?? request
         let threads = (try? await unresolvedDiscussions(remote: remote, request: detailedRequest, cwd: cwd)) ?? []
-        return Self.withEnrichment(threads: threads, checks: [], on: detailedRequest)
+        let checks = (try? await checks(remote: remote, request: detailedRequest, cwd: cwd)) ?? []
+        return Self.withEnrichment(threads: threads, checks: checks, on: detailedRequest)
     }
 
     func createReviewRequest(
@@ -105,8 +106,25 @@ struct GitLabCLIProvider: CodeHostProvider {
     }
 
     func checks(remote: CodeHostRemote, request: ReviewRequest, cwd: URL) async throws -> [ReviewCheck] {
-        _ = (remote, request, cwd)
-        return []
+        let result = try await runner.run(
+            "glab",
+            args: [
+                "ci", "get",
+                "--merge-request", "\(request.number)",
+                "--with-job-details",
+                "--output", "json",
+                "-R", remote.repositorySlug,
+            ],
+            cwd: cwd
+        )
+        if result.exitCode != 0, Self.isNoPipelineReported(result) {
+            return []
+        }
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab ci get", stderr: result.stderr)
+        }
+
+        return try Self.parsePipeline(result.stdout)
     }
 
     func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, cwd: URL) async throws {
@@ -220,6 +238,51 @@ struct GitLabCLIProvider: CodeHostProvider {
         return try reviewRequest(from: item, remote: remote, context: "glab mr view")
     }
 
+    static func parsePipeline(_ json: String) throws -> [ReviewCheck] {
+        let data = Data(json.utf8)
+        let pipeline: GitLabPipeline
+        do {
+            pipeline = try JSONDecoder().decode(GitLabPipeline.self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab ci get output")
+        }
+
+        let workflow = normalizedOptionalString(pipeline.ref)
+        if let jobs = pipeline.jobs, !jobs.isEmpty {
+            return try jobs.map { job in
+                let detailURL = try parseOptionalHTTPURL(
+                    job.webURL,
+                    context: "glab ci get returned an invalid URL"
+                )
+                return ReviewCheck(
+                    id: checkID(for: job, pipeline: pipeline),
+                    name: job.name,
+                    workflow: workflow,
+                    bucket: mapCheckBucket(job.status),
+                    detailURL: detailURL,
+                    completedAt: try parseOptionalGitLabDate(job.finishedAt)
+                )
+            }
+        }
+
+        let detailURL = try parseOptionalHTTPURL(
+            pipeline.webURL,
+            context: "glab ci get returned an invalid URL"
+        )
+        let completedAt = try parseOptionalGitLabDate(pipeline.finishedAt)
+            ?? parseOptionalGitLabDate(pipeline.updatedAt)
+        return [
+            ReviewCheck(
+                id: checkID(for: pipeline),
+                name: "pipeline",
+                workflow: workflow,
+                bucket: mapCheckBucket(pipeline.status),
+                detailURL: detailURL,
+                completedAt: completedAt
+            ),
+        ]
+    }
+
     private static func reviewRequest(
         from item: MRListItem,
         remote: CodeHostRemote,
@@ -282,6 +345,94 @@ struct GitLabCLIProvider: CodeHostProvider {
         default:
             .unknown
         }
+    }
+
+    private static func mapCheckBucket(_ status: String) -> ReviewCheckBucket {
+        switch status.lowercased() {
+        case "success":
+            .pass
+        case "failed":
+            .fail
+        case "running", "pending", "created", "preparing", "waiting_for_resource", "manual", "scheduled":
+            .pending
+        case "canceled", "cancelled":
+            .cancel
+        case "skipped":
+            .skipping
+        default:
+            .unknown
+        }
+    }
+
+    private static func isNoPipelineReported(_ result: ProcessResult) -> Bool {
+        let output = "\(result.stdout)\n\(result.stderr)".lowercased()
+        return output.contains("no pipeline")
+            || output.contains("no pipelines")
+            || output.contains("pipeline not found")
+    }
+
+    private static func parseOptionalHTTPURL(_ value: String?, context: String) throws -> URL? {
+        guard let value = normalizedOptionalString(value) else {
+            return nil
+        }
+        guard let url = URL(string: value), url.isHTTPOrHTTPS else {
+            throw CodeHostProviderError.malformedOutput(context)
+        }
+        return url
+    }
+
+    private static func parseOptionalGitLabDate(_ value: String?) throws -> Date? {
+        guard let value = normalizedOptionalString(value) else {
+            return nil
+        }
+        if let date = parseDate(value, formatOptions: [.withInternetDateTime]) {
+            return date
+        }
+        if let date = parseDate(value, formatOptions: [.withInternetDateTime, .withFractionalSeconds]) {
+            return date
+        }
+        throw CodeHostProviderError.malformedOutput("Unable to parse GitLab date")
+    }
+
+    private static func parseDate(_ value: String, formatOptions: ISO8601DateFormatter.Options) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = formatOptions
+        return formatter.date(from: value)
+    }
+
+    private static func normalizedOptionalString(_ value: String?) -> String? {
+        guard let value else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func checkID(for pipeline: GitLabPipeline) -> String {
+        encodedID([
+            "gitlab-pipeline-check",
+            pipeline.id.map(String.init) ?? "",
+            "pipeline",
+            pipeline.status,
+            pipeline.webURL ?? "",
+        ])
+    }
+
+    private static func checkID(for job: GitLabJob, pipeline: GitLabPipeline) -> String {
+        encodedID([
+            "gitlab-job-check",
+            pipeline.id.map(String.init) ?? "",
+            job.id.map(String.init) ?? "",
+            job.name,
+            job.status,
+            job.webURL ?? "",
+        ])
+    }
+
+    private static func encodedID(_ fields: [String]) -> String {
+        fields
+            .map { "\($0.utf8.count)#\($0)" }
+            .joined()
     }
 
     private static func withEnrichment(
@@ -364,6 +515,42 @@ private struct SourceProject: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case pathWithNamespace = "path_with_namespace"
+    }
+}
+
+private struct GitLabPipeline: Decodable {
+    let id: Int?
+    let status: String
+    let ref: String?
+    let webURL: String?
+    let finishedAt: String?
+    let updatedAt: String?
+    let jobs: [GitLabJob]?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case status
+        case ref
+        case webURL = "web_url"
+        case finishedAt = "finished_at"
+        case updatedAt = "updated_at"
+        case jobs
+    }
+}
+
+private struct GitLabJob: Decodable {
+    let id: Int?
+    let name: String
+    let status: String
+    let webURL: String?
+    let finishedAt: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case status
+        case webURL = "web_url"
+        case finishedAt = "finished_at"
     }
 }
 

--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -127,8 +127,50 @@ struct GitLabCLIProvider: CodeHostProvider {
         return try Self.parsePipeline(result.stdout)
     }
 
-    func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, cwd: URL) async throws {
-        _ = (remote, branch, headSHA, cwd)
+    func rerunFailedChecks(
+        remote: CodeHostRemote,
+        branch: String,
+        headSHA: String,
+        request: ReviewRequest?,
+        cwd: URL
+    ) async throws {
+        _ = headSHA
+        var args = ["ci", "get"]
+        if let request {
+            args.append(contentsOf: ["--merge-request", "\(request.number)"])
+        } else {
+            args.append(contentsOf: ["--branch", branch])
+        }
+        args.append(contentsOf: [
+            "--status", "failed",
+            "--with-job-details",
+            "--output", "json",
+            "-R", remote.repositorySlug,
+        ])
+
+        let result = try await runner.run(
+            "glab",
+            args: args,
+            cwd: cwd
+        )
+        if result.exitCode != 0, Self.isNoPipelineReported(result) {
+            return
+        }
+        guard result.exitCode == 0 else {
+            throw CodeHostProviderError.commandFailed(command: "glab ci get", stderr: result.stderr)
+        }
+
+        let failedJobIDs = try Self.failedJobIDs(fromPipelineJSON: result.stdout)
+        for jobID in failedJobIDs {
+            let retry = try await runner.run(
+                "glab",
+                args: ["ci", "retry", "\(jobID)", "-R", remote.repositorySlug],
+                cwd: cwd
+            )
+            guard retry.exitCode == 0 else {
+                throw CodeHostProviderError.commandFailed(command: "glab ci retry", stderr: retry.stderr)
+            }
+        }
     }
 
     private func reviewRequestDetails(
@@ -239,13 +281,7 @@ struct GitLabCLIProvider: CodeHostProvider {
     }
 
     static func parsePipeline(_ json: String) throws -> [ReviewCheck] {
-        let data = Data(json.utf8)
-        let pipeline: GitLabPipeline
-        do {
-            pipeline = try JSONDecoder().decode(GitLabPipeline.self, from: data)
-        } catch {
-            throw CodeHostProviderError.malformedOutput("Unable to parse glab ci get output")
-        }
+        let pipeline = try decodePipeline(json)
 
         let workflow = normalizedOptionalString(pipeline.ref)
         if let jobs = pipeline.jobs, !jobs.isEmpty {
@@ -281,6 +317,22 @@ struct GitLabCLIProvider: CodeHostProvider {
                 completedAt: completedAt
             ),
         ]
+    }
+
+    private static func decodePipeline(_ json: String) throws -> GitLabPipeline {
+        let data = Data(json.utf8)
+        do {
+            return try JSONDecoder().decode(GitLabPipeline.self, from: data)
+        } catch {
+            throw CodeHostProviderError.malformedOutput("Unable to parse glab ci get output")
+        }
+    }
+
+    private static func failedJobIDs(fromPipelineJSON json: String) throws -> [Int] {
+        let pipeline = try decodePipeline(json)
+        return pipeline.jobs?.compactMap { job in
+            job.status.lowercased() == "failed" ? job.id : nil
+        } ?? []
     }
 
     private static func reviewRequest(

--- a/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
+++ b/Alas/Sources/Integrations/CodeHost/ReviewLoopState.swift
@@ -337,6 +337,7 @@ final class ReviewLoopState {
                 remote: remote,
                 branch: snapshot.local.branchName,
                 headSHA: snapshot.local.headSHA,
+                request: snapshot.reviewRequest,
                 cwd: worktreePath
             )
             return true

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -17,11 +17,11 @@ struct CodeHostProviderTests {
         #expect(registry.provider(for: .gitlab) == nil)
     }
 
-    @Test func liveRegistryIncludesGitHubProvider() {
+    @Test func liveRegistryIncludesGitHubAndGitLabProviders() {
         let registry = CodeHostProviderRegistry.live()
 
         #expect(registry.provider(for: .github)?.kind == .github)
-        #expect(registry.provider(for: .gitlab) == nil)
+        #expect(registry.provider(for: .gitlab)?.kind == .gitlab)
     }
 
     @Test func liveGitHubProviderExposesDirectActionCapabilities() {
@@ -29,6 +29,14 @@ struct CodeHostProviderTests {
 
         #expect(provider?.capabilities.canCreateReviewRequest == true)
         #expect(provider?.capabilities.canRerunFailedChecks == true)
+        #expect(provider?.capabilities.canOpenReviewRequest == true)
+    }
+
+    @Test func liveGitLabProviderStartsReadOnlyUntilActionsAreImplemented() {
+        let provider = CodeHostProviderRegistry.live().provider(for: .gitlab)
+
+        #expect(provider?.capabilities.canCreateReviewRequest == false)
+        #expect(provider?.capabilities.canRerunFailedChecks == false)
         #expect(provider?.capabilities.canOpenReviewRequest == true)
     }
 

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -32,11 +32,11 @@ struct CodeHostProviderTests {
         #expect(provider?.capabilities.canOpenReviewRequest == true)
     }
 
-    @Test func liveGitLabProviderStartsReadOnlyUntilActionsAreImplemented() {
+    @Test func liveGitLabProviderExposesDirectActionCapabilities() {
         let provider = CodeHostProviderRegistry.live().provider(for: .gitlab)
 
-        #expect(provider?.capabilities.canCreateReviewRequest == false)
-        #expect(provider?.capabilities.canRerunFailedChecks == false)
+        #expect(provider?.capabilities.canCreateReviewRequest == true)
+        #expect(provider?.capabilities.canRerunFailedChecks == true)
         #expect(provider?.capabilities.canOpenReviewRequest == true)
     }
 

--- a/AlasTests/Integrations/CodeHostProviderTests.swift
+++ b/AlasTests/Integrations/CodeHostProviderTests.swift
@@ -94,6 +94,12 @@ struct CodeHostProviderTests {
             []
         }
 
-        func rerunFailedChecks(remote: CodeHostRemote, branch: String, headSHA: String, cwd: URL) async throws {}
+        func rerunFailedChecks(
+            remote: CodeHostRemote,
+            branch: String,
+            headSHA: String,
+            request: ReviewRequest?,
+            cwd: URL
+        ) async throws {}
     }
 }

--- a/AlasTests/Integrations/GitHubCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitHubCLIProviderTests.swift
@@ -486,6 +486,7 @@ struct GitHubCLIProviderTests {
             remote: Self.remote,
             branch: "feature/github-provider",
             headSHA: "abc123",
+            request: nil,
             cwd: Self.cwd
         )
 

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -293,6 +293,89 @@ struct GitLabCLIProviderTests {
         }
     }
 
+    @Test func pipelineJSONPrefersJobLevelChecks() throws {
+        let checks = try GitLabCLIProvider.parsePipeline(Self.pipelineWithJobsOutput)
+
+        #expect(checks.count == 2)
+        #expect(checks.map(\.name) == ["build", "test"])
+        #expect(checks.map(\.workflow) == ["feature/gitlab-provider", "feature/gitlab-provider"])
+        #expect(checks.map(\.bucket) == [.pass, .fail])
+        #expect(checks[0].detailURL == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/jobs/101"))
+        #expect(checks[1].detailURL == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/jobs/102"))
+        #expect(checks[0].completedAt == ISO8601DateFormatter().date(from: "2026-06-01T12:34:56Z"))
+        #expect(checks[1].completedAt == ISO8601DateFormatter().date(from: "2026-06-01T12:35:56Z"))
+        #expect(checks[0].id != checks[1].id)
+    }
+
+    @Test func pipelineJSONFallsBackToPipelineLevelCheckWhenJobsAreMissing() throws {
+        let checks = try GitLabCLIProvider.parsePipeline(Self.pipelineOutput)
+
+        #expect(checks.count == 1)
+        #expect(checks[0].name == "pipeline")
+        #expect(checks[0].workflow == "feature/gitlab-provider")
+        #expect(checks[0].bucket == .pass)
+        #expect(checks[0].detailURL == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/pipelines/777"))
+        #expect(checks[0].completedAt == ISO8601DateFormatter().date(from: "2026-06-01T12:36:56Z"))
+    }
+
+    @Test func pipelineCheckStatusesMapGitLabAliases() throws {
+        let cases: [(status: String, bucket: ReviewCheckBucket)] = [
+            ("waiting_for_resource", .pending),
+            ("manual", .pending),
+            ("scheduled", .pending),
+            ("cancelled", .cancel),
+            ("skipped", .skipping),
+            ("blocked", .unknown),
+        ]
+
+        for testCase in cases {
+            let checks = try GitLabCLIProvider.parsePipeline(
+                """
+                {
+                  "id": 777,
+                  "status": "\(testCase.status)",
+                  "ref": "feature/gitlab-provider",
+                  "web_url": "https://gitlab.example.com/platform/mobile/alas/-/pipelines/777",
+                  "jobs": []
+                }
+                """
+            )
+
+            #expect(checks.map(\.bucket) == [testCase.bucket])
+        }
+    }
+
+    @Test func pipelineJSONRejectsMalformedURLAndDate() throws {
+        #expect(throws: CodeHostProviderError.malformedOutput("glab ci get returned an invalid URL")) {
+            _ = try GitLabCLIProvider.parsePipeline(
+                """
+                {
+                  "id": 777,
+                  "status": "success",
+                  "ref": "feature/gitlab-provider",
+                  "web_url": "file:///tmp/pipeline",
+                  "jobs": []
+                }
+                """
+            )
+        }
+
+        #expect(throws: CodeHostProviderError.malformedOutput("Unable to parse GitLab date")) {
+            _ = try GitLabCLIProvider.parsePipeline(
+                """
+                {
+                  "id": 777,
+                  "status": "success",
+                  "ref": "feature/gitlab-provider",
+                  "web_url": "https://gitlab.example.com/platform/mobile/alas/-/pipelines/777",
+                  "finished_at": "not-a-date",
+                  "jobs": []
+                }
+                """
+            )
+        }
+    }
+
     @Test func currentReviewRequestUsesExpectedMRListCommand() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.mrListOutput, stderr: ""),
@@ -309,7 +392,7 @@ struct GitLabCLIProviderTests {
         )
 
         #expect(request?.number == 42)
-        #expect(await runner.commands.map(\.args.first) == ["mr", "mr", "mr"])
+        #expect(await runner.commands.map(\.args.first) == ["mr", "mr", "mr", "ci"])
         #expect(await runner.commands.first == FakeRunner.Command(
             executable: "glab",
             args: [
@@ -337,6 +420,103 @@ struct GitLabCLIProviderTests {
             ],
             cwd: Self.cwd
         ))
+        #expect(await runner.commands[3] == FakeRunner.Command(
+            executable: "glab",
+            args: [
+                "ci", "get",
+                "--merge-request", "42",
+                "--with-job-details",
+                "--output", "json",
+                "-R", "platform/mobile/alas",
+            ],
+            cwd: Self.cwd
+        ))
+    }
+
+    @Test func checksLoadsMRHeadPipeline() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pipelineWithJobsOutput, stderr: ""),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        let checks = try await GitLabCLIProvider(runner: runner).checks(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(checks.map(\.name) == ["build", "test"])
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: [
+                    "ci", "get",
+                    "--merge-request", "42",
+                    "--with-job-details",
+                    "--output", "json",
+                    "-R", "platform/mobile/alas",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func checksReturnsEmptyWhenNoPipelineIsReported() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 1, stdout: "", stderr: "no pipeline found for merge request !42"),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        let checks = try await GitLabCLIProvider(runner: runner).checks(
+            remote: Self.remote,
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(checks.isEmpty)
+    }
+
+    @Test func checksThrowsCommandFailedOnOtherNonzeroExit() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 1, stdout: "", stderr: "authentication failed"),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        await #expect(throws: CodeHostProviderError.commandFailed(
+            command: "glab ci get",
+            stderr: "authentication failed"
+        )) {
+            _ = try await GitLabCLIProvider(runner: runner).checks(
+                remote: Self.remote,
+                request: request,
+                cwd: Self.cwd
+            )
+        }
+    }
+
+    @Test func currentReviewRequestIncludesPipelineChecks() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.mrListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineWithJobsOutput, stderr: ""),
+        ])
+
+        let request = try await GitLabCLIProvider(runner: runner).currentReviewRequest(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headOwner: nil,
+            baseBranch: "origin/main",
+            cwd: Self.cwd
+        )
+
+        #expect(request?.checks.map(\.name) == ["build", "test"])
+        #expect(await runner.commands.map { Array($0.args.prefix(2)) } == [
+            ["mr", "list"],
+            ["mr", "view"],
+            ["mr", "note"],
+            ["ci", "get"],
+        ])
     }
 
     @Test func createReviewRequestUsesExpectedArgsForNormalMR() async throws {
@@ -492,6 +672,42 @@ struct GitLabCLIProviderTests {
     """
 
     private static let discussionsOutput = "[]"
+
+    private static let pipelineOutput = """
+    {
+      "id": 777,
+      "status": "success",
+      "ref": "feature/gitlab-provider",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/pipelines/777",
+      "updated_at": "2026-06-01T12:36:56Z",
+      "jobs": []
+    }
+    """
+
+    private static let pipelineWithJobsOutput = """
+    {
+      "id": 777,
+      "status": "failed",
+      "ref": "feature/gitlab-provider",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/pipelines/777",
+      "jobs": [
+        {
+          "id": 101,
+          "name": "build",
+          "status": "success",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/101",
+          "finished_at": "2026-06-01T12:34:56Z"
+        },
+        {
+          "id": 102,
+          "name": "test",
+          "status": "failed",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/102",
+          "finished_at": "2026-06-01T12:35:56Z"
+        }
+      ]
+    }
+    """
 
     private actor FakeRunner: CodeHostCommandRunning {
         struct Command: Equatable {

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -319,6 +319,23 @@ struct GitLabCLIProviderTests {
         #expect(request.title == "Fork MR")
     }
 
+    @Test func mrListFiltersSingleItemByResolvedSourceProjectID() throws {
+        let request = try #require(try GitLabCLIProvider.parseMRList(
+            Self.singleSourceProjectIDMRListOutput,
+            remote: Self.remote,
+            headOwner: "nacho",
+            sourceProjectPathsByID: [1002: "nacho/alas"]
+        ))
+
+        #expect(request.number == 43)
+        #expect(try GitLabCLIProvider.parseMRList(
+            Self.singleSourceProjectIDMRListOutput,
+            remote: Self.remote,
+            headOwner: "other",
+            sourceProjectPathsByID: [1002: "nacho/alas"]
+        ) == nil)
+    }
+
     @Test func projectPathParsingRequiresPathWithNamespace() throws {
         #expect(try GitLabCLIProvider.parseProjectPath(#"{"path_with_namespace":"nacho/alas"}"#) == "nacho/alas")
         #expect(throws: CodeHostProviderError.malformedOutput("glab api project output is missing path_with_namespace")) {
@@ -564,6 +581,42 @@ struct GitLabCLIProviderTests {
             args: ["mr", "view", "43", "--output", "json", "-R", "platform/mobile/alas"],
             cwd: Self.cwd
         ))
+    }
+
+    @Test func currentReviewRequestResolvesSingleSourceProjectIDBeforeFiltering() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.singleSourceProjectIDMRListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: #"{"path_with_namespace":"other/alas"}"#, stderr: ""),
+        ])
+
+        let request = try await GitLabCLIProvider(runner: runner).currentReviewRequest(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headOwner: "nacho",
+            baseBranch: "origin/main",
+            cwd: Self.cwd
+        )
+
+        #expect(request == nil)
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: [
+                    "mr", "list",
+                    "--source-branch", "feature/gitlab-provider",
+                    "--target-branch", "main",
+                    "--output", "json",
+                    "--per-page", "20",
+                    "-R", "platform/mobile/alas",
+                ],
+                cwd: Self.cwd
+            ),
+            FakeRunner.Command(
+                executable: "glab",
+                args: ["api", "projects/1002", "--hostname", "gitlab.example.com", "--output", "json"],
+                cwd: Self.cwd
+            ),
+        ])
     }
 
     @Test func checksLoadsMRHeadPipeline() async throws {
@@ -991,6 +1044,21 @@ struct GitLabCLIProviderTests {
         "target_branch": "main",
         "source_project_id": 1001
       },
+      {
+        "iid": 43,
+        "title": "Fork MR",
+        "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/43",
+        "state": "opened",
+        "draft": false,
+        "source_branch": "feature/gitlab-provider",
+        "target_branch": "main",
+        "source_project_id": 1002
+      }
+    ]
+    """
+
+    private static let singleSourceProjectIDMRListOutput = """
+    [
       {
         "iid": 43,
         "title": "Fork MR",

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -494,6 +494,137 @@ struct GitLabCLIProviderTests {
         }
     }
 
+    @Test func rerunFailedChecksRetriesFailedJobs() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pipelineWithFailedJobsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        try await GitLabCLIProvider(runner: runner).rerunFailedChecks(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headSHA: "abc123",
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: [
+                    "ci", "get",
+                    "--merge-request", "42",
+                    "--status", "failed",
+                    "--with-job-details",
+                    "--output", "json",
+                    "-R", "platform/mobile/alas",
+                ],
+                cwd: Self.cwd
+            ),
+            FakeRunner.Command(
+                executable: "glab",
+                args: ["ci", "retry", "102", "-R", "platform/mobile/alas"],
+                cwd: Self.cwd
+            ),
+            FakeRunner.Command(
+                executable: "glab",
+                args: ["ci", "retry", "103", "-R", "platform/mobile/alas"],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func rerunFailedChecksDoesNothingWhenNoFailedJobs() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pipelineWithSuccessfulJobsOutput, stderr: ""),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        try await GitLabCLIProvider(runner: runner).rerunFailedChecks(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headSHA: "abc123",
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: [
+                    "ci", "get",
+                    "--merge-request", "42",
+                    "--status", "failed",
+                    "--with-job-details",
+                    "--output", "json",
+                    "-R", "platform/mobile/alas",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func rerunFailedChecksTreatsNoPipelineAsNoop() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 1, stdout: "", stderr: "no pipeline found for branch feature/gitlab-provider"),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        try await GitLabCLIProvider(runner: runner).rerunFailedChecks(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headSHA: "abc123",
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(await runner.commands.count == 1)
+    }
+
+    @Test func rerunFailedChecksThrowsOnGetFailure() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 1, stdout: "", stderr: "authentication failed"),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        await #expect(throws: CodeHostProviderError.commandFailed(
+            command: "glab ci get",
+            stderr: "authentication failed"
+        )) {
+            try await GitLabCLIProvider(runner: runner).rerunFailedChecks(
+                remote: Self.remote,
+                branch: "feature/gitlab-provider",
+                headSHA: "abc123",
+                request: request,
+                cwd: Self.cwd
+            )
+        }
+    }
+
+    @Test func rerunFailedChecksThrowsOnRetryFailure() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pipelineWithFailedJobsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: "", stderr: ""),
+            ProcessResult(exitCode: 1, stdout: "", stderr: "retry failed"),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        await #expect(throws: CodeHostProviderError.commandFailed(
+            command: "glab ci retry",
+            stderr: "retry failed"
+        )) {
+            try await GitLabCLIProvider(runner: runner).rerunFailedChecks(
+                remote: Self.remote,
+                branch: "feature/gitlab-provider",
+                headSHA: "abc123",
+                request: request,
+                cwd: Self.cwd
+            )
+        }
+    }
+
     @Test func currentReviewRequestIncludesPipelineChecks() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: Self.mrListOutput, stderr: ""),
@@ -704,6 +835,58 @@ struct GitLabCLIProviderTests {
           "status": "failed",
           "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/102",
           "finished_at": "2026-06-01T12:35:56Z"
+        }
+      ]
+    }
+    """
+
+    private static let pipelineWithFailedJobsOutput = """
+    {
+      "id": 778,
+      "status": "failed",
+      "ref": "feature/gitlab-provider",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/pipelines/778",
+      "jobs": [
+        {
+          "id": 101,
+          "name": "build",
+          "status": "success",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/101"
+        },
+        {
+          "id": 102,
+          "name": "test",
+          "status": "failed",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/102"
+        },
+        {
+          "id": 103,
+          "name": "lint",
+          "status": "failed",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/103"
+        }
+      ]
+    }
+    """
+
+    private static let pipelineWithSuccessfulJobsOutput = """
+    {
+      "id": 779,
+      "status": "success",
+      "ref": "feature/gitlab-provider",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/pipelines/779",
+      "jobs": [
+        {
+          "id": 104,
+          "name": "build",
+          "status": "success",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/104"
+        },
+        {
+          "id": 105,
+          "name": "test",
+          "status": "skipped",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/105"
         }
       ]
     }

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -121,6 +121,63 @@ struct GitLabCLIProviderTests {
         #expect(request.mergeState == .blocked)
     }
 
+    @Test func discussionsJSONParsesActionableThreads() throws {
+        let threads = try GitLabCLIProvider.parseDiscussions(
+            Self.discussionsOutput,
+            requestURL: URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42")!
+        )
+
+        #expect(threads.count == 2)
+        #expect(threads[0].id == "discussion-1")
+        #expect(threads[0].author == "reviewer")
+        #expect(threads[0].body == "Please surface this unresolved note.")
+        #expect(threads[0].url == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_501"))
+        #expect(threads[0].isResolved == false)
+        #expect(threads[0].isActionable)
+        #expect(threads[1].id == "discussion-2")
+        #expect(threads[1].author == "maintainer")
+        #expect(threads[1].url == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_503"))
+        #expect(threads[1].isResolved == false)
+        #expect(threads[1].isActionable)
+    }
+
+    @Test func discussionsJSONSkipsSystemOnlyDiscussions() throws {
+        let threads = try GitLabCLIProvider.parseDiscussions(
+            Self.systemOnlyDiscussionsOutput,
+            requestURL: URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42")!
+        )
+
+        #expect(threads == [])
+    }
+
+    @Test func discussionsJSONRejectsMalformedURL() throws {
+        let output = """
+        [
+          {
+            "id": "discussion-1",
+            "notes": [
+              {
+                "id": 501,
+                "body": "Please surface this unresolved note.",
+                "system": false,
+                "resolvable": true,
+                "resolved": false,
+                "web_url": "file:///tmp/note",
+                "author": { "username": "reviewer" }
+              }
+            ]
+          }
+        ]
+        """
+
+        #expect(throws: CodeHostProviderError.malformedOutput("glab mr note list returned an invalid URL")) {
+            _ = try GitLabCLIProvider.parseDiscussions(
+                output,
+                requestURL: URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42")!
+            )
+        }
+    }
+
     @Test func mrListReturnsNilForNoItems() throws {
         #expect(try GitLabCLIProvider.parseMRList("[]", remote: Self.remote, headOwner: nil) == nil)
     }
@@ -392,6 +449,8 @@ struct GitLabCLIProviderTests {
         )
 
         #expect(request?.number == 42)
+        #expect(request?.threads.map(\.id) == ["discussion-1", "discussion-2"])
+        #expect(request?.hasActionableFeedback == true)
         #expect(await runner.commands.map(\.args.first) == ["mr", "mr", "mr", "ci"])
         #expect(await runner.commands.first == FakeRunner.Command(
             executable: "glab",
@@ -802,7 +861,71 @@ struct GitLabCLIProviderTests {
     }
     """
 
-    private static let discussionsOutput = "[]"
+    private static let discussionsOutput = """
+    [
+      {
+        "id": "discussion-1",
+        "notes": [
+          {
+            "id": 501,
+            "body": "Please surface this unresolved note.",
+            "system": false,
+            "resolvable": true,
+            "resolved": false,
+            "author": { "username": "reviewer" }
+          },
+          {
+            "id": 502,
+            "body": "changed the title",
+            "system": true,
+            "resolvable": false,
+            "resolved": false,
+            "author": { "username": "gitlab-bot" }
+          }
+        ]
+      },
+      {
+        "id": "discussion-2",
+        "resolved": false,
+        "notes": [
+          {
+            "id": 503,
+            "body": "This general note should also be actionable.",
+            "system": false,
+            "author": { "username": "maintainer" },
+            "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42#note_503"
+          }
+        ]
+      },
+      {
+        "id": "system-only",
+        "notes": [
+          {
+            "id": 504,
+            "body": "added 1 commit",
+            "system": true,
+            "author": { "username": "gitlab-bot" }
+          }
+        ]
+      }
+    ]
+    """
+
+    private static let systemOnlyDiscussionsOutput = """
+    [
+      {
+        "id": "system-only",
+        "notes": [
+          {
+            "id": 504,
+            "body": "added 1 commit",
+            "system": true,
+            "author": { "username": "gitlab-bot" }
+          }
+        ]
+      }
+    ]
+    """
 
     private static let pipelineOutput = """
     {

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import Testing
+@testable import Alas
+
+struct GitLabCLIProviderTests {
+    @Test func isAvailableReturnsTrueOnlyForVersionExitZero() async {
+        let successRunner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "glab 1.101.0", stderr: ""),
+        ])
+        let failureRunner = FakeRunner(results: [
+            ProcessResult(exitCode: 1, stdout: "", stderr: "missing"),
+        ])
+
+        #expect(await GitLabCLIProvider(runner: successRunner).isAvailable())
+        #expect(await GitLabCLIProvider(runner: failureRunner).isAvailable() == false)
+        #expect(await successRunner.commands == [
+            FakeRunner.Command(executable: "glab", args: ["--version"], cwd: nil),
+        ])
+    }
+
+    @Test func authStatusUsesDetectedHost() async {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "gitlab.example.com: Logged in", stderr: ""),
+        ])
+
+        let authenticated = await GitLabCLIProvider(runner: runner).isAuthenticated(remote: Self.remote, cwd: Self.cwd)
+
+        #expect(authenticated)
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: ["auth", "status", "--hostname", "gitlab.example.com"],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func normalizedBaseBranchStripsDetectedRemotePrefixOnly() {
+        #expect(GitLabCLIProvider.normalizedBaseBranch("origin/main", remoteName: "origin") == "main")
+        #expect(GitLabCLIProvider.normalizedBaseBranch("upstream/main", remoteName: "origin") == "upstream/main")
+        #expect(GitLabCLIProvider.normalizedBaseBranch("release/1.0", remoteName: "origin") == "release/1.0")
+    }
+
+    @Test func qualifiedHeadProjectReturnsForkProjectOnlyForDifferentHeadOwner() {
+        #expect(GitLabCLIProvider.qualifiedHeadProject(
+            headOwner: "nacho",
+            baseOwner: "platform/mobile",
+            repository: "alas"
+        ) == "nacho/alas")
+        #expect(GitLabCLIProvider.qualifiedHeadProject(
+            headOwner: nil,
+            baseOwner: "platform/mobile",
+            repository: "alas"
+        ) == nil)
+        #expect(GitLabCLIProvider.qualifiedHeadProject(
+            headOwner: "",
+            baseOwner: "platform/mobile",
+            repository: "alas"
+        ) == nil)
+        #expect(GitLabCLIProvider.qualifiedHeadProject(
+            headOwner: "platform/mobile",
+            baseOwner: "platform/mobile",
+            repository: "alas"
+        ) == nil)
+    }
+
+    @Test func createOutputParsesHTTPURL() throws {
+        let url = try GitLabCLIProvider.parseCreateOutput("https://gitlab.example.com/platform/mobile/alas/-/merge_requests/44\n")
+
+        #expect(url == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/44"))
+    }
+
+    @Test func createOutputParsesFirstHTTPURLFromHumanReadableOutput() throws {
+        let url = try GitLabCLIProvider.parseCreateOutput(
+            """
+            !46 Add GitLab provider (feature/gitlab-provider)
+            https://gitlab.example.com/platform/mobile/alas/-/merge_requests/46
+            """
+        )
+
+        #expect(url == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/46"))
+    }
+
+    @Test func createOutputRejectsNonURLAndNonHTTPURL() {
+        #expect(throws: CodeHostProviderError.malformedOutput("glab mr create returned an invalid URL")) {
+            try GitLabCLIProvider.parseCreateOutput("not a url")
+        }
+        #expect(throws: CodeHostProviderError.malformedOutput("glab mr create returned an invalid URL")) {
+            try GitLabCLIProvider.parseCreateOutput("git@gitlab.example.com:platform/mobile/alas.git")
+        }
+        #expect(throws: CodeHostProviderError.malformedOutput("glab mr create returned an invalid URL")) {
+            try GitLabCLIProvider.parseCreateOutput("file:///tmp/mr")
+        }
+        #expect(throws: CodeHostProviderError.malformedOutput("glab mr create returned an invalid URL")) {
+            try GitLabCLIProvider.parseCreateOutput("https://")
+        }
+    }
+
+    @Test func createReviewRequestUsesExpectedArgsForNormalMR() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/44\n", stderr: ""),
+        ])
+
+        _ = try await GitLabCLIProvider(runner: runner).createReviewRequest(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headOwner: nil,
+            baseBranch: "origin/main",
+            title: "Add GitLab provider",
+            body: "## Summary\n- Adds GitLab support",
+            isDraft: false,
+            cwd: Self.cwd
+        )
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: [
+                    "mr", "create",
+                    "--source-branch", "feature/gitlab-provider",
+                    "--target-branch", "main",
+                    "--title", "Add GitLab provider",
+                    "--description", "## Summary\n- Adds GitLab support",
+                    "--yes",
+                    "-R", "platform/mobile/alas",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func createReviewRequestIncludesHeadProjectForForkHeadOwner() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/46\n", stderr: ""),
+        ])
+
+        _ = try await GitLabCLIProvider(runner: runner).createReviewRequest(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headOwner: "nacho",
+            baseBranch: "main",
+            title: "Add GitLab provider",
+            body: "Body",
+            isDraft: false,
+            cwd: Self.cwd
+        )
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: [
+                    "mr", "create",
+                    "--source-branch", "feature/gitlab-provider",
+                    "--target-branch", "main",
+                    "--title", "Add GitLab provider",
+                    "--description", "Body",
+                    "--yes",
+                    "-R", "platform/mobile/alas",
+                    "--head", "nacho/alas",
+                ],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func createReviewRequestThrowsCommandFailedOnNonzeroExit() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 1, stdout: "", stderr: "create failed"),
+        ])
+
+        await #expect(throws: CodeHostProviderError.commandFailed(
+            command: "glab mr create",
+            stderr: "create failed"
+        )) {
+            _ = try await GitLabCLIProvider(runner: runner).createReviewRequest(
+                remote: Self.remote,
+                branch: "feature/gitlab-provider",
+                headOwner: nil,
+                baseBranch: "main",
+                title: "Add GitLab provider",
+                body: "Body",
+                isDraft: false,
+                cwd: Self.cwd
+            )
+        }
+    }
+
+    @Test func createReviewRequestAddsDraftFlagForDraftMR() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/45\n", stderr: ""),
+        ])
+
+        _ = try await GitLabCLIProvider(runner: runner).createReviewRequest(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headOwner: nil,
+            baseBranch: "main",
+            title: "Add GitLab provider",
+            body: "Body",
+            isDraft: true,
+            cwd: Self.cwd
+        )
+
+        let args = try #require(await runner.commands.first?.args)
+        #expect(args.contains("--draft"))
+    }
+
+    private static let remote = CodeHostRemote(
+        kind: .gitlab,
+        host: "gitlab.example.com",
+        owner: "platform/mobile",
+        repository: "alas",
+        remoteName: "origin",
+        webURL: URL(string: "https://gitlab.example.com/platform/mobile/alas")!
+    )
+
+    private static let cwd = URL(fileURLWithPath: "/tmp/alas")
+
+    private actor FakeRunner: CodeHostCommandRunning {
+        struct Command: Equatable {
+            let executable: String
+            let args: [String]
+            let cwd: URL?
+        }
+
+        private var results: [ProcessResult]
+        private(set) var commands: [Command] = []
+
+        init(results: [ProcessResult]) {
+            self.results = results
+        }
+
+        func run(_ executable: String, args: [String], cwd: URL?) async throws -> ProcessResult {
+            commands.append(Command(executable: executable, args: args, cwd: cwd))
+            guard !results.isEmpty else {
+                return ProcessResult(exitCode: 1, stdout: "", stderr: "unexpected command")
+            }
+            return results.removeFirst()
+        }
+    }
+}

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -96,6 +96,249 @@ struct GitLabCLIProviderTests {
         }
     }
 
+    @Test func mrListJSONParsesReviewRequest() throws {
+        let request = try #require(try GitLabCLIProvider.parseMRList(Self.mrListOutput, remote: Self.remote, headOwner: nil))
+
+        #expect(request.number == 42)
+        #expect(request.title == "Add GitLab provider")
+        #expect(request.url == URL(string: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42"))
+        #expect(request.state == .open)
+        #expect(request.isDraft == false)
+        #expect(request.headRefName == "feature/gitlab-provider")
+        #expect(request.baseRefName == "main")
+        #expect(request.reviewDecision == .unknown)
+        #expect(request.mergeState == .clean)
+        #expect(request.provider == .gitlab)
+    }
+
+    @Test func mrViewJSONParsesReviewRequest() throws {
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        #expect(request.number == 42)
+        #expect(request.title == "Add GitLab provider")
+        #expect(request.isDraft == true)
+        #expect(request.reviewDecision == .reviewRequired)
+        #expect(request.mergeState == .blocked)
+    }
+
+    @Test func mrListReturnsNilForNoItems() throws {
+        #expect(try GitLabCLIProvider.parseMRList("[]", remote: Self.remote, headOwner: nil) == nil)
+    }
+
+    @Test func mrParsingRequiresIID() throws {
+        let listOutput = """
+        [
+          {
+            "id": 4242,
+            "title": "Add GitLab provider",
+            "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42",
+            "state": "opened",
+            "draft": false,
+            "source_branch": "feature/gitlab-provider",
+            "target_branch": "main"
+          }
+        ]
+        """
+        let viewOutput = """
+        {
+          "id": 4242,
+          "title": "Add GitLab provider",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42",
+          "state": "opened",
+          "draft": false,
+          "source_branch": "feature/gitlab-provider",
+          "target_branch": "main"
+        }
+        """
+
+        #expect(throws: CodeHostProviderError.malformedOutput("glab mr list output is missing a merge request iid")) {
+            _ = try GitLabCLIProvider.parseMRList(listOutput, remote: Self.remote, headOwner: nil)
+        }
+        #expect(throws: CodeHostProviderError.malformedOutput("glab mr view output is missing a merge request iid")) {
+            _ = try GitLabCLIProvider.parseMRView(viewOutput, remote: Self.remote)
+        }
+    }
+
+    @Test func mrListFiltersByHeadOwnerWhenSourceProjectMetadataMatches() throws {
+        let output = """
+        [
+          {
+            "iid": 42,
+            "title": "Base project MR",
+            "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42",
+            "state": "opened",
+            "draft": false,
+            "source_branch": "feature/gitlab-provider",
+            "target_branch": "main",
+            "source_project": { "path_with_namespace": "platform/mobile/alas" }
+          },
+          {
+            "iid": 43,
+            "title": "Fork MR",
+            "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/43",
+            "state": "opened",
+            "draft": false,
+            "source_branch": "feature/gitlab-provider",
+            "target_branch": "main",
+            "source_project": { "path_with_namespace": "nacho/alas" }
+          }
+        ]
+        """
+
+        let request = try #require(try GitLabCLIProvider.parseMRList(output, remote: Self.remote, headOwner: "nacho"))
+
+        #expect(request.number == 43)
+        #expect(request.title == "Fork MR")
+    }
+
+    @Test func mrListReturnsNilWhenHeadOwnerMetadataDoesNotMatch() throws {
+        let output = """
+        [
+          {
+            "iid": 42,
+            "title": "Base project MR",
+            "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42",
+            "state": "opened",
+            "draft": false,
+            "source_branch": "feature/gitlab-provider",
+            "target_branch": "main",
+            "source_project_path_with_namespace": "platform/mobile/alas"
+          },
+          {
+            "iid": 43,
+            "title": "Other fork MR",
+            "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/43",
+            "state": "opened",
+            "draft": false,
+            "source_branch": "feature/gitlab-provider",
+            "target_branch": "main",
+            "source_project_path": "other/alas"
+          }
+        ]
+        """
+
+        #expect(try GitLabCLIProvider.parseMRList(output, remote: Self.remote, headOwner: "nacho") == nil)
+    }
+
+    @Test func mrListReturnsNilForAmbiguousHeadOwnerWithoutSourceProjectMetadata() throws {
+        let output = """
+        [
+          {
+            "iid": 42,
+            "title": "First MR",
+            "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42",
+            "state": "opened",
+            "draft": false,
+            "source_branch": "feature/gitlab-provider",
+            "target_branch": "main"
+          },
+          {
+            "iid": 43,
+            "title": "Second MR",
+            "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/43",
+            "state": "opened",
+            "draft": false,
+            "source_branch": "feature/gitlab-provider",
+            "target_branch": "main"
+          }
+        ]
+        """
+
+        #expect(try GitLabCLIProvider.parseMRList(output, remote: Self.remote, headOwner: "nacho") == nil)
+    }
+
+    @Test func mrMergeStatusesMapToReviewMergeState() throws {
+        let cases: [(status: String, mergeState: ReviewMergeState)] = [
+            ("mergeable", .clean),
+            ("can_be_merged", .clean),
+            ("conflict", .dirty),
+            ("conflicts", .dirty),
+            ("cannot_be_merged", .dirty),
+            ("need_rebase", .dirty),
+            ("cannot_be_merged_recheck", .unstable),
+            ("checking", .unstable),
+            ("unchecked", .unstable),
+            ("preparing", .unstable),
+            ("ci_still_running", .unstable),
+            ("commits_status", .unstable),
+            ("approvals_syncing", .unstable),
+            ("not_ready", .unstable),
+            ("requested_changes", .blocked),
+            ("blocked_status", .blocked),
+            ("ci_must_pass", .blocked),
+            ("discussions_not_resolved", .blocked),
+            ("not_approved", .blocked),
+            ("draft_status", .blocked),
+            ("external_status_checks", .blocked),
+            ("security_policy_pipeline_check", .blocked),
+        ]
+
+        for testCase in cases {
+            let output = """
+            {
+              "iid": 42,
+              "title": "Add GitLab provider",
+              "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42",
+              "state": "opened",
+              "draft": false,
+              "source_branch": "feature/gitlab-provider",
+              "target_branch": "main",
+              "detailed_merge_status": "\(testCase.status)"
+            }
+            """
+
+            let request = try GitLabCLIProvider.parseMRView(output, remote: Self.remote)
+
+            #expect(request.mergeState == testCase.mergeState)
+        }
+    }
+
+    @Test func currentReviewRequestUsesExpectedMRListCommand() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.mrListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.mrViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+        ])
+
+        let request = try await GitLabCLIProvider(runner: runner).currentReviewRequest(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headOwner: nil,
+            baseBranch: "origin/main",
+            cwd: Self.cwd
+        )
+
+        #expect(request?.number == 42)
+        #expect(await runner.commands.map(\.args.first) == ["mr", "mr", "mr"])
+        #expect(await runner.commands.first == FakeRunner.Command(
+            executable: "glab",
+            args: [
+                "mr", "list",
+                "--source-branch", "feature/gitlab-provider",
+                "--target-branch", "main",
+                "--output", "json",
+                "--per-page", "20",
+                "-R", "platform/mobile/alas",
+            ],
+            cwd: Self.cwd
+        ))
+        #expect(await runner.commands[1] == FakeRunner.Command(
+            executable: "glab",
+            args: ["mr", "view", "42", "--output", "json", "-R", "platform/mobile/alas"],
+            cwd: Self.cwd
+        ))
+        #expect(await runner.commands[2] == FakeRunner.Command(
+            executable: "glab",
+            args: [
+                "mr", "note", "list", "42",
+                "--state", "unresolved",
+                "--output", "json",
+                "-R", "platform/mobile/alas",
+            ],
+            cwd: Self.cwd
+        ))
+    }
+
     @Test func createReviewRequestUsesExpectedArgsForNormalMR() async throws {
         let runner = FakeRunner(results: [
             ProcessResult(exitCode: 0, stdout: "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/44\n", stderr: ""),
@@ -215,6 +458,40 @@ struct GitLabCLIProviderTests {
     )
 
     private static let cwd = URL(fileURLWithPath: "/tmp/alas")
+
+    private static let mrListOutput = """
+    [
+      {
+        "iid": 42,
+        "title": "Add GitLab provider",
+        "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42",
+        "state": "opened",
+        "draft": false,
+        "source_branch": "feature/gitlab-provider",
+        "target_branch": "main",
+        "merge_status": "can_be_merged",
+        "detailed_merge_status": "mergeable"
+      }
+    ]
+    """
+
+    private static let mrViewOutput = """
+    {
+      "iid": 42,
+      "title": "Add GitLab provider",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42",
+      "state": "opened",
+      "draft": true,
+      "source_branch": "feature/gitlab-provider",
+      "target_branch": "main",
+      "merge_status": "cannot_be_merged",
+      "detailed_merge_status": "not_approved",
+      "approvals_required": 1,
+      "approvals_left": 1
+    }
+    """
+
+    private static let discussionsOutput = "[]"
 
     private actor FakeRunner: CodeHostCommandRunning {
         struct Command: Equatable {

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -304,6 +304,28 @@ struct GitLabCLIProviderTests {
         #expect(try GitLabCLIProvider.parseMRList(output, remote: Self.remote, headOwner: "nacho") == nil)
     }
 
+    @Test func mrListFiltersByResolvedSourceProjectID() throws {
+        let request = try #require(try GitLabCLIProvider.parseMRList(
+            Self.duplicateForkMRListOutput,
+            remote: Self.remote,
+            headOwner: "nacho",
+            sourceProjectPathsByID: [
+                1001: "platform/mobile/alas",
+                1002: "nacho/alas",
+            ]
+        ))
+
+        #expect(request.number == 43)
+        #expect(request.title == "Fork MR")
+    }
+
+    @Test func projectPathParsingRequiresPathWithNamespace() throws {
+        #expect(try GitLabCLIProvider.parseProjectPath(#"{"path_with_namespace":"nacho/alas"}"#) == "nacho/alas")
+        #expect(throws: CodeHostProviderError.malformedOutput("glab api project output is missing path_with_namespace")) {
+            _ = try GitLabCLIProvider.parseProjectPath(#"{"name":"alas"}"#)
+        }
+    }
+
     @Test func mrMergeStatusesMapToReviewMergeState() throws {
         let cases: [(status: String, mergeState: ReviewMergeState)] = [
             ("mergeable", .clean),
@@ -488,6 +510,50 @@ struct GitLabCLIProviderTests {
                 "--output", "json",
                 "-R", "platform/mobile/alas",
             ],
+            cwd: Self.cwd
+        ))
+    }
+
+    @Test func currentReviewRequestResolvesSourceProjectIDsBeforeFilteringForkMRs() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.duplicateForkMRListOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: #"{"path_with_namespace":"platform/mobile/alas"}"#, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: #"{"path_with_namespace":"nacho/alas"}"#, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.forkMRViewOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.discussionsOutput, stderr: ""),
+            ProcessResult(exitCode: 0, stdout: Self.pipelineOutput, stderr: ""),
+        ])
+
+        let request = try await GitLabCLIProvider(runner: runner).currentReviewRequest(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headOwner: "nacho",
+            baseBranch: "origin/main",
+            cwd: Self.cwd
+        )
+
+        #expect(request?.number == 43)
+        #expect(await runner.commands.map { Array($0.args.prefix(2)) } == [
+            ["mr", "list"],
+            ["api", "projects/1001"],
+            ["api", "projects/1002"],
+            ["mr", "view"],
+            ["mr", "note"],
+            ["ci", "get"],
+        ])
+        #expect(await runner.commands[1] == FakeRunner.Command(
+            executable: "glab",
+            args: ["api", "projects/1001", "--hostname", "gitlab.example.com", "--output", "json"],
+            cwd: Self.cwd
+        ))
+        #expect(await runner.commands[2] == FakeRunner.Command(
+            executable: "glab",
+            args: ["api", "projects/1002", "--hostname", "gitlab.example.com", "--output", "json"],
+            cwd: Self.cwd
+        ))
+        #expect(await runner.commands[3] == FakeRunner.Command(
+            executable: "glab",
+            args: ["mr", "view", "43", "--output", "json", "-R", "platform/mobile/alas"],
             cwd: Self.cwd
         ))
     }
@@ -859,6 +925,45 @@ struct GitLabCLIProviderTests {
       "approvals_required": 1,
       "approvals_left": 1
     }
+    """
+
+    private static let forkMRViewOutput = """
+    {
+      "iid": 43,
+      "title": "Fork MR",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/43",
+      "state": "opened",
+      "draft": false,
+      "source_branch": "feature/gitlab-provider",
+      "target_branch": "main",
+      "merge_status": "can_be_merged",
+      "detailed_merge_status": "mergeable"
+    }
+    """
+
+    private static let duplicateForkMRListOutput = """
+    [
+      {
+        "iid": 42,
+        "title": "Base project MR",
+        "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/42",
+        "state": "opened",
+        "draft": false,
+        "source_branch": "feature/gitlab-provider",
+        "target_branch": "main",
+        "source_project_id": 1001
+      },
+      {
+        "iid": 43,
+        "title": "Fork MR",
+        "web_url": "https://gitlab.example.com/platform/mobile/alas/-/merge_requests/43",
+        "state": "opened",
+        "draft": false,
+        "source_branch": "feature/gitlab-provider",
+        "target_branch": "main",
+        "source_project_id": 1002
+      }
+    ]
     """
 
     private static let discussionsOutput = """

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -386,6 +386,14 @@ struct GitLabCLIProviderTests {
         #expect(checks[0].id != checks[1].id)
     }
 
+    @Test func pipelineJSONTreatsAllowedFailureJobsAsNonBlocking() throws {
+        let checks = try GitLabCLIProvider.parsePipeline(Self.pipelineWithAllowedFailureJobsOutput)
+
+        #expect(checks.map(\.name) == ["build", "lint"])
+        #expect(checks.map(\.bucket) == [.pass, .skipping])
+        #expect(checks.max { $0.bucket.severity < $1.bucket.severity }?.bucket == .pass)
+    }
+
     @Test func pipelineJSONFallsBackToPipelineLevelCheckWhenJobsAreMissing() throws {
         let checks = try GitLabCLIProvider.parsePipeline(Self.pipelineOutput)
 
@@ -656,6 +664,36 @@ struct GitLabCLIProviderTests {
             FakeRunner.Command(
                 executable: "glab",
                 args: ["ci", "retry", "103", "-R", "platform/mobile/alas"],
+                cwd: Self.cwd
+            ),
+        ])
+    }
+
+    @Test func rerunFailedChecksSkipsAllowedFailureJobs() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.pipelineWithAllowedFailureJobsOutput, stderr: ""),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        try await GitLabCLIProvider(runner: runner).rerunFailedChecks(
+            remote: Self.remote,
+            branch: "feature/gitlab-provider",
+            headSHA: "abc123",
+            request: request,
+            cwd: Self.cwd
+        )
+
+        #expect(await runner.commands == [
+            FakeRunner.Command(
+                executable: "glab",
+                args: [
+                    "ci", "get",
+                    "--merge-request", "42",
+                    "--status", "failed",
+                    "--with-job-details",
+                    "--output", "json",
+                    "-R", "platform/mobile/alas",
+                ],
                 cwd: Self.cwd
             ),
         ])
@@ -1092,6 +1130,31 @@ struct GitLabCLIProviderTests {
           "name": "lint",
           "status": "failed",
           "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/103"
+        }
+      ]
+    }
+    """
+
+    private static let pipelineWithAllowedFailureJobsOutput = """
+    {
+      "id": 780,
+      "status": "success",
+      "ref": "feature/gitlab-provider",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/pipelines/780",
+      "jobs": [
+        {
+          "id": 106,
+          "name": "build",
+          "status": "success",
+          "allow_failure": false,
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/106"
+        },
+        {
+          "id": 107,
+          "name": "lint",
+          "status": "failed",
+          "allow_failure": true,
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/107"
         }
       ]
     }

--- a/AlasTests/Integrations/ReviewLoopStateTests.swift
+++ b/AlasTests/Integrations/ReviewLoopStateTests.swift
@@ -449,7 +449,11 @@ struct ReviewLoopStateTests {
     }
 
     @Test func rerunFailedChecksUsesProviderWithoutSessionApproval() async throws {
-        let provider = FakeCodeHostProvider(kind: .github)
+        let remote = Self.makeRemote()
+        let provider = FakeCodeHostProvider(
+            kind: .github,
+            request: Self.makeReviewRequest(remote: remote, checks: [])
+        )
         let state = ReviewLoopState(
             worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
             baseBranch: "main",
@@ -461,12 +465,23 @@ struct ReviewLoopStateTests {
 
         #expect(didRun)
         #expect(provider.rerunFailedChecksRequests == [
-            FakeCodeHostProvider.RerunFailedChecksRequest(branch: "feature/review-loop", headSHA: "abc123"),
+            FakeCodeHostProvider.RerunFailedChecksRequest(
+                branch: "feature/review-loop",
+                headSHA: "abc123",
+                requestNumber: 42
+            ),
         ])
     }
 
     @Test func rerunFailedChecksUsesCapturedSnapshotInsteadOfCurrentSnapshot() async throws {
-        let provider = FakeCodeHostProvider(kind: .github)
+        let remote = Self.makeRemote()
+        let provider = FakeCodeHostProvider(
+            kind: .github,
+            requestForBranch: [
+                "feature/captured": Self.makeReviewRequest(remote: remote, number: 42, checks: []),
+                "feature/current": Self.makeReviewRequest(remote: remote, number: 43, checks: []),
+            ]
+        )
         let state = ReviewLoopState(
             worktreePath: URL(fileURLWithPath: "/tmp/alas-review-loop"),
             baseBranch: "main",
@@ -487,7 +502,11 @@ struct ReviewLoopStateTests {
 
         #expect(didRun)
         #expect(provider.rerunFailedChecksRequests == [
-            FakeCodeHostProvider.RerunFailedChecksRequest(branch: "feature/captured", headSHA: "abc123"),
+            FakeCodeHostProvider.RerunFailedChecksRequest(
+                branch: "feature/captured",
+                headSHA: "abc123",
+                requestNumber: 42
+            ),
         ])
     }
 
@@ -866,12 +885,13 @@ struct ReviewLoopStateTests {
 
     private static func makeReviewRequest(
         remote: CodeHostRemote,
+        number: Int = 42,
         headRefName: String = "feature/review-loop",
         checks: [ReviewCheck]
     ) -> ReviewRequest {
         ReviewRequest(
             remote: remote,
-            number: 42,
+            number: number,
             title: "Review loop",
             url: URL(string: "https://github.com/mrmans0n/alas/pull/42")!,
             state: .open,
@@ -914,6 +934,7 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
     struct RerunFailedChecksRequest: Equatable {
         let branch: String
         let headSHA: String
+        let requestNumber: Int?
     }
 
     let kind: CodeHostKind
@@ -1009,9 +1030,14 @@ private final class FakeCodeHostProvider: CodeHostProvider, @unchecked Sendable 
         remote: CodeHostRemote,
         branch: String,
         headSHA: String,
+        request: ReviewRequest?,
         cwd: URL
     ) async throws {
         if let rerunError { throw rerunError }
-        rerunFailedChecksRequests.append(RerunFailedChecksRequest(branch: branch, headSHA: headSHA))
+        rerunFailedChecksRequests.append(RerunFailedChecksRequest(
+            branch: branch,
+            headSHA: headSHA,
+            requestNumber: request?.number
+        ))
     }
 }

--- a/docs/superpowers/specs/2026-06-03-gitlab-review-request-provider-design.md
+++ b/docs/superpowers/specs/2026-06-03-gitlab-review-request-provider-design.md
@@ -1,0 +1,301 @@
+# GitLab Review Request Provider Design
+
+Date: 2026-06-03
+Status: Approved for implementation planning
+
+## Goal
+
+Add GitLab support to the existing review readiness and draft review request
+flow. GitLab should reach parity with the current GitHub integration: detect
+the active review request, create a new review request from the draft tab,
+display CI status, show actionable review feedback, support failed-check retry
+when job details are available, and map mergeability into the shared readiness
+model.
+
+This design treats "full GitLab parity" as parity with the GitHub features
+that Alas currently exposes. It does not add new merge, comment-posting, or
+discussion-resolution actions.
+
+## Context
+
+The current integration layer is already provider-neutral:
+
+- `CodeHostKind` includes `.gitlab`.
+- `CodeHostRemoteDetector` recognizes `gitlab.com` and hosts whose first DNS
+  label is `gitlab`.
+- `ReviewRequest`, `ReviewCheck`, `ReviewThreadSummary`,
+  `ReviewReadinessModel`, and the draft review request tab use provider-neutral
+  concepts.
+- `CodeHostProviderRegistry.live()` only registers `GitHubCLIProvider`.
+
+The GitLab CLI installed locally is `glab 1.101.0`. Its local command surface
+supports the required operations:
+
+- `glab auth status --hostname <host>`
+- `glab mr list --source-branch ... --target-branch ... --output json`
+- `glab mr view <iid> --output json`
+- `glab mr create --source-branch ... --target-branch ... --title ... --description ... --yes`
+- `glab mr note list <iid> --state unresolved --output json`
+- `glab ci get --merge-request <iid> --with-job-details --output json`
+- `glab ci retry <job-id> --pipeline-id <pipeline-id>`
+
+## User Experience
+
+For GitLab remotes, the Changes tab drawer should use the same layout and
+behavior as GitHub, with provider-native labels:
+
+- `GitLab` for provider identity when no merge request exists.
+- `GitLab !123` for an existing merge request.
+- `Create MR`, `Open MR`, and `No MR` labels.
+- Existing readiness chips for unpushed branches, remote-ahead branches, failed
+  checks, pending checks, review feedback, review pending, and ready state.
+
+The draft review request tab remains shared. When opened from a GitLab branch,
+it should show `Draft MR`, call the selected AI tool with the same review
+request prompt, default to a normal MR, and pass `isDraft` to the provider when
+the checkbox is selected.
+
+## Provider Architecture
+
+Add `GitLabCLIProvider: CodeHostProvider` under
+`Alas/Sources/Integrations/CodeHost/`.
+
+Register it in `CodeHostProviderRegistry.live()`:
+
+```swift
+CodeHostProviderRegistry(providers: [
+    .github: GitHubCLIProvider(),
+    .gitlab: GitLabCLIProvider(),
+])
+```
+
+Use the existing `CodeHostCommandRunning` abstraction for command execution so
+provider tests can assert arguments and parse fixtures without invoking `glab`.
+
+GitLab repository slugs can include subgroups. The existing `CodeHostRemote`
+`repositorySlug` already preserves `group/subgroup/repo`, so provider commands
+should pass `-R remote.repositorySlug`.
+
+## Authentication And Availability
+
+`isAvailable()` runs `glab --version` and returns true only for exit code 0.
+
+`isAuthenticated(remote:cwd:)` runs:
+
+```bash
+glab auth status --hostname <remote.host>
+```
+
+GitLab Enterprise hosts should use the detected remote host, not assume
+`gitlab.com`.
+
+## Current Merge Request Detection
+
+`currentReviewRequest(remote:branch:headOwner:baseBranch:cwd:)` should:
+
+1. Normalize the base branch with the existing provider pattern: if the base is
+   `remoteName/main`, pass `main`.
+2. Query open MRs with:
+
+   ```bash
+   glab mr list \
+     --source-branch <branch> \
+     --target-branch <base> \
+     --output json \
+     --per-page 20 \
+     -R <repositorySlug>
+   ```
+
+3. Select the first MR whose source branch matches the local branch. If the
+   output includes source project information and `headOwner` is present, prefer
+   the MR from that source namespace. If the fields are absent, use the first
+   match.
+4. Enrich the selected MR with `glab mr view <iid> --output json` when needed
+   for merge state, draft state, source/target branches, web URL, or review
+   approval fields not present in list output.
+5. Load unresolved discussion summaries.
+6. Load MR head pipeline checks.
+
+The provider should tolerate missing optional fields by mapping them to shared
+unknown values rather than failing the whole refresh.
+
+## Merge Request Creation
+
+`createReviewRequest(...)` should call:
+
+```bash
+glab mr create \
+  --source-branch <branch> \
+  --target-branch <base> \
+  --title <title> \
+  --description <body> \
+  --yes \
+  -R <repositorySlug>
+```
+
+Append `--draft` when `isDraft` is true.
+
+Do not pass `--fill` because Alas is supplying the AI-assisted title and body.
+Do not pass `--push`; the existing readiness validation already requires the
+remote branch to be in sync before creation. Parse the created MR URL from
+stdout. If stdout does not contain a valid HTTP(S) URL, throw
+`CodeHostProviderError.malformedOutput`.
+
+Fork support should be conservative. GitLab's `glab mr create --head` selects a
+head project, but the first implementation should only use it if tests show a
+stable mapping from `headOwner` to GitLab project path. Otherwise, creation from
+same-project branches is supported and fork creation should fail clearly through
+the provider command error.
+
+## CI Checks
+
+For an existing MR, load the head pipeline with:
+
+```bash
+glab ci get --merge-request <iid> --with-job-details --output json -R <repositorySlug>
+```
+
+Map the pipeline and its jobs into `ReviewCheck` values:
+
+- `success` -> `.pass`
+- `failed` -> `.fail`
+- `running`, `pending`, `created`, `preparing`, `waiting_for_resource`,
+  `manual`, `scheduled` -> `.pending`
+- `canceled` -> `.cancel`
+- `skipped` -> `.skipping`
+- unknown values -> `.unknown`
+
+Prefer job-level checks when job details are available because retry operates on
+jobs. If no job details exist, expose one pipeline-level check so the drawer can
+still show failed, pending, or passing status.
+
+Stable check IDs should include provider, pipeline id, job id when present,
+name, status, and detail URL.
+
+## Retry Failed Checks
+
+`rerunFailedChecks(remote:branch:headSHA:cwd:)` should find failed jobs for the
+current branch or current MR. Because the provider protocol only receives
+branch and head SHA, use:
+
+```bash
+glab ci list --ref <branch> --sha <headSHA> --status failed --output json -R <repositorySlug>
+```
+
+Then, for the newest failed pipeline, load failed jobs:
+
+```bash
+glab ci get --pipeline-id <pipeline-id> --status failed --with-job-details --output json -R <repositorySlug>
+```
+
+Retry each failed job with:
+
+```bash
+glab ci retry <job-id> --pipeline-id <pipeline-id> -R <repositorySlug>
+```
+
+If GitLab reports a failed pipeline but no failed job IDs, throw a provider
+error instead of retrying an interactive command or guessing a job name.
+
+## Review Feedback
+
+Load unresolved MR discussions with:
+
+```bash
+glab mr note list <iid> --state unresolved --output json -R <repositorySlug>
+```
+
+Map each discussion that has at least one non-empty user-authored note to
+`ReviewThreadSummary`:
+
+- `id`: discussion id.
+- `author`: first non-system note author username, when available.
+- `body`: first non-system note body.
+- `url`: note or discussion web URL, when available and valid.
+- `isResolved`: false for this query.
+- `isActionable`: true for unresolved diff or general discussions that are not
+  system-only.
+
+Skip system-only discussions because they should not trigger the review
+feedback chip or agent handoff.
+
+## Review Decision And Mergeability
+
+GitLab approvals and mergeability differ from GitHub review decisions, so the
+mapping should be conservative:
+
+- Approved when approval fields indicate the MR has all required approvals.
+- Review required when approvals are required and missing.
+- Unknown when the response does not expose enough approval information.
+
+Map GitLab merge status fields into shared merge states:
+
+- mergeable / can be merged -> `.clean`
+- conflicts / cannot be merged due to conflicts -> `.dirty`
+- checks, approvals, discussions, draft, or policy blockers -> `.blocked`
+- unchecked / checking / preparing -> `.unstable`
+- missing or unrecognized values -> `.unknown`
+
+The readiness drawer should continue to avoid a merge action. This preserves the
+current GitHub boundary.
+
+## Error Handling
+
+Use existing provider errors:
+
+- Missing CLI: `CodeHostProviderError.cliMissing("glab")`
+- Missing auth: `CodeHostProviderError.unauthenticated(remote.host)`
+- Failed command: include the `glab ...` command label and trimmed stderr.
+- Malformed JSON or invalid URLs: `CodeHostProviderError.malformedOutput`.
+
+Optional enrichment failures should not erase the discovered MR. If discussion
+or pipeline loading fails after the MR is found, return the MR with empty
+threads/checks for that enrichment path. Primary MR discovery failures should
+still surface as provider errors.
+
+## Testing
+
+Add `GitLabCLIProviderTests` mirroring the GitHub provider tests:
+
+- availability and auth command behavior.
+- MR list/view parsing.
+- create MR arguments for normal and draft MRs.
+- create output URL parsing.
+- base branch normalization.
+- pipeline/job status mapping.
+- pipeline-level fallback when job details are absent.
+- failed job retry command sequence.
+- unresolved discussion parsing and system-note filtering.
+- command failure and malformed-output errors.
+
+Update shared integration tests where useful:
+
+- `CodeHostProviderRegistry.live()` includes GitLab.
+- `ReviewReadinessModel` keeps MR labels/actions for GitLab.
+- `ReviewLoopState` can refresh a GitLab remote using a fake provider.
+- Draft review request validation/messages use provider-native labels where the
+  current hard-coded `PR` wording would be wrong for GitLab.
+
+Manual verification should cover:
+
+- GitLab branch with no MR.
+- GitLab branch with an existing MR.
+- Draft tab creates normal MR by default.
+- Draft checkbox creates draft MR.
+- MR with passing pipeline.
+- MR with pending pipeline.
+- MR with failed jobs and retry available.
+- MR with unresolved discussion feedback.
+- Missing `glab`.
+- Unauthenticated `glab`.
+
+## Out Of Scope
+
+- Adding a merge action.
+- Posting MR comments or replies.
+- Resolving or reopening MR discussions from Alas.
+- Direct OAuth/token storage.
+- GitLab issue integration.
+- GitLab release integration.
+- Rich pipeline logs inside the drawer.
+- Browser-based interactive `glab mr create --web`.


### PR DESCRIPTION
## Summary
- Add a GitLab CLI code host provider for MR discovery, creation, checks, and failed-job retry.
- Parse GitLab MR, pipeline, and job JSON into the shared review loop model.
- Enable GitLab review-loop actions after provider support is implemented.

## Verification
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- Focused integration suites passed for GitLab provider, review-loop state, provider registry, review readiness, and drawer behavior.
- Full xcodebuild test was started, progressed through many suites, then hung in ACPTerminal kill escalation and was interrupted.