### PR TITLE
fix(gitlab): target pipeline when retrying jobs

### DIFF
--- a/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
+++ b/Alas/Sources/Integrations/CodeHost/GitLabCLIProvider.swift
@@ -171,11 +171,15 @@ struct GitLabCLIProvider: CodeHostProvider {
             throw CodeHostProviderError.commandFailed(command: "glab ci get", stderr: result.stderr)
         }
 
-        let failedJobIDs = try Self.failedJobIDs(fromPipelineJSON: result.stdout)
-        for jobID in failedJobIDs {
+        let retryTargets = try Self.failedJobRetryTargets(fromPipelineJSON: result.stdout)
+        for target in retryTargets {
             let retry = try await runner.run(
                 "glab",
-                args: ["ci", "retry", "\(jobID)", "-R", remote.repositorySlug],
+                args: [
+                    "ci", "retry", "\(target.jobID)",
+                    "--pipeline-id", "\(target.pipelineID)",
+                    "-R", remote.repositorySlug,
+                ],
                 cwd: cwd
             )
             guard retry.exitCode == 0 else {
@@ -424,11 +428,29 @@ struct GitLabCLIProvider: CodeHostProvider {
         }
     }
 
-    private static func failedJobIDs(fromPipelineJSON json: String) throws -> [Int] {
+    private static func failedJobRetryTargets(fromPipelineJSON json: String) throws -> [GitLabRetryTarget] {
         let pipeline = try decodePipeline(json)
-        return pipeline.jobs?.compactMap { job in
-            job.status.lowercased() == "failed" && job.allowFailure != true ? job.id : nil
+        let failedJobs = pipeline.jobs?.filter { job in
+            job.status.lowercased() == "failed" && job.allowFailure != true
         } ?? []
+
+        guard !failedJobs.isEmpty else {
+            if pipeline.status.lowercased() == "failed" {
+                throw CodeHostProviderError.malformedOutput("glab ci get output did not include retryable failed job IDs")
+            }
+            return []
+        }
+
+        guard let pipelineID = pipeline.id else {
+            throw CodeHostProviderError.malformedOutput("glab ci get output is missing a pipeline id for retry")
+        }
+
+        return try failedJobs.map { job in
+            guard let jobID = job.id else {
+                throw CodeHostProviderError.malformedOutput("glab ci get output did not include retryable failed job IDs")
+            }
+            return GitLabRetryTarget(jobID: jobID, pipelineID: pipelineID)
+        }
     }
 
     private static func reviewRequest(
@@ -734,6 +756,11 @@ private struct GitLabJob: Decodable {
         case webURL = "web_url"
         case finishedAt = "finished_at"
     }
+}
+
+private struct GitLabRetryTarget {
+    let jobID: Int
+    let pipelineID: Int
 }
 
 private struct GitLabDiscussion: Decodable {

--- a/AlasTests/Integrations/GitLabCLIProviderTests.swift
+++ b/AlasTests/Integrations/GitLabCLIProviderTests.swift
@@ -711,12 +711,12 @@ struct GitLabCLIProviderTests {
             ),
             FakeRunner.Command(
                 executable: "glab",
-                args: ["ci", "retry", "102", "-R", "platform/mobile/alas"],
+                args: ["ci", "retry", "102", "--pipeline-id", "778", "-R", "platform/mobile/alas"],
                 cwd: Self.cwd
             ),
             FakeRunner.Command(
                 executable: "glab",
-                args: ["ci", "retry", "103", "-R", "platform/mobile/alas"],
+                args: ["ci", "retry", "103", "--pipeline-id", "778", "-R", "platform/mobile/alas"],
                 cwd: Self.cwd
             ),
         ])
@@ -830,6 +830,44 @@ struct GitLabCLIProviderTests {
         await #expect(throws: CodeHostProviderError.commandFailed(
             command: "glab ci retry",
             stderr: "retry failed"
+        )) {
+            try await GitLabCLIProvider(runner: runner).rerunFailedChecks(
+                remote: Self.remote,
+                branch: "feature/gitlab-provider",
+                headSHA: "abc123",
+                request: request,
+                cwd: Self.cwd
+            )
+        }
+    }
+
+    @Test func rerunFailedChecksThrowsWhenFailedPipelineHasNoRetryableJobIDs() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.failedPipelineWithoutRetryableJobIDsOutput, stderr: ""),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        await #expect(throws: CodeHostProviderError.malformedOutput(
+            "glab ci get output did not include retryable failed job IDs"
+        )) {
+            try await GitLabCLIProvider(runner: runner).rerunFailedChecks(
+                remote: Self.remote,
+                branch: "feature/gitlab-provider",
+                headSHA: "abc123",
+                request: request,
+                cwd: Self.cwd
+            )
+        }
+    }
+
+    @Test func rerunFailedChecksThrowsWhenFailedPipelineIsMissingPipelineID() async throws {
+        let runner = FakeRunner(results: [
+            ProcessResult(exitCode: 0, stdout: Self.failedPipelineWithoutPipelineIDOutput, stderr: ""),
+        ])
+        let request = try GitLabCLIProvider.parseMRView(Self.mrViewOutput, remote: Self.remote)
+
+        await #expect(throws: CodeHostProviderError.malformedOutput(
+            "glab ci get output is missing a pipeline id for retry"
         )) {
             try await GitLabCLIProvider(runner: runner).rerunFailedChecks(
                 remote: Self.remote,
@@ -1198,6 +1236,38 @@ struct GitLabCLIProviderTests {
           "name": "lint",
           "status": "failed",
           "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/103"
+        }
+      ]
+    }
+    """
+
+    private static let failedPipelineWithoutRetryableJobIDsOutput = """
+    {
+      "id": 781,
+      "status": "failed",
+      "ref": "feature/gitlab-provider",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/pipelines/781",
+      "jobs": [
+        {
+          "name": "test",
+          "status": "failed",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/unknown"
+        }
+      ]
+    }
+    """
+
+    private static let failedPipelineWithoutPipelineIDOutput = """
+    {
+      "status": "failed",
+      "ref": "feature/gitlab-provider",
+      "web_url": "https://gitlab.example.com/platform/mobile/alas/-/pipelines/unknown",
+      "jobs": [
+        {
+          "id": 108,
+          "name": "test",
+          "status": "failed",
+          "web_url": "https://gitlab.example.com/platform/mobile/alas/-/jobs/108"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- pass the GitLab pipeline id to `glab ci retry` for each failed job retry
- fail clearly when a failed pipeline response has no retryable job id or no pipeline id
- add GitLab provider regression coverage for the retry target behavior

## Verification
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/GitLabCLIProviderTests test`
- `rtk xcodegen`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `rtk xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`