### PR TITLE
Support Cursor ACP question prompts

### DIFF
--- a/Alas.xcodeproj/project.pbxproj
+++ b/Alas.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		18FEAA97EA576EC5276D2B28 /* HarnessPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0544FCFB9BC3E26FDB57CC96 /* HarnessPill.swift */; };
 		190FA1E53291D6D94CC0086C /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8052B601A9C834365A9D880 /* SidebarHeaderView.swift */; };
 		195102F7D680452476D70329 /* GitLabCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C371360F83FE318A5B8AEDBF /* GitLabCLIProviderTests.swift */; };
+		1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */; };
 		1A60F5DDA4E304766FEEC013 /* CodeTextViewAutoPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A8A65C6EC8182FD23AE97 /* CodeTextViewAutoPairTests.swift */; };
 		1AE5FCAF7D44694876754813 /* HookInstallNudgeResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F4827435F746DC54616D0 /* HookInstallNudgeResolverTests.swift */; };
 		1B123A31842DDDB42C6820F1 /* BuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F30C23C9CD0842373F29D1F /* BuildIdentity.swift */; };
@@ -314,6 +315,7 @@
 		523568D4D67F61ACA677EE44 /* SubHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE8B45ECF898B83A616586D /* SubHeader.swift */; };
 		524B70F03B9A934CEEA5FA61 /* LSPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8F6FBCE1218EAB74B608A /* LSPClientTests.swift */; };
 		52A5CDD852333A0C4BDC6995 /* ACPPermissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */; };
+		52D1F226CE8DB1967977D3F3 /* ACPQuestionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */; };
 		5426DC977050AACBCBDA37E9 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAC7481503A68EA0888682 /* AgentDetectorTests.swift */; };
 		542C76AF3A21CBD6B2838CEE /* ACPLaunchSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8528D2A61E1FC9F51296C9F6 /* ACPLaunchSpec.swift */; };
 		551C15188490062DFC77A479 /* MemorySnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5456C0192DBFA5FB61042F76 /* MemorySnapshotTests.swift */; };
@@ -330,6 +332,7 @@
 		57A5A3F4F14E75F6C00A2DC0 /* ACPSessionRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91E5E766925FD6499548CFC /* ACPSessionRunnerTests.swift */; };
 		57D04CD70E3A716B81F58FF8 /* RightPaneStateUnstagePathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAF2B901624C0629A1E3357 /* RightPaneStateUnstagePathsTests.swift */; };
 		5846A180EB68D905E9775401 /* GitService+ReviewLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 764489A630CC6D79FCE0A26A /* GitService+ReviewLoop.swift */; };
+		588A1EB3D20EB2419A5A03B4 /* ACPStdioQuestionDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2015944331CE56AEEF534910 /* ACPStdioQuestionDispatchTests.swift */; };
 		58ED3DFB6576F9B3C473D16C /* ACPNewChatEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7294C0B27241ADEB9A95347A /* ACPNewChatEmptyStateView.swift */; };
 		5936DF2636F0B74BEAB33A57 /* DraftAmendPrefillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB02326DBD7A82431A33C50F /* DraftAmendPrefillTests.swift */; };
 		59765FD789179C1BDC3F1BB9 /* ChangesTreeBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D49EBCE99D6F1690646F80 /* ChangesTreeBuilderTests.swift */; };
@@ -904,6 +907,7 @@
 		FB51C37DBD897B3A690DCDC3 /* ACPNewChatEmptyStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */; };
 		FB5FD89FC2800E173FC31E7A /* ACPAuthFailure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCB7DA8B6EA8CF8B98EA267 /* ACPAuthFailure.swift */; };
 		FBAB18AAEFB289EF765564C5 /* RightPaneSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15DFCD74150803355CC0A95 /* RightPaneSelectionState.swift */; };
+		FC9BC95960AE236F82D69E0B /* ACPQuestionPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */; };
 		FCB5091692C10A45B4E5D6BB /* AppConfigWorktreeOrderingDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0458AFA9BCBC4484B084085 /* AppConfigWorktreeOrderingDecodeTests.swift */; };
 		FCE78F165C46577F64D9B9AD /* CenterSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417CDD7CCA0D0A86E9EE281F /* CenterSelectionState.swift */; };
 		FD7719ABDA6CFCF28BB0F800 /* ACPMessageListPaginationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9272E334A0A5DF460514CF01 /* ACPMessageListPaginationTests.swift */; };
@@ -1043,6 +1047,7 @@
 		1EC659A56A08A30F7784428D /* ACPClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPClient.swift; sourceTree = "<group>"; };
 		1F9B399B5355B20890D8E42C /* ACPAdapterUpdateBannerDeciderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAdapterUpdateBannerDeciderTests.swift; sourceTree = "<group>"; };
 		1FDD958CF56AA9AD319F6C6C /* AlasCLICommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlasCLICommandRouterTests.swift; sourceTree = "<group>"; };
+		2015944331CE56AEEF534910 /* ACPStdioQuestionDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPStdioQuestionDispatchTests.swift; sourceTree = "<group>"; };
 		20556618656218B845371F37 /* TreeSitterHighlighterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeSitterHighlighterTests.swift; sourceTree = "<group>"; };
 		206F1DBCB1C34D71BEBB7DE4 /* ImageCheckerboardBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCheckerboardBackground.swift; sourceTree = "<group>"; };
 		2071DA26A16E9A4A5AC5B3C3 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
@@ -1185,11 +1190,13 @@
 		41B7844FCFC1DD54B2B471F8 /* InstallNudgeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallNudgeBanner.swift; sourceTree = "<group>"; };
 		4246F7A17DCEC4D2A669BC43 /* ImageDiffDifferenceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDiffDifferenceView.swift; sourceTree = "<group>"; };
 		4261E417947C1A21E77C1587 /* GitStatusCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusCache.swift; sourceTree = "<group>"; };
+		4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPrompt.swift; sourceTree = "<group>"; };
 		435D9E527A76820947F426A8 /* ACPFilesystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPFilesystem.swift; sourceTree = "<group>"; };
 		436E8992D7373486BA25D290 /* CodeTextViewCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeTextViewCompletionTests.swift; sourceTree = "<group>"; };
 		43DF691FC778F3A71CE20FBB /* StartupScriptInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupScriptInstallerTests.swift; sourceTree = "<group>"; };
 		4457B30E0C8A22BF06D0BC4B /* ACPPermissionScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPPermissionScope.swift; sourceTree = "<group>"; };
 		447D95D444F6AE08FCFA27A3 /* AppStateCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateCleanupTests.swift; sourceTree = "<group>"; };
+		44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionPromptTests.swift; sourceTree = "<group>"; };
 		44E87586CA07BA62C84BAD24 /* DiffSelectableTextBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffSelectableTextBuilder.swift; sourceTree = "<group>"; };
 		45413FEBB779051893272FC7 /* CommitPrimaryAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommitPrimaryAction.swift; sourceTree = "<group>"; };
 		45513A6B9EAA4E9744502597 /* AppConfigShortcutsCodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigShortcutsCodingTests.swift; sourceTree = "<group>"; };
@@ -1528,6 +1535,7 @@
 		AA98E1DB8D77DE67918D6B9F /* CopilotInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotInstallerTests.swift; sourceTree = "<group>"; };
 		AAEDACEB27E6AF219054496E /* DialogChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogChrome.swift; sourceTree = "<group>"; };
 		AB4C1B7737A289066E01C444 /* WorkspaceLSPManagerStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLSPManagerStatusTests.swift; sourceTree = "<group>"; };
+		AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPQuestionRequest.swift; sourceTree = "<group>"; };
 		ACFF914E16884DAC97F11C76 /* SearchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEmptyState.swift; sourceTree = "<group>"; };
 		AD29EE0AFA5232B1ED728514 /* UnionCanvasGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnionCanvasGeometryTests.swift; sourceTree = "<group>"; };
 		AD85FA11903B85EA889596A3 /* ACPAttachmentMimeTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ACPAttachmentMimeTypeTests.swift; sourceTree = "<group>"; };
@@ -2249,6 +2257,7 @@
 				2EB39DE3614B5BEC4D3EBF13 /* ACPSessionLifecycleTests.swift */,
 				A5D62D907375A5CBAED1E698 /* ACPSessionUpdateTests.swift */,
 				5302E56E1C16EDECDB45CB20 /* ACPStdioClientTests.swift */,
+				2015944331CE56AEEF534910 /* ACPStdioQuestionDispatchTests.swift */,
 				01DB2EFD475B2D7D5D75B06A /* ACPStdioTerminalDispatchTests.swift */,
 				54897710493742A6DFD6ABF3 /* ACPToolCallContentTests.swift */,
 				4E340D23D2484C570F8E4B7F /* FakeJSONRPCTransport.swift */,
@@ -2522,6 +2531,7 @@
 				D0CE3F0637B3CA27B1D87080 /* ACPNewChatEmptyStateTests.swift */,
 				80BAFADCDC3E349AC3DBDDEA /* ACPPlanPillStateTests.swift */,
 				96A230290E0029D45CA1B907 /* ACPPlanSidebarVisibilityTests.swift */,
+				44ACE3DEC81C465524111058 /* ACPQuestionPromptTests.swift */,
 				98A7F35818C95A567DDA586A /* ACPSelectChipTests.swift */,
 				0AB6FA9F258818E8B464CB0A /* ACPSetupNudgeBannerModeTests.swift */,
 				EDABAB5EEE4C15A78B5429E6 /* ComposerActionTests.swift */,
@@ -2549,6 +2559,7 @@
 				074A17527610230DCFBEA13C /* ACPMockClient.swift */,
 				67E03BF5DB4E6BFF8C2FA6A2 /* ACPPermissionRequest.swift */,
 				BEBCF3820A017BBF33B0AB07 /* ACPProtocolVersion.swift */,
+				AB9D4FBF08CBAB59C08BBF1D /* ACPQuestionRequest.swift */,
 				DD1F34E025D235A5CECCE36E /* ACPSessionUpdate.swift */,
 				4D20C843AB88A6EB14D2A1BD /* ACPStdioClient.swift */,
 				10E10C6559E26691EC906737 /* ACPTerminalMessages.swift */,
@@ -2763,6 +2774,7 @@
 				2CDDDC4C6146165CA4C7474E /* ACPPlanPillState.swift */,
 				EC2BB41ECA8AEAB278294B8A /* ACPPlanSidebar.swift */,
 				D7322805CC904D460A8C53C8 /* ACPPlanSidebarVisibility.swift */,
+				4306DE43C5ADCC65310C1169 /* ACPQuestionPrompt.swift */,
 				987ABA2B4C9EA522DC9860B9 /* ACPQueuedBubble.swift */,
 				10602801D3FA990E60CB072D /* ACPQueueHeader.swift */,
 				AE35206EEBD7E3A35C3421EA /* ACPRecoveryPill.swift */,
@@ -3745,6 +3757,8 @@
 				7EC95A2AAEFE78B51D9F599A /* ACPPlanSidebarVisibility.swift in Sources */,
 				E9507AB389CE47A6A48C049B /* ACPProcessLiveness.swift in Sources */,
 				7556121D51C54458FCAFED2A /* ACPProtocolVersion.swift in Sources */,
+				FC9BC95960AE236F82D69E0B /* ACPQuestionPrompt.swift in Sources */,
+				52D1F226CE8DB1967977D3F3 /* ACPQuestionRequest.swift in Sources */,
 				F269D59E1E21AD57EF3EE909 /* ACPQueueHeader.swift in Sources */,
 				518F761277C4C5E4E6C512A3 /* ACPQueuedBubble.swift in Sources */,
 				C85FF0853DE69CE2EB59633E /* ACPRecoveryPill.swift in Sources */,
@@ -4216,6 +4230,7 @@
 				F0CB2589DDF3082F6996A117 /* ACPPlanSidebarVisibilityTests.swift in Sources */,
 				EA6EFDDEAE3FF9D878824EDC /* ACPProcessLivenessTests.swift in Sources */,
 				86759BF3DE64FFAA4FE98822 /* ACPPromptCapabilitiesTests.swift in Sources */,
+				1A56FAF2DE8FFB95272EE948 /* ACPQuestionPromptTests.swift in Sources */,
 				A383F1C9B0B00B2805576209 /* ACPScrollDirectionClassifierTests.swift in Sources */,
 				702EC5CB48F37FC8B6F27FA4 /* ACPSelectChipTests.swift in Sources */,
 				9159297D87B2AA9B7A03F072 /* ACPSessionAgentStateTests.swift in Sources */,
@@ -4247,6 +4262,7 @@
 				AC2574A26E931F0881F560C6 /* ACPSetupCheckerTests.swift in Sources */,
 				07BB2B329992BA535053BB80 /* ACPSetupNudgeBannerModeTests.swift in Sources */,
 				E239749EA0CB37C2C12B3591 /* ACPStdioClientTests.swift in Sources */,
+				588A1EB3D20EB2419A5A03B4 /* ACPStdioQuestionDispatchTests.swift in Sources */,
 				929C2E12D6178FF3728365A2 /* ACPStdioTerminalDispatchTests.swift in Sources */,
 				1B16FCB3621BB868C34334D7 /* ACPStreamingTextTests.swift in Sources */,
 				D874E635B8E9CDB1610D36E8 /* ACPSubmitIntentTests.swift in Sources */,

--- a/Alas/Sources/ACP/ACPHarnessBridge.swift
+++ b/Alas/Sources/ACP/ACPHarnessBridge.swift
@@ -86,6 +86,8 @@ final class ACPHarnessBridge {
             harness.setExternalActivity(sessionId: session.id, agent: agent, state: .busy)
         case .awaitingPermission:
             harness.setExternalActivity(sessionId: session.id, agent: agent, state: .permissionRequest)
+        case .awaitingInput:
+            harness.setExternalActivity(sessionId: session.id, agent: agent, state: .awaitingInput)
         }
     }
 

--- a/Alas/Sources/ACP/Protocol/ACPClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPClient.swift
@@ -47,6 +47,11 @@ protocol ACPClient: AnyObject {
     /// call `respondToPermission(id:decision:)` exactly once per emitted request.
     var permissionRequests: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)> { get }
 
+    /// Ask-user question requests from agent-specific ACP extensions. The
+    /// client owner must call `respondToQuestion(id:response:)` exactly once
+    /// per emitted request.
+    var questionRequests: AsyncStream<ACPQuestionRequest> { get }
+
     /// Filesystem requests (`fs/read_text_file`, `fs/write_text_file`).
     var fileRequests: AsyncStream<ACPFileRequest> { get }
 
@@ -55,6 +60,7 @@ protocol ACPClient: AnyObject {
     var terminalRequests: AsyncStream<ACPTerminalRequest> { get }
 
     func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse)
+    func respondToQuestion(id: JSONRPCID, response: ACPQuestionResponse)
     func respondToFileRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>)
     func respondToTerminalRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>)
 

--- a/Alas/Sources/ACP/Protocol/ACPMockClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPMockClient.swift
@@ -6,6 +6,7 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
     private var asyncScripts: [String: (ACPRequest) async throws -> Data] = [:]
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
+    private let questionsCont: AsyncStream<ACPQuestionRequest>.Continuation
     private let filesCont: AsyncStream<ACPFileRequest>.Continuation
     private let terminalsCont: AsyncStream<ACPTerminalRequest>.Continuation
     private let updateCountLock = NSLock()
@@ -19,6 +20,7 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
         return _yieldedUpdateCount
     }
     let permissionRequests: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>
+    let questionRequests: AsyncStream<ACPQuestionRequest>
     let fileRequests: AsyncStream<ACPFileRequest>
     let terminalRequests: AsyncStream<ACPTerminalRequest>
 
@@ -31,6 +33,9 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
         var p: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation!
         self.permissionRequests = AsyncStream { p = $0 }
         self.permsCont = p
+        var q: AsyncStream<ACPQuestionRequest>.Continuation!
+        self.questionRequests = AsyncStream { q = $0 }
+        self.questionsCont = q
         var f: AsyncStream<ACPFileRequest>.Continuation!
         self.fileRequests = AsyncStream { f = $0 }
         self.filesCont = f
@@ -64,12 +69,19 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
         updatesCont.yield(update)
     }
     func emitPermission(id: JSONRPCID, params: ACPPermissionRequestParams) { permsCont.yield((id, params)) }
+    func emitQuestion(id: JSONRPCID, params: ACPQuestionRequestParams) {
+        questionsCont.yield(.init(id: id, params: params))
+    }
     func emitFile(_ req: ACPFileRequest) { filesCont.yield(req) }
     func emitTerminal(_ req: ACPTerminalRequest) { terminalsCont.yield(req) }
 
     var permissionResponses: [JSONRPCID: ACPPermissionResponse] = [:]
     func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse) {
         permissionResponses[id] = response
+    }
+    var questionResponses: [JSONRPCID: ACPQuestionResponse] = [:]
+    func respondToQuestion(id: JSONRPCID, response: ACPQuestionResponse) {
+        questionResponses[id] = response
     }
     var fileResponses: [JSONRPCID: Result<Data, JSONRPCError>] = [:]
     func respondToFileRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {
@@ -91,6 +103,7 @@ final class ACPMockClient: ACPClient, @unchecked Sendable {
         shutdownCount += 1
         updatesCont.finish()
         permsCont.finish()
+        questionsCont.finish()
         filesCont.finish()
         terminalsCont.finish()
     }

--- a/Alas/Sources/ACP/Protocol/ACPQuestionRequest.swift
+++ b/Alas/Sources/ACP/Protocol/ACPQuestionRequest.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Agent-specific ask-user requests normalized for the Alas UI. V1 is wired
+/// to Cursor's documented `cursor/ask_question` method.
+struct ACPQuestionRequestParams: Codable, Equatable {
+    let toolCallId: String
+    let title: String?
+    let questions: [ACPQuestion]
+}
+
+struct ACPQuestion: Codable, Equatable, Identifiable {
+    let id: String
+    let prompt: String
+    let options: [ACPQuestionOption]
+    let allowMultiple: Bool?
+}
+
+struct ACPQuestionOption: Codable, Equatable, Identifiable, Hashable {
+    let id: String
+    let label: String
+}
+
+struct ACPQuestionAnswer: Codable, Equatable {
+    let questionId: String
+    let selectedOptionIds: [String]
+}
+
+struct ACPQuestionResponse: Codable, Equatable {
+    let outcome: ACPQuestionOutcome
+}
+
+enum ACPQuestionOutcome: Equatable {
+    case answered(answers: [ACPQuestionAnswer])
+    case skipped(reason: String?)
+    case cancelled
+}
+
+extension ACPQuestionOutcome: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case outcome
+        case answers
+        case reason
+    }
+
+    private enum Kind: String, Codable {
+        case answered
+        case skipped
+        case cancelled
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        switch try c.decode(Kind.self, forKey: .outcome) {
+        case .answered:
+            self = .answered(answers: try c.decode([ACPQuestionAnswer].self, forKey: .answers))
+        case .skipped:
+            self = .skipped(reason: try c.decodeIfPresent(String.self, forKey: .reason))
+        case .cancelled:
+            self = .cancelled
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .answered(let answers):
+            try c.encode(Kind.answered, forKey: .outcome)
+            try c.encode(answers, forKey: .answers)
+        case .skipped(let reason):
+            try c.encode(Kind.skipped, forKey: .outcome)
+            try c.encodeIfPresent(reason, forKey: .reason)
+        case .cancelled:
+            try c.encode(Kind.cancelled, forKey: .outcome)
+        }
+    }
+}
+
+struct ACPQuestionRequest {
+    let id: JSONRPCID
+    let params: ACPQuestionRequestParams
+}

--- a/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
+++ b/Alas/Sources/ACP/Protocol/ACPStdioClient.swift
@@ -4,6 +4,7 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     private let transport: JSONRPCStdioTransporting
     private let updatesCont: AsyncStream<ACPSessionUpdateParams>.Continuation
     private let permsCont: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation
+    private let questionsCont: AsyncStream<ACPQuestionRequest>.Continuation
     private let filesCont: AsyncStream<ACPFileRequest>.Continuation
     private let terminalsCont: AsyncStream<ACPTerminalRequest>.Continuation
     private let stderrCont: AsyncStream<Data>.Continuation
@@ -15,6 +16,7 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         return _yieldedUpdateCount
     }
     let permissionRequests: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>
+    let questionRequests: AsyncStream<ACPQuestionRequest>
     let fileRequests: AsyncStream<ACPFileRequest>
     let terminalRequests: AsyncStream<ACPTerminalRequest>
     let incomingStderr: AsyncStream<Data>
@@ -46,6 +48,10 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         self.permissionRequests = AsyncStream { pC = $0 }
         self.permsCont = pC
 
+        var qC: AsyncStream<ACPQuestionRequest>.Continuation!
+        self.questionRequests = AsyncStream { qC = $0 }
+        self.questionsCont = qC
+
         var fC: AsyncStream<ACPFileRequest>.Continuation!
         self.fileRequests = AsyncStream { fC = $0 }
         self.filesCont = fC
@@ -71,6 +77,10 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         var pC: AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)>.Continuation!
         self.permissionRequests = AsyncStream { pC = $0 }
         self.permsCont = pC
+
+        var qC: AsyncStream<ACPQuestionRequest>.Continuation!
+        self.questionRequests = AsyncStream { qC = $0 }
+        self.questionsCont = qC
 
         var fC: AsyncStream<ACPFileRequest>.Continuation!
         self.fileRequests = AsyncStream { fC = $0 }
@@ -114,6 +124,7 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
             for (_, cont) in snapshot { cont.resume(throwing: ACPClientError.notRunning) }
             updatesCont.finish()
             permsCont.finish()
+            questionsCont.finish()
             filesCont.finish()
             terminalsCont.finish()
             stderrCont.finish()
@@ -157,6 +168,9 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
         case "session/request_permission":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPPermissionRequestParams>.self, from: data),
                let id = env.id, let p = env.params { permsCont.yield((id, p)) }
+        case "cursor/ask_question":
+            if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPQuestionRequestParams>.self, from: data),
+               let id = env.id, let p = env.params { questionsCont.yield(.init(id: id, params: p)) }
         case "fs/read_text_file":
             if let env = try? JSONDecoder().decode(JSONRPCEnvelope<ACPFsReadParams>.self, from: data),
                let id = env.id, let p = env.params { filesCont.yield(.read(id: id, params: p)) }
@@ -238,6 +252,18 @@ final class ACPStdioClient: ACPClient, @unchecked Sendable {
     }
 
     func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse) {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let body = try JSONEncoder().encode(response)
+                try self.respond(id: id, body: body)
+            } catch {
+                // Best-effort; caller side has no error path for this.
+            }
+        }
+    }
+
+    func respondToQuestion(id: JSONRPCID, response: ACPQuestionResponse) {
         Task { [weak self] in
             guard let self else { return }
             do {

--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -146,7 +146,7 @@ final class ACPSession: ObservableObject, Identifiable {
         case ready
         case failed(String)
     }
-    enum StreamingState: Equatable { case idle, sending, streaming, awaitingPermission }
+    enum StreamingState: Equatable { case idle, sending, streaming, awaitingPermission, awaitingInput }
     enum SetupState: Equatable {
         case checking
         case ready
@@ -156,6 +156,10 @@ final class ACPSession: ObservableObject, Identifiable {
     struct PendingPermission: Identifiable, Equatable {
         let id: JSONRPCID
         let params: ACPPermissionRequestParams
+    }
+    struct PendingQuestion: Identifiable, Equatable {
+        let id: JSONRPCID
+        let params: ACPQuestionRequestParams
     }
 
     init(id: ID, agentId: String, worktreeId: String, title: String,

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -41,8 +41,10 @@ final class ACPSessionRunner {
     private let onPersist: (() -> Void)?
     private var updatesTask: Task<Void, Never>?
     private var permissionsTask: Task<Void, Never>?
+    private var questionsTask: Task<Void, Never>?
     private var filesTask: Task<Void, Never>?
     private var terminalsTask: Task<Void, Never>?
+    private var pendingQuestionContinuation: CheckedContinuation<ACPQuestionResponse, Never>?
     private var seq: Int64 = 0
     private var steerUndoExpiryTask: Task<Void, Never>?
     /// Monotonic prompt counter + active/cancelled bookkeeping (inherited
@@ -149,6 +151,16 @@ final class ACPSessionRunner {
                 let scopeKey = "tool:\(params.toolCall.title ?? params.toolCall.toolCallId)"
                 let response = await self.policy.evaluate(scopeKey: scopeKey, options: params.options, params: params)
                 self.connection.client.respondToPermission(id: id, response: response)
+            }
+        }
+
+        questionsTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await request in self.connection.client.questionRequests {
+                let response = await self.awaitQuestionResponse(request)
+                if Task.isCancelled { return }
+                self.connection.client.respondToQuestion(id: request.id, response: response)
+                self.flushQueueIfIdle()
             }
         }
 
@@ -269,14 +281,38 @@ final class ACPSessionRunner {
     func stop() {
         updatesTask?.cancel()
         permissionsTask?.cancel()
+        questionsTask?.cancel()
         filesTask?.cancel()
         terminalsTask?.cancel()
+        resolvePendingQuestion(.init(outcome: .cancelled))
         // Kill agent-spawned subprocesses now. ACPSessionManager keeps
         // the ACPSession cached after detach, so the session's deinit-
         // time killAll() won't fire on tab close — without this an
         // active `npm test`/`sleep`/server outlives the agent.
         session.terminalHost.killAll()
         onPersist?()
+    }
+
+    private func awaitQuestionResponse(_ request: ACPQuestionRequest) async -> ACPQuestionResponse {
+        session.transcript.streamingState = .awaitingInput
+        session.transcript.pendingQuestion = .init(id: request.id, params: request.params)
+        return await withCheckedContinuation { continuation in
+            pendingQuestionContinuation = continuation
+        }
+    }
+
+    func answerQuestion(_ response: ACPQuestionResponse) {
+        resolvePendingQuestion(response)
+    }
+
+    private func resolvePendingQuestion(_ response: ACPQuestionResponse) {
+        guard let continuation = pendingQuestionContinuation else { return }
+        pendingQuestionContinuation = nil
+        session.transcript.pendingQuestion = nil
+        if session.transcript.streamingState == .awaitingInput {
+            session.transcript.streamingState = .idle
+        }
+        continuation.resume(returning: response)
     }
 
     private func handleTerminalRequest(_ req: ACPTerminalRequest) {
@@ -505,6 +541,7 @@ final class ACPSessionRunner {
                 }
             }
             policy.userCancelled()
+            resolvePendingQuestion(.init(outcome: .cancelled))
             let changedIndices = session.cancelInFlightToolCalls()
             session.terminalHost.killAll()
             if holdsLeaseForWrite() {

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -45,6 +45,7 @@ final class ACPSessionRunner {
     private var filesTask: Task<Void, Never>?
     private var terminalsTask: Task<Void, Never>?
     private var pendingQuestionContinuation: CheckedContinuation<ACPQuestionResponse, Never>?
+    private var pendingQuestionPreviousStreamingState: ACPSession.StreamingState?
     private var seq: Int64 = 0
     private var steerUndoExpiryTask: Task<Void, Never>?
     /// Monotonic prompt counter + active/cancelled bookkeeping (inherited
@@ -284,7 +285,7 @@ final class ACPSessionRunner {
         questionsTask?.cancel()
         filesTask?.cancel()
         terminalsTask?.cancel()
-        resolvePendingQuestion(.init(outcome: .cancelled))
+        resolvePendingQuestion(.init(outcome: .cancelled), restorePreviousState: false)
         // Kill agent-spawned subprocesses now. ACPSessionManager keeps
         // the ACPSession cached after detach, so the session's deinit-
         // time killAll() won't fire on tab close — without this an
@@ -294,6 +295,7 @@ final class ACPSessionRunner {
     }
 
     private func awaitQuestionResponse(_ request: ACPQuestionRequest) async -> ACPQuestionResponse {
+        pendingQuestionPreviousStreamingState = session.transcript.streamingState
         session.transcript.streamingState = .awaitingInput
         session.transcript.pendingQuestion = .init(id: request.id, params: request.params)
         return await withCheckedContinuation { continuation in
@@ -305,13 +307,19 @@ final class ACPSessionRunner {
         resolvePendingQuestion(response)
     }
 
-    private func resolvePendingQuestion(_ response: ACPQuestionResponse) {
+    private func resolvePendingQuestion(
+        _ response: ACPQuestionResponse,
+        restorePreviousState: Bool = true
+    ) {
         guard let continuation = pendingQuestionContinuation else { return }
         pendingQuestionContinuation = nil
         session.transcript.pendingQuestion = nil
         if session.transcript.streamingState == .awaitingInput {
-            session.transcript.streamingState = .idle
+            session.transcript.streamingState = restorePreviousState
+                ? pendingQuestionPreviousStreamingState ?? .idle
+                : .idle
         }
+        pendingQuestionPreviousStreamingState = nil
         continuation.resume(returning: response)
     }
 
@@ -785,11 +793,11 @@ extension ACPSessionRunner {
     }
 
     /// Drain the queue head if the runner is still live, setup is not
-    /// blocked on auth, transcript state is `.idle`, the head is `.pending`,
-    /// and the head has no `lastError`. Marks the head `.sending`, persists,
-    /// and dispatches `sendNow` with the head's id so success can pop the
-    /// right item and failure can flag the right item without disturbing
-    /// the rest of the queue.
+    /// blocked on auth, no prompt owns the transport, transcript state is
+    /// `.idle`, the head is `.pending`, and the head has no `lastError`.
+    /// Marks the head `.sending`, persists, and dispatches `sendNow` with the
+    /// head's id so success can pop the right item and failure can flag the
+    /// right item without disturbing the rest of the queue.
     ///
     /// Chained drain is implicit: sendNow's completion sets state to
     /// `.idle` and calls back here.
@@ -797,6 +805,7 @@ extension ACPSessionRunner {
         guard holdsLeaseForWrite() else { return }
         guard !steerInProgress,
               session.agentState == .ready,
+              activePromptID == nil,
               session.transcript.streamingState == .idle,
               let head = session.queue.first,
               head.status == .pending,

--- a/Alas/Sources/ACP/Session/ACPTranscript.swift
+++ b/Alas/Sources/ACP/Session/ACPTranscript.swift
@@ -11,6 +11,7 @@ final class ACPTranscript: ObservableObject {
     @Published var messages: [ACPMessage] = []
     @Published var streamingState: ACPSession.StreamingState = .idle
     @Published var pendingPermission: ACPSession.PendingPermission?
+    @Published var pendingQuestion: ACPSession.PendingQuestion?
     /// Tick incremented on every streaming chunk that mutates an existing
     /// agent/thought buffer. The buffer itself publishes (so the row's
     /// inner Text re-renders), but the transcript array doesn't change —

--- a/Alas/Sources/ACP/UI/ACPComposer.swift
+++ b/Alas/Sources/ACP/UI/ACPComposer.swift
@@ -116,7 +116,7 @@ struct ACPInputField: NSViewRepresentable {
                             sendOnEnter: Bool) -> String {
         switch state {
         case .idle: return "Plan, ask, or build — type / for commands"
-        case .sending, .streaming, .awaitingPermission:
+        case .sending, .streaming, .awaitingPermission, .awaitingInput:
             return sendOnEnter
                 ? "Queue a follow-up… (⌥⏎ to steer)"
                 : "Steer the agent… (⌥⏎ to queue)"

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -7,6 +7,7 @@ struct ACPMessageList: View {
     let onOpenDiff: (String) -> Void
     let policy: ACPPermissionPolicy?
     let scopeKey: String
+    let onQuestionResponse: (ACPQuestionResponse) -> Void
     /// Callbacks invoked by the pending bubbles + header. The host wires
     /// these to the runner.
     let onQueueEdit: (QueuedPrompt) -> Void
@@ -61,6 +62,7 @@ struct ACPMessageList: View {
         hasher.combine(transcript.messages.count)
         hasher.combine(session.queue.count)
         hasher.combine(session.queue.first?.status)
+        hasher.combine(transcript.pendingQuestion?.id)
         // Streaming chunks mutate the buffer in place without re-publishing
         // the transcript array; the tick gives the body a reason to re-eval
         // so this signature changes and the tail-scroll fires per chunk.
@@ -113,6 +115,10 @@ struct ACPMessageList: View {
                         if transcript.pendingPermission != nil, let policy = policy {
                             ACPPermissionPrompt(session: session, policy: policy, scopeKey: scopeKey)
                                 .id("__pending_perm__")
+                        }
+                        if transcript.pendingQuestion != nil {
+                            ACPQuestionPrompt(session: session, onRespond: onQuestionResponse)
+                                .id("__pending_question__")
                         }
                         if transcript.streamingState == .streaming {
                             StreamingCaret().frame(width: 8, height: 14)

--- a/Alas/Sources/ACP/UI/ACPQuestionPrompt.swift
+++ b/Alas/Sources/ACP/UI/ACPQuestionPrompt.swift
@@ -1,0 +1,236 @@
+import SwiftUI
+
+struct ACPQuestionPrompt: View {
+    @ObservedObject var session: ACPSession
+    let onRespond: (ACPQuestionResponse) -> Void
+    @Environment(\.theme) private var theme
+    @State private var selection: [String: Set<String>] = [:]
+
+    var body: some View {
+        if let pending = session.transcript.pendingQuestion {
+            content(for: pending.params)
+        }
+    }
+
+    @ViewBuilder
+    private func content(for params: ACPQuestionRequestParams) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header(params)
+            questionBody(params)
+            actionRow(params)
+        }
+        .background(
+            LinearGradient(
+                colors: [theme.color("bg-2").opacity(0.72), theme.color("bg-1").opacity(0.62)],
+                startPoint: .top, endPoint: .bottom
+            )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(theme.color("accent").opacity(0.55), lineWidth: 1)
+        )
+        .shadow(color: theme.color("accent").opacity(0.10), radius: 16, y: 4)
+        .shadow(color: .black.opacity(0.25), radius: 8, y: 2)
+    }
+
+    @ViewBuilder
+    private func header(_ params: ACPQuestionRequestParams) -> some View {
+        HStack(spacing: 8) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(theme.color("accent").opacity(0.18))
+                Image(systemName: "questionmark.bubble")
+                    .font(.system(size: 10))
+                    .foregroundStyle(theme.color("accent"))
+            }
+            .frame(width: 18, height: 18)
+
+            Text("Question")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.6)
+                .textCase(.uppercase)
+                .foregroundStyle(theme.color("accent"))
+
+            if let title = params.title, !title.isEmpty {
+                Text("· \(title)")
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .foregroundStyle(theme.color("fg-faint"))
+            }
+
+            Spacer(minLength: 6)
+
+            QuestionPendingPulse()
+                .frame(width: 6, height: 6)
+            Text("Awaiting input")
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(0.5)
+                .textCase(.uppercase)
+                .foregroundStyle(theme.color("accent"))
+        }
+        .padding(.horizontal, 12).padding(.vertical, 9)
+        .background(theme.color("accent").opacity(0.08))
+    }
+
+    @ViewBuilder
+    private func questionBody(_ params: ACPQuestionRequestParams) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            ForEach(params.questions) { question in
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(question.prompt)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(theme.color("fg"))
+                        .lineSpacing(3)
+                        .fixedSize(horizontal: false, vertical: true)
+                    VStack(alignment: .leading, spacing: 7) {
+                        ForEach(question.options) { option in
+                            optionRow(option: option, question: question)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 12).padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private func optionRow(option: ACPQuestionOption, question: ACPQuestion) -> some View {
+        let selected = selection[question.id]?.contains(option.id) == true
+        Button {
+            toggle(option: option, for: question)
+        } label: {
+            HStack(spacing: 9) {
+                Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 13))
+                    .foregroundStyle(selected ? theme.color("accent") : theme.color("fg-faint"))
+                    .frame(width: 16)
+                Text(option.label)
+                    .font(.system(size: 12))
+                    .foregroundStyle(theme.color("fg"))
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(selected ? theme.color("accent").opacity(0.12) : theme.color("bg-0").opacity(0.45))
+            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .overlay(
+                RoundedRectangle(cornerRadius: 7)
+                    .strokeBorder(selected ? theme.color("accent").opacity(0.5) : theme.color("line"), lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func actionRow(_ params: ACPQuestionRequestParams) -> some View {
+        let answer = Self.answeredResponse(for: params, selection: selection)
+        HStack(spacing: 10) {
+            Button("Skip") {
+                onRespond(.init(outcome: .skipped(reason: nil)))
+            }
+            .buttonStyle(QuestionSecondaryButtonStyle(theme: theme))
+
+            Button("Cancel") {
+                onRespond(.init(outcome: .cancelled))
+            }
+            .buttonStyle(QuestionSecondaryButtonStyle(theme: theme))
+
+            Spacer()
+
+            Button("Answer") {
+                if let answer {
+                    onRespond(answer)
+                }
+            }
+            .buttonStyle(QuestionPrimaryButtonStyle(theme: theme, disabled: answer == nil))
+            .disabled(answer == nil)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 10)
+        .background(theme.color("bg-1").opacity(0.55))
+        .overlay(alignment: .top) {
+            Rectangle().fill(theme.color("line-soft")).frame(height: 0.5)
+        }
+    }
+
+    private func toggle(option: ACPQuestionOption, for question: ACPQuestion) {
+        let allowMultiple = question.allowMultiple == true
+        if allowMultiple {
+            var current = selection[question.id] ?? []
+            if current.contains(option.id) {
+                current.remove(option.id)
+            } else {
+                current.insert(option.id)
+            }
+            selection[question.id] = current
+        } else {
+            selection[question.id] = [option.id]
+        }
+    }
+
+    static func answeredResponse(
+        for params: ACPQuestionRequestParams,
+        selection: [String: Set<String>]
+    ) -> ACPQuestionResponse? {
+        var answers: [ACPQuestionAnswer] = []
+        for question in params.questions {
+            let selected = selection[question.id] ?? []
+            guard !selected.isEmpty else { return nil }
+            let ordered = question.options.map(\.id).filter { selected.contains($0) }
+            answers.append(.init(questionId: question.id, selectedOptionIds: ordered))
+        }
+        return .init(outcome: .answered(answers: answers))
+    }
+}
+
+private struct QuestionPrimaryButtonStyle: ButtonStyle {
+    let theme: Theme
+    let disabled: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 11.5, weight: .semibold))
+            .padding(.horizontal, 12)
+            .frame(height: 26)
+            .background(theme.color("accent").opacity(disabled ? 0.16 : (configuration.isPressed ? 0.78 : 0.95)))
+            .foregroundStyle(disabled ? theme.color("fg-faint") : Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+private struct QuestionSecondaryButtonStyle: ButtonStyle {
+    let theme: Theme
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 11.5, weight: .medium))
+            .padding(.horizontal, 10)
+            .frame(height: 26)
+            .background(theme.color("bg-0").opacity(configuration.isPressed ? 0.8 : 0.55))
+            .foregroundStyle(theme.color("fg-muted"))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(theme.color("line"), lineWidth: 0.5)
+            )
+    }
+}
+
+private struct QuestionPendingPulse: View {
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        Circle()
+            .fill(theme.color("accent"))
+            .overlay(
+                Circle()
+                    .strokeBorder(theme.color("accent").opacity(0.5), lineWidth: 2)
+                    .scaleEffect(1.5)
+                    .opacity(0.35)
+            )
+    }
+}

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -49,11 +49,11 @@ private struct ACPSessionView: View {
     let worktree: Worktree
     let manager: ACPSessionManager
     @ObservedObject var session: ACPSession
-    /// Observed so the body re-evaluates when `pendingPermission`
-    /// arrives — `scopeKey(for:)` reads through this and the value
-    /// is passed down to `ACPMessageList`; otherwise the message
-    /// list gets a stale `""` scope and persisted allow/reject_always
-    /// decisions land under the wrong key.
+    /// Observed so the body re-evaluates when pending user action arrives.
+    /// `scopeKey(for:)` reads the permission value through this and passes
+    /// it down to `ACPMessageList`; otherwise the message list gets a stale
+    /// `""` scope and persisted allow/reject_always decisions land under the
+    /// wrong key.
     @ObservedObject var transcript: ACPTranscript
     @State private var updateState: AdapterUpdateState?
     @State private var dismissedLatest: String?
@@ -142,6 +142,7 @@ private struct ACPSessionView: View {
     private func handleEscape() {
         guard session.transcript.streamingState == .streaming || session.transcript.streamingState == .sending
               || session.transcript.streamingState == .awaitingPermission
+              || session.transcript.streamingState == .awaitingInput
         else { return }
         Task {
             if let runner = manager.runners[sessionId] {
@@ -229,6 +230,9 @@ private struct ACPSessionView: View {
                                 // pending permission request.
                                 policy: manager.runners[sessionId]?.policy,
                                 scopeKey: scopeKey(for: session.transcript.pendingPermission),
+                                onQuestionResponse: { response in
+                                    manager.runners[sessionId]?.answerQuestion(response)
+                                },
                                 onQueueEdit: isMirror ? { _ in } : { item in
                                     // Pull the queued prompt back into the composer
                                     // for editing — appended after any text the user

--- a/Alas/Sources/ACP/UI/ComposerAction.swift
+++ b/Alas/Sources/ACP/UI/ComposerAction.swift
@@ -39,7 +39,7 @@ func composerAction(
     switch streamingState {
     case .idle:
         return hasText ? .send : .hidden
-    case .sending, .streaming, .awaitingPermission:
+    case .sending, .streaming, .awaitingPermission, .awaitingInput:
         return hasText ? .queue(menu: [.steer, .stop]) : .stop
     }
 }

--- a/AlasTests/ACP/ACPHarnessBridgeTests.swift
+++ b/AlasTests/ACP/ACPHarnessBridgeTests.swift
@@ -47,6 +47,18 @@ struct ACPHarnessBridgeTests {
         #expect(harness.activityBySession["s1"]?.state == .permissionRequest)
     }
 
+    @Test("streamingState .awaitingInput writes .awaitingInput")
+    func awaitingInputMapsToAwaitingInput() async {
+        let harness = makeHarness()
+        let bridge = ACPHarnessBridge(harness: harness)
+        let session = ACPSession(id: "s1", agentId: "cursor-agent", worktreeId: "wt", title: "t")
+        bridge.observe(session: session)
+        session.transcript.streamingState = .awaitingInput
+        await Task.yield()
+        #expect(harness.activityBySession["s1"]?.state == .awaitingInput)
+        #expect(harness.activityBySession["s1"]?.agent == .cursor)
+    }
+
     @Test("streamingState .idle removes the entry")
     func idleClearsEntry() async {
         let harness = makeHarness()

--- a/AlasTests/ACP/Protocol/ACPStdioQuestionDispatchTests.swift
+++ b/AlasTests/ACP/Protocol/ACPStdioQuestionDispatchTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import Alas
+
+@Suite("ACPStdioClient question dispatch")
+struct ACPStdioQuestionDispatchTests {
+    @Test("cursor/ask_question incoming frame yields question request")
+    func dispatchesCursorAskQuestion() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try client.start()
+
+        let json = #"""
+        {"jsonrpc":"2.0","id":42,"method":"cursor/ask_question","params":{
+          "toolCallId":"call_123",
+          "title":"Need input",
+          "questions":[{
+            "id":"q1",
+            "prompt":"Which implementation path should I take?",
+            "options":[
+              {"id":"cursor","label":"Implement Cursor first"},
+              {"id":"generic","label":"Wait for generic ACP"}
+            ],
+            "allowMultiple":false
+          }]
+        }}
+        """#
+
+        transport.send(frame: Data(json.utf8))
+
+        var it = client.questionRequests.makeAsyncIterator()
+        let req = await it.next()
+        #expect(req?.id == .number(42))
+        #expect(req?.params.toolCallId == "call_123")
+        #expect(req?.params.title == "Need input")
+        #expect(req?.params.questions.first?.prompt == "Which implementation path should I take?")
+        #expect(req?.params.questions.first?.options.map(\.id) == ["cursor", "generic"])
+        #expect(req?.params.questions.first?.allowMultiple == false)
+    }
+
+    @Test("respondToQuestion sends Cursor-compatible JSON-RPC result")
+    func sendsAnsweredQuestionResponse() async throws {
+        let transport = FakeJSONRPCTransport()
+        let client = ACPStdioClient.makeForTesting(transport: transport)
+        try client.start()
+
+        let response = ACPQuestionResponse(
+            outcome: .answered(answers: [
+                .init(questionId: "q1", selectedOptionIds: ["cursor"])
+            ])
+        )
+
+        client.respondToQuestion(id: .number(42), response: response)
+
+        try await waitUntil {
+            !transport.sentFrames.isEmpty
+        }
+
+        let object = try #require(
+            JSONSerialization.jsonObject(with: transport.sentFrames[0]) as? [String: Any]
+        )
+        #expect(object["jsonrpc"] as? String == "2.0")
+        #expect(object["id"] as? Int == 42)
+        let result = try #require(object["result"] as? [String: Any])
+        let outcome = try #require(result["outcome"] as? [String: Any])
+        #expect(outcome["outcome"] as? String == "answered")
+        let answers = try #require(outcome["answers"] as? [[String: Any]])
+        #expect(answers.first?["questionId"] as? String == "q1")
+        #expect(answers.first?["selectedOptionIds"] as? [String] == ["cursor"])
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping @Sendable () -> Bool
+    ) async throws {
+        let start = ContinuousClock.now
+        while !predicate() {
+            if ContinuousClock.now - start > timeout {
+                Issue.record("timed out waiting for predicate")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}

--- a/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
+++ b/AlasTests/ACP/Protocol/FakeJSONRPCTransport.swift
@@ -7,6 +7,7 @@ import Foundation
 final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable {
     private let cont: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation
     let incoming: AsyncStream<JSONRPCStdioTransport.Incoming>
+    private(set) var sentFrames: [Data] = []
 
     init() {
         var c: AsyncStream<JSONRPCStdioTransport.Incoming>.Continuation!
@@ -19,7 +20,7 @@ final class FakeJSONRPCTransport: JSONRPCStdioTransporting, @unchecked Sendable 
     }
 
     func send(_ data: Data) throws {
-        // Discard outbound bytes in tests (we only care about inbound dispatch).
+        sentFrames.append(data)
     }
 
     func terminate() {

--- a/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerQueueTests.swift
@@ -109,6 +109,17 @@ struct ACPSessionRunnerQueueTests {
         #expect(mock.sent.contains { $0.method == "session/prompt" } == false)
     }
 
+    @Test("flushQueueIfIdle is a no-op while state is .awaitingInput")
+    func noopAwaitingInput() async throws {
+        let (runner, mock, session, _) = try mkRunner()
+        session.transcript.streamingState = .awaitingInput
+        session.enqueue(blocks: [.text("nope")])
+        runner.flushQueueIfIdle()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(session.queue.count == 1)
+        #expect(mock.sent.contains { $0.method == "session/prompt" } == false)
+    }
+
     @Test("flushQueueIfIdle skips a head with lastError; doesn't auto-retry")
     func skipsErroredHead() async throws {
         let (runner, mock, session, _) = try mkRunner()

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -69,6 +69,47 @@ struct ACPSessionRunnerTests {
         #expect(runner.session.transcript.streamingState == .idle)
     }
 
+    @Test("question request waits for user answer and responds to client")
+    func questionRequestWaitsForUserAnswer() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.start()
+
+        let params = ACPQuestionRequestParams(
+            toolCallId: "call_123",
+            title: "Need input",
+            questions: [
+                .init(
+                    id: "q1",
+                    prompt: "Which implementation path should I take?",
+                    options: [
+                        .init(id: "cursor", label: "Implement Cursor first"),
+                        .init(id: "generic", label: "Wait for generic ACP")
+                    ],
+                    allowMultiple: false
+                )
+            ]
+        )
+
+        mock.emitQuestion(id: .number(42), params: params)
+
+        try await waitUntil {
+            runner.session.transcript.pendingQuestion?.params == params
+                && runner.session.transcript.streamingState == .awaitingInput
+        }
+
+        runner.answerQuestion(.init(outcome: .answered(answers: [
+            .init(questionId: "q1", selectedOptionIds: ["cursor"])
+        ])))
+
+        try await waitUntil {
+            mock.questionResponses[.number(42)] == .init(outcome: .answered(answers: [
+                .init(questionId: "q1", selectedOptionIds: ["cursor"])
+            ]))
+        }
+        #expect(runner.session.transcript.pendingQuestion == nil)
+        #expect(runner.session.transcript.streamingState == .idle)
+    }
+
     @Test("prompt completion waits for yielded updates before marking output boundary")
     func promptCompletionWaitsForYieldedUpdatesBeforeBoundary() async throws {
         let url = FileManager.default.temporaryDirectory
@@ -820,6 +861,7 @@ private final class BoundaryRaceClient: ACPClient, @unchecked Sendable {
     let permissionRequests = AsyncStream<(id: JSONRPCID, params: ACPPermissionRequestParams)> { $0.finish() }
     let fileRequests = AsyncStream<ACPFileRequest> { $0.finish() }
     let terminalRequests = AsyncStream<ACPTerminalRequest> { $0.finish() }
+    let questionRequests = AsyncStream<ACPQuestionRequest> { $0.finish() }
 
     var yieldedUpdateCount: Int {
         updateCountLock.lock()
@@ -875,6 +917,7 @@ private final class BoundaryRaceClient: ACPClient, @unchecked Sendable {
     func respondToPermission(id: JSONRPCID, response: ACPPermissionResponse) {}
     func respondToFileRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {}
     func respondToTerminalRequest(id: JSONRPCID, result: Result<Data, JSONRPCError>) {}
+    func respondToQuestion(id: JSONRPCID, response: ACPQuestionResponse) {}
 
     func shutdown() async {
         updatesCont.finish()

--- a/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionRunnerTests.swift
@@ -110,6 +110,72 @@ struct ACPSessionRunnerTests {
         #expect(runner.session.transcript.streamingState == .idle)
     }
 
+    @Test("question answer does not flush queued prompt while original prompt is active")
+    func questionAnswerDoesNotFlushQueueWhilePromptActive() async throws {
+        let (runner, mock) = try makeRunner()
+        runner.session.agentState = .ready
+        runner.start()
+
+        let promptCounter = AsyncCounter()
+        let firstStarted = AsyncGate()
+        let finishFirst = AsyncGate()
+        mock.scriptAsync(method: "session/prompt") { _ in
+            let promptNumber = await promptCounter.next()
+            if promptNumber == 1 {
+                await firstStarted.open()
+                await finishFirst.wait()
+            }
+            return Data("{}".utf8)
+        }
+
+        runner.send(text: "first", attachments: [])
+        await firstStarted.wait()
+        try await waitUntil { runner.session.transcript.streamingState == .sending }
+
+        runner.send(text: "queued", attachments: [], intent: .auto)
+        #expect(runner.session.queue.count == 1)
+
+        let params = ACPQuestionRequestParams(
+            toolCallId: "call_123",
+            title: "Need input",
+            questions: [
+                .init(
+                    id: "q1",
+                    prompt: "Which implementation path should I take?",
+                    options: [
+                        .init(id: "cursor", label: "Implement Cursor first"),
+                        .init(id: "generic", label: "Wait for generic ACP")
+                    ],
+                    allowMultiple: false
+                )
+            ]
+        )
+        mock.emitQuestion(id: .number(42), params: params)
+        try await waitUntil {
+            runner.session.transcript.pendingQuestion?.params == params
+                && runner.session.transcript.streamingState == .awaitingInput
+        }
+
+        runner.answerQuestion(.init(outcome: .answered(answers: [
+            .init(questionId: "q1", selectedOptionIds: ["cursor"])
+        ])))
+
+        try await waitUntil {
+            mock.questionResponses[.number(42)] != nil
+        }
+        #expect(runner.session.transcript.pendingQuestion == nil)
+        #expect(runner.session.transcript.streamingState == .sending)
+        #expect(runner.session.queue.count == 1)
+        #expect(mock.sent.filter { $0.method == "session/prompt" }.count == 1)
+
+        await finishFirst.open()
+        try await waitUntil {
+            mock.sent.filter { $0.method == "session/prompt" }.count == 2
+                && runner.session.queue.isEmpty
+                && runner.session.transcript.streamingState == .idle
+        }
+    }
+
     @Test("prompt completion waits for yielded updates before marking output boundary")
     func promptCompletionWaitsForYieldedUpdatesBeforeBoundary() async throws {
         let url = FileManager.default.temporaryDirectory

--- a/AlasTests/ACP/Session/ACPSubmitIntentTests.swift
+++ b/AlasTests/ACP/Session/ACPSubmitIntentTests.swift
@@ -34,6 +34,12 @@ struct ACPSubmitRouteTests {
         #expect(r == .enqueue)
     }
 
+    @Test(".auto + awaitingInput → enqueue")
+    func awaitingInputAuto() {
+        let r = ACPSubmitRoute.resolve(intent: .auto, state: .awaitingInput, queueEmpty: true, blocksEmpty: false)
+        #expect(r == .enqueue)
+    }
+
     @Test(".steer + busy → steer")
     func steerWhileBusy() {
         let r = ACPSubmitRoute.resolve(intent: .steer, state: .streaming, queueEmpty: false, blocksEmpty: false)

--- a/AlasTests/ACP/UI/ACPComposerPlaceholderTests.swift
+++ b/AlasTests/ACP/UI/ACPComposerPlaceholderTests.swift
@@ -16,7 +16,7 @@ struct ACPComposerPlaceholderTests {
     @Test("busy + sendOnEnter advertises ⏎ as queue and ⌥⏎ as steer")
     func busyDefault() {
         let queueText = "Queue a follow-up… (⌥⏎ to steer)"
-        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission] {
+        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission, .awaitingInput] {
             #expect(ACPInputField.placeholder(for: state, sendOnEnter: true) == queueText)
         }
     }
@@ -24,7 +24,7 @@ struct ACPComposerPlaceholderTests {
     @Test("busy + inverted mapping advertises ⏎ as steer and ⌥⏎ as queue")
     func busyInverted() {
         let steerText = "Steer the agent… (⌥⏎ to queue)"
-        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission] {
+        for state in [ACPSession.StreamingState.sending, .streaming, .awaitingPermission, .awaitingInput] {
             #expect(ACPInputField.placeholder(for: state, sendOnEnter: false) == steerText)
         }
     }

--- a/AlasTests/ACP/UI/ACPQuestionPromptTests.swift
+++ b/AlasTests/ACP/UI/ACPQuestionPromptTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import Alas
+
+@Suite("ACPQuestionPrompt response builder")
+struct ACPQuestionPromptTests {
+    @Test("builds answered response from complete selections")
+    func buildsAnsweredResponse() {
+        let params = ACPQuestionRequestParams(
+            toolCallId: "call_123",
+            title: "Need input",
+            questions: [
+                .init(
+                    id: "q1",
+                    prompt: "Pick one",
+                    options: [.init(id: "a", label: "A")],
+                    allowMultiple: false
+                ),
+                .init(
+                    id: "q2",
+                    prompt: "Pick many",
+                    options: [.init(id: "b", label: "B"), .init(id: "c", label: "C")],
+                    allowMultiple: true
+                )
+            ]
+        )
+
+        let response = ACPQuestionPrompt.answeredResponse(
+            for: params,
+            selection: ["q1": ["a"], "q2": ["b", "c"]]
+        )
+
+        #expect(response == .init(outcome: .answered(answers: [
+            .init(questionId: "q1", selectedOptionIds: ["a"]),
+            .init(questionId: "q2", selectedOptionIds: ["b", "c"])
+        ])))
+    }
+
+    @Test("returns nil until every question has a selection")
+    func requiresEveryQuestion() {
+        let params = ACPQuestionRequestParams(
+            toolCallId: "call_123",
+            title: nil,
+            questions: [
+                .init(
+                    id: "q1",
+                    prompt: "Pick one",
+                    options: [.init(id: "a", label: "A")],
+                    allowMultiple: false
+                )
+            ]
+        )
+
+        #expect(ACPQuestionPrompt.answeredResponse(for: params, selection: [:]) == nil)
+    }
+}

--- a/AlasTests/ACP/UI/ComposerActionTests.swift
+++ b/AlasTests/ACP/UI/ComposerActionTests.swift
@@ -93,7 +93,7 @@ struct ComposerActionTests {
     }
 
     private var busyStates: [ACPSession.StreamingState] {
-        [.sending, .streaming, .awaitingPermission]
+        [.sending, .streaming, .awaitingPermission, .awaitingInput]
     }
 
     private var agentStates: [ACPSession.AgentState] {


### PR DESCRIPTION
## Summary

- Add shared ACP question request/response models and route Cursor's `cursor/ask_question` requests through the stdio client.
- Add session runner pending-question handling so agent turns pause while waiting for user input and resume after answer, skip, or cancel.
- Add an inline chat question prompt UI and wire awaiting-input state through composer, queue, escape handling, and harness activity.

## Verification

- `xcodegen`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -only-testing:AlasTests/ACPStdioQuestionDispatchTests -only-testing:AlasTests/ACPSessionRunnerTests -only-testing:AlasTests/ACPSessionRunnerQueueTests -only-testing:AlasTests/ACPQuestionPromptTests -only-testing:AlasTests/ComposerActionTests -only-testing:AlasTests/ACPComposerPlaceholderTests -only-testing:AlasTests/ACPSubmitRouteTests -only-testing:AlasTests/ACPHarnessBridgeTests test`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build`
- `xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test`