### PR TITLE
feat(changes): add harden commit type

### DIFF
--- a/Alas/Sources/Git/CommitInfo.swift
+++ b/Alas/Sources/Git/CommitInfo.swift
@@ -17,7 +17,7 @@ struct CommitInfo: Identifiable, Hashable {
 extension CommitInfo {
     static let recognisedTypes: Set<String> = [
         "feat", "fix", "chore", "refactor", "perf", "docs", "test", "ci", "build",
-        "style", "revert", "tune",
+        "style", "revert", "tune", "harden",
     ]
 
     /// Splits a commit subject of the form

--- a/AlasTests/CommitInfoTests.swift
+++ b/AlasTests/CommitInfoTests.swift
@@ -43,11 +43,17 @@ struct CommitInfoTests {
     @Test func recognisesAllExpectedTypes() {
         for type in [
             "feat", "fix", "chore", "refactor", "perf", "docs", "test", "ci", "build",
-            "style", "revert", "tune",
+            "style", "revert", "tune", "harden",
         ] {
             let (tag, _) = CommitInfo.parseConventional(subject: "\(type): something")
             #expect(tag == type, "expected \(type) to be recognised")
         }
+    }
+
+    @Test func extractsHardenPrefix() {
+        let (tag, stripped) = CommitInfo.parseConventional(subject: "harden: tighten auth checks")
+        #expect(tag == "harden")
+        #expect(stripped == "tighten auth checks")
     }
 
     @Test func extractsTunePrefix() {


### PR DESCRIPTION
## Summary
- add harden to recognized conventional commit types
- cover harden parsing in commit info tests

## Validation
- xcodegen
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' -quiet build
- xcodebuild -project Alas.xcodeproj -scheme Alas -destination 'platform=macOS' test