### PR TITLE
feat(acp): add Cursor-specific chip presentations for context and fast dropdowns

### DIFF
--- a/Alas/Sources/ACP/Session/ACPChipState.swift
+++ b/Alas/Sources/ACP/Session/ACPChipState.swift
@@ -15,7 +15,14 @@ struct ACPChipState: Equatable {
 struct ACPParameterChip: Identifiable, Equatable {
     let id: String
     let label: String
+    let presentation: ACPParameterChipPresentation
     let spec: ChipSpec
+}
+
+enum ACPParameterChipPresentation: Equatable {
+    case standard
+    case cursorContextWindow
+    case cursorFast
 }
 
 /// A single chip's data, plus a tag remembering where it came from so the
@@ -80,6 +87,7 @@ extension ACPChipState {
             configOptionId(from: thinking),
         ].compactMap { $0 })
         let parameters = parameterChips(from: configOptions,
+                                        agentId: agentId,
                                         excluding: consumedConfigIds)
         var result = ACPChipState(models: models, mode: mode,
                                   thinking: thinking, parameters: parameters,
@@ -167,6 +175,7 @@ extension ACPChipState {
 
     private static func parameterChips(
         from options: [ACPConfigOption],
+        agentId: String,
         excluding consumedIds: Set<String>
     ) -> [ACPParameterChip] {
         options.compactMap { opt in
@@ -179,6 +188,7 @@ extension ACPChipState {
             return ACPParameterChip(
                 id: opt.id,
                 label: opt.name.isEmpty ? opt.id.capitalized : opt.name,
+                presentation: presentation(for: opt, agentId: agentId),
                 spec: ChipSpec(
                     source: .configOption(id: opt.id),
                     options: opt.options.map {
@@ -186,6 +196,23 @@ extension ACPChipState {
                     },
                     currentId: opt.currentValue))
         }
+    }
+
+    private static func presentation(
+        for option: ACPConfigOption,
+        agentId: String
+    ) -> ACPParameterChipPresentation {
+        guard agentId == "cursor-agent" else { return .standard }
+
+        let id = option.id.lowercased()
+        let name = option.name.lowercased()
+        if id == "context" || id == "context_window" || name == "context window" {
+            return .cursorContextWindow
+        }
+        if id == "fast" || name == "fast" {
+            return .cursorFast
+        }
+        return .standard
     }
 
     private static func configOptionId(from spec: ChipSpec?) -> String? {

--- a/Alas/Sources/ACP/UI/ACPComposerShell.swift
+++ b/Alas/Sources/ACP/UI/ACPComposerShell.swift
@@ -338,7 +338,7 @@ struct ACPComposer: View {
 
     private func thinkingChip(_ spec: ChipSpec) -> some View {
         chip(spec: spec,
-             label: chipLabel(prefix: "Thinking", spec: spec),
+             label: iconChipLabel(icon: "🧠", spec: spec, fallback: "Thinking"),
              placeholder: "Thinking",
              accent: theme.color("warn"))
     }
@@ -353,10 +353,43 @@ struct ACPComposer: View {
     }
 
     private func parameterChip(_ parameter: ACPParameterChip) -> some View {
-        chip(spec: parameter.spec,
-             label: chipLabel(prefix: parameter.label, spec: parameter.spec),
-             placeholder: parameter.label,
-             accent: theme.color("fg-muted"))
+        switch parameter.presentation {
+        case .cursorContextWindow:
+            chip(spec: parameter.spec,
+                 label: iconChipLabel(icon: "🪟", spec: parameter.spec, fallback: parameter.label),
+                 placeholder: parameter.label,
+                 accent: cursorContextAccent)
+        case .cursorFast:
+            chip(spec: parameter.spec,
+                 label: iconChipLabel(icon: "🚀", spec: parameter.spec, fallback: parameter.label),
+                 placeholder: parameter.label,
+                 accent: cursorFastAccent)
+        case .standard:
+            chip(spec: parameter.spec,
+                 label: chipLabel(prefix: parameter.label, spec: parameter.spec),
+                 placeholder: parameter.label,
+                 accent: theme.color("fg-muted"))
+        }
+    }
+
+    private var cursorContextAccent: Color {
+        Color(.sRGB, red: 0.28, green: 0.72, blue: 0.88, opacity: 1)
+    }
+
+    private var cursorFastAccent: Color {
+        Color(.sRGB, red: 0.48, green: 0.82, blue: 0.42, opacity: 1)
+    }
+
+    private func iconChipLabel(icon: String, spec: ChipSpec, fallback: String) -> String {
+        "\(icon) \(selectedName(spec: spec, fallback: fallback))"
+    }
+
+    private func selectedName(spec: ChipSpec, fallback: String) -> String {
+        if let id = spec.currentId,
+           let item = spec.options.first(where: { $0.id == id }) {
+            return item.name
+        }
+        return spec.currentId ?? fallback
     }
 
     private func chip(spec: ChipSpec,

--- a/AlasTests/ACP/Session/ACPChipStateTests.swift
+++ b/AlasTests/ACP/Session/ACPChipStateTests.swift
@@ -272,6 +272,27 @@ extension ACPChipStateTests {
         #expect(state.thinking?.options.map { $0.name } == ["None", "Low", "Medium", "High", "Extra High"])
         #expect(state.parameters.map { $0.label } == ["Context", "Fast"])
         #expect(state.parameters.map { $0.spec.currentId } == ["272k", "false"])
+        #expect(state.parameters.map { $0.presentation } == [.cursorContextWindow, .cursorFast])
+    }
+
+    @Test("non-cursor agent: context and fast remain generic parameters")
+    func nonCursorContextAndFastRemainGeneric() {
+        let state = ACPChipState.normalize(
+            agentId: "future-agent",
+            availableModels: [],
+            currentModel: nil,
+            availableModes: [],
+            currentMode: nil,
+            configOptions: [
+                configOption("context",
+                             current: "272k",
+                             options: [("272k", "272k"), ("1m", "1m")]),
+                configOption("fast",
+                             current: "false",
+                             options: [("false", "Off"), ("true", "On")]),
+            ])
+
+        #expect(state.parameters.map { $0.presentation } == [.standard, .standard])
     }
 
     @Test("cursor-agent: no brackets -> no synthesized chips")


### PR DESCRIPTION
## Summary
- Introduces `ACPParameterChipPresentation` enum with `standard`, `cursorContextWindow`, and `cursorFast` cases to drive distinct visual rendering per chip type.
- For `cursor-agent`, the context window chip now renders with a 🪟 icon and blue accent, and the fast chip with a 🚀 icon and green accent; all other agents use the existing generic presentation.
- Extracts a shared `iconChipLabel` helper and reuses it for the thinking chip (🧠), unifying the icon-prefixed label pattern across chip types.

## Testing
- Unit tests added and passing: verifies Cursor agent assigns `.cursorContextWindow` and `.cursorFast` presentations, and that non-Cursor agents always receive `.standard` for the same config option IDs.