### PR TITLE
feat(acp): auto-send transcript context on session restore

### DIFF
--- a/Alas/Sources/ACP/Session/ACPSession.swift
+++ b/Alas/Sources/ACP/Session/ACPSession.swift
@@ -47,6 +47,7 @@ final class ACPSession: ObservableObject, Identifiable {
     @Published var setupState: SetupState = .checking
     @Published var lastError: String?
     @Published var contextRestoreWarning: ContextRestoreWarning?
+    @Published var contextRecoveryStatus: ContextRecoveryStatus?
     /// Runtime-only transcript scroll intent. When true, the ACP message
     /// list follows new content and restores to the latest bottom after
     /// returning to this session. Set false when the user scrolls upward.
@@ -119,6 +120,13 @@ final class ACPSession: ObservableObject, Identifiable {
     struct ContextRestoreWarning: Equatable {
         var message: String
         var canSendTranscript: Bool
+    }
+
+    enum ContextRecoveryStatus: Hashable {
+        case restoring
+        case sendingTranscript
+        case restored
+        case failed(String)
     }
 
     var hasConversationTranscript: Bool {

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -304,10 +304,14 @@ final class ACPSessionManager: ObservableObject {
             // calls / file edits would look conversation-less here and
             // permanently disable the "Send transcript" action — the
             // warning is set once and never recomputed after backfill.
+            let canSendTranscript = Self.wireMessagesHaveConversation(result.wireMessages)
             session.contextRestoreWarning = .init(
                 message: "Agent context could not be restored.",
-                canSendTranscript: Self.wireMessagesHaveConversation(result.wireMessages)
+                canSendTranscript: canSendTranscript
             )
+            if canSendTranscript {
+                session.contextRecoveryStatus = .sendingTranscript
+            }
         }
         session.autoRunEnabled = result.row.autoRun
         // Title intentionally NOT overwritten: `placeholderSession` already
@@ -1152,6 +1156,7 @@ extension ACPSessionManager {
         // `lastError` with the new reason.
         session.lastError = nil
         session.contextRestoreWarning = nil
+        session.contextRecoveryStatus = nil
         session.agentState = .spawning
 
         guard let spec = ACPLaunchCatalog.spec(for: session.agentId) else {
@@ -1248,11 +1253,17 @@ extension ACPSessionManager {
             if freshlyCreated {
                 result = try await connection.newSession(cwd: worktreePath)
             } else if let remoteId = session.remoteSessionId, !remoteId.isEmpty {
+                if session.hasConversationTranscript {
+                    session.contextRecoveryStatus = .restoring
+                }
                 do {
                     result = try await connection.loadSession(cwd: worktreePath, sessionId: remoteId)
                     runner.finishSuppressingLoadReplay(
                         throughYieldedUpdateCount: connection.client.yieldedUpdateCount
                     )
+                    if !pendingRecovery {
+                        session.contextRecoveryStatus = nil
+                    }
                 } catch {
                     runner.finishSuppressingLoadReplay(
                         throughYieldedUpdateCount: connection.client.yieldedUpdateCount
@@ -1274,6 +1285,9 @@ extension ACPSessionManager {
                         message: "Agent context could not be restored.",
                         canSendTranscript: session.hasConversationTranscript
                     )
+                    if session.hasConversationTranscript {
+                        session.contextRecoveryStatus = .sendingTranscript
+                    }
                 }
             } else {
                 result = try await connection.newSession(cwd: worktreePath)
@@ -1290,12 +1304,18 @@ extension ACPSessionManager {
                     message: "Agent context could not be restored.",
                     canSendTranscript: session.hasConversationTranscript
                 )
+                if session.hasConversationTranscript {
+                    session.contextRecoveryStatus = .sendingTranscript
+                }
             }
             if restoreWarning == nil, pendingRecovery {
                 restoreWarning = .init(
                     message: "Agent context could not be restored.",
                     canSendTranscript: session.hasConversationTranscript
                 )
+                if session.hasConversationTranscript {
+                    session.contextRecoveryStatus = .sendingTranscript
+                }
             }
             // Abort the commit if we were taken over OR the manager was disposed
             // while we awaited spawn/initialize — never register a runner or
@@ -1322,7 +1342,9 @@ extension ACPSessionManager {
             runners[sessionId] = runner
             attachSucceeded = true
             session.agentState = .ready
-            if !shouldHoldQueueForRecovery {
+            if shouldHoldQueueForRecovery {
+                sendTranscriptAsContext(sessionId: sessionId, agentName: nil)
+            } else {
                 runner.flushQueueIfIdle()
             }
             stderrTask.cancel()
@@ -1384,10 +1406,14 @@ extension ACPSessionManager {
               let prompt = transcriptContextPrompt(for: session, agentName: agentName)
         else { return false }
 
+        session.contextRecoveryStatus = .sendingTranscript
         runner.sendRecoveryContext(prompt) { delivered in
             if delivered {
                 self.persistContextRecoveryPending(sessionId: sessionId, pending: false)
                 session.contextRestoreWarning = nil
+                session.contextRecoveryStatus = .restored
+            } else {
+                session.contextRecoveryStatus = .failed("Transcript recovery failed.")
             }
         }
         return true

--- a/Alas/Sources/ACP/Session/ACPSessionManager.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionManager.swift
@@ -1358,6 +1358,7 @@ extension ACPSessionManager {
             let base = "ACP initialize/new failed: \(baseMessage)"
             let full = tail.isEmpty ? base : base + "\nstderr: " + tail
             session.lastError = full
+            session.contextRecoveryStatus = nil
             if let authReason {
                 session.setupState = .needsAuth(methods: session.authMethods, reason: authReason)
                 session.agentState = .failed(authReason)

--- a/Alas/Sources/ACP/Session/ACPSessionRunner.swift
+++ b/Alas/Sources/ACP/Session/ACPSessionRunner.swift
@@ -1099,9 +1099,7 @@ extension ACPSessionRunner {
                     let hasNewerActivePrompt = self.activePromptID != nil && !isActivePrompt
                     if isActivePrompt {
                         self.activePromptID = nil
-                        if self.deferCompletedOutputBoundaryUntilUpdatesDrain() {
-                            self.flushQueueIfIdle()
-                        }
+                        self.session.transcript.streamingState = .idle
                     }
                     if !hasNewerActivePrompt {
                         onCompleted?(false)

--- a/Alas/Sources/ACP/UI/ACPMessageList.swift
+++ b/Alas/Sources/ACP/UI/ACPMessageList.swift
@@ -15,6 +15,7 @@ struct ACPMessageList: View {
     let onQueueRetry: (UUID) -> Void
     let onQueueReorder: (Int, Int) -> Void
     let onQueueClearAll: () -> Void
+    let onRetryContextRecovery: () -> Void
     /// Resolves the full persisted content of a tool call by id when an
     /// expanded card's in-memory content was truncated. Wired by the host
     /// to `ACPSessionManager.reloadFullToolCallContent`. Returns nil when
@@ -62,6 +63,7 @@ struct ACPMessageList: View {
         hasher.combine(transcript.messages.count)
         hasher.combine(session.queue.count)
         hasher.combine(session.queue.first?.status)
+        hasher.combine(session.contextRecoveryStatus)
         hasher.combine(transcript.pendingQuestion?.id)
         // Streaming chunks mutate the buffer in place without re-publishing
         // the transcript array; the tick gives the body a reason to re-eval
@@ -147,6 +149,10 @@ struct ACPMessageList: View {
                                 .id("__queue_\(item.id)")
                             }
                         }
+                        if let status = session.contextRecoveryStatus {
+                            contextRecoveryRow(status)
+                                .id("__context_recovery__")
+                        }
                         // Invisible tail spacer that the auto-scroll pins to
                         // the viewport bottom; this guarantees the streaming
                         // caret / last message sits above the composer pill.
@@ -227,6 +233,59 @@ struct ACPMessageList: View {
             DispatchQueue.main.async {
                 releaseRestoring()
             }
+        }
+    }
+
+    @ViewBuilder
+    private func contextRecoveryRow(_ status: ACPSession.ContextRecoveryStatus) -> some View {
+        HStack(spacing: 8) {
+            switch status {
+            case .restoring, .sendingTranscript:
+                Spinner(lineWidth: 1.5)
+                    .frame(width: 12, height: 12)
+            case .restored:
+                Image(systemName: "checkmark.circle")
+                    .foregroundStyle(theme.color("accent"))
+            case .failed:
+                Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
+                    .foregroundStyle(theme.color("warn"))
+            }
+
+            Text(contextRecoveryText(status))
+                .font(.system(size: 12))
+                .foregroundStyle(theme.color("fg-muted"))
+
+            if case .failed = status {
+                Button("Retry") {
+                    onRetryContextRecovery()
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(theme.color("bg-1").opacity(0.65))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(theme.color("line").opacity(0.8), lineWidth: 0.5)
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func contextRecoveryText(_ status: ACPSession.ContextRecoveryStatus) -> String {
+        switch status {
+        case .restoring:
+            return "Restoring model context..."
+        case .sendingTranscript:
+            return "Restoring model context from transcript..."
+        case .restored:
+            return "Transcript restored as model context."
+        case .failed(let message):
+            return message
         }
     }
 

--- a/Alas/Sources/ACP/UI/ACPTabView.swift
+++ b/Alas/Sources/ACP/UI/ACPTabView.swift
@@ -277,6 +277,12 @@ private struct ACPSessionView: View {
                                     // needs to fire from this path.
                                     manager.runners[sessionId]?.flushQueueIfIdle()
                                 },
+                                onRetryContextRecovery: {
+                                    _ = manager.sendTranscriptAsContext(
+                                        sessionId: sessionId,
+                                        agentName: state.agent(id: session.agentId)?.displayName
+                                    )
+                                },
                                 onLoadFullToolCallContent: { toolCallId in
                                     manager.reloadFullToolCallContent(
                                         sessionId: sessionId, toolCallId: toolCallId)
@@ -480,7 +486,7 @@ private struct ACPSessionView: View {
 
     @ViewBuilder
     private func contextRestoreBanner() -> some View {
-        if let warning = session.contextRestoreWarning {
+        if session.contextRecoveryStatus == nil, let warning = session.contextRestoreWarning {
             HStack(spacing: 8) {
                 Image(systemName: "exclamationmark.arrow.triangle.2.circlepath")
                     .foregroundStyle(theme.color("warn"))

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -284,8 +284,8 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(text == "queued prompt")
     }
 
-    @Test("load failure falls back to session/new with transcript warning")
-    func loadFailureFallsBackToNewWithWarning() async throws {
+    @Test("load failure falls back to session/new and auto-sends transcript context")
+    func loadFailureFallsBackToNewAndAutoSendsTranscriptContext() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
         try store.upsertSession(row(remoteSessionId: "remote-old"))
         let priorPrompt: ACPMessage = .user(id: UUID(), text: "prior prompt", attachments: [])
@@ -299,20 +299,32 @@ struct ACPSessionManagerAttachRestoreTests {
             throw JSONRPCError(code: -32601, message: "Method not found", data: nil)
         }
         scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        client.script(method: "session/prompt") { request in
+            let params = try #require(request.params as? ACPSessionPromptParams)
+            #expect(params.sessionId == "remote-new")
+            let block = try #require(params.prompt.first)
+            guard case .text(let text) = block else {
+                Issue.record("Expected text prompt block")
+                return Data("null".utf8)
+            }
+            #expect(text.contains("prior prompt"))
+            return Data("null".utf8)
+        }
         let manager = manager(store: store, client: client)
 
         let session = try #require(manager.placeholderSession(id: "local"))
         await manager.hydrateIfNeeded(id: "local")
         await manager.attach(to: session.id, freshlyCreated: false)
 
-        let methods = client.sent.map(\.method)
-        #expect(methods == ["initialize", "session/load", "session/new"])
+        try await waitUntil {
+            client.sent.map(\.method) == ["initialize", "session/load", "session/new", "session/prompt"]
+                && session.contextRestoreWarning == nil
+        }
         #expect(session.remoteSessionId == "remote-new")
-        let warning = try #require(session.contextRestoreWarning)
-        #expect(warning.canSendTranscript)
+        #expect(session.contextRecoveryStatus == .restored)
         let row = try #require(try store.loadSession(id: "local"))
         #expect(row.remoteSessionId == "remote-new")
-        #expect(row.contextRecoveryPending)
+        #expect(!row.contextRecoveryPending)
     }
 
     @Test("new auth failure enters needsAuth with initialized auth method")
@@ -501,8 +513,8 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.setupState == .needsAuth(methods: [method], reason: "login required"))
     }
 
-    @Test("pending queued prompt waits for transcript recovery after load fallback")
-    func queuedPromptWaitsForTranscriptRecoveryAfterLoadFallback() async throws {
+    @Test("load fallback automatically sends transcript recovery before queued prompt")
+    func loadFallbackAutomaticallySendsTranscriptRecoveryBeforeQueuedPrompt() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
         try store.upsertSession(row(remoteSessionId: "remote-old"))
         try appendMessage(
@@ -527,19 +539,12 @@ struct ACPSessionManagerAttachRestoreTests {
         await manager.hydrateIfNeeded(id: "local")
         await manager.attach(to: session.id, freshlyCreated: false)
 
-        #expect(client.sent.map(\.method) == ["initialize", "session/load", "session/new"])
-        #expect(session.queue.count == 1)
-        #expect(session.contextRestoreWarning?.canSendTranscript == true)
-        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == true)
-
-        let accepted = manager.sendTranscriptAsContext(sessionId: session.id, agentName: "Agent")
-
-        #expect(accepted)
         try await waitUntil {
             client.sent.filter { $0.method == "session/prompt" }.count == 2
                 && session.queue.isEmpty
-                && session.contextRestoreWarning == nil
         }
+        #expect(session.contextRestoreWarning == nil)
+        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == false)
         let prompts = client.sent.compactMap { $0.params as? ACPSessionPromptParams }
         #expect(prompts.count == 2)
         let firstBlock = try #require(prompts.first?.prompt.first)
@@ -575,8 +580,8 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(!row.contextRecoveryPending)
     }
 
-    @Test("pending context recovery survives restart after fallback remote id is persisted")
-    func pendingContextRecoverySurvivesRestart() async throws {
+    @Test("pending context recovery auto-sends after restart")
+    func pendingContextRecoveryAutoSendsAfterRestart() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
         try store.upsertSession(row(remoteSessionId: "remote-new"))
         try store.setContextRecoveryPending(sessionId: "local", pending: true)
@@ -588,16 +593,29 @@ struct ACPSessionManagerAttachRestoreTests {
         let client = ACPMockClient()
         scriptInitialize(client)
         scriptSessionResult(client, method: "session/load", sessionId: "remote-new")
+        client.script(method: "session/prompt") { request in
+            let params = try #require(request.params as? ACPSessionPromptParams)
+            #expect(params.sessionId == "remote-new")
+            let block = try #require(params.prompt.first)
+            guard case .text(let text) = block else {
+                Issue.record("Expected text prompt block")
+                return Data("null".utf8)
+            }
+            #expect(text.contains("Context before restart"))
+            return Data("null".utf8)
+        }
         let manager = manager(store: store, client: client)
 
         let session = try #require(manager.placeholderSession(id: "local"))
         await manager.hydrateIfNeeded(id: "local")
         await manager.attach(to: session.id, freshlyCreated: false)
 
-        #expect(client.sent.map(\.method) == ["initialize", "session/load"])
-        let warning = try #require(session.contextRestoreWarning)
-        #expect(warning.canSendTranscript)
-        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == true)
+        try await waitUntil {
+            client.sent.map(\.method) == ["initialize", "session/load", "session/prompt"]
+                && session.contextRestoreWarning == nil
+        }
+        #expect(session.contextRecoveryStatus == .restored)
+        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == false)
     }
 
     @Test("attach retry clears stale warning before setup failure")
@@ -709,7 +727,6 @@ struct ACPSessionManagerAttachRestoreTests {
     func sendTranscriptContextClearsPersistedPendingFlag() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
         try store.upsertSession(row(remoteSessionId: "remote-new"))
-        try store.setContextRecoveryPending(sessionId: "local", pending: true)
         try appendMessage(
             .user(id: UUID(), text: "What changed?", attachments: []),
             to: store,
@@ -724,6 +741,11 @@ struct ACPSessionManagerAttachRestoreTests {
         let session = try #require(manager.placeholderSession(id: "local"))
         await manager.hydrateIfNeeded(id: "local")
         await manager.attach(to: session.id, freshlyCreated: false)
+        try store.setContextRecoveryPending(sessionId: "local", pending: true)
+        session.contextRestoreWarning = .init(
+            message: "Agent context could not be restored.",
+            canSendTranscript: true
+        )
 
         #expect(session.contextRestoreWarning?.canSendTranscript == true)
         #expect(manager.sendTranscriptAsContext(sessionId: session.id, agentName: "Agent"))
@@ -766,6 +788,7 @@ struct ACPSessionManagerAttachRestoreTests {
                 && session.transcript.streamingState == .idle
         }
         #expect(session.contextRestoreWarning == warning)
+        #expect(session.contextRecoveryStatus == .failed("Transcript recovery failed."))
         #expect(session.transcript.messages.count == messageCountBefore)
     }
 

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -357,6 +357,11 @@ struct ACPSessionManagerAttachRestoreTests {
     func loadAuthFailureDoesNotFallBackToSessionNew() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())
         try store.upsertSession(row(remoteSessionId: "remote-old"))
+        try appendMessage(
+            .user(id: UUID(), text: "prior prompt", attachments: []),
+            to: store,
+            seq: 0
+        )
         let client = ACPMockClient()
         let method = terminalAuthMethod()
         scriptInitialize(client, authMethods: [method])
@@ -378,6 +383,7 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(session.authMethods == [method])
         #expect(session.setupState == .needsAuth(methods: [method], reason: "auth_required: 401"))
         #expect(session.lastError?.contains("auth_required: 401") == true)
+        #expect(session.contextRecoveryStatus == nil)
         if case .failed(let message) = session.agentState {
             #expect(message == "auth_required: 401")
         } else {

--- a/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerAttachRestoreTests.swift
@@ -557,6 +557,46 @@ struct ACPSessionManagerAttachRestoreTests {
         #expect(try store.loadSession(id: "local")?.contextRecoveryPending == false)
     }
 
+    @Test("failed automatic transcript recovery keeps queued prompt blocked")
+    func failedAutomaticTranscriptRecoveryKeepsQueuedPromptBlocked() async throws {
+        let store = try ACPSessionStore(path: tmpStorePath())
+        try store.upsertSession(row(remoteSessionId: "remote-old"))
+        try appendMessage(
+            .user(id: UUID(), text: "Prior context", attachments: []),
+            to: store,
+            seq: 0
+        )
+        try store.upsertQueue(sessionId: "local", items: [
+            QueuedPrompt(blocks: [.text("queued prompt")])
+        ])
+        let client = ACPMockClient()
+        scriptInitialize(client)
+        client.script(method: "session/load") { _ in
+            throw JSONRPCError(code: -32601, message: "Method not found", data: nil)
+        }
+        scriptSessionResult(client, method: "session/new", sessionId: "remote-new")
+        client.script(method: "session/prompt") { _ in
+            throw ACPClientError.noScript(method: "session/prompt")
+        }
+        let manager = manager(store: store, client: client)
+
+        let session = try #require(manager.placeholderSession(id: "local"))
+        await manager.hydrateIfNeeded(id: "local")
+        await manager.attach(to: session.id, freshlyCreated: false)
+
+        try await waitUntil {
+            session.contextRecoveryStatus == .failed("Transcript recovery failed.")
+                && session.transcript.streamingState == .idle
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(client.sent.filter { $0.method == "session/prompt" }.count == 1)
+        #expect(session.queue.count == 1)
+        #expect(session.queue.first?.status == .pending)
+        #expect(session.queue.first?.lastError == nil)
+        #expect(try store.loadSession(id: "local")?.contextRecoveryPending == true)
+    }
+
     @Test("missing remote id falls back to session/new with no-transcript warning")
     func missingRemoteIdFallsBackToNewWithWarning() async throws {
         let store = try ACPSessionStore(path: tmpStorePath())

--- a/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
+++ b/AlasTests/ACP/Session/ACPSessionManagerHydrationTests.swift
@@ -268,6 +268,7 @@ struct ACPSessionManagerHydrationTests {
         #expect(s.hasConversationTranscript == false)
         let warning = try #require(s.contextRestoreWarning)
         #expect(warning.canSendTranscript)
+        #expect(s.contextRecoveryStatus == .sendingTranscript)
     }
 
     @Test("hydrateIfNeeded for short transcripts skips backfill")


### PR DESCRIPTION
## Summary
- On session restore failures, transcript context is now sent to the agent automatically instead of requiring a manual user action.
- A new `ContextRecoveryStatus` state machine (`restoring`, `sendingTranscript`, `restored`, `failed`) drives an inline status row in the message list showing progress and a retry button on failure.
- The `contextRestoreWarning` banner is suppressed while the inline recovery row is active to avoid duplicate messaging.

## Testing
- Updated and renamed existing tests to cover the new auto-send behavior: load failure, pending recovery after restart, and queued-prompt ordering all verify `session/prompt` is sent automatically and `contextRecoveryPending` is cleared.
- Added assertion for `contextRecoveryStatus == .failed(...)` on delivery failure and `.sendingTranscript` on hydration with a recoverable transcript.